### PR TITLE
Fixed pos image

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -105,6 +105,7 @@ namespace OfficeIMO.Examples {
             Images.Example_ReadWordWithImages();
             Images.Example_AddingImagesMultipleTypes(folderPath, false);
             Images.Example_ReadWordWithImagesAndDiffWraps();
+            Images.Example_AddingFixedImages(folderPath, false);
 
             PageBreaks.Example_PageBreaks(folderPath, false);
             PageBreaks.Example_PageBreaks1(folderPath, false);

--- a/OfficeIMO.Examples/Word/Images/ImageFixedPosition.cs
+++ b/OfficeIMO.Examples/Word/Images/ImageFixedPosition.cs
@@ -1,66 +1,73 @@
 using System;
+using System.Runtime.CompilerServices;
 using DocumentFormat.OpenXml.Drawing;
+using DocumentFormat.OpenXml.Drawing.Wordprocessing;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class Images {
         internal static void Example_AddingFixedImages(string folderPath, bool openWord) {
-            Console.WriteLine("[*] Creating standard document with some Images");
-            //string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-            //string imagePaths = System.IO.Path.Combine(baseDirectory, "Images");
+            Console.WriteLine("[*] Creating standard document with an Image in a fixed position.");
             var filePath = System.IO.Path.Combine(folderPath, "BasicDocumentWithImages.docx");
             var imagePaths = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "Images");
 
             using var document = WordDocument.Create(filePath);
-            document.BuiltinDocumentProperties.Title = "This is sparta";
-            document.BuiltinDocumentProperties.Creator = "Przemek";
+            document.BuiltinDocumentProperties.Title = "Fixed image example";
+            document.BuiltinDocumentProperties.Creator = "example";
 
-            var paragraph1 = document.AddParagraph("This paragraph starts with some text");
-            paragraph1.Text = "0th This paragraph started with some other text and was overwritten and made bold.";
-            // lets add image to paragraph
-            paragraph1.AddImage(System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg"), 22, 22);
-            //paragraph1.Image.WrapText = true; // WrapSideValues.Both;
-
-            var paragraph2 = paragraph1.AddText("and more text");
-            paragraph2.Bold = true;
+            var paragraph1 = document.AddParagraph("First Paragraph");
 
             const string fileNameImage = "Kulek.jpg";
             var filePathImage = System.IO.Path.Combine(imagePaths, fileNameImage);
+            // Add an image with a fixed position to paragraph. First we add the image, then we will
+            // edit the position properties.
+            //
+            // The image MUST be constructed with a WrapTextImage property that is NOT inline. Assigning
+            // the WrapTextImage property later was not available at the time of making this example.
+            paragraph1.AddImage(filePathImage, 100, 100, WrapTextImage.Square);
 
-            document.AddParagraph("This adds another picture with 500x500");
-            var paragraph3 = document.AddParagraph();
-            paragraph3.AddImage(filePathImage, 500, 500);
-            //paragraph2.Image.BlackWiteMode = BlackWhiteModeValues.GrayWhite;
-            paragraph3.Image.Rotation = 180;
-            paragraph3.Image.Shape = ShapeTypeValues.ActionButtonMovie;
+            Console.WriteLine("PRE position edit.");
+            // Before editing, we can assess the RelativeFrom and PositionOffset properties of the image.
+            var hRelativeFrom = paragraph1.Image.horizontalPosition.RelativeFrom;
+            var hOffset = paragraph1.Image.horizontalPosition.PositionOffset.Text;
+            var vRelativeFrom = paragraph1.Image.verticalPosition.RelativeFrom;
+            var vOffset = paragraph1.Image.verticalPosition.PositionOffset.Text;
+            Console.WriteLine($"Horizontal RelativeFrom type: {hRelativeFrom.ToString()}");
+            Console.WriteLine($"Horizontal PositionOffset value: {hOffset.ToString()}");
+            Console.WriteLine($"Vertical RelativeFrom type: {vRelativeFrom.ToString()}");
+            Console.WriteLine($"Vertical PositionOffset value: {vOffset.ToString()}");
 
-            document.AddParagraph("This adds another picture with 100x100");
-            var paragraph4 = document.AddParagraph();
-            paragraph4.AddImage(filePathImage, 100, 100);
+            // Begin editing the fixed position properties of the image. You may edit both, however it
+            // is not necessary.
 
-            document.AddParagraph("This adds another picture via Stream with 100x100");
-            var paragraph5 = document.AddParagraph();
-            using (var imageStream = System.IO.File.OpenRead(filePathImage)) {
-                paragraph5.AddImage(imageStream, fileNameImage, 100, 100);
-            }
+            // Edit the horizontal relative from property of the image. Both
+            // the RelativeFrom property and PositionOffset are required.
+            HorizontalPosition horizontalPosition1 = new HorizontalPosition() { 
+                RelativeFrom = HorizontalRelativePositionValues.Page,
+                PositionOffset = new PositionOffset {  Text = "0" }
+            };
+            paragraph1.Image.horizontalPosition = horizontalPosition1;
 
-            // we add paragraph with an image
-            var paragraph6 = document.AddParagraph();
-            paragraph6.AddImage(filePathImage);
-            // we can get the height of the image from paragraph
-            Console.WriteLine("This document has image, which has height of: " + paragraph6.Image.Height + " pixels (I think) ;-)");
-            // we can also overwrite height later on
-            paragraph6.Image.Height = 50;
-            paragraph6.Image.Width = 50;
-            // this doesn't work
-            paragraph6.Image.HorizontalFlip = true;
+            // Edit the vertical relative from property of the image. Both
+            // the RelativeFrom property and PositionOffset are required.
+            VerticalPosition verticalPosition1 = new VerticalPosition() { 
+                RelativeFrom = VerticalRelativePositionValues.Page,
+                PositionOffset = new PositionOffset { Text = "0" }
+            };
+            paragraph1.Image.verticalPosition = verticalPosition1;
 
-            // or we can get any image and overwrite it's size
-            document.Images[0].Height = 200;
-            document.Images[0].Width = 200;
+            Console.WriteLine("POST position edit.");
+            // After editing, lets reassess the properties.
+            hRelativeFrom = paragraph1.Image.horizontalPosition.RelativeFrom;
+            hOffset = paragraph1.Image.horizontalPosition.PositionOffset.Text;
+            vRelativeFrom = paragraph1.Image.verticalPosition.RelativeFrom;
+            vOffset = paragraph1.Image.verticalPosition.PositionOffset.Text;
+            Console.WriteLine($"Horizontal RelativeFrom type: {hRelativeFrom.ToString()}");
+            Console.WriteLine($"Horizontal PositionOffset value: {hOffset.ToString()}");
+            Console.WriteLine($"Vertical RelativeFrom type: {vRelativeFrom.ToString()}");
+            Console.WriteLine($"Vertical PositionOffset value: {vOffset.ToString()}");
 
-            var fileToSave = System.IO.Path.Combine(imagePaths, "OutputPrzemyslawKlysAndKulkozaurr.jpg");
-            document.Images[0].SaveToFile(fileToSave);
+            // This will put the image in the upper top left corner of the document.
 
             document.Save(openWord);
         }

--- a/OfficeIMO.Examples/Word/Images/ImageFixedPosition.cs
+++ b/OfficeIMO.Examples/Word/Images/ImageFixedPosition.cs
@@ -1,0 +1,68 @@
+using System;
+using DocumentFormat.OpenXml.Drawing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Images {
+        internal static void Example_AddingFixedImages(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating standard document with some Images");
+            //string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            //string imagePaths = System.IO.Path.Combine(baseDirectory, "Images");
+            var filePath = System.IO.Path.Combine(folderPath, "BasicDocumentWithImages.docx");
+            var imagePaths = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "Images");
+
+            using var document = WordDocument.Create(filePath);
+            document.BuiltinDocumentProperties.Title = "This is sparta";
+            document.BuiltinDocumentProperties.Creator = "Przemek";
+
+            var paragraph1 = document.AddParagraph("This paragraph starts with some text");
+            paragraph1.Text = "0th This paragraph started with some other text and was overwritten and made bold.";
+            // lets add image to paragraph
+            paragraph1.AddImage(System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg"), 22, 22);
+            //paragraph1.Image.WrapText = true; // WrapSideValues.Both;
+
+            var paragraph2 = paragraph1.AddText("and more text");
+            paragraph2.Bold = true;
+
+            const string fileNameImage = "Kulek.jpg";
+            var filePathImage = System.IO.Path.Combine(imagePaths, fileNameImage);
+
+            document.AddParagraph("This adds another picture with 500x500");
+            var paragraph3 = document.AddParagraph();
+            paragraph3.AddImage(filePathImage, 500, 500);
+            //paragraph2.Image.BlackWiteMode = BlackWhiteModeValues.GrayWhite;
+            paragraph3.Image.Rotation = 180;
+            paragraph3.Image.Shape = ShapeTypeValues.ActionButtonMovie;
+
+            document.AddParagraph("This adds another picture with 100x100");
+            var paragraph4 = document.AddParagraph();
+            paragraph4.AddImage(filePathImage, 100, 100);
+
+            document.AddParagraph("This adds another picture via Stream with 100x100");
+            var paragraph5 = document.AddParagraph();
+            using (var imageStream = System.IO.File.OpenRead(filePathImage)) {
+                paragraph5.AddImage(imageStream, fileNameImage, 100, 100);
+            }
+
+            // we add paragraph with an image
+            var paragraph6 = document.AddParagraph();
+            paragraph6.AddImage(filePathImage);
+            // we can get the height of the image from paragraph
+            Console.WriteLine("This document has image, which has height of: " + paragraph6.Image.Height + " pixels (I think) ;-)");
+            // we can also overwrite height later on
+            paragraph6.Image.Height = 50;
+            paragraph6.Image.Width = 50;
+            // this doesn't work
+            paragraph6.Image.HorizontalFlip = true;
+
+            // or we can get any image and overwrite it's size
+            document.Images[0].Height = 200;
+            document.Images[0].Width = 200;
+
+            var fileToSave = System.IO.Path.Combine(imagePaths, "OutputPrzemyslawKlysAndKulkozaurr.jpg");
+            document.Images[0].SaveToFile(fileToSave);
+
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Images/ImageFixedPosition.cs
+++ b/OfficeIMO.Examples/Word/Images/ImageFixedPosition.cs
@@ -40,19 +40,27 @@ namespace OfficeIMO.Examples.Word {
             // Begin editing the fixed position properties of the image. You may edit both, however it
             // is not necessary.
 
+            // Note that the units for the PositionOffset are taken in EMU's. This is a conversion
+            // for an offset of 1/4 inch.
+            const double emusPerInch = 914400.0;
+            double offsetInches = 0.25;
+            // Non integer values will cause the document properties to be corrupted, cast
+            // to an int for avoiding this.
+            int offsetEmus = (int)(offsetInches * emusPerInch);
+
             // Edit the horizontal relative from property of the image. Both
             // the RelativeFrom property and PositionOffset are required.
-            HorizontalPosition horizontalPosition1 = new HorizontalPosition() { 
+            HorizontalPosition horizontalPosition1 = new HorizontalPosition() {
                 RelativeFrom = HorizontalRelativePositionValues.Page,
-                PositionOffset = new PositionOffset {  Text = "0" }
+                PositionOffset = new PositionOffset { Text = $"{offsetEmus}" }
             };
             paragraph1.Image.horizontalPosition = horizontalPosition1;
 
             // Edit the vertical relative from property of the image. Both
             // the RelativeFrom property and PositionOffset are required.
-            VerticalPosition verticalPosition1 = new VerticalPosition() { 
+            VerticalPosition verticalPosition1 = new VerticalPosition() {
                 RelativeFrom = VerticalRelativePositionValues.Page,
-                PositionOffset = new PositionOffset { Text = "0" }
+                PositionOffset = new PositionOffset { Text = $"{offsetEmus}" }
             };
             paragraph1.Image.verticalPosition = verticalPosition1;
 

--- a/OfficeIMO.Examples/Word/Images/ImageFixedPosition.cs
+++ b/OfficeIMO.Examples/Word/Images/ImageFixedPosition.cs
@@ -22,20 +22,16 @@ namespace OfficeIMO.Examples.Word {
             // Add an image with a fixed position to paragraph. First we add the image, then we will
             // edit the position properties.
             //
-            // The image MUST be constructed with a WrapTextImage property that is NOT inline. Assigning
+            // Note: The image MUST be constructed with a WrapTextImage property that is NOT inline. Assigning
             // the WrapTextImage property later was not available at the time of making this example.
             paragraph1.AddImage(filePathImage, 100, 100, WrapTextImage.Square);
 
             Console.WriteLine("PRE position edit.");
             // Before editing, we can assess the RelativeFrom and PositionOffset properties of the image.
-            var hRelativeFrom = paragraph1.Image.horizontalPosition.RelativeFrom;
-            var hOffset = paragraph1.Image.horizontalPosition.PositionOffset.Text;
-            var vRelativeFrom = paragraph1.Image.verticalPosition.RelativeFrom;
-            var vOffset = paragraph1.Image.verticalPosition.PositionOffset.Text;
-            Console.WriteLine($"Horizontal RelativeFrom type: {hRelativeFrom.ToString()}");
-            Console.WriteLine($"Horizontal PositionOffset value: {hOffset.ToString()}");
-            Console.WriteLine($"Vertical RelativeFrom type: {vRelativeFrom.ToString()}");
-            Console.WriteLine($"Vertical PositionOffset value: {vOffset.ToString()}");
+            DocumentFormat.OpenXml.EnumValue<HorizontalRelativePositionValues> hRelativeFrom;
+            string hOffset, vOffset;
+            DocumentFormat.OpenXml.EnumValue<VerticalRelativePositionValues> vRelativeFrom;
+            checkImageProps(paragraph1);
 
             // Begin editing the fixed position properties of the image. You may edit both, however it
             // is not necessary.
@@ -66,18 +62,22 @@ namespace OfficeIMO.Examples.Word {
 
             Console.WriteLine("POST position edit.");
             // After editing, lets reassess the properties.
-            hRelativeFrom = paragraph1.Image.horizontalPosition.RelativeFrom;
-            hOffset = paragraph1.Image.horizontalPosition.PositionOffset.Text;
-            vRelativeFrom = paragraph1.Image.verticalPosition.RelativeFrom;
-            vOffset = paragraph1.Image.verticalPosition.PositionOffset.Text;
-            Console.WriteLine($"Horizontal RelativeFrom type: {hRelativeFrom.ToString()}");
-            Console.WriteLine($"Horizontal PositionOffset value: {hOffset.ToString()}");
-            Console.WriteLine($"Vertical RelativeFrom type: {vRelativeFrom.ToString()}");
-            Console.WriteLine($"Vertical PositionOffset value: {vOffset.ToString()}");
+            checkImageProps(paragraph1);
 
             // This will put the image in the upper top left corner of the document.
 
             document.Save(openWord);
+
+            static void checkImageProps(WordParagraph paragraph1) { 
+                var hRelativeFrom = paragraph1.Image.horizontalPosition.RelativeFrom;
+                var hOffset = paragraph1.Image.horizontalPosition.PositionOffset.Text;
+                var vRelativeFrom = paragraph1.Image.verticalPosition.RelativeFrom;
+                var vOffset = paragraph1.Image.verticalPosition.PositionOffset.Text;
+                Console.WriteLine($"Horizontal RelativeFrom type: {hRelativeFrom.ToString()}");
+                Console.WriteLine($"Horizontal PositionOffset value: {hOffset.ToString()}");
+                Console.WriteLine($"Vertical RelativeFrom type: {vRelativeFrom.ToString()}");
+                Console.WriteLine($"Vertical PositionOffset value: {vOffset.ToString()}");
+            }
         }
     }
 }

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -36,9 +36,17 @@ namespace OfficeIMO.Word {
                 var hPosition = anchor.HorizontalPosition;
                 return hPosition;
             }
-            set { 
-                var anchor = _Image.Anchor;
-                anchor.HorizontalPosition = value;
+            set {
+                if (_Image.Inline == null) {
+                    var anchor = _Image.Anchor;
+                    anchor.HorizontalPosition = value;
+                }
+                else {
+                    throw new NotImplementedException("Not implemented - blocked by WrapTextImage property setter. WrapTextImage must not be Inline.");
+                    // See the property assignment for WrapTextImage. Until that is implemented,
+                    // this assignment will not be able to override the WrapTextImage property of
+                    // the image - which must not be Inline.
+                }
             }
         }
 
@@ -49,8 +57,16 @@ namespace OfficeIMO.Word {
                 return vPosition;
             }
             set { 
-                var anchor = _Image.Anchor;
-                anchor.VerticalPosition = value;
+                if (_Image.Inline == null) {
+                    var anchor = _Image.Anchor;
+                    anchor.VerticalPosition = value;
+                }
+                else {
+                    throw new NotImplementedException("Not implemented - blocked by WrapTextImage property setter. WrapTextImage must not be Inline.");
+                    // See the property assignment for WrapTextImage. Until that is implemented,
+                    // this assignment will not be able to override the WrapTextImage property of
+                    // the image - which must not be Inline.
+                }
             }
         }
 

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -30,18 +30,24 @@ namespace OfficeIMO.Word {
         private ImagePart _imagePart;
         private WordDocument _document;
 
+        /// <summary>
+        /// Get or set the Image's horizontal position.
+        /// </summary>
         public HorizontalPosition horizontalPosition {
             get {
-                var anchor = _Image.Anchor;
-                var hPosition = anchor.HorizontalPosition;
-                return hPosition;
+                if (_Image.Inline == null) {
+                    var anchor = _Image.Anchor;
+                    var hPosition = anchor.HorizontalPosition;
+                    return hPosition;
+                } else {
+                    throw new InvalidOperationException("Inline images do not have HorizontalPosition property.");
+                }
             }
             set {
                 if (_Image.Inline == null) {
                     var anchor = _Image.Anchor;
                     anchor.HorizontalPosition = value;
-                }
-                else {
+                } else {
                     throw new NotImplementedException("Not implemented - blocked by WrapTextImage property setter. WrapTextImage must not be Inline.");
                     // See the property assignment for WrapTextImage. Until that is implemented,
                     // this assignment will not be able to override the WrapTextImage property of
@@ -50,18 +56,24 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Get or set the Image's vertical position.
+        /// </summary>
         public VerticalPosition verticalPosition {
             get {
-                var anchor = _Image.Anchor;
-                var vPosition = anchor.VerticalPosition;
-                return vPosition;
+                if (_Image.Inline == null) {
+                    var anchor = _Image.Anchor;
+                    var vPosition = anchor.VerticalPosition;
+                    return vPosition;
+                } else {
+                    throw new InvalidOperationException("Inline images do not have HorizontalPosition property.");
+                }
             }
-            set { 
+            set {
                 if (_Image.Inline == null) {
                     var anchor = _Image.Anchor;
                     anchor.VerticalPosition = value;
-                }
-                else {
+                } else {
                     throw new NotImplementedException("Not implemented - blocked by WrapTextImage property setter. WrapTextImage must not be Inline.");
                     // See the property assignment for WrapTextImage. Until that is implemented,
                     // this assignment will not be able to override the WrapTextImage property of

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -30,6 +30,30 @@ namespace OfficeIMO.Word {
         private ImagePart _imagePart;
         private WordDocument _document;
 
+        public HorizontalPosition horizontalPosition {
+            get {
+                var anchor = _Image.Anchor;
+                var hPosition = anchor.HorizontalPosition;
+                return hPosition;
+            }
+            set { 
+                var anchor = _Image.Anchor;
+                anchor.HorizontalPosition = value;
+            }
+        }
+
+        public VerticalPosition verticalPosition {
+            get {
+                var anchor = _Image.Anchor;
+                var vPosition = anchor.VerticalPosition;
+                return vPosition;
+            }
+            set { 
+                var anchor = _Image.Anchor;
+                anchor.VerticalPosition = value;
+            }
+        }
+
         public BlipCompressionValues? CompressionQuality {
             get {
                 if (_Image.Inline != null) {

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -48,10 +48,7 @@ namespace OfficeIMO.Word {
                     var anchor = _Image.Anchor;
                     anchor.HorizontalPosition = value;
                 } else {
-                    throw new NotImplementedException("Not implemented - blocked by WrapTextImage property setter. WrapTextImage must not be Inline.");
-                    // See the property assignment for WrapTextImage. Until that is implemented,
-                    // this assignment will not be able to override the WrapTextImage property of
-                    // the image - which must not be Inline.
+                    throw new InvalidOperationException("Inline images do not have HorizontalPosition property.");
                 }
             }
         }
@@ -66,7 +63,7 @@ namespace OfficeIMO.Word {
                     var vPosition = anchor.VerticalPosition;
                     return vPosition;
                 } else {
-                    throw new InvalidOperationException("Inline images do not have HorizontalPosition property.");
+                    throw new InvalidOperationException("Inline images do not have VerticalPosition property.");
                 }
             }
             set {
@@ -74,10 +71,7 @@ namespace OfficeIMO.Word {
                     var anchor = _Image.Anchor;
                     anchor.VerticalPosition = value;
                 } else {
-                    throw new NotImplementedException("Not implemented - blocked by WrapTextImage property setter. WrapTextImage must not be Inline.");
-                    // See the property assignment for WrapTextImage. Until that is implemented,
-                    // this assignment will not be able to override the WrapTextImage property of
-                    // the image - which must not be Inline.
+                    throw new InvalidOperationException("Inline images do not have VerticalPosition property.");
                 }
             }
         }


### PR DESCRIPTION
This PR adds a feature
* #164 

This is one by exposing positioning properties of the Image
```csharp
        /// <summary>
        /// Get or set the Image's horizontal position.
        /// </summary>
        public HorizontalPosition horizontalPosition {
            get {
                if (_Image.Inline == null) {
                    var anchor = _Image.Anchor;
                    var hPosition = anchor.HorizontalPosition;
                    return hPosition;
                } else {
                    throw new InvalidOperationException("Inline images do not have HorizontalPosition property.");
                }
            }
            set {
                if (_Image.Inline == null) {
                    var anchor = _Image.Anchor;
                    anchor.HorizontalPosition = value;
                } else {
                    throw new InvalidOperationException("Inline images do not have HorizontalPosition property.");
                }
            }
        }

        /// <summary>
        /// Get or set the Image's vertical position.
        /// </summary>
        public VerticalPosition verticalPosition {
            get {
                if (_Image.Inline == null) {
                    var anchor = _Image.Anchor;
                    var vPosition = anchor.VerticalPosition;
                    return vPosition;
                } else {
                    throw new InvalidOperationException("Inline images do not have VerticalPosition property.");
                }
            }
            set {
                if (_Image.Inline == null) {
                    var anchor = _Image.Anchor;
                    anchor.VerticalPosition = value;
                } else {
                    throw new InvalidOperationException("Inline images do not have VerticalPosition property.");
                }
            }
        }
```

Includes an example and test case for the newly exposed properties.