### PR TITLE
pullic FindAndReplace

### DIFF
--- a/OfficeIMO.Tests/Word.Tables.cs
+++ b/OfficeIMO.Tests/Word.Tables.cs
@@ -811,7 +811,7 @@ namespace OfficeIMO.Tests {
                 document.Save(false);
 
             }
-          
+
         }
 
 
@@ -819,7 +819,10 @@ namespace OfficeIMO.Tests {
         public void Test_CreatingWordDocumentWithTablesWithReplace() {
             string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithTablesReplace.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
-             
+
+                document.AddParagraph("Table1 - Test 1");
+                document.AddParagraph("Test1");
+
 
                 WordTable wordTable = document.AddTable(3, 4);
                 wordTable.Rows[0].Cells[0].Paragraphs[0].Text = "Test 1";
@@ -830,7 +833,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-            
+
                 Assert.True(document.Tables.Count == 1);
 
                 var wordTable = document.Tables[0];
@@ -841,7 +844,12 @@ namespace OfficeIMO.Tests {
 
                 WordDocument.FindAndReplace(wordTable.Rows[0].Cells[0].Paragraphs, "Test 1", "Test 11");
                 WordDocument.FindAndReplace(wordTable.Rows[1].Cells[0].Paragraphs, "Test 2", "Test 21");
-               
+
+                // lets make sure find and replace works only on table
+                Assert.True(document.Paragraphs[0].Text == "Table1 - Test 1");
+                Assert.True(document.Paragraphs[1].Text == "Test1");
+
+                // lets check data for table
                 Assert.True(wordTable.Rows[0].Cells[0].Paragraphs[0].Text == "Test 11");
                 Assert.True(wordTable.Rows[1].Cells[0].Paragraphs[0].Text == "Test 21");
                 Assert.True(wordTable.Rows[2].Cells[0].Paragraphs[0].Text == "Test 3");

--- a/OfficeIMO.Tests/Word.Tables.cs
+++ b/OfficeIMO.Tests/Word.Tables.cs
@@ -813,5 +813,42 @@ namespace OfficeIMO.Tests {
             }
           
         }
+
+
+        [Fact]
+        public void Test_CreatingWordDocumentWithTablesWithReplace() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithTablesReplace.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+             
+
+                WordTable wordTable = document.AddTable(3, 4);
+                wordTable.Rows[0].Cells[0].Paragraphs[0].Text = "Test 1";
+                wordTable.Rows[1].Cells[0].Paragraphs[0].Text = "Test 2";
+                wordTable.Rows[2].Cells[0].Paragraphs[0].Text = "Test 3";
+
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+            
+                Assert.True(document.Tables.Count == 1);
+
+                var wordTable = document.Tables[0];
+
+                Assert.True(wordTable.Rows[0].Cells[0].Paragraphs[0].Text == "Test 1");
+                Assert.True(wordTable.Rows[1].Cells[0].Paragraphs[0].Text == "Test 2");
+                Assert.True(wordTable.Rows[2].Cells[0].Paragraphs[0].Text == "Test 3");
+
+                WordDocument.FindAndReplace(wordTable.Rows[0].Cells[0].Paragraphs, "Test 1", "Test 11");
+                WordDocument.FindAndReplace(wordTable.Rows[1].Cells[0].Paragraphs, "Test 2", "Test 21");
+               
+                Assert.True(wordTable.Rows[0].Cells[0].Paragraphs[0].Text == "Test 11");
+                Assert.True(wordTable.Rows[1].Cells[0].Paragraphs[0].Text == "Test 21");
+
+                document.Save();
+            }
+
+        }
+
     }
 }

--- a/OfficeIMO.Tests/Word.Tables.cs
+++ b/OfficeIMO.Tests/Word.Tables.cs
@@ -844,6 +844,7 @@ namespace OfficeIMO.Tests {
                
                 Assert.True(wordTable.Rows[0].Cells[0].Paragraphs[0].Text == "Test 11");
                 Assert.True(wordTable.Rows[1].Cells[0].Paragraphs[0].Text == "Test 21");
+                Assert.True(wordTable.Rows[2].Cells[0].Paragraphs[0].Text == "Test 3");
 
                 document.Save();
             }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -243,14 +243,35 @@ namespace OfficeIMO.Word {
             return list;
         }
 
+        /// <summary>
+        /// FindAdnReplace from the whole doc
+        /// </summary>
+        /// <param name="textToFind"></param>
+        /// <param name="textToReplace"></param>
+        /// <param name="stringComparison"></param>
+        /// <returns></returns>
         public int FindAndReplace(string textToFind, string textToReplace, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase) {
             int countFind = 0;
             FindAndReplaceInternal(textToFind, textToReplace, ref countFind, true, stringComparison);
             return countFind;
         }
 
+        /// <summary>
+        /// FindAdnReplace from the range parparagraphs
+        /// </summary>
+        /// <param name="paragraphs"></param>
+        /// <param name="textToFind"></param>
+        /// <param name="textToReplace"></param>
+        /// <param name="stringComparison"></param>
+        /// <returns></returns>
+        public static  int  FindAndReplace(List<WordParagraph> paragraphs, string textToFind, string textToReplace, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase) {
+            int countFind = 0;
+            FindAndReplaceNested(paragraphs, textToFind, textToReplace, ref countFind, true, stringComparison);
+            return countFind;
+        }
 
-        private List<WordParagraph> FindAndReplaceNested(List<WordParagraph> paragraphs, string textToFind, string textToReplace, ref int count, bool replace, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase) {
+
+        private static List<WordParagraph> FindAndReplaceNested(List<WordParagraph> paragraphs, string textToFind, string textToReplace, ref int count, bool replace, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase) {
             List<WordParagraph> foundParagraphs = ReplaceText(paragraphs, textToFind, textToReplace, ref count, replace, stringComparison);
             return foundParagraphs;
         }


### PR DESCRIPTION
we have the full doc replace ,and sometimes ,we will want just replace from a list paras(indeed it was a real paragraph).so I pulic the  FindAndReplace method

```cs
public static  int  FindAndReplace(List<WordParagraph> paragraphs, string textToFind, string textToReplace, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
```