### PR TITLE
Bump OpenXMLSDK to 2.20

### DIFF
--- a/OfficeIMO.Excel/OfficeIMO.Excel.csproj
+++ b/OfficeIMO.Excel/OfficeIMO.Excel.csproj
@@ -31,7 +31,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DocumentFormat.OpenXml" Version="[2.16.0,3.0.0)" />
+        <PackageReference Include="DocumentFormat.OpenXml" Version="[2.20.0,3.0.0)" />
         <PackageReference Include="SixLabors.ImageSharp" Version="[2.1.9,3.0.0)" />
     </ItemGroup>
 

--- a/OfficeIMO.VerifyTests/OfficeIMO.VerifyTests.csproj
+++ b/OfficeIMO.VerifyTests/OfficeIMO.VerifyTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/OfficeIMO.Word/ImportTableStyle.cs
+++ b/OfficeIMO.Word/ImportTableStyle.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,10 +14,10 @@ namespace OfficeIMO.Word {
             using (var repeaterSourceDocument = WordprocessingDocument.Open(sourcefilepath, true)) {
                 XDocument source_style_doc;
 
-                var repeaterSourceDocumentPackagePart = repeaterSourceDocument.MainDocumentPart.OpenXmlPackage.Package.GetPart(new Uri("/word/styles.xml", UriKind.Relative));
+                var repeaterSourceDocumentStylePart = repeaterSourceDocument.MainDocumentPart.StyleDefinitionsPart;
 
-                //Get styles.xml
-                using (TextReader tr = new StreamReader(repeaterSourceDocumentPackagePart.GetStream())) {
+                // Get styles.xml
+                using (TextReader tr = new StreamReader(repeaterSourceDocumentStylePart.GetStream())) {
                     source_style_doc = XDocument.Load(tr);
                 }
 
@@ -26,25 +26,24 @@ namespace OfficeIMO.Word {
                 using (var targetFileToImportTableStyles = WordprocessingDocument.Open(destinationfilepath, true)) {
                     XDocument dest_style_doc;
 
-                    var destpart = targetFileToImportTableStyles.MainDocumentPart.OpenXmlPackage.Package.GetPart(new Uri("/word/styles.xml", UriKind.Relative));
+                    var destStylePart = targetFileToImportTableStyles.MainDocumentPart.StyleDefinitionsPart;
 
-                    //Get styles.xml
-                    using (TextReader trd = new StreamReader(destpart.GetStream())) {
+                    // Get styles.xml
+                    using (TextReader trd = new StreamReader(destStylePart.GetStream())) {
                         dest_style_doc = XDocument.Load(trd);
                     }
 
-                    //Add all the style elements from source document styles.xml 
+                    // Add all the style elements from source document styles.xml 
                     foreach (var styleelement in tableStylesFromRepeaterSource) {
                         if (!dest_style_doc.Elements(XName.Get("styles", w.NamespaceName)).Any(x => (string)x.Attribute("styleId") == (string)styleelement.Attribute("styleId"))) {
                             dest_style_doc.Element(XName.Get("styles", w.NamespaceName)).Add(styleelement);
                         }
                     }
 
-                    //Save the style.xml of targetFile
-                    using (TextWriter tw = new StreamWriter(destpart.GetStream(FileMode.Create))) {
+                    // Save the style.xml of targetFile
+                    using (TextWriter tw = new StreamWriter(destStylePart.GetStream(FileMode.Create))) {
                         dest_style_doc.Save(tw, SaveOptions.None);
                     }
-
                 }
             }
         }

--- a/OfficeIMO.Word/OfficeIMO.Word.csproj
+++ b/OfficeIMO.Word/OfficeIMO.Word.csproj
@@ -62,7 +62,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DocumentFormat.OpenXml" Version="[2.16.0,3.0.0)" />
+        <PackageReference Include="DocumentFormat.OpenXml" Version="[2.20.0,3.0.0)" />
         <PackageReference Include="SixLabors.ImageSharp" Version="[2.1.9,3.0.0)" />
     </ItemGroup>
 

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -459,9 +459,10 @@ namespace OfficeIMO.Word {
 
         private FileStream _fileStream;
 
-        public FileAccess FileOpenAccess {
-            get { return _wordprocessingDocument.MainDocumentPart.OpenXmlPackage.Package.FileOpenAccess; }
-        }
+        /// <summary>
+        /// FileOpenAccess of the document
+        /// </summary>
+        public FileAccess FileOpenAccess => _wordprocessingDocument.FileOpenAccess;
 
         private static string GetUniqueFilePath(string filePath) {
             if (File.Exists(filePath)) {


### PR DESCRIPTION
This PR adds:
- Bump OpenXMLSDK to 2.20
- Fixes require code to run
- Add missing tests for NET 7.0 in VerifyTests