### PR TITLE
Implement BiDi paragraph property

### DIFF
--- a/Docs/officeimo.word.wordparagraph.md
+++ b/Docs/officeimo.word.wordparagraph.md
@@ -282,6 +282,16 @@ public Nullable<TextDirectionValues> TextDirection { get; set; }
 
 [Nullable&lt;TextDirectionValues&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.nullable-1)<br>
 
+### **BiDi**
+
+```csharp
+public bool BiDi { get; set; }
+```
+
+#### Property Value
+
+[Boolean](https://docs.microsoft.com/en-us/dotnet/api/system.boolean)<br>
+
 ### **LineSpacingRule**
 
 ```csharp

--- a/OfficeIMO.Tests/Word.Properties.cs
+++ b/OfficeIMO.Tests/Word.Properties.cs
@@ -168,6 +168,36 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ReadBiDiProperty() {
+            string tempFile = Path.GetTempFileName();
+            using (WordDocument document = WordDocument.Create(tempFile)) {
+                document.AddParagraph("BiDi paragraph").BiDi = true;
+                document.Save();
+            }
+
+            using (WordDocument document = WordDocument.Load(tempFile)) {
+                Assert.True(document.Paragraphs[0].BiDi);
+            }
+        }
+
+        [Fact]
+        public void Test_SettingBiDiProperty() {
+            bool stateBefore;
+            string originalFile = Path.Combine(_directoryDocuments, "EmptyDocument.docx");
+            string tempFile = Path.GetTempFileName();
+
+            using (WordDocument document = WordDocument.Load(originalFile)) {
+                stateBefore = document.Paragraphs[0].BiDi;
+                document.Paragraphs[0].BiDi = !stateBefore;
+                document.Save(tempFile);
+            }
+
+            using (WordDocument document = WordDocument.Load(tempFile)) {
+                Assert.True(document.Paragraphs[0].BiDi != stateBefore);
+            }
+        }
+
+        [Fact]
         public void Test_SetStyleId() {
            
             string originalFile = Path.Combine(_directoryDocuments, "EmptyDocument.docx");

--- a/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
@@ -261,6 +261,26 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Indicates that paragraph text should be displayed from right to left.
+        /// </summary>
+        public bool BiDi {
+            get {
+                return _paragraphProperties != null && _paragraphProperties.BiDi is not null;
+            }
+            set {
+                if (value) {
+                    if (_paragraphProperties.BiDi == null) {
+                        _paragraphProperties.BiDi = new BiDi();
+                    }
+                } else {
+                    if (_paragraphProperties.BiDi != null) {
+                        _paragraphProperties.BiDi.Remove();
+                    }
+                }
+            }
+        }
+
         public LineSpacingRuleValues? LineSpacingRule {
             get {
                 if (_paragraphProperties != null && _paragraphProperties.SpacingBetweenLines != null) {


### PR DESCRIPTION
## Summary
- add `BiDi` paragraph property for right‑to‑left text
- document new property in `WordParagraph`
- cover BiDi with unit tests and sample DOCX
- remove docx test fixture; generate BiDi doc in tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848889e6b84832ebf01da4f1ecd1e78