### PR TITLE
Adds CleanupDocument method to merge same formatted runs

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -130,6 +130,8 @@ namespace OfficeIMO.Examples {
             Embed.Example_EmbedFileRTFandHTML(folderPath, templatesPath, false);
             Embed.Example_EmbedFileRTFandHTMLandTOC(folderPath, templatesPath, false);
             Embed.Example_EmbedFileMultiple(folderPath, templatesPath, false);
+
+            CleanupDocuments.CleanupDocuments_Sample01(true);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample01.cs
+++ b/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample01.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class CleanupDocuments {
+        public static void CleanupDocuments_Sample01(bool openWord) {
+            Console.WriteLine("[*] Load external Word Document - Sample 1");
+            string documentPaths = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "Templates");
+            string fullPath = System.IO.Path.Combine(documentPaths, "sample1.docx");
+            using (WordDocument document = WordDocument.Load(fullPath, false)) {
+                Console.WriteLine(fullPath);
+                Console.WriteLine("Sections count: " + document.Sections.Count);
+                Console.WriteLine("Tables count: " + document.Tables.Count);
+                Console.WriteLine("Paragraphs count: " + document.Paragraphs.Count);
+
+                var cleanupCount = document.CleanupDocument();
+
+                Console.WriteLine("Removed " + cleanupCount + " runs because of identical formatting.");
+
+                Console.WriteLine("Paragraphs count: " + document.Paragraphs.Count);
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/LoadDocuments/LoadDocuments.Sample1.cs
+++ b/OfficeIMO.Examples/Word/LoadDocuments/LoadDocuments.Sample1.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Examples.Word {
 
             string documentPaths = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "Templates");
             string fullPath = System.IO.Path.Combine(documentPaths, "sample1.docx");
-            using (WordDocument document = WordDocument.Load(System.IO.Path.Combine(documentPaths, "sample1.docx"), false)) {
+            using (WordDocument document = WordDocument.Load(fullPath, false)) {
                 Console.WriteLine(fullPath);
                 Console.WriteLine("Sections count: " + document.Sections.Count);
                 Console.WriteLine("Tables count: " + document.Tables.Count);

--- a/OfficeIMO.Tests/Word.Cleanup.cs
+++ b/OfficeIMO.Tests/Word.Cleanup.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_DocumentCleanupFeature() {
+            string filePath = Path.Combine(_directoryWithFiles, "SimpleWordDocumentReadyToCleanup.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+
+                document.AddParagraph("This is a text ").AddText("more text").AddText(" even longer text").AddText(" and even longer right?");
+
+                Assert.True(document.Paragraphs.Count == 4);
+
+                // since WordParagraph above are actually "Runs" with the same formatting cleanup will merge them as a single WordParagraph (single Run)
+                var changesCount = document.CleanupDocument();
+                Assert.True(changesCount == 3);
+
+                Assert.True(document.Paragraphs.Count == 1);
+
+                Assert.True(document.Paragraphs[0].Text == "This is a text more text even longer text and even longer right?");
+
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "SimpleWordDocumentReadyToCleanup.docx"))) {
+                Assert.True(document.Paragraphs.Count == 1);
+
+                Assert.True(document.Paragraphs[0].Text == "This is a text more text even longer text and even longer right?");
+
+                document.AddParagraph("This is a text 1 ").AddText("more text 1").AddText(" even longer text 1").AddText(" and even longer right?");
+
+                document.Paragraphs[3].Bold = true;
+                document.Paragraphs[4].Bold = true;
+
+                Assert.True(document.Paragraphs.Count == 5);
+
+                document.CleanupDocument();
+
+                Assert.True(document.Paragraphs.Count == 3);
+
+                Assert.True(document.Paragraphs[0].Text == "This is a text more text even longer text and even longer right?");
+                Assert.True(document.Paragraphs[1].Text == "This is a text 1 more text 1");
+                Assert.True(document.Paragraphs[2].Text == " even longer text 1 and even longer right?");
+
+
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "SimpleWordDocumentReadyToCleanup.docx"))) {
+
+                Assert.True(document.Paragraphs.Count == 3);
+
+                document.Save(false);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PrivateMethods.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+using System.Collections.Generic;
+using System.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word;
@@ -33,5 +35,43 @@ public partial class WordDocument {
 
     private Numbering GetNumbering() {
         return _wordprocessingDocument?.MainDocumentPart?.NumberingDefinitionsPart?.Numbering;
+    }
+
+    /// <summary>
+    /// Combines one or multiple Runs having same RunProperties into one Run
+    /// This is very useful to fix the issue of multiple runs with same formatting
+    /// that word creates without user noticing.
+    /// </summary>
+    /// <param name="paragraph"></param>
+    private static int CombineIdenticalRuns(Paragraph paragraph) {
+        List<Run> runsToRemove = new List<Run>();
+        List<Run> runs = paragraph.Elements<Run>().ToList();
+        for (int i = runs.Count - 2; i >= 0; i--) {
+            Text text1 = runs[i].GetFirstChild<Text>();
+            Text text2 = runs[i + 1].GetFirstChild<Text>();
+            if (text1 != null && text2 != null) {
+                string rPr1 = "";
+                string rPr2 = "";
+                if (runs[i].RunProperties != null) rPr1 = runs[i].RunProperties.OuterXml;
+                if (runs[i + 1].RunProperties != null) rPr2 = runs[i + 1].RunProperties.OuterXml;
+                if (rPr1 == rPr2) {
+                    text1.Text += text2.Text;
+
+                    // if the text doesn't have space preservation, during merge potential double spaces
+                    // or start/ending spaces could be removed which will mean the view won't be so pretty
+                    if (text1.Space == null) {
+                        text1.Space = SpaceProcessingModeValues.Preserve;
+                    }
+                    runsToRemove.Add(runs[i + 1]);
+                }
+            }
+        }
+
+        var count = 0;
+        foreach (Run run in runsToRemove) {
+            run.Remove();
+            count++;
+        }
+        return count;
     }
 }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -147,6 +147,8 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// This method will combine identical runs in a paragraph.
         /// This is useful when you have a paragraph with multiple runs of the same style, that Microsoft Word creates.
+        /// This feature is *EXPERIMENTAL* and may not work in all cases.
+        /// It may impact on how your document looks like, please do extensive testing before using this feature.
         /// </summary>
         /// <returns></returns>
         public int CleanupDocument() {

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
-using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 
@@ -144,6 +142,65 @@ namespace OfficeIMO.Word {
         public WordEmbeddedDocument AddEmbeddedDocument(string fileName, AlternativeFormatImportPartType? type = null) {
             WordEmbeddedDocument embeddedDocument = new WordEmbeddedDocument(this, fileName, type);
             return embeddedDocument;
+        }
+
+        /// <summary>
+        /// This method will combine identical runs in a paragraph.
+        /// This is useful when you have a paragraph with multiple runs of the same style, that Microsoft Word creates.
+        /// </summary>
+        /// <returns></returns>
+        public int CleanupDocument() {
+            int count = 0;
+
+            foreach (var paragraph in this.Paragraphs) {
+                count += CombineIdenticalRuns(paragraph._paragraph);
+            }
+
+            foreach (var table in this.Tables) {
+                table.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+            }
+
+            if (this.Header.Default != null) {
+                foreach (var p in this.Header.Default.Paragraphs) count += CombineIdenticalRuns(p._paragraph);
+                foreach (var table in this.Header.Default.Tables) {
+                    table.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+                }
+            }
+
+            if (this.Header.Even != null) {
+                this.Header.Even.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+                foreach (var table in this.Header.Even.Tables) {
+                    table.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+                }
+            }
+            if (this.Header.First != null) {
+                this.Header.First.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+                foreach (var table in this.Header.First.Tables) {
+                    table.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+                }
+            }
+
+            if (this.Footer.Default != null) {
+                this.Footer.Default.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+                foreach (var table in this.Footer.Default.Tables) {
+                    table.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+                }
+            }
+
+            if (this.Footer.Even != null) {
+                this.Footer.Even.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+                foreach (var table in this.Footer.Even.Tables) {
+                    table.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+                }
+            }
+
+            if (this.Footer.First != null) {
+                this.Footer.First.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+                foreach (var table in this.Footer.First.Tables) {
+                    table.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+                }
+            }
+            return count;
         }
     }
 }


### PR DESCRIPTION
This PR adds CleanupDocument() method so one can apply the cleaning up of existing or new documents. Microsoft Word, when you add bold, change color or similar will create separate runs to keep text. This is expected and something that keeps documents nicely formatted. However Microsoft Word for unknown reasons also sometimes adds new Runs that have very same formatting. I guess it could be user changed their mind when it comes to formatting and what was bold now isn't bold anymore.

For example: This is **very** long **line** **of** **text** - that would most likely translate into 7 runs in Microsoft Word OpenXml. So even tho the text line of text is BOLD all the way, it would treat it as 3 separate Runs. While this is ok, most of the time, it becomes really complicated when trying to fine existence of "line of text" within document. Because you are not searching for a single Text, but text split over multiple WordParagraphs. This becomes even more problematic if you add bold, then remove bold and it still stays 7 Runs, while in the Word document it looks like a single line of text. 


```cs
public static void CleanupDocuments_Sample01(bool openWord) {
    Console.WriteLine("[*] Load external Word Document - Sample 1");
    string fullPath = "C:\PathToFile";
    using (WordDocument document = WordDocument.Load(fullPath, false)) {
        Console.WriteLine(fullPath);
        Console.WriteLine("Sections count: " + document.Sections.Count);
        Console.WriteLine("Tables count: " + document.Tables.Count);
        Console.WriteLine("Paragraphs count: " + document.Paragraphs.Count);

        foreach (var paragraph in document.Paragraphs) {
            if (paragraph.Text.StartsWith("You can do")) {
                paragraph.Text = "Maybe you can't!";
            }
        }

        var cleanupCount = document.CleanupDocument();

        Console.WriteLine("Removed " + cleanupCount + " runs because of identical formatting.");

        document.Save(@"C:\SaveAsDifferent123file.docx", openWord);
    }
}
```
