### PR TITLE
Add comment management and tracking

### DIFF
--- a/Docs/officeimo.word.wordcomment.md
+++ b/Docs/officeimo.word.wordcomment.md
@@ -149,3 +149,11 @@ public static List<WordComment> GetAllComments(WordDocument document)
 #### Returns
 
 [List&lt;WordComment&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1)<br>
+
+### **Delete()**
+
+```csharp
+public void Delete()
+```
+
+Deletes the comment and removes its references from the document.

--- a/Docs/officeimo.word.wordsettings.md
+++ b/Docs/officeimo.word.wordsettings.md
@@ -34,6 +34,18 @@ public string ProtectionPassword { set; }
 
 [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
 
+### **TrackComments**
+
+Enable or disable tracking of comments in the document.
+
+```csharp
+public bool TrackComments { get; set; }
+```
+
+#### Property Value
+
+[Boolean](https://docs.microsoft.com/en-us/dotnet/api/system.boolean)<br>
+
 ### **ZoomPreset**
 
 Get or set Zoom Preset for the document

--- a/OfficeIMO.Tests/Word.Comments.cs
+++ b/OfficeIMO.Tests/Word.Comments.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Linq;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_AddReadRemoveComment() {
+            string filePath = Path.Combine(_directoryWithFiles, "Test_AddReadRemoveComment.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Paragraph");
+                document.Paragraphs[0].AddComment("John Doe", "JD", "Sample comment");
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_AddReadRemoveComment.docx"))) {
+                Assert.True(document.Comments.Count == 1);
+                var comment = document.Comments.First();
+                comment.Delete();
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_AddReadRemoveComment.docx"))) {
+                Assert.True(document.Comments.Count == 0);
+            }
+        }
+
+        [Fact]
+        public void Test_TrackCommentsSetting() {
+            string filePath = Path.Combine(_directoryWithFiles, "Test_TrackComments.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.Settings.TrackComments = true;
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_TrackComments.docx"))) {
+                Assert.True(document.Settings.TrackComments);
+                document.Settings.TrackComments = false;
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_TrackComments.docx"))) {
+                Assert.False(document.Settings.TrackComments);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordComment.PublicMethods.cs
+++ b/OfficeIMO.Word/WordComment.PublicMethods.cs
@@ -34,5 +34,28 @@ namespace OfficeIMO.Word {
             }
             return comments;
         }
+
+        /// <summary>
+        /// Deletes this comment and removes all references from the document.
+        /// </summary>
+        public void Delete() {
+            var commentsPart = _document._wordprocessingDocument.MainDocumentPart.WordprocessingCommentsPart;
+            if (commentsPart?.Comments != null) {
+                var cmt = commentsPart.Comments.Elements<Comment>().FirstOrDefault(c => c.Id == _comment.Id);
+                cmt?.Remove();
+                commentsPart.Comments.Save();
+            }
+
+            var body = _document._document.Body;
+            foreach (var start in body.Descendants<CommentRangeStart>().Where(c => c.Id == _comment.Id).ToList()) {
+                start.Remove();
+            }
+            foreach (var end in body.Descendants<CommentRangeEnd>().Where(c => c.Id == _comment.Id).ToList()) {
+                end.Remove();
+            }
+            foreach (var reference in body.Descendants<CommentReference>().Where(c => c.Id == _comment.Id).ToList()) {
+                reference.Parent?.Remove();
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -566,5 +566,26 @@ namespace OfficeIMO.Word {
                 gutterAtTop.Val = value;
             }
         }
+
+        /// <summary>
+        /// Enable or disable tracking of comments in the document.
+        /// </summary>
+        public bool TrackComments {
+            get {
+                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                return settings.GetFirstChild<TrackRevisions>() != null;
+            }
+            set {
+                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                var track = settings.GetFirstChild<TrackRevisions>();
+                if (value) {
+                    if (track == null) {
+                        settings.Append(new TrackRevisions());
+                    }
+                } else {
+                    track?.Remove();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- delete comments via new `WordComment.Delete`
- control comment tracking with `WordSettings.TrackComments`
- document comment deletion and tracking features
- test adding, reading, deleting, and tracking comments

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68542ac52f20832e87f7fa650f0d78ee