### PR TITLE
Add option to enable Verify's diff viewer

### DIFF
--- a/OfficeIMO.VerifyTests/VerifyTestBase.cs
+++ b/OfficeIMO.VerifyTests/VerifyTestBase.cs
@@ -26,7 +26,10 @@ public abstract class VerifyTestBase {
 
     static VerifyTestBase() {
         // To disable Visual Studio popping up on every test execution.
-        Environment.SetEnvironmentVariable("DiffEngine_Disabled", "true");
+        var diffDisabled = Environment.GetEnvironmentVariable("DiffEngine_Disabled");
+        if (string.IsNullOrEmpty(diffDisabled))
+            Environment.SetEnvironmentVariable("DiffEngine_Disabled", "true");
+
         Environment.SetEnvironmentVariable("Verify_DisableClipboard", "true");
     }
 

--- a/README.md
+++ b/README.md
@@ -368,3 +368,5 @@ if you need to add or update a verified snapshot, you can use the powershell scr
 ```bash
 $ pwsh -c ./Build/ApproveVerifyTests.ps1
 ```
+To show a graphical diff instead of console output when Verify tests fail, set
+the environment variable `DiffEngine_Disabled=false` before running the tests.


### PR DESCRIPTION
## Summary
- allow overriding `DiffEngine_Disabled` in `VerifyTestBase`
- document how to show a graphical diff when running Verify tests

## Testing
- `dotnet test OfficeImo.sln --no-build --verbosity minimal`
- `dotnet test OfficeImo.sln --no-build --verbosity quiet` *(fails: 4 failed, 175 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6853ac0bcd68832ea6a823f7400c6bfa