### PR TITLE
Improve chart validation error output

### DIFF
--- a/OfficeIMO.Tests/Word.Charts.cs
+++ b/OfficeIMO.Tests/Word.Charts.cs
@@ -157,7 +157,8 @@ namespace OfficeIMO.Tests {
                 Assert.True(newIds.Min() > maxId);
                 var validation = document.ValidateDocument();
                 var chartErrors = validation.Where(v => v.Description.Contains("chart")).ToList();
-                Assert.Empty(chartErrors);
+                Assert.True(chartErrors.Count == 0,
+                    Word.FormatValidationErrors(chartErrors));
             }
         }
 
@@ -180,7 +181,8 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(filePath)) {
                 var valid = document.ValidateDocument();
                 var chartErrors = valid.Where(v => v.Description.Contains("chart")).ToList();
-                Assert.Empty(chartErrors);
+                Assert.True(chartErrors.Count == 0,
+                    Word.FormatValidationErrors(chartErrors));
             }
         }
 
@@ -220,7 +222,8 @@ namespace OfficeIMO.Tests {
 
                 var validation = document.ValidateDocument();
                 var chartErrors = validation.Where(v => v.Description.Contains("chart")).ToList();
-                Assert.Empty(chartErrors);
+                Assert.True(chartErrors.Count == 0,
+                    Word.FormatValidationErrors(chartErrors));
 
                 // Verify the document can be saved again (full round-trip test)
                 document.Save(false);
@@ -250,7 +253,8 @@ namespace OfficeIMO.Tests {
 
                 var validation = document.ValidateDocument();
                 var chartErrors = validation.Where(v => v.Description.Contains("chart") || v.Description.Contains("legend")).ToList();
-                Assert.Empty(chartErrors);
+                Assert.True(chartErrors.Count == 0,
+                    Word.FormatValidationErrors(chartErrors));
             }
         }
 
@@ -284,7 +288,8 @@ namespace OfficeIMO.Tests {
 
                 var validation = document.ValidateDocument();
                 var chartErrors = validation.Where(v => v.Description.Contains("chart") || v.Description.Contains("legend")).ToList();
-                Assert.Empty(chartErrors);
+                Assert.True(chartErrors.Count == 0,
+                    Word.FormatValidationErrors(chartErrors));
             }
         }
     }

--- a/OfficeIMO.Tests/Word.cs
+++ b/OfficeIMO.Tests/Word.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Office.CustomUI;
 using DocumentFormat.OpenXml.Wordprocessing;
+using DocumentFormat.OpenXml.Validation;
 using OfficeIMO.Word;
 using Xunit;
 
@@ -46,6 +47,16 @@ namespace OfficeIMO.Tests {
                 }
             }
             return found;
+        }
+
+        internal static string FormatValidationErrors(IEnumerable<ValidationErrorInfo> errors) {
+            return string.Join(Environment.NewLine + Environment.NewLine,
+                errors.Select(error =>
+                    $"Description: {error.Description}\n" +
+                    $"Id: {error.Id}\n" +
+                    $"ErrorType: {error.ErrorType}\n" +
+                    $"Part: {error.Part?.Uri}\n" +
+                    $"Path: {error.Path?.XPath}"));
         }
     }
 }


### PR DESCRIPTION
## Summary
- show detailed chart validation failures in chart tests
- add `FormatValidationErrors` helper for test output

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6853a6084c3c832ea453700e1ca6704a