### PR TITLE
Fix xUnit collection assertions

### DIFF
--- a/OfficeIMO.Tests/Word.Hyperlinks.cs
+++ b/OfficeIMO.Tests/Word.Hyperlinks.cs
@@ -344,13 +344,13 @@ namespace OfficeIMO.Tests {
                 paragraph.AddHyperLink("link", new Uri("https://evotec.xyz"));
                 paragraph.AddText(" after");
 
-                Assert.Equal(1, document.HyperLinks.Count);
-                Assert.Equal(1, document._wordprocessingDocument.MainDocumentPart.HyperlinkRelationships.Count());
+                Assert.Single(document.HyperLinks);
+                Assert.Single(document._wordprocessingDocument.MainDocumentPart.HyperlinkRelationships);
 
                 paragraph.RemoveHyperLink();
 
                 Assert.Empty(document.HyperLinks);
-                Assert.Equal(0, document._wordprocessingDocument.MainDocumentPart.HyperlinkRelationships.Count());
+                Assert.Empty(document._wordprocessingDocument.MainDocumentPart.HyperlinkRelationships);
                 Assert.Equal(2, paragraph._paragraph.ChildElements.OfType<Run>().Count());
 
                 document.Save(false);

--- a/OfficeIMO.Tests/Word.Images.Resources.cs
+++ b/OfficeIMO.Tests/Word.Images.Resources.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Tests {
             var paragraph = document.AddParagraph();
             paragraph.AddImageFromResource(Assembly.GetExecutingAssembly(), "OfficeIMO.Tests.Images.Kulek.jpg", 50, 50);
 
-            Assert.Equal(1, document.Images.Count);
+            Assert.Single(document.Images);
             document.Save(false);
         }
     }


### PR DESCRIPTION
## Summary
- use Assert.Single/Assert.Empty to satisfy xUnit2013 analyzer

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6852cd0883b4832ea3f206b3fb21f39a