### PR TITLE
**Breaking Change** - Remove continue & restart numbering from Lists 

### DIFF
--- a/OfficeIMO.Examples/Word/Lists/Lists.Create1.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.Create1.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/OfficeIMO.Examples/Word/Lists/Lists.Create7.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.Create7.cs
@@ -9,7 +9,7 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
 
                 // add list and nest a list
-                WordList wordList1 = document.AddList(WordListStyle.Headings111, false);
+                WordList wordList1 = document.AddList(WordListStyle.Headings111);
                 Console.WriteLine("List (0) ElementsCount (0): " + wordList1.ListItems.Count);
                 Console.WriteLine("List (0) ElementsCount (1): " + document.Lists[0].ListItems.Count);
                 wordList1.AddItem("Text 1");
@@ -26,28 +26,26 @@ namespace OfficeIMO.Examples.Word {
                 wordList1.AddItem("Text 2.1", 1);
                 Console.WriteLine("List (0) ElementsCount (3): " + wordList1.ListItems.Count);
 
-                WordList wordListNested = document.AddList(WordListStyle.Bulleted, false);
+                WordList wordListNested = document.AddList(WordListStyle.Bulleted);
                 wordListNested.AddItem("Nested 1", 1);
                 wordListNested.AddItem("Nested 2", 1);
 
-                WordList wordList2 = document.AddList(WordListStyle.Headings111, true);
-                Console.WriteLine("List 2 - Restart numbering: " + wordList2.RestartNumbering);
+                WordList wordList2 = document.AddList(WordListStyle.Headings111);
+
                 wordList2.AddItem("Section 2");
                 wordList2.AddItem("Section 2.1", 1);
 
-                WordList wordList3 = document.AddList(WordListStyle.Headings111, true);
-                Console.WriteLine("List 3 - Restart numbering: " + wordList3.RestartNumbering);
-                wordList3.RestartNumbering = true;
-                Console.WriteLine("List 3 - Restart numbering after change: " + wordList3.RestartNumbering);
+                WordList wordList3 = document.AddList(WordListStyle.Headings111);
+
                 wordList3.AddItem("Section 1");
                 wordList3.AddItem("Section 1.1", 1);
 
-                WordList wordList4 = document.AddList(WordListStyle.Headings111, true);
+                WordList wordList4 = document.AddList(WordListStyle.Headings111);
                 //wordList4.RestartNumbering = true;
                 wordList4.AddItem("Section 2");
                 wordList4.AddItem("Section 2.1", 1);
 
-                WordList wordList5 = document.AddList(WordListStyle.Headings111, true);
+                WordList wordList5 = document.AddList(WordListStyle.Headings111);
                 //wordList5.RestartNumbering = true;
                 wordList5.AddItem("Section 3");
                 wordList5.AddItem("Section 3.1", 1);

--- a/OfficeIMO.Examples/Word/Lists/Lists.Create8.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.Create8.cs
@@ -9,7 +9,7 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
 
                 // add list and nest a list
-                WordList wordList1 = document.AddList(WordListStyle.Headings111, false);
+                WordList wordList1 = document.AddList(WordListStyle.Headings111);
                 wordList1.AddItem("Text 1");
                 wordList1.AddItem("Text 1.1");
                 wordList1.AddItem("Text 1.2");
@@ -18,7 +18,7 @@ namespace OfficeIMO.Examples.Word {
                 document.AddParagraph("Second List");
                 document.AddParagraph();
 
-                WordList wordList2 = document.AddList(WordListStyle.Headings111, false);
+                WordList wordList2 = document.AddList(WordListStyle.Headings111);
                 wordList2.AddItem("Text 2");
                 wordList2.AddItem("Text 2.1");
                 wordList2.AddItem("Text 2.2");
@@ -28,7 +28,7 @@ namespace OfficeIMO.Examples.Word {
                 document.AddParagraph("Third List");
                 document.AddParagraph();
 
-                WordList wordList3 = document.AddList(WordListStyle.Headings111, false);
+                WordList wordList3 = document.AddList(WordListStyle.Headings111);
                 wordList3.AddItem("Text 3");
                 wordList3.AddItem("Text 3.1");
                 wordList3.AddItem("Text 3.2");

--- a/OfficeIMO.Tests/Word.Lists.cs
+++ b/OfficeIMO.Tests/Word.Lists.cs
@@ -133,8 +133,6 @@ public partial class Word {
 
             var wordList8 = document.AddList(WordListStyle.Bulleted);
 
-            Assert.True(wordList8.RestartNumbering == true);
-
             wordList8.AddItem("Text 9");
             wordList8.AddItem("Text 9.1", 1);
             wordList8.AddItem("Text 9.2", 2);
@@ -151,12 +149,6 @@ public partial class Word {
             var wordList2 = document.AddList(WordListStyle.Headings111);
             wordList2.AddItem("Temp 10");
             wordList2.AddItem("Text 10.1", 1);
-
-            Assert.True(wordList2.RestartNumbering == true);
-
-            wordList2.RestartNumbering = false;
-
-            Assert.True(wordList2.RestartNumbering == false);
 
             paragraph = document
                 .AddParagraph("Paragraph in the middle of the list")
@@ -411,7 +403,7 @@ public partial class Word {
         var filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithListsInTables.docx");
         using (var document = WordDocument.Create(filePath)) {
             Assert.True(document.Lists.Count == 0);
-            WordList wordList1 = document.AddList(WordListStyle.Headings111, true);
+            WordList wordList1 = document.AddList(WordListStyle.Headings111);
             Assert.True(wordList1.ListItems.Count == 0);
             Assert.True(document.Lists[0].ListItems.Count == 0);
             wordList1.AddItem("Text 1");
@@ -429,8 +421,8 @@ public partial class Word {
             Assert.True(document.Lists.Count == 1);
 
 
-            WordList wordListNested = document.AddList(WordListStyle.Bulleted, false);
-            Assert.True(wordListNested.RestartNumbering == true);
+            WordList wordListNested = document.AddList(WordListStyle.Bulleted);
+
             Assert.True(wordListNested.RestartNumberingAfterBreak == false);
             wordListNested.RestartNumberingAfterBreak = true;
             Assert.True(wordListNested.RestartNumberingAfterBreak == true);
@@ -440,8 +432,8 @@ public partial class Word {
             Assert.True(document.Lists[1].ListItems.Count == 2);
             Assert.True(document.Lists.Count == 2);
 
-            WordList wordList2 = document.AddList(WordListStyle.Headings111, true);
-            Assert.True(wordList2.RestartNumbering == false);
+            WordList wordList2 = document.AddList(WordListStyle.Headings111);
+
             wordList2.AddItem("Section 2");
             wordList2.AddItem("Section 2.1", 1);
 
@@ -450,19 +442,17 @@ public partial class Word {
             Assert.True(document.Lists.Count == 3);
 
 
-            WordList wordList3 = document.AddList(WordListStyle.Headings111, true);
-            Assert.True(wordList3.RestartNumbering == false);
-            wordList3.RestartNumbering = true;
-            Assert.True(wordList3.RestartNumbering == true);
+            WordList wordList3 = document.AddList(WordListStyle.Headings111);
+
             wordList3.AddItem("Section 1");
             wordList3.AddItem("Section 1.1", 1);
             Assert.True(wordList3.ListItems.Count == 2);
 
-            WordList wordList4 = document.AddList(WordListStyle.Headings111, true);
+            WordList wordList4 = document.AddList(WordListStyle.Headings111);
             wordList4.AddItem("Section 2");
             wordList4.AddItem("Section 2.1", 1);
 
-            WordList wordList5 = document.AddList(WordListStyle.Headings111, true);
+            WordList wordList5 = document.AddList(WordListStyle.Headings111);
             wordList5.AddItem("Section 3");
             wordList5.AddItem("Section 3.1", 1);
 

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -92,15 +92,15 @@ namespace OfficeIMO.Word {
             return pieChart;
         }
 
-        public WordList AddList(WordListStyle style, bool continueNumbering = false) {
+        public WordList AddList(WordListStyle style) {
             WordList wordList = new WordList(this);
-            wordList.AddList(style, continueNumbering);
+            wordList.AddList(style);
             return wordList;
         }
 
         public WordList AddTableOfContentList(WordListStyle style) {
             WordList wordList = new WordList(this, true);
-            wordList.AddList(style, continueNumbering: true);
+            wordList.AddList(style);
             return wordList;
         }
 

--- a/OfficeIMO.Word/WordHeaderFooter.Methods.cs
+++ b/OfficeIMO.Word/WordHeaderFooter.Methods.cs
@@ -53,9 +53,9 @@ namespace OfficeIMO.Word {
             }
         }
 
-        public WordList AddList(WordListStyle style, bool continueNumbering = false) {
+        public WordList AddList(WordListStyle style) {
             WordList wordList = new WordList(this._document, this);
-            wordList.AddList(style, continueNumbering);
+            wordList.AddList(style);
             return wordList;
         }
     }

--- a/OfficeIMO.Word/WordList.cs
+++ b/OfficeIMO.Word/WordList.cs
@@ -206,43 +206,6 @@ public class WordList {
         }
     }
 
-    public bool RestartNumbering {
-        get {
-            var numbering = _document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart!.Numbering;
-            var listNumbering = numbering.ChildElements.OfType<NumberingInstance>();
-            foreach (var numberingInstance in listNumbering) {
-                if (numberingInstance.NumberID == _numberId) {
-                    var level = numberingInstance.ChildElements.OfType<LevelOverride>().FirstOrDefault();
-                    if (level != null) {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-        set {
-            var numbering = _document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart!.Numbering;
-            var listNumbering = numbering.ChildElements.OfType<NumberingInstance>();
-            foreach (var numberingInstance in listNumbering) {
-                if (numberingInstance.NumberID == _numberId) {
-                    var abstractNumId = new AbstractNumId {
-                        Val = _abstractId
-                    };
-                    NumberingInstance foundNumberingInstance;
-                    if (value == false) {
-                        // continue numbering as it was by default
-                        foundNumberingInstance = DefaultNumberingInstance(abstractNumId, _numberId);
-                    } else {
-                        // restart numbering from 1
-                        foundNumberingInstance = RestartNumberingInstance(abstractNumId, _numberId);
-                    }
-                    numberingInstance.InsertBeforeSelf(foundNumberingInstance);
-                    numberingInstance.Remove();
-                }
-            }
-        }
-    }
-
     /// <summary>
     /// Restarts numbering of a list after a break. Requires a list to be set to RestartNumbering overall.
     /// </summary>
@@ -401,7 +364,7 @@ public class WordList {
         return ids.Count > 0 ? ids.Max() + 1 : 1;
     }
 
-    internal void AddList(WordListStyle style, bool continueNumbering) {
+    internal void AddList(WordListStyle style) {
         CreateNumberingDefinition(_document);
         var numbering = _document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart!.Numbering;
 
@@ -414,11 +377,7 @@ public class WordList {
             Val = _abstractId
         };
         NumberingInstance numberingInstance = new NumberingInstance();
-        if (continueNumbering) {
-            numberingInstance = DefaultNumberingInstance(abstractNumId, _numberId);
-        } else {
-            numberingInstance = RestartNumberingInstance(abstractNumId, _numberId);
-        }
+        numberingInstance = RestartNumberingInstance(abstractNumId, _numberId);
         numbering.Append(numberingInstance, abstractNum);
     }
 

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -315,9 +315,9 @@ namespace OfficeIMO.Word {
             return wordParagraph;
         }
 
-        public WordList AddList(WordListStyle style, bool continueNumbering = false) {
+        public WordList AddList(WordListStyle style) {
             WordList wordList = new WordList(this._document, this);
-            wordList.AddList(style, continueNumbering);
+            wordList.AddList(style);
             return wordList;
         }
 

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -454,9 +454,9 @@ namespace OfficeIMO.Word {
             return wordTable;
         }
 
-        public WordList AddList(WordListStyle style, bool continueNumbering = false) {
+        public WordList AddList(WordListStyle style) {
             WordList wordList = new WordList(this._document, this.Paragraphs.Last());
-            wordList.AddList(style, continueNumbering);
+            wordList.AddList(style);
             return wordList;
         }
     }


### PR DESCRIPTION
Resolve issues described in:
- #204 
- #201 

Basically no longer allows to use `WordList wordList3 = document.AddList(WordListStyle.Headings111, true);` or using `RestartNumbering = true` as each list restarts by itself