### PR TITLE
Adds AddBreak() method to Paragraphs

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -334,7 +334,7 @@ namespace OfficeIMO.Examples {
                 document.AddParagraph("Test 5");
 
                 document.PageBreaks[7].Remove(includingParagraph: false);
-                document.PageBreaks[6].Remove();
+                document.PageBreaks[6].Remove(true);
 
                 Console.WriteLine(document.DocumentIsValid);
                 Console.WriteLine(document.DocumentValidationErrors.Count);

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -30,6 +30,7 @@ namespace OfficeIMO.Examples {
             //BasicDocument.Example_BasicEmptyWord(folderPath, false);
             //BasicDocument.Example_BasicWord(folderPath, false);
             //BasicDocument.Example_BasicWord2(folderPath, false);
+            BasicDocument.Example_BasicWordWithBreaks(folderPath, true);
 
             //AdvancedDocument.Example_AdvancedWord(folderPath, true);
 
@@ -86,7 +87,7 @@ namespace OfficeIMO.Examples {
 
             //HeadersAndFooters.Sections1(folderPath, true);
 
-            Charts.Example_AddingMultipleCharts(folderPath, true);
+            //Charts.Example_AddingMultipleCharts(folderPath, true);
 
             //Console.WriteLine("[*] Creating standard document with multiple paragraphs, with some formatting");
             //filePath = System.IO.Path.Combine(folderPath, "AdvancedParagraphs.docx");

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create02.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create02.cs
@@ -14,17 +14,29 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var paragraph1 = document.AddParagraph("Adding paragraph1 with some text and pressing ENTER");
 
-
                 var paragraph2 = document.AddParagraph("Adding paragraph2 with some text and pressing SHIFT+ENTER");
                 paragraph2.AddBreak();
                 paragraph2.AddText("Continue1");
                 paragraph2.AddBreak();
                 paragraph2.AddText("Continue2");
+                paragraph2.AddText(" Continue3");
+
+                Console.WriteLine("Paragraphs count: " + document.Paragraphs.Count);
+
+                Console.WriteLine("Breaks count: " + document.Breaks.Count);
+                Console.WriteLine("Paragraphs with PageBreaks count: " + document.ParagraphsPageBreaks.Count);
+                Console.WriteLine("Paragraphs with Breaks count: " + document.ParagraphsBreaks.Count);
+
+                document.Breaks[0].Remove(); // removes break before continue1
+
+                Console.WriteLine("Breaks count after removing one: " + document.Breaks.Count);
 
                 var paragraph3 = document.AddParagraph("Adding paragraph3 with some text and pressing ENTER");
 
                 var paragraph4 = document.AddParagraph("Adding paragraph4 with some text and pressing SHIFT+ENTER");
                 paragraph4.AddBreak();
+
+                Console.WriteLine("Breaks count after adding one: " + document.Breaks.Count);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create02.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create02.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class BasicDocument {
+        public static void Example_BasicWordWithBreaks(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating standard document with paragraph & breaks");
+            string filePath = System.IO.Path.Combine(folderPath, "BasicDocumentWithParagraphsAndBreaks.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph1 = document.AddParagraph("Adding paragraph1 with some text and pressing ENTER");
+
+
+                var paragraph2 = document.AddParagraph("Adding paragraph2 with some text and pressing SHIFT+ENTER");
+                paragraph2.AddBreak();
+                paragraph2.AddText("Continue1");
+                paragraph2.AddBreak();
+                paragraph2.AddText("Continue2");
+
+                var paragraph3 = document.AddParagraph("Adding paragraph3 with some text and pressing ENTER");
+
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create02.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create02.cs
@@ -23,6 +23,8 @@ namespace OfficeIMO.Examples.Word {
 
                 var paragraph3 = document.AddParagraph("Adding paragraph3 with some text and pressing ENTER");
 
+                var paragraph4 = document.AddParagraph("Adding paragraph4 with some text and pressing SHIFT+ENTER");
+                paragraph4.AddBreak();
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Tests/Word.Breaks.cs
+++ b/OfficeIMO.Tests/Word.Breaks.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_BasicWordWithBreaks() {
+            var filePath = Path.Combine(_directoryWithFiles, "BasicWordWithBreaks.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph1 = document.AddParagraph("Adding paragraph1 with some text and pressing ENTER");
+                var paragraph2 = document.AddParagraph("Adding paragraph2 with some text and pressing SHIFT+ENTER");
+                paragraph2.AddBreak();
+                paragraph2.AddText("Continue1");
+                paragraph2.AddBreak();
+                paragraph2.AddText("Continue2");
+                paragraph2.AddText(" Continue3");
+
+                Assert.True(document.Paragraphs[0].Text == "Adding paragraph1 with some text and pressing ENTER");
+                Assert.True(document.Paragraphs[1].Text == "Adding paragraph2 with some text and pressing SHIFT+ENTER");
+                Assert.True(document.Paragraphs[2].IsBreak);
+                Assert.True(document.Paragraphs[3].Text == "Continue1");
+
+                Assert.True(document.Paragraphs.Count == 7);
+                Assert.True(document.Breaks.Count == 2);
+                Assert.True(document.ParagraphsPageBreaks.Count == 0);
+
+                document.Breaks[0].Remove(); // removes break before continue1
+
+                Assert.True(document.Paragraphs.Count == 6);
+                Assert.True(document.Breaks.Count == 1);
+                Assert.True(document.Sections[0].ParagraphsBreaks.Count == 1);
+                Assert.True(document.ParagraphsPageBreaks.Count == 0);
+
+                var paragraph3 = document.AddParagraph("Adding paragraph3 with some text and pressing ENTER");
+
+                var paragraph4 = document.AddParagraph("Adding paragraph4 with some text and pressing SHIFT+ENTER");
+                paragraph4.AddBreak();
+
+                Assert.True(document.Paragraphs.Count == 9);
+                Assert.True(document.Breaks.Count == 2);
+                Assert.True(document.ParagraphsPageBreaks.Count == 0);
+                Assert.True(document.ParagraphsBreaks.Count == 2);
+
+                Assert.True(document.Paragraphs[0].Text == "Adding paragraph1 with some text and pressing ENTER");
+                Assert.True(document.Paragraphs[1].Text == "Adding paragraph2 with some text and pressing SHIFT+ENTER");
+                Assert.True(document.Paragraphs[2].IsBreak == false);
+                Assert.True(document.Paragraphs[2].Text == "Continue1");
+                Assert.True(document.Paragraphs[3].IsBreak);
+                Assert.True(document.Paragraphs[4].Text == "Continue2");
+                Assert.True(document.Paragraphs[5].Text == " Continue3");
+
+                Assert.True(document.Sections[0].Paragraphs.Count == 9);
+                Assert.True(document.Sections[0].Breaks.Count == 2);
+                Assert.True(document.Sections[0].ParagraphsBreaks.Count == 2);
+                Assert.True(document.Sections[0].ParagraphsPageBreaks.Count == 0);
+
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.True(document.Paragraphs[0].Text == "Adding paragraph1 with some text and pressing ENTER");
+                Assert.True(document.Paragraphs[1].Text == "Adding paragraph2 with some text and pressing SHIFT+ENTER");
+                Assert.True(document.Paragraphs[2].IsBreak == false);
+                Assert.True(document.Paragraphs[2].Text == "Continue1");
+                Assert.True(document.Paragraphs[3].IsBreak);
+                Assert.True(document.Paragraphs[4].Text == "Continue2");
+                Assert.True(document.Paragraphs[5].Text == " Continue3");
+                Assert.True(document.Paragraphs[6].Text == "Adding paragraph3 with some text and pressing ENTER");
+                Assert.True(document.Paragraphs[7].Text == "Adding paragraph4 with some text and pressing SHIFT+ENTER");
+                Assert.True(document.Paragraphs[8].IsBreak);
+
+                Assert.True(document.Paragraphs.Count == 9);
+                Assert.True(document.Breaks.Count == 2);
+                Assert.True(document.ParagraphsPageBreaks.Count == 0);
+
+                var paragraph4 = document.AddParagraph("Adding paragraph4 with some text and pressing SHIFT+ENTER");
+                paragraph4.AddBreak();
+
+                var paragraph5 = document.AddParagraph("Adding paragraph5 with some text and pressing SHIFT+ENTER");
+                paragraph5.AddBreak();
+
+                Assert.True(document.Paragraphs.Count == 13);
+                Assert.True(document.Breaks.Count == 4);
+                Assert.True(document.ParagraphsBreaks.Count == 4);
+                Assert.True(document.ParagraphsPageBreaks.Count == 0);
+
+                var paragraph6 = document.AddParagraph("Adding paragraph6 with some text and different break");
+                paragraph6.AddBreak(BreakValues.TextWrapping);
+
+                var paragraph7 = document.AddParagraph("Adding paragraph7 with some text and different break");
+                paragraph7.AddBreak(BreakValues.Column);
+
+                var paragraph8 = document.AddParagraph("Adding paragraph8 with some text and different break");
+                paragraph8.AddBreak(BreakValues.Page);
+
+                Assert.True(document.Paragraphs.Count == 19);
+                Assert.True(document.Breaks.Count == 7);
+                Assert.True(document.ParagraphsBreaks.Count == 7);
+                Assert.True(document.ParagraphsPageBreaks.Count == 1);
+
+                Assert.True(document.Sections[0].Paragraphs.Count == 19);
+                Assert.True(document.Sections[0].Breaks.Count == 7);
+                Assert.True(document.Sections[0].ParagraphsPageBreaks.Count == 1);
+                Assert.True(document.Sections[0].ParagraphsBreaks.Count == 7);
+
+                document.Save(false);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Validation.cs
+++ b/OfficeIMO.Tests/Word.Validation.cs
@@ -38,7 +38,7 @@ namespace OfficeIMO.Tests {
                 document.AddParagraph("Test 5");
 
                 document.PageBreaks[7].Remove(includingParagraph: false);
-                document.PageBreaks[6].Remove();
+                document.PageBreaks[6].Remove(true);
 
                 // this is subject to change, since maybe we will fix it
                 Assert.True(document.DocumentIsValid == false);

--- a/OfficeIMO.Word/WordBreak.cs
+++ b/OfficeIMO.Word/WordBreak.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 
 namespace OfficeIMO.Word {
-    public class WordPageBreak {
+    public class WordBreak {
         private WordDocument _document;
         private Paragraph _paragraph;
         private Run _run;
@@ -25,13 +25,13 @@ namespace OfficeIMO.Word {
             }
         }
 
-        public WordPageBreak(WordDocument document, Paragraph paragraph, Run run) {
+        public WordBreak(WordDocument document, Paragraph paragraph, Run run) {
             this._document = document;
             this._paragraph = paragraph;
             this._run = run;
         }
 
-        public void Remove(bool includingParagraph = true) {
+        public void Remove(bool includingParagraph = false) {
             if (includingParagraph) {
                 this._paragraph.Remove();
             } else {

--- a/OfficeIMO.Word/WordBreak.cs
+++ b/OfficeIMO.Word/WordBreak.cs
@@ -5,11 +5,18 @@ using System.Linq;
 using System.Text;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a break in the text.
+    /// Be it page break, soft break, column or text wrapping
+    /// </summary>
     public class WordBreak {
         private WordDocument _document;
-        private Paragraph _paragraph;
-        private Run _run;
+        private readonly Paragraph _paragraph;
+        private readonly Run _run;
 
+        /// <summary>
+        /// Get type of Break in given paragraph
+        /// </summary>
         public BreakValues? BreakType {
             get {
                 if (_run != null) {
@@ -25,12 +32,24 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Create new instance of WordBreak
+        /// </summary>
+        /// <param name="document"></param>
+        /// <param name="paragraph"></param>
+        /// <param name="run"></param>
         public WordBreak(WordDocument document, Paragraph paragraph, Run run) {
             this._document = document;
             this._paragraph = paragraph;
             this._run = run;
         }
 
+        /// <summary>
+        /// Remove the break from WordDocument. By default it removes break without removing paragraph.
+        /// If you want paragraph removed please use IncludingParagraph bool.
+        /// Please remember a paragraph can hold multiple other elements.
+        /// </summary>
+        /// <param name="includingParagraph"></param>
         public void Remove(bool includingParagraph = false) {
             if (includingParagraph) {
                 this._paragraph.Remove();

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -94,7 +94,7 @@ namespace OfficeIMO.Word {
             }
         }
 
-        public List<WordParagraph> ParagrahsBreaks {
+        public List<WordParagraph> ParagraphsBreaks {
             get {
                 List<WordParagraph> list = new List<WordParagraph>();
                 foreach (var section in this.Sections) {

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -94,6 +94,17 @@ namespace OfficeIMO.Word {
             }
         }
 
+        public List<WordParagraph> ParagrahsBreaks {
+            get {
+                List<WordParagraph> list = new List<WordParagraph>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.ParagraphsBreaks);
+                }
+
+                return list;
+            }
+        }
+
         public List<WordParagraph> ParagraphsHyperLinks {
             get {
                 List<WordParagraph> list = new List<WordParagraph>();
@@ -149,11 +160,22 @@ namespace OfficeIMO.Word {
             }
         }
 
-        public List<WordPageBreak> PageBreaks {
+        public List<WordBreak> PageBreaks {
             get {
-                List<WordPageBreak> list = new List<WordPageBreak>();
+                List<WordBreak> list = new List<WordBreak>();
                 foreach (var section in this.Sections) {
                     list.AddRange(section.PageBreaks);
+                }
+
+                return list;
+            }
+        }
+
+        public List<WordBreak> Breaks {
+            get {
+                List<WordBreak> list = new List<WordBreak>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.Breaks);
                 }
 
                 return list;

--- a/OfficeIMO.Word/WordHeaderFooter.Properties.cs
+++ b/OfficeIMO.Word/WordHeaderFooter.Properties.cs
@@ -73,9 +73,9 @@ namespace OfficeIMO.Word {
             get { return Paragraphs.Where(p => p.IsImage).ToList(); }
         }
 
-        public List<WordPageBreak> PageBreaks {
+        public List<WordBreak> PageBreaks {
             get {
-                List<WordPageBreak> list = new List<WordPageBreak>();
+                List<WordBreak> list = new List<WordBreak>();
                 var paragraphs = Paragraphs.Where(p => p.IsPageBreak).ToList();
                 foreach (var paragraph in paragraphs) {
                     list.Add(paragraph.PageBreak);

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -5,7 +5,11 @@ using DocumentFormat.OpenXml.Packaging;
 
 namespace OfficeIMO.Word {
     public partial class WordParagraph {
-
+        /// <summary>
+        /// Add a text to existing paragraph
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
         public WordParagraph AddText(string text) {
             WordParagraph wordParagraph = new WordParagraph(this._document, this._paragraph, new Run());
             wordParagraph.Text = text;
@@ -32,6 +36,12 @@ namespace OfficeIMO.Word {
             return paragraph;
         }
 
+
+        /// <summary>
+        /// Add Break to the paragraph. By default it adds soft break (SHIFT+ENTER)
+        /// </summary>
+        /// <param name="breakType"></param>
+        /// <returns></returns>
         public WordParagraph AddBreak(BreakValues? breakType = null) {
             WordParagraph wordParagraph = new WordParagraph(this._document, this._paragraph, new Run());
             if (breakType != null) {
@@ -42,6 +52,10 @@ namespace OfficeIMO.Word {
             return wordParagraph;
         }
 
+        /// <summary>
+        /// Remove the paragraph from WordDocument
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
         public void Remove() {
             if (_paragraph != null) {
                 if (this._paragraph.Parent != null) {
@@ -49,9 +63,14 @@ namespace OfficeIMO.Word {
                         this.Bookmark.Remove();
                     }
 
-                    if (this.IsPageBreak) {
-                        this.PageBreak.Remove();
+                    if (this.IsBreak) {
+                        this.Break.Remove();
                     }
+
+                    // break should cover this
+                    //if (this.IsPageBreak) {
+                    //    this.PageBreak.Remove();
+                    //}
 
                     if (this.IsEquation) {
                         this.Equation.Remove();

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -32,6 +32,16 @@ namespace OfficeIMO.Word {
             return paragraph;
         }
 
+        public WordParagraph AddBreak(BreakValues? breakType = null) {
+            WordParagraph wordParagraph = new WordParagraph(this._document, this._paragraph, new Run());
+            if (breakType != null) {
+                this._paragraph.Append(new Run(new Break() { Type = breakType }));
+            } else {
+                this._paragraph.Append(new Run(new Break()));
+            }
+            return wordParagraph;
+        }
+
         public void Remove() {
             if (_paragraph != null) {
                 if (this._paragraph.Parent != null) {
@@ -119,7 +129,7 @@ namespace OfficeIMO.Word {
             //Comments comments = null;
             //string id = "0";
 
-            //// Verify that the document contains a 
+            //// Verify that the document contains a
             //// WordProcessingCommentsPart part; if not, add a new one.
             //if (this._document._wordprocessingDocument.MainDocumentPart.GetPartsCountOfType<WordprocessingCommentsPart>() > 0) {
             //    comments = this._document._wordprocessingDocument.MainDocumentPart.WordprocessingCommentsPart.Comments;
@@ -149,7 +159,7 @@ namespace OfficeIMO.Word {
 
             WordComment wordComment = WordComment.Create(_document, author, initials, comment);
 
-            // Specify the text range for the Comment. 
+            // Specify the text range for the Comment.
             // Insert the new CommentRangeStart before the first run of paragraph.
             this._paragraph.InsertBefore(new CommentRangeStart() { Id = wordComment.Id }, this._paragraph.GetFirstChild<Run>());
 

--- a/OfficeIMO.Word/WordParagraph.Run.cs
+++ b/OfficeIMO.Word/WordParagraph.Run.cs
@@ -24,5 +24,15 @@ namespace OfficeIMO.Word {
                 return false;
             }
         }
+
+        public bool IsBreak {
+            get {
+                if (this.Break != null) {
+                    return true;
+                }
+
+                return false;
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -158,12 +158,25 @@ namespace OfficeIMO.Word {
             }
         }
 
-        public WordPageBreak PageBreak {
+        public WordBreak PageBreak {
             get {
                 if (_run != null) {
                     var brake = _run.ChildElements.OfType<Break>().FirstOrDefault();
                     if (brake != null && brake.Type.Value == BreakValues.Page) {
-                        return new WordPageBreak(_document, _paragraph, _run);
+                        return new WordBreak(_document, _paragraph, _run);
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        public WordBreak Break {
+            get {
+                if (_run != null) {
+                    var brake = _run.ChildElements.OfType<Break>().FirstOrDefault();
+                    if (brake != null) {
+                        return new WordBreak(_document, _paragraph, _run);
                     }
                 }
 

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -144,6 +144,9 @@ namespace OfficeIMO.Word {
         internal readonly SdtRun _stdRun;
         internal readonly DocumentFormat.OpenXml.Math.Paragraph _mathParagraph;
 
+        /// <summary>
+        /// Get or set a text within Paragraph
+        /// </summary>
         public string Text {
             get {
                 if (_text == null) {
@@ -158,11 +161,14 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Get PageBreaks within Paragraph
+        /// </summary>
         public WordBreak PageBreak {
             get {
                 if (_run != null) {
                     var brake = _run.ChildElements.OfType<Break>().FirstOrDefault();
-                    if (brake != null && brake.Type.Value == BreakValues.Page) {
+                    if (brake != null && brake.Type != null && brake.Type.Value == BreakValues.Page) {
                         return new WordBreak(_document, _paragraph, _run);
                     }
                 }
@@ -171,6 +177,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Get Breaks within Paragraph
+        /// </summary>
         public WordBreak Break {
             get {
                 if (_run != null) {

--- a/OfficeIMO.Word/WordSection.cs
+++ b/OfficeIMO.Word/WordSection.cs
@@ -16,6 +16,10 @@ namespace OfficeIMO.Word {
             get { return Paragraphs.Where(p => p.IsPageBreak).ToList(); }
         }
 
+        public List<WordParagraph> ParagraphsBreaks {
+            get { return Paragraphs.Where(p => p.IsBreak).ToList(); }
+        }
+
         internal List<WordParagraph> ParagraphsIsListItem {
             get { return Paragraphs.Where(p => p.IsListItem).ToList(); }
         }
@@ -62,12 +66,23 @@ namespace OfficeIMO.Word {
             get { return Paragraphs.Where(p => p.IsImage).ToList(); }
         }
 
-        public List<WordPageBreak> PageBreaks {
+        public List<WordBreak> PageBreaks {
             get {
-                List<WordPageBreak> list = new List<WordPageBreak>();
+                List<WordBreak> list = new List<WordBreak>();
                 var paragraphs = Paragraphs.Where(p => p.IsPageBreak).ToList();
                 foreach (var paragraph in paragraphs) {
                     list.Add(paragraph.PageBreak);
+                }
+                return list;
+            }
+        }
+
+        public List<WordBreak> Breaks {
+            get {
+                List<WordBreak> list = new List<WordBreak>();
+                var paragraphs = Paragraphs.Where(p => p.IsBreak).ToList();
+                foreach (var paragraph in paragraphs) {
+                    list.Add(paragraph.Break);
                 }
                 return list;
             }


### PR DESCRIPTION
Should solve 
- https://github.com/EvotecIT/OfficeIMO/issues/37

![image](https://user-images.githubusercontent.com/15063294/194375619-a43d0d20-50b9-445a-a8c7-d778a4c3fac2.png)

```csharp
public static void Example_BasicWordWithBreaks(string folderPath, bool openWord) {
    Console.WriteLine("[*] Creating standard document with paragraph & breaks");
    string filePath = System.IO.Path.Combine(folderPath, "BasicDocumentWithParagraphsAndBreaks.docx");
    using (WordDocument document = WordDocument.Create(filePath)) {
        var paragraph1 = document.AddParagraph("Adding paragraph1 with some text and pressing ENTER");


        var paragraph2 = document.AddParagraph("Adding paragraph2 with some text and pressing SHIFT+ENTER");
        paragraph2.AddBreak();
        paragraph2.AddText("Continue1");
        paragraph2.AddBreak();
        paragraph2.AddText("Continue2");

        var paragraph3 = document.AddParagraph("Adding paragraph3 with some text and pressing ENTER");


        document.Save(openWord);
    }
}
```

Additionally:
- Renames WordPageBreak to WordBreak to accommodate all Breaks, and not only PageBreak
- *BREAKING CHANGE* Removing WordBreak (or WordPageBreak) no longer by default removes paragraph, but instead requires bool set to true

```csharp
document.Breaks[0].Remove();
document.Breaks[0].Remove(includingParagraph: true);
```

- Add new `IsBreak` property for WordParagraph
- Add `Breaks` property for WordDocument