### PR TITLE
Allows applying custom styling to Hyperlinks

### DIFF
--- a/OfficeIMO.Examples/Word/HyperLinksAndFields/HyperLinks.BasicExample.cs
+++ b/OfficeIMO.Examples/Word/HyperLinksAndFields/HyperLinks.BasicExample.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -21,7 +22,10 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine(document.Sections[0].HyperLinks.Count);
                 document.AddParagraph("Test HYPERLINK ").AddHyperLink(" to website?", new Uri("https://evotec.xyz"), true);
 
-                document.AddParagraph("Test Email Address ").AddHyperLink("Przemysław Klys", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
+                var test = document.AddParagraph("Test Email Address ").AddHyperLink("Przemysław Klys", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"), true);
+                test.Bold = true;
+                test.Italic = true;
+                test.Underline = UnderlineValues.Dash;
 
                 document.AddPageBreak();
                 document.AddPageBreak();

--- a/OfficeIMO.Examples/Word/HyperLinksAndFields/HyperLinks.BasicExample.cs
+++ b/OfficeIMO.Examples/Word/HyperLinksAndFields/HyperLinks.BasicExample.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
+using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class HyperLinks {
@@ -22,24 +23,25 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine(document.Sections[0].HyperLinks.Count);
                 document.AddParagraph("Test HYPERLINK ").AddHyperLink(" to website?", new Uri("https://evotec.xyz"), true);
 
+                // this hyperlink will be styled with defaults, but then changed a bit
                 var test = document.AddParagraph("Test Email Address ").AddHyperLink("Przemysław Klys", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"), true);
                 test.Bold = true;
                 test.Italic = true;
                 test.Underline = UnderlineValues.Dash;
+                test.Color = Color.Green;
 
-                document.AddPageBreak();
-                document.AddPageBreak();
-
+                // this hyperlink will have no style at all
                 document.AddParagraph("Test HYPERLINK ").AddHyperLink(" to website?", new Uri("https://evotec.xyz"));
-                document.AddParagraph("Test HYPERLINK ").AddHyperLink(" to website?", new Uri("https://evotec.pl"));
+
+                // lets style next hyperlink with orange color and make it 20 in size
+                var anotherHyperlink = document.AddParagraph("Test HYPERLINK ").AddHyperLink(" to website?", new Uri("https://evotec.pl"));
+                anotherHyperlink.Color = Color.Orange;
+                anotherHyperlink.FontSize = 20;
 
                 //document.HyperLinks.Last().Remove();
 
                 document.AddParagraph("Test 2").AddBookmark("TestBookmark");
-
-
                 document.AddParagraph("Hello users! Please visit ").AddHyperLink("bookmark below", "TestBookmark", true, "This is link to bookmark below shown within Tooltip");
-
 
                 document.HyperLinks.Last().Uri = new Uri("https://evotec.pl");
                 document.HyperLinks.Last().Anchor = "";
@@ -49,6 +51,5 @@ namespace OfficeIMO.Examples.Word {
                 document.Save(openWord);
             }
         }
-
     }
 }

--- a/OfficeIMO.Tests/Word.Hyperlinks.cs
+++ b/OfficeIMO.Tests/Word.Hyperlinks.cs
@@ -8,6 +8,7 @@ using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using SemanticComparison;
 using Xunit;
+using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Tests {
     public partial class Word {
@@ -25,6 +26,25 @@ namespace OfficeIMO.Tests {
                 document.AddParagraph("Test 1");
 
                 var hyperlink = document.AddParagraph("Hello users! Please visit ").AddHyperLink("bookmark below", "TestBookmark", true, "This is link to bookmark below shown within Tooltip");
+
+                Assert.True(hyperlink.Underline == UnderlineValues.Single);
+                Assert.True(hyperlink.Bold == false);
+                Assert.True(hyperlink.Italic == false);
+                Assert.True(hyperlink.Color == Color.Blue);
+
+                hyperlink.Bold = true;
+                hyperlink.Italic = true;
+
+                Assert.True(hyperlink.Bold);
+                Assert.True(hyperlink.Italic);
+                Assert.True(hyperlink.Underline == UnderlineValues.Single);
+                Assert.True(hyperlink.Color == Color.Blue);
+
+                hyperlink.Color = Color.Red;
+                hyperlink.Underline = UnderlineValues.Dash;
+
+                Assert.True(hyperlink.Color == Color.Red);
+                Assert.True(hyperlink.Underline == UnderlineValues.Dash);
 
                 Assert.True(hyperlink.Hyperlink.Text == "bookmark below");
 
@@ -182,6 +202,107 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Sections[1].HyperLinks[1].History == false);
 
                 document.Save();
+            }
+        }
+
+        [Fact]
+        public void Test_CreatingWordWithHyperlinksVerification() {
+            using (WordDocument document =
+                   WordDocument.Create(Path.Combine(_directoryWithFiles, "HyperlinksTests.docx"))) {
+                Assert.True(document.Paragraphs.Count == 0);
+                Assert.True(document.Sections.Count == 1);
+                Assert.True(document.Fields.Count == 0);
+                Assert.True(document.HyperLinks.Count == 0);
+                Assert.True(document.ParagraphsHyperLinks.Count == 0);
+                Assert.True(document.Bookmarks.Count == 0);
+
+                var paragraph = document.AddParagraph("Test 1");
+                Assert.True(paragraph.Bold == false);
+
+                var hyperlink = document.AddParagraph("Hello users! Please visit ").AddHyperLink("bookmark below",
+                    "TestBookmark", true, "This is link to bookmark below shown within Tooltip");
+
+                Assert.True(hyperlink.Hyperlink._runProperties.Bold == null);
+
+                Assert.True(hyperlink.Underline == UnderlineValues.Single);
+                Assert.True(hyperlink.Bold == false);
+                Assert.True(hyperlink.Italic == false);
+                Assert.True(hyperlink.Color == Color.Blue);
+
+                hyperlink.Bold = true;
+                hyperlink.Italic = true;
+
+                Assert.True(hyperlink.Bold);
+                Assert.True(hyperlink.Italic);
+                Assert.True(hyperlink.Underline == UnderlineValues.Single);
+                Assert.True(hyperlink.Color == Color.Blue);
+
+                hyperlink.Color = Color.Red;
+                hyperlink.Underline = UnderlineValues.Dash;
+
+
+                var hyperlinkWithoutStyle = document.AddParagraph("Hello users! Please visit ").AddHyperLink("bookmark below",
+                    "TestBookmark", false, "This is link to bookmark below shown within Tooltip");
+
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties == null);
+
+                hyperlinkWithoutStyle.Bold = true;
+                Assert.True(hyperlinkWithoutStyle.Bold == true);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Bold != null);
+
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Italic == null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Underline == null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Color == null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Spacing == null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.FontSize == null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.RunFonts == null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Highlight == null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Strike == null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.DoubleStrike == null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Caps == null);
+
+                hyperlinkWithoutStyle.Bold = true;
+                hyperlinkWithoutStyle.Italic = true;
+                hyperlinkWithoutStyle.Color = Color.Red;
+                hyperlinkWithoutStyle.Underline = UnderlineValues.Dash;
+                hyperlinkWithoutStyle.Spacing = 2;
+                hyperlinkWithoutStyle.FontSize = 12;
+                hyperlinkWithoutStyle.FontFamily = "Arial";
+                hyperlinkWithoutStyle.Highlight = HighlightColorValues.Cyan;
+                hyperlinkWithoutStyle.Strike = true;
+                hyperlinkWithoutStyle.DoubleStrike = true;
+                hyperlinkWithoutStyle.CapsStyle = CapsStyle.SmallCaps;
+
+                Assert.True(hyperlinkWithoutStyle.Bold);
+                Assert.True(hyperlinkWithoutStyle.Italic);
+                Assert.True(hyperlinkWithoutStyle.Underline == UnderlineValues.Dash);
+                Assert.True(hyperlinkWithoutStyle.Color == Color.Red);
+                Assert.True(hyperlinkWithoutStyle.Spacing == 2);
+                Assert.True(hyperlinkWithoutStyle.FontSize == 12);
+                Assert.True(hyperlinkWithoutStyle.FontFamily == "Arial");
+                Assert.True(hyperlinkWithoutStyle.Highlight == HighlightColorValues.Cyan);
+                Assert.True(hyperlinkWithoutStyle.Strike);
+                Assert.True(hyperlinkWithoutStyle.DoubleStrike);
+                Assert.True(hyperlinkWithoutStyle.CapsStyle == CapsStyle.SmallCaps);
+
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Bold != null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Italic != null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Underline != null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Color != null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Spacing != null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.FontSize != null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.RunFonts != null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Highlight != null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Strike != null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.DoubleStrike != null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Caps == null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.SmallCaps != null);
+
+                hyperlinkWithoutStyle.CapsStyle = CapsStyle.Caps;
+
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Caps != null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.SmallCaps == null);
+
             }
         }
     }

--- a/OfficeIMO.Tests/Word.Hyperlinks.cs
+++ b/OfficeIMO.Tests/Word.Hyperlinks.cs
@@ -303,6 +303,8 @@ namespace OfficeIMO.Tests {
                 Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Caps != null);
                 Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.SmallCaps == null);
 
+                Assert.True(hyperlinkWithoutStyle.CapsStyle == CapsStyle.Caps);
+
             }
         }
     }

--- a/OfficeIMO.Word/WordHyperLink.cs
+++ b/OfficeIMO.Word/WordHyperLink.cs
@@ -28,7 +28,7 @@ namespace OfficeIMO.Word {
     public class WordHyperLink {
         private readonly WordDocument _document;
         private readonly Paragraph _paragraph;
-        private readonly Hyperlink _hyperlink;
+        internal readonly Hyperlink _hyperlink;
 
         public System.Uri Uri {
             get {
@@ -58,6 +58,18 @@ namespace OfficeIMO.Word {
             }
             set {
                 _hyperlink.Id = value;
+            }
+        }
+
+        internal Run _run {
+            get {
+                return _hyperlink.Descendants<Run>().FirstOrDefault();
+            }
+        }
+
+        internal RunProperties _runProperties {
+            get {
+                return _hyperlink.Descendants<RunProperties>().FirstOrDefault();
             }
         }
 

--- a/OfficeIMO.Word/WordParagraph.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PrivateMethods.cs
@@ -48,6 +48,37 @@ namespace OfficeIMO.Word {
             return this._run;
         }
 
+        internal Run VerifyRun(Paragraph paragraph, Run run) {
+            if (run == null) {
+                run = new Run();
+                paragraph.Append(run);
+            }
+            return run;
+        }
+
+        internal Run VerifyRun(Hyperlink hyperlink, Run run) {
+            if (run == null) {
+                run = new Run();
+                hyperlink.Append(run);
+            }
+            return run;
+        }
+
+        private RunProperties VerifyRunProperties(Hyperlink hyperlink, Run run, RunProperties runProperties) {
+            VerifyRun(hyperlink, run);
+            if (run != null) {
+                if (runProperties == null) {
+                    var text = run.ChildElements.OfType<Text>().FirstOrDefault();
+                    if (text != null) {
+                        text.InsertBeforeSelf(new RunProperties());
+                    } else {
+                        run.Append(new RunProperties());
+                    }
+                }
+            }
+            return runProperties;
+        }
+
         /// <summary>
         /// Check if runProperties exists in run, if not create run, create run properties and and append to run
         /// </summary>

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -1,4 +1,4 @@
-﻿using DocumentFormat.OpenXml.Wordprocessing;
+using DocumentFormat.OpenXml.Wordprocessing;
 using DocumentFormat.OpenXml;
 
 namespace OfficeIMO.Word {
@@ -6,23 +6,32 @@ namespace OfficeIMO.Word {
 
         public bool Bold {
             get {
-                if (_runProperties != null && _runProperties.Bold != null) {
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.Bold != null) {
                     return true;
                 } else {
                     return false;
                 }
             }
             set {
-                VerifyRunProperties();
-                if (value == true) {
-                    _runProperties.Bold = new Bold();
-                    _runProperties.BoldComplexScript = new BoldComplexScript();
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
                 } else {
-                    if (_runProperties.BoldComplexScript != null) {
-                        _runProperties.BoldComplexScript.Remove();
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
+                if (value == true) {
+                    runProperties.Bold = new Bold();
+                    runProperties.BoldComplexScript = new BoldComplexScript();
+                } else {
+                    if (runProperties.BoldComplexScript != null) {
+                        runProperties.BoldComplexScript.Remove();
                     }
-                    if (_runProperties.Bold != null) {
-                        _runProperties.Bold.Remove();
+
+                    if (runProperties.Bold != null) {
+                        runProperties.Bold.Remove();
                     }
                 }
             }
@@ -30,58 +39,82 @@ namespace OfficeIMO.Word {
 
         public bool Italic {
             get {
-                if (_runProperties != null && _runProperties.Italic != null) {
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.Italic != null) {
                     return true;
                 } else {
                     return false;
                 }
             }
             set {
-                VerifyRunProperties();
-                if (value != true) {
-                    _runProperties.Italic = null;
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
                 } else {
-                    _runProperties.Italic = new Italic { };
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
+                if (value != true) {
+                    runProperties.Italic = null;
+                } else {
+                    runProperties.Italic = new Italic { };
                 }
             }
         }
 
         public UnderlineValues? Underline {
             get {
-                if (_runProperties != null && _runProperties.Underline != null) {
-                    return _runProperties.Underline.Val;
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.Underline != null) {
+                    return runProperties.Underline.Val;
                 } else {
                     return null;
                 }
             }
             set {
-                VerifyRunProperties();
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
+                } else {
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
                 if (value != null) {
-                    if (_runProperties.Underline == null) {
-                        _runProperties.Underline = new Underline();
+                    if (runProperties.Underline == null) {
+                        runProperties.Underline = new Underline();
                     }
 
-                    _runProperties.Underline.Val = value;
+                    runProperties.Underline.Val = value;
                 } else {
-                    if (_runProperties.Underline != null) _runProperties.Underline.Remove();
+                    if (runProperties.Underline != null) runProperties.Underline.Remove();
                 }
             }
         }
 
         public bool DoNotCheckSpellingOrGrammar {
             get {
-                if (_runProperties != null && _runProperties.NoProof != null) {
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.NoProof != null) {
                     return true;
                 } else {
                     return false;
                 }
             }
             set {
-                VerifyRunProperties();
-                if (value != true) {
-                    if (_runProperties.NoProof != null) _runProperties.NoProof.Remove();
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
                 } else {
-                    _runProperties.NoProof = new NoProof();
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
+                if (value != true) {
+                    if (runProperties.NoProof != null) runProperties.NoProof.Remove();
+                } else {
+                    runProperties.NoProof = new NoProof();
                 }
             }
         }

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -341,8 +341,10 @@ namespace OfficeIMO.Word {
                     runProperties.SmallCaps = null;
                 } else if (value == CapsStyle.Caps) {
                     runProperties.Caps = new Caps();
+                    runProperties.SmallCaps = null;
                 } else if (value == CapsStyle.SmallCaps) {
                     runProperties.SmallCaps = new SmallCaps();
+                    runProperties.Caps = null;
                 }
             }
         }

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -121,76 +121,108 @@ namespace OfficeIMO.Word {
 
         public int? Spacing {
             get {
-                if (_runProperties != null && _runProperties.Spacing != null) {
-                    return _runProperties.Spacing.Val;
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.Spacing != null) {
+                    return runProperties.Spacing.Val;
                 } else {
                     return null;
                 }
             }
             set {
-                VerifyRunProperties();
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
+                } else {
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
                 if (value != null) {
                     Spacing spacing = new Spacing();
                     spacing.Val = value;
-                    _runProperties.Spacing = spacing;
+                    runProperties.Spacing = spacing;
                 } else {
-                    if (_runProperties.Spacing != null) _runProperties.Spacing.Remove();
+                    if (runProperties.Spacing != null) runProperties.Spacing.Remove();
                 }
             }
         }
 
         public bool Strike {
             get {
-                if (_runProperties != null && _runProperties.Strike != null) {
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.Strike != null) {
                     return true;
                 } else {
                     return false;
                 }
             }
             set {
-                VerifyRunProperties();
-                if (value != true) {
-                    if (_runProperties.Strike != null) _runProperties.Strike.Remove();
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
                 } else {
-                    _runProperties.Strike = new Strike();
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
+                if (value != true) {
+                    if (runProperties.Strike != null) runProperties.Strike.Remove();
+                } else {
+                    runProperties.Strike = new Strike();
                 }
             }
         }
 
         public bool DoubleStrike {
             get {
-                if (_runProperties != null && _runProperties.DoubleStrike != null) {
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.DoubleStrike != null) {
                     return true;
                 } else {
                     return false;
                 }
             }
             set {
-                VerifyRunProperties();
-                if (value != true) {
-                    if (_runProperties.DoubleStrike != null) _runProperties.DoubleStrike.Remove();
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
                 } else {
-                    _runProperties.DoubleStrike = new DoubleStrike();
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
+                if (value != true) {
+                    if (runProperties.DoubleStrike != null) runProperties.DoubleStrike.Remove();
+                } else {
+                    runProperties.DoubleStrike = new DoubleStrike();
                 }
             }
         }
         public int? FontSize {
             get {
-                if (_runProperties != null && _runProperties.FontSize != null) {
-                    var fontSizeInHalfPoint = int.Parse(_runProperties.FontSize.Val);
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.FontSize != null) {
+                    var fontSizeInHalfPoint = int.Parse(runProperties.FontSize.Val);
                     return fontSizeInHalfPoint / 2;
                 } else {
                     return null;
                 }
             }
             set {
-                VerifyRunProperties();
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
+                } else {
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
                 if (value != null) {
                     FontSize fontSize = new FontSize();
                     fontSize.Val = (value * 2).ToString();
-                    _runProperties.FontSize = fontSize;
+                    runProperties.FontSize = fontSize;
                 } else {
-                    if (_runProperties.FontSize != null) _runProperties.FontSize.Remove();
+                    if (runProperties.FontSize != null) runProperties.FontSize.Remove();
                 }
             }
         }
@@ -202,104 +234,140 @@ namespace OfficeIMO.Word {
 
         public string ColorHex {
             get {
-                if (_runProperties != null && _runProperties.Color != null) {
-                    return _runProperties.Color.Val;
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.Color != null) {
+                    return runProperties.Color.Val;
                 } else {
                     return "";
                 }
             }
             set {
-                VerifyRunProperties();
-                //string stringColor = value;
-                // var color = SixLabors.ImageSharp.Color.FromArgb(Convert.ToInt32(stringColor.Substring(0, 2), 16), Convert.ToInt32(stringColor.Substring(2, 2), 16), Convert.ToInt32(stringColor.Substring(4, 2), 16));
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
+                } else {
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
                 if (value != "") {
                     var color = new DocumentFormat.OpenXml.Wordprocessing.Color();
                     color.Val = value.Replace("#", "");
-                    _runProperties.Color = color;
+                    runProperties.Color = color;
                 } else {
-                    if (_runProperties.Color != null) _runProperties.Color.Remove();
+                    if (runProperties.Color != null) runProperties.Color.Remove();
                 }
             }
         }
 
         public ThemeColorValues? ThemeColor {
             get {
-                if (_runProperties != null && _runProperties.Color != null && _runProperties.Color.ThemeColor != null) {
-                    return _runProperties.Color.ThemeColor.Value;
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.Color != null && runProperties.Color.ThemeColor != null) {
+                    return runProperties.Color.ThemeColor.Value;
                 } else {
                     return null;
                 }
             }
             set {
-                VerifyRunProperties();
-                //string stringColor = value;
-                // var color = SixLabors.ImageSharp.Color.FromArgb(Convert.ToInt32(stringColor.Substring(0, 2), 16), Convert.ToInt32(stringColor.Substring(2, 2), 16), Convert.ToInt32(stringColor.Substring(4, 2), 16));
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
+                } else {
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
                 if (value != null) {
                     var color = new DocumentFormat.OpenXml.Wordprocessing.Color {
                         ThemeColor = new EnumValue<ThemeColorValues> {
                             Value = value.Value
                         }
                     };
-                    _runProperties.Color = color;
+                    runProperties.Color = color;
                 } else {
-                    if (_runProperties.Color != null) _runProperties.Color.Remove();
+                    if (runProperties.Color != null) runProperties.Color.Remove();
                 }
             }
         }
 
         public HighlightColorValues? Highlight {
             get {
-                if (_runProperties != null && _runProperties.Highlight != null) {
-                    return _runProperties.Highlight.Val;
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.Highlight != null) {
+                    return runProperties.Highlight.Val;
                 } else {
                     return null;
                 }
             }
             set {
-                VerifyRunProperties();
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
+                } else {
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
                 var highlight = new Highlight {
                     Val = value
                 };
-                _runProperties.Highlight = highlight;
+                runProperties.Highlight = highlight;
             }
         }
 
         public CapsStyle CapsStyle {
             get {
-                if (_runProperties != null && _runProperties.Caps != null) {
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.Caps != null) {
                     return CapsStyle.Caps;
-                } else if (_runProperties != null && _runProperties.SmallCaps != null) {
+                } else if (runProperties != null && runProperties.SmallCaps != null) {
                     return CapsStyle.SmallCaps;
                 } else {
                     return CapsStyle.None;
                 }
             }
             set {
-                VerifyRunProperties();
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
+                } else {
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
                 if (value == CapsStyle.None) {
-                    _runProperties.Caps = null;
-                    _runProperties.SmallCaps = null;
+                    runProperties.Caps = null;
+                    runProperties.SmallCaps = null;
                 } else if (value == CapsStyle.Caps) {
-                    _runProperties.Caps = new Caps();
+                    runProperties.Caps = new Caps();
                 } else if (value == CapsStyle.SmallCaps) {
-                    _runProperties.SmallCaps = new SmallCaps();
+                    runProperties.SmallCaps = new SmallCaps();
                 }
             }
         }
 
         public string FontFamily {
             get {
-                if (_runProperties != null && _runProperties.RunFonts != null) {
-                    return _runProperties.RunFonts.Ascii;
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.RunFonts != null) {
+                    return runProperties.RunFonts.Ascii;
                 } else {
                     return null;
                 }
             }
             set {
-                VerifyRunProperties();
-                var runFonts = new RunFonts();
-                runFonts.Ascii = value;
-                _runProperties.RunFonts = runFonts;
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
+                } else {
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
+                runProperties.RunFonts = new RunFonts {
+                    Ascii = value
+                };
             }
         }
     }


### PR DESCRIPTION
This PR aims to resolve
- #90 

Hyperlinks are a bit like Paragraphs. This means that they have their own Runs, Texts and RunProperties. This PR tries to address this. When users interacts with WordParagraph and the properties such as Bold, Italic (and so on) are applied, and the WordParagraph contains a HyperLink the style will be applied to Hyperlink instead of applying it to a new Run that would not have any impact on styling. 

```cs
internal static void Example_BasicWordWithHyperLinks(string folderPath, bool openWord) {
    Console.WriteLine("[*] Creating standard document with hyperlinks");
    string filePath = System.IO.Path.Combine(folderPath, "BasicDocumentHyperlinks.docx");
    using (WordDocument document = WordDocument.Create(filePath)) {
        document.AddParagraph("Test 1");

        document.AddParagraph("Hello users! Please visit ").AddHyperLink("bookmark below", "TestBookmark", true, "This is link to bookmark below shown within Tooltip");
        Console.WriteLine(document.HyperLinks.Count);
        Console.WriteLine(document.Sections[0].ParagraphsHyperLinks.Count);
        Console.WriteLine(document.ParagraphsHyperLinks.Count);
        Console.WriteLine(document.Sections[0].HyperLinks.Count);
        document.AddParagraph("Test HYPERLINK ").AddHyperLink(" to website?", new Uri("https://evotec.xyz"), true);

        // this hyperlink will be styled with defaults, but then changed a bit
        var test = document.AddParagraph("Test Email Address ").AddHyperLink("Przemysław Klys", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"), true);
        test.Bold = true;
        test.Italic = true;
        test.Underline = UnderlineValues.Dash;
        test.Color = Color.Green;

        // this hyperlink will have no style at all
        document.AddParagraph("Test HYPERLINK ").AddHyperLink(" to website?", new Uri("https://evotec.xyz"));

        // lets style next hyperlink with orange color and make it 20 in size
        var anotherHyperlink = document.AddParagraph("Test HYPERLINK ").AddHyperLink(" to website?", new Uri("https://evotec.pl"));
        anotherHyperlink.Color = Color.Orange;
        anotherHyperlink.FontSize = 20;

        //document.HyperLinks.Last().Remove();

        document.AddParagraph("Test 2").AddBookmark("TestBookmark");
        document.AddParagraph("Hello users! Please visit ").AddHyperLink("bookmark below", "TestBookmark", true, "This is link to bookmark below shown within Tooltip");

        document.HyperLinks.Last().Uri = new Uri("https://evotec.pl");
        document.HyperLinks.Last().Anchor = "";

        Console.WriteLine(document.HyperLinks.Count);

        document.Save(openWord);
    }
}
```

This supports basic Hyperlinks. It's possible for one hyperlink to be styled in a way where even every letter of it has it's own Run, Text, RunProperties, but supporting this in this simplified model seems a bit excessive. 
