### PR TITLE
Allow to set default font, size, and other settings for the whole document

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -31,6 +31,7 @@ namespace OfficeIMO.Examples {
             //BasicDocument.Example_BasicWord(folderPath, false);
             //BasicDocument.Example_BasicWord2(folderPath, false);
             //BasicDocument.Example_BasicWordWithBreaks(folderPath, true);
+            BasicDocument.Example_BasicWordWithDefaultStyleChange(folderPath, true);
 
             //AdvancedDocument.Example_AdvancedWord(folderPath, true);
 
@@ -95,9 +96,9 @@ namespace OfficeIMO.Examples {
             //filePath = System.IO.Path.Combine(folderPath, "AdvancedParagraphs.docx");
             //Example_MultipleParagraphsViaDifferentWays(filePath, false);
 
-            Images.Example_AddingImages(folderPath, true);
-            Images.Example_ReadWordWithImages();
-            Images.Example_AddingImagesMultipleTypes(folderPath, true);
+            //Images.Example_AddingImages(folderPath, true);
+            //Images.Example_ReadWordWithImages();
+            //Images.Example_AddingImagesMultipleTypes(folderPath, true);
             //Console.WriteLine("[*] Creating standard document with page breaks and removing them");
             //filePath = System.IO.Path.Combine(folderPath, "Basic Document with some page breaks.docx");
             //Example_PageBreaks(filePath, true);

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create03.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create03.cs
@@ -12,11 +12,15 @@ namespace OfficeIMO.Examples.Word {
             Console.WriteLine("[*] Creating standard document with different default style");
             string filePath = System.IO.Path.Combine(folderPath, "BasicWordWithDefaultStyleChange.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
-                document.Settings.DefaultFontSize = 30;
-                
-                var paragraph1 = document.AddParagraph("Adding paragraph1 with some text and pressing ENTER");
+                document.Settings.FontSize = 30;
+                document.Settings.FontFamily = "Calibri Light";
+                document.Settings.Language = "pl-PL";
 
-                document.AddParagraph("Adding paragraph1 with some text and pressing ENTER").FontSize = 15;
+                var paragraph1 = document.AddParagraph("To jest po polsku");
+
+                var paragraph2 = document.AddParagraph("Adding paragraph1 with some text and pressing ENTER");
+                paragraph2.FontSize = 15;
+                paragraph2.FontFamily = "Courier New";
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create03.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create03.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class BasicDocument {
+        public static void Example_BasicWordWithDefaultStyleChange(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating standard document with different default style");
+            string filePath = System.IO.Path.Combine(folderPath, "BasicWordWithDefaultStyleChange.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.Settings.DefaultFontSize = 30;
+                
+                var paragraph1 = document.AddParagraph("Adding paragraph1 with some text and pressing ENTER");
+
+                document.AddParagraph("Adding paragraph1 with some text and pressing ENTER").FontSize = 15;
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Settings.cs
+++ b/OfficeIMO.Tests/Word.Settings.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using Xunit;
@@ -35,6 +35,22 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(document.Settings.UpdateFieldsOnOpen == true);
 
+                Assert.True(document.Settings.FontSize == 11); // default value
+
+                document.Settings.FontSize = 30;
+
+                Assert.True(document.Settings.FontSize == 30);
+
+                Assert.True(document.Settings.FontSizeComplexScript == 11);
+
+                document.Settings.FontSizeComplexScript = 20;
+
+                Assert.True(document.Settings.FontSizeComplexScript == 20);
+
+                document.Settings.FontFamily = "Courier New";
+
+                Assert.True(document.Settings.FontFamily == "Courier New");
+
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatingDocumentWithSettings.docx"))) {
@@ -61,6 +77,10 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Settings.UpdateFieldsOnOpen == true);
 
                 document.Settings.UpdateFieldsOnOpen = false;
+
+                Assert.True(document.Settings.FontSizeComplexScript == 20);
+                Assert.True(document.Settings.FontSize == 30);
+                Assert.True(document.Settings.FontFamily == "Courier New");
 
                 document.Save();
             }

--- a/OfficeIMO.Word/WordDocument.Parts.cs
+++ b/OfficeIMO.Word/WordDocument.Parts.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -134,41 +134,115 @@ namespace OfficeIMO.Word {
             document.Settings = this;
         }
 
-
-        public string Language {
-            get {
-                if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles != null) {
-                    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults != null) {
-                        if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault != null) {
+        private RunPropertiesBaseStyle? GetDefaultStyleProperties() {
+            if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles != null) {
+                if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults != null) {
+                    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault != null) {
+                        if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle != null) {
                             if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle != null) {
-                                if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages != null) {
-                                    return this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages.Val;
-                                }
+                                return this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle;
                             }
                         }
+                    }
+                }
+            }
+            return null;
+        }
+
+        private RunPropertiesBaseStyle? SetDefaultStyleProperties() {
+            if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles != null) {
+                if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults == null) {
+                    this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults = new DocDefaults();
+                }
+
+                if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault == null) {
+                    this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault = new RunPropertiesDefault();
+                }
+
+                if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle == null) {
+                    this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle = new RunPropertiesBaseStyle();
+                }
+
+                return this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle;
+            }
+
+            return null;
+        }
+
+        public int? DefaultFontSize {
+            get {
+                var runPropertiesBaseStyle = GetDefaultStyleProperties();
+                if (runPropertiesBaseStyle != null) {
+                    if (runPropertiesBaseStyle.FontSize != null) {
+                        var fontSize = runPropertiesBaseStyle.FontSize.Val;
+                        return int.Parse(fontSize) / 2;
                     }
                 }
                 return null;
             }
             set {
-                if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles != null) {
-                    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults == null) {
-                        this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults = new DocDefaults();
+                var runPropertiesBaseStyle = SetDefaultStyleProperties();
+                if (runPropertiesBaseStyle != null) {
+                    if (runPropertiesBaseStyle.FontSize == null) {
+                        runPropertiesBaseStyle.FontSize = new FontSize();
                     }
+                    runPropertiesBaseStyle.FontSize.Val = (value * 2).ToString();
+                } else {
+                    throw new Exception("Could not set font size. Styles not found.");
+                }
+            }
+        }
 
-                    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault == null) {
-                        this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault = new RunPropertiesDefault();
+
+        public string Language {
+            get {
+                //if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles != null) {
+                //    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults != null) {
+                //        if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault != null) {
+                //            if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle != null) {
+                //                if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages != null) {
+                //                    return this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages.Val;
+                //                }
+                //            }
+                //        }
+                //    }
+                //}
+                var runPropertiesBaseStyle = GetDefaultStyleProperties();
+                if (runPropertiesBaseStyle != null) {
+                    if (runPropertiesBaseStyle.Languages != null) {
+                        return runPropertiesBaseStyle.Languages.Val;
                     }
+                }
+                return null;
+            }
+            set {
+                //if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles != null) {
+                //    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults == null) {
+                //        this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults = new DocDefaults();
+                //    }
 
-                    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle == null) {
-                        this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle = new RunPropertiesBaseStyle();
+                //    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault == null) {
+                //        this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault = new RunPropertiesDefault();
+                //    }
+
+                //    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle == null) {
+                //        this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle = new RunPropertiesBaseStyle();
+                //    }
+
+                //    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages == null) {
+                //        this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages = new Languages();
+                //    }
+
+                //    this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages.Val = value;
+                //}
+                var runPropertiesBaseStyle = SetDefaultStyleProperties();
+                if (runPropertiesBaseStyle != null) {
+                    if (runPropertiesBaseStyle.Languages == null) {
+                        runPropertiesBaseStyle.Languages = new Languages();
                     }
-
-                    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages == null) {
-                        this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages = new Languages();
-                    }
-
-                    this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages.Val = value;
+                    runPropertiesBaseStyle.Languages.Val = value;
+                } else {
+                    throw new Exception("Could not set language. Styles not found.");
                 }
             }
         }

--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -193,20 +193,32 @@ namespace OfficeIMO.Word {
             }
         }
 
+        public int? DefaultFontSizeComplexScript {
+            get {
+                var runPropertiesBaseStyle = GetDefaultStyleProperties();
+                if (runPropertiesBaseStyle != null) {
+                    if (runPropertiesBaseStyle.FontSizeComplexScript != null) {
+                        var fontSize = runPropertiesBaseStyle.FontSizeComplexScript.Val;
+                        return int.Parse(fontSize) / 2;
+                    }
+                }
+                return null;
+            }
+            set {
+                var runPropertiesBaseStyle = SetDefaultStyleProperties();
+                if (runPropertiesBaseStyle != null) {
+                    if (runPropertiesBaseStyle.FontSizeComplexScript == null) {
+                        runPropertiesBaseStyle.FontSizeComplexScript = new FontSizeComplexScript();
+                    }
+                    runPropertiesBaseStyle.FontSizeComplexScript.Val = (value * 2).ToString();
+                } else {
+                    throw new Exception("Could not set font size complex script. Styles not found.");
+                }
+            }
+        }
 
         public string Language {
             get {
-                //if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles != null) {
-                //    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults != null) {
-                //        if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault != null) {
-                //            if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle != null) {
-                //                if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages != null) {
-                //                    return this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages.Val;
-                //                }
-                //            }
-                //        }
-                //    }
-                //}
                 var runPropertiesBaseStyle = GetDefaultStyleProperties();
                 if (runPropertiesBaseStyle != null) {
                     if (runPropertiesBaseStyle.Languages != null) {
@@ -216,25 +228,6 @@ namespace OfficeIMO.Word {
                 return null;
             }
             set {
-                //if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles != null) {
-                //    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults == null) {
-                //        this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults = new DocDefaults();
-                //    }
-
-                //    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault == null) {
-                //        this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault = new RunPropertiesDefault();
-                //    }
-
-                //    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle == null) {
-                //        this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle = new RunPropertiesBaseStyle();
-                //    }
-
-                //    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages == null) {
-                //        this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages = new Languages();
-                //    }
-
-                //    this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle.Languages.Val = value;
-                //}
                 var runPropertiesBaseStyle = SetDefaultStyleProperties();
                 if (runPropertiesBaseStyle != null) {
                     if (runPropertiesBaseStyle.Languages == null) {

--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -11,6 +11,9 @@ namespace OfficeIMO.Word {
     public class WordSettings {
         private WordDocument _document;
 
+        /// <summary>
+        /// Remove protection from document (if it's set).
+        /// </summary>
         public void RemoveProtection() {
             if (this.ProtectionType != null) {
                 DocumentProtection documentProtection = this._document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings.OfType<DocumentProtection>().FirstOrDefault();
@@ -18,6 +21,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Get or set Protection Type for the document
+        /// </summary>
         public DocumentProtectionValues? ProtectionType {
             get {
                 if (this._document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings != null) {
@@ -41,11 +47,19 @@ namespace OfficeIMO.Word {
                 }
             }
         }
+
+        /// <summary>
+        /// Set a Protection Password for the document
+        /// </summary>
         public string ProtectionPassword {
             set {
                 Security.ProtectWordDoc(this._document._wordprocessingDocument, value);
             }
         }
+
+        /// <summary>
+        /// Get or set Zoom Preset for the document
+        /// </summary>
         public PresetZoomValues? ZoomPreset {
             get {
                 var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
@@ -68,6 +82,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Get or Set Zoome Percentage for the document
+        /// </summary>
         public int? ZoomPercentage {
             get {
                 var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
@@ -88,6 +105,10 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Tell Word to update fields when opening word.
+        /// Without this option the document fields won't be refreshed until manual intervention.
+        /// </summary>
         public bool UpdateFieldsOnOpen {
             get {
                 var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
@@ -107,15 +128,6 @@ namespace OfficeIMO.Word {
                 updateFieldsOnOpen.Val = value;
             }
         }
-
-        ////Open Word Setting File
-        //DocumentSettingsPart settingsPart = xmlDOc.MainDocumentPart.GetPartsOfType<DocumentSettingsPart>().First();
-        ////Update Fields
-        //UpdateFieldsOnOpen updateFields = new UpdateFieldsOnOpen();
-        //updateFields.Val = new OnOffValue(true);
-
-        //settingsPart.Settings.PrependChild<UpdateFieldsOnOpen>(updateFields);
-        //settingsPart.Settings.Save();
 
         public WordSettings(WordDocument document) {
             if (document.FileOpenAccess != FileAccess.Read) {
@@ -169,7 +181,10 @@ namespace OfficeIMO.Word {
             return null;
         }
 
-        public int? DefaultFontSize {
+        /// <summary>
+        /// Gets or Sets default font size for the whole document. Default is 11.
+        /// </summary>
+        public int? FontSize {
             get {
                 var runPropertiesBaseStyle = GetDefaultStyleProperties();
                 if (runPropertiesBaseStyle != null) {
@@ -193,7 +208,10 @@ namespace OfficeIMO.Word {
             }
         }
 
-        public int? DefaultFontSizeComplexScript {
+        /// <summary>
+        /// Gets or Sets default font size complex script for the whole document. Default is 11.
+        /// </summary>
+        public int? FontSizeComplexScript {
             get {
                 var runPropertiesBaseStyle = GetDefaultStyleProperties();
                 if (runPropertiesBaseStyle != null) {
@@ -217,6 +235,39 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or Sets default font family for the whole document.
+        /// </summary>
+        public string FontFamily {
+            get {
+                var runPropertiesBaseStyle = GetDefaultStyleProperties();
+                if (runPropertiesBaseStyle != null) {
+                    if (runPropertiesBaseStyle.RunFonts != null) {
+                        var fontFamily = runPropertiesBaseStyle.RunFonts.Ascii;
+                        return fontFamily;
+                    }
+                }
+                return null;
+            }
+            set {
+                var runPropertiesBaseStyle = SetDefaultStyleProperties();
+                if (runPropertiesBaseStyle != null) {
+                    //runPropertiesBaseStyle.RunFonts = new RunFonts();
+                    if (runPropertiesBaseStyle.RunFonts == null) {
+                        runPropertiesBaseStyle.RunFonts = new RunFonts() { AsciiTheme = ThemeFontValues.MinorHighAnsi, HighAnsiTheme = ThemeFontValues.MinorHighAnsi, EastAsiaTheme = ThemeFontValues.MinorHighAnsi, ComplexScriptTheme = ThemeFontValues.MinorBidi };
+                    }
+                    // we need to reset default AsciiTheme, before applying Ascii
+                    runPropertiesBaseStyle.RunFonts.AsciiTheme = null;
+                    runPropertiesBaseStyle.RunFonts.Ascii = value;
+                } else {
+                    throw new Exception("Could not set font family. Styles not found.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or Sets default language for the whole document. Default is en-Us.
+        /// </summary>
         public string Language {
             get {
                 var runPropertiesBaseStyle = GetDefaultStyleProperties();
@@ -234,11 +285,16 @@ namespace OfficeIMO.Word {
                         runPropertiesBaseStyle.Languages = new Languages();
                     }
                     runPropertiesBaseStyle.Languages.Val = value;
+                    //runPropertiesBaseStyle.Languages.EastAsia = value;
                 } else {
                     throw new Exception("Could not set language. Styles not found.");
                 }
             }
         }
+
+        /// <summary>
+        /// Gets or Sets default Background Color for the whole document
+        /// </summary>
         public string BackgroundColor {
             get {
                 if (_document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground != null) {


### PR DESCRIPTION
This PR will address:
- https://github.com/EvotecIT/OfficeIMO/issues/45
- New fields added to WordSettings: FontSize, FontSizeComplexScript, FontFamily

```csharp
        public static void Example_BasicWordWithDefaultStyleChange(string folderPath, bool openWord) {
            Console.WriteLine("[*] Creating standard document with different default style");
            string filePath = System.IO.Path.Combine(folderPath, "BasicWordWithDefaultStyleChange.docx");
            using (WordDocument document = WordDocument.Create(filePath)) {
                document.Settings.FontSize = 30;
                document.Settings.FontFamily = "Calibri Light";
                document.Settings.Language = "pl-PL";

                var paragraph1 = document.AddParagraph("To jest po polsku");

                var paragraph2 = document.AddParagraph("Adding paragraph1 with some text and pressing ENTER");
                paragraph2.FontSize = 15;
                paragraph2.FontFamily = "Courier New";

                document.Save(openWord);
            }
        }
```

