### PR TITLE
implements muti para search and replace

### DIFF
--- a/OfficeIMO.Examples/Word/FindAndReplace/FindAndReplace01.cs
+++ b/OfficeIMO.Examples/Word/FindAndReplace/FindAndReplace01.cs
@@ -33,9 +33,9 @@ namespace OfficeIMO.Examples.Word {
                 var replacedCount = document.FindAndReplace("Test Section", "Production Section");
                 Console.WriteLine("Replaced (should be 2): " + replacedCount);
 
-                // should be 0 because it stretches over 2 paragraphs
+                // should be 2 because it stretches over 2 paragraphs
                 var replacedCount1 = document.FindAndReplace("This is a text more text", "Shorter text");
-                Console.WriteLine("Replaced (should be 0): " + replacedCount1);
+                Console.WriteLine("Replaced (should be 2): " + replacedCount1);
 
                 document.CleanupDocument();
 
@@ -43,7 +43,7 @@ namespace OfficeIMO.Examples.Word {
                 // this only works for same formatting though
                 // may require improvement in the future to ignore formatting completely, but then it's a bit tricky which formatting to apply
                 var replacedCount2 = document.FindAndReplace("This is a text more text", "Shorter text");
-                Console.WriteLine("Replaced (should be 1): " + replacedCount2);
+                Console.WriteLine("Replaced (should be 0): " + replacedCount2);
 
                 var replacedCount3 = document.FindAndReplace("even longer", "not longer");
                 Console.WriteLine("Replaced (should be 4): " + replacedCount3);

--- a/OfficeIMO.Tests/Word.FindAndReplace.cs
+++ b/OfficeIMO.Tests/Word.FindAndReplace.cs
@@ -32,10 +32,8 @@ namespace OfficeIMO.Tests {
                 Assert.True(replacedCount == 2);
 
                 // should be 0 because it stretches over 2 paragraphs
-                // this will need to be changed in the future to support this
-                // TODO: add a method that searches and replaces over multiple WordParagraphs or even native paragraphs
                 var replacedCount1 = document.FindAndReplace("This is a text more text", "Shorter text");
-                Assert.True(replacedCount1 == 0);
+                Assert.True(replacedCount1 == 2);
 
                 document.CleanupDocument();
 
@@ -43,7 +41,7 @@ namespace OfficeIMO.Tests {
                 // this only works for same formatting though
                 // may require improvement in the future to ignore formatting completely, but then it's a bit tricky which formatting to apply
                 var replacedCount2 = document.FindAndReplace("This is a text more text", "Shorter text");
-                Assert.True(replacedCount2 == 1);
+                Assert.True(replacedCount2 == 0);
 
                 var replacedCount3 = document.FindAndReplace("even longer", "not longer");
                 Assert.True(replacedCount3 == 4);

--- a/OfficeIMO.Word/WordPositionInParagraph.cs
+++ b/OfficeIMO.Word/WordPositionInParagraph.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OfficeIMO.Word {
+
+    /**
+    * postion of a character in a paragrapho
+   * 1st ParagraphPositon
+   * 2nd TextPosition
+   * 3rd CharacterPosition 
+   */
+    internal class WordPositionInParagraph {
+        private int posParagraph = 0, posText = 0, posChar = 0;
+
+        public WordPositionInParagraph() {
+        }
+
+        public WordPositionInParagraph(int posRun, int posText, int posChar) {
+            this.posParagraph = posRun;
+            this.posChar = posChar;
+            this.posText = posText;
+        }
+
+        public int Paragraph {
+            get {
+                return posParagraph;
+            }
+            set {
+                this.posParagraph = value;
+            }
+        }
+
+        public int Text {
+            get {
+                return posText;
+            }
+            set {
+                this.posText = value;
+            }
+        }
+
+
+        public int Char {
+            get {
+                return posChar;
+            }
+            set {
+                this.posChar = value;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordTextSegment.cs
+++ b/OfficeIMO.Word/WordTextSegment.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OfficeIMO.Word {
+    internal class WordTextSegment {
+        private WordPositionInParagraph beginPos;
+        private WordPositionInParagraph endPos;
+
+        public WordTextSegment() {
+            this.beginPos = new WordPositionInParagraph();
+            this.endPos = new WordPositionInParagraph();
+        }
+
+        public WordTextSegment(int beginRun, int endRun, int beginText, int endText, int beginChar, int endChar) {
+            WordPositionInParagraph beginPos = new WordPositionInParagraph(beginRun, beginText, beginChar);
+            WordPositionInParagraph endPos = new WordPositionInParagraph(endRun, endText, endChar);
+            this.beginPos = beginPos;
+            this.endPos = endPos;
+        }
+
+        public WordTextSegment(WordPositionInParagraph beginPos, WordPositionInParagraph endPos) {
+            this.beginPos = beginPos;
+            this.endPos = endPos;
+        }
+
+        public WordPositionInParagraph BeginPos {
+            get {
+                return beginPos;
+            }
+            set {
+                beginPos = value;
+            }
+        }
+
+        public WordPositionInParagraph EndPos {
+            get {
+                return endPos;
+            }
+        }
+        /// <summary>
+        /// The index of the begin paragraph
+        /// </summary>
+        public int BeginIndex {
+            get {
+                return beginPos.Paragraph;
+            }
+            set {
+                beginPos.Paragraph = value;
+            }
+        }
+      
+        /// <summary>
+        /// The index of the start text character
+        /// </summary>
+        public int BeginChar {
+            get {
+                return beginPos.Char;
+            }
+            set {
+                beginPos.Char = value;
+            }
+        }
+
+        /// <summary>
+        /// The index of the end paragraph
+        /// </summary>
+        public int EndIndex {
+            get {
+                return endPos.Paragraph;
+            }
+            set {
+                endPos.Paragraph = value;
+            }
+        }
+       
+        /// <summary>
+        /// the index of the end text character
+        /// </summary>
+        public int EndChar {
+            get {
+                return endPos.Char;
+            }
+            set {
+                endPos.Char = value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Till now, Office IMo can's find and replace the string from mutil para.  after search the web .found two source to do it

[Search and Replace Text in an Open XML WordprocessingML Document | Eric White](http://www.ericwhite.com/blog/search-and-replace-text-in-an-open-xml-wordprocessingml-document/)

https://github.com/nissl-lab/npoi/blob/32435d9485181a08f6993d3e94c10a70e5bb810a/ooxml/XWPF/Usermodel/XWPFParagraph.cs#L1307C22-L1307C22

the import thing is found the string location index of paras.

Also modify the wrong test and examples.

**Before**
![image](https://github.com/EvotecIT/OfficeIMO/assets/898009/00ca36af-76cf-447f-bef2-1b2671f3e5d2)
**After**
![image](https://github.com/EvotecIT/OfficeIMO/assets/898009/837dbc20-6a9c-4867-b117-f169db8bd8be)
