### PR TITLE
Improve textboxes to allow multiple Runs/Paragraphs **Breaking Changes**

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -16,154 +16,154 @@ namespace OfficeIMO.Examples {
             string folderPath = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "Documents");
             Setup(folderPath);
 
-            //BasicDocument.Example_BasicEmptyWord(folderPath, false);
-            //BasicDocument.Example_BasicWord(folderPath, false);
-            //BasicDocument.Example_BasicWord2(folderPath, false);
-            //BasicDocument.Example_BasicWordWithBreaks(folderPath, false);
-            //BasicDocument.Example_BasicWordWithDefaultStyleChange(folderPath, false);
-            //BasicDocument.Example_BasicWordWithDefaultFontChange(folderPath, false);
-            //BasicDocument.Example_BasicLoadHamlet(templatesPath, folderPath, false);
-            //BasicDocument.Example_BasicWordWithPolishChars(folderPath, false);
-            //BasicDocument.Example_BasicWordWithNewLines(folderPath, false);
-            //BasicDocument.Example_BasicWordWithTabs(folderPath, false);
-            //BasicDocument.Example_BasicWordWithMargins(folderPath, false);
-            //BasicDocument.Example_BasicWordWithMarginsInCentimeters(folderPath, false);
-            //BasicDocument.Example_BasicWordWithMarginsAndImage(folderPath, false);
-            //BasicDocument.Example_BasicWordWithLineSpacing(folderPath, false);
+            BasicDocument.Example_BasicEmptyWord(folderPath, false);
+            BasicDocument.Example_BasicWord(folderPath, false);
+            BasicDocument.Example_BasicWord2(folderPath, false);
+            BasicDocument.Example_BasicWordWithBreaks(folderPath, false);
+            BasicDocument.Example_BasicWordWithDefaultStyleChange(folderPath, false);
+            BasicDocument.Example_BasicWordWithDefaultFontChange(folderPath, false);
+            BasicDocument.Example_BasicLoadHamlet(templatesPath, folderPath, false);
+            BasicDocument.Example_BasicWordWithPolishChars(folderPath, false);
+            BasicDocument.Example_BasicWordWithNewLines(folderPath, false);
+            BasicDocument.Example_BasicWordWithTabs(folderPath, false);
+            BasicDocument.Example_BasicWordWithMargins(folderPath, false);
+            BasicDocument.Example_BasicWordWithMarginsInCentimeters(folderPath, false);
+            BasicDocument.Example_BasicWordWithMarginsAndImage(folderPath, false);
+            BasicDocument.Example_BasicWordWithLineSpacing(folderPath, false);
 
-            //AdvancedDocument.Example_AdvancedWord(folderPath, false);
-            //AdvancedDocument.Example_AdvancedWord2(folderPath, false);
+            AdvancedDocument.Example_AdvancedWord(folderPath, false);
+            AdvancedDocument.Example_AdvancedWord2(folderPath, false);
 
-            //Paragraphs.Example_BasicParagraphs(folderPath, false);
-            //Paragraphs.Example_BasicParagraphStyles(folderPath, false);
-            //Paragraphs.Example_MultipleParagraphsViaDifferentWays(folderPath, false);
-            //Paragraphs.Example_BasicTabStops(folderPath, false);
+            Paragraphs.Example_BasicParagraphs(folderPath, false);
+            Paragraphs.Example_BasicParagraphStyles(folderPath, false);
+            Paragraphs.Example_MultipleParagraphsViaDifferentWays(folderPath, false);
+            Paragraphs.Example_BasicTabStops(folderPath, false);
 
-            //BasicDocument.Example_BasicDocument(folderPath, false);
-            //BasicDocument.Example_BasicDocumentSaveAs1(folderPath, false);
-            //BasicDocument.Example_BasicDocumentSaveAs2(folderPath, false);
-            //BasicDocument.Example_BasicDocumentSaveAs3(folderPath, false);
-            //BasicDocument.Example_BasicDocumentWithoutUsing(folderPath, false);
+            BasicDocument.Example_BasicDocument(folderPath, false);
+            BasicDocument.Example_BasicDocumentSaveAs1(folderPath, false);
+            BasicDocument.Example_BasicDocumentSaveAs2(folderPath, false);
+            BasicDocument.Example_BasicDocumentSaveAs3(folderPath, false);
+            BasicDocument.Example_BasicDocumentWithoutUsing(folderPath, false);
 
-            //Lists.Example_BasicLists(folderPath, false);
-            //Lists.Example_BasicLists6(folderPath, false);
-            //Lists.Example_BasicLists2(folderPath, false);
-            //Lists.Example_BasicLists3(folderPath, false);
-            //Lists.Example_BasicLists9(folderPath, false);
-            //Lists.Example_BasicLists4(folderPath, false);
-            //Lists.Example_BasicLists2Load(folderPath, false);
-            //Lists.Example_BasicLists7(folderPath, false);
-            //Lists.Example_BasicLists8(folderPath, false);
-            //Tables.Example_BasicTables1(folderPath, false);
-            //Tables.Example_BasicTablesLoad1(folderPath, false);
-            //Tables.Example_BasicTablesLoad2(templatesPath, folderPath, false);
-            //Tables.Example_BasicTablesLoad3(templatesPath, false);
-            //Tables.Example_TablesWidthAndAlignment(folderPath, false);
-            //Tables.Example_AllTables(folderPath, false);
-            //Tables.Example_Tables(folderPath, false);
-            //Tables.Example_TableBorders(folderPath, false);
-            //Tables.Example_NestedTables(folderPath, false);
-            //Tables.Example_TablesAddedAfterParagraph(folderPath, false);
+            Lists.Example_BasicLists(folderPath, false);
+            Lists.Example_BasicLists6(folderPath, false);
+            Lists.Example_BasicLists2(folderPath, false);
+            Lists.Example_BasicLists3(folderPath, false);
+            Lists.Example_BasicLists9(folderPath, false);
+            Lists.Example_BasicLists4(folderPath, false);
+            Lists.Example_BasicLists2Load(folderPath, false);
+            Lists.Example_BasicLists7(folderPath, false);
+            Lists.Example_BasicLists8(folderPath, false);
+            Tables.Example_BasicTables1(folderPath, false);
+            Tables.Example_BasicTablesLoad1(folderPath, false);
+            Tables.Example_BasicTablesLoad2(templatesPath, folderPath, false);
+            Tables.Example_BasicTablesLoad3(templatesPath, false);
+            Tables.Example_TablesWidthAndAlignment(folderPath, false);
+            Tables.Example_AllTables(folderPath, false);
+            Tables.Example_Tables(folderPath, false);
+            Tables.Example_TableBorders(folderPath, false);
+            Tables.Example_NestedTables(folderPath, false);
+            Tables.Example_TablesAddedAfterParagraph(folderPath, false);
 
-            //PageSettings.Example_BasicSettings(folderPath, false);
-            //PageSettings.Example_PageOrientation(folderPath, false);
+            PageSettings.Example_BasicSettings(folderPath, false);
+            PageSettings.Example_PageOrientation(folderPath, false);
 
-            //PageNumbers.Example_PageNumbers1(folderPath, false);
+            PageNumbers.Example_PageNumbers1(folderPath, false);
 
-            //Sections.Example_BasicSections(folderPath, false);
-            //Sections.Example_BasicSections2(folderPath, false);
-            //Sections.Example_BasicSections3WithColumns(folderPath, false);
-            //Sections.Example_SectionsWithParagraphs(folderPath, false);
-            //Sections.Example_SectionsWithHeadersDefault(folderPath, false);
-            //Sections.Example_SectionsWithHeaders(folderPath, false);
-            //Sections.Example_BasicWordWithSections(folderPath, false);
+            Sections.Example_BasicSections(folderPath, false);
+            Sections.Example_BasicSections2(folderPath, false);
+            Sections.Example_BasicSections3WithColumns(folderPath, false);
+            Sections.Example_SectionsWithParagraphs(folderPath, false);
+            Sections.Example_SectionsWithHeadersDefault(folderPath, false);
+            Sections.Example_SectionsWithHeaders(folderPath, false);
+            Sections.Example_BasicWordWithSections(folderPath, false);
 
-            //CoverPages.Example_AddingCoverPage(folderPath, false);
-            //CoverPages.Example_AddingCoverPage2(folderPath, false);
+            CoverPages.Example_AddingCoverPage(folderPath, false);
+            CoverPages.Example_AddingCoverPage2(folderPath, false);
 
-            //LoadDocuments.LoadWordDocument_Sample1(false);
-            //LoadDocuments.LoadWordDocument_Sample2(false);
-            //LoadDocuments.LoadWordDocument_Sample3(false);
+            LoadDocuments.LoadWordDocument_Sample1(false);
+            LoadDocuments.LoadWordDocument_Sample2(false);
+            LoadDocuments.LoadWordDocument_Sample3(false);
 
-            //CustomAndBuiltinProperties.Example_BasicDocumentProperties(folderPath, false);
-            //CustomAndBuiltinProperties.Example_ReadWord(false);
-            //CustomAndBuiltinProperties.Example_BasicCustomProperties(folderPath, false);
-            //CustomAndBuiltinProperties.Example_ValidateDocument(folderPath);
-            //CustomAndBuiltinProperties.Example_ValidateDocument_BeforeSave();
-            //CustomAndBuiltinProperties.Example_LoadDocumentWithProperties(false);
-            //CustomAndBuiltinProperties.Example_Load(false);
+            CustomAndBuiltinProperties.Example_BasicDocumentProperties(folderPath, false);
+            CustomAndBuiltinProperties.Example_ReadWord(false);
+            CustomAndBuiltinProperties.Example_BasicCustomProperties(folderPath, false);
+            CustomAndBuiltinProperties.Example_ValidateDocument(folderPath);
+            CustomAndBuiltinProperties.Example_ValidateDocument_BeforeSave();
+            CustomAndBuiltinProperties.Example_LoadDocumentWithProperties(false);
+            CustomAndBuiltinProperties.Example_Load(false);
 
-            //HyperLinks.EasyExample(folderPath, false);
-            //HyperLinks.Example_BasicWordWithHyperLinks(folderPath, false);
-            //HyperLinks.Example_AddingFields(folderPath, false);
-            //HyperLinks.Example_BasicWordWithHyperLinksInTables(folderPath, false);
+            HyperLinks.EasyExample(folderPath, false);
+            HyperLinks.Example_BasicWordWithHyperLinks(folderPath, false);
+            HyperLinks.Example_AddingFields(folderPath, false);
+            HyperLinks.Example_BasicWordWithHyperLinksInTables(folderPath, false);
 
-            //HeadersAndFooters.Sections1(folderPath, false);
-            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooter0(folderPath, false);
-            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooter(folderPath, false);
-            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooter1(folderPath, false);
+            HeadersAndFooters.Sections1(folderPath, false);
+            HeadersAndFooters.Example_BasicWordWithHeaderAndFooter0(folderPath, false);
+            HeadersAndFooters.Example_BasicWordWithHeaderAndFooter(folderPath, false);
+            HeadersAndFooters.Example_BasicWordWithHeaderAndFooter1(folderPath, false);
 
-            //Charts.Example_AddingMultipleCharts(folderPath, false);
+            Charts.Example_AddingMultipleCharts(folderPath, false);
 
-            //Images.Example_AddingImages(folderPath, false);
-            //Images.Example_ReadWordWithImages();
-            //Images.Example_AddingImagesMultipleTypes(folderPath, false);
-            //Images.Example_ReadWordWithImagesAndDiffWraps();
-            //Images.Example_AddingFixedImages(folderPath, false);
-            //Images.Example_AddingImagesSampleToTable(folderPath, false);
+            Images.Example_AddingImages(folderPath, false);
+            Images.Example_ReadWordWithImages();
+            Images.Example_AddingImagesMultipleTypes(folderPath, false);
+            Images.Example_ReadWordWithImagesAndDiffWraps();
+            Images.Example_AddingFixedImages(folderPath, false);
+            Images.Example_AddingImagesSampleToTable(folderPath, false);
 
-            //PageBreaks.Example_PageBreaks(folderPath, false);
-            //PageBreaks.Example_PageBreaks1(folderPath, false);
+            PageBreaks.Example_PageBreaks(folderPath, false);
+            PageBreaks.Example_PageBreaks1(folderPath, false);
 
-            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooterWithoutSections(folderPath, false);
+            HeadersAndFooters.Example_BasicWordWithHeaderAndFooterWithoutSections(folderPath, false);
 
-            //TOC.Example_BasicTOC1(folderPath, false);
-            //TOC.Example_BasicTOC2(folderPath, false);
+            TOC.Example_BasicTOC1(folderPath, false);
+            TOC.Example_BasicTOC2(folderPath, false);
 
-            //Comments.Example_PlayingWithComments(folderPath, false);
+            Comments.Example_PlayingWithComments(folderPath, false);
 
-            //BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);
-            //BasicExcelFunctionality.BasicExcel_Example2(folderPath, false);
-            //BasicExcelFunctionality.BasicExcel_Example3(false);
+            BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);
+            BasicExcelFunctionality.BasicExcel_Example2(folderPath, false);
+            BasicExcelFunctionality.BasicExcel_Example3(false);
 
-            //BordersAndMargins.Example_BasicWordMarginsSizes(folderPath, false);
-            //BordersAndMargins.Example_BasicPageBorders1(folderPath, false);
-            //BordersAndMargins.Example_BasicPageBorders2(folderPath, false);
+            BordersAndMargins.Example_BasicWordMarginsSizes(folderPath, false);
+            BordersAndMargins.Example_BasicPageBorders1(folderPath, false);
+            BordersAndMargins.Example_BasicPageBorders2(folderPath, false);
 
-            //Bookmarks.Example_BasicWordWithBookmarks(folderPath, false);
-            //Fields.Example_DocumentWithFields(folderPath, false);
-            //Fields.Example_DocumentWithFields02(folderPath, false);
+            Bookmarks.Example_BasicWordWithBookmarks(folderPath, false);
+            Fields.Example_DocumentWithFields(folderPath, false);
+            Fields.Example_DocumentWithFields02(folderPath, false);
 
-            //Watermark.Watermark_Sample2(folderPath, false);
-            //Watermark.Watermark_Sample1(folderPath, false);
-            //Watermark.Watermark_Sample3(folderPath, false);
+            Watermark.Watermark_Sample2(folderPath, false);
+            Watermark.Watermark_Sample1(folderPath, false);
+            Watermark.Watermark_Sample3(folderPath, false);
 
-            //Embed.Example_EmbedFileHTML(folderPath, templatesPath, false);
-            //Embed.Example_EmbedFileRTF(folderPath, templatesPath, false);
-            //Embed.Example_EmbedFileRTFandHTML(folderPath, templatesPath, false);
-            //Embed.Example_EmbedFileRTFandHTMLandTOC(folderPath, templatesPath, false);
-            //Embed.Example_EmbedFileMultiple(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileHTML(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileRTF(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileRTFandHTML(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileRTFandHTMLandTOC(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileMultiple(folderPath, templatesPath, false);
 
-            //CleanupDocuments.CleanupDocuments_Sample01(false);
-            //CleanupDocuments.CleanupDocuments_Sample02(folderPath, false);
+            CleanupDocuments.CleanupDocuments_Sample01(false);
+            CleanupDocuments.CleanupDocuments_Sample02(folderPath, false);
 
-            //FindAndReplace.Example_FindAndReplace01(folderPath, false);
-            //FindAndReplace.Example_FindAndReplace02(folderPath, false);
+            FindAndReplace.Example_FindAndReplace01(folderPath, false);
+            FindAndReplace.Example_FindAndReplace02(folderPath, false);
 
-            //FootNotes.Example_DocumentWithFootNotes(templatesPath, false);
-            //FootNotes.Example_DocumentWithFootNotesEmpty(folderPath, false);
+            FootNotes.Example_DocumentWithFootNotes(templatesPath, false);
+            FootNotes.Example_DocumentWithFootNotesEmpty(folderPath, false);
 
-            //SaveToStream.Example_StreamDocumentProperties(folderPath, false);
+            SaveToStream.Example_StreamDocumentProperties(folderPath, false);
 
-            //Protect.Example_ProtectFinalDocument(folderPath, false);
-            //Protect.Example_ProtectAlwaysReadOnly(folderPath, false);
+            Protect.Example_ProtectFinalDocument(folderPath, false);
+            Protect.Example_ProtectAlwaysReadOnly(folderPath, false);
 
-            WordTextBox.Example_AddingTextbox(folderPath, true);
-            //WordTextBox.Example_AddingTextbox2(folderPath, false);
-            //WordTextBox.Example_AddingTextbox4(folderPath, false);
-            //WordTextBox.Example_AddingTextbox5(folderPath, false);
-            //WordTextBox.Example_AddingTextbox3(folderPath, false);
-            //WordTextBox.Example_AddingTextboxCentimeters(folderPath, false);
+            WordTextBox.Example_AddingTextbox(folderPath, false);
+            WordTextBox.Example_AddingTextbox2(folderPath, false);
+            WordTextBox.Example_AddingTextbox4(folderPath, false);
+            WordTextBox.Example_AddingTextbox5(folderPath, false);
+            WordTextBox.Example_AddingTextbox3(folderPath, false);
+            WordTextBox.Example_AddingTextboxCentimeters(folderPath, false);
         }
     }
 }

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -1,4 +1,5 @@
 using System.IO;
+
 using OfficeIMO.Examples.Excel;
 using OfficeIMO.Examples.Word;
 
@@ -15,154 +16,154 @@ namespace OfficeIMO.Examples {
             string folderPath = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "Documents");
             Setup(folderPath);
 
-            BasicDocument.Example_BasicEmptyWord(folderPath, false);
-            BasicDocument.Example_BasicWord(folderPath, false);
-            BasicDocument.Example_BasicWord2(folderPath, false);
-            BasicDocument.Example_BasicWordWithBreaks(folderPath, false);
-            BasicDocument.Example_BasicWordWithDefaultStyleChange(folderPath, false);
-            BasicDocument.Example_BasicWordWithDefaultFontChange(folderPath, false);
-            BasicDocument.Example_BasicLoadHamlet(templatesPath, folderPath, false);
-            BasicDocument.Example_BasicWordWithPolishChars(folderPath, false);
-            BasicDocument.Example_BasicWordWithNewLines(folderPath, false);
-            BasicDocument.Example_BasicWordWithTabs(folderPath, false);
-            BasicDocument.Example_BasicWordWithMargins(folderPath, false);
-            BasicDocument.Example_BasicWordWithMarginsInCentimeters(folderPath, false);
-            BasicDocument.Example_BasicWordWithMarginsAndImage(folderPath, false);
-            BasicDocument.Example_BasicWordWithLineSpacing(folderPath, false);
+            //BasicDocument.Example_BasicEmptyWord(folderPath, false);
+            //BasicDocument.Example_BasicWord(folderPath, false);
+            //BasicDocument.Example_BasicWord2(folderPath, false);
+            //BasicDocument.Example_BasicWordWithBreaks(folderPath, false);
+            //BasicDocument.Example_BasicWordWithDefaultStyleChange(folderPath, false);
+            //BasicDocument.Example_BasicWordWithDefaultFontChange(folderPath, false);
+            //BasicDocument.Example_BasicLoadHamlet(templatesPath, folderPath, false);
+            //BasicDocument.Example_BasicWordWithPolishChars(folderPath, false);
+            //BasicDocument.Example_BasicWordWithNewLines(folderPath, false);
+            //BasicDocument.Example_BasicWordWithTabs(folderPath, false);
+            //BasicDocument.Example_BasicWordWithMargins(folderPath, false);
+            //BasicDocument.Example_BasicWordWithMarginsInCentimeters(folderPath, false);
+            //BasicDocument.Example_BasicWordWithMarginsAndImage(folderPath, false);
+            //BasicDocument.Example_BasicWordWithLineSpacing(folderPath, false);
 
-            AdvancedDocument.Example_AdvancedWord(folderPath, false);
-            AdvancedDocument.Example_AdvancedWord2(folderPath, false);
+            //AdvancedDocument.Example_AdvancedWord(folderPath, false);
+            //AdvancedDocument.Example_AdvancedWord2(folderPath, false);
 
-            Paragraphs.Example_BasicParagraphs(folderPath, false);
-            Paragraphs.Example_BasicParagraphStyles(folderPath, false);
-            Paragraphs.Example_MultipleParagraphsViaDifferentWays(folderPath, false);
-            Paragraphs.Example_BasicTabStops(folderPath, false);
+            //Paragraphs.Example_BasicParagraphs(folderPath, false);
+            //Paragraphs.Example_BasicParagraphStyles(folderPath, false);
+            //Paragraphs.Example_MultipleParagraphsViaDifferentWays(folderPath, false);
+            //Paragraphs.Example_BasicTabStops(folderPath, false);
 
-            BasicDocument.Example_BasicDocument(folderPath, false);
-            BasicDocument.Example_BasicDocumentSaveAs1(folderPath, false);
-            BasicDocument.Example_BasicDocumentSaveAs2(folderPath, false);
-            BasicDocument.Example_BasicDocumentSaveAs3(folderPath, false);
-            BasicDocument.Example_BasicDocumentWithoutUsing(folderPath, false);
+            //BasicDocument.Example_BasicDocument(folderPath, false);
+            //BasicDocument.Example_BasicDocumentSaveAs1(folderPath, false);
+            //BasicDocument.Example_BasicDocumentSaveAs2(folderPath, false);
+            //BasicDocument.Example_BasicDocumentSaveAs3(folderPath, false);
+            //BasicDocument.Example_BasicDocumentWithoutUsing(folderPath, false);
 
-            Lists.Example_BasicLists(folderPath, false);
-            Lists.Example_BasicLists6(folderPath, false);
-            Lists.Example_BasicLists2(folderPath, false);
-            Lists.Example_BasicLists3(folderPath, false);
-            Lists.Example_BasicLists9(folderPath, false);
-            Lists.Example_BasicLists4(folderPath, false);
-            Lists.Example_BasicLists2Load(folderPath, false);
-            Lists.Example_BasicLists7(folderPath, false);
-            Lists.Example_BasicLists8(folderPath, false);
-            Tables.Example_BasicTables1(folderPath, false);
-            Tables.Example_BasicTablesLoad1(folderPath, false);
-            Tables.Example_BasicTablesLoad2(templatesPath, folderPath, false);
-            Tables.Example_BasicTablesLoad3(templatesPath, false);
-            Tables.Example_TablesWidthAndAlignment(folderPath, false);
-            Tables.Example_AllTables(folderPath, false);
-            Tables.Example_Tables(folderPath, false);
-            Tables.Example_TableBorders(folderPath, false);
-            Tables.Example_NestedTables(folderPath, false);
-            Tables.Example_TablesAddedAfterParagraph(folderPath, false);
+            //Lists.Example_BasicLists(folderPath, false);
+            //Lists.Example_BasicLists6(folderPath, false);
+            //Lists.Example_BasicLists2(folderPath, false);
+            //Lists.Example_BasicLists3(folderPath, false);
+            //Lists.Example_BasicLists9(folderPath, false);
+            //Lists.Example_BasicLists4(folderPath, false);
+            //Lists.Example_BasicLists2Load(folderPath, false);
+            //Lists.Example_BasicLists7(folderPath, false);
+            //Lists.Example_BasicLists8(folderPath, false);
+            //Tables.Example_BasicTables1(folderPath, false);
+            //Tables.Example_BasicTablesLoad1(folderPath, false);
+            //Tables.Example_BasicTablesLoad2(templatesPath, folderPath, false);
+            //Tables.Example_BasicTablesLoad3(templatesPath, false);
+            //Tables.Example_TablesWidthAndAlignment(folderPath, false);
+            //Tables.Example_AllTables(folderPath, false);
+            //Tables.Example_Tables(folderPath, false);
+            //Tables.Example_TableBorders(folderPath, false);
+            //Tables.Example_NestedTables(folderPath, false);
+            //Tables.Example_TablesAddedAfterParagraph(folderPath, false);
 
-            PageSettings.Example_BasicSettings(folderPath, false);
-            PageSettings.Example_PageOrientation(folderPath, false);
+            //PageSettings.Example_BasicSettings(folderPath, false);
+            //PageSettings.Example_PageOrientation(folderPath, false);
 
-            PageNumbers.Example_PageNumbers1(folderPath, false);
+            //PageNumbers.Example_PageNumbers1(folderPath, false);
 
-            Sections.Example_BasicSections(folderPath, false);
-            Sections.Example_BasicSections2(folderPath, false);
-            Sections.Example_BasicSections3WithColumns(folderPath, false);
-            Sections.Example_SectionsWithParagraphs(folderPath, false);
-            Sections.Example_SectionsWithHeadersDefault(folderPath, false);
-            Sections.Example_SectionsWithHeaders(folderPath, false);
-            Sections.Example_BasicWordWithSections(folderPath, false);
+            //Sections.Example_BasicSections(folderPath, false);
+            //Sections.Example_BasicSections2(folderPath, false);
+            //Sections.Example_BasicSections3WithColumns(folderPath, false);
+            //Sections.Example_SectionsWithParagraphs(folderPath, false);
+            //Sections.Example_SectionsWithHeadersDefault(folderPath, false);
+            //Sections.Example_SectionsWithHeaders(folderPath, false);
+            //Sections.Example_BasicWordWithSections(folderPath, false);
 
-            CoverPages.Example_AddingCoverPage(folderPath, false);
-            CoverPages.Example_AddingCoverPage2(folderPath, false);
+            //CoverPages.Example_AddingCoverPage(folderPath, false);
+            //CoverPages.Example_AddingCoverPage2(folderPath, false);
 
-            LoadDocuments.LoadWordDocument_Sample1(false);
-            LoadDocuments.LoadWordDocument_Sample2(false);
-            LoadDocuments.LoadWordDocument_Sample3(false);
+            //LoadDocuments.LoadWordDocument_Sample1(false);
+            //LoadDocuments.LoadWordDocument_Sample2(false);
+            //LoadDocuments.LoadWordDocument_Sample3(false);
 
-            CustomAndBuiltinProperties.Example_BasicDocumentProperties(folderPath, false);
-            CustomAndBuiltinProperties.Example_ReadWord(false);
-            CustomAndBuiltinProperties.Example_BasicCustomProperties(folderPath, false);
-            CustomAndBuiltinProperties.Example_ValidateDocument(folderPath);
-            CustomAndBuiltinProperties.Example_ValidateDocument_BeforeSave();
-            CustomAndBuiltinProperties.Example_LoadDocumentWithProperties(false);
-            CustomAndBuiltinProperties.Example_Load(false);
+            //CustomAndBuiltinProperties.Example_BasicDocumentProperties(folderPath, false);
+            //CustomAndBuiltinProperties.Example_ReadWord(false);
+            //CustomAndBuiltinProperties.Example_BasicCustomProperties(folderPath, false);
+            //CustomAndBuiltinProperties.Example_ValidateDocument(folderPath);
+            //CustomAndBuiltinProperties.Example_ValidateDocument_BeforeSave();
+            //CustomAndBuiltinProperties.Example_LoadDocumentWithProperties(false);
+            //CustomAndBuiltinProperties.Example_Load(false);
 
-            HyperLinks.EasyExample(folderPath, false);
-            HyperLinks.Example_BasicWordWithHyperLinks(folderPath, false);
-            HyperLinks.Example_AddingFields(folderPath, false);
-            HyperLinks.Example_BasicWordWithHyperLinksInTables(folderPath, false);
+            //HyperLinks.EasyExample(folderPath, false);
+            //HyperLinks.Example_BasicWordWithHyperLinks(folderPath, false);
+            //HyperLinks.Example_AddingFields(folderPath, false);
+            //HyperLinks.Example_BasicWordWithHyperLinksInTables(folderPath, false);
 
-            HeadersAndFooters.Sections1(folderPath, false);
-            HeadersAndFooters.Example_BasicWordWithHeaderAndFooter0(folderPath, false);
-            HeadersAndFooters.Example_BasicWordWithHeaderAndFooter(folderPath, false);
-            HeadersAndFooters.Example_BasicWordWithHeaderAndFooter1(folderPath, false);
+            //HeadersAndFooters.Sections1(folderPath, false);
+            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooter0(folderPath, false);
+            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooter(folderPath, false);
+            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooter1(folderPath, false);
 
-            Charts.Example_AddingMultipleCharts(folderPath, false);
+            //Charts.Example_AddingMultipleCharts(folderPath, false);
 
-            Images.Example_AddingImages(folderPath, false);
-            Images.Example_ReadWordWithImages();
-            Images.Example_AddingImagesMultipleTypes(folderPath, false);
-            Images.Example_ReadWordWithImagesAndDiffWraps();
-            Images.Example_AddingFixedImages(folderPath, false);
-            Images.Example_AddingImagesSampleToTable(folderPath, false);
+            //Images.Example_AddingImages(folderPath, false);
+            //Images.Example_ReadWordWithImages();
+            //Images.Example_AddingImagesMultipleTypes(folderPath, false);
+            //Images.Example_ReadWordWithImagesAndDiffWraps();
+            //Images.Example_AddingFixedImages(folderPath, false);
+            //Images.Example_AddingImagesSampleToTable(folderPath, false);
 
-            PageBreaks.Example_PageBreaks(folderPath, false);
-            PageBreaks.Example_PageBreaks1(folderPath, false);
+            //PageBreaks.Example_PageBreaks(folderPath, false);
+            //PageBreaks.Example_PageBreaks1(folderPath, false);
 
-            HeadersAndFooters.Example_BasicWordWithHeaderAndFooterWithoutSections(folderPath, false);
+            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooterWithoutSections(folderPath, false);
 
-            TOC.Example_BasicTOC1(folderPath, false);
-            TOC.Example_BasicTOC2(folderPath, false);
+            //TOC.Example_BasicTOC1(folderPath, false);
+            //TOC.Example_BasicTOC2(folderPath, false);
 
-            Comments.Example_PlayingWithComments(folderPath, false);
+            //Comments.Example_PlayingWithComments(folderPath, false);
 
-            BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);
-            BasicExcelFunctionality.BasicExcel_Example2(folderPath, false);
-            BasicExcelFunctionality.BasicExcel_Example3(false);
+            //BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);
+            //BasicExcelFunctionality.BasicExcel_Example2(folderPath, false);
+            //BasicExcelFunctionality.BasicExcel_Example3(false);
 
-            BordersAndMargins.Example_BasicWordMarginsSizes(folderPath, false);
-            BordersAndMargins.Example_BasicPageBorders1(folderPath, false);
-            BordersAndMargins.Example_BasicPageBorders2(folderPath, false);
+            //BordersAndMargins.Example_BasicWordMarginsSizes(folderPath, false);
+            //BordersAndMargins.Example_BasicPageBorders1(folderPath, false);
+            //BordersAndMargins.Example_BasicPageBorders2(folderPath, false);
 
-            Bookmarks.Example_BasicWordWithBookmarks(folderPath, false);
-            Fields.Example_DocumentWithFields(folderPath, false);
-            Fields.Example_DocumentWithFields02(folderPath, false);
+            //Bookmarks.Example_BasicWordWithBookmarks(folderPath, false);
+            //Fields.Example_DocumentWithFields(folderPath, false);
+            //Fields.Example_DocumentWithFields02(folderPath, false);
 
-            Watermark.Watermark_Sample2(folderPath, false);
-            Watermark.Watermark_Sample1(folderPath, false);
-            Watermark.Watermark_Sample3(folderPath, false);
+            //Watermark.Watermark_Sample2(folderPath, false);
+            //Watermark.Watermark_Sample1(folderPath, false);
+            //Watermark.Watermark_Sample3(folderPath, false);
 
-            Embed.Example_EmbedFileHTML(folderPath, templatesPath, false);
-            Embed.Example_EmbedFileRTF(folderPath, templatesPath, false);
-            Embed.Example_EmbedFileRTFandHTML(folderPath, templatesPath, false);
-            Embed.Example_EmbedFileRTFandHTMLandTOC(folderPath, templatesPath, false);
-            Embed.Example_EmbedFileMultiple(folderPath, templatesPath, false);
+            //Embed.Example_EmbedFileHTML(folderPath, templatesPath, false);
+            //Embed.Example_EmbedFileRTF(folderPath, templatesPath, false);
+            //Embed.Example_EmbedFileRTFandHTML(folderPath, templatesPath, false);
+            //Embed.Example_EmbedFileRTFandHTMLandTOC(folderPath, templatesPath, false);
+            //Embed.Example_EmbedFileMultiple(folderPath, templatesPath, false);
 
-            CleanupDocuments.CleanupDocuments_Sample01(false);
-            CleanupDocuments.CleanupDocuments_Sample02(folderPath, false);
+            //CleanupDocuments.CleanupDocuments_Sample01(false);
+            //CleanupDocuments.CleanupDocuments_Sample02(folderPath, false);
 
-            FindAndReplace.Example_FindAndReplace01(folderPath, false);
-            FindAndReplace.Example_FindAndReplace02(folderPath, false);
+            //FindAndReplace.Example_FindAndReplace01(folderPath, false);
+            //FindAndReplace.Example_FindAndReplace02(folderPath, false);
 
-            FootNotes.Example_DocumentWithFootNotes(templatesPath, false);
-            FootNotes.Example_DocumentWithFootNotesEmpty(folderPath, false);
+            //FootNotes.Example_DocumentWithFootNotes(templatesPath, false);
+            //FootNotes.Example_DocumentWithFootNotesEmpty(folderPath, false);
 
-            SaveToStream.Example_StreamDocumentProperties(folderPath, false);
+            //SaveToStream.Example_StreamDocumentProperties(folderPath, false);
 
-            Protect.Example_ProtectFinalDocument(folderPath, false);
-            Protect.Example_ProtectAlwaysReadOnly(folderPath, false);
+            //Protect.Example_ProtectFinalDocument(folderPath, false);
+            //Protect.Example_ProtectAlwaysReadOnly(folderPath, false);
 
-            WordTextBox.Example_AddingTextbox(folderPath, false);
-            WordTextBox.Example_AddingTextbox2(folderPath, false);
-            WordTextBox.Example_AddingTextbox4(folderPath, false);
-            WordTextBox.Example_AddingTextbox5(folderPath, false);
-            WordTextBox.Example_AddingTextbox3(folderPath, false);
-            WordTextBox.Example_AddingTextboxCentimeters(folderPath, false);
+            WordTextBox.Example_AddingTextbox(folderPath, true);
+            //WordTextBox.Example_AddingTextbox2(folderPath, false);
+            //WordTextBox.Example_AddingTextbox4(folderPath, false);
+            //WordTextBox.Example_AddingTextbox5(folderPath, false);
+            //WordTextBox.Example_AddingTextbox3(folderPath, false);
+            //WordTextBox.Example_AddingTextboxCentimeters(folderPath, false);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample1.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample1.cs
@@ -19,19 +19,19 @@ namespace OfficeIMO.Examples.Word {
 
                 var textBox = document.AddTextBox("[Grab your reader’s attention with a great quote from the document or use this space to emphasize a key point. To place this text box anywhere on the page, just drag it.]");
 
-                Console.WriteLine("TextBox Text: " + textBox.Text);
+                Console.WriteLine("TextBox Text: " + textBox.Paragraphs[0].Text);
 
-                textBox.Text[0] = "We can then modify the text box text";
+                textBox.Paragraphs[0].Text = "We can then modify the text box text";
 
-                Console.WriteLine("TextBox Text: " + textBox.WordParagraph[0].Text);
+                Console.WriteLine("TextBox Text: " + textBox.Paragraphs[0].Text);
 
-                Console.WriteLine("TextBoc Color: " + textBox.WordParagraph[0].Color.ToString());
+                Console.WriteLine("TextBoc Color: " + textBox.Paragraphs[0].Color.ToString());
 
-                textBox.WordParagraph[0].Text = "This is a text box 1";
+                textBox.Paragraphs[0].Text = "This is a text box 1";
 
-                Console.WriteLine("TextBox Text: " + textBox.WordParagraph[0].Text);
+                Console.WriteLine("TextBox Text: " + textBox.Paragraphs[0].Text);
 
-                textBox.WordParagraph[0].Color = Color.Red;
+                textBox.Paragraphs[0].Color = Color.Red;
 
 
                 textBox.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
@@ -67,14 +67,14 @@ namespace OfficeIMO.Examples.Word {
 
                 document.TextBoxes[1].VerticalPositionOffsetCentimeters = 15;
 
-                Console.WriteLine("Color Bottom Border: " + document.TextBoxes[1].WordParagraph[0].Borders.BottomColor);
+                Console.WriteLine("Color Bottom Border: " + document.TextBoxes[1].Paragraphs[0].Borders.BottomColor);
 
-                document.TextBoxes[1].WordParagraph[0].Borders.BottomColor = Color.Red;
-                document.TextBoxes[1].WordParagraph[0].Borders.BottomStyle = DocumentFormat.OpenXml.Wordprocessing.BorderValues.DashDotStroked;
+                document.TextBoxes[1].Paragraphs[0].Borders.BottomColor = Color.Red;
+                document.TextBoxes[1].Paragraphs[0].Borders.BottomStyle = DocumentFormat.OpenXml.Wordprocessing.BorderValues.DashDotStroked;
 
-                Console.WriteLine("Color Bottom Border: " + document.TextBoxes[1].WordParagraph[0].Borders.BottomColor);
+                Console.WriteLine("Color Bottom Border: " + document.TextBoxes[1].Paragraphs[0].Borders.BottomColor);
 
-                document.TextBoxes[1].WordParagraph[0].Borders.BottomThemeColor = null;
+                document.TextBoxes[1].Paragraphs[0].Borders.BottomThemeColor = null;
 
                 document.TextBoxes[1].RelativeWidthPercentage = 0;
                 document.TextBoxes[1].RelativeHeightPercentage = 0;
@@ -82,7 +82,17 @@ namespace OfficeIMO.Examples.Word {
                 document.TextBoxes[1].WidthCentimeters = 7;
                 document.TextBoxes[1].HeightCentimeters = 2.5;
 
-                document.TextBoxes[0].WordParagraph[0].Borders.Type = WordBorder.None;
+                document.TextBoxes[0].Paragraphs[0].Borders.Type = WordBorder.None;
+
+                document.TextBoxes[1].Paragraphs[0].AddParagraph("This is a new paragraph in the text box");
+                Console.WriteLine(document.TextBoxes[1].Paragraphs.Count);
+                Console.WriteLine(document.TextBoxes[1].Paragraphs[0].Text);
+                Console.WriteLine(document.TextBoxes[1].Paragraphs[1].Text);
+
+                document.TextBoxes[1].Paragraphs[1].Text = "New text";
+                Console.WriteLine(document.TextBoxes[1].Paragraphs[1].Text);
+
+                Console.WriteLine(document.TextBoxes[1].Paragraphs[1].Text);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample1.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample1.cs
@@ -1,6 +1,9 @@
 using System;
+
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
+
 using OfficeIMO.Word;
+
 using Color = SixLabors.ImageSharp.Color;
 using HorizontalAlignmentValues = DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalAlignmentValues;
 
@@ -18,17 +21,17 @@ namespace OfficeIMO.Examples.Word {
 
                 Console.WriteLine("TextBox Text: " + textBox.Text);
 
-                textBox.Text = "We can then modify the text box text";
+                textBox.Text[0] = "We can then modify the text box text";
 
-                Console.WriteLine("TextBox Text: " + textBox.WordParagraph.Text);
+                Console.WriteLine("TextBox Text: " + textBox.WordParagraph[0].Text);
 
-                Console.WriteLine("TextBoc Color: " + textBox.WordParagraph.Color.ToString());
+                Console.WriteLine("TextBoc Color: " + textBox.WordParagraph[0].Color.ToString());
 
-                textBox.WordParagraph.Text = "This is a text box 1";
+                textBox.WordParagraph[0].Text = "This is a text box 1";
 
-                Console.WriteLine("TextBox Text: " + textBox.WordParagraph.Text);
+                Console.WriteLine("TextBox Text: " + textBox.WordParagraph[0].Text);
 
-                textBox.WordParagraph.Color = Color.Red;
+                textBox.WordParagraph[0].Color = Color.Red;
 
 
                 textBox.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
@@ -64,14 +67,14 @@ namespace OfficeIMO.Examples.Word {
 
                 document.TextBoxes[1].VerticalPositionOffsetCentimeters = 15;
 
-                Console.WriteLine("Color Bottom Border: " + document.TextBoxes[1].WordParagraph.Borders.BottomColor);
+                Console.WriteLine("Color Bottom Border: " + document.TextBoxes[1].WordParagraph[0].Borders.BottomColor);
 
-                document.TextBoxes[1].WordParagraph.Borders.BottomColor = Color.Red;
-                document.TextBoxes[1].WordParagraph.Borders.BottomStyle = DocumentFormat.OpenXml.Wordprocessing.BorderValues.DashDotStroked;
+                document.TextBoxes[1].WordParagraph[0].Borders.BottomColor = Color.Red;
+                document.TextBoxes[1].WordParagraph[0].Borders.BottomStyle = DocumentFormat.OpenXml.Wordprocessing.BorderValues.DashDotStroked;
 
-                Console.WriteLine("Color Bottom Border: " + document.TextBoxes[1].WordParagraph.Borders.BottomColor);
+                Console.WriteLine("Color Bottom Border: " + document.TextBoxes[1].WordParagraph[0].Borders.BottomColor);
 
-                document.TextBoxes[1].WordParagraph.Borders.BottomThemeColor = null;
+                document.TextBoxes[1].WordParagraph[0].Borders.BottomThemeColor = null;
 
                 document.TextBoxes[1].RelativeWidthPercentage = 0;
                 document.TextBoxes[1].RelativeHeightPercentage = 0;
@@ -79,7 +82,7 @@ namespace OfficeIMO.Examples.Word {
                 document.TextBoxes[1].WidthCentimeters = 7;
                 document.TextBoxes[1].HeightCentimeters = 2.5;
 
-                document.TextBoxes[0].WordParagraph.Borders.Type = WordBorder.None;
+                document.TextBoxes[0].WordParagraph[0].Borders.Type = WordBorder.None;
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample2.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample2.cs
@@ -1,8 +1,11 @@
 using System;
+
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
 using DocumentFormat.OpenXml.Spreadsheet;
 using DocumentFormat.OpenXml.Wordprocessing;
+
 using OfficeIMO.Word;
+
 using Color = SixLabors.ImageSharp.Color;
 using HorizontalAlignmentValues = DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalAlignmentValues;
 
@@ -25,7 +28,7 @@ namespace OfficeIMO.Examples.Word {
 
                 var textBox2 = document.AddTextBox("My textbox on the right");
                 textBox2.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
-                textBox2.WordParagraph.ParagraphAlignment = JustificationValues.Right;
+                textBox2.WordParagraph[0].ParagraphAlignment = JustificationValues.Right;
                 // horizontal alignment overwrites the horizontal position offset so only one will work
                 textBox2.HorizontalAlignment = HorizontalAlignmentValues.Right;
                 textBox2.VerticalPositionOffsetCentimeters = 3;
@@ -40,15 +43,15 @@ namespace OfficeIMO.Examples.Word {
                 textBox3.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
                 textBox3.HorizontalAlignment = HorizontalAlignmentValues.Center;
                 textBox3.VerticalPositionOffsetCentimeters = 10;
-                textBox3.WordParagraph.Borders.BottomStyle = BorderValues.BasicWideOutline;
-                textBox3.WordParagraph.Borders.BottomSize = 10;
-                textBox3.WordParagraph.Borders.BottomColor = Color.Red;
-                textBox3.WordParagraph.Borders.BottomShadow = false;
-                textBox3.WordParagraph.Borders.TopStyle = BorderValues.BasicWideOutline;
-                textBox3.WordParagraph.Borders.LeftStyle = BorderValues.BasicWideOutline;
-                textBox3.WordParagraph.Borders.RightStyle = BorderValues.BasicWideOutline;
+                textBox3.WordParagraph[0].Borders.BottomStyle = BorderValues.BasicWideOutline;
+                textBox3.WordParagraph[0].Borders.BottomSize = 10;
+                textBox3.WordParagraph[0].Borders.BottomColor = Color.Red;
+                textBox3.WordParagraph[0].Borders.BottomShadow = false;
+                textBox3.WordParagraph[0].Borders.TopStyle = BorderValues.BasicWideOutline;
+                textBox3.WordParagraph[0].Borders.LeftStyle = BorderValues.BasicWideOutline;
+                textBox3.WordParagraph[0].Borders.RightStyle = BorderValues.BasicWideOutline;
 
-                textBox3.WordParagraph.Borders.SetBorder(WordParagraphBorderType.Left, BorderValues.BasicWideOutline, Color.Red, 10, false);
+                textBox3.WordParagraph[0].Borders.SetBorder(WordParagraphBorderType.Left, BorderValues.BasicWideOutline, Color.Red, 10, false);
 
                 // remove the textbox
                 textBox2.Remove();

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample2.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample2.cs
@@ -28,7 +28,7 @@ namespace OfficeIMO.Examples.Word {
 
                 var textBox2 = document.AddTextBox("My textbox on the right");
                 textBox2.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
-                textBox2.WordParagraph[0].ParagraphAlignment = JustificationValues.Right;
+                textBox2.Paragraphs[0].ParagraphAlignment = JustificationValues.Right;
                 // horizontal alignment overwrites the horizontal position offset so only one will work
                 textBox2.HorizontalAlignment = HorizontalAlignmentValues.Right;
                 textBox2.VerticalPositionOffsetCentimeters = 3;
@@ -43,15 +43,15 @@ namespace OfficeIMO.Examples.Word {
                 textBox3.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
                 textBox3.HorizontalAlignment = HorizontalAlignmentValues.Center;
                 textBox3.VerticalPositionOffsetCentimeters = 10;
-                textBox3.WordParagraph[0].Borders.BottomStyle = BorderValues.BasicWideOutline;
-                textBox3.WordParagraph[0].Borders.BottomSize = 10;
-                textBox3.WordParagraph[0].Borders.BottomColor = Color.Red;
-                textBox3.WordParagraph[0].Borders.BottomShadow = false;
-                textBox3.WordParagraph[0].Borders.TopStyle = BorderValues.BasicWideOutline;
-                textBox3.WordParagraph[0].Borders.LeftStyle = BorderValues.BasicWideOutline;
-                textBox3.WordParagraph[0].Borders.RightStyle = BorderValues.BasicWideOutline;
+                textBox3.Paragraphs[0].Borders.BottomStyle = BorderValues.BasicWideOutline;
+                textBox3.Paragraphs[0].Borders.BottomSize = 10;
+                textBox3.Paragraphs[0].Borders.BottomColor = Color.Red;
+                textBox3.Paragraphs[0].Borders.BottomShadow = false;
+                textBox3.Paragraphs[0].Borders.TopStyle = BorderValues.BasicWideOutline;
+                textBox3.Paragraphs[0].Borders.LeftStyle = BorderValues.BasicWideOutline;
+                textBox3.Paragraphs[0].Borders.RightStyle = BorderValues.BasicWideOutline;
 
-                textBox3.WordParagraph[0].Borders.SetBorder(WordParagraphBorderType.Left, BorderValues.BasicWideOutline, Color.Red, 10, false);
+                textBox3.Paragraphs[0].Borders.SetBorder(WordParagraphBorderType.Left, BorderValues.BasicWideOutline, Color.Red, 10, false);
 
                 // remove the textbox
                 textBox2.Remove();

--- a/OfficeIMO.Tests/Word.TextBox.cs
+++ b/OfficeIMO.Tests/Word.TextBox.cs
@@ -38,18 +38,18 @@ namespace OfficeIMO.Tests {
                 var textBox2 = document.AddTextBox("My textbox on the right");
                 textBox2.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
                 textBox2.HorizonalPositionOffsetCentimeters = 3;
-                textBox2.WordParagraph[0].ParagraphAlignment = JustificationValues.Right;
+                textBox2.Paragraphs[0].ParagraphAlignment = JustificationValues.Right;
                 textBox2.HorizontalAlignment = HorizontalAlignmentValues.Right;
 
                 Assert.True(document.Paragraphs.Count == 3);
 
                 Assert.True(document.TextBoxes.Count == 2);
 
-                Assert.True(document.TextBoxes[0].Text[0] == "My textbox on the left");
+                Assert.True(document.TextBoxes[0].Paragraphs[0].Text == "My textbox on the left");
 
-                Assert.True(document.TextBoxes[1].Text[0] == "My textbox on the right");
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Text == "My textbox on the right");
 
-                Assert.True(document.TextBoxes[1].WordParagraph[0].ParagraphAlignment == JustificationValues.Right);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].ParagraphAlignment == JustificationValues.Right);
 
                 Assert.True(document.TextBoxes[0].HorizontalPositionRelativeFrom == HorizontalRelativePositionValues.Page);
 
@@ -94,43 +94,43 @@ namespace OfficeIMO.Tests {
                 textBox3.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
                 textBox3.HorizontalAlignment = HorizontalAlignmentValues.Center;
                 textBox3.VerticalPositionOffsetCentimeters = 10;
-                textBox3.WordParagraph[0].Borders.BottomStyle = BorderValues.BasicWideOutline;
+                textBox3.Paragraphs[0].Borders.BottomStyle = BorderValues.BasicWideOutline;
 
 
-                textBox3.WordParagraph[0].Borders.BottomSize = 10;
-                textBox3.WordParagraph[0].Borders.BottomColor = Color.Red;
-                textBox3.WordParagraph[0].Borders.BottomShadow = false;
-                textBox3.WordParagraph[0].Borders.TopStyle = BorderValues.BasicWideOutline;
-                textBox3.WordParagraph[0].Borders.LeftStyle = BorderValues.BasicWideOutline;
-                textBox3.WordParagraph[0].Borders.RightStyle = BorderValues.BasicWideOutline;
+                textBox3.Paragraphs[0].Borders.BottomSize = 10;
+                textBox3.Paragraphs[0].Borders.BottomColor = Color.Red;
+                textBox3.Paragraphs[0].Borders.BottomShadow = false;
+                textBox3.Paragraphs[0].Borders.TopStyle = BorderValues.BasicWideOutline;
+                textBox3.Paragraphs[0].Borders.LeftStyle = BorderValues.BasicWideOutline;
+                textBox3.Paragraphs[0].Borders.RightStyle = BorderValues.BasicWideOutline;
 
-                Assert.True(textBox3.WordParagraph[0].Borders.BottomColorHex == "FF0000");
-                Assert.True(textBox3.WordParagraph[0].Borders.LeftColorHex == null);
-                Assert.True(textBox3.WordParagraph[0].Borders.RightColorHex == null);
-                Assert.True(textBox3.WordParagraph[0].Borders.TopColorHex == null);
-                Assert.True(textBox3.WordParagraph[0].Borders.LeftColor == null);
-                Assert.True(textBox3.WordParagraph[0].Borders.RightColor == null);
-                Assert.True(textBox3.WordParagraph[0].Borders.TopColor == null);
+                Assert.True(textBox3.Paragraphs[0].Borders.BottomColorHex == "FF0000");
+                Assert.True(textBox3.Paragraphs[0].Borders.LeftColorHex == null);
+                Assert.True(textBox3.Paragraphs[0].Borders.RightColorHex == null);
+                Assert.True(textBox3.Paragraphs[0].Borders.TopColorHex == null);
+                Assert.True(textBox3.Paragraphs[0].Borders.LeftColor == null);
+                Assert.True(textBox3.Paragraphs[0].Borders.RightColor == null);
+                Assert.True(textBox3.Paragraphs[0].Borders.TopColor == null);
 
                 Assert.True(document.Paragraphs.Count == 2);
                 Assert.True(document.Sections[0].TextBoxes.Count == 1);
 
-                Assert.True(textBox3.WordParagraph[0].Borders.BottomStyle == BorderValues.BasicWideOutline);
-                Assert.True(textBox3.WordParagraph[0].Borders.BottomSize == 10);
-                Assert.True(textBox3.WordParagraph[0].Borders.BottomColor == Color.Red);
-                Assert.True(textBox3.WordParagraph[0].Borders.BottomShadow == false);
-                Assert.True(textBox3.WordParagraph[0].Borders.TopStyle == BorderValues.BasicWideOutline);
-                Assert.True(textBox3.WordParagraph[0].Borders.LeftStyle == BorderValues.BasicWideOutline);
-                Assert.True(textBox3.WordParagraph[0].Borders.RightStyle == BorderValues.BasicWideOutline);
+                Assert.True(textBox3.Paragraphs[0].Borders.BottomStyle == BorderValues.BasicWideOutline);
+                Assert.True(textBox3.Paragraphs[0].Borders.BottomSize == 10);
+                Assert.True(textBox3.Paragraphs[0].Borders.BottomColor == Color.Red);
+                Assert.True(textBox3.Paragraphs[0].Borders.BottomShadow == false);
+                Assert.True(textBox3.Paragraphs[0].Borders.TopStyle == BorderValues.BasicWideOutline);
+                Assert.True(textBox3.Paragraphs[0].Borders.LeftStyle == BorderValues.BasicWideOutline);
+                Assert.True(textBox3.Paragraphs[0].Borders.RightStyle == BorderValues.BasicWideOutline);
 
-                textBox3.WordParagraph[0].Borders.SetBorder(WordParagraphBorderType.Left, BorderValues.BasicThinLines, Color.Green, 15, false);
+                textBox3.Paragraphs[0].Borders.SetBorder(WordParagraphBorderType.Left, BorderValues.BasicThinLines, Color.Green, 15, false);
 
-                Assert.True(textBox3.WordParagraph[0].Borders.LeftStyle == BorderValues.BasicThinLines);
-                Assert.True(textBox3.WordParagraph[0].Borders.LeftSize == 15);
-                Assert.True(textBox3.WordParagraph[0].Borders.LeftColor == Color.Green);
-                Assert.True(textBox3.WordParagraph[0].Borders.LeftShadow == false);
+                Assert.True(textBox3.Paragraphs[0].Borders.LeftStyle == BorderValues.BasicThinLines);
+                Assert.True(textBox3.Paragraphs[0].Borders.LeftSize == 15);
+                Assert.True(textBox3.Paragraphs[0].Borders.LeftColor == Color.Green);
+                Assert.True(textBox3.Paragraphs[0].Borders.LeftShadow == false);
 
-                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph[0].Borders.LeftColorHex == "008000");
+                Assert.True(document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftColorHex == "008000");
 
 
                 document.Save(false);
@@ -141,116 +141,116 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs.Count == 2);
                 Assert.True(document.TextBoxes.Count == 1);
 
-                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.BottomStyle == BorderValues.BasicWideOutline);
-                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.BottomSize == 10);
-                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.BottomColor == Color.Red);
-                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.BottomShadow == false);
-                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.TopStyle == BorderValues.BasicWideOutline);
-                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.RightStyle == BorderValues.BasicWideOutline);
+                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.BottomStyle == BorderValues.BasicWideOutline);
+                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.BottomSize == 10);
+                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.BottomColor == Color.Red);
+                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.BottomShadow == false);
+                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.TopStyle == BorderValues.BasicWideOutline);
+                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.RightStyle == BorderValues.BasicWideOutline);
 
-                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.LeftStyle == BorderValues.BasicThinLines);
-                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.LeftSize == 15);
-                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.LeftColor == Color.Green);
-                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.LeftShadow == false);
+                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.LeftStyle == BorderValues.BasicThinLines);
+                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.LeftSize == 15);
+                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.LeftColor == Color.Green);
+                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.LeftShadow == false);
 
-                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph[0].Borders.LeftStyle == BorderValues.BasicThinLines);
-                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph[0].Borders.LeftSize == 15);
-                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph[0].Borders.LeftColor == Color.Green);
-                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph[0].Borders.LeftShadow == false);
-
-
-                document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.Type = WordBorder.Shadow;
+                Assert.True(document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftStyle == BorderValues.BasicThinLines);
+                Assert.True(document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftSize == 15);
+                Assert.True(document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftColor == Color.Green);
+                Assert.True(document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftShadow == false);
 
 
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.Type == WordBorder.Shadow);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.BottomStyle == BorderValues.Single);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.BottomSize == 4);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.BottomColor == null);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.BottomShadow == true);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.BottomSpace == 24);
+                document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.Type = WordBorder.Shadow;
 
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.TopStyle == BorderValues.Single);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.TopSize == 4);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.TopColor == null);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.TopShadow == true);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.TopSpace == 24);
 
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.LeftStyle == BorderValues.Single);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.LeftSize == 4);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.LeftColor == null);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.LeftShadow == true);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.LeftSpace == 24);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.Type == WordBorder.Shadow);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.BottomStyle == BorderValues.Single);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.BottomSize == 4);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.BottomColor == null);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.BottomShadow == true);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.BottomSpace == 24);
 
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.RightStyle == BorderValues.Single);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.RightSize == 4);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.RightColor == null);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.RightShadow == true);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.RightSpace == 24);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.TopStyle == BorderValues.Single);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.TopSize == 4);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.TopColor == null);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.TopShadow == true);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.TopSpace == 24);
+
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.LeftStyle == BorderValues.Single);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.LeftSize == 4);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.LeftColor == null);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.LeftShadow == true);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.LeftSpace == 24);
+
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightStyle == BorderValues.Single);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightSize == 4);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightColor == null);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightShadow == true);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightSpace == 24);
 
                 var textBox1 = document.AddTextBox("My textbox in the center with borders");
 
                 Assert.True(document.Paragraphs.Count == 3);
                 Assert.True(document.TextBoxes.Count == 2);
 
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomStyle == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomSize == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomSpace == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomFrame == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomColorHex == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomThemeColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopStyle == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopSize == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopColorHex == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopSpace == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopFrame == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopThemeColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftStyle == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftSize == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftColorHex == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftSpace == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftFrame == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftThemeColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightStyle == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightSize == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightColorHex == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightSpace == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightFrame == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightThemeColor == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomStyle == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomSize == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomColor == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomShadow == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomSpace == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomFrame == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomColorHex == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomThemeColor == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopStyle == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopSize == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopColor == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopColorHex == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopShadow == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopSpace == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopFrame == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopThemeColor == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftStyle == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftSize == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftColor == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftColorHex == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftShadow == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftSpace == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftFrame == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftThemeColor == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightStyle == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightSize == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightColor == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightColorHex == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightShadow == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightSpace == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightFrame == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightThemeColor == null);
 
-                document.TextBoxes[1].WordParagraph[0].Borders.Type = WordBorder.Box;
+                document.TextBoxes[1].Paragraphs[0].Borders.Type = WordBorder.Box;
 
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomStyle == BorderValues.Single);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomSize == 4);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomSpace == 24);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomFrame == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopStyle == BorderValues.Single);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopSize == 4);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopSpace == 24);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopFrame == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftStyle == BorderValues.Single);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftSize == 4);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftSpace == 24);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftFrame == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightStyle == BorderValues.Single);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightSize == 4);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightSpace == 24);
-                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightFrame == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomStyle == BorderValues.Single);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomSize == 4);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomColor == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomShadow == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomSpace == 24);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomFrame == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopStyle == BorderValues.Single);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopSize == 4);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopColor == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopShadow == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopSpace == 24);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopFrame == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftStyle == BorderValues.Single);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftSize == 4);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftColor == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftShadow == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftSpace == 24);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftFrame == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightStyle == BorderValues.Single);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightSize == 4);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightColor == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightShadow == null);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightSpace == 24);
+                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightFrame == null);
 
                 document.Save();
             }
@@ -422,6 +422,32 @@ namespace OfficeIMO.Tests {
                 Assert.True(textBox.Width == 3600000);
                 Assert.True(textBox.Height == 1800000);
 
+
+                document.Save(false);
+                Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");
+            }
+        }
+
+
+        [Fact]
+        public void Test_CreatingWordDocumentWithTextBoxMultipleParagraphs() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreatingWordDocumentWithTextBoxMultipleParagraphs.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+
+                var textBox = document.AddTextBox("[Grab your reader’s attention with a great quote from the document or use this space to emphasize a key point. To place this text box anywhere on the page, just drag it.]");
+
+                Assert.True(textBox.Paragraphs.Count == 1);
+                Assert.True(textBox.Paragraphs[0].Text == "[Grab your reader’s attention with a great quote from the document or use this space to emphasize a key point. To place this text box anywhere on the page, just drag it.]");
+
+                textBox.Paragraphs[0].Text = "We can then modify the text box text";
+                Assert.True(textBox.Paragraphs[0].Text == "We can then modify the text box text");
+
+                textBox.Paragraphs[0].AddParagraph("Another paragraph");
+                Assert.True(textBox.Paragraphs.Count == 2);
+                Assert.True(textBox.Paragraphs[1].Text == "Another paragraph");
+
+                textBox.Paragraphs[1].Text = "This is a text box 1";
+                Assert.True(textBox.Paragraphs[1].Text == "This is a text box 1");
 
                 document.Save(false);
                 Assert.True(HasUnexpectedElements(document) == false, "Document has unexpected elements. Order of elements matters!");

--- a/OfficeIMO.Tests/Word.TextBox.cs
+++ b/OfficeIMO.Tests/Word.TextBox.cs
@@ -38,18 +38,18 @@ namespace OfficeIMO.Tests {
                 var textBox2 = document.AddTextBox("My textbox on the right");
                 textBox2.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
                 textBox2.HorizonalPositionOffsetCentimeters = 3;
-                textBox2.WordParagraph.ParagraphAlignment = JustificationValues.Right;
+                textBox2.WordParagraph[0].ParagraphAlignment = JustificationValues.Right;
                 textBox2.HorizontalAlignment = HorizontalAlignmentValues.Right;
 
                 Assert.True(document.Paragraphs.Count == 3);
 
                 Assert.True(document.TextBoxes.Count == 2);
 
-                Assert.True(document.TextBoxes[0].Text == "My textbox on the left");
+                Assert.True(document.TextBoxes[0].Text[0] == "My textbox on the left");
 
-                Assert.True(document.TextBoxes[1].Text == "My textbox on the right");
+                Assert.True(document.TextBoxes[1].Text[0] == "My textbox on the right");
 
-                Assert.True(document.TextBoxes[1].WordParagraph.ParagraphAlignment == JustificationValues.Right);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].ParagraphAlignment == JustificationValues.Right);
 
                 Assert.True(document.TextBoxes[0].HorizontalPositionRelativeFrom == HorizontalRelativePositionValues.Page);
 
@@ -94,43 +94,43 @@ namespace OfficeIMO.Tests {
                 textBox3.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
                 textBox3.HorizontalAlignment = HorizontalAlignmentValues.Center;
                 textBox3.VerticalPositionOffsetCentimeters = 10;
-                textBox3.WordParagraph.Borders.BottomStyle = BorderValues.BasicWideOutline;
+                textBox3.WordParagraph[0].Borders.BottomStyle = BorderValues.BasicWideOutline;
 
 
-                textBox3.WordParagraph.Borders.BottomSize = 10;
-                textBox3.WordParagraph.Borders.BottomColor = Color.Red;
-                textBox3.WordParagraph.Borders.BottomShadow = false;
-                textBox3.WordParagraph.Borders.TopStyle = BorderValues.BasicWideOutline;
-                textBox3.WordParagraph.Borders.LeftStyle = BorderValues.BasicWideOutline;
-                textBox3.WordParagraph.Borders.RightStyle = BorderValues.BasicWideOutline;
+                textBox3.WordParagraph[0].Borders.BottomSize = 10;
+                textBox3.WordParagraph[0].Borders.BottomColor = Color.Red;
+                textBox3.WordParagraph[0].Borders.BottomShadow = false;
+                textBox3.WordParagraph[0].Borders.TopStyle = BorderValues.BasicWideOutline;
+                textBox3.WordParagraph[0].Borders.LeftStyle = BorderValues.BasicWideOutline;
+                textBox3.WordParagraph[0].Borders.RightStyle = BorderValues.BasicWideOutline;
 
-                Assert.True(textBox3.WordParagraph.Borders.BottomColorHex == "FF0000");
-                Assert.True(textBox3.WordParagraph.Borders.LeftColorHex == null);
-                Assert.True(textBox3.WordParagraph.Borders.RightColorHex == null);
-                Assert.True(textBox3.WordParagraph.Borders.TopColorHex == null);
-                Assert.True(textBox3.WordParagraph.Borders.LeftColor == null);
-                Assert.True(textBox3.WordParagraph.Borders.RightColor == null);
-                Assert.True(textBox3.WordParagraph.Borders.TopColor == null);
+                Assert.True(textBox3.WordParagraph[0].Borders.BottomColorHex == "FF0000");
+                Assert.True(textBox3.WordParagraph[0].Borders.LeftColorHex == null);
+                Assert.True(textBox3.WordParagraph[0].Borders.RightColorHex == null);
+                Assert.True(textBox3.WordParagraph[0].Borders.TopColorHex == null);
+                Assert.True(textBox3.WordParagraph[0].Borders.LeftColor == null);
+                Assert.True(textBox3.WordParagraph[0].Borders.RightColor == null);
+                Assert.True(textBox3.WordParagraph[0].Borders.TopColor == null);
 
                 Assert.True(document.Paragraphs.Count == 2);
                 Assert.True(document.Sections[0].TextBoxes.Count == 1);
 
-                Assert.True(textBox3.WordParagraph.Borders.BottomStyle == BorderValues.BasicWideOutline);
-                Assert.True(textBox3.WordParagraph.Borders.BottomSize == 10);
-                Assert.True(textBox3.WordParagraph.Borders.BottomColor == Color.Red);
-                Assert.True(textBox3.WordParagraph.Borders.BottomShadow == false);
-                Assert.True(textBox3.WordParagraph.Borders.TopStyle == BorderValues.BasicWideOutline);
-                Assert.True(textBox3.WordParagraph.Borders.LeftStyle == BorderValues.BasicWideOutline);
-                Assert.True(textBox3.WordParagraph.Borders.RightStyle == BorderValues.BasicWideOutline);
+                Assert.True(textBox3.WordParagraph[0].Borders.BottomStyle == BorderValues.BasicWideOutline);
+                Assert.True(textBox3.WordParagraph[0].Borders.BottomSize == 10);
+                Assert.True(textBox3.WordParagraph[0].Borders.BottomColor == Color.Red);
+                Assert.True(textBox3.WordParagraph[0].Borders.BottomShadow == false);
+                Assert.True(textBox3.WordParagraph[0].Borders.TopStyle == BorderValues.BasicWideOutline);
+                Assert.True(textBox3.WordParagraph[0].Borders.LeftStyle == BorderValues.BasicWideOutline);
+                Assert.True(textBox3.WordParagraph[0].Borders.RightStyle == BorderValues.BasicWideOutline);
 
-                textBox3.WordParagraph.Borders.SetBorder(WordParagraphBorderType.Left, BorderValues.BasicThinLines, Color.Green, 15, false);
+                textBox3.WordParagraph[0].Borders.SetBorder(WordParagraphBorderType.Left, BorderValues.BasicThinLines, Color.Green, 15, false);
 
-                Assert.True(textBox3.WordParagraph.Borders.LeftStyle == BorderValues.BasicThinLines);
-                Assert.True(textBox3.WordParagraph.Borders.LeftSize == 15);
-                Assert.True(textBox3.WordParagraph.Borders.LeftColor == Color.Green);
-                Assert.True(textBox3.WordParagraph.Borders.LeftShadow == false);
+                Assert.True(textBox3.WordParagraph[0].Borders.LeftStyle == BorderValues.BasicThinLines);
+                Assert.True(textBox3.WordParagraph[0].Borders.LeftSize == 15);
+                Assert.True(textBox3.WordParagraph[0].Borders.LeftColor == Color.Green);
+                Assert.True(textBox3.WordParagraph[0].Borders.LeftShadow == false);
 
-                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph.Borders.LeftColorHex == "008000");
+                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph[0].Borders.LeftColorHex == "008000");
 
 
                 document.Save(false);
@@ -141,122 +141,116 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs.Count == 2);
                 Assert.True(document.TextBoxes.Count == 1);
 
-                Assert.True(document.TextBoxes[0].WordParagraph.Borders.BottomStyle == BorderValues.BasicWideOutline);
-                Assert.True(document.TextBoxes[0].WordParagraph.Borders.BottomSize == 10);
-                Assert.True(document.TextBoxes[0].WordParagraph.Borders.BottomColor == Color.Red);
-                Assert.True(document.TextBoxes[0].WordParagraph.Borders.BottomShadow == false);
-                Assert.True(document.TextBoxes[0].WordParagraph.Borders.TopStyle == BorderValues.BasicWideOutline);
-                Assert.True(document.TextBoxes[0].WordParagraph.Borders.RightStyle == BorderValues.BasicWideOutline);
+                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.BottomStyle == BorderValues.BasicWideOutline);
+                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.BottomSize == 10);
+                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.BottomColor == Color.Red);
+                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.BottomShadow == false);
+                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.TopStyle == BorderValues.BasicWideOutline);
+                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.RightStyle == BorderValues.BasicWideOutline);
 
-                Assert.True(document.TextBoxes[0].WordParagraph.Borders.LeftStyle == BorderValues.BasicThinLines);
-                Assert.True(document.TextBoxes[0].WordParagraph.Borders.LeftSize == 15);
-                Assert.True(document.TextBoxes[0].WordParagraph.Borders.LeftColor == Color.Green);
-                Assert.True(document.TextBoxes[0].WordParagraph.Borders.LeftShadow == false);
+                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.LeftStyle == BorderValues.BasicThinLines);
+                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.LeftSize == 15);
+                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.LeftColor == Color.Green);
+                Assert.True(document.TextBoxes[0].WordParagraph[0].Borders.LeftShadow == false);
 
-                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph.Borders.LeftStyle == BorderValues.BasicThinLines);
-                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph.Borders.LeftSize == 15);
-                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph.Borders.LeftColor == Color.Green);
-                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph.Borders.LeftShadow == false);
-
-
-                document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.Type = WordBorder.Shadow;
+                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph[0].Borders.LeftStyle == BorderValues.BasicThinLines);
+                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph[0].Borders.LeftSize == 15);
+                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph[0].Borders.LeftColor == Color.Green);
+                Assert.True(document.Sections[0].TextBoxes[0].WordParagraph[0].Borders.LeftShadow == false);
 
 
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.Type == WordBorder.Shadow);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.BottomStyle == BorderValues.Single);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.BottomSize == 4);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.BottomColor == null);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.BottomShadow == true);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.BottomSpace == 24);
+                document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.Type = WordBorder.Shadow;
 
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.TopStyle == BorderValues.Single);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.TopSize == 4);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.TopColor == null);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.TopShadow == true);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.TopSpace == 24);
 
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.LeftStyle == BorderValues.Single);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.LeftSize == 4);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.LeftColor == null);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.LeftShadow == true);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.LeftSpace == 24);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.Type == WordBorder.Shadow);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.BottomStyle == BorderValues.Single);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.BottomSize == 4);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.BottomColor == null);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.BottomShadow == true);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.BottomSpace == 24);
 
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.RightStyle == BorderValues.Single);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.RightSize == 4);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.RightColor == null);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.RightShadow == true);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph.Borders.RightSpace == 24);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.TopStyle == BorderValues.Single);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.TopSize == 4);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.TopColor == null);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.TopShadow == true);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.TopSpace == 24);
+
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.LeftStyle == BorderValues.Single);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.LeftSize == 4);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.LeftColor == null);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.LeftShadow == true);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.LeftSpace == 24);
+
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.RightStyle == BorderValues.Single);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.RightSize == 4);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.RightColor == null);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.RightShadow == true);
+                Assert.True(document.ParagraphsTextBoxes[0].TextBox.WordParagraph[0].Borders.RightSpace == 24);
 
                 var textBox1 = document.AddTextBox("My textbox in the center with borders");
 
                 Assert.True(document.Paragraphs.Count == 3);
                 Assert.True(document.TextBoxes.Count == 2);
 
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.BottomStyle == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.BottomSize == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.BottomColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.BottomShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.BottomSpace == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.BottomFrame == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.BottomColorHex == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.BottomThemeColor == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomStyle == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomSize == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomColor == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomShadow == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomSpace == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomFrame == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomColorHex == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomThemeColor == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopStyle == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopSize == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopColor == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopColorHex == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopShadow == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopSpace == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopFrame == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopThemeColor == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftStyle == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftSize == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftColor == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftColorHex == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftShadow == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftSpace == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftFrame == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftThemeColor == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightStyle == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightSize == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightColor == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightColorHex == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightShadow == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightSpace == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightFrame == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightThemeColor == null);
 
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.TopStyle == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.TopSize == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.TopColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.TopColorHex == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.TopShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.TopSpace == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.TopFrame == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.TopThemeColor == null);
+                document.TextBoxes[1].WordParagraph[0].Borders.Type = WordBorder.Box;
 
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.LeftStyle == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.LeftSize == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.LeftColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.LeftColorHex == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.LeftShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.LeftSpace == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.LeftFrame == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.LeftThemeColor == null);
-
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.RightStyle == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.RightSize == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.RightColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.RightColorHex == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.RightShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.RightSpace == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.RightFrame == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.RightThemeColor == null);
-
-                document.TextBoxes[1].WordParagraph.Borders.Type = WordBorder.Box;
-
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.BottomStyle == BorderValues.Single);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.BottomSize == 4);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.BottomColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.BottomShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.BottomSpace == 24);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.BottomFrame == null);
-
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.TopStyle == BorderValues.Single);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.TopSize == 4);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.TopColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.TopShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.TopSpace == 24);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.TopFrame == null);
-
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.LeftStyle == BorderValues.Single);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.LeftSize == 4);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.LeftColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.LeftShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.LeftSpace == 24);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.LeftFrame == null);
-
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.RightStyle == BorderValues.Single);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.RightSize == 4);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.RightColor == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.RightShadow == null);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.RightSpace == 24);
-                Assert.True(document.TextBoxes[1].WordParagraph.Borders.RightFrame == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomStyle == BorderValues.Single);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomSize == 4);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomColor == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomShadow == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomSpace == 24);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.BottomFrame == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopStyle == BorderValues.Single);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopSize == 4);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopColor == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopShadow == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopSpace == 24);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.TopFrame == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftStyle == BorderValues.Single);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftSize == 4);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftColor == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftShadow == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftSpace == 24);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.LeftFrame == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightStyle == BorderValues.Single);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightSize == 4);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightColor == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightShadow == null);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightSpace == 24);
+                Assert.True(document.TextBoxes[1].WordParagraph[0].Borders.RightFrame == null);
 
                 document.Save();
             }

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -9,8 +9,8 @@ using System.Collections.Generic;
 
 namespace OfficeIMO.Word {
     public class WordTextBox {
-        private WordDocument _document;
-        private WordParagraph _wordParagraph;
+        private readonly WordDocument _document;
+        private readonly WordParagraph _wordParagraph;
         private readonly WordHeaderFooter _headerFooter;
         private Run _run => _wordParagraph._run;
 
@@ -62,36 +62,13 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
-        /// Allows to set the text of the text box
-        /// For more advanced text formatting use WordParagraph property
+        /// Gets a list of WordParagraph instances representing the paragraphs in the text box.
+        /// Each WordParagraph is initialized with the WordDocument, the Paragraph, and the Run.
         /// </summary>
-        public List<string> Text {
+        public List<WordParagraph> Paragraphs {
             get {
-                if (_sdtBlock != null) {
-                    return _sdtBlock.Descendants<Text>().Select(t => t.Text).ToList();
-                }
-                return new List<string>();
-            }
-            set {
-                if (_sdtBlock != null) {
-                    var runs = _sdtBlock.Descendants<Run>().ToList();
-                    for (int i = 0; i < Math.Min(runs.Count, value.Count); i++) {
-                        var text = runs[i].GetFirstChild<Text>();
-                        if (text != null) {
-                            text.Text = value[i];
-                        }
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Allows to modify the paragraph of the text box, along with other text formatting
-        /// </summary>
-        public List<WordParagraph> WordParagraph {
-            get {
-                if (_sdtBlock != null) {
-                    return _sdtBlock.Descendants<Run>().Select(run => new WordParagraph(_document, _sdtBlock, run)).ToList();
+                if (_textBoxInfo2 != null) {
+                    return _textBoxInfo2.Descendants<Run>().Select(run => new WordParagraph(_document, _paragraph, run)).ToList();
                 }
                 return new List<WordParagraph>();
             }
@@ -615,12 +592,23 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private Paragraph _sdtBlock {
+        private TextBoxInfo2 _textBoxInfo2 {
             get {
                 var wordprocessingShape = _wordprocessingShape;
                 if (wordprocessingShape != null) {
+                    var textBoxInfo = wordprocessingShape.GetFirstChild<DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2>();
+                    if (textBoxInfo != null) {
+                        return textBoxInfo;
+                    }
+                }
+                return null;
+            }
+        }
 
-
+        private Paragraph _paragraph {
+            get {
+                var wordprocessingShape = _wordprocessingShape;
+                if (wordprocessingShape != null) {
                     var textBoxInfo = wordprocessingShape.GetFirstChild<DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2>();
                     if (textBoxInfo != null) {
                         var textBoxContent = textBoxInfo.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.TextBoxContent>();
@@ -639,7 +627,7 @@ namespace OfficeIMO.Word {
 
         private SdtContentBlock _sdtContentBlock {
             get {
-                var sdtBlock = _sdtBlock;
+                var sdtBlock = _paragraph;
                 if (sdtBlock != null) {
                     var sdtContentBlock = sdtBlock.GetFirstChild<SdtContentBlock>();
                     if (sdtContentBlock != null) {
@@ -967,8 +955,6 @@ namespace OfficeIMO.Word {
 
             shapeProperties1.Append(transform2D1);
             shapeProperties1.Append(presetGeometry1);
-            //shapeProperties1.Append(solidFill1);
-            //shapeProperties1.Append(outline1);
             return shapeProperties1;
         }
 

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -5,6 +5,7 @@ using DocumentFormat.OpenXml.Wordprocessing;
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
 using DocumentFormat.OpenXml.Office2010.Word.DrawingShape;
 using Graphic = DocumentFormat.OpenXml.Drawing.Graphic;
+using System.Collections.Generic;
 
 namespace OfficeIMO.Word {
     public class WordTextBox {
@@ -64,27 +65,20 @@ namespace OfficeIMO.Word {
         /// Allows to set the text of the text box
         /// For more advanced text formatting use WordParagraph property
         /// </summary>
-        public string Text {
+        public List<string> Text {
             get {
                 if (_sdtBlock != null) {
-
-                    var run = _sdtBlock.GetFirstChild<Run>();
-                    if (run != null) {
-                        var text = run.GetFirstChild<Text>();
-                        if (text != null) {
-                            return text.Text;
-                        }
-                    }
+                    return _sdtBlock.Descendants<Text>().Select(t => t.Text).ToList();
                 }
-                return "";
+                return new List<string>();
             }
             set {
                 if (_sdtBlock != null) {
-                    var run = _sdtBlock.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.Run>();
-                    if (run != null) {
-                        var text = run.GetFirstChild<Text>();
+                    var runs = _sdtBlock.Descendants<Run>().ToList();
+                    for (int i = 0; i < Math.Min(runs.Count, value.Count); i++) {
+                        var text = runs[i].GetFirstChild<Text>();
                         if (text != null) {
-                            text.Text = value;
+                            text.Text = value[i];
                         }
                     }
                 }
@@ -94,13 +88,12 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Allows to modify the paragraph of the text box, along with other text formatting
         /// </summary>
-        public WordParagraph WordParagraph {
+        public List<WordParagraph> WordParagraph {
             get {
                 if (_sdtBlock != null) {
-                    var run = _sdtBlock.GetFirstChild<Run>();
-                    return new WordParagraph(_document, _sdtBlock, run);
+                    return _sdtBlock.Descendants<Run>().Select(run => new WordParagraph(_document, _sdtBlock, run)).ToList();
                 }
-                return null;
+                return new List<WordParagraph>();
             }
         }
 


### PR DESCRIPTION
This PR solves:
- #224 

There are **Breaking Changes**:
- Removed `Text` property
- Removed `WordParagraph` property
- Added `Paragraphs` property, allowing for full manipulation

```cs
var textBox = document.AddTextBox("[Grab your reader’s attention with a great quote from the document or use this space to emphasize a key point. To place this text box anywhere on the page, just drag it.]");

Console.WriteLine("TextBox Text: " + textBox.Paragraphs[0].Text);

textBox.Paragraphs[0].Text = "We can then modify the text box text";

Console.WriteLine("TextBox Text: " + textBox.Paragraphs[0].Text);

Console.WriteLine("TextBoc Color: " + textBox.Paragraphs[0].Color.ToString());

textBox.Paragraphs[0].Text = "This is a text box 1";

Console.WriteLine("TextBox Text: " + textBox.Paragraphs[0].Text);
```