### PR TITLE
Bump dependencies / frameworks

### DIFF
--- a/OfficeIMO.Excel/OfficeIMO.Excel.csproj
+++ b/OfficeIMO.Excel/OfficeIMO.Excel.csproj
@@ -1,20 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Description>An Open Source cross-platform .NET library providing an easy way to create Excel documents.</Description>
+        <Description>An Open Source cross-platform .NET library providing an easy way to create
+            Excel documents.</Description>
         <AssemblyName>OfficeIMO.Excel</AssemblyName>
         <AssemblyTitle>OfficeIMO.Excel</AssemblyTitle>
 
         <VersionPrefix>1.0.0</VersionPrefix>
-        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">netstandard2.0;netstandard2.1;net472;net48;net6.0;net7.0;net8.0</TargetFrameworks>
-        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
+            netstandard2.0;net472;net48;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
+            net8.0;net9.0</TargetFrameworks>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
 
         <PackageId>OfficeIMO.Excel</PackageId>
-        <PackageTags>docx;net60;excel;office;openxml;net472;net48;net50;netstandard;netstandard2.0,netstandard2.1;net70</PackageTags>
+        <PackageTags>
+            docx;net60;excel;office;openxml;net472;net48;net50;netstandard;netstandard2.0,netstandard2.1;net70</PackageTags>
         <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
         <PackageLicenseUrl>https://github.com/EvotecIT/OfficeIMO/blob/master/LICENSE</PackageLicenseUrl>
         <DelaySign>False</DelaySign>
@@ -33,7 +37,7 @@
 
     <ItemGroup>
         <PackageReference Include="DocumentFormat.OpenXml" Version="[3.1.0,4.0.0)" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="[2.1.9,3.0.0)" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="[2.1.10,3.0.0)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OfficeIMO.Tests/OfficeIMO.Tests.csproj
+++ b/OfficeIMO.Tests/OfficeIMO.Tests.csproj
@@ -2,10 +2,10 @@
 
     <PropertyGroup>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
-            net472;net48;net6.0;net7.0;net8.0
+            net472;net48;net8.0;net9.0
         </TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
-            net6.0;net7.0;net8.0
+            net8.0;net9.0
         </TargetFrameworks>
         <IsPackable>false</IsPackable>
         <LangVersion>Latest</LangVersion>
@@ -13,7 +13,8 @@
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.18.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.0" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
+        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.0"
+            Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
         <PackageReference Include="SemanticComparison" Version="4.1.0" />
         <PackageReference Include="xunit" Version="2.8.1" />
         <PackageReference Include="coverlet.collector" Version="6.0.2">

--- a/OfficeIMO.VerifyTests/OfficeIMO.VerifyTests.csproj
+++ b/OfficeIMO.VerifyTests/OfficeIMO.VerifyTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/OfficeIMO.Word/OfficeIMO.Word.csproj
+++ b/OfficeIMO.Word/OfficeIMO.Word.csproj
@@ -1,19 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Description>An Open Source cross-platform .NET library providing an easy way to create Microsoft Word (DocX) documents.</Description>
+        <Description>An Open Source cross-platform .NET library providing an easy way to create
+            Microsoft Word (DocX) documents.</Description>
         <AssemblyName>OfficeIMO.Word</AssemblyName>
         <AssemblyTitle>OfficeIMO.Word</AssemblyTitle>
 
-        <VersionPrefix>0.20.0</VersionPrefix>
-        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">netstandard2.0;netstandard2.1;net472;net48;net6.0;net7.0;net8.0</TargetFrameworks>
-        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net6.0;net7.0;net8.0</TargetFrameworks>
+        <VersionPrefix>0.21.0</VersionPrefix>
+        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
+            netstandard2.0;netstandard2.1;net472;net48;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks
+            Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
+            net8.0</TargetFrameworks>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
 
         <PackageId>OfficeIMO.Word</PackageId>
-        <PackageTags>docx;net60;word;office;openxml;net472;net48;net50;netstandard;netstandard2.0,netstandard2.1;net70</PackageTags>
+        <PackageTags>
+            docx;net60;word;office;openxml;net472;net48;net50;netstandard;netstandard2.0,netstandard2.1;net70</PackageTags>
         <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
         <PackageLicenseUrl>https://github.com/EvotecIT/OfficeIMO/blob/master/LICENSE</PackageLicenseUrl>
         <DelaySign>False</DelaySign>
@@ -35,11 +40,13 @@
         <LangVersion>Latest</LangVersion>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
+    <PropertyGroup
+        Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
+    <PropertyGroup
+        Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
 
@@ -64,7 +71,7 @@
 
     <ItemGroup>
         <PackageReference Include="DocumentFormat.OpenXml" Version="[3.1.0,4.0.0)" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="[2.1.9,3.0.0)" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="[2.1.10,3.0.0)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -1,7 +1,3 @@
-# Build and run tests for .NET Desktop or Windows classic desktop solutions.
-# Add steps that publish symbols, save build artifacts, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
-
 trigger:
   batch: true
   branches:
@@ -37,33 +33,13 @@ variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
-  #DotNet3Version: '3.x'
-  DotNet6Version: '6.x'
-  DotNet7Version: '7.x'
   DotNet8Version: '8.x'
+  DotNet9Version: '9.x'
   MSBuildArgs: '"/p:Platform=$(BuildPlatform)" "/p:Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectoryName)\msbuild.binlog"'
 
 steps:
 - task: NuGetToolInstaller@1
   displayName: 'Install Nuget Tool Installer'
-
-#- script: |
-#    brew update
-#    brew tap caskroom/cask
-#    brew install mono-libgdiplus
-#  displayName: "Install Mono-libgdiplus"
-
-- task: UseDotNet@2
-  displayName: 'Install .NET 6.0'
-  inputs:
-    packageType: 'sdk'
-    version: '6.0.x'
-
-- task: UseDotNet@2
-  displayName: 'Install .NET 7.0'
-  inputs:
-    packageType: 'sdk'
-    version: '7.0.x'
 
 - task: UseDotNet@2
   displayName: 'Install .NET 8.0'
@@ -71,23 +47,17 @@ steps:
     packageType: 'sdk'
     version: '8.0.x'
 
-#- task: UseDotNet@2
-#  displayName: Install .NET 3.1
-#  inputs:
-#    version: '3.1.x'
-#    packageType: sdk
-#    includePreviewVersions: false
+- task: UseDotNet@2
+  displayName: 'Install .NET 9.0'
+  inputs:
+    packageType: 'sdk'
+    version: '9.0.x'
 
 # Add a Command To List the Current .NET SDKs (Sanity Check)
 - task: CmdLine@2
   displayName: 'List available .NET SDKs'
   inputs:
     script: 'dotnet --list-sdks'
-
-# - task: NuGetCommand@2
-#   displayName: Install Nuget Packages
-#   inputs:
-#     restoreSolution: '$(solution)'
 
 - task: DotNetCoreCLI@2
   displayName: 'Install Nuget Packages'
@@ -103,41 +73,6 @@ steps:
       dotnet tool install -g dotnet-reportgenerator-globaltool
   continueOnError: true
 
-#- task: DotNetCoreCLI@2
-#  displayName: 'Run Tests'
-#  inputs:
-#    command: 'test'
-#    arguments: '--configuration $(buildConfiguration) --collect:"Xplat Code Coverage"'
-#    publishTestResults: true
-#    projects: '**/*.Tests.csproj'
-
-#- task: DotNetCoreCLI@2
-#  displayName: 'Run Unit Tests (.NET 3.1)'
-#  inputs:
-#    command: 'test'
-#    arguments: '--framework netcoreapp3.1 /noautorsp'
-#    testRunTitle: 'Linux .NET 3.1'
-#  condition: succeededOrFailed()
-
-- task: DotNetCoreCLI@2
-  displayName: 'Run Unit Tests (.NET 6.0)'
-  inputs:
-    command: 'test'
-    arguments: '--framework net6.0 /noautorsp'
-    testRunTitle: 'Linux .NET 6.0'
-  condition: succeededOrFailed()
-
-- task: DotNetCoreCLI@2
-  displayName: 'Run Unit Tests (.NET 7.0)'
-  inputs:
-    command: 'test'
-    arguments: '--framework net7.0 /noautorsp'
-    testRunTitle: 'Linux .NET 7.0'
-    projects: |
-      **/*.Tests.csproj
-      !**/OfficeIMO.VerifyTests.csproj
-  condition: succeededOrFailed()
-
 - task: DotNetCoreCLI@2
   displayName: 'Run Unit Tests (.NET 8.0)'
   inputs:
@@ -146,8 +81,10 @@ steps:
     testRunTitle: 'Linux .NET 8.0'
   condition: succeededOrFailed()
 
-#- task: PublishCodeCoverageResults@1
-#  displayName: 'Publish Code Coverage Report'
-#  inputs:
-#    codeCoverageTool: 'Cobertura'
-#    summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
+- task: DotNetCoreCLI@2
+  displayName: 'Run Unit Tests (.NET 9.0)'
+  inputs:
+    command: 'test'
+    arguments: '--framework net9.0 /noautorsp'
+    testRunTitle: 'Linux .NET 9.0'
+  condition: succeededOrFailed()

--- a/azure-pipelines-macos.yml
+++ b/azure-pipelines-macos.yml
@@ -1,7 +1,3 @@
-# Build and run tests for .NET Desktop or Windows classic desktop solutions.
-# Add steps that publish symbols, save build artifacts, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
-
 trigger:
   batch: true
   branches:
@@ -37,35 +33,13 @@ variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
-  #DotNet3Version: '3.x'
-  DotNet6Version: '6.x'
-  DotNet7Version: '7.x'
   DotNet8Version: '8.x'
+  DotNet9Version: '9.x'
   MSBuildArgs: '"/p:Platform=$(BuildPlatform)" "/p:Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectoryName)\msbuild.binlog"'
 
 steps:
 - task: NuGetToolInstaller@1
   displayName: 'Install Nuget Tool Installer'
-
-# - script: |
-#     brew update
-#     brew tap caskroom/cask
-#     brew install mono-libgdiplus
-#   displayName: "Install Mono-libgdiplus"
-
-- task: UseDotNet@2
-  displayName: 'Install .NET 6.0'
-  inputs:
-    packageType: 'sdk'
-    version: '6.0.x'
-    includePreviewVersions: true
-
-- task: UseDotNet@2
-  displayName: 'Install .NET 7.0'
-  inputs:
-    packageType: 'sdk'
-    version: '7.0.x'
-    includePreviewVersions: true
 
 - task: UseDotNet@2
   displayName: 'Install .NET 8.0'
@@ -74,23 +48,18 @@ steps:
     version: '8.0.x'
     includePreviewVersions: true
 
-#- task: UseDotNet@2
-#  displayName: Install .NET 3.1
-#  inputs:
-#    version: '3.1.x'
-#    packageType: sdk
-#    includePreviewVersions: false
+- task: UseDotNet@2
+  displayName: 'Install .NET 8.0'
+  inputs:
+    packageType: 'sdk'
+    version: '9.0.x'
+    includePreviewVersions: true
 
 # Add a Command To List the Current .NET SDKs (Sanity Check)
 - task: CmdLine@2
   displayName: 'List available .NET SDKs'
   inputs:
     script: 'dotnet --list-sdks'
-
-# - task: NuGetCommand@2
-#   displayName: Install Nuget Packages
-#   inputs:
-#     restoreSolution: '$(solution)'
 
 - task: DotNetCoreCLI@2
   displayName: 'Install Nuget Packages'
@@ -106,48 +75,23 @@ steps:
       dotnet tool install -g dotnet-reportgenerator-globaltool
   continueOnError: true
 
-# - task: DotNetCoreCLI@2
-#   displayName: 'Run Tests'
-#   inputs:
-#     command: 'test'
-#     arguments: --configuration $(buildConfiguration) --collect "Code coverage"
-#     publishTestResults: true
-#     projects: '**/*.Tests.csproj'
-#     testRunTitle: 'macOS Test Run $(buildConfiguration), CPU: $(buildPlatform)'
-
-#- task: DotNetCoreCLI@2
-#  displayName: 'Run Unit Tests (.NET 3.1)'
-#  inputs:
-#    command: 'test'
-#    arguments: '--framework netcoreapp3.1 /noautorsp'
-#    testRunTitle: 'macOS .NET 3.1'
-#  condition: succeededOrFailed()
-
-- task: DotNetCoreCLI@2
-  displayName: 'Run Unit Tests (.NET 6.0)'
-  inputs:
-    command: 'test'
-    arguments: '--framework net6.0 /noautorsp'
-    testRunTitle: 'macOS .NET 6.0'
-  condition: succeededOrFailed()
-
-- task: DotNetCoreCLI@2
-  displayName: 'Run Unit Tests (.NET 7.0)'
-  inputs:
-    command: 'test'
-    arguments: '--framework net7.0 /noautorsp'
-    testRunTitle: 'macOS .NET 7.0'
-    projects: |
-      **/*.Tests.csproj
-      !**/OfficeIMO.VerifyTests.csproj
-  condition: succeededOrFailed()
-
 - task: DotNetCoreCLI@2
   displayName: 'Run Unit Tests (.NET 8.0)'
   inputs:
     command: 'test'
     arguments: '--framework net8.0 /noautorsp'
     testRunTitle: 'macOS .NET 8.0'
+    projects: |
+      **/*.Tests.csproj
+      !**/OfficeIMO.VerifyTests.csproj
+  condition: succeededOrFailed()
+
+- task: DotNetCoreCLI@2
+  displayName: 'Run Unit Tests (.NET 9.0)'
+  inputs:
+    command: 'test'
+    arguments: '--framework net9.0 /noautorsp'
+    testRunTitle: 'macOS .NET 9.0'
     projects: |
       **/*.Tests.csproj
       !**/OfficeIMO.VerifyTests.csproj

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,3 @@
-# Build and run tests for .NET Desktop or Windows classic desktop solutions.
-# Add steps that publish symbols, save build artifacts, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
-
 trigger:
   batch: true
   branches:
@@ -43,29 +39,16 @@ steps:
   displayName: 'Install Nuget Tool Installer'
 
 - task: UseDotNet@2
-  displayName: 'Install .NET 6.0'
-  inputs:
-    packageType: 'sdk'
-    version: '6.0.x'
-
-- task: UseDotNet@2
-  displayName: 'Install .NET 7.0'
-  inputs:
-    packageType: 'sdk'
-    version: '7.0.x'
-
-- task: UseDotNet@2
   displayName: 'Install .NET 8.0'
   inputs:
     packageType: 'sdk'
     version: '8.0.x'
 
-#- task: UseDotNet@2
-#  displayName: Install .NET 3.1
-#  inputs:
-#    version: '3.1.x'
-#    packageType: sdk
-#    includePreviewVersions: false
+- task: UseDotNet@2
+  displayName: 'Install .NET 9.0'
+  inputs:
+    packageType: 'sdk'
+    version: '9.0.x'
 
 # Add a Command To List the Current .NET SDKs (Sanity Check)
 - task: CmdLine@2
@@ -85,17 +68,6 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
 
-# - task: VSTest@2
-#   displayName: Run Tests .NET Framework
-#   inputs:
-#     testSelector: 'testAssemblies'
-#     testAssemblyVer2: |
-#       **\*OfficeIMO.Tests.dll
-#     searchFolder: '$(System.DefaultWorkingDirectory)'
-#     publishRunAttachments: true
-#     codeCoverageEnabled: true
-#     runSettingsFile: CodeCoverage.runsettings
-
 - task: DotNetCoreCLI@2
   displayName: 'Run Tests'
   inputs:
@@ -106,9 +78,3 @@ steps:
       **/*.Tests.csproj
       !**/OfficeIMO.VerifyTests.csproj
     testRunTitle: 'Windows Test Run $(buildConfiguration), CPU: $(buildPlatform)'
-
-# - task: PublishCodeCoverageResults@1
-#   displayName: 'Publish Code Coverage Report'
-#   inputs:
-#     codeCoverageTool: 'Cobertura'
-#     summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'


### PR DESCRIPTION
This PR:
- bumps SixLabors to higher version
- removes net 6.0, net 7.0 and netstandard 2.1
- adds 9.0