### PR TITLE
Add footnote/endnote helper methods

### DIFF
--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Load.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Load.cs
@@ -13,7 +13,17 @@ namespace OfficeIMO.Examples.Word {
             string filePath = System.IO.Path.Combine(templatesPath, "Hamlet.docx");
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                // TODO: add reading/writing FootnoteProperties/EndnoteProperties 
+                Console.WriteLine($"Footnotes position: {document.FootnoteProperties?.FootnotePosition?.Val}");
+                Console.WriteLine($"Endnotes position: {document.EndnoteProperties?.EndnotePosition?.Val}");
+                Console.WriteLine($"Footnotes start: {document.FootnoteProperties?.NumberingStart?.Val}");
+                Console.WriteLine($"Endnotes restart: {document.EndnoteProperties?.NumberingRestart?.Val}");
+
+                document.AddFootnoteProperties(position: FootnotePositionValues.PageBottom,
+                                            restartNumbering: RestartNumberValues.EachSection,
+                                            startNumber: 1);
+                document.AddEndnoteProperties(position: EndnotePositionValues.SectionEnd,
+                                            restartNumbering: RestartNumberValues.EachSection,
+                                            startNumber: 1);
 
                 Console.WriteLine("----");
                 Console.WriteLine(document.Sections.Count);

--- a/OfficeIMO.Tests/Word.FootnoteEndnoteProperties.cs
+++ b/OfficeIMO.Tests/Word.FootnoteEndnoteProperties.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_FootnoteEndnotePropertiesRoundtrip() {
+            string filePath = Path.Combine(_directoryWithFiles, "FootnoteEndnoteProperties.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddFootnoteProperties(NumberFormatValues.LowerRoman,
+                                            FootnotePositionValues.PageBottom,
+                                            RestartNumberValues.EachSection,
+                                            5);
+                document.AddEndnoteProperties(NumberFormatValues.Decimal,
+                                            EndnotePositionValues.SectionEnd,
+                                            RestartNumberValues.EachSection,
+                                            5);
+                document.Save();
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal(NumberFormatValues.LowerRoman, document.Sections[0].FootnoteProperties.NumberingFormat.Val.Value);
+                Assert.Equal(FootnotePositionValues.PageBottom, document.Sections[0].FootnoteProperties.FootnotePosition.Val.Value);
+                Assert.Equal(RestartNumberValues.EachSection, document.Sections[0].FootnoteProperties.NumberingRestart.Val.Value);
+                Assert.Equal(5, document.Sections[0].FootnoteProperties.NumberingStart.Val.Value);
+
+                Assert.Equal(NumberFormatValues.Decimal, document.Sections[0].EndnoteProperties.NumberingFormat.Val.Value);
+                Assert.Equal(EndnotePositionValues.SectionEnd, document.Sections[0].EndnoteProperties.EndnotePosition.Val.Value);
+                Assert.Equal(RestartNumberValues.EachSection, document.Sections[0].EndnoteProperties.NumberingRestart.Val.Value);
+                Assert.Equal(5, document.Sections[0].EndnoteProperties.NumberingStart.Val.Value);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.SectionProperties.cs
+++ b/OfficeIMO.Word/WordDocument.SectionProperties.cs
@@ -73,5 +73,53 @@ namespace OfficeIMO.Word {
                 this.Sections[0].PageSettings = value;
             }
         }
+
+        public FootnoteProperties FootnoteProperties {
+            get {
+                if (this.Sections.Count > 1) {
+                    Debug.WriteLine("This document contains more than 1 section. Consider using Sections[wantedSection].FootnoteProperties.");
+                }
+
+                return this.Sections[0].FootnoteProperties;
+            }
+            set {
+                if (this.Sections.Count > 1) {
+                    Debug.WriteLine("This document contains more than 1 section. Consider using Sections[wantedSection].FootnoteProperties.");
+                }
+
+                this.Sections[0].FootnoteProperties = value;
+            }
+        }
+
+        public EndnoteProperties EndnoteProperties {
+            get {
+                if (this.Sections.Count > 1) {
+                    Debug.WriteLine("This document contains more than 1 section. Consider using Sections[wantedSection].EndnoteProperties.");
+                }
+
+                return this.Sections[0].EndnoteProperties;
+            }
+            set {
+                if (this.Sections.Count > 1) {
+                    Debug.WriteLine("This document contains more than 1 section. Consider using Sections[wantedSection].EndnoteProperties.");
+                }
+
+                this.Sections[0].EndnoteProperties = value;
+            }
+        }
+
+        public void AddFootnoteProperties(NumberFormatValues? numberingFormat = null,
+            FootnotePositionValues? position = null,
+            RestartNumberValues? restartNumbering = null,
+            int? startNumber = null) {
+            this.Sections[0].AddFootnoteProperties(numberingFormat, position, restartNumbering, startNumber);
+        }
+
+        public void AddEndnoteProperties(NumberFormatValues? numberingFormat = null,
+            EndnotePositionValues? position = null,
+            RestartNumberValues? restartNumbering = null,
+            int? startNumber = null) {
+            this.Sections[0].AddEndnoteProperties(numberingFormat, position, restartNumbering, startNumber);
+        }
     }
 }

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -77,5 +77,73 @@ namespace OfficeIMO.Word {
         public WordTextBox AddTextBox(string text, WrapTextImage wrapTextImage = WrapTextImage.Square) {
             return AddParagraph(newRun: true).AddTextBox(text, wrapTextImage);
         }
+
+        public WordSection AddFootnoteProperties(NumberFormatValues? numberingFormat = null,
+            FootnotePositionValues? position = null,
+            RestartNumberValues? restartNumbering = null,
+            int? startNumber = null) {
+            var props = _sectionProperties.GetFirstChild<FootnoteProperties>();
+            if (props == null) {
+                props = new FootnoteProperties();
+                _sectionProperties.Append(props);
+            }
+
+            props.RemoveAllChildren<NumberingFormat>();
+            props.RemoveAllChildren<FootnotePosition>();
+            props.RemoveAllChildren<NumberingRestart>();
+            props.RemoveAllChildren<NumberingStart>();
+
+            if (numberingFormat != null) {
+                props.Append(new NumberingFormat() { Val = numberingFormat });
+            }
+
+            if (position != null) {
+                props.Append(new FootnotePosition() { Val = position });
+            }
+
+            if (restartNumbering != null) {
+                props.Append(new NumberingRestart() { Val = restartNumbering });
+            }
+
+            if (startNumber != null) {
+                props.Append(new NumberingStart() { Val = (UInt16Value)startNumber.Value });
+            }
+
+            return this;
+        }
+
+        public WordSection AddEndnoteProperties(NumberFormatValues? numberingFormat = null,
+            EndnotePositionValues? position = null,
+            RestartNumberValues? restartNumbering = null,
+            int? startNumber = null) {
+            var props = _sectionProperties.GetFirstChild<EndnoteProperties>();
+            if (props == null) {
+                props = new EndnoteProperties();
+                _sectionProperties.Append(props);
+            }
+
+            props.RemoveAllChildren<NumberingFormat>();
+            props.RemoveAllChildren<EndnotePosition>();
+            props.RemoveAllChildren<NumberingRestart>();
+            props.RemoveAllChildren<NumberingStart>();
+
+            if (numberingFormat != null) {
+                props.Append(new NumberingFormat() { Val = numberingFormat });
+            }
+
+            if (position != null) {
+                props.Append(new EndnotePosition() { Val = position });
+            }
+
+            if (restartNumbering != null) {
+                props.Append(new NumberingRestart() { Val = restartNumbering });
+            }
+
+            if (startNumber != null) {
+                props.Append(new NumberingStart() { Val = (UInt16Value)startNumber.Value });
+            }
+
+            return this;
+        }
     }
 }

--- a/OfficeIMO.Word/WordSection.SectionProperties.cs
+++ b/OfficeIMO.Word/WordSection.SectionProperties.cs
@@ -56,5 +56,31 @@ namespace OfficeIMO.Word {
                 if (value != null) columns.ColumnCount = (Int16Value)value.Value;
             }
         }
+
+        public FootnoteProperties FootnoteProperties {
+            get {
+                return _sectionProperties.GetFirstChild<FootnoteProperties>();
+            }
+            set {
+                var existing = _sectionProperties.GetFirstChild<FootnoteProperties>();
+                existing?.Remove();
+                if (value != null) {
+                    _sectionProperties.Append(value);
+                }
+            }
+        }
+
+        public EndnoteProperties EndnoteProperties {
+            get {
+                return _sectionProperties.GetFirstChild<EndnoteProperties>();
+            }
+            set {
+                var existing = _sectionProperties.GetFirstChild<EndnoteProperties>();
+                existing?.Remove();
+                if (value != null) {
+                    _sectionProperties.Append(value);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expose helper methods AddFootnoteProperties and AddEndnoteProperties
- show new API usage in basic load example
- add unit test for round-trip of footnote/endnote properties

## Testing
- `dotnet test OfficeImo.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6847c912edb0832eb4e00ed1ac10181f