### PR TITLE
Improve settings for document with PT-BR and HighAnsi chars

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -31,8 +31,8 @@ namespace OfficeIMO.Examples {
             //BasicDocument.Example_BasicWord(folderPath, false);
             //BasicDocument.Example_BasicWord2(folderPath, false);
             //BasicDocument.Example_BasicWordWithBreaks(folderPath, true);
-            BasicDocument.Example_BasicWordWithDefaultStyleChange(folderPath, true);
-
+            BasicDocument.Example_BasicWordWithDefaultStyleChange(folderPath, false);
+            BasicDocument.Example_BasicWordWithDefaultFontChange(folderPath, true);
             //AdvancedDocument.Example_AdvancedWord(folderPath, true);
 
             //BasicDocument.Example_BasicDocument(folderPath, true);
@@ -178,8 +178,8 @@ namespace OfficeIMO.Examples {
             //filePath = System.IO.Path.Combine(folderPath, "Basic Document with Fields.docx");
             //Example_AddingFields(filePath, true);
 
-            Watermark.Watermark_Sample2(folderPath, true);
-            Watermark.Watermark_Sample1(folderPath, true);
+            //Watermark.Watermark_Sample2(folderPath, true);
+            //Watermark.Watermark_Sample1(folderPath, true);
         }
 
         private static void Example_AddingFields(string filePath, bool openWord) {

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create03.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create03.cs
@@ -9,18 +9,35 @@ using OfficeIMO.Word;
 namespace OfficeIMO.Examples.Word {
     internal static partial class BasicDocument {
         public static void Example_BasicWordWithDefaultStyleChange(string folderPath, bool openWord) {
-            Console.WriteLine("[*] Creating standard document with different default style");
-            string filePath = System.IO.Path.Combine(folderPath, "BasicWordWithDefaultStyleChange.docx");
+            Console.WriteLine("[*] Creating standard document with different default style (PL)");
+            string filePath = System.IO.Path.Combine(folderPath, "BasicWordWithDefaultStyleChangePL.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.Settings.FontSize = 30;
                 document.Settings.FontFamily = "Calibri Light";
                 document.Settings.Language = "pl-PL";
-
+                document.Settings.Language = "pt-Br";
                 var paragraph1 = document.AddParagraph("To jest po polsku");
 
                 var paragraph2 = document.AddParagraph("Adding paragraph1 with some text and pressing ENTER");
                 paragraph2.FontSize = 15;
                 paragraph2.FontFamily = "Courier New";
+
+                document.Save(openWord);
+            }
+        }
+        public static void Example_BasicWordWithDefaultFontChange(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating standard document with different default style (PT/BR)");
+            string filePath = System.IO.Path.Combine(folderPath, "BasicWordWithDefaultStyleChangeBR.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.Settings.FontSize = 30;
+                //document.Settings.FontSizeComplexScript = 30;
+                document.Settings.FontFamily = "Calibri Light";
+                document.Settings.FontFamilyHighAnsi = "Calibri Light";
+                document.Settings.Language = "pt-Br";
+
+                string title = "INSTRUMENTO PARTICULAR DE CONSTITUIÇÃO DE GARANTIA DE ALIENAÇÃO FIDUCIÁRIA DE IMÓVEL";
+
+                document.AddParagraph(title).SetBold().ParagraphAlignment = JustificationValues.Center;
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Tests/Word.Settings.cs
+++ b/OfficeIMO.Tests/Word.Settings.cs
@@ -47,13 +47,22 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(document.Settings.FontSizeComplexScript == 20);
 
+                // those are default values
+                Assert.True(document.Settings.FontFamily == null);
+                Assert.True(document.Settings.FontFamilyHighAnsi == null);
+
                 document.Settings.FontFamily = "Courier New";
 
                 Assert.True(document.Settings.FontFamily == "Courier New");
 
+                document.Settings.FontFamilyHighAnsi = "Courier New";
+
+                Assert.True(document.Settings.FontFamilyHighAnsi == "Courier New");
+
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatingDocumentWithSettings.docx"))) {
+                Assert.True(document.Settings.FontFamilyHighAnsi == "Courier New");
                 Assert.True(document.Settings.Language == "pl-PL");
 
                 document.Settings.Language = "en-US";
@@ -82,9 +91,15 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Settings.FontSize == 30);
                 Assert.True(document.Settings.FontFamily == "Courier New");
 
+                document.Settings.FontFamilyHighAnsi = "Abadi";
+                document.Settings.FontFamily = "Arial Narrow";
+
                 document.Save();
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatingDocumentWithSettings.docx"))) {
+                Assert.True(document.Settings.FontFamily == "Arial Narrow");
+                Assert.True(document.Settings.FontFamilyHighAnsi == "Abadi");
+
                 Assert.True(document.Settings.ProtectionType == null);
                 Assert.True(document.Settings.BackgroundColor == "FFA07A");
                 Assert.True(document.Settings.ZoomPercentage == 100);

--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -238,6 +238,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or Sets default font family for the whole document.
         /// </summary>
+        /// <seealso href="http://officeopenxml.com/WPtextFonts.php">WordProcessingText Fonts </seealso>
         public string FontFamily {
             get {
                 var runPropertiesBaseStyle = GetDefaultStyleProperties();
@@ -259,6 +260,37 @@ namespace OfficeIMO.Word {
                     // we need to reset default AsciiTheme, before applying Ascii
                     runPropertiesBaseStyle.RunFonts.AsciiTheme = null;
                     runPropertiesBaseStyle.RunFonts.Ascii = value;
+                } else {
+                    throw new Exception("Could not set font family. Styles not found.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or Sets default font family for the whole document in highAnsi.
+        /// </summary>
+        /// <seealso href="http://officeopenxml.com/WPtextFonts.php">WordProcessingText Fonts </seealso>
+        public string FontFamilyHighAnsi {
+            get {
+                var runPropertiesBaseStyle = GetDefaultStyleProperties();
+                if (runPropertiesBaseStyle != null) {
+                    if (runPropertiesBaseStyle.RunFonts != null) {
+                        var fontFamily = runPropertiesBaseStyle.RunFonts.HighAnsi;
+                        return fontFamily;
+                    }
+                }
+                return null;
+            }
+            set {
+                var runPropertiesBaseStyle = SetDefaultStyleProperties();
+                if (runPropertiesBaseStyle != null) {
+                    //runPropertiesBaseStyle.RunFonts = new RunFonts();
+                    if (runPropertiesBaseStyle.RunFonts == null) {
+                        runPropertiesBaseStyle.RunFonts = new RunFonts() { AsciiTheme = ThemeFontValues.MinorHighAnsi, HighAnsiTheme = ThemeFontValues.MinorHighAnsi, EastAsiaTheme = ThemeFontValues.MinorHighAnsi, ComplexScriptTheme = ThemeFontValues.MinorBidi };
+                    }
+                    // we also need to change it in highAnsi to fix https://github.com/EvotecIT/OfficeIMO/issues/54
+                    runPropertiesBaseStyle.RunFonts.HighAnsi = value;
+                    runPropertiesBaseStyle.RunFonts.HighAnsiTheme = null;
                 } else {
                     throw new Exception("Could not set font family. Styles not found.");
                 }


### PR DESCRIPTION
Fixes:
- https://github.com/EvotecIT/OfficeIMO/issues/54

Adds:
- FontFamilyHighAnsi for document.Settings which is required for special chars 

```csharp
public static void Example_BasicWordWithDefaultFontChange(string folderPath, bool openWord) {
    Console.WriteLine("[*] Creating standard document with different default style (PT/BR)");
    string filePath = System.IO.Path.Combine(folderPath, "BasicWordWithDefaultStyleChangeBR.docx");
    using (WordDocument document = WordDocument.Create(filePath)) {
        document.Settings.FontSize = 30;
        //document.Settings.FontSizeComplexScript = 30;
        document.Settings.FontFamily = "Calibri Light";
        document.Settings.FontFamilyHighAnsi = "Calibri Light";
        document.Settings.Language = "pt-Br";

        string title = "INSTRUMENTO PARTICULAR DE CONSTITUIÇÃO DE GARANTIA DE ALIENAÇÃO FIDUCIÁRIA DE IMÓVEL";

        document.AddParagraph(title).SetBold().ParagraphAlignment = JustificationValues.Center;

        document.Save(openWord);
    }
}
```

More information: http://officeopenxml.com/WPtextFonts.php