### PR TITLE
Add centimeters conversions to Margins, fix naming emus/twips

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -26,6 +26,7 @@ namespace OfficeIMO.Examples {
             BasicDocument.Example_BasicWordWithNewLines(folderPath, false);
             BasicDocument.Example_BasicWordWithTabs(folderPath, false);
             BasicDocument.Example_BasicWordWithMargins(folderPath, false);
+            BasicDocument.Example_BasicWordWithMarginsInCentimeters(folderPath, false);
             BasicDocument.Example_BasicWordWithMarginsAndImage(folderPath, false);
             BasicDocument.Example_BasicWordWithLineSpacing(folderPath, false);
 
@@ -159,6 +160,7 @@ namespace OfficeIMO.Examples {
             WordTextBox.Example_AddingTextbox4(folderPath, false);
             WordTextBox.Example_AddingTextbox5(folderPath, false);
             WordTextBox.Example_AddingTextbox3(folderPath, false);
+            WordTextBox.Example_AddingTextboxCentimeters(folderPath, false);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create05.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create05.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create06.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create06.cs
@@ -1,0 +1,43 @@
+using System;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class BasicDocument {
+        public static void Example_BasicWordWithMarginsInCentimeters(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating standard document with margins");
+            string filePath = System.IO.Path.Combine(folderPath, "EmptyDocumentWithMarginsCentimeters.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.Sections[0].Margins.BottomCentimeters = 2.30;
+                document.Sections[0].Margins.TopCentimeters = 5.50;
+                document.Sections[0].Margins.LeftCentimeters = 3.01;
+                document.Sections[0].Margins.RightCentimeters = 3.05;
+
+                Console.WriteLine(document.Sections[0].Margins.BottomCentimeters);
+                Console.WriteLine(document.Sections[0].Margins.TopCentimeters);
+                Console.WriteLine(document.Sections[0].Margins.LeftCentimeters);
+                Console.WriteLine(document.Sections[0].Margins.RightCentimeters);
+
+                Console.WriteLine(document.Sections[0].Margins.Bottom);
+                Console.WriteLine(document.Sections[0].Margins.Top);
+                Console.WriteLine(document.Sections[0].Margins.Left.Value);
+                Console.WriteLine(document.Sections[0].Margins.Right.Value);
+
+                //document.Sections[0].Margins.Bottom = 10;
+                //document.Sections[0].Margins.Top = 10;
+                //document.Sections[0].Margins.Left = 600;
+                //document.Sections[0].Margins.Right = 600;
+
+                document.Settings.FontFamily = "Arial";
+                document.Settings.FontSize = 9;
+
+                document.AddParagraph("This should be Arial 9");
+
+                var par = document.AddParagraph("This should be Tahoma 20");
+                par.FontFamily = "Tahoma";
+                par.FontSize = 20;
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample1.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample1.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
-using DocumentFormat.OpenXml.Drawing;
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
-using DocumentFormat.OpenXml.Spreadsheet;
-using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using Color = SixLabors.ImageSharp.Color;
 using HorizontalAlignmentValues = DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalAlignmentValues;

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample6.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample6.cs
@@ -1,0 +1,43 @@
+using System;
+using DocumentFormat.OpenXml.Drawing.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class WordTextBox {
+        internal static void Example_AddingTextboxCentimeters(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating standard document with some textbox");
+
+            var filePath = System.IO.Path.Combine(folderPath, "BasicDocumentWithTextBox15.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Adding paragraph with some text");
+
+                var textBox = document.AddTextBox("[Grab your reader’s attention with a great quote from the document or use this space to emphasize a key point. To place this text box anywhere on the page, just drag it.]");
+
+
+                textBox.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                textBox.HorizonalPositionOffsetCentimeters = 1.5;
+                textBox.VerticalPositionRelativeFrom = VerticalRelativePositionValues.Page;
+
+                textBox.VerticalPositionOffsetCentimeters = 5;
+
+                Console.WriteLine("Vertical Position Offset: " + textBox.VerticalPositionOffset);
+                Console.WriteLine("Vertical Position Offset in CM: " + textBox.VerticalPositionOffsetCentimeters);
+
+
+                document.TextBoxes[0].RelativeWidthPercentage = 0;
+                document.TextBoxes[0].RelativeHeightPercentage = 0;
+
+                document.TextBoxes[0].WidthCentimeters = 10;
+                document.TextBoxes[0].HeightCentimeters = 5;
+
+                Console.WriteLine("Width centimeters: " + textBox.WidthCentimeters);
+                Console.WriteLine("Height centimeters: " + textBox.HeightCentimeters);
+                Console.WriteLine("Width emus: " + textBox.Width);
+                Console.WriteLine("Height emus: " + textBox.Height);
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Margins.cs
+++ b/OfficeIMO.Tests/Word.Margins.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using Xunit;

--- a/OfficeIMO.Tests/Word.Margins.cs
+++ b/OfficeIMO.Tests/Word.Margins.cs
@@ -89,6 +89,35 @@ namespace OfficeIMO.Tests {
 
             }
         }
+
+        [Fact]
+        public void Test_CreatingWordDocumentWithPageMarginsCentimeters() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithSectionsPageMarginsCentimeters.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+
+                document.Sections[0].Margins.BottomCentimeters = 2.30;
+                document.Sections[0].Margins.TopCentimeters = 5.50;
+                document.Sections[0].Margins.LeftCentimeters = 3.01;
+                document.Sections[0].Margins.RightCentimeters = 3.05;
+
+                Assert.True(document.Sections[0].Margins.BottomCentimeters == 2.2998236331569664);
+                Assert.True(document.Sections[0].Margins.TopCentimeters == 5.499118165784832);
+                Assert.True(document.Sections[0].Margins.LeftCentimeters == 3.0088183421516757);
+                Assert.True(document.Sections[0].Margins.RightCentimeters == 3.049382716049383);
+
+                Assert.True(document.Sections[0].Margins.Bottom == 1304);
+                Assert.True(document.Sections[0].Margins.Top == 3118);
+                Assert.True(document.Sections[0].Margins.Left.Value == 1706);
+                Assert.True(document.Sections[0].Margins.Right.Value == 1729);
+
+
+
+                document.Save(false);
+
+                Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
+            }
+
+        }
     }
 
 }

--- a/OfficeIMO.Tests/Word.TextBox.cs
+++ b/OfficeIMO.Tests/Word.TextBox.cs
@@ -400,5 +400,38 @@ namespace OfficeIMO.Tests {
 
             }
         }
+
+        [Fact]
+        public void Test_CreatingWordDocumentWithTextBoxCheckingSize() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreatingWordDocumentWithTextBoxCheckingSize.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+
+                var textBox = document.AddTextBox("[Grab your reader’s attention with a great quote from the document or use this space to emphasize a key point. To place this text box anywhere on the page, just drag it.]");
+
+                textBox.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
+                textBox.HorizonalPositionOffsetCentimeters = 1.5;
+                textBox.VerticalPositionRelativeFrom = VerticalRelativePositionValues.Page;
+
+                textBox.VerticalPositionOffsetCentimeters = 5;
+
+                Assert.True(textBox.VerticalPositionOffset == 1800000);
+                Assert.True(textBox.VerticalPositionOffsetCentimeters == 5.0);
+
+                document.TextBoxes[0].RelativeWidthPercentage = 0;
+                document.TextBoxes[0].RelativeHeightPercentage = 0;
+
+                document.TextBoxes[0].WidthCentimeters = 10;
+                document.TextBoxes[0].HeightCentimeters = 5;
+
+                Assert.True(textBox.WidthCentimeters == 10.0);
+                Assert.True(textBox.HeightCentimeters == 5);
+                Assert.True(textBox.Width == 3600000);
+                Assert.True(textBox.Height == 1800000);
+
+
+                document.Save(false);
+                Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/Helpers.cs
+++ b/OfficeIMO.Word/Helpers.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+using System;
+using System.Diagnostics;
 using System.IO;
 using DocumentFormat.OpenXml.Packaging;
 using SixLabors.ImageSharp.Formats;
@@ -27,6 +28,12 @@ namespace OfficeIMO.Word {
                 Process.Start(startInfo);
             }
         }
+
+        /// <summary>
+        /// Checks if file is locked/used by another process
+        /// </summary>
+        /// <param name="file"></param>
+        /// <returns></returns>
         public static bool IsFileLocked(this FileInfo file) {
             try {
                 using (FileStream stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None)) {
@@ -43,6 +50,12 @@ namespace OfficeIMO.Word {
             //file is not locked
             return false;
         }
+
+        /// <summary>
+        /// Checks if file is locked/used by another process
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <returns></returns>
         public static bool IsFileLocked(this string fileName) {
             try {
                 var file = new FileInfo(fileName);
@@ -61,8 +74,7 @@ namespace OfficeIMO.Word {
             return false;
         }
 
-        internal static ImageСharacteristics GetImageСharacteristics(Stream imageStream)
-        {
+        internal static ImageСharacteristics GetImageСharacteristics(Stream imageStream) {
             using var img = SixLabors.ImageSharp.Image.Load(imageStream, out var imageFormat);
             imageStream.Position = 0;
             var type = ConvertToImagePartType(imageFormat);
@@ -70,8 +82,7 @@ namespace OfficeIMO.Word {
         }
 
         private static ImagePartType ConvertToImagePartType(IImageFormat imageFormat) =>
-            imageFormat.Name switch
-            {
+            imageFormat.Name switch {
                 "BMP" => ImagePartType.Bmp,
                 "GIF" => ImagePartType.Gif,
                 "JPEG" => ImagePartType.Jpeg,
@@ -79,6 +90,86 @@ namespace OfficeIMO.Word {
                 "TIFF" => ImagePartType.Tiff,
                 _ => throw new ImageFormatNotSupportedException($"Image format not supported: {imageFormat.Name}.")
             };
+
+        /// <summary>
+        /// Converts centimeters to EMUs and returns int value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        internal static int? ConvertCentimetersToEmus(double value) {
+            int emus = (int)(value * 360000);
+            return emus;
+        }
+
+        /// <summary>
+        /// Converts centimeters to EMUs and returns int64 value
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        internal static Int64 ConvertCentimetersToEmusInt64(double value) {
+            Int64 emus = (Int64)(value * 360000);
+            return emus;
+        }
+
+        /// <summary>
+        /// Converts EMUs to centimeters
+        /// </summary>
+        /// <param name="emusValue"></param>
+        /// <returns></returns>
+        internal static double? ConvertEmusToCentimeters(int emusValue) {
+            double centimeters = (double)((double)emusValue / (double)360000);
+            return centimeters;
+        }
+
+        /// <summary>
+        /// Converts EMUs to centimeters
+        /// </summary>
+        /// <param name="emusValue"></param>
+        /// <returns></returns>
+        internal static double ConvertEmusToCentimeters(Int64 emusValue) {
+            double centimeters = (double)((double)emusValue / (double)360000);
+            return centimeters;
+        }
+
+        /// <summary>
+        /// Converts twips to centimeters
+        /// </summary>
+        /// <param name="twipsValue"></param>
+        /// <returns></returns>
+        internal static double ConvertTwipsToCentimeters(int twipsValue) {
+            double centimeters = twipsValue / 567.0;
+            return centimeters;
+        }
+
+        /// <summary>
+        /// Converts twips to centimeters
+        /// </summary>
+        /// <param name="twipsValue"></param>
+        /// <returns></returns>
+        internal static double ConvertTwipsToCentimeters(UInt32 twipsValue) {
+            double centimeters = twipsValue / 567.0;
+            return centimeters;
+        }
+
+        /// <summary>
+        /// Converts centimeters to twips
+        /// </summary>
+        /// <param name="cmValue"></param>
+        /// <returns></returns>
+        internal static int ConvertCentimetersToTwips(double cmValue) {
+            int twips = (int)(cmValue * 567.0);
+            return twips;
+        }
+
+        /// <summary>
+        /// Converts centimeters to twips
+        /// </summary>
+        /// <param name="cmValue"></param>
+        /// <returns></returns>
+        internal static UInt32 ConvertCentimetersToTwipsUInt32(double cmValue) {
+            UInt32 twips = (UInt32)(cmValue * 567.0);
+            return twips;
+        }
     }
 
     internal record ImageСharacteristics(double Width, double Height, ImagePartType Type);

--- a/OfficeIMO.Word/WordMargins.cs
+++ b/OfficeIMO.Word/WordMargins.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System;
 using DocumentFormat.OpenXml;
-using DocumentFormat.OpenXml.Office2010.PowerPoint;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
@@ -24,6 +21,10 @@ namespace OfficeIMO.Word {
             _document = wordDocument;
             _section = wordSection;
         }
+
+        /// <summary>
+        /// Get or set the left margin in Twips
+        /// </summary>
         public UInt32Value Left {
             get {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -43,6 +44,10 @@ namespace OfficeIMO.Word {
                 pageMargin.Left = value;
             }
         }
+
+        /// <summary>
+        /// Get or set the right margin in Twips
+        /// </summary>
         public UInt32Value Right {
             get {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -62,6 +67,10 @@ namespace OfficeIMO.Word {
                 pageMargin.Right = value;
             }
         }
+
+        /// <summary>
+        /// Get or set the top margin in Twips
+        /// </summary>
         public int? Top {
             get {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -81,6 +90,10 @@ namespace OfficeIMO.Word {
                 pageMargin.Top = value;
             }
         }
+
+        /// <summary>
+        /// Get or set the left margin in Twips
+        /// </summary>
         public int? Bottom {
             get {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -100,6 +113,63 @@ namespace OfficeIMO.Word {
                 pageMargin.Bottom = value;
             }
         }
+
+        /// <summary>
+        /// Get or set the top margin in centimeters
+        /// </summary>
+        public double? TopCentimeters {
+            get {
+                if (Top != null) {
+                    return Helpers.ConvertTwipsToCentimeters(Top.Value);
+                }
+                return null;
+            }
+            set => Top = Helpers.ConvertCentimetersToTwips(value.Value);
+        }
+
+        /// <summary>
+        /// Get or set the bottom margin in centimeters
+        /// </summary>
+        public double? BottomCentimeters {
+            get {
+                if (Bottom != null) {
+                    return Helpers.ConvertTwipsToCentimeters(Bottom.Value);
+
+                }
+                return null;
+            }
+            set => Bottom = Helpers.ConvertCentimetersToTwips(value.Value);
+        }
+
+        /// <summary>
+        /// Get or set the left margin in centimeters
+        /// </summary>
+        public double? LeftCentimeters {
+            get {
+                if (Left != null) {
+                    return Helpers.ConvertTwipsToCentimeters(Left.Value);
+                }
+                return null;
+            }
+            set => Left = Helpers.ConvertCentimetersToTwipsUInt32(value.Value);
+        }
+
+        /// <summary>
+        /// Get or set the right margin in centimeters
+        /// </summary>
+        public double? RightCentimeters {
+            get {
+                if (Right != null) {
+                    return Helpers.ConvertTwipsToCentimeters(Right.Value);
+                }
+                return null;
+            }
+            set => Right = Helpers.ConvertCentimetersToTwipsUInt32(value.Value);
+        }
+
+        /// <summary>
+        /// Get or set the header distance in Twips
+        /// </summary>
         public UInt32Value HeaderDistance {
             get {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -119,6 +189,10 @@ namespace OfficeIMO.Word {
                 pageMargin.Header = value;
             }
         }
+
+        /// <summary>
+        /// Get or set the footer distance in Twips
+        /// </summary>
         public UInt32Value FooterDistance {
             get {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -138,6 +212,7 @@ namespace OfficeIMO.Word {
                 pageMargin.Footer = value;
             }
         }
+
         public UInt32Value Gutter {
             get {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -245,14 +245,14 @@ namespace OfficeIMO.Word {
         public double? HorizonalPositionOffsetCentimeters {
             get {
                 if (HorizonalPositionOffset != null) {
-                    return ConvertTwipsToCentimeters(HorizonalPositionOffset.Value);
+                    return Helpers.ConvertEmusToCentimeters(HorizonalPositionOffset.Value);
                 }
 
                 return null;
             }
             set {
                 if (value != null) {
-                    HorizonalPositionOffset = ConvertCentimetersToTwips(value.Value);
+                    HorizonalPositionOffset = Helpers.ConvertCentimetersToEmus(value.Value);
                 }
             }
         }
@@ -263,7 +263,7 @@ namespace OfficeIMO.Word {
         public double? VerticalPositionOffsetCentimeters {
             get {
                 if (VerticalPositionOffset != null) {
-                    return ConvertTwipsToCentimeters(VerticalPositionOffset.Value);
+                    return Helpers.ConvertEmusToCentimeters(VerticalPositionOffset.Value);
                 }
 
                 return null;
@@ -271,7 +271,7 @@ namespace OfficeIMO.Word {
 
             set {
                 if (value != null) {
-                    VerticalPositionOffset = ConvertCentimetersToTwips(value.Value);
+                    VerticalPositionOffset = Helpers.ConvertCentimetersToEmus(value.Value);
                 }
             }
         }
@@ -458,19 +458,19 @@ namespace OfficeIMO.Word {
 
         public double WidthCentimeters {
             get {
-                return ConvertTwipsToCentimeters(Width);
+                return Helpers.ConvertEmusToCentimeters(Width);
             }
             set {
-                Width = ConvertCentimetersToTwipsInt64(value);
+                Width = Helpers.ConvertCentimetersToEmusInt64(value);
             }
         }
 
         public double HeightCentimeters {
             get {
-                return ConvertTwipsToCentimeters(Height);
+                return Helpers.ConvertEmusToCentimeters(Height);
             }
             set {
-                Height = ConvertCentimetersToTwipsInt64(value);
+                Height = Helpers.ConvertCentimetersToEmusInt64(value);
             }
         }
 
@@ -722,66 +722,6 @@ namespace OfficeIMO.Word {
                 return horizontalPosition;
             }
             return null;
-        }
-
-        /// <summary>
-        /// Converts centimeters to twips (twentieths of a point)
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        private int? ConvertCentimetersToTwips(double value) {
-            int twips = (int)(value * 360000);
-            return twips;
-        }
-
-        /// <summary>
-        /// Converts centimeters to twips (twentieths of a point) (Int64)
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        private Int64 ConvertCentimetersToTwipsInt64(double value) {
-            Int64 twips = (Int64)(value * 360000);
-            return twips;
-        }
-
-        /// <summary>
-        /// Converts twips (twentieths of a point) to centimeters
-        /// </summary>
-        /// <param name="twipsValue"></param>
-        /// <returns></returns>
-        private double? ConvertTwipsToCentimeters(int twipsValue) {
-            double centimeters = (double)((double)twipsValue / (double)360000);
-            return centimeters;
-        }
-
-        /// <summary>
-        /// Converts emu (English Metric Units) to centimeters  
-        /// </summary>
-        /// <param name="emuValue"></param>
-        /// <returns></returns>
-        private double ConvertEmuToCentimeters(Int64 emuValue) {
-            double centimeters = (double)((double)emuValue / (double)914400);
-            return centimeters;
-        }
-
-        /// <summary>
-        /// Converts centimeters to emu (English Metric Units)
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        private Int64 ConvertCentimetersToEmu(double value) {
-            Int64 emu = (Int64)(value * 914400);
-            return emu;
-        }
-
-        /// <summary>
-        /// Converts twips (twentieths of a point) to centimeters (Int64)
-        /// </summary>
-        /// <param name="twipsValue"></param>
-        /// <returns></returns>
-        private double ConvertTwipsToCentimeters(Int64 twipsValue) {
-            double centimeters = (double)((double)twipsValue / (double)360000);
-            return centimeters;
         }
 
         private void AddAlternateContent(WordDocument wordDocument, WordParagraph wordParagraph, string text, WrapTextImage wrapTextImage) {

--- a/OfficeImo.sln.DotSettings
+++ b/OfficeImo.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Twips/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
- Allow conversion for margins from Centimeters to Emus and back;

```cs
public static void Example_BasicWordWithMarginsInCentimeters(string folderPath, bool openWord) {
    Console.WriteLine("[*] Creating standard document with margins");
    string filePath = System.IO.Path.Combine(folderPath, "EmptyDocumentWithMarginsCentimeters.docx");
    using (WordDocument document = WordDocument.Create(filePath)) {
        document.Sections[0].Margins.BottomCentimeters = 2.30;
        document.Sections[0].Margins.TopCentimeters = 5.50;
        document.Sections[0].Margins.LeftCentimeters = 3.01;
        document.Sections[0].Margins.RightCentimeters = 3.05;

        Console.WriteLine(document.Sections[0].Margins.BottomCentimeters);
        Console.WriteLine(document.Sections[0].Margins.TopCentimeters);
        Console.WriteLine(document.Sections[0].Margins.LeftCentimeters);
        Console.WriteLine(document.Sections[0].Margins.RightCentimeters);

        Console.WriteLine(document.Sections[0].Margins.Bottom);
        Console.WriteLine(document.Sections[0].Margins.Top);
        Console.WriteLine(document.Sections[0].Margins.Left.Value);
        Console.WriteLine(document.Sections[0].Margins.Right.Value);

        //document.Sections[0].Margins.Bottom = 10;
        //document.Sections[0].Margins.Top = 10;
        //document.Sections[0].Margins.Left = 600;
        //document.Sections[0].Margins.Right = 600;

        document.Settings.FontFamily = "Arial";
        document.Settings.FontSize = 9;

        document.AddParagraph("This should be Arial 9");

        var par = document.AddParagraph("This should be Tahoma 20");
        par.FontFamily = "Tahoma";
        par.FontSize = 20;

        document.Save(openWord);
    }
}
```
- Fix some names around twips/emus
- Added tests for conversions in TextBox/Margins
- Added some examples