### PR TITLE
Fix for Incorrectly setting the LineSpacingRule property for paragraph

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -27,6 +27,7 @@ namespace OfficeIMO.Examples {
             BasicDocument.Example_BasicWordWithTabs(folderPath, false);
             BasicDocument.Example_BasicWordWithMargins(folderPath, false);
             BasicDocument.Example_BasicWordWithMarginsAndImage(folderPath, false);
+            BasicDocument.Example_BasicWordWithLineSpacing(folderPath, false);
 
             AdvancedDocument.Example_AdvancedWord(folderPath, false);
             AdvancedDocument.Example_AdvancedWord2(folderPath, false);

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.CreateLineSpacing.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.CreateLineSpacing.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class BasicDocument {
+        public static void Example_BasicWordWithLineSpacing(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating standard document with margins");
+            string filePath = System.IO.Path.Combine(folderPath, "DocumentWithLineSpacing.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var par00 = document.AddParagraph("My text");
+                par00.LineSpacingAfter = 0;
+                par00.LineSpacingBefore = 0;
+
+                var par01 = document.AddParagraph("My declaration");
+                par01.LineSpacingAfter = 0;
+                par01.LineSpacingBefore = 0;
+
+                var par02 = document.AddParagraph("My declaration");
+                par02.LineSpacing = 360;
+                par02.LineSpacingRule = LineSpacingRuleValues.Exact;
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.LineSpacing.cs
+++ b/OfficeIMO.Tests/Word.LineSpacing.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+using Color = SixLabors.ImageSharp.Color;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void Test_CreatingWordDocumentWithLineRules() {
+        var filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithLineRules.docx");
+        using (var document = WordDocument.Create(filePath)) {
+            var par00 = document.AddParagraph("My declaration 1");
+            par00.LineSpacingAfter = 0;
+            par00.LineSpacingBefore = 0;
+
+            var par01 = document.AddParagraph("My declaration 2");
+            par01.LineSpacingAfter = 50;
+            par01.LineSpacingBefore = 0;
+
+            var par02 = document.AddParagraph("My declaration 3");
+            par02.LineSpacing = 360;
+            par02.LineSpacingRule = LineSpacingRuleValues.Exact;
+
+
+            Assert.Equal(0, par00.LineSpacingAfter);
+            Assert.Equal(0, par00.LineSpacingBefore);
+
+            Assert.Equal(50, par01.LineSpacingAfter);
+            Assert.Equal(0, par01.LineSpacingBefore);
+
+            Assert.Equal(360, par02.LineSpacing);
+            Assert.Equal(LineSpacingRuleValues.Exact, par02.LineSpacingRule);
+
+            Assert.Equal(0, document.Paragraphs[0].LineSpacingAfter);
+            Assert.Equal(0, document.Paragraphs[0].LineSpacingBefore);
+
+            Assert.Equal(50, document.Paragraphs[1].LineSpacingAfter);
+            Assert.Equal(0, document.Paragraphs[1].LineSpacingBefore);
+
+            Assert.Equal(360, document.Paragraphs[2].LineSpacing);
+            Assert.Equal(LineSpacingRuleValues.Exact, document.Paragraphs[2].LineSpacingRule);
+            Assert.True(document.Paragraphs[2].Text == "My declaration 3");
+
+            Assert.Equal(3, document.Paragraphs.Count);
+
+            document.Save(false);
+        }
+
+        using (var document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithLineRules.docx"))) {
+            Assert.Equal(0, document.Paragraphs[0].LineSpacingAfter);
+            Assert.Equal(0, document.Paragraphs[0].LineSpacingBefore);
+
+            Assert.Equal(50, document.Paragraphs[1].LineSpacingAfter);
+            Assert.Equal(0, document.Paragraphs[1].LineSpacingBefore);
+
+            Assert.Equal(360, document.Paragraphs[2].LineSpacing);
+            Assert.Equal(LineSpacingRuleValues.Exact, document.Paragraphs[2].LineSpacingRule);
+            Assert.True(document.Paragraphs[2].Text == "My declaration 3");
+
+            var par02 = document.AddParagraph("My declaration 4");
+            par02.LineSpacing = 250;
+            par02.LineSpacingRule = LineSpacingRuleValues.AtLeast;
+
+            document.Save(false);
+        }
+
+        using (var document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithLineRules.docx"))) {
+            Assert.Equal(0, document.Paragraphs[0].LineSpacingAfter);
+            Assert.Equal(0, document.Paragraphs[0].LineSpacingBefore);
+
+            Assert.Equal(50, document.Paragraphs[1].LineSpacingAfter);
+            Assert.Equal(0, document.Paragraphs[1].LineSpacingBefore);
+
+            Assert.Equal(360, document.Paragraphs[2].LineSpacing);
+            Assert.Equal(LineSpacingRuleValues.Exact, document.Paragraphs[2].LineSpacingRule);
+            Assert.True(document.Paragraphs[2].Text == "My declaration 3");
+
+            Assert.Equal(250, document.Paragraphs[3].LineSpacing);
+            Assert.Equal(LineSpacingRuleValues.AtLeast, document.Paragraphs[3].LineSpacingRule);
+            Assert.True(document.Paragraphs[3].Text == "My declaration 4");
+
+        }
+    }
+}

--- a/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
@@ -179,7 +179,6 @@ namespace OfficeIMO.Word {
             //https://startbigthinksmall.wordpress.com/2010/01/04/points-inches-and-emus-measuring-units-in-office-open-xml/
             get {
                 if (_paragraphProperties != null && _paragraphProperties.TextDirection != null) {
-                    //new Indentation() { Left = "720", Right = "0", FirstLine = "0" };
                     if (_paragraphProperties.TextDirection != null) {
                         return _paragraphProperties.TextDirection.Val;
                     } else {
@@ -215,8 +214,7 @@ namespace OfficeIMO.Word {
                 } else {
                     spacing = _paragraphProperties.SpacingBetweenLines;
                 }
-
-                spacing.After = value.ToString();
+                spacing.LineRule = value;
                 _paragraphProperties.SpacingBetweenLines = spacing;
             }
         }


### PR DESCRIPTION
This PR fixes:
- https://github.com/EvotecIT/OfficeIMO/issues/146

It also adds:
- an example for line spacing
- basic testing for line spacing