### PR TITLE
Add ability to use NewLines ("\r\n"/Environment.NewLine) in AddParagraph, AddText

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -23,6 +23,7 @@ namespace OfficeIMO.Examples {
             BasicDocument.Example_BasicWordWithDefaultFontChange(folderPath, false);
             BasicDocument.Example_BasicLoadHamlet(templatesPath, folderPath, false);
             BasicDocument.Example_BasicWordWithPolishChars(folderPath, false);
+            BasicDocument.Example_BasicWordWithNewLines(folderPath, false);
 
             AdvancedDocument.Example_AdvancedWord(folderPath, false);
             AdvancedDocument.Example_AdvancedWord2(folderPath, false);

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.CreateNewLines.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.CreateNewLines.cs
@@ -1,0 +1,58 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class BasicDocument {
+        public static void Example_BasicWordWithNewLines(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating standard document with different default style (PL)");
+            string filePath = System.IO.Path.Combine(folderPath, "BasicWordWithTabs.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+
+                var paragraph1 = document.AddParagraph("This is a start");
+
+                Console.WriteLine("Paragraph count (expected 1): " + document.Paragraphs.Count);
+
+                var paragraph2 = document.AddParagraph("This is a start \t\t And more");
+
+                Console.WriteLine("Paragraph count (expected 2): " + document.Paragraphs.Count);
+
+                var paragraph3 = document.AddParagraph("This is a start \t\t And more");
+                paragraph3.Underline = UnderlineValues.DashLong;
+
+                Console.WriteLine("Paragraph count (expected 3): " + document.Paragraphs.Count);
+
+                // now we will try to add new line characters, that will force the paragraph to be split into pieces
+                // following will split the paragraph into 3 paragraphs - 2 paragraphs with Text, and one Break()
+                var paragraph4 = document.AddParagraph("First line\r\nAnd more in new line");
+
+                Console.WriteLine("Paragraph count (expected 6): " + document.Paragraphs.Count);
+
+                // following will split the paragraph into 3 paragraphs - 2 paragraphs with Text, and one Break()
+                var paragraph6 = document.AddParagraph("First line\nnd more in new line");
+
+                Console.WriteLine("Paragraph count (expected 9): " + document.Paragraphs.Count);
+
+                // following will split the paragraph into 3 paragraphs - 2 paragraphs with Text, and one Break()
+                var paragraph7 = document.AddParagraph("First line" + Environment.NewLine + "And more in new line");
+
+                Console.WriteLine("Paragraph count (expected 12): " + document.Paragraphs.Count);
+
+                // following will split the paragraph into 7 paragraphs - 3 paragraphs with Text, and 4 paragraphs with Break()
+                // additionally there's one paragraph at start
+                var paragraph8 = document.AddParagraph("TestMe").AddText("\nFirst line\r\nAnd more " + Environment.NewLine + "in new line\r\n");
+
+                Console.WriteLine("Paragraph count (expected 20): " + document.Paragraphs.Count);
+
+                // following will split the paragraph into 7 paragraphs - 3 paragraphs with Text, and 4 paragraphs with Break()
+                // additionally there's one paragraph at start
+                // it's the same as above but written in a direct way. All above methods are just shortcuts for this
+                var paragraph9 = document.AddParagraph("TestMe").AddBreak().AddText("First line").AddBreak().AddText("And more ").AddBreak().AddText("in new line").AddBreak();
+
+                Console.WriteLine("Paragraph count (expected 28): " + document.Paragraphs.Count);
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.BreaksNewLine.cs
+++ b/OfficeIMO.Tests/Word.BreaksNewLine.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Drawing;
+using OfficeIMO.Word;
+using Xunit;
+
+using Path = System.IO.Path;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+
+        [Fact]
+        public void Test_CreatingWordDocumentWithNewLines() {
+            var filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithNewLines.docx");
+            using var document = WordDocument.Create(filePath);
+
+            var paragraph1 = document.AddParagraph("This is a start");
+
+            Assert.True(document.Paragraphs.Count == 1);
+
+            var paragraph2 = document.AddParagraph("This is a start \t\t And more");
+
+            Assert.True(document.Paragraphs.Count == 2);
+
+            var paragraph3 = document.AddParagraph("This is a start \t\t And more");
+
+            Assert.True(document.Paragraphs.Count == 3);
+
+            // now we will try to add new line characters, that will force the paragraph to be split into pieces
+            // following will split the paragraph into 3 paragraphs - 2 paragraphs with Text, and one Break()
+            var paragraph4 = document.AddParagraph("First line\r\nAnd more in new line");
+
+            Assert.True(document.Paragraphs.Count == 6);
+
+            // following will split the paragraph into 3 paragraphs - 2 paragraphs with Text, and one Break()
+            var paragraph6 = document.AddParagraph("First line\nnd more in new line");
+
+            Assert.True(document.Paragraphs.Count == 9);
+
+            // following will split the paragraph into 3 paragraphs - 2 paragraphs with Text, and one Break()
+            var paragraph7 = document.AddParagraph("First line" + Environment.NewLine + "And more in new line");
+
+            Assert.True(document.Paragraphs[9].Text == "First line");
+            Assert.True(document.Paragraphs[10].IsBreak);
+            Assert.True(document.Paragraphs[11].Text == "And more in new line");
+
+            Assert.True(document.Paragraphs.Count == 12);
+
+            // following will split the paragraph into 7 paragraphs - 3 paragraphs with Text, and 4 paragraphs with Break()
+            // additionally there's one paragraph at start
+            var paragraph8 = document.AddParagraph("TestMe").AddText("\nFirst line\r\nAnd more " + Environment.NewLine + "in new line\r\n");
+
+            Assert.True(document.Paragraphs.Count == 20);
+            Assert.True(document.Paragraphs[12].Text == "TestMe");
+            Assert.True(document.Paragraphs[13].IsBreak);
+            Assert.True(document.Paragraphs[14].Text == "First line");
+            Assert.True(document.Paragraphs[15].IsBreak);
+            Assert.True(document.Paragraphs[17].IsBreak);
+            Assert.True(document.Paragraphs[19].IsBreak);
+
+            // following will split the paragraph into 7 paragraphs - 3 paragraphs with Text, and 4 paragraphs with Break()
+            // additionally there's one paragraph at start
+            // it's the same as above but written in a direct way. All above methods are just shortcuts for this
+            var paragraph9 = document.AddParagraph("TestMe").AddBreak().AddText("First line").AddBreak().AddText("And more ").AddBreak().AddText("in new line").AddBreak();
+
+            Assert.True(document.Paragraphs.Count == 28);
+
+            document.Save(false);
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -19,7 +19,8 @@ namespace OfficeIMO.Word {
         }
 
         public WordParagraph AddParagraph(string text) {
-            return AddParagraph().SetText(text);
+            //return AddParagraph().SetText(text);
+            return AddParagraph().AddText(text);
         }
 
         public WordParagraph AddPageBreak() {

--- a/OfficeIMO.Word/WordParagraph.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PrivateMethods.cs
@@ -174,28 +174,6 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private void ParseTextForOpenXml(Run run, string text) {
-            //string[] newLineArray = { Environment.NewLine };
-            string[] newLineArray = { Environment.NewLine, "\n", "\r\n", "\n\r" };
-            string[] textArray = text.Split(newLineArray, StringSplitOptions.None);
-
-            bool first = true;
-
-            foreach (string line in textArray) {
-                if (!first) {
-                    run.Append(new Break());
-                }
-
-                first = false;
-
-                Text txt = new Text {
-                    Text = line
-                };
-
-                run.Append(txt);
-            }
-        }
-
         private List<string> ConvertStringToList(string text) {
             string[] splitStrings = { Environment.NewLine, "\r\n", "\n" };
             string[] textSplit = text.Split(splitStrings, StringSplitOptions.RemoveEmptyEntries);

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -12,10 +12,10 @@ namespace OfficeIMO.Word {
         /// <param name="text"></param>
         /// <returns></returns>
         public WordParagraph AddText(string text) {
-            WordParagraph wordParagraph = new WordParagraph(this._document, this._paragraph, new Run());
-            wordParagraph.Text = text;
-            this._paragraph.Append(wordParagraph._run);
-            //this._document._wordprocessingDocument.MainDocumentPart.Document.InsertAfter(wordParagraph._run, this._paragraph);
+            WordParagraph wordParagraph = ConvertToTextWithBreaks(text);
+            //WordParagraph wordParagraph = new WordParagraph(this._document, this._paragraph, new Run());
+            //wordParagraph.Text = text;
+            //this._paragraph.Append(wordParagraph._run);
             return wordParagraph;
         }
 


### PR DESCRIPTION
This PR adds the ability to create line breaks using `\n`, `\r\n` or `Environment.NewLine`

```cs
var test = document.AddParagraph("TestMe").AddText("\nFirst line\r\nAnd more " + Environment.NewLine + "in new line\r\n");
```

Is exactly the same as using it in explicit way:

```cs
var  test = document.AddParagraph("TestMe").AddBreak().AddText("First line").AddBreak().AddText("And more ").AddBreak().AddText("in new line").AddBreak();
```

Keep in mind that doing `document.Paragraphs[0].Text = "\nFirst line\r\nAnd more " + Environment.NewLine + "in new line\r\n");` doesn't do anything for the Breaks(). I believe that using Text property on paragraph explicitly that would create multiple WordParagraphs from a simple `Set` should not do that. 

Full example:

```cs
public static void Example_BasicWordWithNewLines(string folderPath, bool openWord) {
    Console.WriteLine("[*] Creating standard document with different default style (PL)");
    string filePath = System.IO.Path.Combine(folderPath, "BasicWordWithTabs.docx");
    using (WordDocument document = WordDocument.Create(filePath)) {

        var paragraph1 = document.AddParagraph("This is a start");

        Console.WriteLine("Paragraph count (expected 1): " + document.Paragraphs.Count);

        var paragraph2 = document.AddParagraph("This is a start \t\t And more");

        Console.WriteLine("Paragraph count (expected 2): " + document.Paragraphs.Count);

        var paragraph3 = document.AddParagraph("This is a start \t\t And more");
        paragraph3.Underline = UnderlineValues.DashLong;

        Console.WriteLine("Paragraph count (expected 3): " + document.Paragraphs.Count);

        // now we will try to add new line characters, that will force the paragraph to be split into pieces
        // following will split the paragraph into 3 paragraphs - 2 paragraphs with Text, and one Break()
        var paragraph4 = document.AddParagraph("First line\r\nAnd more in new line");

        Console.WriteLine("Paragraph count (expected 6): " + document.Paragraphs.Count);

        // following will split the paragraph into 3 paragraphs - 2 paragraphs with Text, and one Break()
        var paragraph6 = document.AddParagraph("First line\nnd more in new line");

        Console.WriteLine("Paragraph count (expected 9): " + document.Paragraphs.Count);

        // following will split the paragraph into 3 paragraphs - 2 paragraphs with Text, and one Break()
        var paragraph7 = document.AddParagraph("First line" + Environment.NewLine + "And more in new line");

        Console.WriteLine("Paragraph count (expected 12): " + document.Paragraphs.Count);

        // following will split the paragraph into 7 paragraphs - 3 paragraphs with Text, and 4 paragraphs with Break()
        // additionally there's one paragraph at start
        var paragraph8 = document.AddParagraph("TestMe").AddText("\nFirst line\r\nAnd more " + Environment.NewLine + "in new line\r\n");

        Console.WriteLine("Paragraph count (expected 20): " + document.Paragraphs.Count);

        // following will split the paragraph into 7 paragraphs - 3 paragraphs with Text, and 4 paragraphs with Break()
        // additionally there's one paragraph at start
        // it's the same as above but written in a direct way. All above methods are just shortcuts for this
        var paragraph9 = document.AddParagraph("TestMe").AddBreak().AddText("First line").AddBreak().AddText("And more ").AddBreak().AddText("in new line").AddBreak();

        Console.WriteLine("Paragraph count (expected 28): " + document.Paragraphs.Count);

        document.Save(openWord);
    }
}
```