### PR TITLE
Add RepeatHeaderRowAtTheTopOfEachPage to Tables

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -16,154 +16,154 @@ namespace OfficeIMO.Examples {
             string folderPath = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "Documents");
             Setup(folderPath);
 
-            //BasicDocument.Example_BasicEmptyWord(folderPath, false);
-            //BasicDocument.Example_BasicWord(folderPath, false);
-            //BasicDocument.Example_BasicWord2(folderPath, false);
-            //BasicDocument.Example_BasicWordWithBreaks(folderPath, false);
-            //BasicDocument.Example_BasicWordWithDefaultStyleChange(folderPath, false);
-            //BasicDocument.Example_BasicWordWithDefaultFontChange(folderPath, false);
-            //BasicDocument.Example_BasicLoadHamlet(templatesPath, folderPath, false);
-            //BasicDocument.Example_BasicWordWithPolishChars(folderPath, false);
-            //BasicDocument.Example_BasicWordWithNewLines(folderPath, false);
-            //BasicDocument.Example_BasicWordWithTabs(folderPath, false);
-            //BasicDocument.Example_BasicWordWithMargins(folderPath, false);
-            //BasicDocument.Example_BasicWordWithMarginsInCentimeters(folderPath, false);
-            //BasicDocument.Example_BasicWordWithMarginsAndImage(folderPath, false);
-            //BasicDocument.Example_BasicWordWithLineSpacing(folderPath, false);
+            BasicDocument.Example_BasicEmptyWord(folderPath, false);
+            BasicDocument.Example_BasicWord(folderPath, false);
+            BasicDocument.Example_BasicWord2(folderPath, false);
+            BasicDocument.Example_BasicWordWithBreaks(folderPath, false);
+            BasicDocument.Example_BasicWordWithDefaultStyleChange(folderPath, false);
+            BasicDocument.Example_BasicWordWithDefaultFontChange(folderPath, false);
+            BasicDocument.Example_BasicLoadHamlet(templatesPath, folderPath, false);
+            BasicDocument.Example_BasicWordWithPolishChars(folderPath, false);
+            BasicDocument.Example_BasicWordWithNewLines(folderPath, false);
+            BasicDocument.Example_BasicWordWithTabs(folderPath, false);
+            BasicDocument.Example_BasicWordWithMargins(folderPath, false);
+            BasicDocument.Example_BasicWordWithMarginsInCentimeters(folderPath, false);
+            BasicDocument.Example_BasicWordWithMarginsAndImage(folderPath, false);
+            BasicDocument.Example_BasicWordWithLineSpacing(folderPath, false);
 
-            //AdvancedDocument.Example_AdvancedWord(folderPath, false);
-            //AdvancedDocument.Example_AdvancedWord2(folderPath, false);
+            AdvancedDocument.Example_AdvancedWord(folderPath, false);
+            AdvancedDocument.Example_AdvancedWord2(folderPath, false);
 
-            //Paragraphs.Example_BasicParagraphs(folderPath, false);
-            //Paragraphs.Example_BasicParagraphStyles(folderPath, false);
-            //Paragraphs.Example_MultipleParagraphsViaDifferentWays(folderPath, false);
-            //Paragraphs.Example_BasicTabStops(folderPath, false);
+            Paragraphs.Example_BasicParagraphs(folderPath, false);
+            Paragraphs.Example_BasicParagraphStyles(folderPath, false);
+            Paragraphs.Example_MultipleParagraphsViaDifferentWays(folderPath, false);
+            Paragraphs.Example_BasicTabStops(folderPath, false);
 
-            //BasicDocument.Example_BasicDocument(folderPath, false);
-            //BasicDocument.Example_BasicDocumentSaveAs1(folderPath, false);
-            //BasicDocument.Example_BasicDocumentSaveAs2(folderPath, false);
-            //BasicDocument.Example_BasicDocumentSaveAs3(folderPath, false);
-            //BasicDocument.Example_BasicDocumentWithoutUsing(folderPath, false);
+            BasicDocument.Example_BasicDocument(folderPath, false);
+            BasicDocument.Example_BasicDocumentSaveAs1(folderPath, false);
+            BasicDocument.Example_BasicDocumentSaveAs2(folderPath, false);
+            BasicDocument.Example_BasicDocumentSaveAs3(folderPath, false);
+            BasicDocument.Example_BasicDocumentWithoutUsing(folderPath, false);
 
-            //Lists.Example_BasicLists(folderPath, false);
-            //Lists.Example_BasicLists6(folderPath, false);
-            //Lists.Example_BasicLists2(folderPath, false);
-            //Lists.Example_BasicLists3(folderPath, false);
-            //Lists.Example_BasicLists9(folderPath, false);
-            //Lists.Example_BasicLists4(folderPath, false);
-            //Lists.Example_BasicLists2Load(folderPath, false);
-            //Lists.Example_BasicLists7(folderPath, false);
-            //Lists.Example_BasicLists8(folderPath, false);
-            //Tables.Example_BasicTables1(folderPath, false);
-            //Tables.Example_BasicTablesLoad1(folderPath, false);
-            //Tables.Example_BasicTablesLoad2(templatesPath, folderPath, false);
-            //Tables.Example_BasicTablesLoad3(templatesPath, false);
-            //Tables.Example_TablesWidthAndAlignment(folderPath, false);
-            //Tables.Example_AllTables(folderPath, false);
-            //Tables.Example_Tables(folderPath, false);
-            //Tables.Example_TableBorders(folderPath, false);
-            //Tables.Example_NestedTables(folderPath, false);
-            //Tables.Example_TablesAddedAfterParagraph(folderPath, false);
+            Lists.Example_BasicLists(folderPath, false);
+            Lists.Example_BasicLists6(folderPath, false);
+            Lists.Example_BasicLists2(folderPath, false);
+            Lists.Example_BasicLists3(folderPath, false);
+            Lists.Example_BasicLists9(folderPath, false);
+            Lists.Example_BasicLists4(folderPath, false);
+            Lists.Example_BasicLists2Load(folderPath, false);
+            Lists.Example_BasicLists7(folderPath, false);
+            Lists.Example_BasicLists8(folderPath, false);
+            Tables.Example_BasicTables1(folderPath, false);
+            Tables.Example_BasicTablesLoad1(folderPath, false);
+            Tables.Example_BasicTablesLoad2(templatesPath, folderPath, false);
+            Tables.Example_BasicTablesLoad3(templatesPath, false);
+            Tables.Example_TablesWidthAndAlignment(folderPath, false);
+            Tables.Example_AllTables(folderPath, false);
+            Tables.Example_Tables(folderPath, false);
+            Tables.Example_TableBorders(folderPath, false);
+            Tables.Example_NestedTables(folderPath, false);
+            Tables.Example_TablesAddedAfterParagraph(folderPath, false);
 
-            //PageSettings.Example_BasicSettings(folderPath, false);
-            //PageSettings.Example_PageOrientation(folderPath, false);
+            PageSettings.Example_BasicSettings(folderPath, false);
+            PageSettings.Example_PageOrientation(folderPath, false);
 
-            //PageNumbers.Example_PageNumbers1(folderPath, false);
+            PageNumbers.Example_PageNumbers1(folderPath, false);
 
-            //Sections.Example_BasicSections(folderPath, false);
-            //Sections.Example_BasicSections2(folderPath, false);
-            //Sections.Example_BasicSections3WithColumns(folderPath, false);
-            //Sections.Example_SectionsWithParagraphs(folderPath, false);
-            //Sections.Example_SectionsWithHeadersDefault(folderPath, false);
-            //Sections.Example_SectionsWithHeaders(folderPath, false);
-            //Sections.Example_BasicWordWithSections(folderPath, false);
+            Sections.Example_BasicSections(folderPath, false);
+            Sections.Example_BasicSections2(folderPath, false);
+            Sections.Example_BasicSections3WithColumns(folderPath, false);
+            Sections.Example_SectionsWithParagraphs(folderPath, false);
+            Sections.Example_SectionsWithHeadersDefault(folderPath, false);
+            Sections.Example_SectionsWithHeaders(folderPath, false);
+            Sections.Example_BasicWordWithSections(folderPath, false);
 
-            //CoverPages.Example_AddingCoverPage(folderPath, false);
-            //CoverPages.Example_AddingCoverPage2(folderPath, false);
+            CoverPages.Example_AddingCoverPage(folderPath, false);
+            CoverPages.Example_AddingCoverPage2(folderPath, false);
 
-            //LoadDocuments.LoadWordDocument_Sample1(false);
-            //LoadDocuments.LoadWordDocument_Sample2(false);
-            //LoadDocuments.LoadWordDocument_Sample3(false);
+            LoadDocuments.LoadWordDocument_Sample1(false);
+            LoadDocuments.LoadWordDocument_Sample2(false);
+            LoadDocuments.LoadWordDocument_Sample3(false);
 
-            //CustomAndBuiltinProperties.Example_BasicDocumentProperties(folderPath, false);
-            //CustomAndBuiltinProperties.Example_ReadWord(false);
-            //CustomAndBuiltinProperties.Example_BasicCustomProperties(folderPath, false);
-            //CustomAndBuiltinProperties.Example_ValidateDocument(folderPath);
-            //CustomAndBuiltinProperties.Example_ValidateDocument_BeforeSave();
-            //CustomAndBuiltinProperties.Example_LoadDocumentWithProperties(false);
-            //CustomAndBuiltinProperties.Example_Load(false);
+            CustomAndBuiltinProperties.Example_BasicDocumentProperties(folderPath, false);
+            CustomAndBuiltinProperties.Example_ReadWord(false);
+            CustomAndBuiltinProperties.Example_BasicCustomProperties(folderPath, false);
+            CustomAndBuiltinProperties.Example_ValidateDocument(folderPath);
+            CustomAndBuiltinProperties.Example_ValidateDocument_BeforeSave();
+            CustomAndBuiltinProperties.Example_LoadDocumentWithProperties(false);
+            CustomAndBuiltinProperties.Example_Load(false);
 
-            //HyperLinks.EasyExample(folderPath, false);
-            //HyperLinks.Example_BasicWordWithHyperLinks(folderPath, false);
-            //HyperLinks.Example_AddingFields(folderPath, false);
-            //HyperLinks.Example_BasicWordWithHyperLinksInTables(folderPath, false);
+            HyperLinks.EasyExample(folderPath, false);
+            HyperLinks.Example_BasicWordWithHyperLinks(folderPath, false);
+            HyperLinks.Example_AddingFields(folderPath, false);
+            HyperLinks.Example_BasicWordWithHyperLinksInTables(folderPath, false);
 
-            //HeadersAndFooters.Sections1(folderPath, false);
-            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooter0(folderPath, false);
-            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooter(folderPath, false);
-            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooter1(folderPath, false);
+            HeadersAndFooters.Sections1(folderPath, false);
+            HeadersAndFooters.Example_BasicWordWithHeaderAndFooter0(folderPath, false);
+            HeadersAndFooters.Example_BasicWordWithHeaderAndFooter(folderPath, false);
+            HeadersAndFooters.Example_BasicWordWithHeaderAndFooter1(folderPath, false);
 
-            Charts.Example_AddingMultipleCharts(folderPath, true);
+            Charts.Example_AddingMultipleCharts(folderPath, false);
 
-            //Images.Example_AddingImages(folderPath, false);
-            //Images.Example_ReadWordWithImages();
-            //Images.Example_AddingImagesMultipleTypes(folderPath, false);
-            //Images.Example_ReadWordWithImagesAndDiffWraps();
-            //Images.Example_AddingFixedImages(folderPath, false);
-            //Images.Example_AddingImagesSampleToTable(folderPath, false);
+            Images.Example_AddingImages(folderPath, false);
+            Images.Example_ReadWordWithImages();
+            Images.Example_AddingImagesMultipleTypes(folderPath, false);
+            Images.Example_ReadWordWithImagesAndDiffWraps();
+            Images.Example_AddingFixedImages(folderPath, false);
+            Images.Example_AddingImagesSampleToTable(folderPath, false);
 
-            //PageBreaks.Example_PageBreaks(folderPath, false);
-            //PageBreaks.Example_PageBreaks1(folderPath, false);
+            PageBreaks.Example_PageBreaks(folderPath, false);
+            PageBreaks.Example_PageBreaks1(folderPath, false);
 
-            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooterWithoutSections(folderPath, false);
+            HeadersAndFooters.Example_BasicWordWithHeaderAndFooterWithoutSections(folderPath, false);
 
-            //TOC.Example_BasicTOC1(folderPath, false);
-            //TOC.Example_BasicTOC2(folderPath, false);
+            TOC.Example_BasicTOC1(folderPath, false);
+            TOC.Example_BasicTOC2(folderPath, false);
 
-            //Comments.Example_PlayingWithComments(folderPath, false);
+            Comments.Example_PlayingWithComments(folderPath, false);
 
-            //BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);
-            //BasicExcelFunctionality.BasicExcel_Example2(folderPath, false);
-            //BasicExcelFunctionality.BasicExcel_Example3(false);
+            BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);
+            BasicExcelFunctionality.BasicExcel_Example2(folderPath, false);
+            BasicExcelFunctionality.BasicExcel_Example3(false);
 
-            //BordersAndMargins.Example_BasicWordMarginsSizes(folderPath, false);
-            //BordersAndMargins.Example_BasicPageBorders1(folderPath, false);
-            //BordersAndMargins.Example_BasicPageBorders2(folderPath, false);
+            BordersAndMargins.Example_BasicWordMarginsSizes(folderPath, false);
+            BordersAndMargins.Example_BasicPageBorders1(folderPath, false);
+            BordersAndMargins.Example_BasicPageBorders2(folderPath, false);
 
-            //Bookmarks.Example_BasicWordWithBookmarks(folderPath, false);
-            //Fields.Example_DocumentWithFields(folderPath, false);
-            //Fields.Example_DocumentWithFields02(folderPath, false);
+            Bookmarks.Example_BasicWordWithBookmarks(folderPath, false);
+            Fields.Example_DocumentWithFields(folderPath, false);
+            Fields.Example_DocumentWithFields02(folderPath, false);
 
-            //Watermark.Watermark_Sample2(folderPath, false);
-            //Watermark.Watermark_Sample1(folderPath, false);
-            //Watermark.Watermark_Sample3(folderPath, false);
+            Watermark.Watermark_Sample2(folderPath, false);
+            Watermark.Watermark_Sample1(folderPath, false);
+            Watermark.Watermark_Sample3(folderPath, false);
 
-            //Embed.Example_EmbedFileHTML(folderPath, templatesPath, false);
-            //Embed.Example_EmbedFileRTF(folderPath, templatesPath, false);
-            //Embed.Example_EmbedFileRTFandHTML(folderPath, templatesPath, false);
-            //Embed.Example_EmbedFileRTFandHTMLandTOC(folderPath, templatesPath, false);
-            //Embed.Example_EmbedFileMultiple(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileHTML(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileRTF(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileRTFandHTML(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileRTFandHTMLandTOC(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileMultiple(folderPath, templatesPath, false);
 
-            //CleanupDocuments.CleanupDocuments_Sample01(false);
-            //CleanupDocuments.CleanupDocuments_Sample02(folderPath, false);
+            CleanupDocuments.CleanupDocuments_Sample01(false);
+            CleanupDocuments.CleanupDocuments_Sample02(folderPath, false);
 
-            //FindAndReplace.Example_FindAndReplace01(folderPath, false);
-            //FindAndReplace.Example_FindAndReplace02(folderPath, false);
+            FindAndReplace.Example_FindAndReplace01(folderPath, false);
+            FindAndReplace.Example_FindAndReplace02(folderPath, false);
 
-            //FootNotes.Example_DocumentWithFootNotes(templatesPath, false);
-            //FootNotes.Example_DocumentWithFootNotesEmpty(folderPath, false);
+            FootNotes.Example_DocumentWithFootNotes(templatesPath, false);
+            FootNotes.Example_DocumentWithFootNotesEmpty(folderPath, false);
 
-            //SaveToStream.Example_StreamDocumentProperties(folderPath, false);
+            SaveToStream.Example_StreamDocumentProperties(folderPath, false);
 
-            //Protect.Example_ProtectFinalDocument(folderPath, false);
-            //Protect.Example_ProtectAlwaysReadOnly(folderPath, false);
+            Protect.Example_ProtectFinalDocument(folderPath, false);
+            Protect.Example_ProtectAlwaysReadOnly(folderPath, false);
 
-            //WordTextBox.Example_AddingTextbox(folderPath, false);
-            //WordTextBox.Example_AddingTextbox2(folderPath, false);
-            //WordTextBox.Example_AddingTextbox4(folderPath, false);
-            //WordTextBox.Example_AddingTextbox5(folderPath, false);
-            //WordTextBox.Example_AddingTextbox3(folderPath, false);
-            //WordTextBox.Example_AddingTextboxCentimeters(folderPath, false);
+            WordTextBox.Example_AddingTextbox(folderPath, false);
+            WordTextBox.Example_AddingTextbox2(folderPath, false);
+            WordTextBox.Example_AddingTextbox4(folderPath, false);
+            WordTextBox.Example_AddingTextbox5(folderPath, false);
+            WordTextBox.Example_AddingTextbox3(folderPath, false);
+            WordTextBox.Example_AddingTextboxCentimeters(folderPath, false);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/Tables/Tables.Create4.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.Create4.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -19,6 +19,7 @@ namespace OfficeIMO.Examples.Word {
                 paragraph.Underline = UnderlineValues.DotDash;
 
                 WordTable wordTable = document.AddTable(4, 4, WordTableStyle.TableNormal);
+                wordTable.RepeatHeaderRowAtTheTopOfEachPage = true;
                 wordTable.Rows[0].Cells[0].Paragraphs[0].Text = "Test 1";
                 wordTable.Rows[1].Cells[0].Paragraphs[0].Text = "Test 2";
                 wordTable.Rows[2].Cells[0].Paragraphs[0].Text = "Test 3";
@@ -69,6 +70,8 @@ namespace OfficeIMO.Examples.Word {
 
                 wordTable2.Style = WordTableStyle.GridTable7Colorful;
 
+
+                wordTable.AddRow(5);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Tests/Word.Tables.cs
+++ b/OfficeIMO.Tests/Word.Tables.cs
@@ -24,8 +24,35 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[0].Paragraphs[0].Text = "Test 2";
                 wordTable.Rows[2].Cells[0].Paragraphs[0].Text = "Test 3";
 
+                Assert.True(wordTable.RepeatHeaderRowAtTheTopOfEachPage == false);
+
+                Assert.True(wordTable.LastRow.RepeatHeaderRowAtTheTopOfEachPage == false);
+                foreach (var row in wordTable.Rows) {
+                    Assert.True(row.RepeatHeaderRowAtTheTopOfEachPage == false);
+                }
+
+                wordTable.RepeatHeaderRowAtTheTopOfEachPage = true;
+
+                Assert.True(wordTable.RepeatHeaderRowAtTheTopOfEachPage == true);
+
+                Assert.True(wordTable.LastRow.RepeatHeaderRowAtTheTopOfEachPage == true);
+
+                foreach (var row in wordTable.Rows) {
+                    Assert.True(row.RepeatHeaderRowAtTheTopOfEachPage == true);
+                }
+
+                Assert.True(wordTable.Rows.Count == 3);
+
+                wordTable.AddRow(2, 2);
+
+                Assert.True(wordTable.Rows.Count == 5);
+
+                foreach (var row in wordTable.Rows) {
+                    Assert.True(row.RepeatHeaderRowAtTheTopOfEachPage == true);
+                }
+
                 Assert.True(wordTable.Rows[2].Cells[0].Paragraphs[0].Text == "Test 3", "Text in table matches. Actual text: " + wordTable.Rows[2].Cells[0].Paragraphs[0].Text);
-                Assert.True(wordTable.Paragraphs.Count == 12, "Number of paragraphs during creation in table is wrong. Current: " + wordTable.Paragraphs.Count);
+                Assert.True(wordTable.Paragraphs.Count == 16, "Number of paragraphs during creation in table is wrong. Current: " + wordTable.Paragraphs.Count);
 
                 Assert.True(document.Tables.Count == 1, "Tables count matches");
                 Assert.True(document.Lists.Count == 0, "List count matches");
@@ -45,7 +72,7 @@ namespace OfficeIMO.Tests {
 
                 var wordTable = document.Tables[0];
                 Assert.True(wordTable.Rows[2].Cells[0].Paragraphs[0].Text == "Test 3", "Text in table matches. Actual text: " + wordTable.Rows[2].Cells[0].Paragraphs[0].Text);
-                Assert.True(wordTable.Paragraphs.Count == 12, "Number of paragraphs during load in table is wrong. Current: " + wordTable.Paragraphs.Count);
+                Assert.True(wordTable.Paragraphs.Count == 16, "Number of paragraphs during load in table is wrong. Current: " + wordTable.Paragraphs.Count);
 
                 WordTable wordTable2 = document.AddTable(5, 5);
                 wordTable2.Rows[0].Cells[0].Paragraphs[0].Text = "Test 1";
@@ -96,7 +123,7 @@ namespace OfficeIMO.Tests {
 
                 var wordTable1 = document.Tables[0];
                 Assert.True(wordTable1.Rows[2].Cells[0].Paragraphs[0].Text == "Test 3", "Text in table matches. Actual text: " + wordTable1.Rows[2].Cells[0].Paragraphs[0].Text);
-                Assert.True(wordTable1.Paragraphs.Count == 12, "Number of paragraphs during creation in table is wrong. Current: " + wordTable1.Paragraphs.Count);
+                Assert.True(wordTable1.Paragraphs.Count == 16, "Number of paragraphs during creation in table is wrong. Current: " + wordTable1.Paragraphs.Count);
 
                 var wordTable2 = document.Tables[1];
                 Assert.True(wordTable2.Rows[4].Cells[0].Paragraphs[0].Text == "Test 5", "Text in table matches. Actual text: " + wordTable2.Rows[4].Cells[0].Paragraphs[0].Text);

--- a/OfficeIMO.Word/WordTable.cs
+++ b/OfficeIMO.Word/WordTable.cs
@@ -232,6 +232,18 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Specifies that the first row shall be repeated at the top of each page on which the table is displayed.
+        /// </summary>
+        public bool RepeatHeaderRowAtTheTopOfEachPage {
+            get => Rows[0].RepeatHeaderRowAtTheTopOfEachPage;
+            set {
+                foreach (var row in Rows) {
+                    row.RepeatHeaderRowAtTheTopOfEachPage = value;
+                }
+            }
+        }
+
         public int RowsCount => this.Rows.Count;
 
         public List<WordTableRow> Rows {
@@ -406,7 +418,12 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="cellsCount"></param>
         public WordTableRow AddRow(int cellsCount = 0) {
-            WordTableRow row = new WordTableRow(_document, this);
+            // when adding a row to the table, we need to check if the last row has RepeatHeaderRowAtTheTopOfEachPage set
+            // if it does, we need to set it for the new row as well
+            var repeatHeaders = this.LastRow.RepeatHeaderRowAtTheTopOfEachPage;
+            WordTableRow row = new WordTableRow(_document, this) {
+                RepeatHeaderRowAtTheTopOfEachPage = repeatHeaders
+            };
             _table.Append(row._tableRow);
             AddCells(row, cellsCount);
             return row;

--- a/OfficeIMO.Word/WordTableRow.cs
+++ b/OfficeIMO.Word/WordTableRow.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
@@ -63,6 +63,34 @@ namespace OfficeIMO.Word {
                     if (tableRowHeight != null) {
                         tableRowHeight.Remove();
                     }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets header row at the top of each page
+        /// Since this is a table row property, it is not possible to set it for a single row
+        /// </summary>
+        internal bool RepeatHeaderRowAtTheTopOfEachPage {
+            get {
+                if (_tableRow.TableRowProperties != null) {
+                    var rowHeader = _tableRow.TableRowProperties.OfType<TableHeader>().FirstOrDefault();
+                    if (rowHeader != null) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            set {
+                AddTableRowProperties();
+                var rowHeader = _tableRow.TableRowProperties.OfType<TableHeader>().FirstOrDefault();
+                if (rowHeader != null) {
+                    if (value == false) {
+                        rowHeader.Remove();
+                    }
+                } else {
+                    // Add table header
+                    _tableRow.TableRowProperties.InsertAt(new TableHeader(), 0);
                 }
             }
         }


### PR DESCRIPTION
This PR resolves:
- https://github.com/EvotecIT/OfficeIMO/issues/230

```cs
WordTable wordTable = document.AddTable(4, 4, WordTableStyle.TableNormal);
wordTable.RepeatHeaderRowAtTheTopOfEachPage = true;
wordTable.Rows[0].Cells[0].Paragraphs[0].Text = "Test 1";
wordTable.Rows[1].Cells[0].Paragraphs[0].Text = "Test 2";
wordTable.Rows[2].Cells[0].Paragraphs[0].Text = "Test 3";
wordTable.Rows[3].Cells[0].Paragraphs[0].Text = "Test 4";
```