### PR TITLE
Replace deprecated PackageLicenseUrl tags

### DIFF
--- a/OfficeIMO.Excel/OfficeIMO.Excel.csproj
+++ b/OfficeIMO.Excel/OfficeIMO.Excel.csproj
@@ -20,7 +20,7 @@
         <PackageTags>
             docx;net60;excel;office;openxml;net472;net48;net50;netstandard;netstandard2.0,netstandard2.1;net70</PackageTags>
         <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
-        <PackageLicenseUrl>https://github.com/EvotecIT/OfficeIMO/blob/master/LICENSE</PackageLicenseUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <DelaySign>False</DelaySign>
         <IsPublishable>True</IsPublishable>
         <Copyright>(c) 2011 - 2024 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>

--- a/OfficeIMO.Word/OfficeIMO.Word.csproj
+++ b/OfficeIMO.Word/OfficeIMO.Word.csproj
@@ -20,7 +20,7 @@
         <PackageTags>
             docx;net60;word;office;openxml;net472;net48;net50;netstandard;netstandard2.0,netstandard2.1;net70</PackageTags>
         <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
-        <PackageLicenseUrl>https://github.com/EvotecIT/OfficeIMO/blob/master/LICENSE</PackageLicenseUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <DelaySign>False</DelaySign>
         <IsPublishable>True</IsPublishable>
         <Copyright>(c) 2011 - 2024 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>


### PR DESCRIPTION
## Summary
- update license metadata for Word and Excel projects

## Testing
- `dotnet pack OfficeIMO.Word/OfficeIMO.Word.csproj -c Release -o /tmp/pack-word`
- `dotnet pack OfficeIMO.Excel/OfficeIMO.Excel.csproj -c Release -o /tmp/pack-excel`


------
https://chatgpt.com/codex/tasks/task_e_684969c47a44832ead5f90d3d89640bd