### PR TITLE
Add ability to add nested tables (add table into cell of an existing table)

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -55,6 +55,8 @@ namespace OfficeIMO.Examples {
             //Tables.Example_Tables(folderPath, false);
             //Tables.Example_TableBorders(folderPath, true);
 
+            Tables.Example_NestedTables(folderPath, true);
+
             //PageSettings.Example_BasicSettings(folderPath, true);
 
             //PageNumbers.Example_PageNumbers1(folderPath, true);
@@ -86,7 +88,7 @@ namespace OfficeIMO.Examples {
 
             //HeadersAndFooters.Sections1(folderPath, true);
 
-            Charts.Example_AddingMultipleCharts(folderPath, true);
+            //Charts.Example_AddingMultipleCharts(folderPath, true);
 
             //Console.WriteLine("[*] Creating standard document with multiple paragraphs, with some formatting");
             //filePath = System.IO.Path.Combine(folderPath, "AdvancedParagraphs.docx");

--- a/OfficeIMO.Examples/Word/Tables/Tables.NestedTables1.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.NestedTables1.cs
@@ -19,9 +19,61 @@ namespace OfficeIMO.Examples.Word {
                 wordTable.Rows[2].Cells[0].Paragraphs[0].Text = "Test 3";
                 wordTable.Rows[3].Cells[0].Paragraphs[0].Text = "Test 4";
 
-                wordTable.Rows[0].Cells[0].AddTable(3, 2, WordTableStyle.GridTable2Accent2);
+                var table1 = wordTable.Rows[0].Cells[0].AddTable(3, 2, WordTableStyle.GridTable2Accent2);
 
-                wordTable.Rows[0].Cells[1].AddTable(3, 2, WordTableStyle.GridTable2Accent5, true);
+                var table2 = wordTable.Rows[0].Cells[1].AddTable(3, 2, WordTableStyle.GridTable2Accent5, true);
+
+                Console.WriteLine("Table has nested tables: " + document.Tables[0].HasNestedTables);
+                Console.WriteLine("Table1 is nested table: " + document.Tables[0].IsNestedTable);
+
+                Console.WriteLine("Table2 is nested table: " + table1.IsNestedTable);
+                Console.WriteLine("Table3 is nested table: " + table2.IsNestedTable);
+
+
+                wordTable.NestedTables[0].Rows[0].Cells[0].Paragraphs[0].Text = "Nested table 1 / 1st row / 1st cell";
+
+                wordTable.NestedTables[1].Rows[0].Cells[1].Paragraphs[0].Text = "Nested table 2 - 1st row / 2nd cell";
+
+                var paragraph1 = document.AddParagraph("Lets add table number 2 ");
+                paragraph.ParagraphAlignment = JustificationValues.Center;
+                paragraph.Bold = true;
+                paragraph.Underline = UnderlineValues.DotDash;
+
+                WordTable wordTable1 = document.AddTable(5, 5, WordTableStyle.GridTable1LightAccent1);
+                wordTable1.Rows[1].Cells[0].Paragraphs[0].Text = "Test 1.2";
+                wordTable1.Rows[2].Cells[0].Paragraphs[0].Text = "Test 1.3";
+                wordTable1.Rows[3].Cells[0].Paragraphs[0].Text = "Test 1.4";
+                wordTable1.Rows[0].Cells[0].Paragraphs[0].Text = "Test 1.5";
+
+
+                var paragraph2 = document.AddParagraph("Lets add table number 3 ");
+                paragraph.ParagraphAlignment = JustificationValues.Center;
+                paragraph.Bold = true;
+                paragraph.Underline = UnderlineValues.DotDash;
+
+                WordTable wordTable2 = document.AddTable(5, 5, WordTableStyle.GridTable1LightAccent1);
+                wordTable2.Rows[1].Cells[0].Paragraphs[0].Text = "Test 2.2";
+                wordTable2.Rows[2].Cells[0].Paragraphs[0].Text = "Test 2.3";
+                wordTable2.Rows[3].Cells[0].Paragraphs[0].Text = "Test 2.4";
+                wordTable2.Rows[0].Cells[0].Paragraphs[0].Text = "Test 2.5";
+
+
+                var table3 = wordTable2.Rows[0].Cells[0].AddTable(3, 2, WordTableStyle.GridTable2Accent2);
+
+                var table4 = wordTable2.Rows[0].Cells[1].AddTable(3, 2, WordTableStyle.GridTable2Accent5, true);
+
+                var i = 0;
+                foreach (var table in document.TablesIncludingNestedTables) {
+                    Console.WriteLine("Table " + i + " out of " + document.TablesIncludingNestedTables.Count);
+                    if (table.IsNestedTable) {
+                        Console.WriteLine("Nested table Rows count: " + table.RowsCount);
+                        Console.WriteLine("Nested table Parent Rows count: " + table.ParentTable.RowsCount);
+                    } else {
+                        Console.WriteLine("Skipped table, not nested table");
+                    }
+
+                    i++;
+                }
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/Tables/Tables.NestedTables1.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.NestedTables1.cs
@@ -1,11 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
-using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class Tables {

--- a/OfficeIMO.Examples/Word/Tables/Tables.NestedTables1.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.NestedTables1.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Color = SixLabors.ImageSharp.Color;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Tables {
+        internal static void Example_NestedTables(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating standard document with nested tables");
+            string filePath = System.IO.Path.Combine(folderPath, "Document with Nested Tables.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Lets add table ");
+                paragraph.ParagraphAlignment = JustificationValues.Center;
+                paragraph.Bold = true;
+                paragraph.Underline = UnderlineValues.DotDash;
+
+                WordTable wordTable = document.AddTable(4, 4, WordTableStyle.GridTable1LightAccent1);
+                wordTable.Rows[0].Cells[0].Paragraphs[0].Text = "Test 1";
+                wordTable.Rows[1].Cells[0].Paragraphs[0].Text = "Test 2";
+                wordTable.Rows[2].Cells[0].Paragraphs[0].Text = "Test 3";
+                wordTable.Rows[3].Cells[0].Paragraphs[0].Text = "Test 4";
+
+                wordTable.Rows[2].Cells[0].AddTable(2, 2, WordTableStyle.GridTable2Accent2);
+
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Tables/Tables.NestedTables1.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.NestedTables1.cs
@@ -24,8 +24,9 @@ namespace OfficeIMO.Examples.Word {
                 wordTable.Rows[2].Cells[0].Paragraphs[0].Text = "Test 3";
                 wordTable.Rows[3].Cells[0].Paragraphs[0].Text = "Test 4";
 
-                wordTable.Rows[2].Cells[0].AddTable(2, 2, WordTableStyle.GridTable2Accent2);
+                wordTable.Rows[0].Cells[0].AddTable(3, 2, WordTableStyle.GridTable2Accent2);
 
+                wordTable.Rows[0].Cells[1].AddTable(3, 2, WordTableStyle.GridTable2Accent5, true);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Tests/Word.TablesNested.cs
+++ b/OfficeIMO.Tests/Word.TablesNested.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Color = SixLabors.ImageSharp.Color;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_CreatingWordDocumentWithNestedTables() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithNestedTables.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Lets add table ");
+                paragraph.ParagraphAlignment = JustificationValues.Center;
+                paragraph.Bold = true;
+                paragraph.Underline = UnderlineValues.DotDash;
+
+                WordTable wordTable = document.AddTable(4, 4, WordTableStyle.GridTable1LightAccent1);
+                wordTable.Rows[0].Cells[0].Paragraphs[0].Text = "Test 1";
+                wordTable.Rows[1].Cells[0].Paragraphs[0].Text = "Test 2";
+                wordTable.Rows[2].Cells[0].Paragraphs[0].Text = "Test 3";
+                wordTable.Rows[3].Cells[0].Paragraphs[0].Text = "Test 4";
+
+                WordTable wordTable1 = document.AddTable(5, 5, WordTableStyle.GridTable1LightAccent1);
+                wordTable1.Rows[1].Cells[0].Paragraphs[0].Text = "Test 1.2";
+                wordTable1.Rows[2].Cells[0].Paragraphs[0].Text = "Test 1.3";
+                wordTable1.Rows[3].Cells[0].Paragraphs[0].Text = "Test 1.4";
+                wordTable1.Rows[0].Cells[0].Paragraphs[0].Text = "Test 1.5";
+
+
+                WordTable wordTable2 = document.AddTable(5, 5, WordTableStyle.GridTable1LightAccent1);
+                wordTable2.Rows[1].Cells[0].Paragraphs[0].Text = "Test 2.2";
+                wordTable2.Rows[2].Cells[0].Paragraphs[0].Text = "Test 2.3";
+                wordTable2.Rows[3].Cells[0].Paragraphs[0].Text = "Test 2.4";
+                wordTable2.Rows[0].Cells[0].Paragraphs[0].Text = "Test 2.5";
+
+                var table1 = wordTable.Rows[0].Cells[0].AddTable(3, 2, WordTableStyle.GridTable2Accent2);
+
+                var table2 = wordTable.Rows[0].Cells[1].AddTable(3, 2, WordTableStyle.GridTable2Accent5, true);
+
+
+                var table3 = wordTable2.Rows[0].Cells[0].AddTable(3, 2, WordTableStyle.GridTable2Accent2);
+
+                var table4 = wordTable2.Rows[0].Cells[1].AddTable(3, 2, WordTableStyle.GridTable2Accent5, true);
+
+                Assert.True(document.Tables[0].HasNestedTables);
+                Assert.False(document.Tables[0].IsNestedTable);
+
+                Assert.True(table1.IsNestedTable);
+                Assert.True(table2.IsNestedTable);
+
+                wordTable.NestedTables[0].Rows[0].Cells[0].Paragraphs[0].Text = "Nested table 1 / 1st row / 1st cell";
+
+                wordTable.NestedTables[1].Rows[1].Cells[1].Paragraphs[0].Text = "Nested table 2 / 2nd row / 2nd cell";
+
+                Assert.True(table1.Rows[0].Cells[0].Paragraphs[0].Text == "Nested table 1 / 1st row / 1st cell");
+                Assert.True(table2.Rows[1].Cells[1].Paragraphs[0].Text == "Nested table 2 / 2nd row / 2nd cell");
+
+                Assert.True(document.Tables[0].HasNestedTables);
+                Assert.False(document.Tables[0].IsNestedTable);
+
+                Assert.True(document.Tables[0].NestedTables[0].IsNestedTable);
+                Assert.True(document.Tables[0].NestedTables[1].IsNestedTable);
+                Assert.True(document.Tables[0].NestedTables.Count == 2);
+                Assert.True(document.Tables[1].NestedTables.Count == 0);
+                Assert.True(document.Tables[2].NestedTables.Count == 2);
+                Assert.True(document.Tables.Count == 3);
+                Assert.True(document.TablesIncludingNestedTables.Count == 7);
+                Assert.True(document.Sections[0].TablesIncludingNestedTables.Count == 7);
+
+                Assert.True(table1.ParentTable.Rows[1].Cells[0].Paragraphs[0].Text == "Test 2");
+                Assert.True(table3.ParentTable.Rows[1].Cells[0].Paragraphs[0].Text == "Test 2.2");
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithNestedTables.docx"))) {
+                Assert.True(document.Tables[0].HasNestedTables);
+                Assert.False(document.Tables[0].IsNestedTable);
+
+                Assert.True(document.Tables[0].NestedTables[0].IsNestedTable);
+                Assert.True(document.Tables[0].NestedTables[1].IsNestedTable);
+                Assert.True(document.Tables[0].NestedTables.Count == 2);
+                Assert.True(document.Tables[1].NestedTables.Count == 0);
+                Assert.True(document.Tables[2].NestedTables.Count == 2);
+                Assert.True(document.Tables.Count == 3);
+                Assert.True(document.TablesIncludingNestedTables.Count == 7);
+
+                foreach (var table in document.TablesIncludingNestedTables) {
+                    if (table.IsNestedTable) {
+                        Assert.True(table.ParentTable.RowsCount > 0);
+                    } else {
+                        Assert.True(table.ParentTable == null);
+                    }
+                }
+
+                foreach (var table in document.Sections[0].TablesIncludingNestedTables) {
+                    if (table.IsNestedTable) {
+                        Assert.True(table.ParentTable.RowsCount > 0);
+                    } else {
+                        Assert.True(table.ParentTable == null);
+                    }
+                }
+                Assert.True(document.Sections[0].TablesIncludingNestedTables.Count == 7);
+
+                document.Save();
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -176,6 +176,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Provides a list of Bookmarks in the document from all the sections
+        /// </summary>
         public List<WordBookmark> Bookmarks {
             get {
                 List<WordBookmark> list = new List<WordBookmark>();
@@ -187,6 +190,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Provides a list of all tables within the document from all the sections, excluding nested tables
+        /// </summary>
         public List<WordTable> Tables {
             get {
                 List<WordTable> list = new List<WordTable>();
@@ -194,6 +200,19 @@ namespace OfficeIMO.Word {
                     list.AddRange(section.Tables);
                 }
 
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Provides a list of all tables within the document from all the sections, including nested tables
+        /// </summary>
+        public List<WordTable> TablesIncludingNestedTables {
+            get {
+                List<WordTable> list = new List<WordTable>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.TablesIncludingNestedTables);
+                }
                 return list;
             }
         }

--- a/OfficeIMO.Word/WordSection.cs
+++ b/OfficeIMO.Word/WordSection.cs
@@ -167,7 +167,27 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Provides a list of all tables within the section, excluding nested tables
+        /// </summary>
         public List<WordTable> Tables => GetTablesList();
+
+        /// <summary>
+        /// Provides a list of all tables within the section, including nested tables
+        /// </summary>
+        public List<WordTable> TablesIncludingNestedTables {
+            get {
+                List<WordTable> list = new List<WordTable>();
+                foreach (var table in Tables) {
+                    list.Add(table);
+                    // if (table.NestedTables.Count > 0) {
+                    list.AddRange(table.NestedTables);
+                    //}
+                }
+                return list;
+            }
+        }
+
 
         internal WordDocument _document;
         internal SectionProperties _sectionProperties;

--- a/OfficeIMO.Word/WordTable.Properties.cs
+++ b/OfficeIMO.Word/WordTable.Properties.cs
@@ -6,7 +6,7 @@ using DocumentFormat.OpenXml.Wordprocessing;
 namespace OfficeIMO.Word {
     public partial class WordTable {
         /// <summary>
-        ///     Gets or sets a Title/Caption to a Table
+        /// Gets or sets a Title/Caption to a Table
         /// </summary>
         public string Title {
             get {
@@ -26,7 +26,7 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
-        ///     Gets or sets Description for a Table
+        /// Gets or sets Description for a Table
         /// </summary>
         public string Description {
             get {
@@ -126,6 +126,10 @@ namespace OfficeIMO.Word {
             }
         }
 
+
+        /// <summary>
+        /// Get or Set Table Row Height for 1st row
+        /// </summary>
         public List<int> RowHeight {
             get {
                 var listReturn = new List<int>();
@@ -141,6 +145,83 @@ namespace OfficeIMO.Word {
                 }
             }
 
+        }
+
+        /// <summary>
+        /// Get all WordTableCells in a table. A short way to loop thru all cells
+        /// </summary>
+        public List<WordTableCell> Cells {
+            get {
+                var listReturn = new List<WordTableCell>();
+                foreach (var row in this.Rows) {
+                    foreach (var cell in row.Cells) {
+                        listReturn.Add(cell);
+                    }
+                }
+                return listReturn;
+            }
+        }
+
+
+        /// <summary>
+        /// Gets information whether the Table has other nested tables in at least one of the TableCells
+        /// </summary>
+        public bool HasNestedTables {
+            get {
+                foreach (var cell in this.Cells) {
+                    var list = cell._tableCell.Descendants<Table>().ToList();
+                    if (list.Count > 0) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Get all nested tables in the table
+        /// </summary>
+        public List<WordTable> NestedTables {
+            get {
+                var listReturn = new List<WordTable>();
+                foreach (var cell in this.Cells) {
+                    var list = cell._tableCell.Descendants<Table>().ToList();
+                    foreach (var table in list) {
+                        listReturn.Add(new WordTable(this._document, table));
+                    }
+                }
+                return listReturn;
+            }
+        }
+
+        /// <summary>
+        /// Gets information whether the table is nested table (within TableCell)
+        /// </summary>
+        public bool IsNestedTable {
+            get {
+                var openXmlElement = this._table.Parent;
+                if (openXmlElement != null) {
+                    var typeOfParent = openXmlElement.GetType();
+                    if (typeOfParent.FullName == "DocumentFormat.OpenXml.Wordprocessing.TableCell") {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets nested table parent table if table is nested table
+        /// </summary>
+        public WordTable ParentTable {
+            get {
+                if (IsNestedTable) {
+                    Table table = (DocumentFormat.OpenXml.Wordprocessing.Table)this._table.Parent.Parent.Parent;
+                    return new WordTable(this._document, table);
+                }
+
+                return null;
+            }
         }
     }
 }

--- a/OfficeIMO.Word/WordTable.cs
+++ b/OfficeIMO.Word/WordTable.cs
@@ -392,12 +392,21 @@ namespace OfficeIMO.Word {
             header.Append(_table);
         }
 
+        /// <summary>
+        /// Add row to an existing table with the specified number of columns
+        /// </summary>
+        /// <param name="cellsCount"></param>
         public void AddRow(int cellsCount = 0) {
             WordTableRow row = new WordTableRow(_document, this);
             _table.Append(row._tableRow);
             AddCells(row, cellsCount);
         }
 
+        /// <summary>
+        /// Add cells to an existing row
+        /// </summary>
+        /// <param name="row"></param>
+        /// <param name="cellsCount"></param>
         private void AddCells(WordTableRow row, int cellsCount = 0) {
             if (cellsCount == 0) {
                 // we try to get the last row and fill it with same number of cells
@@ -408,6 +417,11 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Add specified number of rows to an existing table with the specified number of columns
+        /// </summary>
+        /// <param name="rowsCount"></param>
+        /// <param name="cellsCount"></param>
         public void AddRow(int rowsCount, int cellsCount) {
             for (int i = 0; i < rowsCount; i++) {
                 AddRow(cellsCount);

--- a/OfficeIMO.Word/WordTable.cs
+++ b/OfficeIMO.Word/WordTable.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
@@ -359,6 +360,17 @@ namespace OfficeIMO.Word {
 
             // Append the table to the document.
             document._wordprocessingDocument.MainDocumentPart.Document.Body.Append(_table);
+        }
+
+        public WordTable(WordDocument document, TableCell wordTableCell, int rows, int columns, WordTableStyle tableStyle) {
+            _document = document;
+
+            _table = GenerateTable(document, rows, columns, tableStyle);
+
+            // Establish Position property
+            Position = new WordTablePosition(this);
+
+            wordTableCell.Append(_table);
         }
 
         internal WordTable(WordDocument document, Footer footer, int rows, int columns, WordTableStyle tableStyle) {

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -447,5 +447,10 @@ namespace OfficeIMO.Word {
             }
 
         }
+
+        public WordTable AddTable(int rows, int columns, WordTableStyle tableStyle = WordTableStyle.TableGrid) {
+            WordTable wordTable = new WordTable(this._document, _tableCell, rows, columns, tableStyle);
+            return wordTable;
+        }
     }
 }

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -448,8 +448,25 @@ namespace OfficeIMO.Word {
 
         }
 
-        public WordTable AddTable(int rows, int columns, WordTableStyle tableStyle = WordTableStyle.TableGrid) {
+        /// <summary>
+        /// Add table to a table cell (nested table)
+        /// </summary>
+        /// <param name="rows"></param>
+        /// <param name="columns"></param>
+        /// <param name="tableStyle"></param>
+        /// <param name="removePrecedingParagraph"></param>
+        /// <returns></returns>
+        public WordTable AddTable(int rows, int columns, WordTableStyle tableStyle = WordTableStyle.TableGrid, bool removePrecedingParagraph = false) {
+            if (removePrecedingParagraph) {
+                var paragraph = _tableCell.ChildElements.OfType<Paragraph>().LastOrDefault();
+                if (paragraph != null) {
+                    paragraph.Remove();
+                }
+            }
+            //this.Paragraphs[this.Paragraphs.Count - 1].Remove();
             WordTable wordTable = new WordTable(this._document, _tableCell, rows, columns, tableStyle);
+            // we need to add an empty paragraph, because that's what is required for tables to work
+            _tableCell.Append(new Paragraph());
             return wordTable;
         }
     }


### PR DESCRIPTION
- Adds ability to add nested table into existing table.  

```csharp
internal static void Example_NestedTables(string folderPath, bool openWord) {
    Console.WriteLine("[*] Creating standard document with nested tables");
    string filePath = System.IO.Path.Combine(folderPath, "Document with Nested Tables.docx");
    using (WordDocument document = WordDocument.Create(filePath)) {
        var paragraph = document.AddParagraph("Lets add table ");
        paragraph.ParagraphAlignment = JustificationValues.Center;
        paragraph.Bold = true;
        paragraph.Underline = UnderlineValues.DotDash;

        WordTable wordTable = document.AddTable(4, 4, WordTableStyle.GridTable1LightAccent1);
        wordTable.Rows[0].Cells[0].Paragraphs[0].Text = "Test 1";
        wordTable.Rows[1].Cells[0].Paragraphs[0].Text = "Test 2";
        wordTable.Rows[2].Cells[0].Paragraphs[0].Text = "Test 3";
        wordTable.Rows[3].Cells[0].Paragraphs[0].Text = "Test 4";

        wordTable.Rows[0].Cells[0].AddTable(3, 2, WordTableStyle.GridTable2Accent2);

        wordTable.Rows[0].Cells[1].AddTable(3, 2, WordTableStyle.GridTable2Accent5, true);

        document.Save(openWord);
    }
}
```

- Adds `NestedTables` property for WordTable to get all nested tables for given table
- Adds `HasNestedTables` property for WordTable to know if table has nested tables
- Adds `IsNestedTable` property for WordTable to know if table is nested table
- Adds `ParentTable` property for WordTable to find parent table if the table is nested
- Added some summaries to multiple table related methods/properties
- Adds `TablesIncludingNestedTables` property to Sections and Document to make it easy to find all tables within document and manipulate them