### PR TITLE
Add image watermark support

### DIFF
--- a/OfficeIMO.Tests/Word.Watermark.cs
+++ b/OfficeIMO.Tests/Word.Watermark.cs
@@ -193,5 +193,32 @@ namespace OfficeIMO.Tests {
                 document.Save();
             }
         }
+
+        [Fact]
+        public void Test_CreatingWordDocumentWithWatermarkImage() {
+            string filePath = Path.Combine(_directoryWithFiles, "Test_WatermarkImage.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Section 0");
+
+                var imagePath = Path.Combine(_directoryWithImages, "PrzemyslawKlysAndKulkozaurr.jpg");
+
+                document.AddHeadersAndFooters();
+                document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Image, imagePath);
+
+                Assert.True(document.Header.Default.Images.Count == 1);
+
+                var section = document.AddSection();
+                section.AddWatermark(WordWatermarkStyle.Image, imagePath);
+
+                Assert.True(document.Sections[1].Header.Default.Images.Count == 1);
+
+                document.Save();
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.True(document.Header.Default.Images.Count == 1);
+                Assert.True(document.Sections[1].Header.Default.Images.Count == 1);
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordWatermark.cs
+++ b/OfficeIMO.Word/WordWatermark.cs
@@ -329,9 +329,18 @@ namespace OfficeIMO.Word {
                     lastParagraph._paragraph.Parent.Append(_sdtBlock);
                 }
             } else {
-                // TODO: Add handling for watermark image
+                if (wordSection.Header.Default == null) {
+                    wordSection.AddHeadersAndFooters();
+                }
 
+                this._wordHeader = wordSection.Header.Default;
 
+                var fileName = System.IO.Path.GetFileName(textOrFilePath);
+                using var imageStream = new System.IO.FileStream(textOrFilePath, System.IO.FileMode.Open);
+
+                var wordParagraph = this._wordHeader.AddParagraph();
+                var imageLocation = WordImage.AddImageToLocation(wordDocument, wordParagraph, imageStream, fileName);
+                AddWatermarkImage(wordParagraph, imageLocation);
             }
         }
 


### PR DESCRIPTION
## Summary
- enable `WordWatermark` to embed images when image style is used from `WordSection`
- add tests covering image watermark usage

## Testing
- `dotnet test` *(fails: NETSDK1045 - current .NET SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6847c4a4128c832eab289e34770b1e86