### PR TITLE
Implement RemoveHyperLink

### DIFF
--- a/OfficeIMO.Tests/Word.Hyperlinks.cs
+++ b/OfficeIMO.Tests/Word.Hyperlinks.cs
@@ -336,5 +336,31 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Test_RemoveHyperLinkMethod() {
+            string filePath = Path.Combine(_directoryWithFiles, "HyperlinkRemove.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Text before ");
+                paragraph.AddHyperLink("link", new Uri("https://evotec.xyz"));
+                paragraph.AddText(" after");
+
+                Assert.Equal(1, document.HyperLinks.Count);
+                Assert.Equal(1, document._wordprocessingDocument.MainDocumentPart.HyperlinkRelationships.Count());
+
+                paragraph.RemoveHyperLink();
+
+                Assert.Empty(document.HyperLinks);
+                Assert.Equal(0, document._wordprocessingDocument.MainDocumentPart.HyperlinkRelationships.Count());
+                Assert.Equal(2, paragraph._paragraph.ChildElements.OfType<Run>().Count());
+
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Empty(document.HyperLinks);
+                Assert.Equal(2, document.Paragraphs[0]._paragraph.ChildElements.OfType<Run>().Count());
+                document.Save();
+            }
+        }
+
     }
 }

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using DocumentFormat.OpenXml.Wordprocessing;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
 using System.Linq;
 using System.Collections.Generic;
 
@@ -94,7 +96,7 @@ namespace OfficeIMO.Word {
                     }
 
                     if (this.IsHyperLink) {
-                        this.Hyperlink.Remove();
+                        this.RemoveHyperLink();
                     }
 
                     if (this.IsListItem) {
@@ -293,6 +295,44 @@ namespace OfficeIMO.Word {
         public WordParagraph AddHyperLink(string text, string anchor, bool addStyle = false, string tooltip = "", bool history = true) {
             var hyperlink = WordHyperLink.AddHyperLink(this, text, anchor, addStyle, tooltip, history);
             return this;
+        }
+
+        /// <summary>
+        /// Removes hyperlink from this paragraph and detaches its relationship.
+        /// </summary>
+        /// <param name="includingParagraph">If true removes the paragraph when it becomes empty.</param>
+        public void RemoveHyperLink(bool includingParagraph = false) {
+            if (_hyperlink != null) {
+                if (!string.IsNullOrEmpty(_hyperlink.Id)) {
+                    OpenXmlElement parent = _paragraph.Parent;
+                    while (parent != null && !(parent is Body) && !(parent is Header) && !(parent is Footer)) {
+                        parent = parent.Parent;
+                    }
+
+                    OpenXmlPart part = _document._wordprocessingDocument.MainDocumentPart;
+                    if (parent is Header header) {
+                        part = header.HeaderPart;
+                    } else if (parent is Footer footer) {
+                        part = footer.FooterPart;
+                    }
+
+                    var rel = part.HyperlinkRelationships.FirstOrDefault(r => r.Id == _hyperlink.Id);
+                    if (rel != null) {
+                        part.DeleteReferenceRelationship(rel);
+                    }
+                }
+
+                _hyperlink.Remove();
+                _hyperlink = null;
+
+                if (includingParagraph) {
+                    if (this._paragraph.ChildElements.Count == 0) {
+                        this._paragraph.Remove();
+                    } else if (this._paragraph.ChildElements.Count == 1 && this._paragraph.ChildElements.OfType<ParagraphProperties>().Any()) {
+                        this._paragraph.Remove();
+                    }
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add `RemoveHyperLink` to `WordParagraph` for deleting links and relationships
- wrap existing hyperlink removal in `WordHyperLink` to use the new logic
- test hyperlink removal keeping other runs intact

## Testing
- `dotnet test OfficeImo.sln -v m`

------
https://chatgpt.com/codex/tasks/task_e_684ff72c295c832e92383bc8810252e5