### PR TITLE
Improve tests, fix HyperLink order, add method ValidateDocument()

### DIFF
--- a/OfficeIMO.Tests/Word.Borders.cs
+++ b/OfficeIMO.Tests/Word.Borders.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -284,6 +284,8 @@ namespace OfficeIMO.Tests {
                 document.Sections[3].SetBorders(WordBorder.None);
                 Assert.True(document.Sections[3].Borders.Type == WordBorder.None);
                 document.Save(false);
+
+                Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
             }
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithBordersBuiltin.docx"))) {

--- a/OfficeIMO.Tests/Word.Fields.cs
+++ b/OfficeIMO.Tests/Word.Fields.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/OfficeIMO.Tests/Word.Hyperlinks.cs
+++ b/OfficeIMO.Tests/Word.Hyperlinks.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -76,6 +76,8 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Sections[0].Bookmarks.Count == 1);
 
                 document.Save(false);
+
+                Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
             }
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "HyperlinksTests.docx"))) {

--- a/OfficeIMO.Tests/Word.Lists.cs
+++ b/OfficeIMO.Tests/Word.Lists.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml.Wordprocessing;
@@ -106,6 +106,8 @@ public partial class Word {
             Assert.Equal(28, section.Paragraphs.Count);
 
             document.Save(false);
+
+            Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
         }
 
         using (var document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists.docx"))) {
@@ -169,6 +171,8 @@ public partial class Word {
             Assert.Equal(45, section.Paragraphs.Count);
 
             document.Save();
+
+            Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
         }
 
         using (var document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists.docx"))) {
@@ -191,6 +195,8 @@ public partial class Word {
             Assert.Equal(45, section.Paragraphs.Count);
 
             document.Save();
+
+            Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
         }
     }
 
@@ -325,6 +331,8 @@ public partial class Word {
             Assert.Single(document.Sections[1].Lists);
 
             document.Save(false);
+
+            Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
         }
 
         using (var document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists2.docx"))) {
@@ -342,6 +350,8 @@ public partial class Word {
             Assert.Equal(2, document.Sections[1].Lists.Count);
 
             document.Save();
+
+            Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
         }
 
         using (var document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithLists2.docx"))) {
@@ -349,13 +359,15 @@ public partial class Word {
             Assert.Equal(5, document.Sections[0].Lists.Count);
             Assert.Equal(2, document.Sections[1].Lists.Count);
             document.Save();
+
+            Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
         }
     }
 
     [Fact]
     public void Test_SavingWordDocumentWithListsToStream() {
         var filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithListsToStream.docx");
-        var wordListStyles = (WordListStyle[]) Enum.GetValues(typeof(WordListStyle));
+        var wordListStyles = (WordListStyle[])Enum.GetValues(typeof(WordListStyle));
         using (var document = WordDocument.Create()) {
             foreach (var listStyle in wordListStyles) {
                 var paragraph = document.AddParagraph(listStyle.ToString());
@@ -369,6 +381,8 @@ public partial class Word {
             using var outputStream = new MemoryStream();
             document.Save(outputStream);
             File.WriteAllBytes(filePath, outputStream.ToArray());
+
+            Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
         }
 
         using (var document = WordDocument.Load(filePath)) {

--- a/OfficeIMO.Tests/Word.Margins.cs
+++ b/OfficeIMO.Tests/Word.Margins.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -62,6 +62,8 @@ namespace OfficeIMO.Tests {
                 Assert.True(section2.Paragraphs[0].Text == "Section 6");
 
                 document.Save(false);
+
+                Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithSectionsPageMargins2.docx"))) {
 

--- a/OfficeIMO.Tests/Word.PageSettings.cs
+++ b/OfficeIMO.Tests/Word.PageSettings.cs
@@ -1,4 +1,4 @@
-﻿using DocumentFormat.OpenXml.Wordprocessing;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using System.IO;
 using Xunit;
@@ -80,6 +80,8 @@ namespace OfficeIMO.Tests {
                 Assert.True(section2.Paragraphs[0].Text == "Section 6");
 
                 document.Save(false);
+
+                Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentPageSettings.docx"))) {
                 Assert.True(document.Sections[0].PageSettings.Orientation == PageOrientationValues.Landscape);

--- a/OfficeIMO.Tests/Word.Save.cs
+++ b/OfficeIMO.Tests/Word.Save.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using OfficeIMO.Word;
 using Xunit;
 
@@ -52,6 +52,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(File.Exists(filePath3));
                 Assert.True(filePath3.IsFileLocked());
+
+                Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
             }
 
             Assert.False(filePath1.IsFileLocked());
@@ -122,8 +124,7 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void Test_SaveToStream()
-        {
+        public void Test_SaveToStream() {
             var document = WordDocument.Create();
             document.AddParagraph("Hello world!");
 

--- a/OfficeIMO.Tests/Word.cs
+++ b/OfficeIMO.Tests/Word.cs
@@ -1,9 +1,12 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Office.CustomUI;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -27,6 +30,23 @@ namespace OfficeIMO.Tests {
             //_directoryDocuments = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "Tests", "TempDocuments");
             _directoryWithFiles = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TempDocuments2");
             Setup(_directoryWithFiles);
+        }
+
+        /// <summary>
+        /// This helps finding unexpected elements during validation
+        /// </summary>
+        /// <param name="document"></param>
+        /// <returns></returns>
+        public bool HasUnexpectedElements(WordDocument document) {
+            bool found = false;
+            foreach (var e in document.DocumentValidationErrors) {
+                if (e.Description.StartsWith("The element has unexpected child element")) {
+                    found = true;
+                    break;
+                }
+            }
+
+            return found;
         }
     }
 }

--- a/OfficeIMO.Tests/Word.cs
+++ b/OfficeIMO.Tests/Word.cs
@@ -33,7 +33,7 @@ namespace OfficeIMO.Tests {
         }
 
         /// <summary>
-        /// This helps finding unexpected elements during validation
+        /// This helps finding unexpected elements during validation. Should prevent unexpected changes
         /// </summary>
         /// <param name="document"></param>
         /// <returns></returns>
@@ -45,7 +45,6 @@ namespace OfficeIMO.Tests {
                     break;
                 }
             }
-
             return found;
         }
     }

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -712,14 +712,17 @@ namespace OfficeIMO.Word {
 
         public List<ValidationErrorInfo> DocumentValidationErrors {
             get {
-                List<ValidationErrorInfo> listErrors = new List<ValidationErrorInfo>();
-                OpenXmlValidator validator = new OpenXmlValidator();
-                foreach (ValidationErrorInfo error in validator.Validate(this._wordprocessingDocument)) {
-                    listErrors.Add(error);
-                }
-
-                return listErrors;
+                return ValidateDocument();
             }
+        }
+
+        public List<ValidationErrorInfo> ValidateDocument(FileFormatVersions fileFormatVersions = FileFormatVersions.Microsoft365) {
+            List<ValidationErrorInfo> listErrors = new List<ValidationErrorInfo>();
+            OpenXmlValidator validator = new OpenXmlValidator(fileFormatVersions);
+            foreach (ValidationErrorInfo error in validator.Validate(this._wordprocessingDocument)) {
+                listErrors.Add(error);
+            }
+            return listErrors;
         }
 
         public WordCompatibilitySettings CompatibilitySettings { get; set; }

--- a/OfficeIMO.Word/WordHyperLink.cs
+++ b/OfficeIMO.Word/WordHyperLink.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
@@ -202,8 +202,8 @@ namespace OfficeIMO.Word {
             if (addStyle) {
                 RunProperties runPropertiesHyperLink = new RunProperties(
                     new RunStyle { Val = "Hyperlink", },
-                    new Underline { Val = UnderlineValues.Single },
-                    new Color { ThemeColor = ThemeColorValues.Hyperlink }
+                    new Color { ThemeColor = ThemeColorValues.Hyperlink, Val = "0000FF" },
+                    new Underline { Val = UnderlineValues.Single }
                 );
                 run.RunProperties = runPropertiesHyperLink;
             }
@@ -246,12 +246,12 @@ namespace OfficeIMO.Word {
 
             // Styling for the hyperlink
             if (addStyle) {
-                RunProperties runPropertiesHyperLink = new RunProperties(
-                    new RunStyle { Val = "Hyperlink", },
-                    new Underline { Val = UnderlineValues.Single },
-                    new Color { ThemeColor = ThemeColorValues.Hyperlink }
-                );
-                run.RunProperties = runPropertiesHyperLink;
+                //RunProperties runPropertiesHyperLink = new RunProperties(
+                //    new RunStyle { Val = "Hyperlink", }
+                //    //new Underline { Val = UnderlineValues.Single }
+                //    //new Color { ThemeColor = ThemeColorValues.Hyperlink }
+                //);
+                //run.RunProperties = runPropertiesHyperLink;
             }
 
             if (tooltip != "") {


### PR DESCRIPTION
This PR solves:
- As part of one PR, we found that the order of elements matters and we didn't notice it during the PR assessment. This PR adds a check right after document saving if there are any unexpected child elements. This should temporary work as an easy way to detect problems. In the long run `document.ValidationErrors should be 0`, but so far we have some issues to solve first
- changes order of elements in Hyperlink for Color, adds missing Value
- Add method `ValidateDocument()` with ability to define file format. Default is Microsoft365.

