### PR TITLE
Add vertical split for table cells

### DIFF
--- a/OfficeIMO.Tests/Word.Tables.cs
+++ b/OfficeIMO.Tests/Word.Tables.cs
@@ -496,6 +496,25 @@ namespace OfficeIMO.Tests {
 
                 document.Save();
             }
+
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithTables.docx"))) {
+                var wordTable = document.Tables[2];
+
+                // split vertically previously merged cells
+                wordTable.Rows[0].Cells[2].SplitVertically(2);
+
+                Assert.Null(wordTable.Rows[0].Cells[2].VerticalMerge);
+                Assert.Null(wordTable.Rows[1].Cells[2].VerticalMerge);
+                Assert.Null(wordTable.Rows[2].Cells[2].VerticalMerge);
+
+                Assert.Equal("Some test 0", wordTable.Rows[0].Cells[2].Paragraphs[0].Text);
+                Assert.Equal("Some test 1", wordTable.Rows[0].Cells[2].Paragraphs[1].Text);
+                Assert.Equal("Some test 2", wordTable.Rows[0].Cells[2].Paragraphs[2].Text);
+                Assert.Equal("", wordTable.Rows[1].Cells[2].Paragraphs[0].Text);
+                Assert.Equal("", wordTable.Rows[2].Cells[2].Paragraphs[0].Text);
+
+                document.Save();
+            }
         }
 
         [Fact]

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -511,6 +511,36 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Splits (unmerge) cells that were merged vertically
+        /// </summary>
+        /// <param name="cellsCount">Number of cells to split including the current one</param>
+        public void SplitVertically(int cellsCount) {
+            AddTableCellProperties();
+            if (_tableCellProperties.VerticalMerge != null) {
+                _tableCellProperties.VerticalMerge.Remove();
+            }
+
+            var tableRow = _tableCell.Parent;
+            var indexOfCell = tableRow.ChildElements.ToList().IndexOf(_tableCell);
+
+            for (int i = 0; i < cellsCount; i++) {
+                if (tableRow != null) {
+                    tableRow = tableRow.NextSibling();
+                    if (tableRow != null) {
+                        var tableCells = tableRow.ChildElements.OfType<TableCell>().ToList()[indexOfCell];
+                        if (tableCells != null) {
+                            _tableCell = tableCells;
+                            AddTableCellProperties();
+                            if (_tableCellProperties.VerticalMerge != null) {
+                                _tableCellProperties.VerticalMerge.Remove();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Add table to a table cell (nested table)
         /// </summary>
         /// <param name="rows"></param>


### PR DESCRIPTION
## Summary
- add `SplitVertically` method to `WordTableCell`
- test splitting merged vertical cells
- fix incorrect table reference in test

## Testing
- `dotnet test --filter Test_CreatingWordDocumentWithTablesWithMerging`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_684ff7358d1c832e90db4d2f2c509967