### PR TITLE
Add AddEmbeddedFragment method

### DIFF
--- a/OfficeIMO.Examples/OfficeIMO.Examples.csproj
+++ b/OfficeIMO.Examples/OfficeIMO.Examples.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>Latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -16,154 +16,155 @@ namespace OfficeIMO.Examples {
             string folderPath = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "Documents");
             Setup(folderPath);
 
-            //BasicDocument.Example_BasicEmptyWord(folderPath, false);
-            //BasicDocument.Example_BasicWord(folderPath, false);
-            //BasicDocument.Example_BasicWord2(folderPath, false);
-            //BasicDocument.Example_BasicWordWithBreaks(folderPath, false);
-            //BasicDocument.Example_BasicWordWithDefaultStyleChange(folderPath, false);
-            //BasicDocument.Example_BasicWordWithDefaultFontChange(folderPath, false);
-            //BasicDocument.Example_BasicLoadHamlet(templatesPath, folderPath, false);
-            //BasicDocument.Example_BasicWordWithPolishChars(folderPath, false);
-            //BasicDocument.Example_BasicWordWithNewLines(folderPath, false);
-            //BasicDocument.Example_BasicWordWithTabs(folderPath, false);
-            //BasicDocument.Example_BasicWordWithMargins(folderPath, false);
-            //BasicDocument.Example_BasicWordWithMarginsInCentimeters(folderPath, false);
-            //BasicDocument.Example_BasicWordWithMarginsAndImage(folderPath, false);
-            //BasicDocument.Example_BasicWordWithLineSpacing(folderPath, false);
+            BasicDocument.Example_BasicEmptyWord(folderPath, false);
+            BasicDocument.Example_BasicWord(folderPath, false);
+            BasicDocument.Example_BasicWord2(folderPath, false);
+            BasicDocument.Example_BasicWordWithBreaks(folderPath, false);
+            BasicDocument.Example_BasicWordWithDefaultStyleChange(folderPath, false);
+            BasicDocument.Example_BasicWordWithDefaultFontChange(folderPath, false);
+            BasicDocument.Example_BasicLoadHamlet(templatesPath, folderPath, false);
+            BasicDocument.Example_BasicWordWithPolishChars(folderPath, false);
+            BasicDocument.Example_BasicWordWithNewLines(folderPath, false);
+            BasicDocument.Example_BasicWordWithTabs(folderPath, false);
+            BasicDocument.Example_BasicWordWithMargins(folderPath, false);
+            BasicDocument.Example_BasicWordWithMarginsInCentimeters(folderPath, false);
+            BasicDocument.Example_BasicWordWithMarginsAndImage(folderPath, false);
+            BasicDocument.Example_BasicWordWithLineSpacing(folderPath, false);
 
-            //AdvancedDocument.Example_AdvancedWord(folderPath, false);
-            //AdvancedDocument.Example_AdvancedWord2(folderPath, false);
+            AdvancedDocument.Example_AdvancedWord(folderPath, false);
+            AdvancedDocument.Example_AdvancedWord2(folderPath, false);
 
-            //Paragraphs.Example_BasicParagraphs(folderPath, false);
-            //Paragraphs.Example_BasicParagraphStyles(folderPath, false);
-            //Paragraphs.Example_MultipleParagraphsViaDifferentWays(folderPath, false);
-            //Paragraphs.Example_BasicTabStops(folderPath, false);
+            Paragraphs.Example_BasicParagraphs(folderPath, false);
+            Paragraphs.Example_BasicParagraphStyles(folderPath, false);
+            Paragraphs.Example_MultipleParagraphsViaDifferentWays(folderPath, false);
+            Paragraphs.Example_BasicTabStops(folderPath, false);
 
-            //BasicDocument.Example_BasicDocument(folderPath, false);
-            //BasicDocument.Example_BasicDocumentSaveAs1(folderPath, false);
-            //BasicDocument.Example_BasicDocumentSaveAs2(folderPath, false);
-            //BasicDocument.Example_BasicDocumentSaveAs3(folderPath, false);
-            //BasicDocument.Example_BasicDocumentWithoutUsing(folderPath, false);
+            BasicDocument.Example_BasicDocument(folderPath, false);
+            BasicDocument.Example_BasicDocumentSaveAs1(folderPath, false);
+            BasicDocument.Example_BasicDocumentSaveAs2(folderPath, false);
+            BasicDocument.Example_BasicDocumentSaveAs3(folderPath, false);
+            BasicDocument.Example_BasicDocumentWithoutUsing(folderPath, false);
 
-            //Lists.Example_BasicLists(folderPath, false);
-            //Lists.Example_BasicLists6(folderPath, false);
-            //Lists.Example_BasicLists2(folderPath, false);
-            //Lists.Example_BasicLists3(folderPath, false);
-            //Lists.Example_BasicLists9(folderPath, false);
-            //Lists.Example_BasicLists4(folderPath, false);
-            //Lists.Example_BasicLists2Load(folderPath, false);
-            //Lists.Example_BasicLists7(folderPath, false);
-            //Lists.Example_BasicLists8(folderPath, false);
-            //Tables.Example_BasicTables1(folderPath, false);
-            //Tables.Example_BasicTablesLoad1(folderPath, false);
-            //Tables.Example_BasicTablesLoad2(templatesPath, folderPath, false);
-            //Tables.Example_BasicTablesLoad3(templatesPath, false);
-            //Tables.Example_TablesWidthAndAlignment(folderPath, false);
-            //Tables.Example_AllTables(folderPath, false);
-            //Tables.Example_Tables(folderPath, false);
-            //Tables.Example_TableBorders(folderPath, false);
-            //Tables.Example_NestedTables(folderPath, false);
-            //Tables.Example_TablesAddedAfterParagraph(folderPath, false);
+            Lists.Example_BasicLists(folderPath, false);
+            Lists.Example_BasicLists6(folderPath, false);
+            Lists.Example_BasicLists2(folderPath, false);
+            Lists.Example_BasicLists3(folderPath, false);
+            Lists.Example_BasicLists9(folderPath, false);
+            Lists.Example_BasicLists4(folderPath, false);
+            Lists.Example_BasicLists2Load(folderPath, false);
+            Lists.Example_BasicLists7(folderPath, false);
+            Lists.Example_BasicLists8(folderPath, false);
+            Tables.Example_BasicTables1(folderPath, false);
+            Tables.Example_BasicTablesLoad1(folderPath, false);
+            Tables.Example_BasicTablesLoad2(templatesPath, folderPath, false);
+            Tables.Example_BasicTablesLoad3(templatesPath, false);
+            Tables.Example_TablesWidthAndAlignment(folderPath, false);
+            Tables.Example_AllTables(folderPath, false);
+            Tables.Example_Tables(folderPath, false);
+            Tables.Example_TableBorders(folderPath, false);
+            Tables.Example_NestedTables(folderPath, false);
+            Tables.Example_TablesAddedAfterParagraph(folderPath, false);
 
-            //PageSettings.Example_BasicSettings(folderPath, false);
-            //PageSettings.Example_PageOrientation(folderPath, false);
+            PageSettings.Example_BasicSettings(folderPath, false);
+            PageSettings.Example_PageOrientation(folderPath, false);
 
-            //PageNumbers.Example_PageNumbers1(folderPath, false);
+            PageNumbers.Example_PageNumbers1(folderPath, false);
 
-            //Sections.Example_BasicSections(folderPath, false);
-            //Sections.Example_BasicSections2(folderPath, false);
-            //Sections.Example_BasicSections3WithColumns(folderPath, false);
-            //Sections.Example_SectionsWithParagraphs(folderPath, false);
-            //Sections.Example_SectionsWithHeadersDefault(folderPath, false);
-            //Sections.Example_SectionsWithHeaders(folderPath, false);
-            //Sections.Example_BasicWordWithSections(folderPath, false);
+            Sections.Example_BasicSections(folderPath, false);
+            Sections.Example_BasicSections2(folderPath, false);
+            Sections.Example_BasicSections3WithColumns(folderPath, false);
+            Sections.Example_SectionsWithParagraphs(folderPath, false);
+            Sections.Example_SectionsWithHeadersDefault(folderPath, false);
+            Sections.Example_SectionsWithHeaders(folderPath, false);
+            Sections.Example_BasicWordWithSections(folderPath, false);
 
-            //CoverPages.Example_AddingCoverPage(folderPath, false);
-            //CoverPages.Example_AddingCoverPage2(folderPath, false);
+            CoverPages.Example_AddingCoverPage(folderPath, false);
+            CoverPages.Example_AddingCoverPage2(folderPath, false);
 
-            //LoadDocuments.LoadWordDocument_Sample1(false);
-            //LoadDocuments.LoadWordDocument_Sample2(false);
-            //LoadDocuments.LoadWordDocument_Sample3(false);
+            LoadDocuments.LoadWordDocument_Sample1(false);
+            LoadDocuments.LoadWordDocument_Sample2(false);
+            LoadDocuments.LoadWordDocument_Sample3(false);
 
-            //CustomAndBuiltinProperties.Example_BasicDocumentProperties(folderPath, false);
-            //CustomAndBuiltinProperties.Example_ReadWord(false);
-            //CustomAndBuiltinProperties.Example_BasicCustomProperties(folderPath, false);
-            //CustomAndBuiltinProperties.Example_ValidateDocument(folderPath);
-            //CustomAndBuiltinProperties.Example_ValidateDocument_BeforeSave();
-            //CustomAndBuiltinProperties.Example_LoadDocumentWithProperties(false);
-            //CustomAndBuiltinProperties.Example_Load(false);
+            CustomAndBuiltinProperties.Example_BasicDocumentProperties(folderPath, false);
+            CustomAndBuiltinProperties.Example_ReadWord(false);
+            CustomAndBuiltinProperties.Example_BasicCustomProperties(folderPath, false);
+            CustomAndBuiltinProperties.Example_ValidateDocument(folderPath);
+            CustomAndBuiltinProperties.Example_ValidateDocument_BeforeSave();
+            CustomAndBuiltinProperties.Example_LoadDocumentWithProperties(false);
+            CustomAndBuiltinProperties.Example_Load(false);
 
-            //HyperLinks.EasyExample(folderPath, false);
-            //HyperLinks.Example_BasicWordWithHyperLinks(folderPath, false);
-            //HyperLinks.Example_AddingFields(folderPath, false);
-            //HyperLinks.Example_BasicWordWithHyperLinksInTables(folderPath, false);
+            HyperLinks.EasyExample(folderPath, false);
+            HyperLinks.Example_BasicWordWithHyperLinks(folderPath, false);
+            HyperLinks.Example_AddingFields(folderPath, false);
+            HyperLinks.Example_BasicWordWithHyperLinksInTables(folderPath, false);
 
-            //HeadersAndFooters.Sections1(folderPath, false);
-            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooter0(folderPath, false);
-            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooter(folderPath, false);
-            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooter1(folderPath, false);
+            HeadersAndFooters.Sections1(folderPath, false);
+            HeadersAndFooters.Example_BasicWordWithHeaderAndFooter0(folderPath, false);
+            HeadersAndFooters.Example_BasicWordWithHeaderAndFooter(folderPath, false);
+            HeadersAndFooters.Example_BasicWordWithHeaderAndFooter1(folderPath, false);
 
-            Charts.Example_AddingMultipleCharts(folderPath, true);
+            Charts.Example_AddingMultipleCharts(folderPath, false);
 
-            //Images.Example_AddingImages(folderPath, false);
-            //Images.Example_ReadWordWithImages();
-            //Images.Example_AddingImagesMultipleTypes(folderPath, false);
-            //Images.Example_ReadWordWithImagesAndDiffWraps();
-            //Images.Example_AddingFixedImages(folderPath, false);
-            //Images.Example_AddingImagesSampleToTable(folderPath, false);
+            Images.Example_AddingImages(folderPath, false);
+            Images.Example_ReadWordWithImages();
+            Images.Example_AddingImagesMultipleTypes(folderPath, false);
+            Images.Example_ReadWordWithImagesAndDiffWraps();
+            Images.Example_AddingFixedImages(folderPath, false);
+            Images.Example_AddingImagesSampleToTable(folderPath, false);
 
-            //PageBreaks.Example_PageBreaks(folderPath, false);
-            //PageBreaks.Example_PageBreaks1(folderPath, false);
+            PageBreaks.Example_PageBreaks(folderPath, false);
+            PageBreaks.Example_PageBreaks1(folderPath, false);
 
-            //HeadersAndFooters.Example_BasicWordWithHeaderAndFooterWithoutSections(folderPath, false);
+            HeadersAndFooters.Example_BasicWordWithHeaderAndFooterWithoutSections(folderPath, false);
 
-            //TOC.Example_BasicTOC1(folderPath, false);
-            //TOC.Example_BasicTOC2(folderPath, false);
+            TOC.Example_BasicTOC1(folderPath, false);
+            TOC.Example_BasicTOC2(folderPath, false);
 
-            //Comments.Example_PlayingWithComments(folderPath, false);
+            Comments.Example_PlayingWithComments(folderPath, false);
 
-            //BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);
-            //BasicExcelFunctionality.BasicExcel_Example2(folderPath, false);
-            //BasicExcelFunctionality.BasicExcel_Example3(false);
+            BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);
+            BasicExcelFunctionality.BasicExcel_Example2(folderPath, false);
+            BasicExcelFunctionality.BasicExcel_Example3(false);
 
-            //BordersAndMargins.Example_BasicWordMarginsSizes(folderPath, false);
-            //BordersAndMargins.Example_BasicPageBorders1(folderPath, false);
-            //BordersAndMargins.Example_BasicPageBorders2(folderPath, false);
+            BordersAndMargins.Example_BasicWordMarginsSizes(folderPath, false);
+            BordersAndMargins.Example_BasicPageBorders1(folderPath, false);
+            BordersAndMargins.Example_BasicPageBorders2(folderPath, false);
 
-            //Bookmarks.Example_BasicWordWithBookmarks(folderPath, false);
-            //Fields.Example_DocumentWithFields(folderPath, false);
-            //Fields.Example_DocumentWithFields02(folderPath, false);
+            Bookmarks.Example_BasicWordWithBookmarks(folderPath, false);
+            Fields.Example_DocumentWithFields(folderPath, false);
+            Fields.Example_DocumentWithFields02(folderPath, false);
 
-            //Watermark.Watermark_Sample2(folderPath, false);
-            //Watermark.Watermark_Sample1(folderPath, false);
-            //Watermark.Watermark_Sample3(folderPath, false);
+            Watermark.Watermark_Sample2(folderPath, false);
+            Watermark.Watermark_Sample1(folderPath, false);
+            Watermark.Watermark_Sample3(folderPath, false);
 
-            //Embed.Example_EmbedFileHTML(folderPath, templatesPath, false);
-            //Embed.Example_EmbedFileRTF(folderPath, templatesPath, false);
-            //Embed.Example_EmbedFileRTFandHTML(folderPath, templatesPath, false);
-            //Embed.Example_EmbedFileRTFandHTMLandTOC(folderPath, templatesPath, false);
-            //Embed.Example_EmbedFileMultiple(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileHTML(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileRTF(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileRTFandHTML(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileRTFandHTMLandTOC(folderPath, templatesPath, false);
+            Embed.Example_EmbedFileMultiple(folderPath, templatesPath, false);
+            Embed.Example_EmbedHTMLFragment(folderPath, false);
 
-            //CleanupDocuments.CleanupDocuments_Sample01(false);
-            //CleanupDocuments.CleanupDocuments_Sample02(folderPath, false);
+            CleanupDocuments.CleanupDocuments_Sample01(false);
+            CleanupDocuments.CleanupDocuments_Sample02(folderPath, false);
 
-            //FindAndReplace.Example_FindAndReplace01(folderPath, false);
-            //FindAndReplace.Example_FindAndReplace02(folderPath, false);
+            FindAndReplace.Example_FindAndReplace01(folderPath, false);
+            FindAndReplace.Example_FindAndReplace02(folderPath, false);
 
-            //FootNotes.Example_DocumentWithFootNotes(templatesPath, false);
-            //FootNotes.Example_DocumentWithFootNotesEmpty(folderPath, false);
+            FootNotes.Example_DocumentWithFootNotes(templatesPath, false);
+            FootNotes.Example_DocumentWithFootNotesEmpty(folderPath, false);
 
-            //SaveToStream.Example_StreamDocumentProperties(folderPath, false);
+            SaveToStream.Example_StreamDocumentProperties(folderPath, false);
 
-            //Protect.Example_ProtectFinalDocument(folderPath, false);
-            //Protect.Example_ProtectAlwaysReadOnly(folderPath, false);
+            Protect.Example_ProtectFinalDocument(folderPath, false);
+            Protect.Example_ProtectAlwaysReadOnly(folderPath, false);
 
-            //WordTextBox.Example_AddingTextbox(folderPath, false);
-            //WordTextBox.Example_AddingTextbox2(folderPath, false);
-            //WordTextBox.Example_AddingTextbox4(folderPath, false);
-            //WordTextBox.Example_AddingTextbox5(folderPath, false);
-            //WordTextBox.Example_AddingTextbox3(folderPath, false);
-            //WordTextBox.Example_AddingTextboxCentimeters(folderPath, false);
+            WordTextBox.Example_AddingTextbox(folderPath, false);
+            WordTextBox.Example_AddingTextbox2(folderPath, false);
+            WordTextBox.Example_AddingTextbox4(folderPath, false);
+            WordTextBox.Example_AddingTextbox5(folderPath, false);
+            WordTextBox.Example_AddingTextbox3(folderPath, false);
+            WordTextBox.Example_AddingTextboxCentimeters(folderPath, false);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/Embed/EmbedFragmentHTML.cs
+++ b/OfficeIMO.Examples/Word/Embed/EmbedFragmentHTML.cs
@@ -1,0 +1,53 @@
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Embed {
+
+        public static void Example_EmbedHTMLFragment(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating standard document with embedded HTML fragment");
+            string filePath = System.IO.Path.Combine(folderPath, "EmbeddedFragmentHTML.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                Console.WriteLine("Embedded documents in word: " + document.EmbeddedDocuments.Count);
+                Console.WriteLine("Embedded documents in Section 0: " + document.Sections[0].EmbeddedDocuments.Count);
+
+                document.AddParagraph("Add HTML document in DOCX");
+
+                document.AddSection();
+
+                Console.WriteLine("Embedded documents in Section 1: " + document.Sections[1].EmbeddedDocuments.Count);
+
+                var htmlContent = """
+                                  <html lang="en">
+                                  <P>This is a paragraph.</P>
+                                  <P>This is another paragraph.</P>
+                                  <P>This is a paragraph with <STRONG>bold</STRONG> text.</P>
+                                  <P>This is a paragraph with <EM>italic</EM> text.</P>
+                                  <ul>
+                                    <li>Item 1</li>
+                                    <li>Item 2</li>
+                                    <li>Item 3</li>
+                                  </ul>
+                                  <ol>
+                                    <li>Item 1</li>
+                                    <li>Item 2</li>
+                                    <li>Item 3</li>
+                                  </ol>
+                                  <P>This is a paragraph with a <A href=""https://www.google.com"">link</A>.</P>
+                                  </html>
+                                  """;
+
+                document.AddEmbeddedFragment(htmlContent, AlternativeFormatImportPartType.Html);
+
+                document.EmbeddedDocuments[0].Save("C:\\TEMP\\EmbeddedFragment.html");
+
+                Console.WriteLine("Embedded documents in word: " + document.EmbeddedDocuments.Count);
+                Console.WriteLine("Embedded documents in Section 0: " + document.Sections[0].EmbeddedDocuments.Count);
+                Console.WriteLine("Embedded documents in Section 1: " + document.Sections[1].EmbeddedDocuments.Count);
+                Console.WriteLine("Content type: " + document.EmbeddedDocuments[0].ContentType);
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/OfficeIMO.Tests.csproj
+++ b/OfficeIMO.Tests/OfficeIMO.Tests.csproj
@@ -8,6 +8,7 @@
             net6.0;net7.0;net8.0
         </TargetFrameworks>
         <IsPackable>false</IsPackable>
+        <LangVersion>Latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.17.0" />
@@ -23,6 +24,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+
     </ItemGroup>
 
     <ItemGroup>

--- a/OfficeIMO.Tests/Word.EmbeddedDocuments.cs
+++ b/OfficeIMO.Tests/Word.EmbeddedDocuments.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using Xunit;
@@ -135,6 +136,36 @@ public partial class Word {
 
             var list2 = document._document.MainDocumentPart.AlternativeFormatImportParts;
             Assert.True(list2.Count() == 2);
+
+
+            var htmlContent = """
+                              <html lang="en">
+                              <P>This is a paragraph.</P>
+                              <P>This is another paragraph.</P>
+                              <P>This is a paragraph with <STRONG>bold</STRONG> text.</P>
+                              <P>This is a paragraph with <EM>italic</EM> text.</P>
+                              <ul>
+                                <li>Item 1</li>
+                                <li>Item 2</li>
+                                <li>Item 3</li>
+                              </ul>
+                              <ol>
+                                <li>Item 1</li>
+                                <li>Item 2</li>
+                                <li>Item 3</li>
+                              </ol>
+                              <P>This is a paragraph with a <A href=""https://www.google.com"">link</A>.</P>
+                              </html>
+                              """;
+
+            document.AddEmbeddedFragment(htmlContent, AlternativeFormatImportPartType.Html);
+
+            Assert.True(document.EmbeddedDocuments.Count == 3);
+            Assert.True(document.Sections[0].EmbeddedDocuments.Count == 2);
+            Assert.True(document.Sections[1].EmbeddedDocuments.Count == 1);
+
+            var list3 = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            Assert.True(list3.Count() == 3);
         }
     }
 }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -145,7 +145,12 @@ namespace OfficeIMO.Word {
         }
 
         public WordEmbeddedDocument AddEmbeddedDocument(string fileName, AlternativeFormatImportPartType? type = null) {
-            WordEmbeddedDocument embeddedDocument = new WordEmbeddedDocument(this, fileName, type);
+            WordEmbeddedDocument embeddedDocument = new WordEmbeddedDocument(this, fileName, type, false);
+            return embeddedDocument;
+        }
+
+        public WordEmbeddedDocument AddEmbeddedFragment(string htmlContent, AlternativeFormatImportPartType type) {
+            WordEmbeddedDocument embeddedDocument = new WordEmbeddedDocument(this, htmlContent, type, true);
             return embeddedDocument;
         }
 

--- a/OfficeIMO.Word/WordEmbeddedDocument.cs
+++ b/OfficeIMO.Word/WordEmbeddedDocument.cs
@@ -68,10 +68,10 @@ namespace OfficeIMO.Word {
             }
         }
 
-        public WordEmbeddedDocument(WordDocument wordDocument, string fileName, AlternativeFormatImportPartType? alternativeFormatImportPartType) {
+        public WordEmbeddedDocument(WordDocument wordDocument, string fileNameOrContent, AlternativeFormatImportPartType? alternativeFormatImportPartType, bool htmlFragment) {
             AlternativeFormatImportPartType partType;
             if (alternativeFormatImportPartType == null) {
-                FileInfo fileInfo = new FileInfo(fileName);
+                FileInfo fileInfo = new FileInfo(fileNameOrContent);
                 if (fileInfo.Extension == ".rtf") {
                     partType = AlternativeFormatImportPartType.Rtf;
                 } else if (fileInfo.Extension == ".html") {
@@ -93,7 +93,8 @@ namespace OfficeIMO.Word {
 
             AlternativeFormatImportPart chunk = mainDocPart.AddAlternativeFormatImportPart(partType, altChunk.Id);
 
-            var documentContent = File.ReadAllText(fileName, Encoding.ASCII);
+            // if it's a fragment, we don't need to read the file
+            var documentContent = htmlFragment ? fileNameOrContent : File.ReadAllText(fileNameOrContent, Encoding.ASCII);
 
             using (MemoryStream ms = new MemoryStream(Encoding.ASCII.GetBytes(documentContent))) {
                 chunk.FeedData(ms);


### PR DESCRIPTION
This PR resolves:
- https://github.com/EvotecIT/OfficeIMO/issues/228

The following example shows the use case. Remember that opening and closing <HTML> tags are necessary; otherwise, Microsoft Word won't open the file.

```cs
var htmlContent = """
                  <html lang="en">
                  <P>This is a paragraph.</P>
                  <P>This is another paragraph.</P>
                  <P>This is a paragraph with <STRONG>bold</STRONG> text.</P>
                  <P>This is a paragraph with <EM>italic</EM> text.</P>
                  <ul>
                    <li>Item 1</li>
                    <li>Item 2</li>
                    <li>Item 3</li>
                  </ul>
                  <ol>
                    <li>Item 1</li>
                    <li>Item 2</li>
                    <li>Item 3</li>
                  </ol>
                  <P>This is a paragraph with a <A href=""https://www.google.com"">link</A>.</P>
                  </html>
                  """;

document.AddEmbeddedFragment(htmlContent, AlternativeFormatImportPartType.Html);
```