### PR TITLE
Add support for Tabs

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -23,6 +23,7 @@ namespace OfficeIMO.Examples {
             BasicDocument.Example_BasicWordWithDefaultFontChange(folderPath, false);
             BasicDocument.Example_BasicLoadHamlet(templatesPath, folderPath, false);
             BasicDocument.Example_BasicWordWithPolishChars(folderPath, false);
+            BasicDocument.Example_BasicWordWithTabs(folderPath, false);
 
             AdvancedDocument.Example_AdvancedWord(folderPath, false);
             AdvancedDocument.Example_AdvancedWord2(folderPath, false);

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Tabs.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Tabs.cs
@@ -16,18 +16,18 @@ namespace OfficeIMO.Examples.Word {
 
                 Console.WriteLine(document.Paragraphs.Count);
 
-                Console.WriteLine(document.Paragraphs[1].IsTabChar);
-                Console.WriteLine(document.Paragraphs[2].IsTabChar);
+                Console.WriteLine(document.Paragraphs[1].IsTab);
+                Console.WriteLine(document.Paragraphs[2].IsTab);
 
-                Console.WriteLine(paragraph1.IsTabChar);
+                Console.WriteLine(paragraph1.IsTab);
 
                 var paragraph2 = document.AddParagraph("Adding paragraph1 with some text and pressing ENTER").AddTab();
 
                 Console.WriteLine(document.Paragraphs.Count);
 
-                Console.WriteLine(paragraph2.IsTabChar);
+                Console.WriteLine(paragraph2.IsTab);
 
-                paragraph2.TabChar.Remove();
+                paragraph2.Tab.Remove();
                 document.Save(openWord);
             }
         }

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Tabs.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Tabs.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class BasicDocument {
+        public static void Example_BasicWordWithTabs(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating standard document with tabs");
+            string filePath = System.IO.Path.Combine(folderPath, "BasicWordWithTabs.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph1 = document.AddParagraph("To jest po polsku").AddTab().AddTab().AddText("Test");
+
+                Console.WriteLine(document.Paragraphs.Count);
+
+                Console.WriteLine(document.Paragraphs[1].IsTabChar);
+                Console.WriteLine(document.Paragraphs[2].IsTabChar);
+
+                Console.WriteLine(paragraph1.IsTabChar);
+
+                var paragraph2 = document.AddParagraph("Adding paragraph1 with some text and pressing ENTER").AddTab();
+
+                Console.WriteLine(document.Paragraphs.Count);
+
+                Console.WriteLine(paragraph2.IsTabChar);
+
+                paragraph2.TabChar.Remove();
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Tabs.cs
+++ b/OfficeIMO.Tests/Word.Tabs.cs
@@ -43,7 +43,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs[1].IsTab == true);
                 Assert.True(document.Paragraphs[2].IsTab == true);
                 Assert.True(document.Sections[0].ParagraphsTabStops.Count == 0);
-                Assert.True(document.Sections[0].ParagraphsTabs.Count == 0);
+                Assert.True(document.Sections[0].ParagraphsTabs.Count == 2);
                 document.Save();
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithTabs.docx"))) {

--- a/OfficeIMO.Tests/Word.Tabs.cs
+++ b/OfficeIMO.Tests/Word.Tabs.cs
@@ -1,0 +1,146 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_CreatingWordDocumentWithTabStops() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreateDocumentWithTabStops.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                Assert.True(document.Settings.DefaultTabStop == 720);
+                Assert.True(document.Settings.CharacterSpacingControl == CharacterSpacingValues.DoNotCompress);
+
+                document.Settings.DefaultTabStop = 2880;
+                document.Settings.CharacterSpacingControl = CharacterSpacingValues.CompressPunctuation;
+
+                Assert.True(document.Settings.DefaultTabStop == 2880);
+                Assert.True(document.Settings.CharacterSpacingControl == CharacterSpacingValues.CompressPunctuation);
+
+                var paragraph = document.AddParagraph("\tFirst Line");
+
+                Assert.True(document.Paragraphs.Count == 1);
+                Assert.True(paragraph.TabStops.Count == 0);
+
+                var tab1 = paragraph.AddTabStop(1440);
+
+                Assert.True(paragraph.TabStops.Count == 1);
+
+                var tab2 = paragraph.AddTabStop(1440);
+                tab2.Alignment = TabStopValues.Left;
+                tab2.Leader = TabStopLeaderCharValues.Hyphen;
+                tab2.Position = 1440;
+
+                paragraph.AddText("\tMore text");
+
+                Assert.True(paragraph.TabStops.Count == 2);
+
+                var paragraph1 = document.AddParagraph("\tNext Line");
+
+                var tab3 = paragraph1.AddTabStop(5000);
+                tab3.Leader = TabStopLeaderCharValues.Hyphen;
+
+                var tab4 = paragraph1.AddTabStop(1440 * 2);
+                paragraph1.AddText("\tEven more text");
+
+
+                var tab5 = paragraph1.AddTabStop(1440 * 3, TabStopValues.Decimal, TabStopLeaderCharValues.MiddleDot);
+                paragraph1.AddText("\tLast more text");
+
+                Assert.True(paragraph.TabStops.Count == 2);
+                Assert.True(paragraph1.TabStops.Count == 3);
+
+                Assert.True(document.Paragraphs.Count == 5);
+                // First paragraph with 2 runs, having 2 tab stops
+                Assert.True(document.Paragraphs[0].TabStops.Count == 2);
+                Assert.True(document.Paragraphs[1].TabStops.Count == 2);
+                // Actual new paragraph with 3 runs, having 3 tab stops
+                Assert.True(document.Paragraphs[2].TabStops.Count == 3);
+                Assert.True(document.Paragraphs[3].TabStops.Count == 3);
+                Assert.True(document.Paragraphs[4].TabStops.Count == 3);
+
+                // two WordParagraphs, share same Paragraph, and same ParagraphProperties, so the tab stops are shared
+                Assert.True(document.Paragraphs[0].TabStops[0].Alignment == TabStopValues.Left);
+                Assert.True(document.Paragraphs[0].TabStops[0].Leader == TabStopLeaderCharValues.None);
+                Assert.True(document.Paragraphs[0].TabStops[0].Position == 1440);
+
+                Assert.True(document.Paragraphs[0].TabStops[1].Alignment == TabStopValues.Left);
+                Assert.True(document.Paragraphs[0].TabStops[1].Leader == TabStopLeaderCharValues.Hyphen);
+                Assert.True(document.Paragraphs[0].TabStops[1].Position == 1440);
+
+                // three WordParagraphs, share same Paragraph, and same ParagraphProperties, so the tab stops are shared
+                Assert.True(document.Paragraphs[2].TabStops[0].Alignment == TabStopValues.Left);
+                Assert.True(document.Paragraphs[2].TabStops[0].Leader == TabStopLeaderCharValues.Hyphen);
+                Assert.True(document.Paragraphs[2].TabStops[0].Position == 5000);
+
+                Assert.True(document.Paragraphs[3].TabStops[1].Alignment == TabStopValues.Left);
+                Assert.True(document.Paragraphs[3].TabStops[1].Leader == TabStopLeaderCharValues.None);
+                Assert.True(document.Paragraphs[3].TabStops[1].Position == 2880);
+
+                Assert.True(document.Paragraphs[4].TabStops[2].Alignment == TabStopValues.Decimal);
+                Assert.True(document.Paragraphs[4].TabStops[2].Leader == TabStopLeaderCharValues.MiddleDot);
+                Assert.True(document.Paragraphs[4].TabStops[2].Position == 1440 * 3);
+
+                Assert.True(document.Sections[0].Paragraphs[0].TabStops.Count == 2);
+
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithTabStops.docx"))) {
+                Assert.True(document.Settings.DefaultTabStop == 2880);
+                Assert.True(document.Settings.CharacterSpacingControl == CharacterSpacingValues.CompressPunctuation);
+
+                Assert.True(document.Paragraphs.Count == 5);
+                // First paragraph with 2 runs, having 2 tab stops
+                Assert.True(document.Paragraphs[0].TabStops.Count == 2);
+                Assert.True(document.Paragraphs[1].TabStops.Count == 2);
+                // Actual new paragraph with 3 runs, having 3 tab stops
+                Assert.True(document.Paragraphs[2].TabStops.Count == 3);
+                Assert.True(document.Paragraphs[3].TabStops.Count == 3);
+                Assert.True(document.Paragraphs[4].TabStops.Count == 3);
+
+                // two WordParagraphs, share same Paragraph, and same ParagraphProperties, so the tab stops are shared
+                Assert.True(document.Paragraphs[0].TabStops[0].Alignment == TabStopValues.Left);
+                Assert.True(document.Paragraphs[0].TabStops[0].Leader == TabStopLeaderCharValues.None);
+                Assert.True(document.Paragraphs[0].TabStops[0].Position == 1440);
+
+                Assert.True(document.Paragraphs[0].TabStops[1].Alignment == TabStopValues.Left);
+                Assert.True(document.Paragraphs[0].TabStops[1].Leader == TabStopLeaderCharValues.Hyphen);
+                Assert.True(document.Paragraphs[0].TabStops[1].Position == 1440);
+
+                // three WordParagraphs, share same Paragraph, and same ParagraphProperties, so the tab stops are shared
+                Assert.True(document.Paragraphs[2].TabStops[0].Alignment == TabStopValues.Left);
+                Assert.True(document.Paragraphs[2].TabStops[0].Leader == TabStopLeaderCharValues.Hyphen);
+                Assert.True(document.Paragraphs[2].TabStops[0].Position == 5000);
+
+                Assert.True(document.Paragraphs[3].TabStops[1].Alignment == TabStopValues.Left);
+                Assert.True(document.Paragraphs[3].TabStops[1].Leader == TabStopLeaderCharValues.None);
+                Assert.True(document.Paragraphs[3].TabStops[1].Position == 2880);
+
+                Assert.True(document.Paragraphs[4].TabStops[2].Alignment == TabStopValues.Decimal);
+                Assert.True(document.Paragraphs[4].TabStops[2].Leader == TabStopLeaderCharValues.MiddleDot);
+                Assert.True(document.Paragraphs[4].TabStops[2].Position == 1440 * 3);
+
+                Assert.True(document.Sections[0].Paragraphs[0].TabStops.Count == 2);
+
+                document.Paragraphs[4].TabStops[2].Position = 1440 * 4;
+                document.Paragraphs[4].TabStops[2].Alignment = TabStopValues.Right;
+
+                var tab4 = document.Paragraphs[4].AddTabStop(1440 * 2, TabStopValues.Bar, TabStopLeaderCharValues.Dot);
+
+                document.Save();
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithTabStops.docx"))) {
+                Assert.True(document.Paragraphs[4].TabStops[2].Alignment == TabStopValues.Right);
+                Assert.True(document.Paragraphs[4].TabStops[2].Leader == TabStopLeaderCharValues.MiddleDot);
+                Assert.True(document.Paragraphs[4].TabStops[2].Position == 1440 * 4);
+
+                Assert.True(document.Paragraphs[4].TabStops[3].Alignment == TabStopValues.Bar);
+                Assert.True(document.Paragraphs[4].TabStops[3].Leader == TabStopLeaderCharValues.Dot);
+                Assert.True(document.Paragraphs[4].TabStops[3].Position == 1440 * 2);
+
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Tabs.cs
+++ b/OfficeIMO.Tests/Word.Tabs.cs
@@ -7,138 +7,47 @@ using Xunit;
 namespace OfficeIMO.Tests {
     public partial class Word {
         [Fact]
-        public void Test_CreatingWordDocumentWithTabStops() {
-            string filePath = Path.Combine(_directoryWithFiles, "CreateDocumentWithTabStops.docx");
+        public void Test_CreatingWordDocumentWithTabs() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreateDocumentWithTabs.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
-                Assert.True(document.Settings.DefaultTabStop == 720);
-                Assert.True(document.Settings.CharacterSpacingControl == CharacterSpacingValues.DoNotCompress);
+                var paragraph1 = document.AddParagraph("Some text before adding tab").AddTab().AddTab().AddText("Test");
 
-                document.Settings.DefaultTabStop = 2880;
-                document.Settings.CharacterSpacingControl = CharacterSpacingValues.CompressPunctuation;
+                Assert.True(document.ParagraphsTabStops.Count == 0);
+                Assert.True(document.ParagraphsTabs.Count == 2);
+                Assert.True(document.Paragraphs[0].Text == "Some text before adding tab");
+                Assert.True(document.Paragraphs.Count == 4);
 
-                Assert.True(document.Settings.DefaultTabStop == 2880);
-                Assert.True(document.Settings.CharacterSpacingControl == CharacterSpacingValues.CompressPunctuation);
+                Assert.True(document.Paragraphs[1].IsTab == true);
+                Assert.True(document.Paragraphs[2].IsTab == true);
 
-                var paragraph = document.AddParagraph("\tFirst Line");
+                Assert.True(paragraph1.IsTab == false);
 
-                Assert.True(document.Paragraphs.Count == 1);
-                Assert.True(paragraph.TabStops.Count == 0);
+                var paragraph2 = document.AddParagraph("Adding paragraph1 with some text and pressing ENTER").AddTab();
 
-                var tab1 = paragraph.AddTabStop(1440);
+                Assert.True(document.Paragraphs.Count == 6);
+                Assert.True(paragraph2.IsTab == true);
 
-                Assert.True(paragraph.TabStops.Count == 1);
+                Assert.True(document.ParagraphsTabs.Count == 3);
 
-                var tab2 = paragraph.AddTabStop(1440);
-                tab2.Alignment = TabStopValues.Left;
-                tab2.Leader = TabStopLeaderCharValues.Hyphen;
-                tab2.Position = 1440;
-
-                paragraph.AddText("\tMore text");
-
-                Assert.True(paragraph.TabStops.Count == 2);
-
-                var paragraph1 = document.AddParagraph("\tNext Line");
-
-                var tab3 = paragraph1.AddTabStop(5000);
-                tab3.Leader = TabStopLeaderCharValues.Hyphen;
-
-                var tab4 = paragraph1.AddTabStop(1440 * 2);
-                paragraph1.AddText("\tEven more text");
-
-
-                var tab5 = paragraph1.AddTabStop(1440 * 3, TabStopValues.Decimal, TabStopLeaderCharValues.MiddleDot);
-                paragraph1.AddText("\tLast more text");
-
-                Assert.True(paragraph.TabStops.Count == 2);
-                Assert.True(paragraph1.TabStops.Count == 3);
+                paragraph2.Tab.Remove();
 
                 Assert.True(document.Paragraphs.Count == 5);
-                // First paragraph with 2 runs, having 2 tab stops
-                Assert.True(document.Paragraphs[0].TabStops.Count == 2);
-                Assert.True(document.Paragraphs[1].TabStops.Count == 2);
-                // Actual new paragraph with 3 runs, having 3 tab stops
-                Assert.True(document.Paragraphs[2].TabStops.Count == 3);
-                Assert.True(document.Paragraphs[3].TabStops.Count == 3);
-                Assert.True(document.Paragraphs[4].TabStops.Count == 3);
 
-                // two WordParagraphs, share same Paragraph, and same ParagraphProperties, so the tab stops are shared
-                Assert.True(document.Paragraphs[0].TabStops[0].Alignment == TabStopValues.Left);
-                Assert.True(document.Paragraphs[0].TabStops[0].Leader == TabStopLeaderCharValues.None);
-                Assert.True(document.Paragraphs[0].TabStops[0].Position == 1440);
-
-                Assert.True(document.Paragraphs[0].TabStops[1].Alignment == TabStopValues.Left);
-                Assert.True(document.Paragraphs[0].TabStops[1].Leader == TabStopLeaderCharValues.Hyphen);
-                Assert.True(document.Paragraphs[0].TabStops[1].Position == 1440);
-
-                // three WordParagraphs, share same Paragraph, and same ParagraphProperties, so the tab stops are shared
-                Assert.True(document.Paragraphs[2].TabStops[0].Alignment == TabStopValues.Left);
-                Assert.True(document.Paragraphs[2].TabStops[0].Leader == TabStopLeaderCharValues.Hyphen);
-                Assert.True(document.Paragraphs[2].TabStops[0].Position == 5000);
-
-                Assert.True(document.Paragraphs[3].TabStops[1].Alignment == TabStopValues.Left);
-                Assert.True(document.Paragraphs[3].TabStops[1].Leader == TabStopLeaderCharValues.None);
-                Assert.True(document.Paragraphs[3].TabStops[1].Position == 2880);
-
-                Assert.True(document.Paragraphs[4].TabStops[2].Alignment == TabStopValues.Decimal);
-                Assert.True(document.Paragraphs[4].TabStops[2].Leader == TabStopLeaderCharValues.MiddleDot);
-                Assert.True(document.Paragraphs[4].TabStops[2].Position == 1440 * 3);
-
-                Assert.True(document.Sections[0].Paragraphs[0].TabStops.Count == 2);
+                Assert.True(document.ParagraphsTabs.Count == 2);
 
                 document.Save(false);
             }
-            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithTabStops.docx"))) {
-                Assert.True(document.Settings.DefaultTabStop == 2880);
-                Assert.True(document.Settings.CharacterSpacingControl == CharacterSpacingValues.CompressPunctuation);
-
-                Assert.True(document.Paragraphs.Count == 5);
-                // First paragraph with 2 runs, having 2 tab stops
-                Assert.True(document.Paragraphs[0].TabStops.Count == 2);
-                Assert.True(document.Paragraphs[1].TabStops.Count == 2);
-                // Actual new paragraph with 3 runs, having 3 tab stops
-                Assert.True(document.Paragraphs[2].TabStops.Count == 3);
-                Assert.True(document.Paragraphs[3].TabStops.Count == 3);
-                Assert.True(document.Paragraphs[4].TabStops.Count == 3);
-
-                // two WordParagraphs, share same Paragraph, and same ParagraphProperties, so the tab stops are shared
-                Assert.True(document.Paragraphs[0].TabStops[0].Alignment == TabStopValues.Left);
-                Assert.True(document.Paragraphs[0].TabStops[0].Leader == TabStopLeaderCharValues.None);
-                Assert.True(document.Paragraphs[0].TabStops[0].Position == 1440);
-
-                Assert.True(document.Paragraphs[0].TabStops[1].Alignment == TabStopValues.Left);
-                Assert.True(document.Paragraphs[0].TabStops[1].Leader == TabStopLeaderCharValues.Hyphen);
-                Assert.True(document.Paragraphs[0].TabStops[1].Position == 1440);
-
-                // three WordParagraphs, share same Paragraph, and same ParagraphProperties, so the tab stops are shared
-                Assert.True(document.Paragraphs[2].TabStops[0].Alignment == TabStopValues.Left);
-                Assert.True(document.Paragraphs[2].TabStops[0].Leader == TabStopLeaderCharValues.Hyphen);
-                Assert.True(document.Paragraphs[2].TabStops[0].Position == 5000);
-
-                Assert.True(document.Paragraphs[3].TabStops[1].Alignment == TabStopValues.Left);
-                Assert.True(document.Paragraphs[3].TabStops[1].Leader == TabStopLeaderCharValues.None);
-                Assert.True(document.Paragraphs[3].TabStops[1].Position == 2880);
-
-                Assert.True(document.Paragraphs[4].TabStops[2].Alignment == TabStopValues.Decimal);
-                Assert.True(document.Paragraphs[4].TabStops[2].Leader == TabStopLeaderCharValues.MiddleDot);
-                Assert.True(document.Paragraphs[4].TabStops[2].Position == 1440 * 3);
-
-                Assert.True(document.Sections[0].Paragraphs[0].TabStops.Count == 2);
-
-                document.Paragraphs[4].TabStops[2].Position = 1440 * 4;
-                document.Paragraphs[4].TabStops[2].Alignment = TabStopValues.Right;
-
-                var tab4 = document.Paragraphs[4].AddTabStop(1440 * 2, TabStopValues.Bar, TabStopLeaderCharValues.Dot);
-
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithTabs.docx"))) {
+                Assert.True(document.ParagraphsTabStops.Count == 0);
+                Assert.True(document.ParagraphsTabs.Count == 2);
+                Assert.True(document.Paragraphs[1].IsTab == true);
+                Assert.True(document.Paragraphs[2].IsTab == true);
+                Assert.True(document.Sections[0].ParagraphsTabStops.Count == 0);
+                Assert.True(document.Sections[0].ParagraphsTabs.Count == 0);
                 document.Save();
             }
-            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithTabStops.docx"))) {
-                Assert.True(document.Paragraphs[4].TabStops[2].Alignment == TabStopValues.Right);
-                Assert.True(document.Paragraphs[4].TabStops[2].Leader == TabStopLeaderCharValues.MiddleDot);
-                Assert.True(document.Paragraphs[4].TabStops[2].Position == 1440 * 4);
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithTabs.docx"))) {
 
-                Assert.True(document.Paragraphs[4].TabStops[3].Alignment == TabStopValues.Bar);
-                Assert.True(document.Paragraphs[4].TabStops[3].Leader == TabStopLeaderCharValues.Dot);
-                Assert.True(document.Paragraphs[4].TabStops[3].Position == 1440 * 2);
 
             }
         }

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -105,6 +105,28 @@ namespace OfficeIMO.Word {
             }
         }
 
+        public List<WordParagraph> ParagraphsTabs {
+            get {
+                List<WordParagraph> list = new List<WordParagraph>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.ParagraphsTabs);
+                }
+
+                return list;
+            }
+        }
+
+        public List<WordParagraph> ParagraphsTabStops {
+            get {
+                List<WordParagraph> list = new List<WordParagraph>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.ParagraphsTabStops);
+                }
+
+                return list;
+            }
+        }
+
         public List<WordParagraph> ParagraphsFields {
             get {
                 List<WordParagraph> list = new List<WordParagraph>();
@@ -282,6 +304,17 @@ namespace OfficeIMO.Word {
                 List<WordHyperLink> list = new List<WordHyperLink>();
                 foreach (var section in this.Sections) {
                     list.AddRange(section.HyperLinks);
+                }
+
+                return list;
+            }
+        }
+
+        public List<WordTabChar> TabChars {
+            get {
+                List<WordTabChar> list = new List<WordTabChar>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.Tabs);
                 }
 
                 return list;

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -283,10 +283,27 @@ namespace OfficeIMO.Word {
             return wordTable;
         }
 
-        public WordTab AddTabStop(int position, TabStopValues alignment = TabStopValues.Left, TabStopLeaderCharValues leader = TabStopLeaderCharValues.None) {
-            var wordTab = new WordTab(this);
+        /// <summary>
+        /// Provides ability for configuration of Tabs in a paragraph
+        /// by adding one or more TabStops
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="alignment"></param>
+        /// <param name="leader"></param>
+        /// <returns></returns>
+        public WordTabStop AddTabStop(int position, TabStopValues alignment = TabStopValues.Left, TabStopLeaderCharValues leader = TabStopLeaderCharValues.None) {
+            var wordTab = new WordTabStop(this);
             wordTab.AddTab(position, alignment, leader);
             return wordTab;
+        }
+
+        /// <summary>
+        /// Adds a Tab to a paragraph
+        /// </summary>
+        /// <returns></returns>
+        public WordParagraph AddTab() {
+            var wordParagraph = WordTabChar.AddTab(this._document, this);
+            return wordParagraph;
         }
     }
 }

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -207,11 +207,23 @@ namespace OfficeIMO.Word {
             }
         }
 
+        public WordTabChar TabChar {
+            get {
+                if (_run != null) {
+                    var tabChar = _run.ChildElements.OfType<TabChar>().FirstOrDefault();
+                    if (tabChar != null) {
+                        return new WordTabChar(_document, _paragraph, _run);
+                    }
+                }
+
+                return null;
+            }
+        }
+
         public WordParagraph(WordDocument document = null, bool newParagraph = true, bool newRun = true) {
             this._document = document;
 
             if (newParagraph) {
-
                 this._paragraph = new Paragraph();
                 this._paragraph.AppendChild(new ParagraphProperties());
 
@@ -219,6 +231,16 @@ namespace OfficeIMO.Word {
                     this._run = new Run();
                     this._paragraph.AppendChild(_run);
                 }
+            }
+        }
+
+        internal WordParagraph(WordDocument document, Paragraph paragraph, bool newRun = true) {
+            this._document = document;
+            this._paragraph = paragraph;
+
+            if (newRun) {
+                this._run = new Run();
+                this._paragraph.AppendChild(_run);
             }
         }
 
@@ -399,13 +421,23 @@ namespace OfficeIMO.Word {
             }
         }
 
-        public List<WordTab> TabStops {
+        public bool IsTabChar {
             get {
-                List<WordTab> list = new List<WordTab>();
+                if (this.TabChar != null) {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        public List<WordTabStop> TabStops {
+            get {
+                List<WordTabStop> list = new List<WordTabStop>();
                 if (_paragraph != null && _paragraphProperties != null) {
                     if (_paragraphProperties.Tabs != null) {
                         foreach (TabStop tab in _paragraphProperties.Tabs) {
-                            list.Add(new WordTab(this, tab));
+                            list.Add(new WordTabStop(this, tab));
                         }
                     }
                 }

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -207,7 +207,7 @@ namespace OfficeIMO.Word {
             }
         }
 
-        public WordTabChar TabChar {
+        public WordTabChar Tab {
             get {
                 if (_run != null) {
                     var tabChar = _run.ChildElements.OfType<TabChar>().FirstOrDefault();
@@ -421,9 +421,9 @@ namespace OfficeIMO.Word {
             }
         }
 
-        public bool IsTabChar {
+        public bool IsTab {
             get {
-                if (this.TabChar != null) {
+                if (this.Tab != null) {
                     return true;
                 }
 

--- a/OfficeIMO.Word/WordSection.cs
+++ b/OfficeIMO.Word/WordSection.cs
@@ -44,12 +44,32 @@ namespace OfficeIMO.Word {
             get { return Paragraphs.Where(p => p.IsField).ToList(); }
         }
 
+        /// <summary>
+        /// Provides a list of paragraphs that contain Bookmarks
+        /// </summary>
         public List<WordParagraph> ParagraphsBookmarks {
             get { return Paragraphs.Where(p => p.IsBookmark).ToList(); }
         }
 
+        /// <summary>
+        /// Provies a list of paragraphs that contain Equations
+        /// </summary>
         public List<WordParagraph> ParagraphsEquations {
             get { return Paragraphs.Where(p => p.IsEquation).ToList(); }
+        }
+
+        /// <summary>
+        /// Provies a list of paragraphs that contain Tabs
+        /// </summary>
+        public List<WordParagraph> ParagraphsTabs {
+            get { return Paragraphs.Where(p => p.IsTab).ToList(); }
+        }
+
+        /// <summary>
+        /// Provides a list of paragraphs that contain TabStops
+        /// </summary>
+        public List<WordParagraph> ParagraphsTabStops {
+            get { return Paragraphs.Where(p => p.TabStops.Count > 0).ToList(); }
         }
 
         /// <summary>
@@ -129,6 +149,17 @@ namespace OfficeIMO.Word {
                 var paragraphs = Paragraphs.Where(p => p.IsHyperLink).ToList();
                 foreach (var paragraph in paragraphs) {
                     list.Add(paragraph.Hyperlink);
+                }
+                return list;
+            }
+        }
+
+        public List<WordTabChar> Tabs {
+            get {
+                List<WordTabChar> list = new List<WordTabChar>();
+                var paragraphs = Paragraphs.Where(p => p.IsTab).ToList();
+                foreach (var paragraph in paragraphs) {
+                    list.Add(paragraph.Tab);
                 }
                 return list;
             }

--- a/OfficeIMO.Word/WordTabChar.cs
+++ b/OfficeIMO.Word/WordTabChar.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word {
+    public class WordTabChar {
+        private WordDocument _document;
+        private readonly Paragraph _paragraph;
+        private readonly Run _run;
+
+        public WordTabChar(WordDocument document, Paragraph paragraph, Run run) {
+            this._document = document;
+            this._paragraph = paragraph;
+            this._run = run;
+        }
+
+        public void Remove(bool includingParagraph = false) {
+            if (includingParagraph) {
+                this._paragraph.Remove();
+            } else {
+                if (_run.ChildElements.Count == 1) {
+                    this._run.Remove();
+                } else {
+                    this._run.ChildElements.OfType<TabChar>().FirstOrDefault()?.Remove();
+                }
+            }
+        }
+
+        internal static WordParagraph AddTab(WordDocument document, WordParagraph wordParagraph) {
+            var newWordParagraph = new WordParagraph(document, wordParagraph._paragraph, true);
+            newWordParagraph._run.Append(new TabChar());
+            return newWordParagraph;
+        }
+    }
+}

--- a/OfficeIMO.Word/WordTabStop.cs
+++ b/OfficeIMO.Word/WordTabStop.cs
@@ -1,12 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-using DocumentFormat.OpenXml.Office.CustomUI;
 using DocumentFormat.OpenXml.Wordprocessing;
 using Tabs = DocumentFormat.OpenXml.Wordprocessing.Tabs;
 
 namespace OfficeIMO.Word {
-    public class WordTab {
+    public class WordTabStop {
 
         private WordParagraph _paragraph { get; set; }
 
@@ -49,16 +45,16 @@ namespace OfficeIMO.Word {
         }
 
 
-        public WordTab(WordParagraph wordParagraph) {
+        public WordTabStop(WordParagraph wordParagraph) {
             _paragraph = wordParagraph;
         }
 
-        public WordTab(WordParagraph wordParagraph, TabStop tab) {
+        public WordTabStop(WordParagraph wordParagraph, TabStop tab) {
             _paragraph = wordParagraph;
             _tabStop = tab;
         }
 
-        internal WordTab AddTab(int position, TabStopValues alignment = TabStopValues.Left, TabStopLeaderCharValues leader = TabStopLeaderCharValues.None) {
+        internal WordTabStop AddTab(int position, TabStopValues alignment = TabStopValues.Left, TabStopLeaderCharValues leader = TabStopLeaderCharValues.None) {
             TabStop tabStop1 = new TabStop() { Val = alignment, Leader = leader, Position = position };
             _tabs.Append(tabStop1);
             _tabStop = tabStop1;


### PR DESCRIPTION
This PR solves:
- https://github.com/EvotecIT/OfficeIMO/issues/126

Add ability to add tabs to the document. 

```cs
public static void Example_BasicWordWithTabs(string folderPath, bool openWord) {
    Console.WriteLine("[*] Creating standard document with tabs");
    string filePath = System.IO.Path.Combine(folderPath, "BasicWordWithTabs.docx");
    using (WordDocument document = WordDocument.Create(filePath)) {
        var paragraph1 = document.AddParagraph("To jest po polsku").AddTab().AddTab().AddText("Test");

        Console.WriteLine(document.Paragraphs.Count);

        Console.WriteLine(document.Paragraphs[1].IsTabChar);
        Console.WriteLine(document.Paragraphs[2].IsTabChar);

        Console.WriteLine(paragraph1.IsTabChar);

        var paragraph2 = document.AddParagraph("Adding paragraph1 with some text and pressing ENTER").AddTab();

        Console.WriteLine(document.Paragraphs.Count);

        Console.WriteLine(paragraph2.IsTabChar);

        paragraph2.TabChar.Remove();
        document.Save(openWord);
    }
}
```