### PR TITLE
Fix embedded object configuration

### DIFF
--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -150,6 +150,7 @@ namespace OfficeIMO.Word {
 
         public WordParagraph AddEmbeddedObject(string filePath, string imageFilePath) {
             return this.AddParagraph().AddEmbeddedObject(filePath, imageFilePath);
+        }
         public WordEmbeddedDocument AddEmbeddedDocument(string fileName, WordAlternativeFormatImportPartType? type = null) {
             return new WordEmbeddedDocument(this, fileName, type, false);
         }

--- a/OfficeIMO.Word/WordEmbeddedObject.cs
+++ b/OfficeIMO.Word/WordEmbeddedObject.cs
@@ -39,6 +39,23 @@ namespace OfficeIMO.Word {
         //    return paragraph1;
         //}
 
+        private (string contentType, string programId) GetObjectInfo(string fileName) {
+            string extension = System.IO.Path.GetExtension(fileName).ToLower();
+            return extension switch {
+                ".xlsx" => ("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "Excel.Sheet.12"),
+                ".xls"  => ("application/vnd.ms-excel", "Excel.Sheet.8"),
+                ".docx" => ("application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Word.Document.12"),
+                ".doc"  => ("application/msword", "Word.Document.8"),
+                ".pptx" => ("application/vnd.openxmlformats-officedocument.presentationml.presentation", "PowerPoint.Show.12"),
+                ".ppt"  => ("application/vnd.ms-powerpoint", "PowerPoint.Show.8"),
+                ".pdf"  => ("application/pdf", "AcroExch.Document.DC"),
+                ".html" => ("text/html", "htmlfile"),
+                ".htm"  => ("text/html", "htmlfile"),
+                ".rtf"  => ("application/rtf", "Word.RTF.8"),
+                _       => ("application/octet-stream", "Package")
+            };
+        }
+
         private EmbeddedObject ConvertFileToEmbeddedObject(WordDocument wordDocument, string fileName, string fileImage) {
             ImagePart imagePart = wordDocument._document.MainDocumentPart.AddImagePart(ImagePartType.Png);
             using (FileStream stream = new FileStream(fileImage, FileMode.Open)) {
@@ -46,8 +63,7 @@ namespace OfficeIMO.Word {
             }
             MainDocumentPart mainPart = wordDocument._document.MainDocumentPart;
 
-            var contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-            var programId = "Excel.Sheet.12";
+            var (contentType, programId) = GetObjectInfo(fileName);
             //ProgId = "Package",
             //var contentType = "application/vnd.openxmlformats-officedocument.oleObject";
             //var programId = "Package";
@@ -58,8 +74,6 @@ namespace OfficeIMO.Word {
             using (FileStream fileStream = new FileStream(fileName, FileMode.Open)) {
                 embeddedObjectPart.FeedData(fileStream);
             }
-
-            var test = embeddedObjectPart.ContentType;
 
             var idImagePart = mainPart.GetIdOfPart(imagePart);
             var idEmbeddedObjectPart = mainPart.GetIdOfPart(embeddedObjectPart);
@@ -151,19 +165,9 @@ namespace OfficeIMO.Word {
                 Type = Ovml.OleValues.Embed,
                 ProgId = programId,
                 ShapeId = "_x0000_i1029",
-                // DrawAspect = Ovml.OleDrawAspectValues.Content,
                 DrawAspect = Ovml.OleDrawAspectValues.Content,
-                ObjectId = "_1736428651",
+                ObjectId = "_" + Guid.NewGuid().ToString("N"),
                 Id = packageEmbedId
-            };
-
-
-            Ovml.OleObject oleObject2 = new Ovml.OleObject() {
-                Type = Ovml.OleValues.Embed,
-                ProgId = "Package",
-                ShapeId = "_x0000_i1025",
-                DrawAspect = Ovml.OleDrawAspectValues.Content,
-                ObjectId = "_1736440255", Id = "rId5"
             };
 
 

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -321,6 +321,7 @@ namespace OfficeIMO.Word {
         public WordParagraph AddEmbeddedObject(string filePath, string imageFilePath) {
             var wordEmbeddedObject = new WordEmbeddedObject(this, this._document, filePath, imageFilePath, "");
             return this;
+        }
 
         /// <summary>
         /// Provides ability for configuration of Tabs in a paragraph


### PR DESCRIPTION
## Summary
- map embedded object extensions to correct content types and ProgIds
- generate a unique object id when embedding

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_684889d435dc832e967f8a067f63c882