### PR TITLE
[WordTextBox] Add additional features

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -823,7 +823,7 @@ internal static void Example_AddingImagesSample4(string folderPath, bool openWor
 
 
     var paragraph3 = document.AddParagraph("Image will be in front of text");
-    paragraph3.AddImage(System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg"), 200, 200, WrapImageText.InFrontText, "Przemek and Kulek on an image");
+    paragraph3.AddImage(System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg"), 200, 200, WrapImageText.InFrontOfText, "Przemek and Kulek on an image");
 
 
     var paragraph5 = document.AddParagraph("Image will be Square");

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -156,6 +156,7 @@ namespace OfficeIMO.Examples {
 
             WordTextBox.Example_AddingTextbox(folderPath, false);
             WordTextBox.Example_AddingTextbox2(folderPath, false);
+            WordTextBox.Example_AddingTextbox4(folderPath, false);
 
         }
     }

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -151,13 +151,13 @@ namespace OfficeIMO.Examples {
 
             SaveToStream.Example_StreamDocumentProperties(folderPath, false);
 
-            Protect.Example_ProtectFinalDocument(folderPath, true);
-            Protect.Example_ProtectAlwaysReadOnly(folderPath, true);
+            Protect.Example_ProtectFinalDocument(folderPath, false);
+            Protect.Example_ProtectAlwaysReadOnly(folderPath, false);
 
             WordTextBox.Example_AddingTextbox(folderPath, false);
             WordTextBox.Example_AddingTextbox2(folderPath, false);
             WordTextBox.Example_AddingTextbox4(folderPath, false);
-
+            WordTextBox.Example_AddingTextbox5(folderPath, false);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/Images/Images.Sample1.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.Sample1.cs
@@ -18,8 +18,10 @@ namespace OfficeIMO.Examples.Word {
             var paragraph1 = document.AddParagraph("This paragraph starts with some text");
             paragraph1.Text = "0th This paragraph started with some other text and was overwritten and made bold.";
             // lets add image to paragraph
-            paragraph1.AddImage(System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg"), 22, 22);
-            //paragraph1.Image.WrapText = true; // WrapSideValues.Both;
+            var paragraphImage = paragraph1.AddImage(System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg"), 22, 22, WrapTextImage.BehindText);
+
+            Console.WriteLine(paragraph1.Image.WrapText);
+            Console.WriteLine(paragraphImage.Image.WrapText);
 
             var paragraph2 = paragraph1.AddText("and more text");
             paragraph2.Bold = true;

--- a/OfficeIMO.Examples/Word/Images/Images.Sample4.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.Sample4.cs
@@ -20,7 +20,7 @@ namespace OfficeIMO.Examples.Word {
 
 
             var paragraph3 = document.AddParagraph("Image will be in front of text");
-            paragraph3.AddImage(System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg"), 200, 200, WrapTextImage.InFrontText, "Przemek and Kulek on an image");
+            paragraph3.AddImage(System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg"), 200, 200, WrapTextImage.InFrontOfText, "Przemek and Kulek on an image");
 
 
             var paragraph5 = document.AddParagraph("Image will be Square");

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample4.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample4.cs
@@ -76,6 +76,19 @@ namespace OfficeIMO.Examples.Word {
 
                 Console.WriteLine("Textbox7 (body) wraptext (Through): " + textBox7.WrapText);
 
+                document.AddPageBreak();
+
+                document.Sections[0].AddTextBox("My textbox 8 center - Square", WrapTextImage.Square);
+                document.Sections[0].TextBoxes[0].HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Margin;
+                document.Sections[0].TextBoxes[0].VerticalPositionOffsetCentimeters = 10;
+
+                //document.AddPageBreak();
+
+                document.AddSection();
+
+                var wordTextbox = document.Sections[1].AddTextBox("My textbox 9 center - Square", WrapTextImage.Square);
+                wordTextbox.VerticalPositionOffsetCentimeters = 10;
+
                 document.Save(openWord);
             }
         }

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample4.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample4.cs
@@ -1,0 +1,83 @@
+using System;
+using DocumentFormat.OpenXml.Drawing.Wordprocessing;
+using DocumentFormat.OpenXml.Spreadsheet;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Color = SixLabors.ImageSharp.Color;
+using HorizontalAlignmentValues = DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalAlignmentValues;
+using Text = DocumentFormat.OpenXml.Spreadsheet.Text;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class WordTextBox {
+        internal static void Example_AddingTextbox4(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating standard document with some textbox");
+
+            var filePath = System.IO.Path.Combine(folderPath, "BasicDocumentWithTextBox4.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Adding paragraph with some text");
+
+                document.AddHeadersAndFooters();
+
+                var textBox = document.Header.Default.AddTextBox("My textbox in header");
+
+                Console.WriteLine("Textbox (header) wraptext: " + textBox.WrapText);
+
+                textBox.WrapText = WrapTextImage.Square;
+
+                Console.WriteLine("Textbox (header) wraptext: " + textBox.WrapText);
+
+                //var textBox1 = document.AddTextBox("My textbox 1 left - InLineWithText", WrapTextImage.InLineWithText);
+                //textBox1.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                //textBox1.HorizontalAlignment = HorizontalAlignmentValues.Left;
+                //textBox1.VerticalPositionOffsetCentimeters = 6;
+
+                //Console.WriteLine("Textbox1 (body) wraptext (InLineWithText): " + textBox1.WrapText);
+
+                var textBox2 = document.AddTextBox("My textbox 2 right - square", WrapTextImage.Square);
+                textBox2.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                textBox2.HorizontalAlignment = HorizontalAlignmentValues.Right;
+                textBox2.VerticalPositionOffsetCentimeters = 6;
+
+                Console.WriteLine("Textbox2 (body) wraptext (Square): " + textBox2.WrapText);
+
+                var textBox3 = document.AddTextBox("My textbox 3 center - tight", WrapTextImage.Tight);
+                textBox3.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                textBox3.HorizontalAlignment = HorizontalAlignmentValues.Center;
+                textBox3.VerticalPositionOffsetCentimeters = 6;
+
+                Console.WriteLine("Textbox3 (body) wraptext (Tight): " + textBox3.WrapText);
+
+                var textBox4 = document.AddTextBox("My textbox 4 left - behind text", WrapTextImage.BehindText);
+                textBox4.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                textBox4.HorizontalAlignment = HorizontalAlignmentValues.Left;
+                textBox4.VerticalPositionOffsetCentimeters = 9;
+
+                Console.WriteLine("Textbox4 (body) wraptext (BehindText): " + textBox4.WrapText);
+
+                var textBox5 = document.AddTextBox("My textbox 5 right - in front of text", WrapTextImage.InFrontOfText);
+                textBox5.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                textBox5.HorizontalAlignment = HorizontalAlignmentValues.Right;
+                textBox5.VerticalPositionOffsetCentimeters = 9;
+
+                Console.WriteLine("Textbox5 (body) wraptext (InFrontOfText): " + textBox5.WrapText);
+
+                var textBox6 = document.AddTextBox("My textbox 6 left - top and bottom", WrapTextImage.TopAndBottom);
+                textBox6.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                textBox6.HorizontalAlignment = HorizontalAlignmentValues.Left;
+                textBox6.VerticalPositionOffsetCentimeters = 12;
+
+                Console.WriteLine("Textbox6 (body) wraptext (TopAndBottom): " + textBox6.WrapText);
+
+                var textBox7 = document.AddTextBox("My textbox 7 right - through", WrapTextImage.Through);
+                textBox7.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                textBox7.HorizontalAlignment = HorizontalAlignmentValues.Right;
+                textBox7.VerticalPositionOffsetCentimeters = 12;
+
+                Console.WriteLine("Textbox7 (body) wraptext (Through): " + textBox7.WrapText);
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample5.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample5.cs
@@ -1,0 +1,30 @@
+using System;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class WordTextBox {
+        internal static void Example_AddingTextbox5(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating standard document with inline textbox");
+
+            var filePath = System.IO.Path.Combine(folderPath, "BasicDocumentWithTextBox5.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Adding paragraph with some text");
+
+                var textBox = document.AddTextBox("My textbox right - inline", WrapTextImage.InLineWithText);
+
+                Console.WriteLine("[i] TextBox2 (inline): " + textBox.WrapText);
+
+                textBox.WrapText = WrapTextImage.Square;
+
+                Console.WriteLine("[i] TextBox2 (square): " + textBox.WrapText);
+
+                textBox.WrapText = WrapTextImage.InLineWithText;
+
+                Console.WriteLine("[i] TextBox2 (square): " + textBox.WrapText);
+
+                document.Save(true);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Images.cs
+++ b/OfficeIMO.Tests/Word.Images.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using DocumentFormat.OpenXml.Drawing;
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
@@ -22,7 +23,15 @@ namespace OfficeIMO.Tests {
 
             // lets add image to paragraph
             paragraph.AddImage(Path.Combine(_directoryWithImages, "PrzemyslawKlysAndKulkozaurr.jpg"), 22, 22);
-            //paragraph.Image.WrapText = true; // WrapSideValues.Both;
+            Assert.True(paragraph.Image.WrapText == WrapTextImage.InLineWithText);
+
+            paragraph.Image.WrapText = WrapTextImage.BehindText;
+
+            Assert.True(paragraph.Image.WrapText == WrapTextImage.BehindText);
+
+            paragraph.Image.WrapText = WrapTextImage.InLineWithText;
+
+            Assert.True(paragraph.Image.WrapText == WrapTextImage.InLineWithText);
 
             var paragraph5 = paragraph.AddText("and more text");
             paragraph5.Bold = true;
@@ -79,6 +88,8 @@ namespace OfficeIMO.Tests {
             Assert.Equal(4, document.Images.Count);
             Assert.Equal(4, document.Sections[0].Images.Count);
             document.Save(false);
+
+            Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
         }
 
 
@@ -230,6 +241,8 @@ namespace OfficeIMO.Tests {
             Assert.True(document.Paragraphs[6].Image.WrapText == WrapTextImage.Through);
 
             document.Save(false);
+
+            Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
         }
 
         [Fact]
@@ -290,6 +303,8 @@ namespace OfficeIMO.Tests {
             Assert.NotEqual(vRelativeFromFail, document.Paragraphs[1].Image.verticalPosition.RelativeFrom.Value);
 
             document.Save(false);
+
+            Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
         }
 
         [Fact]
@@ -324,7 +339,38 @@ namespace OfficeIMO.Tests {
             Assert.True(document.Header.Default.Tables.Count == 1);
 
             document.Save(false);
+
+            Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
         }
+
+        [Fact]
+        public void Test_CreatingWordDocumentWithImagesInline() {
+            var filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithImagesInline.docx");
+            using var document = WordDocument.Create(filePath);
+
+            var paragraph = document.AddParagraph("This paragraph starts with some text");
+            paragraph.Text = "0th This paragraph started with some other text and was overwritten and made bold.";
+
+            // lets add image to paragraph
+            var imageParagraph = paragraph.AddImage(Path.Combine(_directoryWithImages, "PrzemyslawKlysAndKulkozaurr.jpg"), 22, 22, WrapTextImage.InLineWithText);
+
+            Assert.True(document.Images[0].WrapText == WrapTextImage.InLineWithText);
+
+            Assert.True(imageParagraph.Image.WrapText == WrapTextImage.InLineWithText);
+
+            imageParagraph.Image.WrapText = WrapTextImage.Square;
+
+            Assert.True(imageParagraph.Image.WrapText == WrapTextImage.Square);
+
+            var paragraph5 = paragraph.AddText("and more text");
+            paragraph5.Bold = true;
+
+
+            document.Save(false);
+
+            Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
+        }
+
     }
 
 }

--- a/OfficeIMO.Tests/Word.Images.cs
+++ b/OfficeIMO.Tests/Word.Images.cs
@@ -174,7 +174,7 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(document.Images[0].WrapText == WrapTextImage.InLineWithText);
                 Assert.True(document.Images[1].WrapText == WrapTextImage.Square);
-                Assert.True(document.Images[2].WrapText == WrapTextImage.InFrontText);
+                Assert.True(document.Images[2].WrapText == WrapTextImage.InFrontOfText);
                 Assert.True(document.Images[3].WrapText == WrapTextImage.BehindText);
                 Assert.True(document.Header.Default.Images[0].WrapText == WrapTextImage.InLineWithText);
 
@@ -206,7 +206,7 @@ namespace OfficeIMO.Tests {
             paragraph2.AddImage(filePathImage, 100, 100, WrapTextImage.BehindText);
 
             var paragraph3 = document.AddParagraph("This is a test document with images wraps");
-            paragraph3.AddImage(filePathImage, 100, 100, WrapTextImage.InFrontText);
+            paragraph3.AddImage(filePathImage, 100, 100, WrapTextImage.InFrontOfText);
 
             var paragraph4 = document.AddParagraph("This is a test document with images wraps");
             paragraph4.AddImage(filePathImage, 100, 100, WrapTextImage.TopAndBottom);
@@ -223,7 +223,7 @@ namespace OfficeIMO.Tests {
             Assert.True(document.Paragraphs.Count == 7);
             Assert.True(document.Paragraphs[0].Image.WrapText == WrapTextImage.InLineWithText);
             Assert.True(document.Paragraphs[1].Image.WrapText == WrapTextImage.BehindText);
-            Assert.True(document.Paragraphs[2].Image.WrapText == WrapTextImage.InFrontText);
+            Assert.True(document.Paragraphs[2].Image.WrapText == WrapTextImage.InFrontOfText);
             Assert.True(document.Paragraphs[3].Image.WrapText == WrapTextImage.TopAndBottom);
             Assert.True(document.Paragraphs[4].Image.WrapText == WrapTextImage.Square);
             Assert.True(document.Paragraphs[5].Image.WrapText == WrapTextImage.Tight);

--- a/OfficeIMO.Tests/Word.TextBox.cs
+++ b/OfficeIMO.Tests/Word.TextBox.cs
@@ -272,5 +272,97 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.TextBoxes.Count == 1);
             }
         }
+
+        [Fact]
+        public void Test_CreatingWordDocumentWithTextBoxInSectionsAndHeaders() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreateDocumentWithTextBoxesInSectionsAndHeaders.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+
+                document.AddHeadersAndFooters();
+
+                Assert.True(document.Sections.Count == 1);
+
+                document.AddPageBreak();
+                document.AddSection();
+
+                Assert.True(document.Sections.Count == 2);
+
+                document.AddTextBox("This is a textbox");
+
+                Assert.True(document.Sections[0].TextBoxes.Count == 0);
+                Assert.True(document.Sections[1].TextBoxes.Count == 1);
+
+                document.Sections[0].AddTextBox("This is a textbox in section 0");
+
+                Assert.True(document.Sections[0].TextBoxes.Count == 1);
+                Assert.True(document.Sections[1].TextBoxes.Count == 1);
+                Assert.True(document.TextBoxes.Count == 2);
+
+                document.AddPageBreak();
+                document.AddSection();
+
+                document.Save(false);
+
+                Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithTextBoxesInSectionsAndHeaders.docx"))) {
+                Assert.True(document.Sections[0].TextBoxes.Count == 1);
+                Assert.True(document.Sections[1].TextBoxes.Count == 1);
+                Assert.True(document.TextBoxes.Count == 2);
+
+                var textBox2 = document.AddTextBox("My textbox 2 right - square", WrapTextImage.Square);
+                textBox2.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                textBox2.HorizontalAlignment = HorizontalAlignmentValues.Right;
+                textBox2.VerticalPositionOffsetCentimeters = 6;
+
+                Assert.True(textBox2.WrapText == WrapTextImage.Square);
+
+                var textBox3 = document.AddTextBox("My textbox 3 center - tight", WrapTextImage.Tight);
+                textBox3.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                textBox3.HorizontalAlignment = HorizontalAlignmentValues.Center;
+                textBox3.VerticalPositionOffsetCentimeters = 6;
+
+                Assert.True(textBox3.WrapText == WrapTextImage.Tight);
+
+                var textBox4 = document.AddTextBox("My textbox 4 left - behind text", WrapTextImage.BehindText);
+                textBox4.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                textBox4.HorizontalAlignment = HorizontalAlignmentValues.Left;
+                textBox4.VerticalPositionOffsetCentimeters = 9;
+
+                Assert.True(textBox4.WrapText == WrapTextImage.BehindText);
+
+                var textBox5 = document.AddTextBox("My textbox 5 right - in front of text", WrapTextImage.InFrontOfText);
+                textBox5.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                textBox5.HorizontalAlignment = HorizontalAlignmentValues.Right;
+                textBox5.VerticalPositionOffsetCentimeters = 9;
+
+                Assert.True(textBox5.WrapText == WrapTextImage.InFrontOfText);
+
+                var textBox6 = document.AddTextBox("My textbox 6 left - top and bottom", WrapTextImage.TopAndBottom);
+                textBox6.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                textBox6.HorizontalAlignment = HorizontalAlignmentValues.Left;
+                textBox6.VerticalPositionOffsetCentimeters = 12;
+
+                Assert.True(textBox6.WrapText == WrapTextImage.TopAndBottom);
+
+                var textBox7 = document.AddTextBox("My textbox 7 right - through", WrapTextImage.Through);
+                textBox7.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                textBox7.HorizontalAlignment = HorizontalAlignmentValues.Right;
+                textBox7.VerticalPositionOffsetCentimeters = 12;
+
+                Assert.True(textBox7.WrapText == WrapTextImage.Through);
+
+                Assert.True(document.Sections[0].TextBoxes.Count == 1);
+                Assert.True(document.Sections[1].TextBoxes.Count == 1);
+                Assert.True(document.Sections[2].TextBoxes.Count == 6);
+                Assert.True(document.TextBoxes.Count == 8);
+
+                document.Save();
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithTextBoxesInSectionsAndHeaders.docx"))) {
+
+
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Word.TextBox.cs
+++ b/OfficeIMO.Tests/Word.TextBox.cs
@@ -364,5 +364,41 @@ namespace OfficeIMO.Tests {
 
             }
         }
+
+
+        [Fact]
+        public void Test_CreatingWordDocumentWithTextBoxAdditionalFeatures() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreateDocumentWithTextBoxesAdditionalFeatures.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var wrapTextList = (WrapTextImage[])Enum.GetValues(typeof(WrapTextImage));
+                var count = 0;
+                foreach (var wrapper in wrapTextList) {
+                    count += 3;
+                    var textBox2 = document.AddTextBox("My textbox - " + wrapper, wrapper);
+                    textBox2.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                    textBox2.HorizontalAlignment = HorizontalAlignmentValues.Right;
+                    textBox2.VerticalPositionOffsetCentimeters = count;
+                }
+
+                count = 0;
+                foreach (var wrapper in wrapTextList) {
+                    Assert.True(document.TextBoxes[count].WrapText == wrapper);
+                    count++;
+                }
+
+                document.Save(false);
+                Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithTextBoxesAdditionalFeatures.docx"))) {
+
+
+                document.Save();
+                Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithTextBoxesAdditionalFeatures.docx"))) {
+
+
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -119,8 +119,8 @@ namespace OfficeIMO.Word {
             return wordCoverPage;
         }
 
-        public WordTextBox AddTextBox(string text) {
-            WordTextBox wordTextBox = new WordTextBox(this, text);
+        public WordTextBox AddTextBox(string text, WrapTextImage wrapTextImage = WrapTextImage.Square) {
+            WordTextBox wordTextBox = new WordTextBox(this, text, wrapTextImage);
             return wordTextBox;
         }
 

--- a/OfficeIMO.Word/WordHeader.cs
+++ b/OfficeIMO.Word/WordHeader.cs
@@ -84,8 +84,8 @@ namespace OfficeIMO.Word {
             return new WordWatermark(this._document, this._section, this, watermarkStyle, text);
         }
 
-        public WordTextBox AddTextBox(string text, bool noWrap = false) {
-            WordTextBox wordTextBox = new WordTextBox(this._document, this, text, noWrap);
+        public WordTextBox AddTextBox(string text, WrapTextImage wrapTextImage = WrapTextImage.Square) {
+            WordTextBox wordTextBox = new WordTextBox(this._document, this, text, wrapTextImage);
             return wordTextBox;
         }
     }

--- a/OfficeIMO.Word/WordHeader.cs
+++ b/OfficeIMO.Word/WordHeader.cs
@@ -84,8 +84,8 @@ namespace OfficeIMO.Word {
             return new WordWatermark(this._document, this._section, this, watermarkStyle, text);
         }
 
-        public WordTextBox AddTextBox(string text) {
-            WordTextBox wordTextBox = new WordTextBox(this._document, this, text);
+        public WordTextBox AddTextBox(string text, bool noWrap = false) {
+            WordTextBox wordTextBox = new WordTextBox(this._document, this, text, noWrap);
             return wordTextBox;
         }
     }

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -12,16 +12,6 @@ using ShapeProperties = DocumentFormat.OpenXml.Drawing.Pictures.ShapeProperties;
 using DocumentFormat.OpenXml.Office2010.Word.Drawing;
 
 namespace OfficeIMO.Word {
-    public enum WrapTextImage {
-        InLineWithText,
-        Square,
-        Tight,
-        Through,
-        TopAndBottom,
-        BehindText,
-        InFrontText
-    }
-
     public class WordImage {
         private const double EnglishMetricUnitsPerInch = 914400;
         private const double PixelsPerInch = 96;
@@ -485,91 +475,13 @@ namespace OfficeIMO.Word {
             }
         }
 
-
+        /// <summary>
+        /// Gets or sets the image's wrap text.
+        /// </summary>
         public WrapTextImage? WrapText {
-            get {
-                if (_Image.Inline != null) {
-                    return WrapTextImage.InLineWithText;
-                } else if (_Image.Anchor != null) {
-                    var wrapSquare = _Image.Anchor.OfType<WrapSquare>().FirstOrDefault();
-                    if (wrapSquare != null) {
-                        return WrapTextImage.Square;
-                    }
-                    var wrapTight = _Image.Anchor.OfType<WrapTight>().FirstOrDefault();
-                    if (wrapTight != null) {
-                        return WrapTextImage.Tight;
-                    }
-                    var wrapThrough = _Image.Anchor.OfType<WrapThrough>().FirstOrDefault();
-                    if (wrapThrough != null) {
-                        return WrapTextImage.Through;
-                    }
-                    var wrapTopAndBottom = _Image.Anchor.OfType<WrapTopBottom>().FirstOrDefault();
-                    if (wrapTopAndBottom != null) {
-                        return WrapTextImage.TopAndBottom;
-                    }
-                    var wrapNone = _Image.Anchor.OfType<WrapNone>().FirstOrDefault();
-                    var behindDoc = _Image.Anchor.BehindDoc;
-                    if (wrapNone != null && behindDoc != null && behindDoc.Value == true) {
-                        return WrapTextImage.BehindText;
-                    } else if (wrapNone != null && behindDoc != null && behindDoc.Value == false) {
-                        return WrapTextImage.InFrontText;
-                    }
-                }
-
-                return null;
-            }
-            set {
-                throw new NotImplementedException("This needs to be implemented properly!");
-                // TODO - Implement
-                // REQUIRES FIXING, DOESNT WORK AT ALL
-                if (value == WrapTextImage.InLineWithText) {
-                    if (_Image.Inline != null) {
-                        // we don't do anything, because it's already inline
-                    } else if (_Image.Anchor != null) {
-
-                    }
-                } else {
-
-
-                }
-
-
-                //if (_Image.Anchor == null) {
-                //    var inline = _Image.Inline.CloneNode(true);
-
-                //    IEnumerable<OpenXmlElement> clonedElements = _Image.Inline
-                //        .Elements()
-                //        .Select(e => e.CloneNode(true))
-                //        .ToList();
-
-                //    var childInline = inline.Descendants();
-                //    //Anchor anchor1 = new Anchor() { BehindDoc = true };
-                //    var graphic = clonedElements.OfType<Graphic>().FirstOrDefault();
-                //    Anchor anchor1 = GetAnchor(100, 100, graphic, _Image.Inline.DocProperties.Name, "dfdfdf", WrapImageText.BehindText);
-
-                //    //WrapNone wrapNone1 = new WrapNone();
-                //    //anchor1.Append(wrapNone1);
-                //    _Image.Append(anchor1);
-                //    //_Image.Anchor.OfType<DocProperties>().FirstOrDefault().Remove();
-                //    //_Image.Anchor.Append(clonedElements.OfType<DocProperties>().FirstOrDefault());
-
-                //    _Image.Inline.Remove();
-
-                //    //_Image.Anchor.Append(clonedElements);
-                //} else {
-                //    _Image.Anchor.AllowOverlap = true;
-                //}
-            }
+            get => WordWrapTextImage.GetWrapTextImage(_Image.Anchor, _Image.Inline);
+            set => WordWrapTextImage.SetWrapTextImage(_Image.Anchor, _Image.Inline, value);
         }
-
-        //public WordImage(WordDocument document, string filePath, ShapeTypeValues shape = ShapeTypeValues.Rectangle, BlipCompressionValues compressionQuality = BlipCompressionValues.Print) {
-        //    double width;
-        //    double height;
-        //    using (var img = SixLabors.ImageSharp.Image.Load(filePath)) {
-        //        width = img.Width;
-        //        height = img.Height;
-        //    }
-        //}
 
         public WordImage(
             WordDocument document,
@@ -684,7 +596,7 @@ namespace OfficeIMO.Word {
             bool behindDoc;
             if (wrapImage == WrapTextImage.BehindText) {
                 behindDoc = true;
-            } else if (wrapImage == WrapTextImage.InFrontText) {
+            } else if (wrapImage == WrapTextImage.InFrontOfText) {
                 behindDoc = false;
             } else {
                 // i think this is default for other cases, except for InlineText which is handled outside of Anchor
@@ -725,60 +637,7 @@ namespace OfficeIMO.Word {
             EffectExtent effectExtent1 = new EffectExtent() { LeftEdge = 0L, TopEdge = 0L, RightEdge = 0L, BottomEdge = 1905L };
             anchor1.Append(effectExtent1);
 
-            if (wrapImage == WrapTextImage.Square) {
-                WrapSquare wrapSquare1 = new WrapSquare() {
-                    WrapText = WrapTextValues.BothSides
-                };
-                anchor1.Append(wrapSquare1);
-            } else if (wrapImage == WrapTextImage.Tight) {
-                WrapTight wrapTight1 = new WrapTight() { WrapText = WrapTextValues.BothSides };
-                WrapPolygon wrapPolygon1 = new WrapPolygon() { Edited = false };
-                StartPoint startPoint1 = new StartPoint() { X = 0L, Y = 0L };
-                // the values are probably wrong and content oriented
-                // would require some more research on how to calculate them
-                var lineTo1 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 0L, Y = 21384L };
-                var lineTo2 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 21384L, Y = 21384L };
-                var lineTo3 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 21384L, Y = 0L };
-                var lineTo4 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 0L, Y = 0L };
-
-                wrapPolygon1.Append(startPoint1);
-                wrapPolygon1.Append(lineTo1);
-                wrapPolygon1.Append(lineTo2);
-                wrapPolygon1.Append(lineTo3);
-                wrapPolygon1.Append(lineTo4);
-
-                wrapTight1.Append(wrapPolygon1);
-                anchor1.Append(wrapTight1);
-            } else if (wrapImage == WrapTextImage.Through) {
-                WrapThrough wrapThrough1 = new WrapThrough() { WrapText = WrapTextValues.BothSides };
-                WrapPolygon wrapPolygon1 = new WrapPolygon() { Edited = false };
-                StartPoint startPoint1 = new StartPoint() { X = 0L, Y = 0L };
-                // the values are probably wrong and content oriented
-                // would require some more research on how to calculate them
-                var lineTo1 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 0L, Y = 21384L };
-                var lineTo2 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 21384L, Y = 21384L };
-                var lineTo3 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 21384L, Y = 0L };
-                var lineTo4 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 0L, Y = 0L };
-
-                wrapPolygon1.Append(startPoint1);
-                wrapPolygon1.Append(lineTo1);
-                wrapPolygon1.Append(lineTo2);
-                wrapPolygon1.Append(lineTo3);
-                wrapPolygon1.Append(lineTo4);
-                wrapThrough1.Append(wrapPolygon1);
-                anchor1.Append(wrapThrough1);
-            } else if (wrapImage == WrapTextImage.TopAndBottom) {
-                WrapTopBottom wrapTopBottom1 = new WrapTopBottom() {
-                    //Values don't seem to matter
-                    //DistanceFromTop = (UInt32Value)20U,
-                    //DistanceFromBottom = (UInt32Value)20U
-                };
-                anchor1.Append(wrapTopBottom1);
-            } else {
-                // behind text, in front of text have this option 
-                WrapNone wrapNone1 = new WrapNone();
-                anchor1.Append(wrapNone1);
-            }
+            WordWrapTextImage.AppendWrapTextImage(anchor1, wrapImage);
 
             DocProperties docProperties1 = new DocProperties() { Id = (UInt32Value)1U, Name = imageName, Description = description };
             anchor1.Append(docProperties1);

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Drawing;
@@ -480,7 +479,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public WrapTextImage? WrapText {
             get => WordWrapTextImage.GetWrapTextImage(_Image.Anchor, _Image.Inline);
-            set => WordWrapTextImage.SetWrapTextImage(_Image.Anchor, _Image.Inline, value);
+            set => WordWrapTextImage.SetWrapTextImage(_Image, _Image.Anchor, _Image.Inline, value);
         }
 
         public WordImage(

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -175,8 +175,10 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="section"></param>
         /// <returns></returns>
-        public WordParagraph AddParagraphAfterSelf(WordSection section) {
-            WordParagraph paragraph = new WordParagraph(section._document, true, false);
+        public WordParagraph AddParagraphAfterSelf(WordSection section, WordParagraph paragraph = null) {
+            if (paragraph == null) {
+                paragraph = new WordParagraph(section._document, true, false);
+            }
             this._paragraph.InsertAfterSelf(paragraph._paragraph);
             return paragraph;
         }
@@ -356,6 +358,11 @@ namespace OfficeIMO.Word {
             var wordEndNote = WordEndNote.AddEndNote(this._document, this, endNoteWordParagraph);
             return wordEndNote;
 
+        }
+
+        public WordTextBox AddTextBox(string text, WrapTextImage wrapTextImage) {
+            WordTextBox wordTextBox = new WordTextBox(this._document, this, text, wrapTextImage);
+            return wordTextBox;
         }
     }
 }

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -31,11 +31,9 @@ namespace OfficeIMO.Word {
         /// <returns></returns>
         public WordParagraph AddImage(string filePathImage, double? width = null, double? height = null, WrapTextImage wrapImageText = WrapTextImage.InLineWithText, string description = "") {
             var wordImage = new WordImage(_document, this, filePathImage, width, height, wrapImageText, description);
-            //var wordImage = new WordImage(_document, filePathImage, width, height);
-            var paragraph = new WordParagraph(_document);
             VerifyRun();
             _run.Append(wordImage._Image);
-            return paragraph;
+            return this;
         }
         /// <summary>
         /// Add image from Stream with ability to provide width and height of the image
@@ -50,10 +48,9 @@ namespace OfficeIMO.Word {
         /// <returns></returns>
         public WordParagraph AddImage(Stream imageStream, string fileName, double? width, double? height, WrapTextImage wrapImageText = WrapTextImage.InLineWithText, string description = "") {
             var wordImage = new WordImage(_document, this, imageStream, fileName, width, height, wrapImageText, description);
-            var paragraph = new WordParagraph(_document);
             VerifyRun();
             _run.Append(wordImage._Image);
-            return paragraph;
+            return this;
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -73,7 +73,7 @@ namespace OfficeIMO.Word {
             WordHeadersAndFooters.AddHeadersAndFooters(this);
         }
 
-        public WordTextBox AddTextBox(string text, WrapTextImage wrapTextImage) {
+        public WordTextBox AddTextBox(string text, WrapTextImage wrapTextImage = WrapTextImage.Square) {
             return AddParagraph(newRun: true).AddTextBox(text, wrapTextImage);
         }
     }

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -13,6 +13,18 @@ namespace OfficeIMO.Word {
             return WordMargins.SetMargins(this, pageMargins);
         }
 
+        public WordParagraph AddParagraph(bool newRun) {
+            var wordParagraph = new WordParagraph(_document, newParagraph: true, newRun: newRun);
+            if (this.Paragraphs.Count == 0) {
+                WordParagraph paragraph = this._document.AddParagraph(wordParagraph);
+                return paragraph;
+            } else {
+                WordParagraph lastParagraphWithinSection = this.Paragraphs.Last();
+                WordParagraph paragraph = lastParagraphWithinSection.AddParagraphAfterSelf(this, wordParagraph);
+                return paragraph;
+            }
+        }
+
         public WordParagraph AddParagraph(string text = "") {
             if (this.Paragraphs.Count == 0) {
                 WordParagraph paragraph = this._document.AddParagraph();
@@ -46,19 +58,23 @@ namespace OfficeIMO.Word {
         }
 
         public WordParagraph AddHorizontalLine(BorderValues lineType = BorderValues.Single, SixLabors.ImageSharp.Color? color = null, uint size = 12, uint space = 1) {
-            return this.AddParagraph().AddHorizontalLine(lineType, color, size, space);
+            return this.AddParagraph("").AddHorizontalLine(lineType, color, size, space);
         }
 
         public WordParagraph AddHyperLink(string text, Uri uri, bool addStyle = false, string tooltip = "", bool history = true) {
-            return this.AddParagraph().AddHyperLink(text, uri, addStyle, tooltip, history);
+            return this.AddParagraph("").AddHyperLink(text, uri, addStyle, tooltip, history);
         }
 
         public WordParagraph AddHyperLink(string text, string anchor, bool addStyle = false, string tooltip = "", bool history = true) {
-            return this.AddParagraph().AddHyperLink(text, anchor, addStyle, tooltip, history);
+            return this.AddParagraph("").AddHyperLink(text, anchor, addStyle, tooltip, history);
         }
 
         public void AddHeadersAndFooters() {
             WordHeadersAndFooters.AddHeadersAndFooters(this);
+        }
+
+        public WordTextBox AddTextBox(string text, WrapTextImage wrapTextImage) {
+            return AddParagraph(newRun: true).AddTextBox(text, wrapTextImage);
         }
     }
 }

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -344,6 +344,12 @@ namespace OfficeIMO.Word {
             }
         }
 
+        public TextBodyProperties TextBodyProperties {
+            get {
+                return _wordprocessingShape.ChildElements.OfType<TextBodyProperties>().FirstOrDefault();
+            }
+        }
+
         public DocumentFormat.OpenXml.Office2010.Word.Drawing.SizeRelativeHorizontallyValues? SizeRelativeHorizontally {
             get {
                 var anchor = _anchor;

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -47,7 +47,15 @@ namespace OfficeIMO.Word {
             paragraph._run.Append(new RunProperties());
             AddAlternateContent(wordDocument, paragraph, text, wrapTextImage);
 
+            _wordParagraph = paragraph;
+        }
+
+        public WordTextBox(WordDocument wordDocument, WordParagraph paragraph, string text, WrapTextImage wrapTextImage) {
             _document = wordDocument;
+
+            paragraph._run.Append(new RunProperties());
+            AddAlternateContent(wordDocument, paragraph, text, wrapTextImage);
+
             _wordParagraph = paragraph;
         }
 

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -132,7 +132,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public WrapTextImage? WrapText {
             get => WordWrapTextImage.GetWrapTextImage(_anchor, _inline);
-            set => WordWrapTextImage.SetWrapTextImage(_anchor, _inline, value);
+            set => WordWrapTextImage.SetWrapTextImage(_drawing, _anchor, _inline, value);
         }
 
         public DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalAlignmentValues HorizontalAlignment {
@@ -474,6 +474,23 @@ namespace OfficeIMO.Word {
             }
         }
 
+        private Drawing _drawing {
+            get {
+                var alternateContent = _run.ChildElements.OfType<AlternateContent>().FirstOrDefault();
+                if (alternateContent != null) {
+                    var alternateContentChoice = alternateContent.ChildElements.OfType<AlternateContentChoice>().FirstOrDefault();
+                    if (alternateContentChoice != null) {
+                        var drawing = alternateContentChoice.ChildElements.OfType<DocumentFormat.OpenXml.Wordprocessing.Drawing>().FirstOrDefault();
+                        if (drawing != null) {
+                            return drawing;
+                        }
+                    }
+                }
+
+                return null;
+            }
+        }
+
         private Inline _inline {
             get {
                 var alternateContent = _run.ChildElements.OfType<AlternateContent>().FirstOrDefault();
@@ -510,6 +527,76 @@ namespace OfficeIMO.Word {
                 }
                 return null;
             }
+        }
+
+        internal static Anchor ConvertInlineToAnchor(Inline inline, WrapTextImage wrapTextImage) {
+            Anchor anchor1 = new Anchor() { DistanceFromTop = (UInt32Value)91440U, DistanceFromBottom = (UInt32Value)91440U, DistanceFromLeft = (UInt32Value)114300U, DistanceFromRight = (UInt32Value)114300U, SimplePos = false, RelativeHeight = (UInt32Value)251659264U, BehindDoc = false, Locked = false, LayoutInCell = true, AllowOverlap = true, EditId = "39C62DE8", AnchorId = "3E379294" };
+            anchor1.AddNamespaceDeclaration("wp14", "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing");
+            anchor1.AddNamespaceDeclaration("wp", "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing");
+            SimplePosition simplePosition1 = new SimplePosition() { X = 0L, Y = 0L };
+
+            HorizontalPosition horizontalPosition1 = new HorizontalPosition() { RelativeFrom = HorizontalRelativePositionValues.Page };
+            HorizontalAlignment horizontalAlignment1 = new HorizontalAlignment();
+            horizontalAlignment1.Text = "center";
+            horizontalPosition1.Append(horizontalAlignment1);
+
+            VerticalPosition verticalPosition1 = new VerticalPosition() { RelativeFrom = VerticalRelativePositionValues.Page };
+            PositionOffset positionOffset1 = new PositionOffset();
+            positionOffset1.Text = "182880";
+            verticalPosition1.Append(positionOffset1);
+
+            // Copy INLINE to ANCHOR
+            Extent extent1 = (Extent)inline.Extent.CloneNode(true);
+            EffectExtent effectExtent1 = (EffectExtent)inline.EffectExtent.CloneNode(true);
+            DocProperties docProperties1 = (DocProperties)inline.DocProperties.CloneNode(true);
+            NonVisualGraphicFrameDrawingProperties nonVisualGraphicFrameDrawingProperties1 = (NonVisualGraphicFrameDrawingProperties)inline.NonVisualGraphicFrameDrawingProperties.CloneNode(true);
+            Graphic graphic1 = (Graphic)inline.Graphic.CloneNode(true);
+
+            // continuation of anchor
+            DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth relativeWidth1 = new DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth() { ObjectId = DocumentFormat.OpenXml.Office2010.Word.Drawing.SizeRelativeHorizontallyValues.Margin };
+            DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentageWidth percentageWidth1 = new DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentageWidth();
+            percentageWidth1.Text = "58500";
+
+            relativeWidth1.Append(percentageWidth1);
+
+            DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeHeight relativeHeight1 = new DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeHeight() { RelativeFrom = DocumentFormat.OpenXml.Office2010.Word.Drawing.SizeRelativeVerticallyValues.Margin };
+            DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentageHeight percentageHeight1 = new DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentageHeight();
+            percentageHeight1.Text = "20000";
+
+            relativeHeight1.Append(percentageHeight1);
+
+            anchor1.Append(simplePosition1);
+            anchor1.Append(horizontalPosition1);
+            anchor1.Append(verticalPosition1);
+            anchor1.Append(extent1);
+            anchor1.Append(effectExtent1);
+
+            WordWrapTextImage.AppendWrapTextImage(anchor1, wrapTextImage);
+
+            anchor1.Append(docProperties1);
+            anchor1.Append(nonVisualGraphicFrameDrawingProperties1);
+            anchor1.Append(graphic1);
+            anchor1.Append(relativeWidth1);
+            anchor1.Append(relativeHeight1);
+            return anchor1;
+        }
+
+        internal static Inline ConvertAnchorToInline(Anchor anchor) {
+            Inline inline1 = new Inline() { DistanceFromTop = (UInt32Value)0U, DistanceFromBottom = (UInt32Value)0U, DistanceFromLeft = (UInt32Value)0U, DistanceFromRight = (UInt32Value)0U, AnchorId = "29D0141D", EditId = "5A52866D" };
+
+            Extent extent1 = (Extent)anchor.Extent.CloneNode(true);
+            EffectExtent effectExtent1 = (EffectExtent)anchor.EffectExtent.CloneNode(true);
+            DocProperties docProperties1 = (DocProperties)anchor.OfType<DocProperties>().FirstOrDefault()?.CloneNode(true);
+            NonVisualGraphicFrameDrawingProperties nonVisualGraphicFrameDrawingProperties1 = (NonVisualGraphicFrameDrawingProperties)anchor.OfType<NonVisualGraphicFrameDrawingProperties>().FirstOrDefault()?.CloneNode(true);
+            Graphic graphic1 = (Graphic)anchor.OfType<Graphic>().FirstOrDefault()?.CloneNode(true);
+
+            inline1.Append(extent1);
+            inline1.Append(effectExtent1);
+            inline1.Append(docProperties1);
+            inline1.Append(nonVisualGraphicFrameDrawingProperties1);
+            inline1.Append(graphic1);
+
+            return inline1;
         }
 
         private DocumentFormat.OpenXml.Drawing.GraphicData _graphicData {

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -913,7 +913,7 @@ namespace OfficeIMO.Word {
             RunProperties runProperties1 = new RunProperties();
             run1.Append(runProperties1);
 
-            foreach (var part in text.Split(new string[] { Environment.NewLine, "\r\n", "\n" }, StringSplitOptions.None)) {
+            foreach (var part in text.Split(new string[] { Environment.NewLine, "\r\n", "\n", "\r" }, StringSplitOptions.None)) {
                 Text textPart = new Text();
                 textPart.Text = part;
                 run1.Append(textPart);

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -358,9 +358,7 @@ namespace OfficeIMO.Word {
                 TextBodyProperties.RemoveChild(TextBodyProperties.ChildElements.OfType<DocumentFormat.OpenXml.Drawing.ShapeAutoFit>().FirstOrDefault());
                 if (value) {
                     TextBodyProperties.Append(new DocumentFormat.OpenXml.Drawing.ShapeAutoFit());
-                }
-                else
-                {
+                } else {
                     TextBodyProperties.Append(new DocumentFormat.OpenXml.Drawing.NoAutoFit());
                 }
             }
@@ -913,12 +911,14 @@ namespace OfficeIMO.Word {
 
             Run run1 = new Run();
             RunProperties runProperties1 = new RunProperties();
-
-            Text text1 = new Text();
-            text1.Text = text;
-
             run1.Append(runProperties1);
-            run1.Append(text1);
+
+            foreach (var part in text.Split(new string[] { Environment.NewLine, "\r\n", "\n" }, StringSplitOptions.None)) {
+                Text textPart = new Text();
+                textPart.Text = part;
+                run1.Append(textPart);
+                run1.Append(new Break());
+            }
 
             paragraph1.Append(paragraphProperties1);
             paragraph1.Append(run1);

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -4,6 +4,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
 using DocumentFormat.OpenXml.Office2010.Word.DrawingShape;
+using Graphic = DocumentFormat.OpenXml.Drawing.Graphic;
 
 namespace OfficeIMO.Word {
     public class WordTextBox {
@@ -479,9 +480,12 @@ namespace OfficeIMO.Word {
                 if (alternateContent != null) {
                     var alternateContentChoice = alternateContent.ChildElements.OfType<AlternateContentChoice>().FirstOrDefault();
                     if (alternateContentChoice != null) {
-                        var inline = alternateContentChoice.ChildElements.OfType<Inline>().FirstOrDefault();
-                        if (inline != null) {
-                            return inline;
+                        var drawing = alternateContentChoice.ChildElements.OfType<DocumentFormat.OpenXml.Wordprocessing.Drawing>().FirstOrDefault();
+                        if (drawing != null) {
+                            var inline = drawing.Inline;
+                            if (inline != null) {
+                                return inline;
+                            }
                         }
                     }
                 }
@@ -688,181 +692,62 @@ namespace OfficeIMO.Word {
             AlternateContent alternateContent1 = new AlternateContent();
             AlternateContentChoice alternateContentChoice1 = new AlternateContentChoice() { Requires = "wps" };
 
-            DocumentFormat.OpenXml.Wordprocessing.Drawing drawing1 = new DocumentFormat.OpenXml.Wordprocessing.Drawing {
-                Anchor = GenerateAnchor(text, wrapTextImage)
-            };
-
+            DocumentFormat.OpenXml.Wordprocessing.Drawing drawing1;
+            if (wrapTextImage == WrapTextImage.InLineWithText) {
+                // inline
+                drawing1 = new DocumentFormat.OpenXml.Wordprocessing.Drawing {
+                    Inline = GenerateInline(text)
+                };
+            } else {
+                // anchor
+                drawing1 = new DocumentFormat.OpenXml.Wordprocessing.Drawing {
+                    Anchor = GenerateAnchor(text, wrapTextImage)
+                };
+            }
             alternateContentChoice1.Append(drawing1);
-
-            //AlternateContentFallback alternateContentFallback1 = GenerateAlternateContentFallback(text);
 
             alternateContent1.Append(alternateContentChoice1);
             //alternateContent1.Append(alternateContentFallback1);
             wordParagraph._run.Append(alternateContent1);
         }
 
-        /// <summary>
-        /// This part is available when Microsoft Word creates TextBox. Not sure if it is needed.
-        /// </summary>
-        /// <param name="text"></param>
-        /// <returns></returns>
-        //public AlternateContentFallback GenerateAlternateContentFallback(string text) {
-        //    AlternateContentFallback alternateContentFallback1 = new AlternateContentFallback();
+        private Inline GenerateInline(string text) {
+            Inline inline1 = new Inline() { DistanceFromTop = (UInt32Value)0U, DistanceFromBottom = (UInt32Value)0U, DistanceFromLeft = (UInt32Value)0U, DistanceFromRight = (UInt32Value)0U, AnchorId = "29D0141D", EditId = "5A52866D" };
 
-        //    DocumentFormat.OpenXml.Wordprocessing.Picture picture1 = new DocumentFormat.OpenXml.Wordprocessing.Picture();
+            Extent extent1 = GenerateExtent();
+            EffectExtent effectExtent1 = GenerateEffectExtent();
+            DocProperties docProperties1 = GenerateDocProperties();
+            NonVisualGraphicFrameDrawingProperties nonVisualGraphicFrameDrawingProperties1 = GenerateNonVisualGraphicFrameDrawingProperties();
+            Graphic graphic1 = GenerateGraphic(text);
 
-        //    V.Shapetype shapetype1 = new V.Shapetype() { Id = "_x0000_t202", CoordinateSize = "21600,21600", OptionalNumber = 202, EdgePath = "m,l,21600r21600,l21600,xe" };
-        //    shapetype1.AddNamespaceDeclaration("w14", "http://schemas.microsoft.com/office/word/2010/wordml");
-        //    shapetype1.AddNamespaceDeclaration("o", "urn:schemas-microsoft-com:office:office");
-        //    shapetype1.AddNamespaceDeclaration("v", "urn:schemas-microsoft-com:vml");
-        //    shapetype1.SetAttribute(new OpenXmlAttribute("w14", "anchorId", "http://schemas.microsoft.com/office/word/2010/wordml", "3E379294"));
-        //    V.Stroke stroke1 = new V.Stroke() { JoinStyle = V.StrokeJoinStyleValues.Miter };
-        //    V.Path path1 = new V.Path() { AllowGradientShape = true, ConnectionPointType = Ovml.ConnectValues.Rectangle };
+            inline1.Append(extent1);
+            inline1.Append(effectExtent1);
+            inline1.Append(docProperties1);
+            inline1.Append(nonVisualGraphicFrameDrawingProperties1);
+            inline1.Append(graphic1);
 
-        //    shapetype1.Append(stroke1);
-        //    shapetype1.Append(path1);
+            return inline1;
+        }
 
-        //    V.Shape shape1 = new V.Shape() { Id = "Text Box 2", Style = "position:absolute;margin-left:0;margin-top:228.5pt;width:273.6pt;height:110.55pt;z-index:251659264;visibility:visible;mso-wrap-style:square;mso-width-percent:585;mso-height-percent:200;mso-wrap-distance-left:9pt;mso-wrap-distance-top:7.2pt;mso-wrap-distance-right:9pt;mso-wrap-distance-bottom:7.2pt;mso-position-horizontal:center;mso-position-horizontal-relative:page;mso-position-vertical:absolute;mso-position-vertical-relative:page;mso-width-percent:585;mso-height-percent:200;mso-width-relative:margin;mso-height-relative:margin;v-text-anchor:top", OptionalString = "_x0000_s1026", Filled = false, Stroked = false, Type = "#_x0000_t202", EncodedPackage = "UEsDBBQABgAIAAAAIQC2gziS/gAAAOEBAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbJSRQU7DMBBF\n90jcwfIWJU67QAgl6YK0S0CoHGBkTxKLZGx5TGhvj5O2G0SRWNoz/78nu9wcxkFMGNg6quQqL6RA\n0s5Y6ir5vt9lD1JwBDIwOMJKHpHlpr69KfdHjyxSmriSfYz+USnWPY7AufNIadK6MEJMx9ApD/oD\nOlTrorhX2lFEilmcO2RdNtjC5xDF9pCuTyYBB5bi6bQ4syoJ3g9WQ0ymaiLzg5KdCXlKLjvcW893\nSUOqXwnz5DrgnHtJTxOsQfEKIT7DmDSUCaxw7Rqn8787ZsmRM9e2VmPeBN4uqYvTtW7jvijg9N/y\nJsXecLq0q+WD6m8AAAD//wMAUEsDBBQABgAIAAAAIQA4/SH/1gAAAJQBAAALAAAAX3JlbHMvLnJl\nbHOkkMFqwzAMhu+DvYPRfXGawxijTi+j0GvpHsDYimMaW0Yy2fr2M4PBMnrbUb/Q94l/f/hMi1qR\nJVI2sOt6UJgd+ZiDgffL8ekFlFSbvV0oo4EbChzGx4f9GRdb25HMsYhqlCwG5lrLq9biZkxWOiqY\n22YiTra2kYMu1l1tQD30/bPm3wwYN0x18gb45AdQl1tp5j/sFB2T0FQ7R0nTNEV3j6o9feQzro1i\nOWA14Fm+Q8a1a8+Bvu/d/dMb2JY5uiPbhG/ktn4cqGU/er3pcvwCAAD//wMAUEsDBBQABgAIAAAA\nIQB1oTJD+QEAAM4DAAAOAAAAZHJzL2Uyb0RvYy54bWysU11v2yAUfZ+0/4B4X+ykzppYcaquXaZJ\n3YfU7gdgjGM04DIgsbNfvwt202h7q+YHBL7cc+8597C5GbQiR+G8BFPR+SynRBgOjTT7iv542r1b\nUeIDMw1TYERFT8LTm+3bN5velmIBHahGOIIgxpe9rWgXgi2zzPNOaOZnYIXBYAtOs4BHt88ax3pE\n1ypb5Pn7rAfXWAdceI9/78cg3Sb8thU8fGtbLwJRFcXeQlpdWuu4ZtsNK/eO2U7yqQ32ii40kwaL\nnqHuWWDk4OQ/UFpyBx7aMOOgM2hbyUXigGzm+V9sHjtmReKC4nh7lsn/P1j+9fhovzsShg8w4AAT\nCW8fgP/0xMBdx8xe3DoHfSdYg4XnUbKst76cUqPUvvQRpO6/QINDZocACWhonY6qIE+C6DiA01l0\nMQTC8edVcV1cLzDEMTYv8qv1aplqsPI53TofPgnQJG4q6nCqCZ4dH3yI7bDy+UqsZmAnlUqTVYb0\nFV0vF8uUcBHRMqDxlNQVXeXxG60QWX40TUoOTKpxjwWUmWhHpiPnMNQDXoz0a2hOKICD0WD4IHDT\ngftNSY/mqqj/dWBOUKI+GxRxPS+K6MZ0KJaJvruM1JcRZjhCVTRQMm7vQnJw5OrtLYq9k0mGl06m\nXtE0SZ3J4NGVl+d06+UZbv8AAAD//wMAUEsDBBQABgAIAAAAIQCcOsjJ3wAAAAgBAAAPAAAAZHJz\nL2Rvd25yZXYueG1sTI/NTsMwEITvSLyDtUjcqNPSNiFkU5WfckJCFC69OfGSRI3tyHba8PYsJ7jN\nalYz3xSbyfTiRD50ziLMZwkIsrXTnW0QPj92NxmIEJXVqneWEL4pwKa8vChUrt3ZvtNpHxvBITbk\nCqGNccilDHVLRoWZG8iy9+W8UZFP30jt1ZnDTS8XSbKWRnWWG1o10GNL9XE/GoRX8ofsbsweusPT\n7vnteKurl61GvL6atvcgIk3x7xl+8RkdSmaq3Gh1ED0CD4kIy1XKgu3VMl2AqBDWaTYHWRby/4Dy\nBwAA//8DAFBLAQItABQABgAIAAAAIQC2gziS/gAAAOEBAAATAAAAAAAAAAAAAAAAAAAAAABbQ29u\ndGVudF9UeXBlc10ueG1sUEsBAi0AFAAGAAgAAAAhADj9If/WAAAAlAEAAAsAAAAAAAAAAAAAAAAA\nLwEAAF9yZWxzLy5yZWxzUEsBAi0AFAAGAAgAAAAhAHWhMkP5AQAAzgMAAA4AAAAAAAAAAAAAAAAA\nLgIAAGRycy9lMm9Eb2MueG1sUEsBAi0AFAAGAAgAAAAhAJw6yMnfAAAACAEAAA8AAAAAAAAAAAAA\nAAAAUwQAAGRycy9kb3ducmV2LnhtbFBLBQYAAAAABAAEAPMAAABfBQAAAAA=\n" };
-        //    shape1.AddNamespaceDeclaration("o", "urn:schemas-microsoft-com:office:office");
-        //    shape1.AddNamespaceDeclaration("v", "urn:schemas-microsoft-com:vml");
 
-        //    V.TextBox textBox1 = new V.TextBox() { Style = "mso-fit-shape-to-text:t" };
-
-        //    DocumentFormat.OpenXml.Wordprocessing.TextBoxContent textBoxContent1 = new DocumentFormat.OpenXml.Wordprocessing.TextBoxContent();
-
-        //    DocumentFormat.OpenXml.Wordprocessing.SdtBlock sdtBlock1 = new DocumentFormat.OpenXml.Wordprocessing.SdtBlock();
-
-        //    DocumentFormat.OpenXml.Wordprocessing.SdtProperties sdtProperties1 = new DocumentFormat.OpenXml.Wordprocessing.SdtProperties();
-
-        //    DocumentFormat.OpenXml.Wordprocessing.RunProperties runProperties1 = new DocumentFormat.OpenXml.Wordprocessing.RunProperties();
-        //    DocumentFormat.OpenXml.Wordprocessing.Italic italic1 = new DocumentFormat.OpenXml.Wordprocessing.Italic();
-        //    DocumentFormat.OpenXml.Wordprocessing.ItalicComplexScript italicComplexScript1 = new DocumentFormat.OpenXml.Wordprocessing.ItalicComplexScript();
-        //    DocumentFormat.OpenXml.Wordprocessing.Color color1 = new DocumentFormat.OpenXml.Wordprocessing.Color() { Val = "156082", ThemeColor = DocumentFormat.OpenXml.Wordprocessing.ThemeColorValues.Accent1 };
-        //    DocumentFormat.OpenXml.Wordprocessing.FontSize fontSize1 = new DocumentFormat.OpenXml.Wordprocessing.FontSize() { Val = "24" };
-        //    DocumentFormat.OpenXml.Wordprocessing.FontSizeComplexScript fontSizeComplexScript1 = new DocumentFormat.OpenXml.Wordprocessing.FontSizeComplexScript() { Val = "24" };
-
-        //    runProperties1.Append(italic1);
-        //    runProperties1.Append(italicComplexScript1);
-        //    runProperties1.Append(color1);
-        //    runProperties1.Append(fontSize1);
-        //    runProperties1.Append(fontSizeComplexScript1);
-        //    DocumentFormat.OpenXml.Wordprocessing.SdtId sdtId1 = new DocumentFormat.OpenXml.Wordprocessing.SdtId() { Val = 1469011327 };
-        //    DocumentFormat.OpenXml.Wordprocessing.TemporarySdt temporarySdt1 = new DocumentFormat.OpenXml.Wordprocessing.TemporarySdt();
-        //    DocumentFormat.OpenXml.Wordprocessing.ShowingPlaceholder showingPlaceholder1 = new DocumentFormat.OpenXml.Wordprocessing.ShowingPlaceholder();
-
-        //    DocumentFormat.OpenXml.Office2013.Word.Appearance appearance1 = new DocumentFormat.OpenXml.Office2013.Word.Appearance() { Val = DocumentFormat.OpenXml.Office2013.Word.SdtAppearance.Hidden };
-        //    appearance1.AddNamespaceDeclaration("w15", "http://schemas.microsoft.com/office/word/2012/wordml");
-
-        //    sdtProperties1.Append(runProperties1);
-        //    sdtProperties1.Append(sdtId1);
-        //    sdtProperties1.Append(temporarySdt1);
-        //    sdtProperties1.Append(showingPlaceholder1);
-        //    sdtProperties1.Append(appearance1);
-
-        //    DocumentFormat.OpenXml.Wordprocessing.SdtContentBlock sdtContentBlock1 = new DocumentFormat.OpenXml.Wordprocessing.SdtContentBlock();
-
-        //    DocumentFormat.OpenXml.Wordprocessing.Paragraph paragraph1 = new DocumentFormat.OpenXml.Wordprocessing.Paragraph() { RsidParagraphAddition = "00B16DB6", RsidRunAdditionDefault = "00B16DB6", ParagraphId = "506E57D5", TextId = "77777777" };
-        //    paragraph1.AddNamespaceDeclaration("w14", "http://schemas.microsoft.com/office/word/2010/wordml");
-
-        //    DocumentFormat.OpenXml.Wordprocessing.ParagraphProperties paragraphProperties1 = new DocumentFormat.OpenXml.Wordprocessing.ParagraphProperties();
-
-        //    DocumentFormat.OpenXml.Wordprocessing.ParagraphBorders paragraphBorders1 = new DocumentFormat.OpenXml.Wordprocessing.ParagraphBorders();
-        //    DocumentFormat.OpenXml.Wordprocessing.TopBorder topBorder1 = new DocumentFormat.OpenXml.Wordprocessing.TopBorder() { Val = DocumentFormat.OpenXml.Wordprocessing.BorderValues.Single, Color = "156082", ThemeColor = DocumentFormat.OpenXml.Wordprocessing.ThemeColorValues.Accent1, Size = (UInt32Value)24U, Space = (UInt32Value)8U };
-        //    DocumentFormat.OpenXml.Wordprocessing.BottomBorder bottomBorder1 = new DocumentFormat.OpenXml.Wordprocessing.BottomBorder() { Val = DocumentFormat.OpenXml.Wordprocessing.BorderValues.Single, Color = "156082", ThemeColor = DocumentFormat.OpenXml.Wordprocessing.ThemeColorValues.Accent1, Size = (UInt32Value)24U, Space = (UInt32Value)8U };
-
-        //    paragraphBorders1.Append(topBorder1);
-        //    paragraphBorders1.Append(bottomBorder1);
-        //    DocumentFormat.OpenXml.Wordprocessing.SpacingBetweenLines spacingBetweenLines1 = new DocumentFormat.OpenXml.Wordprocessing.SpacingBetweenLines() { After = "0" };
-
-        //    DocumentFormat.OpenXml.Wordprocessing.ParagraphMarkRunProperties paragraphMarkRunProperties1 = new DocumentFormat.OpenXml.Wordprocessing.ParagraphMarkRunProperties();
-        //    DocumentFormat.OpenXml.Wordprocessing.Italic italic2 = new DocumentFormat.OpenXml.Wordprocessing.Italic();
-        //    DocumentFormat.OpenXml.Wordprocessing.ItalicComplexScript italicComplexScript2 = new DocumentFormat.OpenXml.Wordprocessing.ItalicComplexScript();
-        //    DocumentFormat.OpenXml.Wordprocessing.Color color2 = new DocumentFormat.OpenXml.Wordprocessing.Color() { Val = "156082", ThemeColor = DocumentFormat.OpenXml.Wordprocessing.ThemeColorValues.Accent1 };
-        //    DocumentFormat.OpenXml.Wordprocessing.FontSize fontSize2 = new DocumentFormat.OpenXml.Wordprocessing.FontSize() { Val = "24" };
-
-        //    paragraphMarkRunProperties1.Append(italic2);
-        //    paragraphMarkRunProperties1.Append(italicComplexScript2);
-        //    paragraphMarkRunProperties1.Append(color2);
-        //    paragraphMarkRunProperties1.Append(fontSize2);
-
-        //    paragraphProperties1.Append(paragraphBorders1);
-        //    paragraphProperties1.Append(spacingBetweenLines1);
-        //    paragraphProperties1.Append(paragraphMarkRunProperties1);
-
-        //    DocumentFormat.OpenXml.Wordprocessing.Run run1 = new DocumentFormat.OpenXml.Wordprocessing.Run();
-
-        //    DocumentFormat.OpenXml.Wordprocessing.RunProperties runProperties2 = new DocumentFormat.OpenXml.Wordprocessing.RunProperties();
-        //    DocumentFormat.OpenXml.Wordprocessing.Italic italic3 = new DocumentFormat.OpenXml.Wordprocessing.Italic();
-        //    DocumentFormat.OpenXml.Wordprocessing.ItalicComplexScript italicComplexScript3 = new DocumentFormat.OpenXml.Wordprocessing.ItalicComplexScript();
-        //    DocumentFormat.OpenXml.Wordprocessing.Color color3 = new DocumentFormat.OpenXml.Wordprocessing.Color() { Val = "156082", ThemeColor = DocumentFormat.OpenXml.Wordprocessing.ThemeColorValues.Accent1 };
-        //    DocumentFormat.OpenXml.Wordprocessing.FontSize fontSize3 = new DocumentFormat.OpenXml.Wordprocessing.FontSize() { Val = "24" };
-        //    DocumentFormat.OpenXml.Wordprocessing.FontSizeComplexScript fontSizeComplexScript2 = new DocumentFormat.OpenXml.Wordprocessing.FontSizeComplexScript() { Val = "24" };
-
-        //    runProperties2.Append(italic3);
-        //    runProperties2.Append(italicComplexScript3);
-        //    runProperties2.Append(color3);
-        //    runProperties2.Append(fontSize3);
-        //    runProperties2.Append(fontSizeComplexScript2);
-        //    DocumentFormat.OpenXml.Wordprocessing.Text text1 = new DocumentFormat.OpenXml.Wordprocessing.Text();
-        //    text1.Text = text;
-
-        //    run1.Append(runProperties2);
-        //    run1.Append(text1);
-
-        //    paragraph1.Append(paragraphProperties1);
-        //    paragraph1.Append(run1);
-
-        //    sdtContentBlock1.Append(paragraph1);
-
-        //    sdtBlock1.Append(sdtProperties1);
-        //    sdtBlock1.Append(sdtContentBlock1);
-
-        //    textBoxContent1.Append(sdtBlock1);
-
-        //    textBox1.Append(textBoxContent1);
-
-        //    Wvml.TextWrap textWrap1 = new Wvml.TextWrap() { Type = Wvml.WrapValues.TopAndBottom, AnchorX = Wvml.HorizontalAnchorValues.Page, AnchorY = Wvml.VerticalAnchorValues.Page };
-        //    textWrap1.AddNamespaceDeclaration("w10", "urn:schemas-microsoft-com:office:word");
-
-        //    shape1.Append(textBox1);
-        //    shape1.Append(textWrap1);
-
-        //    picture1.Append(shapetype1);
-        //    picture1.Append(shape1);
-
-        //    alternateContentFallback1.Append(picture1);
-        //    return alternateContentFallback1;
-        //}
-
-        private Anchor GenerateAnchor(string text, WrapTextImage wrapTextImage) {
-            Anchor anchor1 = new Anchor() { DistanceFromTop = (UInt32Value)91440U, DistanceFromBottom = (UInt32Value)91440U, DistanceFromLeft = (UInt32Value)114300U, DistanceFromRight = (UInt32Value)114300U, SimplePos = false, RelativeHeight = (UInt32Value)251659264U, BehindDoc = false, Locked = false, LayoutInCell = true, AllowOverlap = true, EditId = "39C62DE8", AnchorId = "3E379294" };
-            anchor1.AddNamespaceDeclaration("wp14", "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing");
-            anchor1.AddNamespaceDeclaration("wp", "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing");
-            SimplePosition simplePosition1 = new SimplePosition() { X = 0L, Y = 0L };
-
-            HorizontalPosition horizontalPosition1 = new HorizontalPosition() { RelativeFrom = HorizontalRelativePositionValues.Page };
-            HorizontalAlignment horizontalAlignment1 = new HorizontalAlignment();
-            horizontalAlignment1.Text = "center";
-
-            horizontalPosition1.Append(horizontalAlignment1);
-
-            VerticalPosition verticalPosition1 = new VerticalPosition() { RelativeFrom = VerticalRelativePositionValues.Page };
-            PositionOffset positionOffset1 = new PositionOffset();
-            positionOffset1.Text = "182880";
-
-            verticalPosition1.Append(positionOffset1);
+        private Extent GenerateExtent() {
             Extent extent1 = new Extent() { Cx = 2360930L, Cy = 1404620L };
+            return extent1;
+        }
+
+        private EffectExtent GenerateEffectExtent() {
             EffectExtent effectExtent1 = new EffectExtent() { LeftEdge = 0L, TopEdge = 0L, RightEdge = 0L, BottomEdge = 0L };
+            return effectExtent1;
+        }
+
+        private DocProperties GenerateDocProperties() {
             DocProperties docProperties1 = new DocProperties() { Id = (UInt32Value)307U, Name = "Text Box 2" };
+            return docProperties1;
+        }
 
-            NonVisualGraphicFrameDrawingProperties nonVisualGraphicFrameDrawingProperties1 = new NonVisualGraphicFrameDrawingProperties();
-
-            DocumentFormat.OpenXml.Drawing.GraphicFrameLocks graphicFrameLocks1 = new DocumentFormat.OpenXml.Drawing.GraphicFrameLocks();
-            graphicFrameLocks1.AddNamespaceDeclaration("a", "http://schemas.openxmlformats.org/drawingml/2006/main");
-
-            nonVisualGraphicFrameDrawingProperties1.Append(graphicFrameLocks1);
-
+        private Graphic GenerateGraphic(string text) {
             DocumentFormat.OpenXml.Drawing.Graphic graphic1 = new DocumentFormat.OpenXml.Drawing.Graphic();
+
             graphic1.AddNamespaceDeclaration("a", "http://schemas.openxmlformats.org/drawingml/2006/main");
 
             DocumentFormat.OpenXml.Drawing.GraphicData graphicData1 = new DocumentFormat.OpenXml.Drawing.GraphicData() { Uri = "http://schemas.microsoft.com/office/word/2010/wordprocessingShape" };
@@ -896,6 +781,45 @@ namespace OfficeIMO.Word {
 
             graphic1.Append(graphicData1);
 
+            return graphic1;
+        }
+
+        private NonVisualGraphicFrameDrawingProperties GenerateNonVisualGraphicFrameDrawingProperties() {
+            NonVisualGraphicFrameDrawingProperties nonVisualGraphicFrameDrawingProperties1 = new NonVisualGraphicFrameDrawingProperties();
+
+            DocumentFormat.OpenXml.Drawing.GraphicFrameLocks graphicFrameLocks1 = new DocumentFormat.OpenXml.Drawing.GraphicFrameLocks();
+            graphicFrameLocks1.AddNamespaceDeclaration("a", "http://schemas.openxmlformats.org/drawingml/2006/main");
+
+            nonVisualGraphicFrameDrawingProperties1.Append(graphicFrameLocks1);
+            return nonVisualGraphicFrameDrawingProperties1;
+        }
+
+        private Anchor GenerateAnchor(string text, WrapTextImage wrapTextImage) {
+            Anchor anchor1 = new Anchor() { DistanceFromTop = (UInt32Value)91440U, DistanceFromBottom = (UInt32Value)91440U, DistanceFromLeft = (UInt32Value)114300U, DistanceFromRight = (UInt32Value)114300U, SimplePos = false, RelativeHeight = (UInt32Value)251659264U, BehindDoc = false, Locked = false, LayoutInCell = true, AllowOverlap = true, EditId = "39C62DE8", AnchorId = "3E379294" };
+            anchor1.AddNamespaceDeclaration("wp14", "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing");
+            anchor1.AddNamespaceDeclaration("wp", "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing");
+            SimplePosition simplePosition1 = new SimplePosition() { X = 0L, Y = 0L };
+
+            HorizontalPosition horizontalPosition1 = new HorizontalPosition() { RelativeFrom = HorizontalRelativePositionValues.Page };
+            HorizontalAlignment horizontalAlignment1 = new HorizontalAlignment();
+            horizontalAlignment1.Text = "center";
+
+            horizontalPosition1.Append(horizontalAlignment1);
+
+            VerticalPosition verticalPosition1 = new VerticalPosition() { RelativeFrom = VerticalRelativePositionValues.Page };
+            PositionOffset positionOffset1 = new PositionOffset();
+            positionOffset1.Text = "182880";
+
+            verticalPosition1.Append(positionOffset1);
+
+            // same content as per inline
+            Extent extent1 = GenerateExtent();
+            EffectExtent effectExtent1 = GenerateEffectExtent();
+            DocProperties docProperties1 = GenerateDocProperties();
+            NonVisualGraphicFrameDrawingProperties nonVisualGraphicFrameDrawingProperties1 = GenerateNonVisualGraphicFrameDrawingProperties();
+            Graphic graphic1 = GenerateGraphic(text);
+
+            // continuation of anchor
             DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth relativeWidth1 = new DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth() { ObjectId = DocumentFormat.OpenXml.Office2010.Word.Drawing.SizeRelativeHorizontallyValues.Margin };
             DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentageWidth percentageWidth1 = new DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentageWidth();
             percentageWidth1.Text = "58500";

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -57,14 +57,12 @@ namespace OfficeIMO.Word {
         public string Text {
             get {
                 if (_sdtBlock != null) {
-                    var paragraph = _sdtContentBlock.GetFirstChild<Paragraph>();
-                    if (paragraph != null) {
-                        var run = paragraph.GetFirstChild<Run>();
-                        if (run != null) {
-                            var text = run.GetFirstChild<Text>();
-                            if (text != null) {
-                                return text.Text;
-                            }
+
+                    var run = _sdtBlock.GetFirstChild<Run>();
+                    if (run != null) {
+                        var text = run.GetFirstChild<Text>();
+                        if (text != null) {
+                            return text.Text;
                         }
                     }
                 }
@@ -72,14 +70,11 @@ namespace OfficeIMO.Word {
             }
             set {
                 if (_sdtBlock != null) {
-                    var paragraph = _sdtContentBlock.GetFirstChild<Paragraph>();
-                    if (paragraph != null) {
-                        var run = paragraph.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.Run>();
-                        if (run != null) {
-                            var text = run.GetFirstChild<Text>();
-                            if (text != null) {
-                                text.Text = value;
-                            }
+                    var run = _sdtBlock.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.Run>();
+                    if (run != null) {
+                        var text = run.GetFirstChild<Text>();
+                        if (text != null) {
+                            text.Text = value;
                         }
                     }
                 }
@@ -91,12 +86,9 @@ namespace OfficeIMO.Word {
         /// </summary>
         public WordParagraph WordParagraph {
             get {
-                if (_sdtContentBlock != null) {
-                    var paragraph = _sdtContentBlock.GetFirstChild<Paragraph>();
-                    if (paragraph != null) {
-                        var run = paragraph.GetFirstChild<Run>();
-                        return new WordParagraph(_document, paragraph, run);
-                    }
+                if (_sdtBlock != null) {
+                    var run = _sdtBlock.GetFirstChild<Run>();
+                    return new WordParagraph(_document, _sdtBlock, run);
                 }
                 return null;
             }
@@ -486,7 +478,7 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private SdtBlock _sdtBlock {
+        private Paragraph _sdtBlock {
             get {
                 var wordprocessingShape = _wordprocessingShape;
                 if (wordprocessingShape != null) {
@@ -496,7 +488,7 @@ namespace OfficeIMO.Word {
                     if (textBoxInfo != null) {
                         var textBoxContent = textBoxInfo.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.TextBoxContent>();
                         if (textBoxContent != null) {
-                            var sdtBlock = textBoxContent.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.SdtBlock>();
+                            var sdtBlock = textBoxContent.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.Paragraph>();
                             if (sdtBlock != null) {
                                 return sdtBlock;
                             }
@@ -822,151 +814,27 @@ namespace OfficeIMO.Word {
 
             DocumentFormat.OpenXml.Drawing.GraphicData graphicData1 = new DocumentFormat.OpenXml.Drawing.GraphicData() { Uri = "http://schemas.microsoft.com/office/word/2010/wordprocessingShape" };
 
-            DocumentFormat.OpenXml.Office2010.Word.DrawingShape.WordprocessingShape wordprocessingShape1 = new DocumentFormat.OpenXml.Office2010.Word.DrawingShape.WordprocessingShape();
+            WordprocessingShape wordprocessingShape1 = new WordprocessingShape();
             wordprocessingShape1.AddNamespaceDeclaration("wps", "http://schemas.microsoft.com/office/word/2010/wordprocessingShape");
 
-            DocumentFormat.OpenXml.Office2010.Word.DrawingShape.NonVisualDrawingShapeProperties nonVisualDrawingShapeProperties1 = new DocumentFormat.OpenXml.Office2010.Word.DrawingShape.NonVisualDrawingShapeProperties() { TextBox = true };
+            NonVisualDrawingShapeProperties nonVisualDrawingShapeProperties1 = new NonVisualDrawingShapeProperties() { TextBox = true };
             DocumentFormat.OpenXml.Drawing.ShapeLocks shapeLocks1 = new DocumentFormat.OpenXml.Drawing.ShapeLocks() { NoChangeArrowheads = true };
 
             nonVisualDrawingShapeProperties1.Append(shapeLocks1);
 
-            DocumentFormat.OpenXml.Office2010.Word.DrawingShape.ShapeProperties shapeProperties1 = GenerateShapeProperties();
+            ShapeProperties shapeProperties1 = GenerateShapeProperties();
+            TextBoxInfo2 textBoxInfo21 = new TextBoxInfo2();
 
-            //A.Transform2D transform2D1 = new DocumentFormat.OpenXml.Drawing.Transform2D();
-            //A.Offset offset1 = new DocumentFormat.OpenXml.Drawing.Offset() { X = 0L, Y = 0L };
-            //A.Extents extents1 = new DocumentFormat.OpenXml.Drawing.Extents() { Cx = 3474720L, Cy = 1403985L };
+            var txtBoxContent = GenerateTextBoxContent(text);
+            textBoxInfo21.Append(txtBoxContent);
 
-            //transform2D1.Append(offset1);
-            //transform2D1.Append(extents1);
-
-            //A.PresetGeometry presetGeometry1 = new DocumentFormat.OpenXml.Drawing.PresetGeometry() { Preset = DocumentFormat.OpenXml.Drawing.ShapeTypeValues.Rectangle };
-            //A.AdjustValueList adjustValueList1 = new DocumentFormat.OpenXml.Drawing.AdjustValueList();
-
-            //presetGeometry1.Append(adjustValueList1);
-            //A.NoFill noFill1 = new DocumentFormat.OpenXml.Drawing.NoFill();
-
-            //A.Outline outline1 = new DocumentFormat.OpenXml.Drawing.Outline() { Width = 9525 };
-            //A.NoFill noFill2 = new DocumentFormat.OpenXml.Drawing.NoFill();
-            //A.Miter miter1 = new DocumentFormat.OpenXml.Drawing.Miter() { Limit = 800000 };
-            //A.HeadEnd headEnd1 = new DocumentFormat.OpenXml.Drawing.HeadEnd();
-            //A.TailEnd tailEnd1 = new DocumentFormat.OpenXml.Drawing.TailEnd();
-
-            //outline1.Append(noFill2);
-            //outline1.Append(miter1);
-            //outline1.Append(headEnd1);
-            //outline1.Append(tailEnd1);
-
-            //shapeProperties1.Append(transform2D1);
-            //shapeProperties1.Append(presetGeometry1);
-            //shapeProperties1.Append(noFill1);
-            //shapeProperties1.Append(outline1);
-
-            DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2 textBoxInfo21 = new DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2();
-
-            DocumentFormat.OpenXml.Wordprocessing.TextBoxContent textBoxContent1 = new DocumentFormat.OpenXml.Wordprocessing.TextBoxContent();
-
-            DocumentFormat.OpenXml.Wordprocessing.SdtBlock sdtBlock1 = new DocumentFormat.OpenXml.Wordprocessing.SdtBlock();
-
-            DocumentFormat.OpenXml.Wordprocessing.SdtProperties sdtProperties1 = new DocumentFormat.OpenXml.Wordprocessing.SdtProperties();
-
-            DocumentFormat.OpenXml.Wordprocessing.RunProperties runProperties1 = new DocumentFormat.OpenXml.Wordprocessing.RunProperties();
-            DocumentFormat.OpenXml.Wordprocessing.Italic italic1 = new DocumentFormat.OpenXml.Wordprocessing.Italic();
-            DocumentFormat.OpenXml.Wordprocessing.ItalicComplexScript italicComplexScript1 = new DocumentFormat.OpenXml.Wordprocessing.ItalicComplexScript();
-            DocumentFormat.OpenXml.Wordprocessing.Color color1 = new DocumentFormat.OpenXml.Wordprocessing.Color() { Val = "156082", ThemeColor = DocumentFormat.OpenXml.Wordprocessing.ThemeColorValues.Accent1 };
-            DocumentFormat.OpenXml.Wordprocessing.FontSize fontSize1 = new DocumentFormat.OpenXml.Wordprocessing.FontSize() { Val = "24" };
-            DocumentFormat.OpenXml.Wordprocessing.FontSizeComplexScript fontSizeComplexScript1 = new DocumentFormat.OpenXml.Wordprocessing.FontSizeComplexScript() { Val = "24" };
-
-            runProperties1.Append(italic1);
-            runProperties1.Append(italicComplexScript1);
-            runProperties1.Append(color1);
-            runProperties1.Append(fontSize1);
-            runProperties1.Append(fontSizeComplexScript1);
-            DocumentFormat.OpenXml.Wordprocessing.SdtId sdtId1 = new DocumentFormat.OpenXml.Wordprocessing.SdtId() { Val = 1469011327 };
-            DocumentFormat.OpenXml.Wordprocessing.TemporarySdt temporarySdt1 = new DocumentFormat.OpenXml.Wordprocessing.TemporarySdt();
-            DocumentFormat.OpenXml.Wordprocessing.ShowingPlaceholder showingPlaceholder1 = new DocumentFormat.OpenXml.Wordprocessing.ShowingPlaceholder();
-
-            DocumentFormat.OpenXml.Office2013.Word.Appearance appearance1 = new DocumentFormat.OpenXml.Office2013.Word.Appearance() { Val = DocumentFormat.OpenXml.Office2013.Word.SdtAppearance.Hidden };
-            appearance1.AddNamespaceDeclaration("w15", "http://schemas.microsoft.com/office/word/2012/wordml");
-
-            sdtProperties1.Append(runProperties1);
-            sdtProperties1.Append(sdtId1);
-            sdtProperties1.Append(temporarySdt1);
-            sdtProperties1.Append(showingPlaceholder1);
-            sdtProperties1.Append(appearance1);
-
-            DocumentFormat.OpenXml.Wordprocessing.SdtContentBlock sdtContentBlock1 = new DocumentFormat.OpenXml.Wordprocessing.SdtContentBlock();
-
-            DocumentFormat.OpenXml.Wordprocessing.Paragraph paragraph1 = new DocumentFormat.OpenXml.Wordprocessing.Paragraph() { RsidParagraphAddition = "00B16DB6", RsidRunAdditionDefault = "00B16DB6", ParagraphId = "506E57D5", TextId = "77777777" };
-            paragraph1.AddNamespaceDeclaration("w14", "http://schemas.microsoft.com/office/word/2010/wordml");
-
-            DocumentFormat.OpenXml.Wordprocessing.ParagraphProperties paragraphProperties1 = new DocumentFormat.OpenXml.Wordprocessing.ParagraphProperties();
-
-            //W.ParagraphBorders paragraphBorders1 = new DocumentFormat.OpenXml.Wordprocessing.ParagraphBorders();
-            //W.TopBorder topBorder1 = new DocumentFormat.OpenXml.Wordprocessing.TopBorder() { Val = DocumentFormat.OpenXml.Wordprocessing.BorderValues.Single, Color = "156082", ThemeColor = DocumentFormat.OpenXml.Wordprocessing.ThemeColorValues.Accent1, Size = (UInt32Value)24U, Space = (UInt32Value)8U };
-            //W.BottomBorder bottomBorder1 = new DocumentFormat.OpenXml.Wordprocessing.BottomBorder() { Val = DocumentFormat.OpenXml.Wordprocessing.BorderValues.Single, Color = "156082", ThemeColor = DocumentFormat.OpenXml.Wordprocessing.ThemeColorValues.Accent1, Size = (UInt32Value)24U, Space = (UInt32Value)8U };
-
-            //paragraphBorders1.Append(topBorder1);
-            //paragraphBorders1.Append(bottomBorder1);
-            DocumentFormat.OpenXml.Wordprocessing.SpacingBetweenLines spacingBetweenLines1 = new DocumentFormat.OpenXml.Wordprocessing.SpacingBetweenLines() { After = "0" };
-
-            DocumentFormat.OpenXml.Wordprocessing.ParagraphMarkRunProperties paragraphMarkRunProperties1 = new DocumentFormat.OpenXml.Wordprocessing.ParagraphMarkRunProperties();
-            DocumentFormat.OpenXml.Wordprocessing.Italic italic2 = new DocumentFormat.OpenXml.Wordprocessing.Italic();
-            DocumentFormat.OpenXml.Wordprocessing.ItalicComplexScript italicComplexScript2 = new DocumentFormat.OpenXml.Wordprocessing.ItalicComplexScript();
-            DocumentFormat.OpenXml.Wordprocessing.Color color2 = new DocumentFormat.OpenXml.Wordprocessing.Color() { Val = "156082", ThemeColor = DocumentFormat.OpenXml.Wordprocessing.ThemeColorValues.Accent1 };
-            DocumentFormat.OpenXml.Wordprocessing.FontSize fontSize2 = new DocumentFormat.OpenXml.Wordprocessing.FontSize() { Val = "24" };
-
-            paragraphMarkRunProperties1.Append(italic2);
-            paragraphMarkRunProperties1.Append(italicComplexScript2);
-            paragraphMarkRunProperties1.Append(color2);
-            paragraphMarkRunProperties1.Append(fontSize2);
-
-            //paragraphProperties1.Append(paragraphBorders1);
-            paragraphProperties1.Append(spacingBetweenLines1);
-            paragraphProperties1.Append(paragraphMarkRunProperties1);
-
-            DocumentFormat.OpenXml.Wordprocessing.Run run1 = new DocumentFormat.OpenXml.Wordprocessing.Run();
-
-            DocumentFormat.OpenXml.Wordprocessing.RunProperties runProperties2 = new DocumentFormat.OpenXml.Wordprocessing.RunProperties();
-            DocumentFormat.OpenXml.Wordprocessing.Italic italic3 = new DocumentFormat.OpenXml.Wordprocessing.Italic();
-            DocumentFormat.OpenXml.Wordprocessing.ItalicComplexScript italicComplexScript3 = new DocumentFormat.OpenXml.Wordprocessing.ItalicComplexScript();
-            DocumentFormat.OpenXml.Wordprocessing.Color color3 = new DocumentFormat.OpenXml.Wordprocessing.Color() { Val = "156082", ThemeColor = DocumentFormat.OpenXml.Wordprocessing.ThemeColorValues.Accent1 };
-            DocumentFormat.OpenXml.Wordprocessing.FontSize fontSize3 = new DocumentFormat.OpenXml.Wordprocessing.FontSize() { Val = "24" };
-            DocumentFormat.OpenXml.Wordprocessing.FontSizeComplexScript fontSizeComplexScript2 = new DocumentFormat.OpenXml.Wordprocessing.FontSizeComplexScript() { Val = "24" };
-
-            runProperties2.Append(italic3);
-            runProperties2.Append(italicComplexScript3);
-            runProperties2.Append(color3);
-            runProperties2.Append(fontSize3);
-            runProperties2.Append(fontSizeComplexScript2);
-            DocumentFormat.OpenXml.Wordprocessing.Text text1 = new DocumentFormat.OpenXml.Wordprocessing.Text();
-            text1.Text = text;
-
-            run1.Append(runProperties2);
-            run1.Append(text1);
-
-            paragraph1.Append(paragraphProperties1);
-            paragraph1.Append(run1);
-
-            sdtContentBlock1.Append(paragraph1);
-
-            sdtBlock1.Append(sdtProperties1);
-            sdtBlock1.Append(sdtContentBlock1);
-
-            textBoxContent1.Append(sdtBlock1);
-
-            textBoxInfo21.Append(textBoxContent1);
-
-            DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBodyProperties textBodyProperties1 = new DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBodyProperties() { Rotation = 0, Vertical = DocumentFormat.OpenXml.Drawing.TextVerticalValues.Horizontal, Wrap = DocumentFormat.OpenXml.Drawing.TextWrappingValues.Square, LeftInset = 91440, TopInset = 45720, RightInset = 91440, BottomInset = 45720, Anchor = DocumentFormat.OpenXml.Drawing.TextAnchoringTypeValues.Top, AnchorCenter = false };
+            TextBodyProperties textBodyProperties1 = new TextBodyProperties() { Rotation = 0, Vertical = DocumentFormat.OpenXml.Drawing.TextVerticalValues.Horizontal, Wrap = DocumentFormat.OpenXml.Drawing.TextWrappingValues.Square, LeftInset = 91440, TopInset = 45720, RightInset = 91440, BottomInset = 45720, Anchor = DocumentFormat.OpenXml.Drawing.TextAnchoringTypeValues.Top, AnchorCenter = false };
             DocumentFormat.OpenXml.Drawing.ShapeAutoFit shapeAutoFit1 = new DocumentFormat.OpenXml.Drawing.ShapeAutoFit();
 
             textBodyProperties1.Append(shapeAutoFit1);
 
             wordprocessingShape1.Append(nonVisualDrawingShapeProperties1);
             wordprocessingShape1.Append(shapeProperties1);
-
-            //ShapeStyle shapeStyle1 = GenerateShapeStyle();
-            //wordprocessingShape1.Append(shapeStyle1);
-
 
             wordprocessingShape1.Append(textBoxInfo21);
             wordprocessingShape1.Append(textBodyProperties1);
@@ -992,13 +860,11 @@ namespace OfficeIMO.Word {
             anchor1.Append(verticalPosition1);
             anchor1.Append(extent1);
             anchor1.Append(effectExtent1);
-            if(noWrap)
-            {
+            if (noWrap) {
                 WrapNone wrapNone = new WrapNone();
                 anchor1.Append(wrapNone);
 
-            } else
-            {
+            } else {
                 WrapTopBottom wrapTopBottom1 = new WrapTopBottom();
                 anchor1.Append(wrapTopBottom1);
             }
@@ -1008,6 +874,35 @@ namespace OfficeIMO.Word {
             anchor1.Append(relativeWidth1);
             anchor1.Append(relativeHeight1);
             return anchor1;
+        }
+
+        public TextBoxContent GenerateTextBoxContent(string text) {
+            TextBoxContent textBoxContent1 = new TextBoxContent();
+
+            Paragraph paragraph1 = new Paragraph() { RsidParagraphAddition = "00000000", RsidRunAdditionDefault = "006713BC", ParagraphId = "100FFE99", TextId = "27C5287F" };
+
+            ParagraphProperties paragraphProperties1 = new ParagraphProperties();
+            SpacingBetweenLines spacingBetweenLines1 = new SpacingBetweenLines() { After = "0" };
+
+            ParagraphMarkRunProperties paragraphMarkRunProperties1 = new ParagraphMarkRunProperties();
+
+            paragraphProperties1.Append(spacingBetweenLines1);
+            paragraphProperties1.Append(paragraphMarkRunProperties1);
+
+            Run run1 = new Run();
+            RunProperties runProperties1 = new RunProperties();
+
+            Text text1 = new Text();
+            text1.Text = text;
+
+            run1.Append(runProperties1);
+            run1.Append(text1);
+
+            paragraph1.Append(paragraphProperties1);
+            paragraph1.Append(run1);
+
+            textBoxContent1.Append(paragraph1);
+            return textBoxContent1;
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -350,6 +350,22 @@ namespace OfficeIMO.Word {
             }
         }
 
+        public bool AutoFitToTextSize {
+            get {
+                return TextBodyProperties.ChildElements.OfType<DocumentFormat.OpenXml.Drawing.ShapeAutoFit>().Any();
+            }
+            set {
+                TextBodyProperties.RemoveChild(TextBodyProperties.ChildElements.OfType<DocumentFormat.OpenXml.Drawing.ShapeAutoFit>().FirstOrDefault());
+                if (value) {
+                    TextBodyProperties.Append(new DocumentFormat.OpenXml.Drawing.ShapeAutoFit());
+                }
+                else
+                {
+                    TextBodyProperties.Append(new DocumentFormat.OpenXml.Drawing.NoAutoFit());
+                }
+            }
+        }
+
         public DocumentFormat.OpenXml.Office2010.Word.Drawing.SizeRelativeHorizontallyValues? SizeRelativeHorizontally {
             get {
                 var anchor = _anchor;

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -17,11 +17,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="wordDocument"></param>
         /// <param name="text"></param>
-        public WordTextBox(WordDocument wordDocument, string text) {
+        public WordTextBox(WordDocument wordDocument, string text, bool noWrap = false) {
             var paragraph = new WordParagraph(wordDocument, true, true);
             wordDocument.AddParagraph(paragraph);
             paragraph._run.Append(new RunProperties());
-            AddAlternateContent(wordDocument, paragraph, text);
+            AddAlternateContent(wordDocument, paragraph, text, noWrap);
 
             _document = wordDocument;
             _wordParagraph = paragraph;
@@ -38,13 +38,13 @@ namespace OfficeIMO.Word {
             _wordParagraph = new WordParagraph(wordDocument, paragraph, run);
         }
 
-        public WordTextBox(WordDocument wordDocument, WordHeaderFooter wordHeaderFooter, string text) {
+        public WordTextBox(WordDocument wordDocument, WordHeaderFooter wordHeaderFooter, string text, bool noWrap = false) {
             _document = wordDocument;
             _headerFooter = wordHeaderFooter;
 
             var paragraph = wordHeaderFooter.AddParagraph(newRun: true);
             paragraph._run.Append(new RunProperties());
-            AddAlternateContent(wordDocument, paragraph, text);
+            AddAlternateContent(wordDocument, paragraph, text, noWrap);
 
             _document = wordDocument;
             _wordParagraph = paragraph;
@@ -638,13 +638,13 @@ namespace OfficeIMO.Word {
             return centimeters;
         }
 
-        private void AddAlternateContent(WordDocument wordDocument, WordParagraph wordParagraph, string text) {
+        private void AddAlternateContent(WordDocument wordDocument, WordParagraph wordParagraph, string text, bool noWrap = false) {
 
             AlternateContent alternateContent1 = new AlternateContent();
             AlternateContentChoice alternateContentChoice1 = new AlternateContentChoice() { Requires = "wps" };
 
             DocumentFormat.OpenXml.Wordprocessing.Drawing drawing1 = new DocumentFormat.OpenXml.Wordprocessing.Drawing {
-                Anchor = GenerateAnchor(text)
+                Anchor = GenerateAnchor(text, noWrap)
             };
 
             alternateContentChoice1.Append(drawing1);
@@ -789,7 +789,7 @@ namespace OfficeIMO.Word {
         //    return alternateContentFallback1;
         //}
 
-        private Anchor GenerateAnchor(string text) {
+        private Anchor GenerateAnchor(string text, bool noWrap = false) {
             Anchor anchor1 = new Anchor() { DistanceFromTop = (UInt32Value)91440U, DistanceFromBottom = (UInt32Value)91440U, DistanceFromLeft = (UInt32Value)114300U, DistanceFromRight = (UInt32Value)114300U, SimplePos = false, RelativeHeight = (UInt32Value)251659264U, BehindDoc = false, Locked = false, LayoutInCell = true, AllowOverlap = true, EditId = "39C62DE8", AnchorId = "3E379294" };
             anchor1.AddNamespaceDeclaration("wp14", "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing");
             anchor1.AddNamespaceDeclaration("wp", "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing");
@@ -808,7 +808,6 @@ namespace OfficeIMO.Word {
             verticalPosition1.Append(positionOffset1);
             Extent extent1 = new Extent() { Cx = 2360930L, Cy = 1404620L };
             EffectExtent effectExtent1 = new EffectExtent() { LeftEdge = 0L, TopEdge = 0L, RightEdge = 0L, BottomEdge = 0L };
-            WrapTopBottom wrapTopBottom1 = new WrapTopBottom();
             DocProperties docProperties1 = new DocProperties() { Id = (UInt32Value)307U, Name = "Text Box 2" };
 
             NonVisualGraphicFrameDrawingProperties nonVisualGraphicFrameDrawingProperties1 = new NonVisualGraphicFrameDrawingProperties();
@@ -993,7 +992,16 @@ namespace OfficeIMO.Word {
             anchor1.Append(verticalPosition1);
             anchor1.Append(extent1);
             anchor1.Append(effectExtent1);
-            anchor1.Append(wrapTopBottom1);
+            if(noWrap)
+            {
+                WrapNone wrapNone = new WrapNone();
+                anchor1.Append(wrapNone);
+
+            } else
+            {
+                WrapTopBottom wrapTopBottom1 = new WrapTopBottom();
+                anchor1.Append(wrapTopBottom1);
+            }
             anchor1.Append(docProperties1);
             anchor1.Append(nonVisualGraphicFrameDrawingProperties1);
             anchor1.Append(graphic1);

--- a/OfficeIMO.Word/WordWrapTextImage.cs
+++ b/OfficeIMO.Word/WordWrapTextImage.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DocumentFormat.OpenXml.Drawing.Wordprocessing;
+
+namespace OfficeIMO.Word {
+    public enum WrapTextImage {
+        InLineWithText,
+        Square,
+        Tight,
+        Through,
+        TopAndBottom,
+        BehindText,
+        InFrontOfText,
+    }
+
+    public class WordWrapTextImage {
+        private WordWrapTextImage(WrapTextImage wrapTextImage) {
+
+        }
+
+        public static Anchor AppendWrapTextImage(Anchor anchor, WrapTextImage wrapImage) {
+            if (wrapImage == WrapTextImage.Square) {
+                WrapSquare wrapSquare1 = new WrapSquare() {
+                    WrapText = WrapTextValues.BothSides
+                };
+                anchor.Append(wrapSquare1);
+            } else if (wrapImage == WrapTextImage.Tight) {
+                WrapTight wrapTight1 = WordWrapTextImage.WrapTight;
+                anchor.Append(wrapTight1);
+            } else if (wrapImage == WrapTextImage.Through) {
+                WrapThrough wrapThrough1 = WordWrapTextImage.WrapThrough;
+                anchor.Append(wrapThrough1);
+            } else if (wrapImage == WrapTextImage.TopAndBottom) {
+                WrapTopBottom wrapTopBottom1 = WordWrapTextImage.WrapTopBottom;
+                anchor.Append(wrapTopBottom1);
+            } else if (wrapImage == WrapTextImage.BehindText) {
+                WrapNone wrapNone1 = new WrapNone();
+                anchor.Append(wrapNone1);
+                anchor.BehindDoc = true;
+            } else if (wrapImage == WrapTextImage.InFrontOfText) {
+                WrapNone wrapNone1 = new WrapNone();
+                anchor.Append(wrapNone1);
+                anchor.BehindDoc = false;
+            } else {
+                throw new InvalidOperationException("WrapTextImage: " + wrapImage + " not supported yet.");
+            }
+            return anchor;
+        }
+
+        public static WrapTextImage? GetWrapTextImage(Anchor anchor, Inline inline) {
+            if (anchor != null) {
+                var wrapSquare = anchor.OfType<WrapSquare>().FirstOrDefault();
+                if (wrapSquare != null) {
+                    return WrapTextImage.Square;
+                }
+                var wrapTight = anchor.OfType<WrapTight>().FirstOrDefault();
+                if (wrapTight != null) {
+                    return WrapTextImage.Tight;
+                }
+                var wrapThrough = anchor.OfType<WrapThrough>().FirstOrDefault();
+                if (wrapThrough != null) {
+                    return WrapTextImage.Through;
+                }
+                var wrapTopAndBottom = anchor.OfType<WrapTopBottom>().FirstOrDefault();
+                if (wrapTopAndBottom != null) {
+                    return WrapTextImage.TopAndBottom;
+                }
+                var wrapNone = anchor.OfType<WrapNone>().FirstOrDefault();
+                var behindDoc = anchor.BehindDoc;
+                if (wrapNone != null && behindDoc != null && behindDoc.Value == true) {
+                    return WrapTextImage.BehindText;
+                } else if (wrapNone != null && behindDoc != null && behindDoc.Value == false) {
+                    return WrapTextImage.InFrontOfText;
+                }
+            } else if (inline != null) {
+                return WrapTextImage.InLineWithText;
+            }
+            return null;
+        }
+
+        public static void SetWrapTextImage(Anchor anchor, Inline inline, WrapTextImage? wrapImage) {
+            var currentWrap = GetWrapTextImage(anchor, inline);
+            if (currentWrap == wrapImage) {
+                // nothing to do
+                return;
+            }
+            if (anchor != null) {
+                // remove current Wrap
+                if (currentWrap == WrapTextImage.Square) {
+                    anchor.OfType<WrapSquare>().FirstOrDefault()?.Remove();
+                } else if (currentWrap == WrapTextImage.Tight) {
+                    anchor.OfType<WrapTight>().FirstOrDefault()?.Remove();
+                } else if (currentWrap == WrapTextImage.Through) {
+                    anchor.OfType<WrapThrough>().FirstOrDefault()?.Remove();
+                } else if (currentWrap == WrapTextImage.TopAndBottom) {
+                    anchor.OfType<WrapTopBottom>().FirstOrDefault()?.Remove();
+                } else if (currentWrap == WrapTextImage.BehindText) {
+                    anchor.OfType<WrapNone>().FirstOrDefault()?.Remove();
+                    anchor.BehindDoc = true;
+                } else if (currentWrap == WrapTextImage.InFrontOfText) {
+                    anchor.OfType<WrapNone>().FirstOrDefault()?.Remove();
+                    anchor.BehindDoc = false;
+                } else if (currentWrap == WrapTextImage.InLineWithText) {
+                    // this requires support for Inline rather than Anchor which is not yet implemented
+                    throw new InvalidOperationException("InLineWithText is not supported.");
+                }
+
+                // wrap needs to be inserted after extent or it will not work
+                var extent = anchor.Elements<Extent>().FirstOrDefault();
+                if (extent != null) {
+                    if (wrapImage == WrapTextImage.Square) {
+                        var wrap = new WrapSquare() { WrapText = WrapTextValues.BothSides };
+                        extent.InsertAfterSelf(wrap);
+                    } else if (wrapImage == WrapTextImage.Tight) {
+                        anchor.Append(new WrapTight() { WrapText = WrapTextValues.BothSides });
+                    } else if (wrapImage == WrapTextImage.Through) {
+                        var wrap = WordWrapTextImage.WrapThrough;
+                        extent.InsertAfterSelf(wrap);
+                    } else if (wrapImage == WrapTextImage.TopAndBottom) {
+                        var wrap = WordWrapTextImage.WrapTopBottom;
+                        extent.InsertAfterSelf(wrap);
+                    } else if (wrapImage == WrapTextImage.BehindText) {
+                        var wrap = new WrapNone();
+                        extent.InsertAfterSelf(wrap);
+                        anchor.BehindDoc = false;
+                    } else if (wrapImage == WrapTextImage.InFrontOfText) {
+                        var wrap = new WrapNone();
+                        extent.InsertAfterSelf(wrap);
+                        anchor.BehindDoc = true;
+                    } else if (wrapImage == WrapTextImage.InLineWithText) {
+                        // this requires support for Inline rather than Anchor which is not yet implemented
+                        throw new InvalidOperationException("InLineWithText is not supported.");
+                    }
+                } else {
+                    throw new InvalidOperationException("Extent is missing. Weird. Shouldn't happen.");
+                }
+            } else if (inline != null) {
+                // this requires support for Inline rather than Anchor which is not yet implemented
+                throw new InvalidOperationException("InLineWithText is not supported.");
+            }
+        }
+
+
+        public static WrapTopBottom WrapTopBottom {
+            get {
+                WrapTopBottom wrapTopBottom1 = new WrapTopBottom() {
+                    //Values don't seem to matter
+                    //DistanceFromTop = (UInt32Value)20U,
+                    //DistanceFromBottom = (UInt32Value)20U
+                };
+                return wrapTopBottom1;
+            }
+        }
+
+        public static WrapThrough WrapThrough {
+            get {
+                WrapThrough wrapThrough1 = new WrapThrough() { WrapText = WrapTextValues.BothSides };
+                WrapPolygon wrapPolygon1 = new WrapPolygon() { Edited = false };
+                StartPoint startPoint1 = new StartPoint() { X = 0L, Y = 0L };
+                // the values are probably wrong and content oriented
+                // would require some more research on how to calculate them
+                var lineTo1 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 0L, Y = 21384L };
+                var lineTo2 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 21384L, Y = 21384L };
+                var lineTo3 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 21384L, Y = 0L };
+                var lineTo4 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 0L, Y = 0L };
+
+                wrapPolygon1.Append(startPoint1);
+                wrapPolygon1.Append(lineTo1);
+                wrapPolygon1.Append(lineTo2);
+                wrapPolygon1.Append(lineTo3);
+                wrapPolygon1.Append(lineTo4);
+                wrapThrough1.Append(wrapPolygon1);
+                return wrapThrough1;
+            }
+        }
+
+        public static WrapTight WrapTight {
+            get {
+                WrapTight wrapTight1 = new WrapTight() { WrapText = WrapTextValues.BothSides };
+                WrapPolygon wrapPolygon1 = new WrapPolygon() { Edited = false };
+                StartPoint startPoint1 = new StartPoint() { X = 0L, Y = 0L };
+                // the values are probably wrong and content oriented
+                // would require some more research on how to calculate them
+                var lineTo1 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 0L, Y = 21384L };
+                var lineTo2 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 21384L, Y = 21384L };
+                var lineTo3 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 21384L, Y = 0L };
+                var lineTo4 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.LineTo() { X = 0L, Y = 0L };
+
+                wrapPolygon1.Append(startPoint1);
+                wrapPolygon1.Append(lineTo1);
+                wrapPolygon1.Append(lineTo2);
+                wrapPolygon1.Append(lineTo3);
+                wrapPolygon1.Append(lineTo4);
+
+                wrapTight1.Append(wrapPolygon1);
+                return wrapTight1;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordWrapTextImage.cs
+++ b/OfficeIMO.Word/WordWrapTextImage.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
 
 namespace OfficeIMO.Word {
@@ -80,65 +78,75 @@ namespace OfficeIMO.Word {
             return null;
         }
 
-        public static void SetWrapTextImage(Anchor anchor, Inline inline, WrapTextImage? wrapImage) {
+        public static void SetWrapTextImage(DocumentFormat.OpenXml.Wordprocessing.Drawing drawing, Anchor anchor, Inline inline, WrapTextImage? wrapImage) {
             var currentWrap = GetWrapTextImage(anchor, inline);
             if (currentWrap == wrapImage) {
                 // nothing to do
                 return;
             }
             if (anchor != null) {
-                // remove current Wrap
-                if (currentWrap == WrapTextImage.Square) {
-                    anchor.OfType<WrapSquare>().FirstOrDefault()?.Remove();
-                } else if (currentWrap == WrapTextImage.Tight) {
-                    anchor.OfType<WrapTight>().FirstOrDefault()?.Remove();
-                } else if (currentWrap == WrapTextImage.Through) {
-                    anchor.OfType<WrapThrough>().FirstOrDefault()?.Remove();
-                } else if (currentWrap == WrapTextImage.TopAndBottom) {
-                    anchor.OfType<WrapTopBottom>().FirstOrDefault()?.Remove();
-                } else if (currentWrap == WrapTextImage.BehindText) {
-                    anchor.OfType<WrapNone>().FirstOrDefault()?.Remove();
-                    anchor.BehindDoc = true;
-                } else if (currentWrap == WrapTextImage.InFrontOfText) {
-                    anchor.OfType<WrapNone>().FirstOrDefault()?.Remove();
-                    anchor.BehindDoc = false;
-                } else if (currentWrap == WrapTextImage.InLineWithText) {
-                    // this requires support for Inline rather than Anchor which is not yet implemented
-                    throw new InvalidOperationException("InLineWithText is not supported.");
-                }
-
-                // wrap needs to be inserted after extent or it will not work
-                var extent = anchor.Elements<Extent>().FirstOrDefault();
-                if (extent != null) {
-                    if (wrapImage == WrapTextImage.Square) {
-                        var wrap = new WrapSquare() { WrapText = WrapTextValues.BothSides };
-                        extent.InsertAfterSelf(wrap);
-                    } else if (wrapImage == WrapTextImage.Tight) {
-                        anchor.Append(new WrapTight() { WrapText = WrapTextValues.BothSides });
-                    } else if (wrapImage == WrapTextImage.Through) {
-                        var wrap = WordWrapTextImage.WrapThrough;
-                        extent.InsertAfterSelf(wrap);
-                    } else if (wrapImage == WrapTextImage.TopAndBottom) {
-                        var wrap = WordWrapTextImage.WrapTopBottom;
-                        extent.InsertAfterSelf(wrap);
-                    } else if (wrapImage == WrapTextImage.BehindText) {
-                        var wrap = new WrapNone();
-                        extent.InsertAfterSelf(wrap);
-                        anchor.BehindDoc = false;
-                    } else if (wrapImage == WrapTextImage.InFrontOfText) {
-                        var wrap = new WrapNone();
-                        extent.InsertAfterSelf(wrap);
-                        anchor.BehindDoc = true;
-                    } else if (wrapImage == WrapTextImage.InLineWithText) {
-                        // this requires support for Inline rather than Anchor which is not yet implemented
-                        throw new InvalidOperationException("InLineWithText is not supported.");
-                    }
+                if (wrapImage == WrapTextImage.InLineWithText) {
+                    var convertedInline = WordTextBox.ConvertAnchorToInline(anchor);
+                    drawing.Append(convertedInline);
+                    drawing.OfType<Anchor>().FirstOrDefault()?.Remove();
                 } else {
-                    throw new InvalidOperationException("Extent is missing. Weird. Shouldn't happen.");
+                    // remove current Wrap
+                    if (currentWrap == WrapTextImage.Square) {
+                        anchor.OfType<WrapSquare>().FirstOrDefault()?.Remove();
+                    } else if (currentWrap == WrapTextImage.Tight) {
+                        anchor.OfType<WrapTight>().FirstOrDefault()?.Remove();
+                    } else if (currentWrap == WrapTextImage.Through) {
+                        anchor.OfType<WrapThrough>().FirstOrDefault()?.Remove();
+                    } else if (currentWrap == WrapTextImage.TopAndBottom) {
+                        anchor.OfType<WrapTopBottom>().FirstOrDefault()?.Remove();
+                    } else if (currentWrap == WrapTextImage.BehindText) {
+                        anchor.OfType<WrapNone>().FirstOrDefault()?.Remove();
+                        anchor.BehindDoc = true;
+                    } else if (currentWrap == WrapTextImage.InFrontOfText) {
+                        anchor.OfType<WrapNone>().FirstOrDefault()?.Remove();
+                        anchor.BehindDoc = false;
+                    } else if (currentWrap == WrapTextImage.InLineWithText) {
+                        // this won't really happen
+                    }
+
+                    // wrap needs to be inserted after extent or it will not work
+                    var extent = anchor.Elements<Extent>().FirstOrDefault();
+                    if (extent != null) {
+                        if (wrapImage == WrapTextImage.Square) {
+                            var wrap = new WrapSquare() { WrapText = WrapTextValues.BothSides };
+                            extent.InsertAfterSelf(wrap);
+                        } else if (wrapImage == WrapTextImage.Tight) {
+                            anchor.Append(new WrapTight() { WrapText = WrapTextValues.BothSides });
+                        } else if (wrapImage == WrapTextImage.Through) {
+                            var wrap = WordWrapTextImage.WrapThrough;
+                            extent.InsertAfterSelf(wrap);
+                        } else if (wrapImage == WrapTextImage.TopAndBottom) {
+                            var wrap = WordWrapTextImage.WrapTopBottom;
+                            extent.InsertAfterSelf(wrap);
+                        } else if (wrapImage == WrapTextImage.BehindText) {
+                            var wrap = new WrapNone();
+                            extent.InsertAfterSelf(wrap);
+                            anchor.BehindDoc = false;
+                        } else if (wrapImage == WrapTextImage.InFrontOfText) {
+                            var wrap = new WrapNone();
+                            extent.InsertAfterSelf(wrap);
+                            anchor.BehindDoc = true;
+                        } else if (wrapImage == WrapTextImage.InLineWithText) {
+                            throw new InvalidOperationException("WrapTextImage.InLineWithText should be handled before.");
+                        }
+                    } else {
+                        throw new InvalidOperationException("Extent is missing. Weird. Shouldn't happen.");
+                    }
                 }
             } else if (inline != null) {
-                // this requires support for Inline rather than Anchor which is not yet implemented
-                throw new InvalidOperationException("InLineWithText is not supported.");
+                if (wrapImage == WrapTextImage.InLineWithText) {
+                    // nothing to do
+                    return;
+                } else {
+                    var convertedAnchor = WordTextBox.ConvertInlineToAnchor(inline, wrapImage.Value);
+                    drawing.Append(convertedAnchor);
+                    drawing.OfType<Inline>().FirstOrDefault()?.Remove();
+                }
             }
         }
 


### PR DESCRIPTION
This PR adds the following features:
- Use Paragraph instead of StdBlock (so that text within a TextBox is no "variable" anymore)
- Allow changing the insets of the TextBox so that there is no gap between the text of the TextBox and its border
- Allow the TextBox to be set to "AutoFitText" or not
- Allow the text to be multiline by respecting the page breaks
- Added Wrapping functionality including inline
- Added ability to convert inline to other wrapping types and vice versa (keep in mind that some properties are lost then or go to their defaults)
- Fixes wrong paragraph being returned when AddImage is used

Breaking change:
- Changes `WrapTextImage.InFrontText` to `WrapTextImage.InFrontOfText` to match Word naming