### PR TITLE
Fix check IsToc for Word.Lists

### DIFF
--- a/OfficeIMO.Tests/Word.Lists.cs
+++ b/OfficeIMO.Tests/Word.Lists.cs
@@ -6,348 +6,378 @@ using OfficeIMO.Word;
 using Xunit;
 using Color = SixLabors.ImageSharp.Color;
 
-namespace OfficeIMO.Tests {
-    public partial class Word {
-        [Fact]
-        public void Test_CreatingWordDocumentWithLists() {
-            string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists.docx");
-            using (WordDocument document = WordDocument.Create(filePath)) {
-                var paragraph = document.AddParagraph("First List");
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void Test_CreatingWordDocumentWithLists() {
+        var filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists.docx");
+        using (var document = WordDocument.Create(filePath)) {
+            var paragraph = document.AddParagraph("First List");
+            paragraph.ParagraphAlignment = JustificationValues.Center;
+
+            Assert.False(document.Paragraphs[0].IsEmpty, "Paragraph is empty");
+
+            Assert.Empty(document.Lists);
+
+            var wordList1 = document.AddList(WordListStyle.Heading1ai);
+            wordList1.AddItem("Text 1");
+            wordList1.AddItem("Text 2", 1);
+            wordList1.AddItem("Text 3", 2);
+
+            Assert.False(document.Paragraphs[0].IsListItem, "Paragraph is empty");
+            Assert.True(document.Paragraphs[1].IsListItem, "Paragraph is list item 1");
+            Assert.True(document.Paragraphs[2].IsListItem, "Paragraph is list item 1");
+            Assert.True(document.Paragraphs[3].IsListItem, "Paragraph is list item 2");
+            Assert.Equal("Text 3", document.Paragraphs[3].Text);
+
+            Assert.Equal("Text 1", document.Lists[0].ListItems[0].Text);
+            Assert.Equal("Text 2", document.Lists[0].ListItems[1].Text);
+            Assert.Equal("Text 3", document.Lists[0].ListItems[2].Text);
+
+            Assert.Single(document.Lists);
+
+            paragraph = document
+                .AddParagraph("This is second list")
+                .SetColor(Color.OrangeRed)
+                .SetUnderline(UnderlineValues.Double);
+
+            var wordList2 = document.AddList(WordListStyle.ArticleSections);
+            wordList2.AddItem("Temp 2");
+            wordList2.AddItem("Text 2", 1);
+            wordList2.AddItem("Text 3", 2);
+
+            Assert.Equal(2, document.Lists.Count);
+
+            paragraph = document
+                .AddParagraph("This is third list")
+                .SetColor(Color.Blue)
+                .SetUnderline(UnderlineValues.Double);
+
+            var wordList3 = document.AddList(WordListStyle.BulletedChars);
+            wordList3.AddItem("Text 3");
+            wordList3.AddItem("Text 2", 1);
+            wordList3.AddItem("Text 3", 2);
+
+            paragraph = document
+                .AddParagraph("This is fourth list")
+                .SetColor(Color.DeepPink)
+                .SetUnderline(UnderlineValues.Double);
+
+            var wordList4 = document.AddList(WordListStyle.Headings111);
+            wordList4.AddItem("Text 4");
+            wordList4.AddItem("Text 2", 1);
+            wordList4.AddItem("Text 3", 2);
+
+            paragraph = document
+                .AddParagraph("This is five list")
+                .SetColor(Color.DeepPink)
+                .SetUnderline(UnderlineValues.Double);
+
+            WordList wordList5 = document.AddList(WordListStyle.Headings111Shifted);
+            wordList5.AddItem("Text 5");
+            wordList5.AddItem("Text 2", 1);
+            wordList5.AddItem("Text 3", 2);
+
+            paragraph = document
+                .AddParagraph("This is 6th list")
+                .SetColor(Color.DeepPink)
+                .SetUnderline(UnderlineValues.Double);
+
+            var wordList6 = document.AddList(WordListStyle.Chapters);
+            wordList6.AddItem("Text 6");
+            wordList6.AddItem("Text 2");
+            wordList6.AddItem("Text 3");
+
+            paragraph = document
+                .AddParagraph("This is 7th list")
+                .SetColor(Color.DeepPink)
+                .SetUnderline(UnderlineValues.Double);
+
+            var wordList7 = document.AddList(WordListStyle.HeadingIA1);
+            wordList7.AddItem("Text 7");
+            wordList7.AddItem("Text 2", 1);
+            wordList7.AddItem("Text 3", 2);
+
+            Assert.Equal(7, document.Lists.Count);
+            Assert.Equal(28, document.Paragraphs.Count);
+
+            var section = Assert.Single(document.Sections);
+            Assert.Equal(28, section.Paragraphs.Count);
+
+            document.Save(false);
+        }
+
+        using (var document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists.docx"))) {
+            Assert.False(document.Paragraphs[0].IsListItem, "Paragraph is empty");
+            Assert.True(document.Paragraphs[1].IsListItem, "Paragraph is list item 1");
+            Assert.True(document.Paragraphs[2].IsListItem, "Paragraph is list item 1");
+            Assert.True(document.Paragraphs[3].IsListItem, "Paragraph is list item 2");
+            Assert.Equal("Text 3", document.Paragraphs[3].Text);
+            Assert.Equal("Text 1", document.Lists[0].ListItems[0].Text);
+            Assert.Equal("Text 2", document.Lists[0].ListItems[1].Text);
+            Assert.Equal("Text 3", document.Lists[0].ListItems[2].Text);
+            Assert.Equal(2, document.Lists[0].ListItems[2].ListItemLevel);
+
+            document.Lists[0].ListItems[2].ListItemLevel = 1;
+            document.Lists[0].ListItems[2].Text = "Text 4";
+
+            Assert.Equal(1, document.Lists[0].ListItems[2].ListItemLevel);
+
+            var paragraph = document
+                .AddParagraph("This is 9th list")
+                .SetColor(Color.MediumAquamarine)
+                .SetUnderline(UnderlineValues.Double);
+
+            var wordList8 = document.AddList(WordListStyle.Bulleted);
+            wordList8.AddItem("Text 9");
+            wordList8.AddItem("Text 9.1", 1);
+            wordList8.AddItem("Text 9.2", 2);
+            wordList8.AddItem("Text 9.3", 2);
+            wordList8.AddItem("Text 9.4", 0);
+            wordList8.AddItem("Text 9.5", 0);
+            wordList8.AddItem("Text 9.6", 1);
+
+            paragraph = document
+                .AddParagraph("This is 10th list")
+                .SetColor(Color.ForestGreen)
+                .SetUnderline(UnderlineValues.Double);
+
+            var wordList2 = document.AddList(WordListStyle.Headings111);
+            wordList2.AddItem("Temp 10");
+            wordList2.AddItem("Text 10.1", 1);
+
+            paragraph = document
+                .AddParagraph("Paragraph in the middle of the list")
+                .SetColor(Color.Aquamarine); //.SetUnderline(UnderlineValues.Double);
+
+            wordList2.AddItem("Text 10.2", 2);
+            wordList2.AddItem("Text 10.3", 2);
+
+            paragraph = document
+                .AddParagraph("This is 10th list")
+                .SetColor(Color.ForestGreen).SetUnderline(UnderlineValues.Double);
+
+            var wordList3 = document.AddList(WordListStyle.Headings111);
+            wordList3.AddItem("Temp 11");
+            wordList3.AddItem("Text 11.1", 1);
+
+            Assert.Equal(10, document.Lists.Count);
+            Assert.Equal(45, document.Paragraphs.Count);
+
+            var section = Assert.Single(document.Sections);
+            Assert.Equal(45, section.Paragraphs.Count);
+
+            document.Save();
+        }
+
+        using (var document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists.docx"))) {
+            Assert.False(document.Paragraphs[0].IsListItem, "Paragraph is empty");
+            Assert.True(document.Paragraphs[1].IsListItem, "Paragraph is list item 1");
+            Assert.True(document.Paragraphs[2].IsListItem, "Paragraph is list item 1");
+            Assert.True(document.Paragraphs[3].IsListItem, "Paragraph is list item 2");
+
+            Assert.Equal("Text 1", document.Lists[0].ListItems[0].Text);
+            Assert.Equal("Text 2", document.Lists[0].ListItems[1].Text);
+            // should work after reloading after last save
+            Assert.Equal(1, document.Lists[0].ListItems[2].ListItemLevel);
+            Assert.Equal("Text 4", document.Lists[0].ListItems[2].Text);
+            Assert.Equal("Text 4", document.Paragraphs[3].Text);
+            // We continue with the rest
+            Assert.Equal(10, document.Lists.Count);
+            Assert.Equal(45, document.Paragraphs.Count);
+
+            var section = Assert.Single(document.Sections);
+            Assert.Equal(45, section.Paragraphs.Count);
+
+            document.Save();
+        }
+    }
+
+    [Fact]
+    public void Test_CreatingWordDocumentWithLists2() {
+        var filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists2.docx");
+        using (var document = WordDocument.Create(filePath)) {
+            var paragraph = document.AddParagraph("Basic paragraph - Page 4");
+            paragraph.ParagraphAlignment = JustificationValues.Center;
+
+            var wordList = document.AddList(WordListStyle.Headings111);
+            wordList.AddItem("Text 1").SetCapsStyle(CapsStyle.SmallCaps);
+            wordList.AddItem("Text 2.1", 1).SetColor(Color.Brown);
+            wordList.AddItem("Text 2.2", 1).SetColor(Color.Brown);
+            wordList.AddItem("Text 2.3", 1).SetColor(Color.Brown);
+            wordList.AddItem("Text 2.3.4", 2).SetColor(Color.Brown);
+            // here we set another list element but we also change it using standard paragraph change
+            paragraph = wordList.AddItem("Text 3");
+            paragraph.Bold = true;
+            paragraph.SetItalic();
+
+            Assert.Single(document.Lists);
+
+            paragraph = document
+                .AddParagraph("This is second list")
+                .SetColor(Color.OrangeRed)
+                .SetUnderline(UnderlineValues.Double);
+
+            WordList wordList1 = document.AddList(WordListStyle.HeadingIA1);
+            wordList1.AddItem("Temp 1").SetCapsStyle(CapsStyle.SmallCaps);
+            wordList1.AddItem("Temp 2.1", 1).SetColor(Color.Brown);
+            wordList1.AddItem("Temp 2.2", 1).SetColor(Color.Brown);
+            wordList1.AddItem("Temp 2.3", 1).SetColor(Color.Brown);
+            wordList1.AddItem("Temp 2.3.4", 2).SetColor(Color.Brown).Remove();
+            wordList1.ListItems[1].Remove();
+            paragraph = wordList1.AddItem("Temp 3");
+
+            Assert.Equal(2, document.Lists.Count);
+            Assert.Equal(2, document.Sections[0].Lists.Count);
+
+            paragraph = document
+                .AddParagraph("This is third list")
+                .SetColor(Color.Blue)
+                .SetUnderline(UnderlineValues.Double);
+
+            var wordList2 = document.AddList(WordListStyle.BulletedChars);
+            wordList2.AddItem("Oops 1").SetCapsStyle(CapsStyle.SmallCaps);
+            wordList2.AddItem("Oops 2.1", 1).SetColor(Color.Brown);
+            wordList2.AddItem("Oops 2.2", 1).SetColor(Color.Brown);
+            wordList2.AddItem("Oops 2.3", 1).SetColor(Color.Brown);
+            wordList2.AddItem("Oops 2.3.4", 2).SetColor(Color.Brown);
+
+            Assert.Equal(3, document.Lists.Count);
+            Assert.Equal(3, document.Sections[0].Lists.Count);
+
+            paragraph = document
+                .AddParagraph("This is fourth list")
+                .SetColor(Color.DeepPink)
+                .SetUnderline(UnderlineValues.Double);
+
+            var wordList3 = document.AddList(WordListStyle.Heading1ai);
+            wordList3.AddItem("4th 1").SetCapsStyle(CapsStyle.SmallCaps);
+            wordList3.AddItem("4th 2.1", 1).SetColor(Color.Brown);
+            wordList3.AddItem("4th 2.2", 1).SetColor(Color.Brown);
+            wordList3.AddItem("4th 2.3", 1).SetColor(Color.Brown);
+            wordList3.AddItem("4th 2.3.4", 2).SetColor(Color.Brown);
+
+            Assert.Equal(4, document.Lists.Count);
+            Assert.Equal(4, document.Sections[0].Lists.Count);
+
+            paragraph = document
+                .AddParagraph("This is five list")
+                .SetColor(Color.DeepPink)
+                .SetUnderline(UnderlineValues.Double);
+
+            var wordList4 = document.AddList(WordListStyle.Headings111Shifted);
+            wordList4.AddItem("5th 1").SetCapsStyle(CapsStyle.SmallCaps);
+            wordList4.AddItem("5th 2.1", 1).SetColor(Color.Brown);
+            wordList4.AddItem("5th 2.2", 1).SetColor(Color.Brown);
+            wordList4.AddItem("5th 2.3", 1).SetColor(Color.Brown);
+            wordList4.AddItem("5th 2.3.4", 2).SetColor(Color.Brown);
+
+            Assert.Equal(5, document.Lists.Count);
+            Assert.Equal(6, document.Lists[0].ListItems.Count);
+            Assert.Equal(4, document.Lists[1].ListItems.Count);
+            Assert.Equal(5, document.Lists[2].ListItems.Count);
+            Assert.Equal(5, document.Lists[3].ListItems.Count);
+            Assert.Equal(5, document.Lists[4].ListItems.Count);
+
+            document.Lists[3].ListItems[2].Text = "Overwrite Text 2.2";
+            document.Lists[4].ListItems[2].Text = "Overwrite Text 2.12";
+
+            Assert.Equal(5, document.Lists.Count);
+
+            document.Lists[3].AddItem("Added 2.3.5", 3).SetColor(Color.DimGrey);
+            document.Lists[2].AddItem("Added 2.3.5", 3).SetColor(Color.DimGrey);
+
+            Assert.Equal(5, document.Lists.Count);
+
+            Assert.Equal("Text 1", document.Lists[0].ListItems[0].Text);
+            Assert.Equal("Text 2.1", document.Lists[0].ListItems[1].Text);
+            Assert.Equal("Temp 2.2", document.Lists[1].ListItems[1].Text);
+            Assert.Equal("Temp 2.3", document.Lists[1].ListItems[2].Text);
+
+            Assert.Equal("Oops 2.1", document.Lists[2].ListItems[1].Text);
+            Assert.Equal("Oops 2.2", document.Lists[2].ListItems[2].Text);
+
+            Assert.Equal("Overwrite Text 2.2", document.Lists[3].ListItems[2].Text);
+            Assert.Equal("Overwrite Text 2.12", document.Lists[4].ListItems[2].Text);
+
+            Assert.Equal(6, document.Lists[2].ListItems.Count);
+            Assert.Equal(6, document.Lists[3].ListItems.Count);
+
+            var section = document.AddSection();
+            section.PageSettings.Orientation = PageOrientationValues.Landscape;
+
+            Assert.Equal(PageOrientationValues.Portrait, document.Sections[0].PageSettings.Orientation);
+            Assert.Equal(PageOrientationValues.Landscape, document.Sections[1].PageSettings.Orientation);
+
+            Assert.Equal(5, document.Lists.Count);
+            Assert.Equal(5, document.Sections[0].Lists.Count);
+
+            Assert.Empty(document.Sections[1].Lists);
+
+            var wordList5 = document.AddList(WordListStyle.Headings111);
+            wordList5.AddItem("Section 1").SetCapsStyle(CapsStyle.SmallCaps);
+            wordList5.AddItem("Section 2.1", 1).SetColor(Color.Brown);
+            wordList5.AddItem("Section 2.2", 1).SetColor(Color.Brown);
+
+            Assert.Equal(6, document.Lists.Count);
+            Assert.Equal(5, document.Sections[0].Lists.Count);
+            Assert.Single(document.Sections[1].Lists);
+
+            document.Save(false);
+        }
+
+        using (var document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists2.docx"))) {
+            Assert.Equal(6, document.Lists.Count);
+            Assert.Equal(5, document.Sections[0].Lists.Count);
+            Assert.Single(document.Sections[1].Lists);
+
+            var wordList6 = document.AddList(WordListStyle.Headings111);
+            wordList6.AddItem("Section 1").SetCapsStyle(CapsStyle.SmallCaps);
+            wordList6.AddItem("Section 2.1", 1).SetColor(Color.Brown);
+            wordList6.AddItem("Section 2.2", 1).SetColor(Color.Brown);
+
+            Assert.Equal(7, document.Lists.Count);
+            Assert.Equal(5, document.Sections[0].Lists.Count);
+            Assert.Equal(2, document.Sections[1].Lists.Count);
+
+            document.Save();
+        }
+
+        using (var document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists2.docx"))) {
+            Assert.Equal(7, document.Lists.Count);
+            Assert.Equal(5, document.Sections[0].Lists.Count);
+            Assert.Equal(2, document.Sections[1].Lists.Count);
+            document.Save();
+        }
+    }
+
+    [Fact]
+    public void Test_SavingWordDocumentWithListsToStream() {
+        var filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithListsToStream.docx");
+        var wordListStyles = (WordListStyle[]) Enum.GetValues(typeof(WordListStyle));
+        using (var document = WordDocument.Create()) {
+            foreach (var listStyle in wordListStyles) {
+                var paragraph = document.AddParagraph(listStyle.ToString());
+                paragraph.SetColor(Color.Red).SetBold();
                 paragraph.ParagraphAlignment = JustificationValues.Center;
 
-                Assert.True(document.Paragraphs[0].IsEmpty == false, "Paragraph is empty");
-
-                Assert.True(document.Lists.Count == 0, "List count matches");
-
-                WordList wordList1 = document.AddList(WordListStyle.Heading1ai);
+                var wordList1 = document.AddList(listStyle);
                 wordList1.AddItem("Text 1");
-                wordList1.AddItem("Text 2", 1);
-                wordList1.AddItem("Text 3", 2);
-
-                Assert.True(document.Paragraphs[0].IsListItem == false, "Paragraph is empty");
-                Assert.True(document.Paragraphs[1].IsListItem == true, "Paragraph is list item 1");
-                Assert.True(document.Paragraphs[2].IsListItem == true, "Paragraph is list item 1");
-                Assert.True(document.Paragraphs[3].IsListItem == true, "Paragraph is list item 2");
-                Assert.True(document.Paragraphs[3].Text == "Text 3", "Paragraph text match");
-
-                Assert.True(document.Lists[0].ListItems[0].Text == "Text 1", "Paragraph text match");
-                Assert.True(document.Lists[0].ListItems[1].Text == "Text 2", "Paragraph text match");
-                Assert.True(document.Lists[0].ListItems[2].Text == "Text 3", "Paragraph text match");
-
-                Assert.True(document.Lists.Count == 1, "List count matches");
-
-                paragraph = document.AddParagraph("This is second list").SetColor(Color.OrangeRed).SetUnderline(UnderlineValues.Double);
-
-                WordList wordList2 = document.AddList(WordListStyle.ArticleSections);
-                wordList2.AddItem("Temp 2");
-                wordList2.AddItem("Text 2", 1);
-                wordList2.AddItem("Text 3", 2);
-
-                Assert.True(document.Lists.Count == 2, "List count matches");
-
-                paragraph = document.AddParagraph("This is third list").SetColor(Color.Blue).SetUnderline(UnderlineValues.Double);
-
-                WordList wordList3 = document.AddList(WordListStyle.BulletedChars);
-                wordList3.AddItem("Text 3");
-                wordList3.AddItem("Text 2", 1);
-                wordList3.AddItem("Text 3", 2);
-
-                paragraph = document.AddParagraph("This is fourth list").SetColor(Color.DeepPink).SetUnderline(UnderlineValues.Double);
-
-                WordList wordList4 = document.AddList(WordListStyle.Headings111);
-                wordList4.AddItem("Text 4");
-                wordList4.AddItem("Text 2", 1);
-                wordList4.AddItem("Text 3", 2);
-
-                paragraph = document.AddParagraph("This is five list").SetColor(Color.DeepPink).SetUnderline(UnderlineValues.Double);
-
-                WordList wordList5 = document.AddList(WordListStyle.Headings111Shifted);
-                wordList5.AddItem("Text 5");
-                wordList5.AddItem("Text 2", 1);
-                wordList5.AddItem("Text 3", 2);
-
-                paragraph = document.AddParagraph("This is 6th list").SetColor(Color.DeepPink).SetUnderline(UnderlineValues.Double);
-
-                WordList wordList6 = document.AddList(WordListStyle.Chapters);
-                wordList6.AddItem("Text 6");
-                wordList6.AddItem("Text 2");
-                wordList6.AddItem("Text 3");
-
-                paragraph = document.AddParagraph("This is 7th list").SetColor(Color.DeepPink).SetUnderline(UnderlineValues.Double);
-
-                WordList wordList7 = document.AddList(WordListStyle.HeadingIA1);
-                wordList7.AddItem("Text 7");
-                wordList7.AddItem("Text 2", 1);
-                wordList7.AddItem("Text 3", 2);
-
-                Assert.True(document.Lists.Count == 7, "List count matches");
-
-                Assert.True(document.Paragraphs.Count == 28, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
-
-                Assert.True(document.Sections.Count == 1, "Number of sections during creation is wrong.");
-
-                Assert.True(document.Sections[0].Paragraphs.Count == 28, "Number of paragraphs on 1st section is wrong.");
-                document.Save(false);
             }
 
-            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists.docx"))) {
-                Assert.True(document.Paragraphs[0].IsListItem == false, "Paragraph is empty");
-                Assert.True(document.Paragraphs[1].IsListItem == true, "Paragraph is list item 1");
-                Assert.True(document.Paragraphs[2].IsListItem == true, "Paragraph is list item 1");
-                Assert.True(document.Paragraphs[3].IsListItem == true, "Paragraph is list item 2");
-                Assert.True(document.Paragraphs[3].Text == "Text 3", "Paragraph text match");
-
-                Assert.True(document.Lists[0].ListItems[0].Text == "Text 1", "Paragraph text match");
-                Assert.True(document.Lists[0].ListItems[1].Text == "Text 2", "Paragraph text match");
-                Assert.True(document.Lists[0].ListItems[2].Text == "Text 3", "Paragraph text match");
-                Assert.True(document.Lists[0].ListItems[2].ListItemLevel == 2, "Level doesn't match");
-
-                document.Lists[0].ListItems[2].ListItemLevel = 1;
-                document.Lists[0].ListItems[2].Text = "Text 4";
-
-                Assert.True(document.Lists[0].ListItems[2].ListItemLevel == 1, "Level doesn't match");
-
-                var paragraph = document.AddParagraph("This is 9th list").SetColor(Color.MediumAquamarine).SetUnderline(UnderlineValues.Double);
-
-                WordList wordList8 = document.AddList(WordListStyle.Bulleted);
-                wordList8.AddItem("Text 9");
-                wordList8.AddItem("Text 9.1", 1);
-                wordList8.AddItem("Text 9.2", 2);
-                wordList8.AddItem("Text 9.3", 2);
-                wordList8.AddItem("Text 9.4", 0);
-                wordList8.AddItem("Text 9.5", 0);
-                wordList8.AddItem("Text 9.6", 1);
-
-                paragraph = document.AddParagraph("This is 10th list").SetColor(Color.ForestGreen).SetUnderline(UnderlineValues.Double);
-
-                WordList wordList2 = document.AddList(WordListStyle.Headings111);
-                wordList2.AddItem("Temp 10");
-                wordList2.AddItem("Text 10.1", 1);
-
-                paragraph = document.AddParagraph("Paragraph in the middle of the list").SetColor(Color.Aquamarine); //.SetUnderline(UnderlineValues.Double);
-
-                wordList2.AddItem("Text 10.2", 2);
-                wordList2.AddItem("Text 10.3", 2);
-
-                paragraph = document.AddParagraph("This is 10th list").SetColor(Color.ForestGreen).SetUnderline(UnderlineValues.Double);
-
-                WordList wordList3 = document.AddList(WordListStyle.Headings111);
-                wordList3.AddItem("Temp 11");
-                wordList3.AddItem("Text 11.1", 1);
-
-                Assert.True(document.Lists.Count == 10, "List count matches");
-
-                Assert.True(document.Paragraphs.Count == 45, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
-
-                Assert.True(document.Sections.Count == 1, "Number of sections during creation is wrong.");
-
-                Assert.True(document.Sections[0].Paragraphs.Count == 45, "Number of paragraphs on 1st section is wrong.");
-                document.Save();
-            }
-
-            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists.docx"))) {
-                Assert.True(document.Paragraphs[0].IsListItem == false, "Paragraph is empty");
-                Assert.True(document.Paragraphs[1].IsListItem == true, "Paragraph is list item 1");
-                Assert.True(document.Paragraphs[2].IsListItem == true, "Paragraph is list item 1");
-                Assert.True(document.Paragraphs[3].IsListItem == true, "Paragraph is list item 2");
-
-
-                Assert.True(document.Lists[0].ListItems[0].Text == "Text 1", "Paragraph text match");
-                Assert.True(document.Lists[0].ListItems[1].Text == "Text 2", "Paragraph text match");
-                // should work after reloading after last save
-                Assert.True(document.Lists[0].ListItems[2].ListItemLevel == 1, "Level doesn't match");
-                Assert.True(document.Lists[0].ListItems[2].Text == "Text 4", "Paragraph text match");
-                Assert.True(document.Paragraphs[3].Text == "Text 4", "Paragraph text match");
-                // We continue with the rest
-
-                Assert.True(document.Lists.Count == 10, "List count matches");
-
-                Assert.True(document.Paragraphs.Count == 45, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
-
-                Assert.True(document.Sections.Count == 1, "Number of sections during creation is wrong.");
-
-                Assert.True(document.Sections[0].Paragraphs.Count == 45, "Number of paragraphs on 1st section is wrong.");
-                document.Save();
-            }
+            using var outputStream = new MemoryStream();
+            document.Save(outputStream);
+            File.WriteAllBytes(filePath, outputStream.ToArray());
         }
 
-        [Fact]
-        public void Test_CreatingWordDocumentWithLists2() {
-            string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists2.docx");
-            using (WordDocument document = WordDocument.Create(filePath)) {
-                var paragraph = document.AddParagraph("Basic paragraph - Page 4");
-                paragraph.ParagraphAlignment = JustificationValues.Center;
-
-                WordList wordList = document.AddList(WordListStyle.Headings111);
-                wordList.AddItem("Text 1").SetCapsStyle(CapsStyle.SmallCaps);
-                wordList.AddItem("Text 2.1", 1).SetColor(Color.Brown);
-                wordList.AddItem("Text 2.2", 1).SetColor(Color.Brown);
-                wordList.AddItem("Text 2.3", 1).SetColor(Color.Brown);
-                wordList.AddItem("Text 2.3.4", 2).SetColor(Color.Brown);
-                // here we set another list element but we also change it using standard paragraph change
-                paragraph = wordList.AddItem("Text 3");
-                paragraph.Bold = true;
-                paragraph.SetItalic();
-
-                Assert.True(document.Lists.Count == 1);
-
-                paragraph = document.AddParagraph("This is second list").SetColor(Color.OrangeRed).SetUnderline(UnderlineValues.Double);
-
-                WordList wordList1 = document.AddList(WordListStyle.HeadingIA1);
-                wordList1.AddItem("Temp 1").SetCapsStyle(CapsStyle.SmallCaps);
-                wordList1.AddItem("Temp 2.1", 1).SetColor(Color.Brown);
-                wordList1.AddItem("Temp 2.2", 1).SetColor(Color.Brown);
-                wordList1.AddItem("Temp 2.3", 1).SetColor(Color.Brown);
-                wordList1.AddItem("Temp 2.3.4", 2).SetColor(Color.Brown).Remove();
-                wordList1.ListItems[1].Remove();
-                paragraph = wordList1.AddItem("Temp 3");
-
-                Assert.True(document.Lists.Count == 2);
-                Assert.True(document.Sections[0].Lists.Count == 2);
-
-                paragraph = document.AddParagraph("This is third list").SetColor(Color.Blue).SetUnderline(UnderlineValues.Double);
-
-                WordList wordList2 = document.AddList(WordListStyle.BulletedChars);
-                wordList2.AddItem("Oops 1").SetCapsStyle(CapsStyle.SmallCaps);
-                wordList2.AddItem("Oops 2.1", 1).SetColor(Color.Brown);
-                wordList2.AddItem("Oops 2.2", 1).SetColor(Color.Brown);
-                wordList2.AddItem("Oops 2.3", 1).SetColor(Color.Brown);
-                wordList2.AddItem("Oops 2.3.4", 2).SetColor(Color.Brown);
-
-                Assert.True(document.Lists.Count == 3);
-                Assert.True(document.Sections[0].Lists.Count == 3);
-
-                paragraph = document.AddParagraph("This is fourth list").SetColor(Color.DeepPink).SetUnderline(UnderlineValues.Double);
-
-                WordList wordList3 = document.AddList(WordListStyle.Heading1ai);
-                wordList3.AddItem("4th 1").SetCapsStyle(CapsStyle.SmallCaps);
-                wordList3.AddItem("4th 2.1", 1).SetColor(Color.Brown);
-                wordList3.AddItem("4th 2.2", 1).SetColor(Color.Brown);
-                wordList3.AddItem("4th 2.3", 1).SetColor(Color.Brown);
-                wordList3.AddItem("4th 2.3.4", 2).SetColor(Color.Brown);
-
-                Assert.True(document.Lists.Count == 4);
-                Assert.True(document.Sections[0].Lists.Count == 4);
-
-                paragraph = document.AddParagraph("This is five list").SetColor(Color.DeepPink).SetUnderline(UnderlineValues.Double);
-
-                WordList wordList4 = document.AddList(WordListStyle.Headings111Shifted);
-                wordList4.AddItem("5th 1").SetCapsStyle(CapsStyle.SmallCaps);
-                wordList4.AddItem("5th 2.1", 1).SetColor(Color.Brown);
-                wordList4.AddItem("5th 2.2", 1).SetColor(Color.Brown);
-                wordList4.AddItem("5th 2.3", 1).SetColor(Color.Brown);
-                wordList4.AddItem("5th 2.3.4", 2).SetColor(Color.Brown);
-
-                Assert.True(document.Lists.Count == 5);
-                Assert.True(document.Lists[0].ListItems.Count == 6);
-                Assert.True(document.Lists[1].ListItems.Count == 4);
-                Assert.True(document.Lists[2].ListItems.Count == 5);
-                Assert.True(document.Lists[3].ListItems.Count == 5);
-                Assert.True(document.Lists[4].ListItems.Count == 5);
-
-                document.Lists[3].ListItems[2].Text = "Overwrite Text 2.2";
-                document.Lists[4].ListItems[2].Text = "Overwrite Text 2.12";
-
-                Assert.True(document.Lists.Count == 5);
-
-                document.Lists[3].AddItem("Added 2.3.5", 3).SetColor(Color.DimGrey);
-                document.Lists[2].AddItem("Added 2.3.5", 3).SetColor(Color.DimGrey);
-
-                Assert.True(document.Lists.Count == 5);
-
-                Assert.True(document.Lists[0].ListItems[0].Text == "Text 1");
-                Assert.True(document.Lists[0].ListItems[1].Text == "Text 2.1");
-
-                Assert.True(document.Lists[1].ListItems[1].Text == "Temp 2.2");
-                Assert.True(document.Lists[1].ListItems[2].Text == "Temp 2.3");
-
-                Assert.True(document.Lists[2].ListItems[1].Text == "Oops 2.1");
-                Assert.True(document.Lists[2].ListItems[2].Text == "Oops 2.2");
-
-                Assert.True(document.Lists[3].ListItems[2].Text == "Overwrite Text 2.2");
-                Assert.True(document.Lists[4].ListItems[2].Text == "Overwrite Text 2.12");
-
-                Assert.True(document.Lists[2].ListItems.Count == 6);
-                Assert.True(document.Lists[3].ListItems.Count == 6);
-
-
-                var section = document.AddSection();
-                section.PageSettings.Orientation = PageOrientationValues.Landscape;
-
-                Assert.True(document.Sections[0].PageSettings.Orientation == PageOrientationValues.Portrait);
-                Assert.True(document.Sections[1].PageSettings.Orientation == PageOrientationValues.Landscape);
-
-                Assert.True(document.Lists.Count == 5);
-                Assert.True(document.Sections[0].Lists.Count == 5);
-
-
-                Assert.True(document.Sections[1].Lists.Count == 0);
-
-                WordList wordList5 = document.AddList(WordListStyle.Headings111);
-                wordList5.AddItem("Section 1").SetCapsStyle(CapsStyle.SmallCaps);
-                wordList5.AddItem("Section 2.1", 1).SetColor(SixLabors.ImageSharp.Color.Brown);
-                wordList5.AddItem("Section 2.2", 1).SetColor(SixLabors.ImageSharp.Color.Brown);
-
-                Assert.True(document.Lists.Count == 6);
-                Assert.True(document.Sections[0].Lists.Count == 5);
-                Assert.True(document.Sections[1].Lists.Count == 1);
-
-                document.Save(false);
-            }
-
-            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists2.docx"))) {
-                Assert.True(document.Lists.Count == 6);
-
-                Assert.True(document.Sections[0].Lists.Count == 5);
-                Assert.True(document.Sections[1].Lists.Count == 1);
-
-                WordList wordList6 = document.AddList(WordListStyle.Headings111);
-                wordList6.AddItem("Section 1").SetCapsStyle(CapsStyle.SmallCaps);
-                wordList6.AddItem("Section 2.1", 1).SetColor(SixLabors.ImageSharp.Color.Brown);
-                wordList6.AddItem("Section 2.2", 1).SetColor(SixLabors.ImageSharp.Color.Brown);
-
-                Assert.True(document.Lists.Count == 7);
-                Assert.True(document.Sections[0].Lists.Count == 5);
-                Assert.True(document.Sections[1].Lists.Count == 2);
-
-                document.Save();
-            }
-
-            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists2.docx"))) {
-                Assert.True(document.Lists.Count == 7);
-                Assert.True(document.Sections[0].Lists.Count == 5);
-                Assert.True(document.Sections[1].Lists.Count == 2);
-                document.Save();
-            }
-        }
-
-        [Fact]
-        public void Test_SavingWordDocumentWithListsToStream() {
-            var filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithListsToStream.docx");
-            var wordListStyles = (WordListStyle[]) Enum.GetValues(typeof(WordListStyle));
-            using (var document = WordDocument.Create()) {
-                foreach (var listStyle in wordListStyles) {
-                    var paragraph = document.AddParagraph(listStyle.ToString());
-                    paragraph.SetColor(Color.Red).SetBold();
-                    paragraph.ParagraphAlignment = JustificationValues.Center;
-
-                    var wordList1 = document.AddList(listStyle);
-                    wordList1.AddItem("Text 1");
-                }
-
-                using var outputStream = new MemoryStream();
-                document.Save(outputStream);
-                File.WriteAllBytes(filePath, outputStream.ToArray());
-            }
-
-            using (var document = WordDocument.Load(filePath)) {
-                Assert.Equal(wordListStyles.Length, document.Lists.Count);
-                var abstractNums = document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart!
-                    .Numbering.ChildElements.OfType<AbstractNum>().ToArray();
-                for (var idx = 0; idx < abstractNums.Length; idx++) {
-                    var style = WordListStyles.GetStyle(wordListStyles[idx]);
-                    Assert.Equal(style, abstractNums[idx]);
-                }
+        using (var document = WordDocument.Load(filePath)) {
+            Assert.Equal(wordListStyles.Length, document.Lists.Count);
+            var abstractNums = document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart!
+                .Numbering.ChildElements.OfType<AbstractNum>().ToArray();
+            for (var idx = 0; idx < abstractNums.Length; idx++) {
+                var style = WordListStyles.GetStyle(wordListStyles[idx]);
+                Assert.Equal(style, abstractNums[idx]);
             }
         }
     }

--- a/OfficeIMO.Word/WordList.cs
+++ b/OfficeIMO.Word/WordList.cs
@@ -26,13 +26,9 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool IsToc {
             get {
-                foreach (var paragraph in ListItems) {
-                    var style = paragraph.Style.ToString();
-                    if (style.Remove(style.Length - 1) == "Heading") {
-                        return true;
-                    }
-                }
-                return false;
+                return ListItems
+                    .Select(paragraph => paragraph.Style.ToString())
+                    .Any(style => style.StartsWith("Heading", StringComparison.Ordinal));
             }
         }
 

--- a/OfficeIMO.Word/WordList.cs
+++ b/OfficeIMO.Word/WordList.cs
@@ -1,196 +1,175 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using DocumentFormat.OpenXml;
-using DocumentFormat.OpenXml.CustomProperties;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 
-namespace OfficeIMO.Word {
-    public class WordList {
-        private readonly WordprocessingDocument _wordprocessingDocument;
-        private readonly WordDocument _document;
-        // private readonly WordSection _section;
-        private int _abstractId;
-        internal int _numberId;
+namespace OfficeIMO.Word;
 
-        /// <summary>
-        /// This provides a way to set items to be treated with heading style
-        /// </summary>
-        private readonly bool _isToc;
+public class WordList {
+    private readonly WordprocessingDocument _wordprocessingDocument;
+    private readonly WordDocument _document;
+    // private readonly WordSection _section;
+    private int _abstractId;
+    internal int _numberId;
 
-        /// <summary>
-        /// This provides a way to set it teams to be treated with heading style during load 
-        /// </summary>
-        public bool IsToc {
-            get {
-                return ListItems
-                    .Select(paragraph => paragraph.Style.ToString())
-                    .Any(style => style.StartsWith("Heading", StringComparison.Ordinal));
-            }
+    /// <summary>
+    /// This provides a way to set items to be treated with heading style
+    /// </summary>
+    private readonly bool _isToc;
+
+    /// <summary>
+    /// This provides a way to set it teams to be treated with heading style during load
+    /// </summary>
+    public bool IsToc {
+        get {
+            return ListItems
+                .Select(paragraph => paragraph.Style.ToString())
+                .Any(style => style.StartsWith("Heading", StringComparison.Ordinal));
+        }
+    }
+
+    public List<WordParagraph> ListItems {
+        get {
+            return _document.Paragraphs
+                .Where(paragraph => paragraph.IsListItem && paragraph._listNumberId == _numberId)
+                .ToList();
+        }
+    }
+
+    public WordList(WordDocument wordDocument, WordSection section, bool isToc = false) {
+        _document = wordDocument;
+        _wordprocessingDocument = wordDocument._wordprocessingDocument;
+        //_section = section;
+        _isToc = isToc;
+        // section.Lists.Add(this);
+    }
+
+    public WordList(WordDocument wordDocument, WordSection section, int numberId) {
+        _document = wordDocument;
+        _wordprocessingDocument = wordDocument._wordprocessingDocument;
+        //  _section = section;
+        _numberId = numberId;
+    }
+
+    public WordParagraph AddItem(string text, int level = 0) {
+        var paragraph = new Paragraph();
+
+        var run = new Run();
+        run.Append(new RunProperties());
+        run.Append(new Text { Space = SpaceProcessingModeValues.Preserve });
+        paragraph.Append(run);
+
+        var paragraphProperties = new ParagraphProperties();
+        paragraphProperties.Append(new ParagraphStyleId { Val = "ListParagraph" });
+        paragraphProperties.Append(
+            new NumberingProperties(
+                new NumberingLevelReference { Val = level },
+                new NumberingId { Val = _numberId }
+            ));
+        paragraph.Append(paragraphProperties);
+
+        _wordprocessingDocument.MainDocumentPart!.Document.Body!.AppendChild(paragraph);
+
+        var wordParagraph = new WordParagraph(_document, paragraph, run) {
+            Text = text
+        };
+
+        // this simplifies TOC for user usage
+        if (_isToc || IsToc) {
+            wordParagraph.Style = WordParagraphStyle.GetStyle(level);
         }
 
-        public List<WordParagraph> ListItems {
-            get {
-                var listItems = new List<WordParagraph>();
-                foreach (WordParagraph paragraph in this._document.Paragraphs) {
-                    if (paragraph.IsListItem) {
-                        if (_numberId == paragraph._listNumberId) {
-                            listItems.Add(paragraph);
-                        }
-                    }
-                }
-                return listItems;
-            }
-        }
+        return wordParagraph;
+    }
 
-        public WordList(WordDocument wordDocument, WordSection section, bool isToc = false) {
-            _document = wordDocument;
-            _wordprocessingDocument = wordDocument._wordprocessingDocument;
-            //_section = section;
-            _isToc = isToc;
-            // section.Lists.Add(this);
-        }
+    internal static int GetNextAbstractNum(Numbering numbering) {
+        var ids = numbering.ChildElements
+            .OfType<AbstractNum>()
+            .Select(element => (int) element.AbstractNumberId)
+            .ToList();
+        return ids.Count > 0 ? ids.Max() + 1 : 1;
+    }
 
-        public WordList(WordDocument wordDocument, WordSection section, int numberId) {
-            _document = wordDocument;
-            _wordprocessingDocument = wordDocument._wordprocessingDocument;
-            //  _section = section;
-            _numberId = numberId;
-        }
+    internal static int GetNextNumberingInstance(Numbering numbering) {
+        var ids = numbering.ChildElements
+            .OfType<NumberingInstance>()
+            .Select(element => (int) element.NumberID)
+            .ToList();
+        return ids.Count > 0 ? ids.Max() + 1 : 1;
+    }
 
-        private void CreateNumberingDefinition(WordDocument document) {
-            NumberingDefinitionsPart numberingDefinitionsPart = document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart;
-            if (numberingDefinitionsPart == null) {
-                numberingDefinitionsPart = _wordprocessingDocument.MainDocumentPart.AddNewPart<NumberingDefinitionsPart>();
-            }
+    internal void AddList(WordListStyle style) {
+        CreateNumberingDefinition(_document);
+        var numbering = _document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart!.Numbering;
 
-            Numbering numbering = _document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart.Numbering;
-            if (numbering == null) {
-                numbering = new Numbering();
-                numbering.Save(_document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart);
-            }
-        }
+        _abstractId = GetNextAbstractNum(numbering);
+        _numberId = GetNextNumberingInstance(numbering);
 
-        internal static int GetNextAbstractNum(Numbering numbering) {
-            var ids = new List<int>();
-            foreach (var element in numbering.ChildElements.OfType<AbstractNum>()) {
-                ids.Add(element.AbstractNumberId);
-            }
-            if (ids.Count > 0) {
-                return ids.Max() + 1;
-            } else {
-                return 1;
-            }
-        }
+        var abstractNum = WordListStyles.GetStyle(style);
+        abstractNum.AbstractNumberId = _abstractId;
+        var abstractNumId = new AbstractNumId {
+            Val = _abstractId
+        };
+        var numberingInstance = new NumberingInstance(abstractNumId) {
+            NumberID = _numberId
+        };
+        numbering.Append(numberingInstance, abstractNum);
+    }
 
-        internal static int GetNextNumberingInstance(Numbering numbering) {
-            var ids = new List<int>();
-            foreach (var element in numbering.ChildElements.OfType<NumberingInstance>()) {
-                ids.Add(element.NumberID);
-            }
+    // TODO this isn't working yet, needs implementation
+    internal void AddList(CustomListStyles style = CustomListStyles.Bullet, string levelText = "·", int levelIndex = 0) {
+        CreateNumberingDefinition(_document);
 
-            if (ids.Count > 0) {
-                return ids.Max() + 1;
-            } else {
-                return 1;
-            }
-        }
+        // we take current list number from the document
+        //_numberId = _document._listNumbers;
 
-        internal void AddList(WordListStyle style) {
-            CreateNumberingDefinition(_document);
-            var numbering = _document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart.Numbering;
+        var numberingFormatValues = CustomListStyle.GetStyle(style);
 
-            _abstractId = GetNextAbstractNum(numbering);
-            _numberId = GetNextNumberingInstance(numbering);
+        var level = new Level(
+            new NumberingFormat { Val = numberingFormatValues },
+            new LevelText { Val = levelText }
+        ) {
+            LevelIndex = 1
+        };
+        var level1 = new Level(
+            new NumberingFormat { Val = numberingFormatValues },
+            new LevelText { Val = levelText }
+        ) {
+            LevelIndex = 2
+        };
+        var abstractNum = new AbstractNum(level, level1) {
+            AbstractNumberId = 0
+        };
+        //abstractNum.Nsid = new Nsid();
 
-            AbstractNum abstractNum = WordListStyles.GetStyle(style);
-            abstractNum.AbstractNumberId = _abstractId;
-            AbstractNumId abstractNumId = new AbstractNumId();
-            abstractNumId.Val = _abstractId;
-            NumberingInstance numberingInstance = new NumberingInstance(abstractNumId);
-            numberingInstance.NumberID = _numberId;
-            numbering.Append(numberingInstance, abstractNum);
-        }
+        var numbering = _document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart!.Numbering;
+        numbering.Append(abstractNum);
 
-        internal void AddList(CustomListStyles style = CustomListStyles.Bullet, string levelText = "·", int levelIndex = 0) {
-            // TODO this isn't working yet, needs implementation
-            CreateNumberingDefinition(_document);
-            if (_document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart.Numbering == null) {
-                Numbering numbering = new Numbering();
-                numbering.Save(_document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart);
-            }
+        var abstractNumId = new AbstractNumId {
+            Val = 0
+        };
+        var numberingInstance = new NumberingInstance(abstractNumId) {
+            NumberID = _numberId
+        };
 
-            // we take current list number from the document
-            //_numberId = _document._listNumbers;
+        //LevelOverride levelOverride = new LevelOverride();
+        //levelOverride.StartOverrideNumberingValue = new StartOverrideNumberingValue();
+        //levelOverride.StartOverrideNumberingValue.Val = 1;
+        //numberingInstance.Append(levelOverride);
 
-            var numberingFormatValues = CustomListStyle.GetStyle(style);
+        numbering.Append(numberingInstance);
+    }
 
-            Level level = new Level(
-                new NumberingFormat() { Val = numberingFormatValues },
-                new LevelText() { Val = levelText }
-            );
-            level.LevelIndex = 1;
+    private void CreateNumberingDefinition(WordDocument document) {
+        var numberingDefinitionsPart =
+            document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart
+            ?? _wordprocessingDocument.MainDocumentPart!.AddNewPart<NumberingDefinitionsPart>();
 
-            Level level1 = new Level(
-                new NumberingFormat() { Val = numberingFormatValues },
-                new LevelText() { Val = levelText }
-            );
-            level1.LevelIndex = 2;
-
-            AbstractNum abstractNum = new AbstractNum(level, level1);
-            abstractNum.AbstractNumberId = 0;
-            //abstractNum.Nsid = new Nsid();
-
-            AbstractNumId abstractNumId = new AbstractNumId();
-            abstractNumId.Val = 0;
-
-            NumberingInstance numberingInstance = new NumberingInstance(abstractNumId);
-            numberingInstance.NumberID = _numberId;
-
-
-            //LevelOverride levelOverride = new LevelOverride();
-            //levelOverride.StartOverrideNumberingValue = new StartOverrideNumberingValue();
-            //levelOverride.StartOverrideNumberingValue.Val = 1;
-            //numberingInstance.Append(levelOverride);
-
-
-            _document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart.Numbering.Append(abstractNum);
-            _document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart.Numbering.Append(numberingInstance);
-        }
-
-        public WordParagraph AddItem(string text, int level = 0) {
-            Text textProperty = new Text() { Space = SpaceProcessingModeValues.Preserve };
-            RunProperties runProperties = new RunProperties();
-            ParagraphStyleId paragraphStyleId = new ParagraphStyleId() { Val = "ListParagraph" };
-            NumberingProperties numberingProperties = new NumberingProperties(
-                new NumberingLevelReference() { Val = level },
-                new NumberingId() { Val = this._numberId }
-            );
-            ParagraphProperties paragraphProperties = new ParagraphProperties();
-            paragraphProperties.Append(paragraphStyleId);
-            paragraphProperties.Append(numberingProperties);
-
-            Run run = new Run();
-            run.Append(runProperties);
-            run.Append(textProperty);
-
-            Paragraph paragraph = new Paragraph();
-            paragraph.Append(paragraphProperties);
-            paragraph.Append(run);
-
-            this._wordprocessingDocument.MainDocumentPart.Document.Body.AppendChild(paragraph);
-
-            WordParagraph wordParagraph = new WordParagraph(_document, paragraph, run);
-            wordParagraph.Text = text;
-            // this simplifies TOC for user usage
-            if (_isToc || IsToc) {
-                wordParagraph.Style = WordParagraphStyle.GetStyle(level);
-            }
-
-            return wordParagraph;
+        if (numberingDefinitionsPart.Numbering == null) {
+            numberingDefinitionsPart.Numbering = new Numbering();
+            numberingDefinitionsPart.Numbering.Save(_document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart);
         }
     }
 }


### PR DESCRIPTION
Fix `IsToc` check when `"Heading"` exists with more than 1 character ending

P.S. I can remove the refactoring commit
Hide whitespaces will help watch diff
<details>

![image](https://user-images.githubusercontent.com/2669927/202654155-741785f2-216c-44fb-b69a-c96ec9f69297.png)

</details>
