### PR TITLE
Downgrade DocumentFormat.OpenXml

### DIFF
--- a/OfficeIMO.Word/OfficeIMO.Word.csproj
+++ b/OfficeIMO.Word/OfficeIMO.Word.csproj
@@ -62,8 +62,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DocumentFormat.OpenXml" Version="2.19.0" />
+        <PackageReference Include="DocumentFormat.OpenXml" Version="2.16.0" />
         <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+        <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR downgrades:
- Downgrades DocumentFormat.OpenXml to 2.16.0 to be inline with ClosedXML (according to ClosedXML author there is a bug in 2.19
- Adds System.IO.Packaging 6.0.0