### PR TITLE
Add Pie 3D chart support

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -109,6 +109,7 @@
 [WordParagraphStyles](./officeimo.word.wordparagraphstyles.md)
 
 [WordPieChart](./officeimo.word.wordpiechart.md)
+[WordPieChart3D](./officeimo.word.wordpiechart3d.md)
 
 [WordSection](./officeimo.word.wordsection.md)
 

--- a/Docs/officeimo.word.wordpiechart3d.md
+++ b/Docs/officeimo.word.wordpiechart3d.md
@@ -1,0 +1,49 @@
+# WordPieChart3D
+
+Namespace: OfficeIMO.Word
+
+```csharp
+public class WordPieChart3D : WordChart
+```
+
+Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) → [WordChart](./officeimo.word.wordchart.md) → [WordPieChart3D](./officeimo.word.wordpiechart3d.md)
+
+## Methods
+
+### **CreatePie3DChart(Chart)**
+```csharp
+internal static Chart CreatePie3DChart(Chart chart)
+```
+
+#### Parameters
+`chart` Chart<br>
+
+#### Returns
+Chart<br>
+
+### **GeneratePie3DChart(Chart)**
+```csharp
+internal static Chart GeneratePie3DChart(Chart chart)
+```
+
+#### Parameters
+`chart` Chart<br>
+
+#### Returns
+Chart<br>
+
+### **AddPie3DChartSeries(UInt32Value, String, Color, List<string>, List<int>)**
+```csharp
+internal static PieChartSeries AddPie3DChartSeries(UInt32Value index, string series, Color color, List<string> categories, List<int> data)
+```
+
+#### Parameters
+`index` UInt32Value<br>
+`series` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+`color` Color<br>
+`categories` [List&lt;String&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1)<br>
+`data` [List&lt;Int32&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1)<br>
+
+#### Returns
+PieChartSeries<br>
+

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -123,6 +123,7 @@ namespace OfficeIMO.Examples {
             Charts.Example_ScatterChart(folderPath, false);
             Charts.Example_RadarChart(folderPath, false);
             Charts.Example_Bar3DChart(folderPath, false);
+            Charts.Example_Pie3DChart(folderPath, false);
 
             Images.Example_AddingImages(folderPath, false);
             Images.Example_ReadWordWithImages();

--- a/OfficeIMO.Examples/Word/Charts/Charts.Pie3D.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Pie3D.cs
@@ -1,0 +1,28 @@
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Charts {
+        public static void Example_Pie3DChart(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a 3-D pie chart");
+            string filePath = System.IO.Path.Combine(folderPath, "Pie3DChart.docx");
+            using WordDocument document = WordDocument.Create(filePath);
+            var pie3d = document.AddChart("Pie3D chart");
+            pie3d.AddPie3D("Poland", 15);
+            pie3d.AddPie3D("USA", 30);
+            pie3d.AddPie3D("Brazil", 20);
+            document.Save(false);
+
+            var valid = document.ValidateDocument();
+            if (valid.Count > 0) {
+                Console.WriteLine("Document has validation errors:");
+                foreach (var error in valid) {
+                    Console.WriteLine(error.Id + ": " + error.Description);
+                }
+            } else {
+                Console.WriteLine("Document is valid.");
+            }
+
+            document.Open(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Charts/Charts.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.cs
@@ -158,6 +158,11 @@ namespace OfficeIMO.Examples.Word {
                 bar3d.AddCategories(categories);
                 bar3d.AddBar3D("USA", new List<int>() { 5, 2, 3, 4 }, SixLabors.ImageSharp.Color.DarkOrange);
 
+                var pie3d = document.AddChart("Pie3D chart");
+                pie3d.AddPie3D("Poland", 15);
+                pie3d.AddPie3D("USA", 30);
+                pie3d.AddPie3D("Brazil", 20);
+
 
                 Console.WriteLine("Charts count: " + document.Sections[0].Charts.Count);
                 Console.WriteLine("Images count: " + document.Sections[0].Images.Count);

--- a/OfficeIMO.Tests/Word.Charts.cs
+++ b/OfficeIMO.Tests/Word.Charts.cs
@@ -121,14 +121,21 @@ namespace OfficeIMO.Tests {
                 var bar3dXml = bar3dPart.ChartSpace.GetFirstChild<Chart>().PlotArea.GetFirstChild<Bar3DChart>();
                 Assert.NotNull(bar3dXml);
 
+                var pie3d = document.AddChart();
+                pie3d.AddPie3D("Poland", 10);
+                pie3d.AddPie3D("USA", 20);
+                var pie3dPart = document._wordprocessingDocument.MainDocumentPart.ChartParts.Last();
+                var pie3dXml = pie3dPart.ChartSpace.GetFirstChild<Chart>().PlotArea.GetFirstChild<Pie3DChart>();
+                Assert.NotNull(pie3dXml);
+
                 document.Save(false);
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
 
                 Assert.True(document.Sections[0].Charts.Count == 3);
-                Assert.True(document.Sections[1].Charts.Count == 5);
-                Assert.True(document.Charts.Count == 8);
+                Assert.True(document.Sections[1].Charts.Count == 6);
+                Assert.True(document.Charts.Count == 9);
 
                 document.Save(false);
             }

--- a/OfficeIMO.Word/WordChart.PublicMethods.cs
+++ b/OfficeIMO.Word/WordChart.PublicMethods.cs
@@ -16,6 +16,16 @@ namespace OfficeIMO.Word {
             return this;
         }
 
+        public WordChart AddPie3D<T>(string category, T value) {
+            if (!(value is int || value is double || value is float)) {
+                throw new NotSupportedException("Value must be of type int, double, or float");
+            }
+            EnsureChartExistsPie3D();
+            AddSingleCategory(category);
+            AddSingleValue(value);
+            return this;
+        }
+
         public void AddChartLine<T>(string name, int[] values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsLine();
             if (_chart != null) {

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -65,6 +65,7 @@ namespace OfficeIMO.Word {
         /// .AddScatter() to add a scatter chart
         /// .AddRadar() to add a radar chart
         /// .AddBar3D() to add a 3-D bar chart.
+        /// .AddPie3D() to add a 3-D pie chart.
         /// You can't mix and match the types of charts.
         /// </summary>
         /// <param name="title">The title.</param>

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -431,6 +431,7 @@ namespace OfficeIMO.Word {
         /// .AddScatter() to add a scatter chart
         /// .AddRadar() to add a radar chart
         /// .AddBar3D() to add a 3-D bar chart.
+        /// .AddPie3D() to add a 3-D pie chart.
         /// You can't mix and match the types of charts.
         /// </summary>
         /// <param name="title">The title.</param>


### PR DESCRIPTION
## Summary
- implement pie 3-D charts
- add EnsureChartExistsPie3D and public AddPie3D method
- provide Pie3D example and unit tests
- document pie 3-D charts

## Testing
- `dotnet test --no-build` *(fails: dotnet restore requires network)*
- `dotnet format --verify-no-changes` *(fails: required references did not load)*

------
https://chatgpt.com/codex/tasks/task_e_6852cc69c28c832e92824e0c5f8decac