### PR TITLE
Added the ability to clear the default empty paragraph in TableCell.

### DIFF
--- a/OfficeIMO.Tests/Word.Tables.cs
+++ b/OfficeIMO.Tests/Word.Tables.cs
@@ -859,5 +859,64 @@ namespace OfficeIMO.Tests {
 
         }
 
+        [Fact]
+        public void Test_CreatingWordDocumentWithTablesClearParagraphs() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithTables.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                Assert.True(document.Paragraphs.Count == 0, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
+                Assert.True(document.Tables.Count == 0, "Tables count matches");
+                Assert.True(document.Lists.Count == 0, "List count matches");
+
+                var paragraph = document.AddParagraph("Basic paragraph - Page 4");
+                paragraph.ParagraphAlignment = JustificationValues.Center;
+
+                WordTable wordTable = document.AddTable(3, 4);
+                wordTable.Rows[0].Cells[0].Paragraphs[0].Text = "Test 1";
+                wordTable.Rows[1].Cells[0].Paragraphs[0].Text = "Test 2";
+                wordTable.Rows[2].Cells[0].Paragraphs[0].Text = "Test 3";
+
+                wordTable.Rows[0].Cells[1].Paragraphs[0].Text = "Test Row 0 Cell 1";
+
+                Assert.True(document.Tables.Count == 1);
+                Assert.True(document.Tables[0].Rows[0].Cells[0].Paragraphs.Count == 1);
+                Assert.True(document.Tables[0].Rows[0].Cells[1].Paragraphs.Count == 1);
+
+                // add 2 more texts to the same cell as new paragraphs
+                wordTable.Rows[0].Cells[0].Paragraphs[0].AddParagraph("New");
+                wordTable.Rows[0].Cells[0].Paragraphs[1].AddParagraph("New more");
+
+                Assert.True(document.Tables[0].Rows[0].Cells[0].Paragraphs.Count == 3);
+
+                Assert.True(document.Tables[0].Rows[0].Cells[0].Paragraphs[0].Text == "Test 1");
+                Assert.True(document.Tables[0].Rows[0].Cells[0].Paragraphs[1].Text == "New");
+                Assert.True(document.Tables[0].Rows[0].Cells[0].Paragraphs[2].Text == "New more");
+
+                // replace existing paragraphs with single one 
+                wordTable.Rows[0].Cells[0].AddParagraph("New paragraph, delete rest", true);
+
+                Assert.True(document.Tables[0].Rows[0].Cells[0].Paragraphs.Count == 1);
+                Assert.True(document.Tables[0].Rows[0].Cells[0].Paragraphs[0].Text == "New paragraph, delete rest");
+
+                // lets try to add new paragraph to the same cell, using WordParagraph
+                Assert.True(document.Tables[0].Rows[0].Cells[1].Paragraphs.Count == 1);
+                Assert.True(document.Tables[0].Rows[0].Cells[1].Paragraphs[0].Text == "Test Row 0 Cell 1");
+
+                WordParagraph paragraph1 = new WordParagraph {
+                    Text = "Paragraph added separately as WordParagraph",
+                    Bold = true,
+                    Italic = true
+                };
+
+                wordTable.Rows[0].Cells[1].AddParagraph(paragraph1);
+
+                Assert.True(document.Tables[0].Rows[0].Cells[1].Paragraphs.Count == 2);
+                Assert.True(document.Tables[0].Rows[0].Cells[1].Paragraphs[0].Text == "Test Row 0 Cell 1");
+                Assert.True(document.Tables[0].Rows[0].Cells[1].Paragraphs[1].Text == "Paragraph added separately as WordParagraph");
+                Assert.True(document.Tables[0].Rows[0].Cells[1].Paragraphs[1].Bold == true);
+                Assert.True(document.Tables[0].Rows[0].Cells[1].Paragraphs[1].Italic == true);
+
+                document.Save(false);
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -112,7 +112,7 @@ namespace OfficeIMO.Word {
             // a deletePrevious that will replace the last paragraph.
             // NOTE: Raise this during PR.
             if (removeExistingParagraphs) {
-                var paragraphs = _tableCell.ChildElements.OfType<Paragraph>();
+                var paragraphs = _tableCell.ChildElements.OfType<Paragraph>().ToList();
                 foreach (var wordParagraph in paragraphs) {
                     wordParagraph.Remove();
                 }
@@ -128,9 +128,10 @@ namespace OfficeIMO.Word {
         /// Add paragraph to the table cell with text
         /// </summary>
         /// <param name="text"></param>
+        /// <param name="removeExistingParagraphs"></param>
         /// <returns></returns>
-        public WordParagraph AddParagraph(string text) {
-            return AddParagraph().SetText(text);
+        public WordParagraph AddParagraph(string text, bool removeExistingParagraphs = false) {
+            return AddParagraph(paragraph: null, removeExistingParagraphs).SetText(text);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -102,21 +102,20 @@ namespace OfficeIMO.Word {
         /// <param name="paragraph">The paragraph to add to this cell, if
         /// this is not passed then a new empty paragraph with settings from
         /// the previous paragraph will be added.</param>
-        /// <param name="reset">If reset is not passed or false then add
-        /// the given paragraph into the cell. If reset is true then clear
+        /// <param name="removeExistingParagraphs">If value is not passed or false then add
+        /// the given paragraph into the cell. If set to true then clear
         /// every existing paragraph before adding the new paragraph.
         /// </param>
         /// <returns>A reference to the added paragraph.</returns>
-        public WordParagraph AddParagraph(WordParagraph paragraph = null, bool reset = false) {
+        public WordParagraph AddParagraph(WordParagraph paragraph = null, bool removeExistingParagraphs = false) {
             // Considering between implementing a reset that clears all paragraphs or
             // a deletePrevious that will replace the last paragraph.
             // NOTE: Raise this during PR.
-            if (reset) {
+            if (removeExistingParagraphs) {
                 var paragraphs = _tableCell.ChildElements.OfType<Paragraph>();
                 foreach (var wordParagraph in paragraphs) {
                     wordParagraph.Remove();
                 }
-                
             }
             if (paragraph == null) {
                 paragraph = new WordParagraph(this._document);
@@ -355,7 +354,7 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
-        /// Splits (unmerge) cells that were merged 
+        /// Splits (unmerge) cells that were merged
         /// </summary>
         /// <param name="cellsCount"></param>
         public void SplitHorizontally(int cellsCount) {
@@ -375,7 +374,7 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
-        /// Merges two or more cells together vertically 
+        /// Merges two or more cells together vertically
         /// </summary>
         /// <param name="cellsCount"></param>
         /// <param name="copyParagraphs"></param>

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -113,8 +113,8 @@ namespace OfficeIMO.Word {
             // NOTE: Raise this during PR.
             if (reset) {
                 var paragraphs = _tableCell.ChildElements.OfType<Paragraph>();
-                foreach (var paragraph in paragraphs) {
-                    paragraph.Remove();
+                foreach (var wordParagraph in paragraphs) {
+                    wordParagraph.Remove();
                 }
                 
             }

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -99,9 +99,25 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Add paragraph to the table cell
         /// </summary>
-        /// <param name="paragraph"></param>
-        /// <returns></returns>
-        public WordParagraph AddParagraph(WordParagraph paragraph = null) {
+        /// <param name="paragraph">The paragraph to add to this cell, if
+        /// this is not passed then a new empty paragraph with settings from
+        /// the previous paragraph will be added.</param>
+        /// <param name="reset">If reset is not passed or false then add
+        /// the given paragraph into the cell. If reset is true then clear
+        /// every existing paragraph before adding the new paragraph.
+        /// </param>
+        /// <returns>A reference to the added paragraph.</returns>
+        public WordParagraph AddParagraph(WordParagraph paragraph = null, bool reset = false) {
+            // Considering between implementing a reset that clears all paragraphs or
+            // a deletePrevious that will replace the last paragraph.
+            // NOTE: Raise this during PR.
+            if (reset) {
+                var paragraphs = _tableCell.ChildElements.OfType<Paragraph>();
+                foreach (var paragraph in paragraphs) {
+                    paragraph.Remove();
+                }
+                
+            }
             if (paragraph == null) {
                 paragraph = new WordParagraph(this._document);
             }


### PR DESCRIPTION
Working with this library, I was having each cell being with an empty paragraph default styling. This pull request adds an optional parameter to the function for adding a paragraph, if left out or false the behavior will not change. When true the method will now remove every paragraph under the table cell. I had also considered making the parameter toggle deleting the prior paragraph only. This may be better, I decided against proposing that because a full reset is easier to think through in my mind.

The comment about mentioning in the PR ought to be removed, I have also documented the return value, parameter, and new parameter in the documentation comment.

This PR is untested.