### PR TITLE
Rename color

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,24 @@
-﻿#### - 0.1.5 - 2022.06.04
+﻿#### - 0.1.6
+
+##### What's Changed
+* Rename `Color` to `ColorHex` property for Paragraphs *BREAKING CHANGE*
+* Add `Color` property for Paragraphs as `SixLabors.ImageSharp.Color` *BREAKING CHANGE*
+
+For example:
+
+```csharp
+var paragraph = document.AddParagraph("Basic paragraph");
+paragraph.ParagraphAlignment = JustificationValues.Center;
+paragraph.Color = SixLabors.ImageSharp.Color.Red;
+```
+
+```csharp
+var paragraph = document.AddParagraph("Basic paragraph");
+paragraph.ParagraphAlignment = JustificationValues.Center;
+paragraph.ColorHex = "#FFFF00";
+```
+
+#### - 0.1.5 - 2022.06.04
 
 ##### What's Changed
 * Fixes `TableOfContent.Update()`

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -27,9 +27,9 @@ namespace OfficeIMO.Examples {
             string folderPath = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "Documents");
             Setup(folderPath);
 
-            //BasicDocument.Example_BasicEmptyWord(folderPath, false);
-            //BasicDocument.Example_BasicWord(folderPath, true);
-            //BasicDocument.Example_BasicWord2(folderPath, true);
+            BasicDocument.Example_BasicEmptyWord(folderPath, true);
+            BasicDocument.Example_BasicWord(folderPath, true);
+            BasicDocument.Example_BasicWord2(folderPath, true);
 
             //BasicDocument.Example_BasicDocument(folderPath, true);
             //BasicDocument.Example_BasicDocumentSaveAs1(folderPath, true);
@@ -48,7 +48,7 @@ namespace OfficeIMO.Examples {
             //Tables.Example_BasicTablesLoad2(templatesPath, folderPath, true);
             //Tables.Example_AllTables(folderPath, false);
             //Tables.Example_Tables(folderPath, false);
-            Tables.Example_TableBorders(folderPath, true);
+            //Tables.Example_TableBorders(folderPath, true);
 
             //PageSettings.Example_BasicSettings(folderPath, true);
 
@@ -415,52 +415,52 @@ namespace OfficeIMO.Examples {
 
                 paragraph = document.AddParagraph("8th This text should be colored.");
                 paragraph.Bold = true;
-                paragraph.Color = "4F48E2";
+                paragraph.ColorHex = "4F48E2";
                 paragraph.IndentationAfter = 1400;
 
 
                 paragraph = document.AddParagraph("This is very long line that we will use to show indentation that will work across multiple lines and more and more and even more than that. One, two, three, don't worry baby.");
                 paragraph.Bold = true;
-                paragraph.Color = "#FF0000";
+                paragraph.ColorHex = "#FF0000";
                 paragraph.IndentationBefore = 720;
                 paragraph.IndentationFirstLine = 1400;
 
 
                 paragraph = document.AddParagraph("9th This text should be colored and Arial.");
                 paragraph.Bold = true;
-                paragraph.Color = "4F48E2";
+                paragraph.ColorHex = "4F48E2";
                 paragraph.FontFamily = "Arial";
                 paragraph.VerticalCharacterAlignmentOnLine = VerticalTextAlignmentValues.Bottom;
 
                 paragraph = document.AddParagraph("10th This text should be colored and Tahoma.");
                 paragraph.Bold = true;
-                paragraph.Color = "4F48E2";
+                paragraph.ColorHex = "4F48E2";
                 paragraph.FontFamily = "Tahoma";
                 paragraph.FontSize = 20;
                 paragraph.LineSpacingBefore = 300;
 
                 paragraph = document.AddParagraph("12th This text should be colored and Tahoma and text direction changed");
                 paragraph.Bold = true;
-                paragraph.Color = "4F48E2";
+                paragraph.ColorHex = "4F48E2";
                 paragraph.FontFamily = "Tahoma";
                 paragraph.FontSize = 10;
                 paragraph.TextDirection = TextDirectionValues.TopToBottomRightToLeftRotated;
 
                 paragraph = document.AddParagraph("Spacing Test 1");
                 paragraph.Bold = true;
-                paragraph.Color = "4F48E2";
+                paragraph.ColorHex = "4F48E2";
                 paragraph.FontFamily = "Tahoma";
                 paragraph.LineSpacingAfter = 720;
 
                 paragraph = document.AddParagraph("Spacing Test 2");
                 paragraph.Bold = true;
-                paragraph.Color = "4F48E2";
+                paragraph.ColorHex = "4F48E2";
                 paragraph.FontFamily = "Tahoma";
 
 
                 paragraph = document.AddParagraph("Spacing Test 3");
                 paragraph.Bold = true;
-                paragraph.Color = "4F48E2";
+                paragraph.ColorHex = "4F48E2";
                 paragraph.FontFamily = "Tahoma";
                 paragraph.ParagraphAlignment = JustificationValues.Center;
                 paragraph.LineSpacing = 1500;
@@ -574,7 +574,7 @@ namespace OfficeIMO.Examples {
                 document.AddParagraph().Text = "Some text on next page";
 
                 var paragraph1 = document.AddParagraph("Test").AddText("Test2");
-                paragraph1.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph1.Color = SixLabors.ImageSharp.Color.Red;
                 paragraph1.AddText("Test3");
 
                 paragraph = document.AddParagraph("Some paragraph");
@@ -586,14 +586,14 @@ namespace OfficeIMO.Examples {
 
                 paragraph = document.AddParagraph("Basic paragraph");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 paragraph = document.AddParagraph("2nd paragraph");
                 paragraph.Bold = true;
                 paragraph = paragraph.AddText(" continue?");
                 paragraph.Underline = UnderlineValues.DashLong;
                 paragraph = paragraph.AddText(" More text");
-                paragraph.Color = SixLabors.ImageSharp.Color.CornflowerBlue.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.CornflowerBlue;
 
                 // remove last paragraph
                 document.Paragraphs.Last().Remove();
@@ -603,7 +603,7 @@ namespace OfficeIMO.Examples {
                 paragraph = paragraph.AddText(" continue?");
                 paragraph.Underline = UnderlineValues.DashLong;
                 paragraph = paragraph.AddText(" More text");
-                paragraph.Color = SixLabors.ImageSharp.Color.CornflowerBlue.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.CornflowerBlue;
 
                 // remove paragraph
                 int countParagraphs = document.Paragraphs.Count;
@@ -715,31 +715,31 @@ namespace OfficeIMO.Examples {
 
                 var paragraph = document.AddParagraph("Basic paragraph - Page 1");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 //paragraph = document.InsertPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 2");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 //paragraph = document.InsertPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 3");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 //paragraph = document.InsertPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 4");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 //paragraph = document.InsertPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 5");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 //var section2 = document.InsertSection(SectionMarkValues.NextPage);
                 var section2 = document.AddSection();
@@ -763,24 +763,24 @@ namespace OfficeIMO.Examples {
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 6");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 paragraph = document.AddPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 7");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
 
                 paragraph = document.AddParagraph("Basic paragraph - Section 3.1");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 paragraph = document.AddPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Section 3.2");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 paragraph = document.AddPageBreak();
 
@@ -831,7 +831,7 @@ namespace OfficeIMO.Examples {
 
                 var paragraph = document.AddParagraph("Basic paragraph - Page 1");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 var paragraphInHeaderO = document.Header.Default.AddParagraph();
                 paragraphInHeaderO.Text = "Odd Header / Section 0";
@@ -843,13 +843,13 @@ namespace OfficeIMO.Examples {
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 2");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 document.AddPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 3");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 // 2 section, 9 paragraphs + 7 pagebreaks = 15 paragraphs, 7 pagebreaks
                 Console.WriteLine("+ Paragraphs: " + document.Paragraphs.Count);
@@ -886,14 +886,14 @@ namespace OfficeIMO.Examples {
 
                 var paragraph = document.AddParagraph("Basic paragraph - Page 3");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Blue.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Blue;
 
                 paragraph.SetBold().SetFontFamily("Tahoma");
                 paragraph.AddText(" This is continuation").SetUnderline(UnderlineValues.Double).SetHighlight(HighlightColorValues.DarkGreen).SetFontSize(15).SetColor(Color.Aqua);
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 4");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Blue.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Blue;
 
                 paragraph.SetBold().SetFontFamily("Tahoma");
                 paragraph.AddText(" This is continuation").SetUnderline(UnderlineValues.Double).SetHighlight(HighlightColorValues.DarkGreen).SetFontSize(15).SetColor(Color.Yellow);
@@ -931,7 +931,7 @@ namespace OfficeIMO.Examples {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var paragraph = document.AddParagraph("Basic paragraph - Page 4");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Blue.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Blue;
 
                 paragraph.AddText(" This is continuation").SetUnderline(UnderlineValues.Double).SetFontSize(15).SetColor(Color.Yellow).SetHighlight(HighlightColorValues.DarkGreen);
 
@@ -975,7 +975,7 @@ namespace OfficeIMO.Examples {
 
                 var paragraph = document.AddParagraph("Basic paragraph - Page 1");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 var section2 = document.AddSection();
                 section2.AddHeadersAndFooters();
@@ -985,7 +985,7 @@ namespace OfficeIMO.Examples {
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 2");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 var section3 = document.AddSection();
                 section3.AddHeadersAndFooters();
@@ -995,7 +995,7 @@ namespace OfficeIMO.Examples {
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 3");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 // 2 section, 9 paragraphs + 7 pagebreaks = 15 paragraphs, 7 pagebreaks
                 Console.WriteLine("+ Paragraphs: " + document.Paragraphs.Count);
@@ -1040,7 +1040,7 @@ namespace OfficeIMO.Examples {
                 // change same paragraph using section
                 document.Sections[1].Paragraphs[0].Bold = true;
                 // or Paragraphs list for the whole document
-                document.Paragraphs[1].Color = "7178a8";
+                document.Paragraphs[1].ColorHex = "7178a8";
 
                 var paragraph = section1.AddParagraph("We missed paragraph on 1 section (2nd page)");
                 var newParagraph = paragraph.AddParagraphAfterSelf();

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create.cs
@@ -23,20 +23,20 @@ namespace OfficeIMO.Examples.Word {
             Console.WriteLine("[*] Creating standard document with paragraph");
             string filePath = System.IO.Path.Combine(folderPath, "BasicDocumentWithParagraphs.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
-                var paragraph = document.AddParagraph("Basic paragraph");
+                var paragraph = document.AddParagraph("Adding paragraph with some text");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
                 Console.WriteLine(SixLabors.ImageSharp.Color.Blue.ToHexColor());
                 Console.WriteLine(SixLabors.ImageSharp.Color.Crimson.ToHexColor());
                 Console.WriteLine(SixLabors.ImageSharp.Color.Aquamarine.ToHexColor());
 
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
-                paragraph = document.AddParagraph("2nd paragraph");
+                paragraph = document.AddParagraph("Adding another paragraph with some more text");
                 paragraph.Bold = true;
-                paragraph = paragraph.AddText(" continue?");
+                paragraph = paragraph.AddText(" , but now we also decided to add more text to this paragraph using different style");
                 paragraph.Underline = UnderlineValues.DashLong;
-                paragraph = paragraph.AddText("More text");
-                paragraph.Color = SixLabors.ImageSharp.Color.CornflowerBlue.ToHexColor();
+                paragraph = paragraph.AddText(" , and we still continue adding more text to existing paragraph.");
+                paragraph.Color = SixLabors.ImageSharp.Color.CornflowerBlue;
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample5.cs
+++ b/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample5.cs
@@ -19,7 +19,7 @@ namespace OfficeIMO.Examples.Word {
 
                 var paragraph = document.AddParagraph("Basic paragraph");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Tests/Word.HeadersAndFooter.cs
+++ b/OfficeIMO.Tests/Word.HeadersAndFooter.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Tests {
 
                 var paragraph = document.AddParagraph("Basic paragraph - Page 1");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 var paragraphInHeader = document.Header.Default.AddParagraph();
                 paragraphInHeader.Text = "Default Header / Section 0";
@@ -23,13 +23,13 @@ namespace OfficeIMO.Tests {
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 2");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 document.AddPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 3");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 Assert.True(document.Header.Default.Paragraphs[0].Text == "Default Header / Section 0", "Text for default header is wrong (section 0)");
 
@@ -60,7 +60,7 @@ namespace OfficeIMO.Tests {
 
                 var paragraph = document.AddParagraph("Basic paragraph - Page 1");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 var paragraphInHeaderO = document.Header.Default.AddParagraph();
                 paragraphInHeaderO.Text = "Odd Header / Section 0";
@@ -72,13 +72,13 @@ namespace OfficeIMO.Tests {
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 2");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 document.AddPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 3");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 Assert.True(document.Header.Default.Paragraphs.Count == 1, "Should only have X paragraphs");
                 Assert.True(document.Header.Default.Paragraphs[0].Text == "Odd Header / Section 0", "Text for default header is wrong (section 0)");
@@ -119,7 +119,7 @@ namespace OfficeIMO.Tests {
 
                 var paragraph = document.AddParagraph("Basic paragraph - Page 1");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 var paragraphInHeaderF = document.Header.First.AddParagraph();
                 paragraphInHeaderF.Text = "First Header / Section 0";
@@ -134,13 +134,13 @@ namespace OfficeIMO.Tests {
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 2");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 document.AddPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 3");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 Assert.True(document.Header.Default.Paragraphs.Count == 1, "Should only have X paragraphs");
                 Assert.True(document.Header.Default.Paragraphs[0].Text == "Odd Header / Section 0", "Text for default header is wrong (section 0)");

--- a/OfficeIMO.Tests/Word.Paragraphs.cs
+++ b/OfficeIMO.Tests/Word.Paragraphs.cs
@@ -16,18 +16,21 @@ namespace OfficeIMO.Tests {
 
                 var paragraph = document.AddParagraph("Basic paragraph - Page 1");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Blue.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Blue;
 
                 paragraph.SetBold().SetFontFamily("Tahoma");
                 paragraph.AddText(" This is continuation").SetUnderline(UnderlineValues.Double).SetFontSize(15).SetColor(Color.Yellow).SetHighlight(HighlightColorValues.DarkGreen);
 
                 paragraph.AddText(" this is more continuation").SetItalic().SetCapsStyle(CapsStyle.Caps);
 
-                Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Blue.ToHexColor(), "1st paragraph color should be the same");
+                Assert.True(document.Paragraphs[0].ColorHex == SixLabors.ImageSharp.Color.Blue.ToHexColor(), "1st paragraph color should be the same");
+                Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Blue, "1st paragraph color should be the same");
                 Assert.True(document.Paragraphs[0].Bold == true, "Basic paragraph - Page 1");
                 Assert.True(document.Paragraphs[0].FontFamily == "Tahoma", "1st paragraph should be set with Tahoma");
 
-                Assert.True(document.Paragraphs[1].Color == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[1].Color);
+                Assert.True(document.Paragraphs[1].ColorHex == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[1].Color);
+                Assert.True(document.Paragraphs[1].Color == SixLabors.ImageSharp.Color.Yellow, "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[1].Color);
+
                 Assert.True(document.Paragraphs[1].Bold == false, "2nd paragraph should not be bold");
                 Assert.True(document.Paragraphs[1].FontFamily == null, "2nd paragraph should be not set. Expected: " + document.Paragraphs[1].FontFamily);
                 Assert.True(document.Paragraphs[1].Underline == UnderlineValues.Double, "2nd paragraph should be underline double. " + document.Paragraphs[1].Underline);
@@ -42,11 +45,14 @@ namespace OfficeIMO.Tests {
                 document.Save();
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Blue.ToHexColor(), "1st paragraph color should be the same");
+                Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Blue, "1st paragraph color should be the same");
+                Assert.True(document.Paragraphs[0].ColorHex == SixLabors.ImageSharp.Color.Blue.ToHexColor(), "1st paragraph color should be the same");
                 Assert.True(document.Paragraphs[0].Bold == true, "Basic paragraph - Page 1");
                 Assert.True(document.Paragraphs[0].FontFamily == "Tahoma", "1st paragraph should be set with Tahoma");
 
-                Assert.True(document.Paragraphs[1].Color == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[1].Color);
+                Assert.True(document.Paragraphs[1].ColorHex == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[1].Color);
+                Assert.True(document.Paragraphs[1].Color == SixLabors.ImageSharp.Color.Yellow, "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[1].Color);
+
                 Assert.True(document.Paragraphs[1].Bold == false, "2nd paragraph should not be bold");
                 Assert.True(document.Paragraphs[1].FontFamily == null, "2nd paragraph should be not set. Expected: " + document.Paragraphs[1].FontFamily);
                 Assert.True(document.Paragraphs[1].Underline == UnderlineValues.Double, "2nd paragraph should be underline double. " + document.Paragraphs[1].Underline);
@@ -69,13 +75,13 @@ namespace OfficeIMO.Tests {
 
                 var paragraph = document.AddParagraph("Basic paragraph - Page 1");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.ColorHex = SixLabors.ImageSharp.Color.Red.ToHexColor();
 
                 document.AddPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 2");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Yellow.ToHexColor();
+                paragraph.ColorHex = SixLabors.ImageSharp.Color.Yellow.ToHexColor();
 
                 Assert.True(paragraph.DoNotCheckSpellingOrGrammar == false, "DoNotCheckSpellingOrGrammar should not be set.");
                 paragraph.DoNotCheckSpellingOrGrammar = true;
@@ -85,7 +91,7 @@ namespace OfficeIMO.Tests {
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 3");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Blue.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Blue;
 
                 paragraph.SetBold().SetFontFamily("Tahoma");
                 paragraph.AddText(" This is continuation").SetUnderline(UnderlineValues.Double).SetHighlight(HighlightColorValues.DarkGreen).SetFontSize(15).SetColor(Color.Yellow);
@@ -105,17 +111,22 @@ namespace OfficeIMO.Tests {
                 var expectedParagraph2 = new Likeness<WordParagraph, WordParagraph>(document.Sections[0].Paragraphs[2]);
                 Assert.True(expectedParagraph2.Equals(document.Paragraphs[2]) == true);
 
-                Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Red.ToHexColor(), "1st paragraph color should be the same");
+                Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Red, "1st paragraph color should be the same");
+                Assert.True(document.Paragraphs[0].ColorHex == SixLabors.ImageSharp.Color.Red.ToHexColor(), "1st paragraph color should be the same");
                 Assert.True(document.Paragraphs[1].IsPageBreak == true, "2nd paragraph color should be the page break");
-                Assert.True(document.Paragraphs[2].Color == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "3rd paragraph color should be the same");
+                Assert.True(document.Paragraphs[2].Color == SixLabors.ImageSharp.Color.Yellow, "3rd paragraph color should be the same");
+                Assert.True(document.Paragraphs[2].ColorHex == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "3rd paragraph color should be the same");
                 Assert.True(document.Paragraphs[2].DoNotCheckSpellingOrGrammar == true, "3rd paragraph DoNotCheckSpellingOrGrammar should be set");
                 Assert.True(document.Paragraphs[3].IsPageBreak == true, "4th paragraph color should be the page break");
                 Assert.True(document.Paragraphs[3].DoNotCheckSpellingOrGrammar == false, "4th paragraph DoNotCheckSpellingOrGrammar should not be set");
-                Assert.True(document.Paragraphs[4].Color == SixLabors.ImageSharp.Color.Blue.ToHexColor(), "5th paragraph color should be the same");
+                Assert.True(document.Paragraphs[4].Color == SixLabors.ImageSharp.Color.Blue, "5th paragraph color should be the same");
+                Assert.True(document.Paragraphs[4].ColorHex == SixLabors.ImageSharp.Color.Blue.ToHexColor(), "5th paragraph color should be the same");
                 Assert.True(document.Paragraphs[4].Bold == true, "5th paragraph should be bold");
                 Assert.True(document.Paragraphs[4].FontFamily == "Tahoma", "5th paragraph should be set with Tahoma");
 
-                Assert.True(document.Paragraphs[5].Color == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[5].Color);
+                Assert.True(document.Paragraphs[5].Color == SixLabors.ImageSharp.Color.Yellow, "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[5].Color);
+                Assert.True(document.Paragraphs[5].ColorHex == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[5].Color);
+
                 Assert.True(document.Paragraphs[5].Bold == false, "2nd paragraph should not be bold");
                 Assert.True(document.Paragraphs[5].FontFamily == null, "2nd paragraph should be not set. Expected: " + document.Paragraphs[5].FontFamily);
                 Assert.True(document.Paragraphs[5].Underline == UnderlineValues.Double, "2nd paragraph should be underline double. " + document.Paragraphs[5].Underline);
@@ -136,15 +147,15 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs[0].Text == "Basic paragraph - Page 1", "1st paragraph text doesn't match. Current: " + document.Paragraphs[0].Text);
                 Assert.True(document.Paragraphs[0].Text == document.Sections[0].Paragraphs[0].Text, "1st paragraph of 1st section should be the same 1");
                 //Assert.True(document.Paragraphs[0] == document.Sections[0].Paragraphs[0], "1st paragraph of 1st section should be the same 2");
-                Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Red.ToHexColor(), "1st paragraph color should be the same");
+                Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Red, "1st paragraph color should be the same");
                 Assert.True(document.Paragraphs[1].IsPageBreak == true, "2nd paragraph color should be the page break");
-                Assert.True(document.Paragraphs[2].Color == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "3rd paragraph color should be the same");
+                Assert.True(document.Paragraphs[2].Color == SixLabors.ImageSharp.Color.Yellow, "3rd paragraph color should be the same");
                 Assert.True(document.Paragraphs[3].IsPageBreak == true, "4th paragraph color should be the page break");
-                Assert.True(document.Paragraphs[4].Color == SixLabors.ImageSharp.Color.Blue.ToHexColor(), "5th paragraph color should be the same");
+                Assert.True(document.Paragraphs[4].Color == SixLabors.ImageSharp.Color.Blue, "5th paragraph color should be the same");
                 Assert.True(document.Paragraphs[4].Bold == true, "5th paragraph should be bold");
                 Assert.True(document.Paragraphs[4].FontFamily == "Tahoma", "5th paragraph should be set with Tahoma");
 
-                Assert.True(document.Paragraphs[5].Color == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "2nd paragraph color should be (load) " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[5].Color);
+                Assert.True(document.Paragraphs[5].Color == SixLabors.ImageSharp.Color.Yellow, "2nd paragraph color should be (load) " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[5].Color);
                 Assert.True(document.Paragraphs[5].Bold == false, "2nd paragraph should not be bold");
                 Assert.True(document.Paragraphs[5].FontFamily == null, "2nd paragraph should be not set. Expected: " + document.Paragraphs[5].FontFamily);
                 Assert.True(document.Paragraphs[5].Underline == UnderlineValues.Double, "2nd paragraph should be underline double. " + document.Paragraphs[5].Underline);
@@ -179,13 +190,13 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs[0].Text == "Basic paragraph - Page 1", "1st paragraph text doesn't match. Current: " + document.Paragraphs[0].Text);
                 Assert.True(document.Paragraphs[0].Text == document.Sections[0].Paragraphs[0].Text, "1st paragraph of 1st section should be the same 1");
                 //Assert.True(document.Paragraphs[0] == document.Sections[0].Paragraphs[0], "1st paragraph of 1st section should be the same 2");
-                Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Red.ToHexColor(), "1st paragraph color should be the same");
+                Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Red, "1st paragraph color should be the same");
                 Assert.True(document.Paragraphs[1].IsPageBreak == true, "2nd paragraph color should be the page break");
-                Assert.True(document.Paragraphs[2].Color == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "3rd paragraph color should be the same");
+                Assert.True(document.Paragraphs[2].Color == SixLabors.ImageSharp.Color.Yellow, "3rd paragraph color should be the same");
                 Assert.True(document.Paragraphs[2].DoubleStrike == true, "DoubleStrike should be set");
                 Assert.True(document.Paragraphs[2].Spacing == 20, "Spacing should be set");
                 Assert.True(document.Paragraphs[3].IsPageBreak == true, "4th paragraph color should be the page break");
-                Assert.True(document.Paragraphs[4].Color == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[4].Color);
+                Assert.True(document.Paragraphs[4].Color == SixLabors.ImageSharp.Color.Yellow, "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[4].Color);
                 Assert.True(document.Paragraphs[4].Bold == false, "2nd paragraph should not be bold");
                 Assert.True(document.Paragraphs[4].IsPageBreak == false, "2nd paragraph should not be page break. " + document.Paragraphs[4].IsPageBreak);
                 Assert.True(document.Paragraphs[4].DoubleStrike == false, "2nd paragraph should not be double strike. " + document.Paragraphs[4].DoubleStrike);
@@ -202,13 +213,13 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs[0].Text == "Basic paragraph - Page 1", "1st paragraph text doesn't match. Current: " + document.Paragraphs[0].Text);
                 Assert.True(document.Paragraphs[0].Text == document.Sections[0].Paragraphs[0].Text, "1st paragraph of 1st section should be the same 1");
                 //Assert.True(document.Paragraphs[0] == document.Sections[0].Paragraphs[0], "1st paragraph of 1st section should be the same 2");
-                Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Red.ToHexColor(), "1st paragraph color should be the same");
+                Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Red, "1st paragraph color should be the same");
                 Assert.True(document.Paragraphs[1].IsPageBreak == true, "2nd paragraph color should be the page break");
-                Assert.True(document.Paragraphs[2].Color == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "3rd paragraph color should be the same");
+                Assert.True(document.Paragraphs[2].Color == SixLabors.ImageSharp.Color.Yellow, "3rd paragraph color should be the same");
                 Assert.True(document.Paragraphs[2].DoubleStrike == true, "DoubleStrike should be set");
                 Assert.True(document.Paragraphs[2].Spacing == 20, "Spacing should be set");
                 Assert.True(document.Paragraphs[3].IsPageBreak == true, "4th paragraph color should be the page break");
-                Assert.True(document.Paragraphs[4].Color == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[4].Color);
+                Assert.True(document.Paragraphs[4].Color == SixLabors.ImageSharp.Color.Yellow, "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[4].Color);
                 Assert.True(document.Paragraphs[4].Bold == false, "2nd paragraph should not be bold");
                 Assert.True(document.Paragraphs[4].IsPageBreak == false, "2nd paragraph should not be page break. " + document.Paragraphs[4].IsPageBreak);
                 Assert.True(document.Paragraphs[4].DoubleStrike == false, "2nd paragraph should not be double strike. " + document.Paragraphs[4].DoubleStrike);

--- a/OfficeIMO.Tests/Word.Properties.cs
+++ b/OfficeIMO.Tests/Word.Properties.cs
@@ -18,19 +18,19 @@ namespace OfficeIMO.Tests {
 
                 var paragraph = document.AddParagraph("Basic paragraph - Page 1");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 document.AddPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 2");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 document.AddPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 3");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 Assert.True(document.Paragraphs.Count == 5, "Paragraphs count doesn't match. Provided: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count() == 2, "PageBreaks count doesn't match. Provided: " + document.PageBreaks.Count);
@@ -59,19 +59,19 @@ namespace OfficeIMO.Tests {
 
                 var paragraph = document.AddParagraph("Basic paragraph - Page 1");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 document.AddPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 2");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 document.AddPageBreak();
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 3");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
-                paragraph.Color = SixLabors.ImageSharp.Color.Red.ToHexColor();
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
                 string date = "7/7/2011 10:48";
                 DateTime dateTime = DateTime.ParseExact(date, "M/d/yyyy hh:mm", CultureInfo.CurrentCulture);

--- a/OfficeIMO.Tests/Word.Tables.cs
+++ b/OfficeIMO.Tests/Word.Tables.cs
@@ -80,7 +80,7 @@ namespace OfficeIMO.Tests {
                 wordTable2.Rows[2].Cells[2].Paragraphs[2].SetColor(Color.Green);
 
                 Assert.True(wordTable2.Rows[2].Cells[2].Paragraphs[2].Text == "Change me");
-                Assert.True(wordTable2.Rows[2].Cells[2].Paragraphs[2].Color == Color.Green.ToHexColor());
+                Assert.True(wordTable2.Rows[2].Cells[2].Paragraphs[2].Color == Color.Green);
 
 
                 document.Save();

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -162,7 +162,12 @@ namespace OfficeIMO.Word {
             }
         }
 
-        public string Color {
+        public SixLabors.ImageSharp.Color Color {
+            get { return SixLabors.ImageSharp.Color.Parse("#" + ColorHex); }
+            set { this.ColorHex = value.ToHexColor(); }
+        }
+
+        public string ColorHex {
             get {
                 if (_runProperties != null && _runProperties.Color != null) {
                     return _runProperties.Color.Val;
@@ -176,7 +181,7 @@ namespace OfficeIMO.Word {
                 // var color = SixLabors.ImageSharp.Color.FromArgb(Convert.ToInt32(stringColor.Substring(0, 2), 16), Convert.ToInt32(stringColor.Substring(2, 2), 16), Convert.ToInt32(stringColor.Substring(4, 2), 16));
                 if (value != "") {
                     var color = new DocumentFormat.OpenXml.Wordprocessing.Color();
-                    color.Val = value;
+                    color.Val = value.Replace("#", "");
                     _runProperties.Color = color;
                 } else {
                     if (_runProperties.Color != null) _runProperties.Color.Remove();

--- a/OfficeIMO.Word/WordParagraph.RunPropertiesMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.RunPropertiesMethods.cs
@@ -35,11 +35,11 @@ namespace OfficeIMO.Word {
             return this;
         }
         public WordParagraph SetColorHex(string color) {
-            this.Color = color.Replace("#", "");
+            this.ColorHex = color;
             return this;
         }
         public WordParagraph SetColor(SixLabors.ImageSharp.Color color) {
-            this.Color = color.ToHexColor();
+            this.Color = color;
             return this;
         }
         public WordParagraph SetHighlight(HighlightColorValues highlight) {


### PR DESCRIPTION
This PR fixes paragraphs to work the same way as colors for other objects in OfficeIMO. I believe it's better to use Color for SixLabors.ImageSharp.Color rather than it being Hex. Hex is still an option tho.

* Rename `Color` to `ColorHex` property for Paragraphs *BREAKING CHANGE*
* Add `Color` property for Paragraphs as `SixLabors.ImageSharp.Color` *BREAKING CHANGE*

For example:

```csharp
var paragraph = document.AddParagraph("Basic paragraph");
paragraph.ParagraphAlignment = JustificationValues.Center;
paragraph.Color = SixLabors.ImageSharp.Color.Red;
```

```csharp
var paragraph = document.AddParagraph("Basic paragraph");
paragraph.ParagraphAlignment = JustificationValues.Center;
paragraph.ColorHex = "#FFFF00";
```