### PR TITLE
Fix Assert.True Any usage

### DIFF
--- a/OfficeIMO.Tests/Word.Revisions.cs
+++ b/OfficeIMO.Tests/Word.Revisions.cs
@@ -29,13 +29,13 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.True(document._document.Body.Descendants<InsertedRun>().Any());
-                Assert.True(document._document.Body.Descendants<DeletedRun>().Any());
+                Assert.Contains(document._document.Body.Descendants<InsertedRun>(), run => run.InnerText == "Added");
+                Assert.Contains(document._document.Body.Descendants<DeletedRun>(), run => run.InnerText == "Removed");
 
                 document.AcceptRevisions();
 
-                Assert.False(document._document.Body.Descendants<InsertedRun>().Any());
-                Assert.False(document._document.Body.Descendants<DeletedRun>().Any());
+                Assert.DoesNotContain(document._document.Body.Descendants<InsertedRun>(), run => run.InnerText == "Added");
+                Assert.DoesNotContain(document._document.Body.Descendants<DeletedRun>(), run => run.InnerText == "Removed");
                 Assert.Equal(2, document.Paragraphs.Count);
                 Assert.Equal("Before", document.Paragraphs[0].Text);
                 Assert.Equal("Added", document.Paragraphs[1].Text);


### PR DESCRIPTION
## Summary
- replace usage of `Assert.True(...Any())`/`Assert.False(...Any())` with `Assert.Contains` and `Assert.DoesNotContain` per xUnit analyzer guidelines

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6852f48d6c6c832ea432891918ebe18e