### PR TITLE
Fixed SaveAs functionality

### DIFF
--- a/OfficeIMO.Tests/Word.Save.cs
+++ b/OfficeIMO.Tests/Word.Save.cs
@@ -89,7 +89,7 @@ namespace OfficeIMO.Tests {
             }
             using (WordDocument document = WordDocument.Load(filePath4)) {
                 Assert.True(document.Paragraphs.Count == 4);
-                Assert.True(filePath3.IsFileLocked() == true);
+                Assert.True(filePath4.IsFileLocked() == true);
             }
 
             Assert.True(filePath1.IsFileLocked() == false);


### PR DESCRIPTION
- OpenXmlPackage's now kept in MemoryStream and Cloned on Save.
- Fixed typo in Test_Save unit test.
- Added CopyPackageProperties() because Open-XML-SDK doesn't do this automatically on Clone or SaveAs [(see issue #1150)](https://github.com/OfficeDev/Open-XML-SDK/issues/1150)