### PR TITLE
Support new chart types

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -116,6 +116,13 @@ namespace OfficeIMO.Examples {
             HeadersAndFooters.Example_BasicWordWithHeaderAndFooter1(folderPath, false);
 
             Charts.Example_AddingMultipleCharts(folderPath, false);
+            Charts.Example_BarChart(folderPath, false);
+            Charts.Example_PieChart(folderPath, false);
+            Charts.Example_LineChart(folderPath, false);
+            Charts.Example_AreaChart(folderPath, false);
+            Charts.Example_ScatterChart(folderPath, false);
+            Charts.Example_RadarChart(folderPath, false);
+            Charts.Example_Bar3DChart(folderPath, false);
 
             Images.Example_AddingImages(folderPath, false);
             Images.Example_ReadWordWithImages();

--- a/OfficeIMO.Examples/Word/Charts/Charts.Area.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Area.cs
@@ -1,0 +1,21 @@
+using DocumentFormat.OpenXml.Drawing.Charts;
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Charts {
+        public static void Example_AreaChart(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with an area chart");
+            string filePath = System.IO.Path.Combine(folderPath, "AreaChart.docx");
+            using WordDocument document = WordDocument.Create(filePath);
+            List<string> categories = new() { "Food", "Housing", "Mix", "Data" };
+            var areaChart = document.AddChart("Area chart");
+            areaChart.AddCategories(categories);
+            areaChart.AddArea("Brazil", new List<int> { 100, 1, 18, 230 }, Color.Brown);
+            areaChart.AddArea("Poland", new List<int> { 13, 20, 230, 150 }, Color.Green);
+            areaChart.AddArea("USA", new List<int> { 10, 305, 18, 23 }, Color.AliceBlue);
+            areaChart.AddLegend(LegendPositionValues.Top);
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Charts/Charts.Area.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Area.cs
@@ -15,7 +15,19 @@ namespace OfficeIMO.Examples.Word {
             areaChart.AddArea("Poland", new List<int> { 13, 20, 230, 150 }, Color.Green);
             areaChart.AddArea("USA", new List<int> { 10, 305, 18, 23 }, Color.AliceBlue);
             areaChart.AddLegend(LegendPositionValues.Top);
-            document.Save(openWord);
+            document.Save(false);
+
+            var valid = document.ValidateDocument();
+            if (valid.Count > 0) {
+                Console.WriteLine("Document has validation errors:");
+                foreach (var error in valid) {
+                    Console.WriteLine(error.Id + ": " + error.Description);
+                }
+            } else {
+                Console.WriteLine("Document is valid.");
+            }
+
+            document.Open(openWord);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/Charts/Charts.Bar.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Bar.cs
@@ -16,7 +16,19 @@ namespace OfficeIMO.Examples.Word {
             barChart.AddBar("Poland", new List<int> { 13, 20, 230, 150 }, Color.Green);
             barChart.BarGrouping = BarGroupingValues.Clustered;
             barChart.BarDirection = BarDirectionValues.Column;
-            document.Save(openWord);
+            document.Save(false);
+
+            var valid = document.ValidateDocument();
+            if (valid.Count > 0) {
+                Console.WriteLine("Document has validation errors:");
+                foreach (var error in valid) {
+                    Console.WriteLine(error.Id + ": " + error.Description);
+                }
+            } else {
+                Console.WriteLine("Document is valid.");
+            }
+
+            document.Open(openWord);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/Charts/Charts.Bar.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Bar.cs
@@ -1,0 +1,22 @@
+using DocumentFormat.OpenXml.Drawing.Charts;
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Charts {
+        public static void Example_BarChart(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a bar chart");
+            string filePath = System.IO.Path.Combine(folderPath, "BarChart.docx");
+            using WordDocument document = WordDocument.Create(filePath);
+            List<string> categories = new() { "Food", "Housing", "Mix", "Data" };
+            var barChart = document.AddChart("Bar chart");
+            barChart.AddCategories(categories);
+            barChart.AddBar("USA", new List<int> { 10, 35, 18, 23 }, Color.AliceBlue);
+            barChart.AddBar("Brazil", new List<int> { 15, 30, 8, 18 }, Color.Brown);
+            barChart.AddBar("Poland", new List<int> { 13, 20, 230, 150 }, Color.Green);
+            barChart.BarGrouping = BarGroupingValues.Clustered;
+            barChart.BarDirection = BarDirectionValues.Column;
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Charts/Charts.Bar3D.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Bar3D.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Charts {
+        public static void Example_Bar3DChart(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a 3-D bar chart");
+            string filePath = System.IO.Path.Combine(folderPath, "Bar3DChart.docx");
+            using WordDocument document = WordDocument.Create(filePath);
+            List<string> categories = new() { "Food", "Housing", "Mix", "Data" };
+            var bar3d = document.AddChart("Bar3D chart");
+            bar3d.AddCategories(categories);
+            bar3d.AddBar3D("USA", new List<int> { 5, 2, 3, 4 }, Color.DarkOrange);
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Charts/Charts.Bar3D.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Bar3D.cs
@@ -12,7 +12,19 @@ namespace OfficeIMO.Examples.Word {
             var bar3d = document.AddChart("Bar3D chart");
             bar3d.AddCategories(categories);
             bar3d.AddBar3D("USA", new List<int> { 5, 2, 3, 4 }, Color.DarkOrange);
-            document.Save(openWord);
+            document.Save(false);
+
+            var valid = document.ValidateDocument();
+            if (valid.Count > 0) {
+                Console.WriteLine("Document has validation errors:");
+                foreach (var error in valid) {
+                    Console.WriteLine(error.Id + ": " + error.Description);
+                }
+            } else {
+                Console.WriteLine("Document is valid.");
+            }
+
+            document.Open(openWord);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/Charts/Charts.Line.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Line.cs
@@ -14,7 +14,19 @@ namespace OfficeIMO.Examples.Word {
             lineChart.AddLine("USA", new List<int> { 10, 35, 18, 23 }, Color.AliceBlue);
             lineChart.AddLine("Brazil", new List<int> { 10, 35, 300, 18 }, Color.Brown);
             lineChart.AddLine("Poland", new List<int> { 13, 20, 230, 150 }, Color.Green);
-            document.Save(openWord);
+            document.Save(false);
+
+            var valid = document.ValidateDocument();
+            if (valid.Count > 0) {
+                Console.WriteLine("Document has validation errors:");
+                foreach (var error in valid) {
+                    Console.WriteLine(error.Id + ": " + error.Description);
+                }
+            } else {
+                Console.WriteLine("Document is valid.");
+            }
+
+            document.Open(openWord);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/Charts/Charts.Line.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Line.cs
@@ -1,0 +1,20 @@
+using DocumentFormat.OpenXml.Drawing.Charts;
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Charts {
+        public static void Example_LineChart(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a line chart");
+            string filePath = System.IO.Path.Combine(folderPath, "LineChart.docx");
+            using WordDocument document = WordDocument.Create(filePath);
+            List<string> categories = new() { "Food", "Housing", "Mix", "Data" };
+            var lineChart = document.AddChart("Line chart");
+            lineChart.AddChartAxisX(categories);
+            lineChart.AddLine("USA", new List<int> { 10, 35, 18, 23 }, Color.AliceBlue);
+            lineChart.AddLine("Brazil", new List<int> { 10, 35, 300, 18 }, Color.Brown);
+            lineChart.AddLine("Poland", new List<int> { 13, 20, 230, 150 }, Color.Green);
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Charts/Charts.Pie.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Pie.cs
@@ -1,0 +1,16 @@
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Charts {
+        public static void Example_PieChart(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a pie chart");
+            string filePath = System.IO.Path.Combine(folderPath, "PieChart.docx");
+            using WordDocument document = WordDocument.Create(filePath);
+            var pieChart = document.AddChart("Pie chart");
+            pieChart.AddPie("Poland", 15);
+            pieChart.AddPie("USA", 30);
+            pieChart.AddPie("Brazil", 20);
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Charts/Charts.Pie.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Pie.cs
@@ -10,7 +10,19 @@ namespace OfficeIMO.Examples.Word {
             pieChart.AddPie("Poland", 15);
             pieChart.AddPie("USA", 30);
             pieChart.AddPie("Brazil", 20);
-            document.Save(openWord);
+            document.Save(false);
+
+            var valid = document.ValidateDocument();
+            if (valid.Count > 0) {
+                Console.WriteLine("Document has validation errors:");
+                foreach (var error in valid) {
+                    Console.WriteLine(error.Id + ": " + error.Description);
+                }
+            } else {
+                Console.WriteLine("Document is valid.");
+            }
+
+            document.Open(openWord);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/Charts/Charts.Radar.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Radar.cs
@@ -12,7 +12,19 @@ namespace OfficeIMO.Examples.Word {
             var radarChart = document.AddChart("Radar chart");
             radarChart.AddCategories(categories);
             radarChart.AddRadar("USA", new List<int> { 1, 5, 3, 2 }, Color.Blue);
-            document.Save(openWord);
+            document.Save(false);
+
+            var valid = document.ValidateDocument();
+            if (valid.Count > 0) {
+                Console.WriteLine("Document has validation errors:");
+                foreach (var error in valid) {
+                    Console.WriteLine(error.Id + ": " + error.Description);
+                }
+            } else {
+                Console.WriteLine("Document is valid.");
+            }
+
+            document.Open(openWord);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/Charts/Charts.Radar.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Radar.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Charts {
+        public static void Example_RadarChart(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a radar chart");
+            string filePath = System.IO.Path.Combine(folderPath, "RadarChart.docx");
+            using WordDocument document = WordDocument.Create(filePath);
+            List<string> categories = new() { "Food", "Housing", "Mix", "Data" };
+            var radarChart = document.AddChart("Radar chart");
+            radarChart.AddCategories(categories);
+            radarChart.AddRadar("USA", new List<int> { 1, 5, 3, 2 }, Color.Blue);
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Charts/Charts.Scatter.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Scatter.cs
@@ -10,7 +10,20 @@ namespace OfficeIMO.Examples.Word {
             using WordDocument document = WordDocument.Create(filePath);
             var scatterChart = document.AddChart("Scatter chart");
             scatterChart.AddScatter("Data", new List<double> { 1, 2, 3 }, new List<double> { 3, 2, 1 }, Color.Red);
-            document.Save(openWord);
+
+            document.Save(false);
+
+            var valid = document.ValidateDocument();
+            if (valid.Count > 0) {
+                Console.WriteLine("Document has validation errors:");
+                foreach (var error in valid) {
+                    Console.WriteLine(error.Id + ": " + error.Description);
+                }
+            } else {
+                Console.WriteLine("Document is valid.");
+            }
+
+            document.Open(openWord);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/Charts/Charts.Scatter.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Scatter.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Charts {
+        public static void Example_ScatterChart(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a scatter chart");
+            string filePath = System.IO.Path.Combine(folderPath, "ScatterChart.docx");
+            using WordDocument document = WordDocument.Create(filePath);
+            var scatterChart = document.AddChart("Scatter chart");
+            scatterChart.AddScatter("Data", new List<double> { 1, 2, 3 }, new List<double> { 3, 2, 1 }, Color.Red);
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Charts/Charts.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.cs
@@ -147,6 +147,17 @@ namespace OfficeIMO.Examples.Word {
                 areaChart.AddArea("USA", new List<int>() { 10, 305, 18, 23 }, SixLabors.ImageSharp.Color.AliceBlue);
                 areaChart.AddLegend(LegendPositionValues.Top);
 
+                var scatterChart = document.AddChart("Scatter chart");
+                scatterChart.AddScatter("Data", new List<double>() { 1, 2, 3 }, new List<double>() { 3, 2, 1 }, SixLabors.ImageSharp.Color.Red);
+
+                var radarChart = document.AddChart("Radar chart");
+                radarChart.AddCategories(categories);
+                radarChart.AddRadar("USA", new List<int>() { 1, 5, 3, 2 }, SixLabors.ImageSharp.Color.Blue);
+
+                var bar3d = document.AddChart("Bar3D chart");
+                bar3d.AddCategories(categories);
+                bar3d.AddBar3D("USA", new List<int>() { 5, 2, 3, 4 }, SixLabors.ImageSharp.Color.DarkOrange);
+
 
                 Console.WriteLine("Charts count: " + document.Sections[0].Charts.Count);
                 Console.WriteLine("Images count: " + document.Sections[0].Images.Count);

--- a/OfficeIMO.Examples/Word/Charts/Charts.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.cs
@@ -5,7 +5,7 @@ using OfficeIMO.Word;
 using SixLabors.ImageSharp;
 
 namespace OfficeIMO.Examples.Word {
-    internal static class Charts {
+    internal static partial class Charts {
         public static void Example_AddingMultipleCharts(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating standard document with charts");
             string filePath = System.IO.Path.Combine(folderPath, "Charts Document2.docx");

--- a/OfficeIMO.Examples/Word/Charts/Charts.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.cs
@@ -162,7 +162,20 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine("Charts count: " + document.Sections[0].Charts.Count);
                 Console.WriteLine("Images count: " + document.Sections[0].Images.Count);
 
-                document.Save(openWord);
+
+
+                document.Save(false);
+
+                var valid = document.ValidateDocument();
+                if (valid.Count > 0) {
+                    Console.WriteLine("Document has validation errors:");
+                    foreach (var error in valid) {
+                        Console.WriteLine(error.Id + ": " + error.Description);
+                    }
+                } else {
+                    Console.WriteLine("Document is valid.");
+                }
+
             }
         }
     }

--- a/OfficeIMO.Examples/Word/Charts/Charts.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.cs
@@ -46,8 +46,8 @@ namespace OfficeIMO.Examples.Word {
                 pieChart2.AddPie("USA", 30);
 
                 document.AddParagraph("This is a pie chart with 3 pies");
-                document.AddChart("Test")
-                    .AddPie("Poland", 15)
+                document.AddChart("Test1")
+                    .AddPie("Poland", 16)
                     .AddPie("USA", 30)
                     .AddPie("Brazil", 20.2).SetTitle("new title");
 
@@ -162,8 +162,6 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine("Charts count: " + document.Sections[0].Charts.Count);
                 Console.WriteLine("Images count: " + document.Sections[0].Images.Count);
 
-
-
                 document.Save(false);
 
                 var valid = document.ValidateDocument();
@@ -176,6 +174,7 @@ namespace OfficeIMO.Examples.Word {
                     Console.WriteLine("Document is valid.");
                 }
 
+                document.Open(openWord);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.Charts.cs
+++ b/OfficeIMO.Tests/Word.Charts.cs
@@ -100,14 +100,34 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Charts.Count == 5);
                 Assert.True(document.ParagraphsCharts.Count == 5);
 
+                var scatter = document.AddChart();
+                scatter.AddScatter("data", new List<double> { 1, 2 }, new List<double> { 2, 1 }, Color.Red);
+                var scatterPart = document._wordprocessingDocument.MainDocumentPart.ChartParts.Last();
+                var scatterXml = scatterPart.ChartSpace.GetFirstChild<Chart>().PlotArea.GetFirstChild<ScatterChart>();
+                Assert.NotNull(scatterXml);
+
+                var radar = document.AddChart();
+                radar.AddCategories(categories);
+                radar.AddRadar("USA", new List<int> { 1, 2, 3, 4 }, Color.Green);
+                var radarPart = document._wordprocessingDocument.MainDocumentPart.ChartParts.Last();
+                var radarXml = radarPart.ChartSpace.GetFirstChild<Chart>().PlotArea.GetFirstChild<RadarChart>();
+                Assert.NotNull(radarXml);
+
+                var bar3d = document.AddChart();
+                bar3d.AddCategories(categories);
+                bar3d.AddBar3D("USA", new List<int> { 1, 2, 3, 4 }, Color.Blue);
+                var bar3dPart = document._wordprocessingDocument.MainDocumentPart.ChartParts.Last();
+                var bar3dXml = bar3dPart.ChartSpace.GetFirstChild<Chart>().PlotArea.GetFirstChild<Bar3DChart>();
+                Assert.NotNull(bar3dXml);
+
                 document.Save(false);
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
 
                 Assert.True(document.Sections[0].Charts.Count == 3);
-                Assert.True(document.Sections[1].Charts.Count == 2);
-                Assert.True(document.Charts.Count == 5);
+                Assert.True(document.Sections[1].Charts.Count == 5);
+                Assert.True(document.Charts.Count == 8);
 
                 document.Save(false);
             }

--- a/OfficeIMO.Tests/Word.Charts.cs
+++ b/OfficeIMO.Tests/Word.Charts.cs
@@ -176,5 +176,109 @@ namespace OfficeIMO.Tests {
                 Assert.Empty(chartErrors);
             }
         }
+
+        [Fact]
+        public void Test_ChartsWithDecimalValues() {
+            var filePath = Path.Combine(_directoryWithFiles, "ChartsWithDecimalValues.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                // Test decimal values that could cause culture-dependent serialization issues
+                var decimalValues = new[] { 20.2, 15.7, 8.9, 12.4 };
+
+                // Test Pie Chart with decimal values
+                document.AddParagraph("Pie Chart with Decimal Values:");
+                var pieChart = document.AddChart("Pie Chart Test");
+                pieChart.AddPie("Category A", decimalValues[0]);
+                pieChart.AddPie("Category B", decimalValues[1]);
+                pieChart.AddPie("Category C", decimalValues[2]);
+
+                // Test Bar Chart with decimal values
+                document.AddParagraph("Bar Chart with Decimal Values:");
+                var barChart = document.AddChart("Bar Chart Test");
+                barChart.AddCategories(new List<string> { "Q1", "Q2", "Q3", "Q4" });
+                barChart.AddBar("Sales", new List<double> { decimalValues[0], decimalValues[1], decimalValues[2], decimalValues[3] }, Color.Blue);
+
+                // Test Line Chart with decimal values
+                document.AddParagraph("Line Chart with Decimal Values:");
+                var lineChart = document.AddChart("Line Chart Test");
+                lineChart.AddChartAxisX(new List<string> { "Jan", "Feb", "Mar", "Apr" });
+                lineChart.AddLine("Growth", new List<double> { decimalValues[0], decimalValues[1], decimalValues[2], decimalValues[3] }, Color.Red);
+
+                document.Save(false);
+            }
+
+            // Verify document can be loaded and validates correctly
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal(3, document.Charts.Count);
+
+                var validation = document.ValidateDocument();
+                var chartErrors = validation.Where(v => v.Description.Contains("chart")).ToList();
+                Assert.Empty(chartErrors);
+
+                // Verify the document can be saved again (full round-trip test)
+                document.Save(false);
+            }
+        }
+
+        [Fact]
+        public void Test_AreaChartWithLegend() {
+            var filePath = Path.Combine(_directoryWithFiles, "AreaChartWithLegend.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var categories = new List<string> { "Food", "Housing", "Mix", "Data" };
+
+                // Create area chart with legend (this was causing validation errors before the fix)
+                var areaChart = document.AddChart("Area Chart");
+                areaChart.AddCategories(categories);
+                areaChart.AddArea("Brazil", new List<int> { 100, 1, 18, 230 }, Color.Brown);
+                areaChart.AddArea("Poland", new List<int> { 13, 20, 230, 150 }, Color.Green);
+                areaChart.AddArea("USA", new List<int> { 10, 305, 18, 23 }, Color.AliceBlue);
+                areaChart.AddLegend(LegendPositionValues.Top);
+
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Single(document.Charts);
+
+                var validation = document.ValidateDocument();
+                var chartErrors = validation.Where(v => v.Description.Contains("chart") || v.Description.Contains("legend")).ToList();
+                Assert.Empty(chartErrors);
+            }
+        }
+
+        [Fact]
+        public void Test_LegendPositioning() {
+            var filePath = Path.Combine(_directoryWithFiles, "LegendPositioning.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var categories = new List<string> { "A", "B", "C" };
+
+                // Test different legend positions to ensure they all validate correctly
+                var positions = new[] {
+                    LegendPositionValues.Top,
+                    LegendPositionValues.Bottom,
+                    LegendPositionValues.Left,
+                    LegendPositionValues.Right
+                };
+
+                foreach (var position in positions) {
+                    var chart = document.AddChart($"Chart with {position} Legend");
+                    chart.AddCategories(categories);
+                    chart.AddBar("Data", new List<int> { 1, 2, 3 }, Color.Blue);
+                    chart.AddLegend(position);
+                }
+
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal(4, document.Charts.Count);
+
+                var validation = document.ValidateDocument();
+                var chartErrors = validation.Where(v => v.Description.Contains("chart") || v.Description.Contains("legend")).ToList();
+                Assert.Empty(chartErrors);
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Word.Charts.cs
+++ b/OfficeIMO.Tests/Word.Charts.cs
@@ -131,6 +131,23 @@ namespace OfficeIMO.Tests {
 
                 document.Save(false);
             }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var maxId = document._wordprocessingDocument.MainDocumentPart
+                    .ChartParts.SelectMany(p => p.ChartSpace.GetFirstChild<Chart>()
+                    .Descendants<AxisId>())
+                    .Max(a => a.Val!.Value);
+
+                var chart = document.AddChart();
+                chart.AddCategories(new List<string> { "A", "B" });
+                chart.AddBar("T", new List<int> { 1, 2 }, Color.Blue);
+
+                var newIds = document._wordprocessingDocument.MainDocumentPart
+                    .ChartParts.Last().ChartSpace.GetFirstChild<Chart>()
+                    .Descendants<AxisId>().Select(a => a.Val!.Value);
+
+                Assert.True(newIds.Min() > maxId);
+            }
         }
     }
 }

--- a/OfficeIMO.VerifyTests/Word/verified/ChartTests.AddingMultipleCharts.verified.txt
+++ b/OfficeIMO.VerifyTests/Word/verified/ChartTests.AddingMultipleCharts.verified.txt
@@ -59,7 +59,7 @@
           <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
             <wp:extent cx="5715000" cy="5715000" />
             <wp:effectExtent l="0" t="0" r="19050" b="19050" />
-            <wp:docPr id="2" name="chart" />
+            <wp:docPr id="3" name="chart" />
             <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
               <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
                 <c:chart xmlns:p6="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" p6:id="R00000002" />
@@ -82,7 +82,7 @@
           <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
             <wp:extent cx="5715000" cy="5715000" />
             <wp:effectExtent l="0" t="0" r="19050" b="19050" />
-            <wp:docPr id="2" name="chart" />
+            <wp:docPr id="4" name="chart" />
             <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
               <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
                 <c:chart xmlns:p6="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" p6:id="R00000003" />
@@ -105,7 +105,7 @@
           <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
             <wp:extent cx="5715000" cy="5715000" />
             <wp:effectExtent l="0" t="0" r="19050" b="19050" />
-            <wp:docPr id="2" name="chart" />
+            <wp:docPr id="5" name="chart" />
             <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
               <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
                 <c:chart xmlns:p6="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" p6:id="R00000004" />
@@ -128,7 +128,7 @@
           <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
             <wp:extent cx="5715000" cy="5715000" />
             <wp:effectExtent l="0" t="0" r="19050" b="19050" />
-            <wp:docPr id="2" name="chart" />
+            <wp:docPr id="6" name="chart" />
             <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
               <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
                 <c:chart xmlns:p6="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" p6:id="R00000005" />
@@ -10962,60 +10962,11 @@
   <c:roundedCorners val="0" />
   <c:chart>
     <c:autoTitleDeleted val="0" />
-    <c:plotVisOnly val="1" />
-    <c:dispBlanksAs val="gap" />
-    <c:showDLblsOverMax val="0" />
     <c:plotArea>
       <c:layout />
-      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="148921728" />
-        <c:scaling>
-          <c:orientation val="minMax" />
-        </c:scaling>
-        <c:delete val="0" />
-        <c:axPos val="b" />
-        <c:majorTickMark val="out" />
-        <c:minorTickMark val="none" />
-        <c:tickLblPos val="nextTo" />
-        <c:crossAx val="154227840" />
-        <c:crosses val="autoZero" />
-        <c:auto val="1" />
-        <c:lblAlgn val="ctr" />
-        <c:lblOffset val="100" />
-        <c:noMultiLvlLbl val="0" />
-      </c:catAx>
-      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="154227840" />
-        <c:scaling>
-          <c:orientation val="minMax" />
-        </c:scaling>
-        <c:delete val="0" />
-        <c:axPos val="l" />
-        <c:numFmt formatCode="General" sourceLinked="0" />
-        <c:majorGridlines />
-        <c:majorTickMark val="out" />
-        <c:minorTickMark val="none" />
-        <c:tickLblPos val="nextTo" />
-        <c:crossAx val="148921728" />
-        <c:crosses val="autoZero" />
-        <c:crossBetween val="between" />
-      </c:valAx>
       <c:barChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:dLbls xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-          <c:showLegendKey val="0" />
-          <c:showVal val="0" />
-          <c:showCatName val="0" />
-          <c:showSerName val="0" />
-          <c:showPercent val="0" />
-          <c:showBubbleSize val="0" />
-          <c:showLeaderLines val="1" />
-        </c:dLbls>
         <c:barDir val="col" />
         <c:grouping val="clustered" />
-        <c:gapWidth val="200" />
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921728" />
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="154227840" />
-        <c:overlap val="0" />
         <c:ser>
           <c:idx val="0" />
           <c:order val="0" />
@@ -11054,8 +11005,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>10</c:v>
               </c:pt>
@@ -11109,8 +11060,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>13</c:v>
               </c:pt>
@@ -11164,8 +11115,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>10</c:v>
               </c:pt>
@@ -11181,56 +11132,6 @@
             </c:numLit>
           </c:val>
         </c:ser>
-      </c:barChart>
-    </c:plotArea>
-  </c:chart>
-</c:chartSpace>
-<!--------------------------------------------------------------------------------------------------------------------->
-/word/charts/chart2.xml
-<!--------------------------------------------------------------------------------------------------------------------->
-<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
-  <c:roundedCorners val="1" />
-  <c:chart>
-    <c:autoTitleDeleted val="0" />
-    <c:plotVisOnly val="1" />
-    <c:dispBlanksAs val="gap" />
-    <c:showDLblsOverMax val="0" />
-    <c:plotArea>
-      <c:layout />
-      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="148921728" />
-        <c:scaling>
-          <c:orientation val="minMax" />
-        </c:scaling>
-        <c:delete val="0" />
-        <c:axPos val="b" />
-        <c:majorTickMark val="out" />
-        <c:minorTickMark val="none" />
-        <c:tickLblPos val="nextTo" />
-        <c:crossAx val="154227840" />
-        <c:crosses val="autoZero" />
-        <c:auto val="1" />
-        <c:lblAlgn val="ctr" />
-        <c:lblOffset val="100" />
-        <c:noMultiLvlLbl val="0" />
-      </c:catAx>
-      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="154227840" />
-        <c:scaling>
-          <c:orientation val="minMax" />
-        </c:scaling>
-        <c:delete val="0" />
-        <c:axPos val="l" />
-        <c:numFmt formatCode="General" sourceLinked="0" />
-        <c:majorGridlines />
-        <c:majorTickMark val="out" />
-        <c:minorTickMark val="none" />
-        <c:tickLblPos val="nextTo" />
-        <c:crossAx val="148921728" />
-        <c:crosses val="autoZero" />
-        <c:crossBetween val="between" />
-      </c:valAx>
-      <c:barChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
         <c:dLbls xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
           <c:showLegendKey val="0" />
           <c:showVal val="0" />
@@ -11240,12 +11141,62 @@
           <c:showBubbleSize val="0" />
           <c:showLeaderLines val="1" />
         </c:dLbls>
+        <c:gapWidth val="200" />
+        <c:overlap val="0" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921729" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921730" />
+      </c:barChart>
+      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921729" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="b" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921730" />
+        <c:crosses val="autoZero" />
+        <c:auto val="1" />
+        <c:lblAlgn val="ctr" />
+        <c:lblOffset val="100" />
+        <c:noMultiLvlLbl val="0" />
+      </c:catAx>
+      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921730" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="l" />
+        <c:majorGridlines />
+        <c:numFmt formatCode="General" sourceLinked="0" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921729" />
+        <c:crosses val="autoZero" />
+        <c:crossBetween val="between" />
+      </c:valAx>
+    </c:plotArea>
+    <c:plotVisOnly val="1" />
+    <c:dispBlanksAs val="gap" />
+    <c:showDLblsOverMax val="0" />
+  </c:chart>
+</c:chartSpace>
+<!--------------------------------------------------------------------------------------------------------------------->
+/word/charts/chart2.xml
+<!--------------------------------------------------------------------------------------------------------------------->
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <c:roundedCorners val="1" />
+  <c:chart>
+    <c:autoTitleDeleted val="0" />
+    <c:plotArea>
+      <c:layout />
+      <c:barChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
         <c:barDir val="bar" />
         <c:grouping val="standard" />
-        <c:gapWidth val="200" />
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921728" />
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="154227840" />
-        <c:overlap val="0" />
         <c:ser>
           <c:idx val="0" />
           <c:order val="0" />
@@ -11284,31 +11235,14 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="1" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="1" />
               <c:pt idx="0">
                 <c:v>15</c:v>
               </c:pt>
             </c:numLit>
           </c:val>
         </c:ser>
-      </c:barChart>
-    </c:plotArea>
-  </c:chart>
-</c:chartSpace>
-<!--------------------------------------------------------------------------------------------------------------------->
-/word/charts/chart3.xml
-<!--------------------------------------------------------------------------------------------------------------------->
-<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
-  <c:roundedCorners val="0" />
-  <c:chart>
-    <c:autoTitleDeleted val="0" />
-    <c:plotVisOnly val="1" />
-    <c:dispBlanksAs val="gap" />
-    <c:showDLblsOverMax val="0" />
-    <c:plotArea>
-      <c:layout />
-      <c:pieChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
         <c:dLbls xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
           <c:showLegendKey val="0" />
           <c:showVal val="0" />
@@ -11318,6 +11252,60 @@
           <c:showBubbleSize val="0" />
           <c:showLeaderLines val="1" />
         </c:dLbls>
+        <c:gapWidth val="200" />
+        <c:overlap val="0" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921731" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921732" />
+      </c:barChart>
+      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921731" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="b" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921732" />
+        <c:crosses val="autoZero" />
+        <c:auto val="1" />
+        <c:lblAlgn val="ctr" />
+        <c:lblOffset val="100" />
+        <c:noMultiLvlLbl val="0" />
+      </c:catAx>
+      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921732" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="l" />
+        <c:majorGridlines />
+        <c:numFmt formatCode="General" sourceLinked="0" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921731" />
+        <c:crosses val="autoZero" />
+        <c:crossBetween val="between" />
+      </c:valAx>
+    </c:plotArea>
+    <c:plotVisOnly val="1" />
+    <c:dispBlanksAs val="gap" />
+    <c:showDLblsOverMax val="0" />
+  </c:chart>
+</c:chartSpace>
+<!--------------------------------------------------------------------------------------------------------------------->
+/word/charts/chart3.xml
+<!--------------------------------------------------------------------------------------------------------------------->
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <c:roundedCorners val="0" />
+  <c:chart>
+    <c:autoTitleDeleted val="0" />
+    <c:plotArea>
+      <c:layout />
+      <c:pieChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
         <c:ser>
           <c:idx val="0" />
           <c:order val="0" />
@@ -11331,7 +11319,6 @@
               </c:strCache>
             </c:strRef>
           </c:tx>
-          <c:invertIfNegative />
           <c:cat>
             <c:strLit>
               <c:ptCount val="3" />
@@ -11348,8 +11335,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="3" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="3" />
               <c:pt idx="0">
                 <c:v>15</c:v>
               </c:pt>
@@ -11362,8 +11349,20 @@
             </c:numLit>
           </c:val>
         </c:ser>
+        <c:dLbls xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+          <c:showLegendKey val="0" />
+          <c:showVal val="0" />
+          <c:showCatName val="0" />
+          <c:showSerName val="0" />
+          <c:showPercent val="0" />
+          <c:showBubbleSize val="0" />
+          <c:showLeaderLines val="1" />
+        </c:dLbls>
       </c:pieChart>
     </c:plotArea>
+    <c:plotVisOnly val="1" />
+    <c:dispBlanksAs val="gap" />
+    <c:showDLblsOverMax val="0" />
   </c:chart>
 </c:chartSpace>
 <!--------------------------------------------------------------------------------------------------------------------->
@@ -11373,57 +11372,10 @@
   <c:roundedCorners val="0" />
   <c:chart>
     <c:autoTitleDeleted val="0" />
-    <c:plotVisOnly val="1" />
-    <c:dispBlanksAs val="gap" />
-    <c:showDLblsOverMax val="0" />
     <c:plotArea>
       <c:layout />
-      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="148921728" />
-        <c:scaling>
-          <c:orientation val="minMax" />
-        </c:scaling>
-        <c:delete val="0" />
-        <c:axPos val="b" />
-        <c:majorTickMark val="out" />
-        <c:minorTickMark val="none" />
-        <c:tickLblPos val="nextTo" />
-        <c:crossAx val="154227840" />
-        <c:crosses val="autoZero" />
-        <c:auto val="1" />
-        <c:lblAlgn val="ctr" />
-        <c:lblOffset val="100" />
-        <c:noMultiLvlLbl val="0" />
-      </c:catAx>
-      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="154227840" />
-        <c:scaling>
-          <c:orientation val="minMax" />
-        </c:scaling>
-        <c:delete val="0" />
-        <c:axPos val="l" />
-        <c:numFmt formatCode="General" sourceLinked="0" />
-        <c:majorGridlines />
-        <c:majorTickMark val="out" />
-        <c:minorTickMark val="none" />
-        <c:tickLblPos val="nextTo" />
-        <c:crossAx val="148921728" />
-        <c:crosses val="autoZero" />
-        <c:crossBetween val="between" />
-      </c:valAx>
       <c:lineChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
         <c:grouping val="standard" />
-        <c:dLbls xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-          <c:showLegendKey val="0" />
-          <c:showVal val="0" />
-          <c:showCatName val="0" />
-          <c:showSerName val="0" />
-          <c:showPercent val="0" />
-          <c:showBubbleSize val="0" />
-          <c:showLeaderLines val="1" />
-        </c:dLbls>
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921728" />
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="154227840" />
         <c:ser>
           <c:idx val="0" />
           <c:order val="0" />
@@ -11442,7 +11394,6 @@
               <a:srgbClr val="F0F8FF" />
             </a:solidFill>
           </c:spPr>
-          <c:invertIfNegative />
           <c:cat>
             <c:strLit>
               <c:ptCount val="4" />
@@ -11462,8 +11413,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>10</c:v>
               </c:pt>
@@ -11497,7 +11448,6 @@
               <a:srgbClr val="A52A2A" />
             </a:solidFill>
           </c:spPr>
-          <c:invertIfNegative />
           <c:cat>
             <c:strLit>
               <c:ptCount val="4" />
@@ -11517,8 +11467,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>10</c:v>
               </c:pt>
@@ -11552,7 +11502,6 @@
               <a:srgbClr val="008000" />
             </a:solidFill>
           </c:spPr>
-          <c:invertIfNegative />
           <c:cat>
             <c:strLit>
               <c:ptCount val="4" />
@@ -11572,8 +11521,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>13</c:v>
               </c:pt>
@@ -11589,8 +11538,55 @@
             </c:numLit>
           </c:val>
         </c:ser>
+        <c:dLbls xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+          <c:showLegendKey val="0" />
+          <c:showVal val="0" />
+          <c:showCatName val="0" />
+          <c:showSerName val="0" />
+          <c:showPercent val="0" />
+          <c:showBubbleSize val="0" />
+          <c:showLeaderLines val="1" />
+        </c:dLbls>
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921733" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921734" />
       </c:lineChart>
+      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921733" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="b" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921734" />
+        <c:crosses val="autoZero" />
+        <c:auto val="1" />
+        <c:lblAlgn val="ctr" />
+        <c:lblOffset val="100" />
+        <c:noMultiLvlLbl val="0" />
+      </c:catAx>
+      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921734" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="l" />
+        <c:majorGridlines />
+        <c:numFmt formatCode="General" sourceLinked="0" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921733" />
+        <c:crosses val="autoZero" />
+        <c:crossBetween val="between" />
+      </c:valAx>
     </c:plotArea>
+    <c:plotVisOnly val="1" />
+    <c:dispBlanksAs val="gap" />
+    <c:showDLblsOverMax val="0" />
   </c:chart>
 </c:chartSpace>
 <!--------------------------------------------------------------------------------------------------------------------->
@@ -11600,57 +11596,10 @@
   <c:roundedCorners val="0" />
   <c:chart>
     <c:autoTitleDeleted val="0" />
-    <c:plotVisOnly val="1" />
-    <c:dispBlanksAs val="gap" />
-    <c:showDLblsOverMax val="0" />
     <c:plotArea>
       <c:layout />
-      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="148921728" />
-        <c:scaling>
-          <c:orientation val="minMax" />
-        </c:scaling>
-        <c:delete val="0" />
-        <c:axPos val="b" />
-        <c:majorTickMark val="out" />
-        <c:minorTickMark val="none" />
-        <c:tickLblPos val="nextTo" />
-        <c:crossAx val="154227840" />
-        <c:crosses val="autoZero" />
-        <c:auto val="1" />
-        <c:lblAlgn val="ctr" />
-        <c:lblOffset val="100" />
-        <c:noMultiLvlLbl val="0" />
-      </c:catAx>
-      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="154227840" />
-        <c:scaling>
-          <c:orientation val="minMax" />
-        </c:scaling>
-        <c:delete val="0" />
-        <c:axPos val="l" />
-        <c:numFmt formatCode="General" sourceLinked="0" />
-        <c:majorGridlines />
-        <c:majorTickMark val="out" />
-        <c:minorTickMark val="none" />
-        <c:tickLblPos val="nextTo" />
-        <c:crossAx val="148921728" />
-        <c:crosses val="autoZero" />
-        <c:crossBetween val="between" />
-      </c:valAx>
       <c:lineChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
         <c:grouping val="standard" />
-        <c:dLbls xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-          <c:showLegendKey val="0" />
-          <c:showVal val="0" />
-          <c:showCatName val="0" />
-          <c:showSerName val="0" />
-          <c:showPercent val="0" />
-          <c:showBubbleSize val="0" />
-          <c:showLeaderLines val="1" />
-        </c:dLbls>
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921728" />
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="154227840" />
         <c:ser>
           <c:idx val="0" />
           <c:order val="0" />
@@ -11669,7 +11618,6 @@
               <a:srgbClr val="F0F8FF" />
             </a:solidFill>
           </c:spPr>
-          <c:invertIfNegative />
           <c:cat>
             <c:strLit>
               <c:ptCount val="4" />
@@ -11689,8 +11637,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>10</c:v>
               </c:pt>
@@ -11724,7 +11672,6 @@
               <a:srgbClr val="A52A2A" />
             </a:solidFill>
           </c:spPr>
-          <c:invertIfNegative />
           <c:cat>
             <c:strLit>
               <c:ptCount val="4" />
@@ -11744,8 +11691,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>10</c:v>
               </c:pt>
@@ -11779,7 +11726,6 @@
               <a:srgbClr val="008000" />
             </a:solidFill>
           </c:spPr>
-          <c:invertIfNegative />
           <c:cat>
             <c:strLit>
               <c:ptCount val="4" />
@@ -11799,8 +11745,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>13</c:v>
               </c:pt>
@@ -11816,8 +11762,55 @@
             </c:numLit>
           </c:val>
         </c:ser>
+        <c:dLbls xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+          <c:showLegendKey val="0" />
+          <c:showVal val="0" />
+          <c:showCatName val="0" />
+          <c:showSerName val="0" />
+          <c:showPercent val="0" />
+          <c:showBubbleSize val="0" />
+          <c:showLeaderLines val="1" />
+        </c:dLbls>
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921735" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921736" />
       </c:lineChart>
+      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921735" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="b" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921736" />
+        <c:crosses val="autoZero" />
+        <c:auto val="1" />
+        <c:lblAlgn val="ctr" />
+        <c:lblOffset val="100" />
+        <c:noMultiLvlLbl val="0" />
+      </c:catAx>
+      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921736" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="l" />
+        <c:majorGridlines />
+        <c:numFmt formatCode="General" sourceLinked="0" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921735" />
+        <c:crosses val="autoZero" />
+        <c:crossBetween val="between" />
+      </c:valAx>
     </c:plotArea>
+    <c:plotVisOnly val="1" />
+    <c:dispBlanksAs val="gap" />
+    <c:showDLblsOverMax val="0" />
   </c:chart>
 </c:chartSpace>
 <!--------------------------------------------------------------------------------------------------------------------->

--- a/OfficeIMO.Word/WordChart.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordChart.PrivateMethods.cs
@@ -134,9 +134,12 @@ namespace OfficeIMO.Word {
         }
 
         private Chart GenerateChartBar(Chart chart) {
-            BarChart barChart1 = CreateBarChart();
-            CategoryAxis categoryAxis1 = AddCategoryAxis();
-            ValueAxis valueAxis1 = AddValueAxis();
+            UInt32Value catId = GenerateAxisId();
+            UInt32Value valId = GenerateAxisId();
+
+            BarChart barChart1 = CreateBarChart(catId, valId);
+            CategoryAxis categoryAxis1 = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
+            ValueAxis valueAxis1 = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
             chart.PlotArea.Append(categoryAxis1);
             chart.PlotArea.Append(valueAxis1);
             chart.PlotArea.Append(barChart1);
@@ -144,7 +147,7 @@ namespace OfficeIMO.Word {
             return chart;
         }
 
-        private BarChart CreateBarChart(BarDirectionValues? barDirection = null) {
+        private BarChart CreateBarChart(UInt32Value catAxisId, UInt32Value valAxisId, BarDirectionValues? barDirection = null) {
             barDirection ??= BarDirectionValues.Bar;
             BarChart barChart1 = new BarChart();
             barChart1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
@@ -156,10 +159,10 @@ namespace OfficeIMO.Word {
             BarGrouping barGrouping1 = new BarGrouping() { Val = BarGroupingValues.Standard };
             GapWidth gapWidth1 = new GapWidth() { Val = (UInt16Value)200U };
 
-            AxisId axisId1 = new AxisId() { Val = (UInt32Value)148921728U };
+            AxisId axisId1 = new AxisId() { Val = catAxisId };
             axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
-            AxisId axisId2 = new AxisId() { Val = (UInt32Value)154227840U };
+            AxisId axisId2 = new AxisId() { Val = valAxisId };
             axisId2.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
             Overlap overlap1 = new Overlap() { Val = 0 };
 
@@ -251,7 +254,7 @@ namespace OfficeIMO.Word {
             return chartShapeProperties1;
 
         }
-        private LineChart CreateLineChart() {
+        private LineChart CreateLineChart(UInt32Value catAxisId, UInt32Value valAxisId) {
             LineChart lineChart1 = new LineChart();
             lineChart1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
             Grouping grouping1 = new Grouping() { Val = GroupingValues.Standard };
@@ -261,10 +264,10 @@ namespace OfficeIMO.Word {
             lineChart1.Append(grouping1);
             lineChart1.Append(dataLabels1);
 
-            AxisId axisId1 = new AxisId() { Val = (UInt32Value)148921728U };
+            AxisId axisId1 = new AxisId() { Val = catAxisId };
             axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
-            AxisId axisId2 = new AxisId() { Val = (UInt32Value)154227840U };
+            AxisId axisId2 = new AxisId() { Val = valAxisId };
             axisId2.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
             lineChart1.Append(axisId1);
@@ -273,9 +276,12 @@ namespace OfficeIMO.Word {
         }
 
         private Chart GenerateLineChart(Chart chart) {
-            LineChart lineChart1 = CreateLineChart();
-            CategoryAxis categoryAxis1 = AddCategoryAxis();
-            ValueAxis valueAxis1 = AddValueAxis();
+            UInt32Value catId = GenerateAxisId();
+            UInt32Value valId = GenerateAxisId();
+
+            LineChart lineChart1 = CreateLineChart(catId, valId);
+            CategoryAxis categoryAxis1 = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
+            ValueAxis valueAxis1 = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
             //chart.PlotArea.Append(layout1);
             chart.PlotArea.Append(categoryAxis1);
             chart.PlotArea.Append(valueAxis1);
@@ -315,7 +321,7 @@ namespace OfficeIMO.Word {
 
         }
 
-        private AreaChart CreateAreaChart() {
+        private AreaChart CreateAreaChart(UInt32Value catAxisId, UInt32Value valAxisId) {
             AreaChart chart = new AreaChart();
             chart.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
             Grouping grouping1 = new Grouping() { Val = GroupingValues.Standard };
@@ -325,10 +331,10 @@ namespace OfficeIMO.Word {
 
             chart.Append(grouping1);
 
-            AxisId axisId1 = new AxisId() { Val = (UInt32Value)148921728U };
+            AxisId axisId1 = new AxisId() { Val = catAxisId };
             axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
-            AxisId axisId2 = new AxisId() { Val = (UInt32Value)154227840U };
+            AxisId axisId2 = new AxisId() { Val = valAxisId };
             axisId2.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
             chart.Append(axisId1);
@@ -337,10 +343,13 @@ namespace OfficeIMO.Word {
         }
 
         private Chart GenerateAreaChart(Chart chart) {
-            AreaChart areaChart = CreateAreaChart();
+            UInt32Value catId = GenerateAxisId();
+            UInt32Value valId = GenerateAxisId();
 
-            CategoryAxis categoryAxis1 = AddCategoryAxis();
-            ValueAxis valueAxis1 = AddValueAxis();
+            AreaChart areaChart = CreateAreaChart(catId, valId);
+
+            CategoryAxis categoryAxis1 = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
+            ValueAxis valueAxis1 = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
 
             //chart.PlotArea.Append(layout1);
             chart.PlotArea.Append(categoryAxis1);
@@ -459,7 +468,7 @@ namespace OfficeIMO.Word {
             return scSeries;
         }
 
-        private RadarChart CreateRadarChart() {
+        private RadarChart CreateRadarChart(UInt32Value catAxisId, UInt32Value valAxisId) {
             RadarChart chart = new RadarChart();
             chart.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
@@ -469,10 +478,10 @@ namespace OfficeIMO.Word {
             RadarStyle style = new RadarStyle() { Val = RadarStyleValues.Standard };
             chart.Append(style);
 
-            AxisId axisId1 = new AxisId() { Val = (UInt32Value)148921728U };
+            AxisId axisId1 = new AxisId() { Val = catAxisId };
             axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
-            AxisId axisId2 = new AxisId() { Val = (UInt32Value)154227840U };
+            AxisId axisId2 = new AxisId() { Val = valAxisId };
             axisId2.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
             chart.Append(axisId1);
@@ -481,9 +490,12 @@ namespace OfficeIMO.Word {
         }
 
         private Chart GenerateRadarChart(Chart chart) {
-            RadarChart radarChart = CreateRadarChart();
-            CategoryAxis catAxis = AddCategoryAxis();
-            ValueAxis valAxis = AddValueAxis();
+            UInt32Value catId = GenerateAxisId();
+            UInt32Value valId = GenerateAxisId();
+
+            RadarChart radarChart = CreateRadarChart(catId, valId);
+            CategoryAxis catAxis = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
+            ValueAxis valAxis = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
 
             chart.PlotArea.Append(catAxis);
             chart.PlotArea.Append(valAxis);
@@ -513,7 +525,7 @@ namespace OfficeIMO.Word {
             return radarSeries;
         }
 
-        private Bar3DChart CreateBar3DChart() {
+        private Bar3DChart CreateBar3DChart(UInt32Value catAxisId, UInt32Value valAxisId) {
             Bar3DChart chart = new Bar3DChart();
             chart.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
             chart.Append(new BarDirection() { Val = BarDirectionValues.Column });
@@ -521,9 +533,9 @@ namespace OfficeIMO.Word {
             chart.Append(new GapWidth() { Val = (UInt16Value)150U });
             chart.Append(new Overlap() { Val = 0 });
 
-            AxisId axisId1 = new AxisId() { Val = (UInt32Value)148921728U };
+            AxisId axisId1 = new AxisId() { Val = catAxisId };
             axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
-            AxisId axisId2 = new AxisId() { Val = (UInt32Value)154227840U };
+            AxisId axisId2 = new AxisId() { Val = valAxisId };
             axisId2.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
             chart.Append(axisId1);
@@ -532,9 +544,12 @@ namespace OfficeIMO.Word {
         }
 
         private Chart GenerateBar3DChart(Chart chart) {
-            Bar3DChart chart3d = CreateBar3DChart();
-            CategoryAxis catAxis = AddCategoryAxis();
-            ValueAxis valAxis = AddValueAxis();
+            UInt32Value catId = GenerateAxisId();
+            UInt32Value valId = GenerateAxisId();
+
+            Bar3DChart chart3d = CreateBar3DChart(catId, valId);
+            CategoryAxis catAxis = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
+            ValueAxis valAxis = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
 
             chart.PlotArea.Append(catAxis);
             chart.PlotArea.Append(valAxis);

--- a/OfficeIMO.Word/WordChart.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordChart.PrivateMethods.cs
@@ -382,7 +382,12 @@ namespace OfficeIMO.Word {
             return lineChartSeries1;
         }
 
-        private ScatterChart CreateScatterChart() {
+        private static UInt32Value GenerateAxisId() {
+            int id = System.Threading.Interlocked.Increment(ref _axisIdSeed);
+            return (UInt32Value)(uint)id;
+        }
+
+        private ScatterChart CreateScatterChart(UInt32Value xAxisId, UInt32Value yAxisId) {
             ScatterChart chart = new ScatterChart();
             chart.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
             chart.Append(new ScatterStyle() { Val = ScatterStyleValues.Marker });
@@ -390,10 +395,10 @@ namespace OfficeIMO.Word {
             DataLabels labels = AddDataLabel();
             chart.Append(labels);
 
-            AxisId axisId1 = new AxisId() { Val = (UInt32Value)148921728U };
+            AxisId axisId1 = new AxisId() { Val = xAxisId };
             axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
-            AxisId axisId2 = new AxisId() { Val = (UInt32Value)154227840U };
+            AxisId axisId2 = new AxisId() { Val = yAxisId };
             axisId2.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
             chart.Append(axisId1);
@@ -402,10 +407,10 @@ namespace OfficeIMO.Word {
         }
 
         private Chart GenerateScatterChart(Chart chart) {
-            ScatterChart scatter = CreateScatterChart();
+            UInt32Value xId = GenerateAxisId();
+            UInt32Value yId = GenerateAxisId();
 
-            UInt32Value xId = 148921728U;
-            UInt32Value yId = 154227840U;
+            ScatterChart scatter = CreateScatterChart(xId, yId);
 
             ValueAxis xAxis = AddValueAxisInternal(xId, yId, AxisPositionValues.Bottom);
             ValueAxis yAxis = AddValueAxisInternal(yId, xId, AxisPositionValues.Left);

--- a/OfficeIMO.Word/WordChart.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordChart.PrivateMethods.cs
@@ -403,8 +403,12 @@ namespace OfficeIMO.Word {
 
         private Chart GenerateScatterChart(Chart chart) {
             ScatterChart scatter = CreateScatterChart();
-            ValueAxis xAxis = AddValueAxis();
-            ValueAxis yAxis = AddValueAxis();
+
+            UInt32Value xId = 148921728U;
+            UInt32Value yId = 154227840U;
+
+            ValueAxis xAxis = AddValueAxisInternal(xId, yId, AxisPositionValues.Bottom);
+            ValueAxis yAxis = AddValueAxisInternal(yId, xId, AxisPositionValues.Left);
 
             chart.PlotArea.Append(xAxis);
             chart.PlotArea.Append(yAxis);

--- a/OfficeIMO.Word/WordChart.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordChart.PrivateMethods.cs
@@ -126,8 +126,8 @@ namespace OfficeIMO.Word {
 
         private Chart CreatePieChart(Chart chart) {
             PieChart pieChart1 = new PieChart();
-            DataLabels dataLabels1 = AddDataLabel();
             pieChart1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+            DataLabels dataLabels1 = AddDataLabel();
             pieChart1.Append(dataLabels1);
             chart.PlotArea.Append(pieChart1);
             return chart;
@@ -140,9 +140,9 @@ namespace OfficeIMO.Word {
             BarChart barChart1 = CreateBarChart(catId, valId);
             CategoryAxis categoryAxis1 = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
             ValueAxis valueAxis1 = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
+            chart.PlotArea.Append(barChart1);
             chart.PlotArea.Append(categoryAxis1);
             chart.PlotArea.Append(valueAxis1);
-            chart.PlotArea.Append(barChart1);
 
             return chart;
         }
@@ -152,12 +152,10 @@ namespace OfficeIMO.Word {
             BarChart barChart1 = new BarChart();
             barChart1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
-            DataLabels dataLabels1 = AddDataLabel();
-            barChart1.Append(dataLabels1);
-
             BarDirection barDirection1 = new BarDirection() { Val = barDirection };
             BarGrouping barGrouping1 = new BarGrouping() { Val = BarGroupingValues.Standard };
             GapWidth gapWidth1 = new GapWidth() { Val = (UInt16Value)200U };
+            DataLabels dataLabels1 = AddDataLabel();
 
             AxisId axisId1 = new AxisId() { Val = catAxisId };
             axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
@@ -169,9 +167,10 @@ namespace OfficeIMO.Word {
             barChart1.Append(barDirection1);
             barChart1.Append(barGrouping1);
             barChart1.Append(gapWidth1);
+            barChart1.Append(dataLabels1);
+            barChart1.Append(overlap1);
             barChart1.Append(axisId1);
             barChart1.Append(axisId2);
-            barChart1.Append(overlap1);
             return barChart1;
         }
 
@@ -283,9 +282,9 @@ namespace OfficeIMO.Word {
             CategoryAxis categoryAxis1 = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
             ValueAxis valueAxis1 = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
             //chart.PlotArea.Append(layout1);
+            chart.PlotArea.Append(lineChart1);
             chart.PlotArea.Append(categoryAxis1);
             chart.PlotArea.Append(valueAxis1);
-            chart.PlotArea.Append(lineChart1);
             return chart;
         }
 
@@ -326,10 +325,10 @@ namespace OfficeIMO.Word {
             chart.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
             Grouping grouping1 = new Grouping() { Val = GroupingValues.Standard };
 
+            chart.Append(grouping1);
+
             DataLabels dataLabels1 = AddDataLabel();
             chart.Append(dataLabels1);
-
-            chart.Append(grouping1);
 
             AxisId axisId1 = new AxisId() { Val = catAxisId };
             axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
@@ -352,9 +351,9 @@ namespace OfficeIMO.Word {
             ValueAxis valueAxis1 = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
 
             //chart.PlotArea.Append(layout1);
+            chart.PlotArea.Append(areaChart);
             chart.PlotArea.Append(categoryAxis1);
             chart.PlotArea.Append(valueAxis1);
-            chart.PlotArea.Append(areaChart);
 
 
             return chart;
@@ -424,9 +423,9 @@ namespace OfficeIMO.Word {
             ValueAxis xAxis = AddValueAxisInternal(xId, yId, AxisPositionValues.Bottom);
             ValueAxis yAxis = AddValueAxisInternal(yId, xId, AxisPositionValues.Left);
 
+            chart.PlotArea.Append(scatter);
             chart.PlotArea.Append(xAxis);
             chart.PlotArea.Append(yAxis);
-            chart.PlotArea.Append(scatter);
 
             return chart;
         }
@@ -472,11 +471,11 @@ namespace OfficeIMO.Word {
             RadarChart chart = new RadarChart();
             chart.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
-            DataLabels labels = AddDataLabel();
-            chart.Append(labels);
-
             RadarStyle style = new RadarStyle() { Val = RadarStyleValues.Standard };
             chart.Append(style);
+
+            DataLabels labels = AddDataLabel();
+            chart.Append(labels);
 
             AxisId axisId1 = new AxisId() { Val = catAxisId };
             axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
@@ -497,9 +496,9 @@ namespace OfficeIMO.Word {
             CategoryAxis catAxis = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
             ValueAxis valAxis = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
 
+            chart.PlotArea.Append(radarChart);
             chart.PlotArea.Append(catAxis);
             chart.PlotArea.Append(valAxis);
-            chart.PlotArea.Append(radarChart);
             return chart;
         }
 
@@ -551,9 +550,9 @@ namespace OfficeIMO.Word {
             CategoryAxis catAxis = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
             ValueAxis valAxis = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
 
+            chart.PlotArea.Append(chart3d);
             chart.PlotArea.Append(catAxis);
             chart.PlotArea.Append(valAxis);
-            chart.PlotArea.Append(chart3d);
             return chart;
         }
 

--- a/OfficeIMO.Word/WordChart.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordChart.PrivateMethods.cs
@@ -381,5 +381,188 @@ namespace OfficeIMO.Word {
 
             return lineChartSeries1;
         }
+
+        private ScatterChart CreateScatterChart() {
+            ScatterChart chart = new ScatterChart();
+            chart.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+            chart.Append(new ScatterStyle() { Val = ScatterStyleValues.Marker });
+
+            DataLabels labels = AddDataLabel();
+            chart.Append(labels);
+
+            AxisId axisId1 = new AxisId() { Val = (UInt32Value)148921728U };
+            axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+
+            AxisId axisId2 = new AxisId() { Val = (UInt32Value)154227840U };
+            axisId2.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+
+            chart.Append(axisId1);
+            chart.Append(axisId2);
+            return chart;
+        }
+
+        private Chart GenerateScatterChart(Chart chart) {
+            ScatterChart scatter = CreateScatterChart();
+            ValueAxis xAxis = AddValueAxis();
+            ValueAxis yAxis = AddValueAxis();
+
+            chart.PlotArea.Append(xAxis);
+            chart.PlotArea.Append(yAxis);
+            chart.PlotArea.Append(scatter);
+
+            return chart;
+        }
+
+        private ScatterChartSeries AddScatterChartSeries(UInt32Value index, string series, SixLabors.ImageSharp.Color color, List<double> xValues, List<double> yValues) {
+            ScatterChartSeries scSeries = new ScatterChartSeries();
+            DocumentFormat.OpenXml.Drawing.Charts.Index idx = new DocumentFormat.OpenXml.Drawing.Charts.Index() { Val = index };
+            Order order = new Order() { Val = index };
+
+            SeriesText text = new SeriesText();
+            var seriesRef = AddSeries(0, series);
+            text.Append(seriesRef);
+
+            var shape = AddShapeProperties(color);
+
+            XValues x = new XValues();
+            NumberLiteral xLit = new NumberLiteral();
+            xLit.Append(new PointCount() { Val = (uint)xValues.Count });
+            for (int i = 0; i < xValues.Count; i++) {
+                xLit.Append(new NumericPoint() { Index = (uint)i, NumericValue = new NumericValue(xValues[i].ToString()) });
+            }
+            x.Append(xLit);
+
+            YValues y = new YValues();
+            NumberLiteral yLit = new NumberLiteral();
+            yLit.Append(new PointCount() { Val = (uint)yValues.Count });
+            for (int i = 0; i < yValues.Count; i++) {
+                yLit.Append(new NumericPoint() { Index = (uint)i, NumericValue = new NumericValue(yValues[i].ToString()) });
+            }
+            y.Append(yLit);
+
+            scSeries.Append(idx);
+            scSeries.Append(order);
+            scSeries.Append(text);
+            scSeries.Append(shape);
+            scSeries.Append(x);
+            scSeries.Append(y);
+
+            return scSeries;
+        }
+
+        private RadarChart CreateRadarChart() {
+            RadarChart chart = new RadarChart();
+            chart.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+
+            DataLabels labels = AddDataLabel();
+            chart.Append(labels);
+
+            RadarStyle style = new RadarStyle() { Val = RadarStyleValues.Standard };
+            chart.Append(style);
+
+            AxisId axisId1 = new AxisId() { Val = (UInt32Value)148921728U };
+            axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+
+            AxisId axisId2 = new AxisId() { Val = (UInt32Value)154227840U };
+            axisId2.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+
+            chart.Append(axisId1);
+            chart.Append(axisId2);
+            return chart;
+        }
+
+        private Chart GenerateRadarChart(Chart chart) {
+            RadarChart radarChart = CreateRadarChart();
+            CategoryAxis catAxis = AddCategoryAxis();
+            ValueAxis valAxis = AddValueAxis();
+
+            chart.PlotArea.Append(catAxis);
+            chart.PlotArea.Append(valAxis);
+            chart.PlotArea.Append(radarChart);
+            return chart;
+        }
+
+        private RadarChartSeries AddRadarChartSeries<T>(UInt32Value index, string series, SixLabors.ImageSharp.Color color, List<string> categories, List<T> values) {
+            RadarChartSeries radarSeries = new RadarChartSeries();
+            DocumentFormat.OpenXml.Drawing.Charts.Index idx = new DocumentFormat.OpenXml.Drawing.Charts.Index() { Val = index };
+            Order order = new Order() { Val = index };
+
+            SeriesText text = new SeriesText();
+            var seriesRef = AddSeries(0, series);
+            text.Append(seriesRef);
+
+            var shape = AddShapeProperties(color);
+            CategoryAxisData cats = AddCategoryAxisData(categories);
+            Values vals = AddValuesAxisData(values);
+
+            radarSeries.Append(idx);
+            radarSeries.Append(order);
+            radarSeries.Append(text);
+            radarSeries.Append(shape);
+            radarSeries.Append(cats);
+            radarSeries.Append(vals);
+            return radarSeries;
+        }
+
+        private Bar3DChart CreateBar3DChart() {
+            Bar3DChart chart = new Bar3DChart();
+            chart.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+            chart.Append(new BarDirection() { Val = BarDirectionValues.Column });
+            chart.Append(new BarGrouping() { Val = BarGroupingValues.Clustered });
+            chart.Append(new GapWidth() { Val = (UInt16Value)150U });
+            chart.Append(new Overlap() { Val = 0 });
+
+            AxisId axisId1 = new AxisId() { Val = (UInt32Value)148921728U };
+            axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+            AxisId axisId2 = new AxisId() { Val = (UInt32Value)154227840U };
+            axisId2.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+
+            chart.Append(axisId1);
+            chart.Append(axisId2);
+            return chart;
+        }
+
+        private Chart GenerateBar3DChart(Chart chart) {
+            Bar3DChart chart3d = CreateBar3DChart();
+            CategoryAxis catAxis = AddCategoryAxis();
+            ValueAxis valAxis = AddValueAxis();
+
+            chart.PlotArea.Append(catAxis);
+            chart.PlotArea.Append(valAxis);
+            chart.PlotArea.Append(chart3d);
+            return chart;
+        }
+
+        private BarChartSeries AddBar3DChartSeries<T>(UInt32Value index, string series, SixLabors.ImageSharp.Color color, List<string> categories, List<T> values) {
+            BarChartSeries series3d = AddBarChartSeries(index, series, color, categories, values);
+            return series3d;
+        }
+
+        private void EnsureChartExistsScatter() {
+            if (_chart == null) {
+                _chart = GenerateChart();
+                _chart = GenerateScatterChart(_chart);
+                _chartPart.ChartSpace.Append(_chart);
+                UpdateTitle();
+            }
+        }
+
+        private void EnsureChartExistsRadar() {
+            if (_chart == null) {
+                _chart = GenerateChart();
+                _chart = GenerateRadarChart(_chart);
+                _chartPart.ChartSpace.Append(_chart);
+                UpdateTitle();
+            }
+        }
+
+        private void EnsureChartExistsBar3D() {
+            if (_chart == null) {
+                _chart = GenerateChart();
+                _chart = GenerateBar3DChart(_chart);
+                _chartPart.ChartSpace.Append(_chart);
+                UpdateTitle();
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordChart.PublicMethods.cs
+++ b/OfficeIMO.Word/WordChart.PublicMethods.cs
@@ -97,6 +97,39 @@ namespace OfficeIMO.Word {
             }
         }
 
+        public void AddScatter(string name, List<double> xValues, List<double> yValues, SixLabors.ImageSharp.Color color) {
+            EnsureChartExistsScatter();
+            if (_chart != null) {
+                var scatterChart = _chart.PlotArea.GetFirstChild<ScatterChart>();
+                if (scatterChart != null) {
+                    var series = AddScatterChartSeries(this._index, name, color, xValues, yValues);
+                    scatterChart.Append(series);
+                }
+            }
+        }
+
+        public void AddRadar<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
+            EnsureChartExistsRadar();
+            if (_chart != null) {
+                var radarChart = _chart.PlotArea.GetFirstChild<RadarChart>();
+                if (radarChart != null) {
+                    var series = AddRadarChartSeries(this._index, name, color, this.Categories, values);
+                    radarChart.Append(series);
+                }
+            }
+        }
+
+        public void AddBar3D<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
+            EnsureChartExistsBar3D();
+            if (_chart != null) {
+                var chart3d = _chart.PlotArea.GetFirstChild<Bar3DChart>();
+                if (chart3d != null) {
+                    var series = AddBar3DChartSeries(this._index, name, color, this.Categories, values);
+                    chart3d.Append(series);
+                }
+            }
+        }
+
         public void AddLegend(LegendPositionValues legendPosition) {
             if (_chart != null) {
                 Legend legend = new Legend();

--- a/OfficeIMO.Word/WordChart.PublicMethods.cs
+++ b/OfficeIMO.Word/WordChart.PublicMethods.cs
@@ -151,7 +151,16 @@ namespace OfficeIMO.Word {
                 Overlay overlay = new Overlay() { Val = false };
                 legend.Append(postion);
                 legend.Append(overlay);
-                _chart.Append(legend);
+
+                // Insert legend in correct position according to OpenXML schema
+                // Legend should come after PlotArea but before other elements like PlotVisibleOnly
+                var plotVisibleOnly = _chart.GetFirstChild<PlotVisibleOnly>();
+                if (plotVisibleOnly != null) {
+                    _chart.InsertBefore(legend, plotVisibleOnly);
+                } else {
+                    // If no PlotVisibleOnly, just append at the end
+                    _chart.Append(legend);
+                }
             }
         }
     }

--- a/OfficeIMO.Word/WordChart.PublicMethods.cs
+++ b/OfficeIMO.Word/WordChart.PublicMethods.cs
@@ -22,7 +22,7 @@ namespace OfficeIMO.Word {
                 var lineChart = _chart.PlotArea.GetFirstChild<LineChart>();
                 if (lineChart != null) {
                     LineChartSeries lineChartSeries = AddLineChartSeries(this._index, name, color, this.Categories, values.ToList());
-                    lineChart.Append(lineChartSeries);
+                    InsertSeries(lineChart, lineChartSeries);
                 }
             }
         }
@@ -39,7 +39,7 @@ namespace OfficeIMO.Word {
             var lineChart = _chart.PlotArea.GetFirstChild<LineChart>();
             if (lineChart != null) {
                 LineChartSeries lineChartSeries = AddLineChartSeries(this._index, name, color, this.Categories, values);
-                lineChart.Append(lineChartSeries);
+                InsertSeries(lineChart, lineChartSeries);
             }
 
         }
@@ -53,7 +53,7 @@ namespace OfficeIMO.Word {
             var barChart = _chart.PlotArea.GetFirstChild<BarChart>();
             if (barChart != null) {
                 BarChartSeries barChartSeries = AddBarChartSeries(this._index, name, color, this.Categories, new List<int>() { values });
-                barChart.Append(barChartSeries);
+                InsertSeries(barChart, barChartSeries);
             }
         }
 
@@ -62,7 +62,7 @@ namespace OfficeIMO.Word {
             var barChart = _chart.PlotArea.GetFirstChild<BarChart>();
             if (barChart != null) {
                 BarChartSeries barChartSeries = AddBarChartSeries(this._index, name, color, this.Categories, values);
-                barChart.Append(barChartSeries);
+                InsertSeries(barChart, barChartSeries);
             }
         }
 
@@ -71,7 +71,7 @@ namespace OfficeIMO.Word {
             var barChart = _chart.PlotArea.GetFirstChild<BarChart>();
             if (barChart != null) {
                 BarChartSeries barChartSeries = AddBarChartSeries(this._index, name, color, this.Categories, values.ToList());
-                barChart.Append(barChartSeries);
+                InsertSeries(barChart, barChartSeries);
             }
         }
 
@@ -81,7 +81,7 @@ namespace OfficeIMO.Word {
                 var barChart = _chart.PlotArea.GetFirstChild<AreaChart>();
                 if (barChart != null) {
                     AreaChartSeries areaChartSeries = AddAreaChartSeries(this._index, name, color, this.Categories, values);
-                    barChart.Append(areaChartSeries);
+                    InsertSeries(barChart, areaChartSeries);
                 }
             }
         }
@@ -92,7 +92,7 @@ namespace OfficeIMO.Word {
                 var barChart = _chart.PlotArea.GetFirstChild<AreaChart>();
                 if (barChart != null) {
                     AreaChartSeries areaChartSeries = AddAreaChartSeries(this._index, name, color, this.Categories, values.ToList());
-                    barChart.Append(areaChartSeries);
+                    InsertSeries(barChart, areaChartSeries);
                 }
             }
         }
@@ -103,7 +103,7 @@ namespace OfficeIMO.Word {
                 var scatterChart = _chart.PlotArea.GetFirstChild<ScatterChart>();
                 if (scatterChart != null) {
                     var series = AddScatterChartSeries(this._index, name, color, xValues, yValues);
-                    scatterChart.Append(series);
+                    InsertSeries(scatterChart, series);
                 }
             }
         }
@@ -114,7 +114,7 @@ namespace OfficeIMO.Word {
                 var radarChart = _chart.PlotArea.GetFirstChild<RadarChart>();
                 if (radarChart != null) {
                     var series = AddRadarChartSeries(this._index, name, color, this.Categories, values);
-                    radarChart.Append(series);
+                    InsertSeries(radarChart, series);
                 }
             }
         }
@@ -125,7 +125,7 @@ namespace OfficeIMO.Word {
                 var chart3d = _chart.PlotArea.GetFirstChild<Bar3DChart>();
                 if (chart3d != null) {
                     var series = AddBar3DChartSeries(this._index, name, color, this.Categories, values);
-                    chart3d.Append(series);
+                    InsertSeries(chart3d, series);
                 }
             }
         }

--- a/OfficeIMO.Word/WordChart.cs
+++ b/OfficeIMO.Word/WordChart.cs
@@ -13,6 +13,7 @@ using PlotArea = DocumentFormat.OpenXml.Drawing.Charts.PlotArea;
 
 namespace OfficeIMO.Word {
     public partial class WordChart : WordElement {
+        private static int _axisIdSeed = 148921728;
         public WordChart(WordDocument document, WordParagraph paragraph, Drawing drawing) {
             _document = document;
             _drawing = drawing;

--- a/OfficeIMO.Word/WordChart.cs
+++ b/OfficeIMO.Word/WordChart.cs
@@ -103,22 +103,26 @@ namespace OfficeIMO.Word {
         }
 
         private ValueAxis AddValueAxis() {
+            return AddValueAxisInternal((UInt32Value)154227840U, (UInt32Value)148921728U, AxisPositionValues.Left);
+        }
+
+        private ValueAxis AddValueAxisInternal(UInt32Value axisId, UInt32Value crossingAxis, AxisPositionValues position) {
             ValueAxis valueAxis1 = new ValueAxis();
             valueAxis1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
-            AxisId axisId4 = new AxisId() { Val = (UInt32Value)154227840U };
+            AxisId axisId4 = new AxisId() { Val = axisId };
 
             Scaling scaling2 = new Scaling();
             Orientation orientation2 = new Orientation() { Val = OrientationValues.MinMax };
 
             scaling2.Append(orientation2);
             Delete delete2 = new Delete() { Val = false };
-            AxisPosition axisPosition2 = new AxisPosition() { Val = AxisPositionValues.Left };
+            AxisPosition axisPosition2 = new AxisPosition() { Val = position };
             DocumentFormat.OpenXml.Drawing.Charts.NumberingFormat numberingFormat1 = new DocumentFormat.OpenXml.Drawing.Charts.NumberingFormat() { FormatCode = "General", SourceLinked = false };
             MajorGridlines majorGridlines1 = new MajorGridlines();
             MajorTickMark majorTickMark2 = new MajorTickMark() { Val = TickMarkValues.Outside };
             MinorTickMark minorTickMark2 = new MinorTickMark() { Val = TickMarkValues.None };
             TickLabelPosition tickLabelPosition2 = new TickLabelPosition() { Val = TickLabelPositionValues.NextTo };
-            CrossingAxis crossingAxis2 = new CrossingAxis() { Val = (UInt32Value)148921728U };
+            CrossingAxis crossingAxis2 = new CrossingAxis() { Val = crossingAxis };
             Crosses crosses2 = new Crosses() { Val = CrossesValues.AutoZero };
             CrossBetween crossBetween1 = new CrossBetween() { Val = CrossBetweenValues.Between };
 

--- a/OfficeIMO.Word/WordChart.cs
+++ b/OfficeIMO.Word/WordChart.cs
@@ -66,20 +66,24 @@ namespace OfficeIMO.Word {
             }
         }
         private CategoryAxis AddCategoryAxis() {
+            return AddCategoryAxisInternal((UInt32Value)148921728U, (UInt32Value)154227840U, AxisPositionValues.Bottom);
+        }
+
+        private CategoryAxis AddCategoryAxisInternal(UInt32Value axisId, UInt32Value crossingAxis, AxisPositionValues position) {
             CategoryAxis categoryAxis1 = new CategoryAxis();
             categoryAxis1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
-            AxisId axisId3 = new AxisId() { Val = (UInt32Value)148921728U };
+            AxisId axisId3 = new AxisId() { Val = axisId };
 
             Scaling scaling1 = new Scaling();
             Orientation orientation1 = new Orientation() { Val = OrientationValues.MinMax };
 
             scaling1.Append(orientation1);
             Delete delete1 = new Delete() { Val = false };
-            AxisPosition axisPosition1 = new AxisPosition() { Val = AxisPositionValues.Bottom };
+            AxisPosition axisPosition1 = new AxisPosition() { Val = position };
             MajorTickMark majorTickMark1 = new MajorTickMark() { Val = TickMarkValues.Outside };
             MinorTickMark minorTickMark1 = new MinorTickMark() { Val = TickMarkValues.None };
             TickLabelPosition tickLabelPosition1 = new TickLabelPosition() { Val = TickLabelPositionValues.NextTo };
-            CrossingAxis crossingAxis1 = new CrossingAxis() { Val = (UInt32Value)154227840U };
+            CrossingAxis crossingAxis1 = new CrossingAxis() { Val = crossingAxis };
             Crosses crosses1 = new Crosses() { Val = CrossesValues.AutoZero };
             AutoLabeled autoLabeled1 = new AutoLabeled() { Val = true };
             LabelAlignment labelAlignment1 = new LabelAlignment() { Val = LabelAlignmentValues.Center };

--- a/OfficeIMO.Word/WordChart.cs
+++ b/OfficeIMO.Word/WordChart.cs
@@ -219,14 +219,14 @@ namespace OfficeIMO.Word {
             PlotVisibleOnly plotVisibleOnly1 = new PlotVisibleOnly() { Val = true };
             DisplayBlanksAs displayBlanksAs1 = new DisplayBlanksAs() { Val = DisplayBlanksAsValues.Gap };
             ShowDataLabelsOverMaximum showDataLabelsOverMaximum1 = new ShowDataLabelsOverMaximum() { Val = false };
-            chart1.Append(autoTitleDeleted1);
-            chart1.Append(plotVisibleOnly1);
-            chart1.Append(displayBlanksAs1);
-            chart1.Append(showDataLabelsOverMaximum1);
-            chart1.Append(plotArea1);
             if (!string.IsNullOrEmpty(title)) {
                 chart1.Append(AddTitle(title));
             }
+            chart1.Append(autoTitleDeleted1);
+            chart1.Append(plotArea1);
+            chart1.Append(plotVisibleOnly1);
+            chart1.Append(displayBlanksAs1);
+            chart1.Append(showDataLabelsOverMaximum1);
             return chart1;
         }
 
@@ -301,8 +301,8 @@ namespace OfficeIMO.Word {
             NumberLiteral literal = new NumberLiteral();
             FormatCode format = new FormatCode() { Text = "General" };
             PointCount count = new PointCount() { Val = (uint)dataList.Count };
-            literal.Append(count);
             literal.Append(format);
+            literal.Append(count);
             var index = 0;
             foreach (var data in dataList) {
                 var numericPoint = new NumericPoint() { Index = Convert.ToUInt32(index), NumericValue = new NumericValue() { Text = data.ToString() } };

--- a/OfficeIMO.Word/WordChart.cs
+++ b/OfficeIMO.Word/WordChart.cs
@@ -14,6 +14,20 @@ using PlotArea = DocumentFormat.OpenXml.Drawing.Charts.PlotArea;
 namespace OfficeIMO.Word {
     public partial class WordChart : WordElement {
         private static int _axisIdSeed = 148921728;
+
+        internal static void InitializeAxisIdSeed(WordprocessingDocument document) {
+            uint max = (uint)_axisIdSeed;
+            foreach (var part in document.MainDocumentPart.ChartParts) {
+                var chart = part.ChartSpace.GetFirstChild<Chart>();
+                if (chart == null) continue;
+                foreach (var axis in chart.Descendants<AxisId>()) {
+                    if (axis.Val != null && axis.Val.Value > max) {
+                        max = axis.Val.Value;
+                    }
+                }
+            }
+            _axisIdSeed = (int)max;
+        }
         public WordChart(WordDocument document, WordParagraph paragraph, Drawing drawing) {
             _document = document;
             _drawing = drawing;

--- a/OfficeIMO.Word/WordChart.cs
+++ b/OfficeIMO.Word/WordChart.cs
@@ -10,10 +10,27 @@ using Formula = DocumentFormat.OpenXml.Drawing.Charts.Formula;
 using Legend = DocumentFormat.OpenXml.Drawing.Charts.Legend;
 using NumericValue = DocumentFormat.OpenXml.Drawing.Charts.NumericValue;
 using PlotArea = DocumentFormat.OpenXml.Drawing.Charts.PlotArea;
+using System.Threading;
 
 namespace OfficeIMO.Word {
     public partial class WordChart : WordElement {
         private static int _axisIdSeed = 148921728;
+        private static int _docPrIdSeed = 1;
+
+        internal static void InitializeDocPrIdSeed(WordprocessingDocument document) {
+            uint max = (uint)_docPrIdSeed;
+            foreach (var prop in document.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties>()) {
+                if (prop.Id != null && prop.Id > max) {
+                    max = prop.Id;
+                }
+            }
+            _docPrIdSeed = (int)max;
+        }
+
+        private static UInt32Value GenerateDocPrId() {
+            int id = System.Threading.Interlocked.Increment(ref _docPrIdSeed);
+            return (UInt32Value)(uint)id;
+        }
 
         internal static void InitializeAxisIdSeed(WordprocessingDocument document) {
             uint max = (uint)_axisIdSeed;
@@ -353,7 +370,7 @@ namespace OfficeIMO.Word {
             inline1.AddNamespaceDeclaration("wp", "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing");
             DocumentFormat.OpenXml.Drawing.Wordprocessing.Extent extent1 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.Extent() { Cx = (long)width * EnglishMetricUnitsPerInch / PixelsPerInch, Cy = (long)height * EnglishMetricUnitsPerInch / PixelsPerInch };
             DocumentFormat.OpenXml.Drawing.Wordprocessing.EffectExtent effectExtent1 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.EffectExtent() { LeftEdge = 0L, TopEdge = 0L, RightEdge = 19050L, BottomEdge = 19050L };
-            DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties docProperties1 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties() { Id = (UInt32Value)2U, Name = "chart" };
+            DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties docProperties1 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties() { Id = GenerateDocPrId(), Name = "chart" };
 
             DocumentFormat.OpenXml.Drawing.Graphic graphic1 = new DocumentFormat.OpenXml.Drawing.Graphic();
             graphic1.AddNamespaceDeclaration("a", "http://schemas.openxmlformats.org/drawingml/2006/main");

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -61,7 +61,10 @@ namespace OfficeIMO.Word {
         /// .AddBar() to add a bar chart
         /// .AddLine() to add a line chart
         /// .AddPie() to add a pie chart
-        /// .AddArea() to add an area chart.
+        /// .AddArea() to add an area chart
+        /// .AddScatter() to add a scatter chart
+        /// .AddRadar() to add a radar chart
+        /// .AddBar3D() to add a 3-D bar chart.
         /// You can't mix and match the types of charts.
         /// </summary>
         /// <param name="title">The title.</param>

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -704,6 +704,7 @@ namespace OfficeIMO.Word {
             word._document = wordDocument.MainDocumentPart.Document;
             word.LoadDocument();
             WordChart.InitializeAxisIdSeed(wordDocument);
+            WordChart.InitializeDocPrIdSeed(wordDocument);
 
             // initialize abstract number id for lists to make sure those are unique
             WordListStyles.InitializeAbstractNumberId(word._wordprocessingDocument);
@@ -731,6 +732,7 @@ namespace OfficeIMO.Word {
             document._document = wordDocument.MainDocumentPart.Document;
             document.LoadDocument();
             WordChart.InitializeAxisIdSeed(wordDocument);
+            WordChart.InitializeDocPrIdSeed(wordDocument);
 
             // initialize abstract number id for lists to make sure those are unique
             WordListStyles.InitializeAbstractNumberId(document._wordprocessingDocument);

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -703,6 +703,7 @@ namespace OfficeIMO.Word {
             word._wordprocessingDocument = wordDocument;
             word._document = wordDocument.MainDocumentPart.Document;
             word.LoadDocument();
+            WordChart.InitializeAxisIdSeed(wordDocument);
 
             // initialize abstract number id for lists to make sure those are unique
             WordListStyles.InitializeAbstractNumberId(word._wordprocessingDocument);
@@ -729,6 +730,7 @@ namespace OfficeIMO.Word {
             document._wordprocessingDocument = wordDocument;
             document._document = wordDocument.MainDocumentPart.Document;
             document.LoadDocument();
+            WordChart.InitializeAxisIdSeed(wordDocument);
 
             // initialize abstract number id for lists to make sure those are unique
             WordListStyles.InitializeAbstractNumberId(document._wordprocessingDocument);

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -401,7 +401,10 @@ namespace OfficeIMO.Word {
         /// .AddBar() to add a bar chart
         /// .AddLine() to add a line chart
         /// .AddPie() to add a pie chart
-        /// .AddArea() to add an area chart.
+        /// .AddArea() to add an area chart
+        /// .AddScatter() to add a scatter chart
+        /// .AddRadar() to add a radar chart
+        /// .AddBar3D() to add a 3-D bar chart.
         /// You can't mix and match the types of charts.
         /// </summary>
         /// <param name="title">The title.</param>


### PR DESCRIPTION
## Summary
- extend `WordChart` to create scatter, radar and 3‑D bar charts
- expose builders for the new chart types
- demonstrate new chart types in examples
- test chart XML for the new elements

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_6850078aea04832e99d566352613a7e4