### PR TITLE
Add 3‑D line chart

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -83,6 +83,7 @@
 [WordImage](./officeimo.word.wordimage.md)
 
 [WordLineChart](./officeimo.word.wordlinechart.md)
+[WordLineChart3D](./officeimo.word.wordlinechart3d.md)
 
 [WordList](./officeimo.word.wordlist.md)
 

--- a/Docs/officeimo.word.wordlinechart3d.md
+++ b/Docs/officeimo.word.wordlinechart3d.md
@@ -1,0 +1,49 @@
+# WordLineChart3D
+
+Namespace: OfficeIMO.Word
+
+```csharp
+public class WordLineChart3D : WordChart
+```
+
+Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) → [WordChart](./officeimo.word.wordchart.md) → [WordLineChart3D](./officeimo.word.wordlinechart3d.md)
+
+## Methods
+
+### **CreateLine3DChart(UInt32Value, UInt32Value)**
+```csharp
+internal static Line3DChart CreateLine3DChart(UInt32Value catAxisId, UInt32Value valAxisId)
+```
+
+#### Parameters
+`catAxisId` UInt32Value<br>
+`valAxisId` UInt32Value<br>
+
+#### Returns
+Line3DChart<br>
+
+### **GenerateLine3DChart(Chart)**
+```csharp
+internal static Chart GenerateLine3DChart(Chart chart)
+```
+
+#### Parameters
+`chart` Chart<br>
+
+#### Returns
+Chart<br>
+
+### **AddLine3DChartSeries(UInt32Value, String, Color, List<string>, List<int>)**
+```csharp
+internal static LineChartSeries AddLine3DChartSeries(UInt32Value index, string series, Color color, List<string> categories, List<int> data)
+```
+
+#### Parameters
+`index` UInt32Value<br>
+`series` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+`color` Color<br>
+`categories` [List&lt;String&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1)<br>
+`data` [List&lt;Int32&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1)<br>
+
+#### Returns
+LineChartSeries<br>

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -124,6 +124,7 @@ namespace OfficeIMO.Examples {
             Charts.Example_RadarChart(folderPath, false);
             Charts.Example_Bar3DChart(folderPath, false);
             Charts.Example_Pie3DChart(folderPath, false);
+            Charts.Example_Line3DChart(folderPath, false);
 
             Images.Example_AddingImages(folderPath, false);
             Images.Example_ReadWordWithImages();

--- a/OfficeIMO.Examples/Word/Charts/Charts.Line3D.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Line3D.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Charts {
+        public static void Example_Line3DChart(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a 3-D line chart");
+            string filePath = System.IO.Path.Combine(folderPath, "Line3DChart.docx");
+            using WordDocument document = WordDocument.Create(filePath);
+            List<string> categories = new() { "Food", "Housing", "Mix", "Data" };
+            var line3d = document.AddChart("Line3D chart");
+            line3d.AddChartAxisX(categories);
+            line3d.AddLine3D("USA", new List<int> { 5, 2, 3, 4 }, Color.Purple);
+            document.Save(false);
+
+            var valid = document.ValidateDocument();
+            if (valid.Count > 0) {
+                Console.WriteLine("Document has validation errors:");
+                foreach (var error in valid) {
+                    Console.WriteLine(error.Id + ": " + error.Description);
+                }
+            } else {
+                Console.WriteLine("Document is valid.");
+            }
+
+            document.Open(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Charts.cs
+++ b/OfficeIMO.Tests/Word.Charts.cs
@@ -170,6 +170,28 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_Line3DChartAxisCount() {
+            var filePath = Path.Combine(_directoryWithFiles, "Line3DChartAxisCount.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var categories = new List<string> { "A", "B", "C" };
+                var chart = document.AddChart();
+                chart.AddChartAxisX(categories);
+                chart.AddLine3D("Series", new List<int> { 1, 2, 3 }, Color.Blue);
+
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var part = document._wordprocessingDocument.MainDocumentPart.ChartParts.First();
+                var line3d = part.ChartSpace.GetFirstChild<Chart>()
+                    .PlotArea.GetFirstChild<Line3DChart>();
+                var axisCount = line3d.Elements<AxisId>().Count();
+                Assert.Equal(2, axisCount);
+            }
+        }
+
+        [Fact]
         public void Test_ChartsValidation() {
             var filePath = Path.Combine(_directoryWithFiles, "ChartsValidation.docx");
 

--- a/OfficeIMO.Tests/Word.Charts.cs
+++ b/OfficeIMO.Tests/Word.Charts.cs
@@ -128,14 +128,21 @@ namespace OfficeIMO.Tests {
                 var pie3dXml = pie3dPart.ChartSpace.GetFirstChild<Chart>().PlotArea.GetFirstChild<Pie3DChart>();
                 Assert.NotNull(pie3dXml);
 
+                var line3d = document.AddChart();
+                line3d.AddChartAxisX(categories);
+                line3d.AddLine3D("USA", new List<int> { 1, 2, 3, 4 }, Color.Purple);
+                var line3dPart = document._wordprocessingDocument.MainDocumentPart.ChartParts.Last();
+                var line3dXml = line3dPart.ChartSpace.GetFirstChild<Chart>().PlotArea.GetFirstChild<Line3DChart>();
+                Assert.NotNull(line3dXml);
+
                 document.Save(false);
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
 
                 Assert.True(document.Sections[0].Charts.Count == 3);
-                Assert.True(document.Sections[1].Charts.Count == 6);
-                Assert.True(document.Charts.Count == 9);
+                Assert.True(document.Sections[1].Charts.Count == 7);
+                Assert.True(document.Charts.Count == 10);
 
                 document.Save(false);
             }

--- a/OfficeIMO.VerifyTests/Word/ChartTests.cs
+++ b/OfficeIMO.VerifyTests/Word/ChartTests.cs
@@ -66,6 +66,11 @@ public class ChartTests : VerifyTestBase {
         lineChart2.AddLine("Brazil", new List<int> { 10, 35, 300, 18 }, Color.Brown);
         lineChart2.AddLine("Poland", new List<int> { 13, 20, 230, 150 }, Color.Green);
 
+        document.AddParagraph("Adding a 3-D line chart");
+        var line3d = document.AddChart();
+        line3d.AddChartAxisX(categories);
+        line3d.AddLine3D("USA", new List<int> { 5, 2, 3, 4 }, Color.Purple);
+
         document.Save();
 
         await DoTest(document._wordprocessingDocument);

--- a/OfficeIMO.VerifyTests/Word/verified/ChartTests.AddingMultipleCharts.verified.txt
+++ b/OfficeIMO.VerifyTests/Word/verified/ChartTests.AddingMultipleCharts.verified.txt
@@ -138,6 +138,29 @@
         </w:drawing>
       </w:r>
     </w:p>
+    <w:p>
+      <w:pPr />
+      <w:r>
+        <w:t xml:space="preserve">Adding a 3-D line chart</w:t>
+      </w:r>
+    </w:p>
+    <w:p>
+      <w:pPr />
+      <w:r>
+        <w:drawing>
+          <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+            <wp:extent cx="5715000" cy="5715000" />
+            <wp:effectExtent l="0" t="0" r="19050" b="19050" />
+            <wp:docPr id="7" name="chart" />
+            <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+                <c:chart xmlns:p6="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" p6:id="R00000006" />
+              </a:graphicData>
+            </a:graphic>
+          </wp:inline>
+        </w:drawing>
+      </w:r>
+    </w:p>
     <w:sectPr w:rsidR="R00000001" />
   </w:body>
 </w:document>
@@ -11804,6 +11827,122 @@
         <c:minorTickMark val="none" />
         <c:tickLblPos val="nextTo" />
         <c:crossAx val="148921735" />
+        <c:crosses val="autoZero" />
+        <c:crossBetween val="between" />
+      </c:valAx>
+    </c:plotArea>
+    <c:plotVisOnly val="1" />
+    <c:dispBlanksAs val="gap" />
+    <c:showDLblsOverMax val="0" />
+  </c:chart>
+</c:chartSpace>
+<!--------------------------------------------------------------------------------------------------------------------->
+/word/charts/chart6.xml
+<!--------------------------------------------------------------------------------------------------------------------->
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <c:roundedCorners val="0" />
+  <c:chart>
+    <c:autoTitleDeleted val="0" />
+    <c:plotArea>
+      <c:layout />
+      <c:line3DChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:grouping val="standard" />
+        <c:ser>
+          <c:idx val="0" />
+          <c:order val="0" />
+          <c:tx>
+            <c:strRef>
+              <c:f />
+              <c:strCache>
+                <c:pt idx="0">
+                  <c:v>USA</c:v>
+                </c:pt>
+              </c:strCache>
+            </c:strRef>
+          </c:tx>
+          <c:spPr>
+            <a:solidFill>
+              <a:srgbClr val="800080" />
+            </a:solidFill>
+          </c:spPr>
+          <c:cat>
+            <c:strLit>
+              <c:ptCount val="4" />
+              <c:pt idx="0">
+                <c:v>Food</c:v>
+              </c:pt>
+              <c:pt idx="1">
+                <c:v>Housing</c:v>
+              </c:pt>
+              <c:pt idx="2">
+                <c:v>Mix</c:v>
+              </c:pt>
+              <c:pt idx="3">
+                <c:v>Data</c:v>
+              </c:pt>
+            </c:strLit>
+          </c:cat>
+          <c:val>
+            <c:numLit>
+              <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
+              <c:pt idx="0">
+                <c:v>5</c:v>
+              </c:pt>
+              <c:pt idx="1">
+                <c:v>2</c:v>
+              </c:pt>
+              <c:pt idx="2">
+                <c:v>3</c:v>
+              </c:pt>
+              <c:pt idx="3">
+                <c:v>4</c:v>
+              </c:pt>
+            </c:numLit>
+          </c:val>
+        </c:ser>
+        <c:dLbls xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+          <c:showLegendKey val="0" />
+          <c:showVal val="0" />
+          <c:showCatName val="0" />
+          <c:showSerName val="0" />
+          <c:showPercent val="0" />
+          <c:showBubbleSize val="0" />
+          <c:showLeaderLines val="1" />
+        </c:dLbls>
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921737" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921738" />
+      </c:line3DChart>
+      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921737" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="b" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921738" />
+        <c:crosses val="autoZero" />
+        <c:auto val="1" />
+        <c:lblAlgn val="ctr" />
+        <c:lblOffset val="100" />
+        <c:noMultiLvlLbl val="0" />
+      </c:catAx>
+      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921738" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="l" />
+        <c:majorGridlines />
+        <c:numFmt formatCode="General" sourceLinked="0" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921737" />
         <c:crosses val="autoZero" />
         <c:crossBetween val="between" />
       </c:valAx>

--- a/OfficeIMO.Word/WordChart.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordChart.PrivateMethods.cs
@@ -609,14 +609,10 @@ namespace OfficeIMO.Word {
             chart.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
             Grouping grouping = new Grouping() { Val = GroupingValues.Standard };
-            VaryColors varyColors = new VaryColors() { Val = false };
             DataLabels labels = AddDataLabel();
-            GapDepth gapDepth = new GapDepth() { Val = (UInt16Value)150U };
 
             chart.Append(grouping);
-            chart.Append(varyColors);
             chart.Append(labels);
-            chart.Append(gapDepth);
 
             AxisId axisId1 = new AxisId() { Val = catAxisId };
             axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");

--- a/OfficeIMO.Word/WordChart.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordChart.PrivateMethods.cs
@@ -609,10 +609,14 @@ namespace OfficeIMO.Word {
             chart.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
 
             Grouping grouping = new Grouping() { Val = GroupingValues.Standard };
+            VaryColors varyColors = new VaryColors() { Val = false };
             DataLabels labels = AddDataLabel();
+            GapDepth gapDepth = new GapDepth() { Val = (UInt16Value)150U };
 
             chart.Append(grouping);
+            chart.Append(varyColors);
             chart.Append(labels);
+            chart.Append(gapDepth);
 
             AxisId axisId1 = new AxisId() { Val = catAxisId };
             axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");

--- a/OfficeIMO.Word/WordChart.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordChart.PrivateMethods.cs
@@ -613,7 +613,6 @@ namespace OfficeIMO.Word {
 
             chart.Append(grouping);
             chart.Append(labels);
-            chart.Append(new GapDepth() { Val = (UInt16Value)150U });
 
             AxisId axisId1 = new AxisId() { Val = catAxisId };
             axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");

--- a/OfficeIMO.Word/WordChart.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordChart.PrivateMethods.cs
@@ -610,9 +610,11 @@ namespace OfficeIMO.Word {
 
             Grouping grouping = new Grouping() { Val = GroupingValues.Standard };
             DataLabels labels = AddDataLabel();
+            GapDepth gapDepth = new GapDepth() { Val = (UInt16Value)150U };
 
             chart.Append(grouping);
             chart.Append(labels);
+            chart.Append(gapDepth);
 
             AxisId axisId1 = new AxisId() { Val = catAxisId };
             axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");

--- a/OfficeIMO.Word/WordChart.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordChart.PrivateMethods.cs
@@ -604,6 +604,46 @@ namespace OfficeIMO.Word {
             return series3d;
         }
 
+        private Line3DChart CreateLine3DChart(UInt32Value catAxisId, UInt32Value valAxisId) {
+            Line3DChart chart = new Line3DChart();
+            chart.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+
+            Grouping grouping = new Grouping() { Val = GroupingValues.Standard };
+            DataLabels labels = AddDataLabel();
+
+            chart.Append(grouping);
+            chart.Append(labels);
+            chart.Append(new GapDepth() { Val = (UInt16Value)150U });
+
+            AxisId axisId1 = new AxisId() { Val = catAxisId };
+            axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+            AxisId axisId2 = new AxisId() { Val = valAxisId };
+            axisId2.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+
+            chart.Append(axisId1);
+            chart.Append(axisId2);
+            return chart;
+        }
+
+        private Chart GenerateLine3DChart(Chart chart) {
+            UInt32Value catId = GenerateAxisId();
+            UInt32Value valId = GenerateAxisId();
+
+            Line3DChart chart3d = CreateLine3DChart(catId, valId);
+            CategoryAxis catAxis = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
+            ValueAxis valAxis = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
+
+            chart.PlotArea.Append(chart3d);
+            chart.PlotArea.Append(catAxis);
+            chart.PlotArea.Append(valAxis);
+            return chart;
+        }
+
+        private LineChartSeries AddLine3DChartSeries<T>(UInt32Value index, string series, SixLabors.ImageSharp.Color color, List<string> categories, List<T> values) {
+            LineChartSeries series3d = AddLineChartSeries(index, series, color, categories, values);
+            return series3d;
+        }
+
         private PieChartSeries AddPie3DChartSeries<T>(UInt32Value index, string series, SixLabors.ImageSharp.Color color, List<string> categories, List<T> values) {
             PieChartSeries pieSeries = new PieChartSeries();
             DocumentFormat.OpenXml.Drawing.Charts.Index idx = new DocumentFormat.OpenXml.Drawing.Charts.Index() { Val = index };
@@ -672,6 +712,15 @@ namespace OfficeIMO.Word {
             if (_chart == null) {
                 _chart = GenerateChart();
                 _chart = GeneratePie3DChart(_chart);
+                _chartPart.ChartSpace.Append(_chart);
+                UpdateTitle();
+            }
+        }
+
+        private void EnsureChartExistsLine3D() {
+            if (_chart == null) {
+                _chart = GenerateChart();
+                _chart = GenerateLine3DChart(_chart);
                 _chartPart.ChartSpace.Append(_chart);
                 UpdateTitle();
             }

--- a/OfficeIMO.Word/WordChart.PublicMethods.cs
+++ b/OfficeIMO.Word/WordChart.PublicMethods.cs
@@ -154,6 +154,17 @@ namespace OfficeIMO.Word {
             }
         }
 
+        public void AddLine3D<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
+            EnsureChartExistsLine3D();
+            if (_chart != null) {
+                var line3d = _chart.PlotArea.GetFirstChild<Line3DChart>();
+                if (line3d != null) {
+                    var series = AddLine3DChartSeries(this._index, name, color, this.Categories, values);
+                    InsertSeries(line3d, series);
+                }
+            }
+        }
+
         public void AddLegend(LegendPositionValues legendPosition) {
             if (_chart != null) {
                 Legend legend = new Legend();

--- a/OfficeIMO.Word/WordChart.cs
+++ b/OfficeIMO.Word/WordChart.cs
@@ -64,11 +64,19 @@ namespace OfficeIMO.Word {
                 var ids = new List<UInt32Value>();
                 if (_chart != null) {
                     var lineChart = _chart.PlotArea.GetFirstChild<LineChart>();
+                    var line3dChart = _chart.PlotArea.GetFirstChild<Line3DChart>();
                     var barChart = _chart.PlotArea.GetFirstChild<BarChart>();
+                    var bar3dChart = _chart.PlotArea.GetFirstChild<Bar3DChart>();
                     var pieChart = _chart.PlotArea.GetFirstChild<PieChart>();
+                    var pie3dChart = _chart.PlotArea.GetFirstChild<Pie3DChart>();
                     var areaChart = _chart.PlotArea.GetFirstChild<AreaChart>();
                     if (lineChart != null) {
                         var series = lineChart.ChildElements.OfType<LineChartSeries>();
+                        foreach (var index in series) {
+                            ids.Add(index.Index.Val);
+                        }
+                    } else if (line3dChart != null) {
+                        var series = line3dChart.ChildElements.OfType<LineChartSeries>();
                         foreach (var index in series) {
                             ids.Add(index.Index.Val);
                         }
@@ -77,8 +85,18 @@ namespace OfficeIMO.Word {
                         foreach (var index in series) {
                             ids.Add(index.Index.Val);
                         }
+                    } else if (pie3dChart != null) {
+                        var series = pie3dChart.ChildElements.OfType<PieChartSeries>();
+                        foreach (var index in series) {
+                            ids.Add(index.Index.Val);
+                        }
                     } else if (barChart != null) {
                         var series = barChart.ChildElements.OfType<BarChartSeries>();
+                        foreach (var index in series) {
+                            ids.Add(index.Index.Val);
+                        }
+                    } else if (bar3dChart != null) {
+                        var series = bar3dChart.ChildElements.OfType<BarChartSeries>();
                         foreach (var index in series) {
                             ids.Add(index.Index.Val);
                         }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -66,6 +66,7 @@ namespace OfficeIMO.Word {
         /// .AddRadar() to add a radar chart
         /// .AddBar3D() to add a 3-D bar chart.
         /// .AddPie3D() to add a 3-D pie chart.
+        /// .AddLine3D() to add a 3-D line chart.
         /// You can't mix and match the types of charts.
         /// </summary>
         /// <param name="title">The title.</param>

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -432,6 +432,7 @@ namespace OfficeIMO.Word {
         /// .AddRadar() to add a radar chart
         /// .AddBar3D() to add a 3-D bar chart.
         /// .AddPie3D() to add a 3-D pie chart.
+        /// .AddLine3D() to add a 3-D line chart.
         /// You can't mix and match the types of charts.
         /// </summary>
         /// <param name="title">The title.</param>


### PR DESCRIPTION
## Summary
- support 3‑D line charts
- add example and docs
- verify test snapshot updated
- update chart docs to mention AddLine3D

## Testing
- `dotnet test --no-build` *(fails: Assert.Empty() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_6852f5c41734832e9cc3129529a3e20d