### PR TITLE
Fix vertical merge when cell properties missing

### DIFF
--- a/OfficeIMO.Examples/Word/Tables/Tables.Create2.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.Create2.cs
@@ -90,6 +90,7 @@ namespace OfficeIMO.Examples.Word {
                 wordTable = document.AddTable(7, 4, WordTableStyle.PlainTable1);
 
                 wordTable.Rows[0].Cells[2].Paragraphs[0].Text = "Some test 0";
+                wordTable.Rows[0].Cells[0].MergeVertically(1);
                 wordTable.Rows[1].Cells[2].Paragraphs[0].Text = "Some test 1";
                 wordTable.Rows[2].Cells[2].Paragraphs[0].Text = "Some test 2";
                 wordTable.Rows[3].Cells[2].Paragraphs[0].Text = "Some test 3";

--- a/OfficeIMO.Tests/Word.Tables.cs
+++ b/OfficeIMO.Tests/Word.Tables.cs
@@ -509,8 +509,7 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[2].Cells[0].Paragraphs[0].Text = "Another";
 
                 // simulate cell loaded without properties
-                wordTable.Rows[0].Cells[0]._tableCellProperties.Remove();
-                wordTable.Rows[0].Cells[0]._tableCellProperties = null;
+                wordTable.Rows[0].Cells[0].RemoveTableCellProperties();
 
                 wordTable.Rows[0].Cells[0].MergeVertically(1, true);
 

--- a/OfficeIMO.Tests/Word.Tables.cs
+++ b/OfficeIMO.Tests/Word.Tables.cs
@@ -513,12 +513,12 @@ namespace OfficeIMO.Tests {
 
                 wordTable.Rows[0].Cells[0].MergeVertically(1, true);
 
-                Assert.True(wordTable.Rows[0].Cells[0].VerticalMerge == MergedCellValues.Restart);
-                Assert.True(wordTable.Rows[1].Cells[0].VerticalMerge == MergedCellValues.Continue);
-                Assert.True(wordTable.Rows[2].Cells[0].VerticalMerge == null);
-                Assert.True(wordTable.Rows[0].Cells[0].Paragraphs[0].Text == "Top");
-                Assert.True(wordTable.Rows[0].Cells[0].Paragraphs[1].Text == "Bottom");
-                Assert.True(wordTable.Rows[1].Cells[0].Paragraphs[0].Text == "");
+                Assert.Equal(MergedCellValues.Restart, wordTable.Rows[0].Cells[0].VerticalMerge);
+                Assert.Equal(MergedCellValues.Continue, wordTable.Rows[1].Cells[0].VerticalMerge);
+                Assert.Null(wordTable.Rows[2].Cells[0].VerticalMerge);
+                Assert.Equal("Top", wordTable.Rows[0].Cells[0].Paragraphs[0].Text);
+                Assert.Equal("Bottom", wordTable.Rows[0].Cells[0].Paragraphs[1].Text);
+                Assert.Equal("", wordTable.Rows[1].Cells[0].Paragraphs[0].Text);
 
                 document.Save();
             }

--- a/OfficeIMO.Tests/Word.Tables.cs
+++ b/OfficeIMO.Tests/Word.Tables.cs
@@ -497,6 +497,46 @@ namespace OfficeIMO.Tests {
                 document.Save();
             }
         }
+
+        [Fact]
+        public void Test_MergeVerticallyFirstColumnMissingProperties() {
+            string filePath = Path.Combine(_directoryWithFiles, "VerticalMergeMissingProperties.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable wordTable = document.AddTable(3, 1, WordTableStyle.PlainTable1);
+
+                wordTable.Rows[0].Cells[0].Paragraphs[0].Text = "Top";
+                wordTable.Rows[1].Cells[0].Paragraphs[0].Text = "Bottom";
+                wordTable.Rows[2].Cells[0].Paragraphs[0].Text = "Another";
+
+                // simulate cell loaded without properties
+                wordTable.Rows[0].Cells[0]._tableCellProperties.Remove();
+                wordTable.Rows[0].Cells[0]._tableCellProperties = null;
+
+                wordTable.Rows[0].Cells[0].MergeVertically(1, true);
+
+                Assert.True(wordTable.Rows[0].Cells[0].VerticalMerge == MergedCellValues.Restart);
+                Assert.True(wordTable.Rows[1].Cells[0].VerticalMerge == MergedCellValues.Continue);
+                Assert.True(wordTable.Rows[2].Cells[0].VerticalMerge == null);
+                Assert.True(wordTable.Rows[0].Cells[0].Paragraphs[0].Text == "Top");
+                Assert.True(wordTable.Rows[0].Cells[0].Paragraphs[1].Text == "Bottom");
+                Assert.True(wordTable.Rows[1].Cells[0].Paragraphs[0].Text == "");
+
+                document.Save();
+            }
+
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "VerticalMergeMissingProperties.docx"))) {
+                var wordTable = document.Tables[0];
+
+                Assert.True(wordTable.Rows[0].Cells[0].VerticalMerge == MergedCellValues.Restart);
+                Assert.True(wordTable.Rows[1].Cells[0].VerticalMerge == MergedCellValues.Continue);
+                Assert.True(wordTable.Rows[2].Cells[0].VerticalMerge == null);
+                Assert.True(wordTable.Rows[0].Cells[0].Paragraphs[0].Text == "Top");
+                Assert.True(wordTable.Rows[0].Cells[0].Paragraphs[1].Text == "Bottom");
+                Assert.True(wordTable.Rows[1].Cells[0].Paragraphs[0].Text == "");
+
+                document.Save();
+            }
+        }
         [Fact]
         public void Test_CreatingWordDocumentWithTablesWithSections() {
             string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithTablesAndSections.docx");

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -362,6 +362,16 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Remove TableCellProperties from current cell (used mostly for testing)
+        /// </summary>
+        internal void RemoveTableCellProperties() {
+            if (_tableCell.TableCellProperties != null) {
+                _tableCell.TableCellProperties.Remove();
+                _tableCellProperties = null;
+            }
+        }
+
+        /// <summary>
         /// Remove a cell from a table
         /// </summary>
         public void Remove() {

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -352,6 +352,16 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Ensure that TableCellProperties exist for current cell
+        /// </summary>
+        internal void AddTableCellProperties() {
+            if (_tableCell.TableCellProperties == null) {
+                _tableCell.InsertAt(new TableCellProperties(), 0);
+            }
+            _tableCellProperties = _tableCell.TableCellProperties;
+        }
+
+        /// <summary>
         /// Remove a cell from a table
         /// </summary>
         public void Remove() {
@@ -366,7 +376,8 @@ namespace OfficeIMO.Word {
         /// <param name="copyParagraphs"></param>
         public void MergeHorizontally(int cellsCount, bool copyParagraphs = false) {
             var temporaryCell = _tableCell;
-            _tableCell.TableCellProperties.HorizontalMerge = new HorizontalMerge {
+            AddTableCellProperties();
+            _tableCellProperties.HorizontalMerge = new HorizontalMerge {
                 Val = MergedCellValues.Restart
             };
 
@@ -374,6 +385,7 @@ namespace OfficeIMO.Word {
                 if (_tableCell != null) {
                     _tableCell = (TableCell)_tableCell.NextSibling();
                     if (_tableCell != null) {
+                        AddTableCellProperties();
                         if (copyParagraphs) {
                             // lets find all paragraphs and move them to first table cell
                             var paragraphs = _tableCell.ChildElements.OfType<Paragraph>();
@@ -411,15 +423,17 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="cellsCount"></param>
         public void SplitHorizontally(int cellsCount) {
-            if (_tableCell.TableCellProperties.HorizontalMerge != null) {
-                _tableCell.TableCellProperties.HorizontalMerge.Remove();
+            AddTableCellProperties();
+            if (_tableCellProperties.HorizontalMerge != null) {
+                _tableCellProperties.HorizontalMerge.Remove();
             }
             for (int i = 0; i < cellsCount; i++) {
                 if (_tableCell != null) {
                     _tableCell = (TableCell)_tableCell.NextSibling();
                     if (_tableCell != null) {
-                        if (_tableCell.TableCellProperties.HorizontalMerge != null) {
-                            _tableCell.TableCellProperties.HorizontalMerge.Remove();
+                        AddTableCellProperties();
+                        if (_tableCellProperties.HorizontalMerge != null) {
+                            _tableCellProperties.HorizontalMerge.Remove();
                         }
                     }
                 }
@@ -433,7 +447,8 @@ namespace OfficeIMO.Word {
         /// <param name="copyParagraphs"></param>
         public void MergeVertically(int cellsCount, bool copyParagraphs = false) {
             var temporaryCell = _tableCell;
-            _tableCell.TableCellProperties.VerticalMerge = new VerticalMerge {
+            AddTableCellProperties();
+            _tableCellProperties.VerticalMerge = new VerticalMerge {
                 Val = MergedCellValues.Restart
             };
             var tableRow = _tableCell.Parent;
@@ -449,6 +464,7 @@ namespace OfficeIMO.Word {
                             if (tableCells != null) {
                                 _tableCell = tableCells;
                                 if (_tableCell != null) {
+                                    AddTableCellProperties();
                                     if (copyParagraphs) {
                                         // lets find all paragraphs and move them to first table cell
                                         var paragraphs = _tableCell.ChildElements.OfType<Paragraph>();
@@ -472,7 +488,7 @@ namespace OfficeIMO.Word {
                                     }
 
                                     // then for every table cell we need to continue merging until cellsCount
-                                    _tableCell.TableCellProperties.VerticalMerge = new VerticalMerge {
+                                    _tableCellProperties.VerticalMerge = new VerticalMerge {
                                         Val = MergedCellValues.Continue
                                     };
                                 }


### PR DESCRIPTION
## Summary
- ensure table cell has TableCellProperties before merging
- update merge/split methods to handle missing properties
- add regression tests

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68489a9b6e2c832eb8d57eee3c4712ff