### PR TITLE
Add Area3D chart support

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -32,6 +32,8 @@
 
 [WordBarChart3D](./officeimo.word.wordbarchart3d.md)
 
+[WordAreaChart3D](./officeimo.word.wordareachart3d.md)
+
 [WordBookmark](./officeimo.word.wordbookmark.md)
 
 [WordBorder](./officeimo.word.wordborder.md)

--- a/Docs/officeimo.word.wordareachart3d.md
+++ b/Docs/officeimo.word.wordareachart3d.md
@@ -1,0 +1,44 @@
+# WordAreaChart3D
+
+Namespace: OfficeIMO.Word
+
+```csharp
+public class WordAreaChart3D : WordChart
+```
+
+Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) → [WordChart](./officeimo.word.wordchart.md) → **WordAreaChart3D**
+
+## Methods
+
+### **CreateArea3DChart(UInt32Value, UInt32Value)**
+```csharp
+internal static Area3DChart CreateArea3DChart(UInt32Value catAxisId, UInt32Value valAxisId)
+```
+#### Parameters
+`catAxisId` UInt32Value<br>
+`valAxisId` UInt32Value<br>
+#### Returns
+Area3DChart<br>
+
+### **GenerateArea3DChart(Chart)**
+```csharp
+internal static Chart GenerateArea3DChart(Chart chart)
+```
+#### Parameters
+`chart` Chart<br>
+#### Returns
+Chart<br>
+
+### **AddArea3DChartSeries(UInt32Value, String, Color, List<string>, List<int>)**
+```csharp
+internal static AreaChartSeries AddArea3DChartSeries(UInt32Value index, string series, Color color, List<string> categories, List<int> data)
+```
+#### Parameters
+`index` UInt32Value<br>
+`series` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+`color` Color<br>
+`categories` [List&lt;String&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1)<br>
+`data` [List&lt;Int32&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1)<br>
+#### Returns
+AreaChartSeries<br>
+

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -125,6 +125,7 @@ namespace OfficeIMO.Examples {
             Charts.Example_Bar3DChart(folderPath, false);
             Charts.Example_Pie3DChart(folderPath, false);
             Charts.Example_Line3DChart(folderPath, false);
+            Charts.Example_Area3DChart(folderPath, false);
 
             Images.Example_AddingImages(folderPath, false);
             Images.Example_ReadWordWithImages();

--- a/OfficeIMO.Examples/Word/Charts/Charts.Area3D.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Area3D.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Charts {
+        public static void Example_Area3DChart(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a 3-D area chart");
+            string filePath = System.IO.Path.Combine(folderPath, "Area3DChart.docx");
+            using WordDocument document = WordDocument.Create(filePath);
+            List<string> categories = new() { "Food", "Housing", "Mix", "Data" };
+            var area3d = document.AddChart("Area3D chart");
+            area3d.AddCategories(categories);
+            area3d.AddArea3D("USA", new List<int> { 5, 2, 3, 4 }, Color.DarkBlue);
+            document.Save(false);
+
+            var valid = document.ValidateDocument();
+            if (valid.Count > 0) {
+                Console.WriteLine("Document has validation errors:");
+                foreach (var error in valid) {
+                    Console.WriteLine(error.Id + ": " + error.Description);
+                }
+            } else {
+                Console.WriteLine("Document is valid.");
+            }
+
+            document.Open(openWord);
+        }
+    }
+}

--- a/OfficeIMO.VerifyTests/Word/ChartTests.cs
+++ b/OfficeIMO.VerifyTests/Word/ChartTests.cs
@@ -71,6 +71,11 @@ public class ChartTests : VerifyTestBase {
         line3d.AddChartAxisX(categories);
         line3d.AddLine3D("USA", new List<int> { 5, 2, 3, 4 }, Color.Purple);
 
+        document.AddParagraph("Adding a 3-D area chart");
+        var area3d = document.AddChart();
+        area3d.AddCategories(categories);
+        area3d.AddArea3D("USA", new List<int> { 5, 2, 3, 4 }, Color.DarkBlue);
+
         document.Save();
 
         await DoTest(document._wordprocessingDocument);

--- a/OfficeIMO.VerifyTests/Word/verified/ChartTests.AddingMultipleCharts.verified.txt
+++ b/OfficeIMO.VerifyTests/Word/verified/ChartTests.AddingMultipleCharts.verified.txt
@@ -161,6 +161,29 @@
         </w:drawing>
       </w:r>
     </w:p>
+    <w:p>
+      <w:pPr />
+      <w:r>
+        <w:t xml:space="preserve">Adding a 3-D area chart</w:t>
+      </w:r>
+    </w:p>
+    <w:p>
+      <w:pPr />
+      <w:r>
+        <w:drawing>
+          <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+            <wp:extent cx="5715000" cy="5715000" />
+            <wp:effectExtent l="0" t="0" r="19050" b="19050" />
+            <wp:docPr id="8" name="chart" />
+            <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+                <c:chart xmlns:p6="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" p6:id="R00000007" />
+              </a:graphicData>
+            </a:graphic>
+          </wp:inline>
+        </w:drawing>
+      </w:r>
+    </w:p>
     <w:sectPr w:rsidR="R00000001" />
   </w:body>
 </w:document>
@@ -11910,6 +11933,7 @@
           <c:showBubbleSize val="0" />
           <c:showLeaderLines val="1" />
         </c:dLbls>
+        <c:gapDepth val="150" />
         <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921737" />
         <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921738" />
       </c:line3DChart>
@@ -11943,6 +11967,116 @@
         <c:minorTickMark val="none" />
         <c:tickLblPos val="nextTo" />
         <c:crossAx val="148921737" />
+        <c:crosses val="autoZero" />
+        <c:crossBetween val="between" />
+      </c:valAx>
+    </c:plotArea>
+    <c:plotVisOnly val="1" />
+    <c:dispBlanksAs val="gap" />
+    <c:showDLblsOverMax val="0" />
+  </c:chart>
+</c:chartSpace>
+<!--------------------------------------------------------------------------------------------------------------------->
+/word/charts/chart7.xml
+<!--------------------------------------------------------------------------------------------------------------------->
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <c:roundedCorners val="0" />
+  <c:chart>
+    <c:autoTitleDeleted val="0" />
+    <c:plotArea>
+      <c:layout />
+      <c:area3DChart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:grouping val="standard" />
+        <c:ser>
+          <c:idx val="0" />
+          <c:order val="0" />
+          <c:tx>
+            <c:v>USA</c:v>
+          </c:tx>
+          <c:spPr>
+            <a:solidFill>
+              <a:srgbClr val="00008B" />
+            </a:solidFill>
+          </c:spPr>
+          <c:cat>
+            <c:strLit>
+              <c:ptCount val="4" />
+              <c:pt idx="0">
+                <c:v>Food</c:v>
+              </c:pt>
+              <c:pt idx="1">
+                <c:v>Housing</c:v>
+              </c:pt>
+              <c:pt idx="2">
+                <c:v>Mix</c:v>
+              </c:pt>
+              <c:pt idx="3">
+                <c:v>Data</c:v>
+              </c:pt>
+            </c:strLit>
+          </c:cat>
+          <c:val>
+            <c:numLit>
+              <c:formatCode>General</c:formatCode>
+              <c:ptCount val="4" />
+              <c:pt idx="0">
+                <c:v>5</c:v>
+              </c:pt>
+              <c:pt idx="1">
+                <c:v>2</c:v>
+              </c:pt>
+              <c:pt idx="2">
+                <c:v>3</c:v>
+              </c:pt>
+              <c:pt idx="3">
+                <c:v>4</c:v>
+              </c:pt>
+            </c:numLit>
+          </c:val>
+        </c:ser>
+        <c:dLbls xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+          <c:showLegendKey val="0" />
+          <c:showVal val="0" />
+          <c:showCatName val="0" />
+          <c:showSerName val="0" />
+          <c:showPercent val="0" />
+          <c:showBubbleSize val="0" />
+          <c:showLeaderLines val="1" />
+        </c:dLbls>
+        <c:gapDepth val="150" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921739" />
+        <c:axId xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" val="148921740" />
+      </c:area3DChart>
+      <c:catAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921739" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="b" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921740" />
+        <c:crosses val="autoZero" />
+        <c:auto val="1" />
+        <c:lblAlgn val="ctr" />
+        <c:lblOffset val="100" />
+        <c:noMultiLvlLbl val="0" />
+      </c:catAx>
+      <c:valAx xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+        <c:axId val="148921740" />
+        <c:scaling>
+          <c:orientation val="minMax" />
+        </c:scaling>
+        <c:delete val="0" />
+        <c:axPos val="l" />
+        <c:majorGridlines />
+        <c:numFmt formatCode="General" sourceLinked="0" />
+        <c:majorTickMark val="out" />
+        <c:minorTickMark val="none" />
+        <c:tickLblPos val="nextTo" />
+        <c:crossAx val="148921739" />
         <c:crosses val="autoZero" />
         <c:crossBetween val="between" />
       </c:valAx>

--- a/OfficeIMO.Word/WordChart.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordChart.PrivateMethods.cs
@@ -682,6 +682,49 @@ namespace OfficeIMO.Word {
             return chart;
         }
 
+        private Area3DChart CreateArea3DChart(UInt32Value catAxisId, UInt32Value valAxisId) {
+            Area3DChart chart = new Area3DChart();
+            chart.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+
+            Grouping grouping = new Grouping() { Val = GroupingValues.Standard };
+            chart.Append(grouping);
+
+            DataLabels labels = AddDataLabel();
+            GapDepth gapDepth = new GapDepth() { Val = (UInt16Value)150U };
+
+            chart.Append(labels);
+            chart.Append(gapDepth);
+
+            AxisId axisId1 = new AxisId() { Val = catAxisId };
+            axisId1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+            AxisId axisId2 = new AxisId() { Val = valAxisId };
+            axisId2.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+
+            chart.Append(axisId1);
+            chart.Append(axisId2);
+
+            return chart;
+        }
+
+        private Chart GenerateArea3DChart(Chart chart) {
+            UInt32Value catId = GenerateAxisId();
+            UInt32Value valId = GenerateAxisId();
+
+            Area3DChart area3d = CreateArea3DChart(catId, valId);
+            CategoryAxis catAxis = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
+            ValueAxis valAxis = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
+
+            chart.PlotArea.Append(area3d);
+            chart.PlotArea.Append(catAxis);
+            chart.PlotArea.Append(valAxis);
+
+            return chart;
+        }
+
+        private AreaChartSeries AddArea3DChartSeries<T>(UInt32Value index, string series, SixLabors.ImageSharp.Color color, List<string> categories, List<T> values) {
+            return AddAreaChartSeries(index, series, color, categories, values);
+        }
+
         private void EnsureChartExistsScatter() {
             if (_chart == null) {
                 _chart = GenerateChart();
@@ -695,6 +738,15 @@ namespace OfficeIMO.Word {
             if (_chart == null) {
                 _chart = GenerateChart();
                 _chart = GenerateRadarChart(_chart);
+                _chartPart.ChartSpace.Append(_chart);
+                UpdateTitle();
+            }
+        }
+
+        private void EnsureChartExistsArea3D() {
+            if (_chart == null) {
+                _chart = GenerateChart();
+                _chart = GenerateArea3DChart(_chart);
                 _chartPart.ChartSpace.Append(_chart);
                 UpdateTitle();
             }

--- a/OfficeIMO.Word/WordChart.PublicMethods.cs
+++ b/OfficeIMO.Word/WordChart.PublicMethods.cs
@@ -165,6 +165,17 @@ namespace OfficeIMO.Word {
             }
         }
 
+        public void AddArea3D<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
+            EnsureChartExistsArea3D();
+            if (_chart != null) {
+                var area3d = _chart.PlotArea.GetFirstChild<Area3DChart>();
+                if (area3d != null) {
+                    var series = AddArea3DChartSeries(this._index, name, color, this.Categories, values);
+                    InsertSeries(area3d, series);
+                }
+            }
+        }
+
         public void AddLegend(LegendPositionValues legendPosition) {
             if (_chart != null) {
                 Legend legend = new Legend();


### PR DESCRIPTION
## Summary
- implement Area3D chart helpers and series creation
- expose AddArea3D on WordChart
- generate Area3D example and update Program
- support Area3D in tests and documentation

## Testing
- `dotnet restore`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68541e177b30832eb9609980fda55453