### PR TITLE
Add rectangle shape support

### DIFF
--- a/OfficeIMO.Tests/Word.Shapes.cs
+++ b/OfficeIMO.Tests/Word.Shapes.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_CreatingWordDocumentWithShapes() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreateDocumentWithShapes.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Paragraph with shape");
+                var shape = paragraph.AddShape(100, 50, "#FF0000");
+
+                Assert.True(document.Paragraphs.Count == 1);
+                Assert.NotNull(paragraph.Shape);
+                Assert.Equal(100d, shape.Width, 1);
+                Assert.Equal(50d, shape.Height, 1);
+
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithShapes.docx"))) {
+                Assert.True(document.Paragraphs[0].Shape != null);
+                Assert.Equal(100d, document.Paragraphs[0].Shape.Width, 1);
+                Assert.Equal(50d, document.Paragraphs[0].Shape.Height, 1);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -452,5 +452,16 @@ namespace OfficeIMO.Word {
             WordTextBox wordTextBox = new WordTextBox(this._document, this, text, wrapTextImage);
             return wordTextBox;
         }
+
+        /// <summary>
+        /// Add a rectangle shape to the paragraph.
+        /// </summary>
+        /// <param name="widthPt">Width in points.</param>
+        /// <param name="heightPt">Height in points.</param>
+        /// <param name="fillColor">Fill color in hex format.</param>
+        public WordShape AddShape(double widthPt, double heightPt, string fillColor = "#FFFFFF") {
+            WordShape wordShape = new WordShape(this._document, this, widthPt, heightPt, fillColor);
+            return wordShape;
+        }
     }
 }

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -10,6 +10,7 @@ using Run = DocumentFormat.OpenXml.Wordprocessing.Run;
 using RunProperties = DocumentFormat.OpenXml.Wordprocessing.RunProperties;
 using TabStop = DocumentFormat.OpenXml.Wordprocessing.TabStop;
 using Text = DocumentFormat.OpenXml.Wordprocessing.Text;
+using V = DocumentFormat.OpenXml.Vml;
 
 namespace OfficeIMO.Word {
     public partial class WordParagraph : WordElement {
@@ -572,9 +573,31 @@ namespace OfficeIMO.Word {
             }
         }
 
+        public WordShape Shape {
+            get {
+                if (_run != null) {
+                    var rectangle = _run.Descendants<V.Rectangle>().FirstOrDefault();
+                    if (rectangle != null) {
+                        return new WordShape(_document, _paragraph, _run);
+                    }
+                }
+                return null;
+            }
+        }
+
         public bool IsTextBox {
             get {
                 if (this.TextBox != null) {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        public bool IsShape {
+            get {
+                if (this.Shape != null) {
                     return true;
                 }
 

--- a/OfficeIMO.Word/WordShape.cs
+++ b/OfficeIMO.Word/WordShape.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using V = DocumentFormat.OpenXml.Vml;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents simple rectangle shape inside a paragraph.
+    /// </summary>
+    public class WordShape : WordElement {
+        internal WordDocument _document;
+        internal WordParagraph _wordParagraph;
+        internal Run _run;
+        internal V.Rectangle _rectangle;
+
+        internal WordShape(WordDocument document, WordParagraph paragraph, double widthPt, double heightPt, string fillColor = "#FFFFFF") {
+            _document = document;
+            _wordParagraph = paragraph;
+            _rectangle = new V.Rectangle() {
+                Id = "Rectangle" + Guid.NewGuid().ToString("N"),
+                Style = $"width:{widthPt}pt;height:{heightPt}pt;mso-wrap-style:square",
+                FillColor = fillColor,
+                Stroked = false
+            };
+
+            Picture pict = new Picture();
+            pict.Append(_rectangle);
+
+            _run = new Run();
+            _run.Append(pict);
+            paragraph._paragraph.Append(_run);
+        }
+
+        internal WordShape(WordDocument document, Paragraph paragraph, Run run) {
+            _document = document;
+            _wordParagraph = new WordParagraph(document, paragraph, run);
+            _run = run;
+            _rectangle = run.Descendants<V.Rectangle>().FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Width of the shape in points.
+        /// </summary>
+        public double Width {
+            get {
+            var style = _rectangle.Style?.Value;
+            if (style != null) {
+                foreach (var part in style.Split(';')) {
+                    var kv = part.Split(':');
+                    if (kv.Length == 2 && kv[0] == "width") {
+                        return double.Parse(kv[1].Replace("pt", ""), CultureInfo.InvariantCulture);
+                    }
+                }
+            }
+            return 0;
+        }
+        }
+
+        /// <summary>
+        /// Height of the shape in points.
+        /// </summary>
+        public double Height {
+            get {
+            var style = _rectangle.Style?.Value;
+            if (style != null) {
+                foreach (var part in style.Split(';')) {
+                    var kv = part.Split(':');
+                    if (kv.Length == 2 && kv[0] == "height") {
+                        return double.Parse(kv[1].Replace("pt", ""), CultureInfo.InvariantCulture);
+                    }
+                }
+            }
+            return 0;
+        }
+        }
+
+        /// <summary>
+        /// Removes the shape from the paragraph.
+        /// </summary>
+        public void Remove() {
+            _run?.Remove();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `WordShape` to manage rectangle shapes
- support creating shapes via `WordParagraph.AddShape`
- expose `Shape` property on `WordParagraph`
- test basic shape insertion

## Testing
- `dotnet test OfficeImo.sln --no-build -v minimal` *(fails: "The argument ... is invalid")*

------
https://chatgpt.com/codex/tasks/task_e_68501de67c5c832ea1f1dc74b32f405a