### PR TITLE
Fixes Color to return Null instead throw an error

### DIFF
--- a/OfficeIMO.Examples/Word/Paragraphs/Paragraphs.BasicExample.cs
+++ b/OfficeIMO.Examples/Word/Paragraphs/Paragraphs.BasicExample.cs
@@ -1,7 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
-using SixLabors.ImageSharp;
 using Color = SixLabors.ImageSharp.Color;
 
 internal static partial class Paragraphs {
@@ -13,9 +12,11 @@ internal static partial class Paragraphs {
             var paragraph = document.AddParagraph("Basic paragraph - Page 4");
             paragraph.ParagraphAlignment = JustificationValues.Center;
             paragraph.Color = SixLabors.ImageSharp.Color.Blue;
+            paragraph.AddText(" This is continutation in the same line");
+            paragraph.AddBreak(BreakValues.TextWrapping);
+            paragraph.AddText(" This is continuation, in another line").SetUnderline(UnderlineValues.Double).SetFontSize(15).SetColor(Color.Yellow).SetHighlight(HighlightColorValues.DarkGreen);
 
-            paragraph.AddText(" This is continuation").SetUnderline(UnderlineValues.Double).SetFontSize(15).SetColor(Color.Yellow).SetHighlight(HighlightColorValues.DarkGreen);
-
+            var paragraph1 = document.AddParagraph("Here's another paragraph ").AddText(" which continues here, but will continue in another line ").AddBreak(BreakValues.TextWrapping).AddText("to confirm that breaks with TextWrapping is working properly");
 
             Console.WriteLine("+ Color: " + paragraph.Color);
             Console.WriteLine("+ Color 0: " + document.Paragraphs[0].Color);

--- a/OfficeIMO.Tests/Word.Breaks.cs
+++ b/OfficeIMO.Tests/Word.Breaks.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.IO;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using Xunit;
+using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Tests {
     public partial class Word {
@@ -106,6 +107,30 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Sections[0].Breaks.Count == 7);
                 Assert.True(document.Sections[0].ParagraphsPageBreaks.Count == 1);
                 Assert.True(document.Sections[0].ParagraphsBreaks.Count == 7);
+
+                document.Save(false);
+            }
+        }
+        [Fact]
+        public void Test_BasicWordWithDifferentBreaks() {
+            var filePath = Path.Combine(_directoryWithFiles, "BasicWordWithBreaksDifferent.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Basic paragraph - Page 4");
+                paragraph.ParagraphAlignment = JustificationValues.Center;
+                paragraph.Color = SixLabors.ImageSharp.Color.Blue;
+                paragraph.AddText(" This is continutation in the same line");
+                paragraph.AddBreak(BreakValues.TextWrapping);
+                paragraph.AddText(" This is continuation, in another line").SetUnderline(UnderlineValues.Double).SetFontSize(15).SetColor(Color.Yellow).SetHighlight(HighlightColorValues.DarkGreen);
+
+                var paragraph1 = document.AddParagraph("Here's another paragraph ").AddText(" which continues here, but will continue in another line ").AddBreak(BreakValues.TextWrapping).AddText("to confirm that breaks with TextWrapping is working properly");
+
+                Assert.True(paragraph.Color == SixLabors.ImageSharp.Color.Blue);
+                Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Blue);
+                Assert.True(document.Paragraphs[1].Color == null);
+                Assert.True(document.Paragraphs[2].IsBreak == true);
+                Assert.True(document.Paragraphs[2].Break.BreakType == BreakValues.TextWrapping);
+                Assert.True(document.Sections.Count == 1);
+                Assert.True(document.Sections[0].Paragraphs.Count == 8);
 
                 document.Save(false);
             }

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -227,9 +227,19 @@ namespace OfficeIMO.Word {
             }
         }
 
-        public SixLabors.ImageSharp.Color Color {
-            get { return SixLabors.ImageSharp.Color.Parse("#" + ColorHex); }
-            set { this.ColorHex = value.ToHexColor(); }
+        public SixLabors.ImageSharp.Color? Color {
+            get {
+                if (ColorHex == "") {
+                    return null;
+                }
+                return SixLabors.ImageSharp.Color.Parse("#" + ColorHex);
+
+            }
+            set {
+                if (value != null) {
+                    this.ColorHex = value.Value.ToHexColor();
+                }
+            }
         }
 
         public string ColorHex {


### PR DESCRIPTION
Fixes:
- https://github.com/EvotecIT/OfficeIMO/issues/113

Adds tests:
- for Color (null)
- for Break (TextWrapping)