### PR TITLE
Skip creation of run, which isn't needed

### DIFF
--- a/OfficeIMO.Tests/Word.Bookmarks.cs
+++ b/OfficeIMO.Tests/Word.Bookmarks.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -95,6 +95,10 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.ParagraphsBookmarks[3].Bookmark.Name == "EndOfDocument");
                 Assert.True(document.ParagraphsBookmarks[4].Bookmark.Name == "EndofEnds");
 
+                document.AddBookmark("Add bookmark straight to document. This shouldn't throw");
+
+                Assert.True(document.Bookmarks.Count == 6);
+                Assert.True(document.Paragraphs.Count == 17);
                 document.Save(false);
             }
         }

--- a/OfficeIMO.Word/WordBookmark.cs
+++ b/OfficeIMO.Word/WordBookmark.cs
@@ -51,10 +51,15 @@ namespace OfficeIMO.Word {
             BookmarkStart bms = new BookmarkStart() { Name = bookmarkName, Id = paragraph._document.BookmarkId.ToString() };
             BookmarkEnd bme = new BookmarkEnd() { Id = paragraph._document.BookmarkId.ToString() };
 
-            paragraph.VerifyRun();
+            //paragraph.VerifyRun();
+            if (paragraph._run == null) {
+                paragraph._paragraph.Append(bms);
+                paragraph._paragraph.Append(bme);
+            } else {
+                var bm = paragraph._run.InsertAfterSelf(bms);
+                bm.InsertAfterSelf(bme);
+            }
 
-            var bm = paragraph._run.InsertAfterSelf(bms);
-            bm.InsertAfterSelf(bme);
 
             paragraph._bookmarkStart = bms;
             return paragraph;


### PR DESCRIPTION
Fixes:
- https://github.com/EvotecIT/OfficeIMO/issues/66

Don't nessecary create run, if it's not there, as it isn't needed. 
Add test to make sure it doesn't throw