### PR TITLE
Add unit conversion helpers

### DIFF
--- a/OfficeIMO.Tests/Word.Indentation.cs
+++ b/OfficeIMO.Tests/Word.Indentation.cs
@@ -1,0 +1,43 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_ParagraphIndentationPoints() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithIndentationPoints.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Indented paragraph");
+                paragraph.IndentationBeforePoints = 10;
+                paragraph.IndentationAfterPoints = 5;
+                paragraph.IndentationFirstLinePoints = 15;
+                paragraph.IndentationHangingPoints = 2;
+
+                Assert.Equal(10, paragraph.IndentationBeforePoints);
+                Assert.Equal(5, paragraph.IndentationAfterPoints);
+                Assert.Equal(15, paragraph.IndentationFirstLinePoints);
+                Assert.Equal(2, paragraph.IndentationHangingPoints);
+
+                Assert.Equal(200, paragraph.IndentationBefore);
+                Assert.Equal(100, paragraph.IndentationAfter);
+                Assert.Equal(300, paragraph.IndentationFirstLine);
+                Assert.Equal(40, paragraph.IndentationHanging);
+
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var p = document.Paragraphs[0];
+                Assert.Equal(10, p.IndentationBeforePoints);
+                Assert.Equal(5, p.IndentationAfterPoints);
+                Assert.Equal(15, p.IndentationFirstLinePoints);
+                Assert.Equal(2, p.IndentationHangingPoints);
+                Assert.Equal(200, p.IndentationBefore);
+                Assert.Equal(100, p.IndentationAfter);
+                Assert.Equal(300, p.IndentationFirstLine);
+                Assert.Equal(40, p.IndentationHanging);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/Helpers.cs
+++ b/OfficeIMO.Word/Helpers.cs
@@ -201,6 +201,66 @@ namespace OfficeIMO.Word {
             double centimeters = (points / 72) * 2.54;
             return centimeters;
         }
+
+        /// <summary>
+        /// Converts twips (twentieths of a point) to points
+        /// </summary>
+        /// <param name="twipsValue">The value in twips.</param>
+        /// <returns>Points value.</returns>
+        internal static double ConvertTwipsToPoints(int twipsValue) {
+            double points = twipsValue / 20.0;
+            return Math.Round(points, 2);
+        }
+
+        /// <summary>
+        /// Converts twips (twentieths of a point) to points
+        /// </summary>
+        /// <param name="twipsValue">The value in twips.</param>
+        /// <returns>Points value.</returns>
+        internal static double ConvertTwipsToPoints(UInt32 twipsValue) {
+            double points = twipsValue / 20.0;
+            return Math.Round(points, 2);
+        }
+
+        /// <summary>
+        /// Converts points to twips (twentieths of a point)
+        /// </summary>
+        /// <param name="points">The points value.</param>
+        /// <returns>Twips value.</returns>
+        internal static int ConvertPointsToTwips(double points) {
+            int twips = (int)Math.Round(points * 20.0);
+            return twips;
+        }
+
+        /// <summary>
+        /// Converts points to twips (twentieths of a point)
+        /// </summary>
+        /// <param name="points">The points value.</param>
+        /// <returns>Twips value.</returns>
+        internal static UInt32 ConvertPointsToTwipsUInt32(double points) {
+            UInt32 twips = (UInt32)Math.Round(points * 20.0);
+            return twips;
+        }
+
+        /// <summary>
+        /// Converts EMUs to points
+        /// </summary>
+        /// <param name="emusValue">EMUs value.</param>
+        /// <returns>Points value.</returns>
+        internal static double ConvertEmusToPoints(Int64 emusValue) {
+            double points = emusValue / 12700.0;
+            return points;
+        }
+
+        /// <summary>
+        /// Converts points to EMUs
+        /// </summary>
+        /// <param name="points">Points value.</param>
+        /// <returns>EMUs value.</returns>
+        internal static Int64 ConvertPointsToEmusInt64(double points) {
+            Int64 emus = (Int64)(points * 12700.0);
+            return emus;
+        }
     }
 
     internal record ImageCharacteristics(double Width, double Height, CustomImagePartType Type);

--- a/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
@@ -79,6 +79,23 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the indentation before in points.
+        /// </summary>
+        public double? IndentationBeforePoints {
+            get {
+                if (IndentationBefore != null) {
+                    return Helpers.ConvertTwipsToPoints(IndentationBefore.Value);
+                }
+                return null;
+            }
+            set {
+                if (value != null) {
+                    IndentationBefore = Helpers.ConvertPointsToTwips(value.Value);
+                }
+            }
+        }
+
         public int? IndentationAfter {
             // TODO: probably needs calculated values instead of just values
             //https://startbigthinksmall.wordpress.com/2010/01/04/points-inches-and-emus-measuring-units-in-office-open-xml/
@@ -104,6 +121,23 @@ namespace OfficeIMO.Word {
 
                 indentation.Right = value.ToString();
                 _paragraphProperties.Indentation = indentation;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the indentation after in points.
+        /// </summary>
+        public double? IndentationAfterPoints {
+            get {
+                if (IndentationAfter != null) {
+                    return Helpers.ConvertTwipsToPoints(IndentationAfter.Value);
+                }
+                return null;
+            }
+            set {
+                if (value != null) {
+                    IndentationAfter = Helpers.ConvertPointsToTwips(value.Value);
+                }
             }
         }
 
@@ -152,6 +186,23 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the first line indentation in points.
+        /// </summary>
+        public double? IndentationFirstLinePoints {
+            get {
+                if (IndentationFirstLine != null) {
+                    return Helpers.ConvertTwipsToPoints(IndentationFirstLine.Value);
+                }
+                return null;
+            }
+            set {
+                if (value != null) {
+                    IndentationFirstLine = Helpers.ConvertPointsToTwips(value.Value);
+                }
+            }
+        }
+
         public int? IndentationHanging {
             // TODO: probably needs calculated values instead of just values
             //https://startbigthinksmall.wordpress.com/2010/01/04/points-inches-and-emus-measuring-units-in-office-open-xml/
@@ -177,6 +228,23 @@ namespace OfficeIMO.Word {
 
                 indentation.Hanging = value.ToString();
                 _paragraphProperties.Indentation = indentation;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the hanging indentation in points.
+        /// </summary>
+        public double? IndentationHangingPoints {
+            get {
+                if (IndentationHanging != null) {
+                    return Helpers.ConvertTwipsToPoints(IndentationHanging.Value);
+                }
+                return null;
+            }
+            set {
+                if (value != null) {
+                    IndentationHanging = Helpers.ConvertPointsToTwips(value.Value);
+                }
             }
         }
 

--- a/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
@@ -52,8 +52,6 @@ namespace OfficeIMO.Word {
         }
 
         public int? IndentationBefore {
-            // TODO: probably needs calculated values instead of just values
-            //https://startbigthinksmall.wordpress.com/2010/01/04/points-inches-and-emus-measuring-units-in-office-open-xml/
             get {
                 if (_paragraphProperties != null && _paragraphProperties.Indentation != null) {
                     //new Indentation() { Left = "720", Right = "0", FirstLine = "0" };
@@ -97,8 +95,6 @@ namespace OfficeIMO.Word {
         }
 
         public int? IndentationAfter {
-            // TODO: probably needs calculated values instead of just values
-            //https://startbigthinksmall.wordpress.com/2010/01/04/points-inches-and-emus-measuring-units-in-office-open-xml/
             get {
                 if (_paragraphProperties != null && _paragraphProperties.Indentation != null) {
                     //new Indentation() { Left = "720", Right = "0", FirstLine = "0" };
@@ -160,8 +156,6 @@ namespace OfficeIMO.Word {
         }
 
         public int? IndentationFirstLine {
-            // TODO: probably needs calculated values instead of just values
-            //https://startbigthinksmall.wordpress.com/2010/01/04/points-inches-and-emus-measuring-units-in-office-open-xml/
             get {
                 if (_paragraphProperties != null && _paragraphProperties.Indentation != null) {
                     if (_paragraphProperties.Indentation.FirstLine != "") {
@@ -204,8 +198,6 @@ namespace OfficeIMO.Word {
         }
 
         public int? IndentationHanging {
-            // TODO: probably needs calculated values instead of just values
-            //https://startbigthinksmall.wordpress.com/2010/01/04/points-inches-and-emus-measuring-units-in-office-open-xml/
             get {
                 if (_paragraphProperties != null && _paragraphProperties.Indentation != null) {
                     //new Indentation() { Left = "720", Right = "0", FirstLine = "0" };

--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ This list of features is for times when you want to quickly fix something rather
 This features are available as part of `WordHelpers` class.
 
 - ☑️ Remove Headers and Footers from a file
-- ☑️ Set paragraph indentation using point values
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This list of features is for times when you want to quickly fix something rather
 This features are available as part of `WordHelpers` class.
 
 - ☑️ Remove Headers and Footers from a file
+- ☑️ Set paragraph indentation using point values
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- convert twips and EMUs to points and back
- allow setting paragraph indentation using point values
- document new option in README
- add indentation unit test

## Testing
- `dotnet test OfficeImo.sln -v minimal` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6847c48b1f54832e8eb75d65d98c7748