### PR TITLE
[Possibly breaking change] Set HighAnsi, EastAsia and ComplexScript at the same time as FontFamily

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -21,7 +21,8 @@ namespace OfficeIMO.Examples {
             BasicDocument.Example_BasicWordWithBreaks(folderPath, false);
             BasicDocument.Example_BasicWordWithDefaultStyleChange(folderPath, false);
             BasicDocument.Example_BasicWordWithDefaultFontChange(folderPath, false);
-            BasicDocument.Example_BasicLoadHamlet(templatesPath, folderPath, true);
+            BasicDocument.Example_BasicLoadHamlet(templatesPath, folderPath, false);
+            BasicDocument.Example_BasicWordWithPolishChars(folderPath, false);
 
             AdvancedDocument.Example_AdvancedWord(folderPath, false);
             AdvancedDocument.Example_AdvancedWord2(folderPath, false);

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.CreateFontFamily.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.CreateFontFamily.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class BasicDocument {
+        public static void Example_BasicWordWithPolishChars(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating standard document with polish chars");
+            string filePath = System.IO.Path.Combine(folderPath, "BasicDocumentWithPolishChars.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Adding paragraph with some text with special chars to check if FontFamily works correctly for those");
+
+                paragraph.Color = SixLabors.ImageSharp.Color.Red;
+
+                // this is only a test of setting FontFamily per paragraph. Please use document.Settings.FontFamily to set it per document.
+                paragraph = document.AddParagraph("Wszedł kot do domu, gdzie były różne buty. ");
+                paragraph.FontFamily = "Courier New";
+                paragraph = paragraph.AddText("Chodził tak sobie i chodził, i się nachodził. ");
+                paragraph.FontFamily = "Courier New";
+                paragraph = paragraph.AddText("A potem jeszcze pochodził, i wąchał. A wszystko to nagrało życie. ");
+                paragraph.FontFamily = "Courier New";
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.CreateFontFamily.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.CreateFontFamily.cs
@@ -23,6 +23,12 @@ namespace OfficeIMO.Examples.Word {
                 paragraph.FontFamily = "Courier New";
                 paragraph = paragraph.AddText("A potem jeszcze pochodził, i wąchał. A wszystko to nagrało życie. ");
                 paragraph.FontFamily = "Courier New";
+
+                paragraph = document.AddParagraph("English العربية");
+                paragraph.FontFamily = "Courier New"; // overwrites all styles
+                paragraph.FontFamilyEastAsia = "Arial"; // to change east asia font family
+                paragraph.FontFamilyHighAnsi = "Arial"; // to change high ansi font family
+                paragraph.FontFamilyComplexScript = "Arial"; // to change complex script font family
                 document.Save(openWord);
             }
         }

--- a/OfficeIMO.Tests/Word.Paragraphs.cs
+++ b/OfficeIMO.Tests/Word.Paragraphs.cs
@@ -18,6 +18,7 @@ namespace OfficeIMO.Tests {
                 paragraph.ParagraphAlignment = JustificationValues.Center;
                 paragraph.Color = SixLabors.ImageSharp.Color.Blue;
 
+                // set font family sets it for FontFamily, FontFamilyEastAsia, FontFamilyHighAnsi and FontFamilyComplexScript
                 paragraph.SetBold().SetFontFamily("Tahoma");
                 paragraph.AddText(" This is continuation").SetUnderline(UnderlineValues.Double).SetFontSize(15).SetColor(Color.Yellow).SetHighlight(HighlightColorValues.DarkGreen);
 
@@ -27,6 +28,39 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Blue, "1st paragraph color should be the same");
                 Assert.True(document.Paragraphs[0].Bold == true, "Basic paragraph - Page 1");
                 Assert.True(document.Paragraphs[0].FontFamily == "Tahoma", "1st paragraph should be set with Tahoma");
+                Assert.True(document.Paragraphs[0].FontFamilyEastAsia == "Tahoma");
+                Assert.True(document.Paragraphs[0].FontFamilyHighAnsi == "Tahoma");
+                Assert.True(document.Paragraphs[0].FontFamilyComplexScript == "Tahoma");
+
+                paragraph.FontFamilyEastAsia = "Arial";
+
+                Assert.True(document.Paragraphs[0].FontFamily == "Tahoma", "1st paragraph should be set with Tahoma");
+                Assert.True(document.Paragraphs[0].FontFamilyEastAsia == "Arial");
+                Assert.True(document.Paragraphs[0].FontFamilyHighAnsi == "Tahoma");
+                Assert.True(document.Paragraphs[0].FontFamilyComplexScript == "Tahoma");
+
+                paragraph.FontFamilyHighAnsi = "Calibri";
+
+                Assert.True(document.Paragraphs[0].FontFamily == "Tahoma", "1st paragraph should be set with Tahoma");
+                Assert.True(document.Paragraphs[0].FontFamilyEastAsia == "Arial");
+                Assert.True(document.Paragraphs[0].FontFamilyHighAnsi == "Calibri");
+                Assert.True(document.Paragraphs[0].FontFamilyComplexScript == "Tahoma");
+
+                paragraph.FontFamilyEastAsia = null;
+
+                Assert.True(document.Paragraphs[0].FontFamily == "Tahoma", "1st paragraph should be set with Tahoma");
+                Assert.True(document.Paragraphs[0].FontFamilyEastAsia == null);
+                Assert.True(document.Paragraphs[0].FontFamilyHighAnsi == "Calibri");
+                Assert.True(document.Paragraphs[0].FontFamilyComplexScript == "Tahoma");
+
+                paragraph.FontFamilyEastAsia = null;
+                paragraph.FontFamilyComplexScript = null;
+                paragraph.FontFamilyHighAnsi = null;
+
+                Assert.True(document.Paragraphs[0].FontFamily == "Tahoma", "1st paragraph should be set with Tahoma");
+                Assert.True(document.Paragraphs[0].FontFamilyEastAsia == null);
+                Assert.True(document.Paragraphs[0].FontFamilyHighAnsi == null);
+                Assert.True(document.Paragraphs[0].FontFamilyComplexScript == null);
 
                 Assert.True(document.Paragraphs[1].ColorHex == SixLabors.ImageSharp.Color.Yellow.ToHexColor(), "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[1].Color);
                 Assert.True(document.Paragraphs[1].Color == SixLabors.ImageSharp.Color.Yellow, "2nd paragraph color should be " + SixLabors.ImageSharp.Color.Yellow.ToHexColor() + " Was: " + document.Paragraphs[1].Color);

--- a/OfficeIMO.Tests/Word.Settings.cs
+++ b/OfficeIMO.Tests/Word.Settings.cs
@@ -56,14 +56,36 @@ namespace OfficeIMO.Tests {
                 document.Settings.FontFamily = "Courier New";
 
                 Assert.True(document.Settings.FontFamily == "Courier New");
+                Assert.True(document.Settings.FontFamilyEastAsia == "Courier New");
+                Assert.True(document.Settings.FontFamilyComplexScript == "Courier New");
+                Assert.True(document.Settings.FontFamilyHighAnsi == "Courier New");
 
-                document.Settings.FontFamilyHighAnsi = "Courier New";
+                document.Settings.FontFamilyHighAnsi = "Arial";
+                Assert.True(document.Settings.FontFamilyHighAnsi == "Arial");
+                Assert.True(document.Settings.FontFamily == "Courier New");
+                Assert.True(document.Settings.FontFamilyEastAsia == "Courier New");
+                Assert.True(document.Settings.FontFamilyComplexScript == "Courier New");
+
+                document.Settings.FontFamily = "Times New Roman";
+                Assert.True(document.Settings.FontFamily == "Times New Roman");
+                Assert.True(document.Settings.FontFamilyHighAnsi == "Times New Roman");
+                Assert.True(document.Settings.FontFamilyEastAsia == "Times New Roman");
+                Assert.True(document.Settings.FontFamilyComplexScript == "Times New Roman");
+
+                document.Settings.FontFamilyHighAnsi = "Arial";
+                Assert.True(document.Settings.FontFamilyHighAnsi == "Arial");
+                Assert.True(document.Settings.FontFamily == "Times New Roman");
+                Assert.True(document.Settings.FontFamilyEastAsia == "Times New Roman");
+                Assert.True(document.Settings.FontFamilyComplexScript == "Times New Roman");
+
+                document.Settings.FontFamilyEastAsia = null;
+                Assert.True(document.Settings.FontFamilyEastAsia == null);
+
+                document.Settings.FontFamilyComplexScript = null;
+                Assert.True(document.Settings.FontFamilyComplexScript == null);
 
                 document.CompatibilitySettings.CompatibilityMode = CompatibilityMode.Word2003;
                 Assert.True(document.CompatibilitySettings.CompatibilityMode == CompatibilityMode.Word2003);
-
-
-                Assert.True(document.Settings.FontFamilyHighAnsi == "Courier New");
 
                 document.Save(false);
             }
@@ -72,7 +94,7 @@ namespace OfficeIMO.Tests {
                 document.CompatibilitySettings.CompatibilityMode = CompatibilityMode.Word2007;
                 Assert.True(document.CompatibilitySettings.CompatibilityMode == CompatibilityMode.Word2007);
 
-                Assert.True(document.Settings.FontFamilyHighAnsi == "Courier New");
+                Assert.True(document.Settings.FontFamilyHighAnsi == "Arial");
                 Assert.True(document.Settings.Language == "pl-PL");
 
                 document.Settings.Language = "en-US";
@@ -99,9 +121,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(document.Settings.FontSizeComplexScript == 20);
                 Assert.True(document.Settings.FontSize == 30);
-                Assert.True(document.Settings.FontFamily == "Courier New");
+                Assert.True(document.Settings.FontFamily == "Times New Roman");
 
-                document.Settings.FontFamily = "Arial Narrow";
                 document.Settings.FontFamilyHighAnsi = "Abadi";
 
                 document.Save();
@@ -111,9 +132,8 @@ namespace OfficeIMO.Tests {
                 document.CompatibilitySettings.CompatibilityMode = CompatibilityMode.Word2010;
                 Assert.True(document.CompatibilitySettings.CompatibilityMode == CompatibilityMode.Word2010);
 
-
                 Assert.True(document.Settings.FontFamilyHighAnsi == "Abadi");
-                Assert.True(document.Settings.FontFamily == "Arial Narrow");
+                Assert.True(document.Settings.FontFamily == "Times New Roman");
 
                 Assert.True(document.Settings.ProtectionType == null);
                 Assert.True(document.Settings.BackgroundColor == "FFA07A");

--- a/OfficeIMO.Tests/Word.Settings.cs
+++ b/OfficeIMO.Tests/Word.Settings.cs
@@ -101,8 +101,8 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Settings.FontSize == 30);
                 Assert.True(document.Settings.FontFamily == "Courier New");
 
-                document.Settings.FontFamilyHighAnsi = "Abadi";
                 document.Settings.FontFamily = "Arial Narrow";
+                document.Settings.FontFamilyHighAnsi = "Abadi";
 
                 document.Save();
             }
@@ -112,8 +112,8 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.CompatibilitySettings.CompatibilityMode == CompatibilityMode.Word2010);
 
 
-                Assert.True(document.Settings.FontFamily == "Arial Narrow");
                 Assert.True(document.Settings.FontFamilyHighAnsi == "Abadi");
+                Assert.True(document.Settings.FontFamily == "Arial Narrow");
 
                 Assert.True(document.Settings.ProtectionType == null);
                 Assert.True(document.Settings.BackgroundColor == "FFA07A");

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -359,6 +359,14 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// FontFamily gets and sets the FontFamily of a WordParagraph.
+        /// To make sure that FontFamily works correctly on special characters
+        /// we change the RunFonts.Ascii and RunFonts.HighAnsi, EastAsia and ComplexScript properties
+        /// If you want to set different FontFamily for HighAnsi, EastAsia and ComplexScript
+        /// please use FontFamilyHighAnsi, FontFamilyEastAsia or FontFamilyComplexScript
+        /// in proper order (to overwrite given FontFamily)
+        /// </summary>
         public string FontFamily {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -377,9 +385,111 @@ namespace OfficeIMO.Word {
                     VerifyRunProperties();
                     runProperties = _runProperties;
                 }
-                runProperties.RunFonts = new RunFonts {
-                    Ascii = value
-                };
+
+                if (runProperties.RunFonts == null) {
+                    runProperties.RunFonts = new RunFonts { };
+                }
+
+                if (value == "") {
+                    runProperties.RunFonts.Ascii = null;
+                } else {
+                    runProperties.RunFonts.Ascii = value;
+                    // we set the same font for HighAnsi as well, because in 90% cases it's required for special characters
+                    // and it should be the same
+                    runProperties.RunFonts.HighAnsi = value;
+                    runProperties.RunFonts.ComplexScript = value;
+                    runProperties.RunFonts.EastAsia = value;
+                }
+            }
+        }
+
+        public string FontFamilyHighAnsi {
+            get {
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.RunFonts != null) {
+                    return runProperties.RunFonts.HighAnsi;
+                } else {
+                    return null;
+                }
+            }
+            set {
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
+                } else {
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
+                if (runProperties.RunFonts == null) {
+                    runProperties.RunFonts = new RunFonts { };
+                }
+
+                if (value == "") {
+                    runProperties.RunFonts.HighAnsi = null;
+                } else {
+                    runProperties.RunFonts.HighAnsi = value;
+                }
+            }
+        }
+
+        public string FontFamilyEastAsia {
+            get {
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.RunFonts != null) {
+                    return runProperties.RunFonts.EastAsia;
+                } else {
+                    return null;
+                }
+            }
+            set {
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
+                } else {
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
+                if (runProperties.RunFonts == null) {
+                    runProperties.RunFonts = new RunFonts { };
+                }
+
+                if (value == "") {
+                    runProperties.RunFonts.EastAsia = null;
+                } else {
+                    runProperties.RunFonts.EastAsia = value;
+                }
+            }
+        }
+
+        public string FontFamilyComplexScript {
+            get {
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.RunFonts != null) {
+                    return runProperties.RunFonts.ComplexScript;
+                } else {
+                    return null;
+                }
+            }
+            set {
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
+                } else {
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
+                if (runProperties.RunFonts == null) {
+                    runProperties.RunFonts = new RunFonts { };
+                }
+
+                if (value == "") {
+                    runProperties.RunFonts.ComplexScript = null;
+                } else {
+                    runProperties.RunFonts.ComplexScript = value;
+                }
             }
         }
     }

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml.Wordprocessing;
 using DocumentFormat.OpenXml;
 
@@ -390,7 +391,7 @@ namespace OfficeIMO.Word {
                     runProperties.RunFonts = new RunFonts { };
                 }
 
-                if (value == "") {
+                if (string.IsNullOrEmpty(value)) {
                     runProperties.RunFonts.Ascii = null;
                 } else {
                     runProperties.RunFonts.Ascii = value;
@@ -425,7 +426,7 @@ namespace OfficeIMO.Word {
                     runProperties.RunFonts = new RunFonts { };
                 }
 
-                if (value == "") {
+                if (string.IsNullOrEmpty(value)) {
                     runProperties.RunFonts.HighAnsi = null;
                 } else {
                     runProperties.RunFonts.HighAnsi = value;
@@ -455,7 +456,7 @@ namespace OfficeIMO.Word {
                     runProperties.RunFonts = new RunFonts { };
                 }
 
-                if (value == "") {
+                if (string.IsNullOrEmpty(value)) {
                     runProperties.RunFonts.EastAsia = null;
                 } else {
                     runProperties.RunFonts.EastAsia = value;
@@ -485,7 +486,7 @@ namespace OfficeIMO.Word {
                     runProperties.RunFonts = new RunFonts { };
                 }
 
-                if (value == "") {
+                if (string.IsNullOrEmpty(value)) {
                     runProperties.RunFonts.ComplexScript = null;
                 } else {
                     runProperties.RunFonts.ComplexScript = value;

--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -351,7 +351,11 @@ namespace OfficeIMO.Word {
                         runPropertiesBaseStyle.RunFonts = new RunFonts() { AsciiTheme = ThemeFontValues.MinorHighAnsi, HighAnsiTheme = ThemeFontValues.MinorHighAnsi, EastAsiaTheme = ThemeFontValues.MinorHighAnsi, ComplexScriptTheme = ThemeFontValues.MinorBidi };
                     }
                     // we also need to change it in highAnsi to fix https://github.com/EvotecIT/OfficeIMO/issues/54
-                    runPropertiesBaseStyle.RunFonts.HighAnsi = value;
+                    if (string.IsNullOrEmpty(value)) {
+                        runPropertiesBaseStyle.RunFonts.HighAnsi = null;
+                    } else {
+                        runPropertiesBaseStyle.RunFonts.HighAnsi = value;
+                    }
                     runPropertiesBaseStyle.RunFonts.HighAnsiTheme = null;
                 } else {
                     throw new Exception("Could not set font family. Styles not found.");
@@ -380,7 +384,11 @@ namespace OfficeIMO.Word {
                     if (runPropertiesBaseStyle.RunFonts == null) {
                         runPropertiesBaseStyle.RunFonts = new RunFonts() { AsciiTheme = ThemeFontValues.MinorHighAnsi, HighAnsiTheme = ThemeFontValues.MinorHighAnsi, EastAsiaTheme = ThemeFontValues.MinorHighAnsi, ComplexScriptTheme = ThemeFontValues.MinorBidi };
                     }
-                    runPropertiesBaseStyle.RunFonts.EastAsia = value;
+                    if (string.IsNullOrEmpty(value)) {
+                        runPropertiesBaseStyle.RunFonts.EastAsia = null;
+                    } else {
+                        runPropertiesBaseStyle.RunFonts.EastAsia = value;
+                    }
                     runPropertiesBaseStyle.RunFonts.EastAsiaTheme = null;
                 } else {
                     throw new Exception("Could not set font family. Styles not found.");
@@ -409,7 +417,11 @@ namespace OfficeIMO.Word {
                     if (runPropertiesBaseStyle.RunFonts == null) {
                         runPropertiesBaseStyle.RunFonts = new RunFonts() { AsciiTheme = ThemeFontValues.MinorHighAnsi, HighAnsiTheme = ThemeFontValues.MinorHighAnsi, EastAsiaTheme = ThemeFontValues.MinorHighAnsi, ComplexScriptTheme = ThemeFontValues.MinorBidi };
                     }
-                    runPropertiesBaseStyle.RunFonts.ComplexScript = value;
+                    if (string.IsNullOrEmpty(value)) {
+                        runPropertiesBaseStyle.RunFonts.ComplexScript = null;
+                    } else {
+                        runPropertiesBaseStyle.RunFonts.ComplexScript = value;
+                    }
                     runPropertiesBaseStyle.RunFonts.ComplexScriptTheme = null;
                 } else {
                     throw new Exception("Could not set font family. Styles not found.");

--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -313,6 +313,9 @@ namespace OfficeIMO.Word {
                     // we need to reset default AsciiTheme, before applying Ascii
                     runPropertiesBaseStyle.RunFonts.AsciiTheme = null;
                     runPropertiesBaseStyle.RunFonts.Ascii = value;
+                    // we also set highAnsi to the same value
+                    runPropertiesBaseStyle.RunFonts.HighAnsi = value;
+                    runPropertiesBaseStyle.RunFonts.HighAnsiTheme = null;
                 } else {
                     throw new Exception("Could not set font family. Styles not found.");
                 }

--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -313,9 +313,15 @@ namespace OfficeIMO.Word {
                     // we need to reset default AsciiTheme, before applying Ascii
                     runPropertiesBaseStyle.RunFonts.AsciiTheme = null;
                     runPropertiesBaseStyle.RunFonts.Ascii = value;
-                    // we also set highAnsi to the same value
+                    // we also set HighAnsi to the same value
                     runPropertiesBaseStyle.RunFonts.HighAnsi = value;
                     runPropertiesBaseStyle.RunFonts.HighAnsiTheme = null;
+                    // we also set EastAsia to the same value
+                    runPropertiesBaseStyle.RunFonts.EastAsia = value;
+                    runPropertiesBaseStyle.RunFonts.EastAsiaTheme = null;
+                    // we also set ComplexScript to the same value
+                    runPropertiesBaseStyle.RunFonts.ComplexScript = value;
+                    runPropertiesBaseStyle.RunFonts.ComplexScriptTheme = null;
                 } else {
                     throw new Exception("Could not set font family. Styles not found.");
                 }
@@ -323,7 +329,7 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
-        /// Gets or Sets default font family for the whole document in highAnsi.
+        /// Gets or Sets default font family for the whole document in HighAnsi.
         /// </summary>
         /// <seealso href="http://officeopenxml.com/WPtextFonts.php">WordProcessingText Fonts </seealso>
         public string FontFamilyHighAnsi {
@@ -347,6 +353,64 @@ namespace OfficeIMO.Word {
                     // we also need to change it in highAnsi to fix https://github.com/EvotecIT/OfficeIMO/issues/54
                     runPropertiesBaseStyle.RunFonts.HighAnsi = value;
                     runPropertiesBaseStyle.RunFonts.HighAnsiTheme = null;
+                } else {
+                    throw new Exception("Could not set font family. Styles not found.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or Sets default font family for the whole document in EastAsia.
+        /// </summary>
+        /// <seealso href="http://officeopenxml.com/WPtextFonts.php">WordProcessingText Fonts </seealso>
+        public string FontFamilyEastAsia {
+            get {
+                var runPropertiesBaseStyle = GetDefaultStyleProperties();
+                if (runPropertiesBaseStyle != null) {
+                    if (runPropertiesBaseStyle.RunFonts != null) {
+                        var fontFamily = runPropertiesBaseStyle.RunFonts.EastAsia;
+                        return fontFamily;
+                    }
+                }
+                return null;
+            }
+            set {
+                var runPropertiesBaseStyle = SetDefaultStyleProperties();
+                if (runPropertiesBaseStyle != null) {
+                    if (runPropertiesBaseStyle.RunFonts == null) {
+                        runPropertiesBaseStyle.RunFonts = new RunFonts() { AsciiTheme = ThemeFontValues.MinorHighAnsi, HighAnsiTheme = ThemeFontValues.MinorHighAnsi, EastAsiaTheme = ThemeFontValues.MinorHighAnsi, ComplexScriptTheme = ThemeFontValues.MinorBidi };
+                    }
+                    runPropertiesBaseStyle.RunFonts.EastAsia = value;
+                    runPropertiesBaseStyle.RunFonts.EastAsiaTheme = null;
+                } else {
+                    throw new Exception("Could not set font family. Styles not found.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or Sets default font family for the whole document in ComplexScript.
+        /// </summary>
+        /// <seealso href="http://officeopenxml.com/WPtextFonts.php">WordProcessingText Fonts </seealso>
+        public string FontFamilyComplexScript {
+            get {
+                var runPropertiesBaseStyle = GetDefaultStyleProperties();
+                if (runPropertiesBaseStyle != null) {
+                    if (runPropertiesBaseStyle.RunFonts != null) {
+                        var fontFamily = runPropertiesBaseStyle.RunFonts.ComplexScript;
+                        return fontFamily;
+                    }
+                }
+                return null;
+            }
+            set {
+                var runPropertiesBaseStyle = SetDefaultStyleProperties();
+                if (runPropertiesBaseStyle != null) {
+                    if (runPropertiesBaseStyle.RunFonts == null) {
+                        runPropertiesBaseStyle.RunFonts = new RunFonts() { AsciiTheme = ThemeFontValues.MinorHighAnsi, HighAnsiTheme = ThemeFontValues.MinorHighAnsi, EastAsiaTheme = ThemeFontValues.MinorHighAnsi, ComplexScriptTheme = ThemeFontValues.MinorBidi };
+                    }
+                    runPropertiesBaseStyle.RunFonts.ComplexScript = value;
+                    runPropertiesBaseStyle.RunFonts.ComplexScriptTheme = null;
                 } else {
                     throw new Exception("Could not set font family. Styles not found.");
                 }


### PR DESCRIPTION
This PR addresses:
- https://github.com/EvotecIT/OfficeIMO/issues/124

In the begining of OfficeIMO we only supported FontFamily as part of `Document.Settings.FontFamily` and `Paragraph.FontFamily`. The thing is there are 3 other settings in FontFamily. Those are HighAnsi, ComplexScript and EastAsia. I've added `FontFamilyHighAnsi` to global settings as a separate option, but forgot to add it for Paragraph. While I could just add HighAnsi to Paragraph I believe this is not enough to address issue. 

Most languages such as Polish have special chars. If we set FontFamily to Arial and we use mix of standard chars and special chars łążćźż it would only change FontFamily for standard chars and leave special chars on it's defaults. This makes no sense to treat special chars differently from my perspective. Therefore in this change:

- If you change FontFamily on Document.Settings or Paragraph it will set it on Ascii, HighAnsi, EastAsia and ComplexScript.
- If you want to then change it to a different font for those special chars or settings you can do it directly thru exposed properties.

This PR adds:
- `Paragraph.FontFamilyHighAnsi`
- `Paragraph.FontFamilyEastAsia`
- `Paragraph.FontFamilyComplexScript`
- `Document.Settings.FontFamilyEastAsia`
- `Document.Settings.FontFamilyComplexScript`