### PR TITLE
Fix chart docPr ids

### DIFF
--- a/OfficeIMO.VerifyTests/Word/verified/ChartTests.AddingMultipleCharts.verified.txt
+++ b/OfficeIMO.VerifyTests/Word/verified/ChartTests.AddingMultipleCharts.verified.txt
@@ -36,7 +36,7 @@
           <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
             <wp:extent cx="5715000" cy="5715000" />
             <wp:effectExtent l="0" t="0" r="19050" b="19050" />
-            <wp:docPr id="2" name="chart" />
+            <wp:docPr id="1" name="chart" />
             <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
               <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
                 <c:chart xmlns:p6="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" p6:id="R00000001" />
@@ -82,7 +82,7 @@
           <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
             <wp:extent cx="5715000" cy="5715000" />
             <wp:effectExtent l="0" t="0" r="19050" b="19050" />
-            <wp:docPr id="2" name="chart" />
+            <wp:docPr id="3" name="chart" />
             <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
               <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
                 <c:chart xmlns:p6="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" p6:id="R00000003" />
@@ -105,7 +105,7 @@
           <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
             <wp:extent cx="5715000" cy="5715000" />
             <wp:effectExtent l="0" t="0" r="19050" b="19050" />
-            <wp:docPr id="2" name="chart" />
+            <wp:docPr id="4" name="chart" />
             <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
               <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
                 <c:chart xmlns:p6="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" p6:id="R00000004" />
@@ -128,7 +128,7 @@
           <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
             <wp:extent cx="5715000" cy="5715000" />
             <wp:effectExtent l="0" t="0" r="19050" b="19050" />
-            <wp:docPr id="2" name="chart" />
+            <wp:docPr id="5" name="chart" />
             <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
               <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
                 <c:chart xmlns:p6="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" p6:id="R00000005" />
@@ -10962,45 +10962,12 @@
   <c:roundedCorners val="0" />
   <c:chart>
     <c:autoTitleDeleted val="0" />
-    <c:plotVisOnly val="1" />
-    <c:dispBlanksAs val="gap" />
-    <c:showDLblsOverMax val="0" />
     <c:plotArea>
       <c:layout />
-      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="148921728" />
-        <c:scaling>
-          <c:orientation val="minMax" />
-        </c:scaling>
-        <c:delete val="0" />
-        <c:axPos val="b" />
-        <c:majorTickMark val="out" />
-        <c:minorTickMark val="none" />
-        <c:tickLblPos val="nextTo" />
-        <c:crossAx val="154227840" />
-        <c:crosses val="autoZero" />
-        <c:auto val="1" />
-        <c:lblAlgn val="ctr" />
-        <c:lblOffset val="100" />
-        <c:noMultiLvlLbl val="0" />
-      </c:catAx>
-      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="154227840" />
-        <c:scaling>
-          <c:orientation val="minMax" />
-        </c:scaling>
-        <c:delete val="0" />
-        <c:axPos val="l" />
-        <c:numFmt formatCode="General" sourceLinked="0" />
-        <c:majorGridlines />
-        <c:majorTickMark val="out" />
-        <c:minorTickMark val="none" />
-        <c:tickLblPos val="nextTo" />
-        <c:crossAx val="148921728" />
-        <c:crosses val="autoZero" />
-        <c:crossBetween val="between" />
-      </c:valAx>
       <c:barChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:barDir val="col" />
+        <c:grouping val="clustered" />
+        <c:gapWidth val="200" />
         <c:dLbls xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
           <c:showLegendKey val="0" />
           <c:showVal val="0" />
@@ -11010,12 +10977,9 @@
           <c:showBubbleSize val="0" />
           <c:showLeaderLines val="1" />
         </c:dLbls>
-        <c:barDir val="col" />
-        <c:grouping val="clustered" />
-        <c:gapWidth val="200" />
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921728" />
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="154227840" />
         <c:overlap val="0" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921729" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921730" />
         <c:ser>
           <c:idx val="0" />
           <c:order val="0" />
@@ -11054,8 +11018,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>10</c:v>
               </c:pt>
@@ -11109,8 +11073,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>13</c:v>
               </c:pt>
@@ -11164,8 +11128,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>10</c:v>
               </c:pt>
@@ -11182,23 +11146,8 @@
           </c:val>
         </c:ser>
       </c:barChart>
-    </c:plotArea>
-  </c:chart>
-</c:chartSpace>
-<!--------------------------------------------------------------------------------------------------------------------->
-/word/charts/chart2.xml
-<!--------------------------------------------------------------------------------------------------------------------->
-<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
-  <c:roundedCorners val="1" />
-  <c:chart>
-    <c:autoTitleDeleted val="0" />
-    <c:plotVisOnly val="1" />
-    <c:dispBlanksAs val="gap" />
-    <c:showDLblsOverMax val="0" />
-    <c:plotArea>
-      <c:layout />
       <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="148921728" />
+        <c:axId val="148921729" />
         <c:scaling>
           <c:orientation val="minMax" />
         </c:scaling>
@@ -11207,7 +11156,7 @@
         <c:majorTickMark val="out" />
         <c:minorTickMark val="none" />
         <c:tickLblPos val="nextTo" />
-        <c:crossAx val="154227840" />
+        <c:crossAx val="148921730" />
         <c:crosses val="autoZero" />
         <c:auto val="1" />
         <c:lblAlgn val="ctr" />
@@ -11215,7 +11164,7 @@
         <c:noMultiLvlLbl val="0" />
       </c:catAx>
       <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="154227840" />
+        <c:axId val="148921730" />
         <c:scaling>
           <c:orientation val="minMax" />
         </c:scaling>
@@ -11226,11 +11175,29 @@
         <c:majorTickMark val="out" />
         <c:minorTickMark val="none" />
         <c:tickLblPos val="nextTo" />
-        <c:crossAx val="148921728" />
+        <c:crossAx val="148921729" />
         <c:crosses val="autoZero" />
         <c:crossBetween val="between" />
       </c:valAx>
+    </c:plotArea>
+    <c:plotVisOnly val="1" />
+    <c:dispBlanksAs val="gap" />
+    <c:showDLblsOverMax val="0" />
+  </c:chart>
+</c:chartSpace>
+<!--------------------------------------------------------------------------------------------------------------------->
+/word/charts/chart2.xml
+<!--------------------------------------------------------------------------------------------------------------------->
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <c:roundedCorners val="1" />
+  <c:chart>
+    <c:autoTitleDeleted val="0" />
+    <c:plotArea>
+      <c:layout />
       <c:barChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:barDir val="bar" />
+        <c:grouping val="standard" />
+        <c:gapWidth val="200" />
         <c:dLbls xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
           <c:showLegendKey val="0" />
           <c:showVal val="0" />
@@ -11240,12 +11207,9 @@
           <c:showBubbleSize val="0" />
           <c:showLeaderLines val="1" />
         </c:dLbls>
-        <c:barDir val="bar" />
-        <c:grouping val="standard" />
-        <c:gapWidth val="200" />
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921728" />
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="154227840" />
         <c:overlap val="0" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921731" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921732" />
         <c:ser>
           <c:idx val="0" />
           <c:order val="0" />
@@ -11284,8 +11248,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="1" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="1" />
               <c:pt idx="0">
                 <c:v>15</c:v>
               </c:pt>
@@ -11293,7 +11257,43 @@
           </c:val>
         </c:ser>
       </c:barChart>
+      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921731" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="b" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921732" />
+        <c:crosses val="autoZero" />
+        <c:auto val="1" />
+        <c:lblAlgn val="ctr" />
+        <c:lblOffset val="100" />
+        <c:noMultiLvlLbl val="0" />
+      </c:catAx>
+      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921732" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="l" />
+        <c:numFmt formatCode="General" sourceLinked="0" />
+        <c:majorGridlines />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921731" />
+        <c:crosses val="autoZero" />
+        <c:crossBetween val="between" />
+      </c:valAx>
     </c:plotArea>
+    <c:plotVisOnly val="1" />
+    <c:dispBlanksAs val="gap" />
+    <c:showDLblsOverMax val="0" />
   </c:chart>
 </c:chartSpace>
 <!--------------------------------------------------------------------------------------------------------------------->
@@ -11303,9 +11303,6 @@
   <c:roundedCorners val="0" />
   <c:chart>
     <c:autoTitleDeleted val="0" />
-    <c:plotVisOnly val="1" />
-    <c:dispBlanksAs val="gap" />
-    <c:showDLblsOverMax val="0" />
     <c:plotArea>
       <c:layout />
       <c:pieChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
@@ -11364,6 +11361,9 @@
         </c:ser>
       </c:pieChart>
     </c:plotArea>
+    <c:plotVisOnly val="1" />
+    <c:dispBlanksAs val="gap" />
+    <c:showDLblsOverMax val="0" />
   </c:chart>
 </c:chartSpace>
 <!--------------------------------------------------------------------------------------------------------------------->
@@ -11373,44 +11373,8 @@
   <c:roundedCorners val="0" />
   <c:chart>
     <c:autoTitleDeleted val="0" />
-    <c:plotVisOnly val="1" />
-    <c:dispBlanksAs val="gap" />
-    <c:showDLblsOverMax val="0" />
     <c:plotArea>
       <c:layout />
-      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="148921728" />
-        <c:scaling>
-          <c:orientation val="minMax" />
-        </c:scaling>
-        <c:delete val="0" />
-        <c:axPos val="b" />
-        <c:majorTickMark val="out" />
-        <c:minorTickMark val="none" />
-        <c:tickLblPos val="nextTo" />
-        <c:crossAx val="154227840" />
-        <c:crosses val="autoZero" />
-        <c:auto val="1" />
-        <c:lblAlgn val="ctr" />
-        <c:lblOffset val="100" />
-        <c:noMultiLvlLbl val="0" />
-      </c:catAx>
-      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="154227840" />
-        <c:scaling>
-          <c:orientation val="minMax" />
-        </c:scaling>
-        <c:delete val="0" />
-        <c:axPos val="l" />
-        <c:numFmt formatCode="General" sourceLinked="0" />
-        <c:majorGridlines />
-        <c:majorTickMark val="out" />
-        <c:minorTickMark val="none" />
-        <c:tickLblPos val="nextTo" />
-        <c:crossAx val="148921728" />
-        <c:crosses val="autoZero" />
-        <c:crossBetween val="between" />
-      </c:valAx>
       <c:lineChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
         <c:grouping val="standard" />
         <c:dLbls xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
@@ -11422,8 +11386,8 @@
           <c:showBubbleSize val="0" />
           <c:showLeaderLines val="1" />
         </c:dLbls>
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921728" />
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="154227840" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921733" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921734" />
         <c:ser>
           <c:idx val="0" />
           <c:order val="0" />
@@ -11462,8 +11426,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>10</c:v>
               </c:pt>
@@ -11517,8 +11481,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>10</c:v>
               </c:pt>
@@ -11572,8 +11536,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>13</c:v>
               </c:pt>
@@ -11590,7 +11554,43 @@
           </c:val>
         </c:ser>
       </c:lineChart>
+      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921733" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="b" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921734" />
+        <c:crosses val="autoZero" />
+        <c:auto val="1" />
+        <c:lblAlgn val="ctr" />
+        <c:lblOffset val="100" />
+        <c:noMultiLvlLbl val="0" />
+      </c:catAx>
+      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921734" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="l" />
+        <c:numFmt formatCode="General" sourceLinked="0" />
+        <c:majorGridlines />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921733" />
+        <c:crosses val="autoZero" />
+        <c:crossBetween val="between" />
+      </c:valAx>
     </c:plotArea>
+    <c:plotVisOnly val="1" />
+    <c:dispBlanksAs val="gap" />
+    <c:showDLblsOverMax val="0" />
   </c:chart>
 </c:chartSpace>
 <!--------------------------------------------------------------------------------------------------------------------->
@@ -11600,44 +11600,8 @@
   <c:roundedCorners val="0" />
   <c:chart>
     <c:autoTitleDeleted val="0" />
-    <c:plotVisOnly val="1" />
-    <c:dispBlanksAs val="gap" />
-    <c:showDLblsOverMax val="0" />
     <c:plotArea>
       <c:layout />
-      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="148921728" />
-        <c:scaling>
-          <c:orientation val="minMax" />
-        </c:scaling>
-        <c:delete val="0" />
-        <c:axPos val="b" />
-        <c:majorTickMark val="out" />
-        <c:minorTickMark val="none" />
-        <c:tickLblPos val="nextTo" />
-        <c:crossAx val="154227840" />
-        <c:crosses val="autoZero" />
-        <c:auto val="1" />
-        <c:lblAlgn val="ctr" />
-        <c:lblOffset val="100" />
-        <c:noMultiLvlLbl val="0" />
-      </c:catAx>
-      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
-        <c:axId val="154227840" />
-        <c:scaling>
-          <c:orientation val="minMax" />
-        </c:scaling>
-        <c:delete val="0" />
-        <c:axPos val="l" />
-        <c:numFmt formatCode="General" sourceLinked="0" />
-        <c:majorGridlines />
-        <c:majorTickMark val="out" />
-        <c:minorTickMark val="none" />
-        <c:tickLblPos val="nextTo" />
-        <c:crossAx val="148921728" />
-        <c:crosses val="autoZero" />
-        <c:crossBetween val="between" />
-      </c:valAx>
       <c:lineChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
         <c:grouping val="standard" />
         <c:dLbls xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
@@ -11649,8 +11613,8 @@
           <c:showBubbleSize val="0" />
           <c:showLeaderLines val="1" />
         </c:dLbls>
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921728" />
-        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="154227840" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921735" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921736" />
         <c:ser>
           <c:idx val="0" />
           <c:order val="0" />
@@ -11689,8 +11653,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>10</c:v>
               </c:pt>
@@ -11744,8 +11708,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>10</c:v>
               </c:pt>
@@ -11799,8 +11763,8 @@
           </c:cat>
           <c:val>
             <c:numLit>
-              <c:ptCount val="4" />
               <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
               <c:pt idx="0">
                 <c:v>13</c:v>
               </c:pt>
@@ -11817,7 +11781,43 @@
           </c:val>
         </c:ser>
       </c:lineChart>
+      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921735" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="b" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921736" />
+        <c:crosses val="autoZero" />
+        <c:auto val="1" />
+        <c:lblAlgn val="ctr" />
+        <c:lblOffset val="100" />
+        <c:noMultiLvlLbl val="0" />
+      </c:catAx>
+      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921736" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="l" />
+        <c:numFmt formatCode="General" sourceLinked="0" />
+        <c:majorGridlines />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921735" />
+        <c:crosses val="autoZero" />
+        <c:crossBetween val="between" />
+      </c:valAx>
     </c:plotArea>
+    <c:plotVisOnly val="1" />
+    <c:dispBlanksAs val="gap" />
+    <c:showDLblsOverMax val="0" />
   </c:chart>
 </c:chartSpace>
 <!--------------------------------------------------------------------------------------------------------------------->

--- a/OfficeIMO.Word/WordChart.cs
+++ b/OfficeIMO.Word/WordChart.cs
@@ -28,6 +28,16 @@ namespace OfficeIMO.Word {
             }
             _axisIdSeed = (int)max;
         }
+
+        private static UInt32Value GenerateDocPrId(WordDocument document) {
+            uint max = 0;
+            foreach (var docPr in document._wordprocessingDocument.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties>()) {
+                if (docPr.Id != null && docPr.Id.Value > max) {
+                    max = docPr.Id.Value;
+                }
+            }
+            return (UInt32Value)(max + 1);
+        }
         public WordChart(WordDocument document, WordParagraph paragraph, Drawing drawing) {
             _document = document;
             _drawing = drawing;
@@ -353,7 +363,8 @@ namespace OfficeIMO.Word {
             inline1.AddNamespaceDeclaration("wp", "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing");
             DocumentFormat.OpenXml.Drawing.Wordprocessing.Extent extent1 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.Extent() { Cx = (long)width * EnglishMetricUnitsPerInch / PixelsPerInch, Cy = (long)height * EnglishMetricUnitsPerInch / PixelsPerInch };
             DocumentFormat.OpenXml.Drawing.Wordprocessing.EffectExtent effectExtent1 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.EffectExtent() { LeftEdge = 0L, TopEdge = 0L, RightEdge = 19050L, BottomEdge = 19050L };
-            DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties docProperties1 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties() { Id = (UInt32Value)2U, Name = "chart" };
+            UInt32Value docPrId = GenerateDocPrId(_document);
+            DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties docProperties1 = new DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties() { Id = docPrId, Name = "chart" };
 
             DocumentFormat.OpenXml.Drawing.Graphic graphic1 = new DocumentFormat.OpenXml.Drawing.Graphic();
             graphic1.AddNamespaceDeclaration("a", "http://schemas.openxmlformats.org/drawingml/2006/main");

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -591,6 +591,8 @@ namespace OfficeIMO.Word {
             // initialize abstract number id for lists to make sure those are unique
             WordListStyles.InitializeAbstractNumberId(word._wordprocessingDocument);
 
+            WordChart.InitializeAxisIdSeed(wordDocument);
+
             //word.Save();
             return word;
         }


### PR DESCRIPTION
## Summary
- ensure docPr ids are generated from the document to avoid duplicates
- update AddMultipleCharts verification

## Testing
- `dotnet test --filter "FullyQualifiedName~OfficeIMO.Tests.Word.Test_ChartsValidation" --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68504da159d4832e8d8025a224a52d39