### PR TITLE
FIxes PageOrientation when mixed with PageSize

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,7 +1,7 @@
 ﻿#### - 0.1.7 - 2022.06.12
 
 ##### What's Changed
-* Fixes orientation of page/section if set before page size is applied
+* Fixes **PageOrientation** of page/section if set before page size is applied. In case that happens it always reverted back to `Portrait` mode which is default for newly set **PageSizes**.
 
 #### - 0.1.6 - 2022.06.11
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,9 @@
-﻿#### - 0.1.6 - 2022.06.11
+﻿#### - 0.1.7 - 2022.06.12
+
+##### What's Changed
+* Fixes orientation of page/section if set before page size is applied
+
+#### - 0.1.6 - 2022.06.11
 
 ##### What's Changed
 * Rename `Color` to `ColorHex` property for Paragraphs *BREAKING CHANGE*

--- a/OfficeIMO.Tests/Word.Sections.cs
+++ b/OfficeIMO.Tests/Word.Sections.cs
@@ -475,5 +475,31 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Sections[6].Margins.FooterDistance == 720);
             }
         }
+
+
+        [Fact]
+        public void Test_CreatingSections() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentSections.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+
+                document.AddParagraph("Test 1");
+
+                var section1 = document.AddSection();
+                section1.PageOrientation = PageOrientationValues.Landscape;
+                section1.PageSettings.PageSize = WordPageSize.A4;
+                section1.AddParagraph("Test 1");
+
+                Assert.True(section1.PageOrientation == PageOrientationValues.Landscape);
+                Assert.True(section1.PageSettings.Orientation == PageOrientationValues.Landscape);
+                Assert.True(document.Sections[1].PageOrientation == PageOrientationValues.Landscape);
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentSections.docx"))) {
+
+
+                Assert.True(document.Sections[1].PageOrientation == PageOrientationValues.Landscape);
+            }
+        }
+
     }
 }

--- a/OfficeIMO.Word/WordPageSizes.cs
+++ b/OfficeIMO.Word/WordPageSizes.cs
@@ -6,16 +6,51 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// PaperSizes used in Microsoft Office
+    /// </summary>
     public enum WordPageSize {
+        /// <summary>
+        /// Custom/unknown paper size that is not defined within OfficeIMO
+        /// </summary>
         Unknown,
+        /// <summary>
+        /// Letter is part of the North American loose paper size series.
+        /// It is the standard for business and academic documents, and measures 216 × 279 mm or 8.5 × 11 inches.
+        /// </summary>
         Letter,
+        /// <summary>
+        /// Legal is part of the North American loose paper size series.
+        /// It is used to make legal pads, and measures 216 × 356 mm or 8.5 × 14 inches.
+        /// </summary>
         Legal,
+        /// <summary>
+        /// Statement paper size 5.5 x 8.5 inches
+        /// </summary>
         Statement,
+        /// <summary>
+        /// Executive paper size 7.25 x 10.50 inches.
+        /// </summary>
         Executive,
+        /// <summary>
+        /// An A3 piece of paper measures 297 × 420 mm or 11.7 × 16.5 inches.
+        /// </summary>
         A3,
+        /// <summary>
+        /// An A4 piece of paper measures 210 × 297 mm or 8.3 × 11.7 inches
+        /// </summary>
         A4,
+        /// <summary>
+        /// An A5 piece of paper measures 148 × 210 mm or 5.8 × 8.3 inches.
+        /// </summary>
         A5,
+        /// <summary>
+        /// An A6 piece of paper measures 105 × 148 mm or 4.1 × 5.8 inches.
+        /// </summary>
         A6,
+        /// <summary>
+        /// A B5 piece of paper measures 176 × 250 mm or 6.9 × 9.8 inches.
+        /// </summary>
         B5
     }
 
@@ -23,6 +58,9 @@ namespace OfficeIMO.Word {
         private readonly WordSection _section;
         private readonly WordDocument _document;
 
+        /// <summary>
+        /// This element specifies the properties (size and orientation) for all pages in the current section.
+        /// </summary>
         public WordPageSize? PageSize {
             get {
                 var pageSize = _section._sectionProperties.ChildElements.OfType<PageSize>().FirstOrDefault();
@@ -76,13 +114,30 @@ namespace OfficeIMO.Word {
                     if (pageSize == null) {
                         _section._sectionProperties.Append(pageSizeSettings);
                     } else {
+                        // page size already exists, we will be overwriting it, but before we do, we need to make sure to fix page orientation
+                        // since it may be already set
+                        bool requiresPageOrient = false;
+                        PageOrientationValues pageOrientation = PageOrientationValues.Portrait;
+                        if (pageSize.Orient != null && pageSize.Orient.Value != PageOrientationValues.Portrait) {
+                            pageOrientation = pageSize.Orient;
+                            requiresPageOrient = true;
+                        }
+                        // remove page size (faster than reassign all properties).
                         pageSize.Remove();
                         _section._sectionProperties.Append(pageSizeSettings);
+
+                        // we now need to set page orientation back if it was set
+                        if (requiresPageOrient) {
+                            SetOrientation(_section._sectionProperties, pageOrientation);
+                        }
                     }
                 }
             }
         }
 
+        /// <summary>
+        /// Get or Set section/page Width
+        /// </summary>
         public UInt32Value Width {
             get {
                 var pageSize = _section._sectionProperties.ChildElements.OfType<PageSize>().FirstOrDefault();
@@ -104,6 +159,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Get or Set section/page Height
+        /// </summary>
         public UInt32Value Height {
             get {
                 var pageSize = _section._sectionProperties.ChildElements.OfType<PageSize>().FirstOrDefault();
@@ -125,6 +183,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Get or Set section/page Code
+        /// </summary>
         public UInt16Value Code {
             get {
                 var pageSize = _section._sectionProperties.ChildElements.OfType<PageSize>().FirstOrDefault();
@@ -181,11 +242,19 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Get or Set section/page Orientation
+        /// </summary>
         public PageOrientationValues Orientation {
             get => GetOrientation(_section._sectionProperties);
             set => SetOrientation(_section._sectionProperties, value);
         }
 
+        /// <summary>
+        /// Manipulate section/page settings
+        /// </summary>
+        /// <param name="wordDocument"></param>
+        /// <param name="wordSection"></param>
         public WordPageSizes(WordDocument wordDocument, WordSection wordSection) {
             _section = wordSection;
             _document = wordDocument;


### PR DESCRIPTION
This PR fixes a problem when you set PageOrientation before setting PageSize. In case that happens it always revert back to `Portrait`