### PR TITLE
Add checkbox structured document tag

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -34,6 +34,7 @@ namespace OfficeIMO.Examples {
 
             AdvancedDocument.Example_AdvancedWord(folderPath, false);
             AdvancedDocument.Example_AdvancedWord2(folderPath, false);
+            AdvancedDocument.Example_CheckBoxesAdvanced(folderPath, false);
 
             Paragraphs.Example_BasicParagraphs(folderPath, false);
             Paragraphs.Example_BasicParagraphStyles(folderPath, false);

--- a/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.CheckBoxes.cs
+++ b/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.CheckBoxes.cs
@@ -1,0 +1,35 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class AdvancedDocument {
+        public static void Example_CheckBoxesAdvanced(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating advanced check box document");
+            string filePath = System.IO.Path.Combine(folderPath, "AdvancedCheckBoxes.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Options list:");
+
+                var table = document.AddTable(3, 2, WordTableStyle.TableGrid);
+                table.Rows[0].Cells[0].Paragraphs[0].AddCheckBox(true);
+                table.Rows[0].Cells[1].Paragraphs[0].Text = "First option";
+
+                table.Rows[1].Cells[0].Paragraphs[0].AddCheckBox(false);
+                table.Rows[1].Cells[1].Paragraphs[0].AddHyperLink("Second link", new Uri("https://evotec.xyz"), true, "Hyperlink example");
+
+                table.Rows[2].Cells[0].Paragraphs[0].AddCheckBox(true);
+                table.Rows[2].Cells[1].Paragraphs[0].AddField(WordFieldType.Date);
+
+                document.AddParagraph("Tasks:");
+                var list = document.AddList(WordListStyle.Bulleted);
+                list.AddItem("Task 1").AddCheckBox();
+                list.AddItem("Task 2").AddCheckBox(true);
+
+                document.AddHeadersAndFooters();
+                document.Footer.Default.AddPageNumber();
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.CheckBoxes.cs
+++ b/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.CheckBoxes.cs
@@ -26,7 +26,6 @@ namespace OfficeIMO.Examples.Word {
                 list.AddItem("Task 2").AddCheckBox(true);
 
                 document.AddHeadersAndFooters();
-                document.Footer.Default.AddPageNumber();
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Tests/Word.CheckBoxes.cs
+++ b/OfficeIMO.Tests/Word.CheckBoxes.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_AddingCheckBoxes() {
+            string filePath = Path.Combine(_directoryWithFiles, "CheckBoxDocument.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                var p1 = document.AddParagraph("Option 1");
+                p1.AddCheckBox(true);
+                var p2 = document.AddParagraph("Option 2");
+                p2.AddCheckBox();
+
+                var table = document.AddTable(2, 2);
+                table.Rows[0].Cells[0].Paragraphs[0].AddCheckBox();
+                table.Rows[0].Cells[1].Paragraphs[0].Text = "Table option";
+
+                var list = document.AddList(WordListStyle.Bulleted);
+                list.AddItem("Task 1").AddCheckBox();
+
+                Assert.True(document.Paragraphs[0].IsCheckBox);
+                Assert.True(document.Paragraphs[0].CheckBox.Checked);
+                Assert.False(document.Paragraphs[1].CheckBox.Checked);
+
+                document.Paragraphs[1].CheckBox.Checked = true;
+                Assert.True(document.Paragraphs[1].CheckBox.Checked);
+
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(5, document.Paragraphs.Count);
+                Assert.All(document.Paragraphs, p => Assert.True(p.IsCheckBox || p.Text != null));
+                Assert.True(document.Paragraphs[1].CheckBox.Checked);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.CheckBoxes.cs
+++ b/OfficeIMO.Tests/Word.CheckBoxes.cs
@@ -22,20 +22,24 @@ namespace OfficeIMO.Tests {
                 var list = document.AddList(WordListStyle.Bulleted);
                 list.AddItem("Task 1").AddCheckBox();
 
-                Assert.True(document.Paragraphs[0].IsCheckBox);
-                Assert.True(document.Paragraphs[0].CheckBox.Checked);
-                Assert.False(document.Paragraphs[1].CheckBox.Checked);
+                var checkBoxes = document.Paragraphs.Where(p => p.IsCheckBox).ToList();
+                Assert.Equal(3, checkBoxes.Count);
+                Assert.True(checkBoxes[0].CheckBox.Checked);
+                Assert.False(checkBoxes[1].CheckBox.Checked);
 
-                document.Paragraphs[1].CheckBox.Checked = true;
-                Assert.True(document.Paragraphs[1].CheckBox.Checked);
+                checkBoxes[1].CheckBox.Checked = true;
+                Assert.True(checkBoxes[1].CheckBox.Checked);
 
                 document.Save(false);
             }
 
             using (var document = WordDocument.Load(filePath)) {
-                Assert.Equal(5, document.Paragraphs.Count);
+                Assert.Equal(6, document.Paragraphs.Count);
                 Assert.All(document.Paragraphs, p => Assert.True(p.IsCheckBox || p.Text != null));
-                Assert.True(document.Paragraphs[1].CheckBox.Checked);
+
+                var reloadedCheckBoxes = document.Paragraphs.Where(p => p.IsCheckBox).ToList();
+                Assert.Equal(3, reloadedCheckBoxes.Count);
+                Assert.True(reloadedCheckBoxes[1].CheckBox.Checked);
             }
         }
     }

--- a/OfficeIMO.Word/WordCheckBox.cs
+++ b/OfficeIMO.Word/WordCheckBox.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using W14 = DocumentFormat.OpenXml.Office2010.Word;
+
+namespace OfficeIMO.Word {
+    public class WordCheckBox : WordElement {
+        private readonly WordDocument _document;
+        private readonly Paragraph _paragraph;
+        internal readonly SdtRun _sdtRun;
+
+        internal WordCheckBox(WordDocument document, Paragraph paragraph, SdtRun sdtRun) {
+            _document = document;
+            _paragraph = paragraph;
+            _sdtRun = sdtRun;
+        }
+
+        public bool Checked {
+            get {
+                var cb = _sdtRun.SdtProperties.GetFirstChild<W14.SdtContentCheckBox>();
+                var chk = cb?.GetFirstChild<W14.Checked>();
+                return chk != null && chk.Val == W14.OnOffValues.One;
+            }
+            set {
+                var cb = _sdtRun.SdtProperties.GetFirstChild<W14.SdtContentCheckBox>();
+                if (cb == null) return;
+                var chk = cb.GetFirstChild<W14.Checked>() ?? cb.AppendChild(new W14.Checked());
+                chk.Val = value ? W14.OnOffValues.One : W14.OnOffValues.Zero;
+                var run = _sdtRun.SdtContentRun.GetFirstChild<Run>();
+                var text = run?.GetFirstChild<Text>();
+                if (text != null) {
+                    text.Text = value ? "☒" : "☐";
+                }
+            }
+        }
+
+        public void Remove() {
+            _sdtRun.Remove();
+        }
+
+        public static WordParagraph AddCheckBox(WordParagraph paragraph, bool isChecked = false, string alias = null) {
+            SdtRun sdtRun = new SdtRun();
+            SdtProperties sdtProperties = new SdtProperties();
+            SdtId sdtId = new SdtId() { Val = new Random().Next() };
+            var checkBox = new W14.SdtContentCheckBox();
+            var checkedElement = new W14.Checked() { Val = isChecked ? W14.OnOffValues.One : W14.OnOffValues.Zero };
+            var checkedState = new W14.CheckedState() { Font = "MS Gothic", Val = "2612" };
+            var uncheckedState = new W14.UncheckedState() { Font = "MS Gothic", Val = "2610" };
+            checkBox.Append(checkedElement);
+            checkBox.Append(checkedState);
+            checkBox.Append(uncheckedState);
+            sdtProperties.Append(sdtId);
+            if (!string.IsNullOrEmpty(alias)) {
+                sdtProperties.Append(new SdtAlias() { Val = alias });
+            }
+            sdtProperties.Append(checkBox);
+
+            SdtContentRun contentRun = new SdtContentRun();
+            Run run = new Run();
+            RunProperties runProps = new RunProperties();
+            RunFonts fonts = new RunFonts() { Hint = FontTypeHintValues.EastAsia, Ascii = "MS Gothic", HighAnsi = "MS Gothic", EastAsia = "MS Gothic" };
+            runProps.Append(fonts);
+            Text text = new Text(isChecked ? "☒" : "☐");
+            run.Append(runProps);
+            run.Append(text);
+            contentRun.Append(run);
+
+            sdtRun.Append(sdtProperties);
+            sdtRun.Append(contentRun);
+
+            paragraph._paragraph.Append(sdtRun);
+            paragraph._stdRun = sdtRun;
+            return paragraph;
+        }
+    }
+}

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -281,6 +281,17 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Add a check box content control to this paragraph.
+        /// </summary>
+        /// <param name="isChecked">Specifies whether the check box is initially checked.</param>
+        /// <param name="alias">Optional alias for the control.</param>
+        /// <returns>The paragraph that this was called on.</returns>
+        public WordParagraph AddCheckBox(bool isChecked = false, string alias = null) {
+            WordCheckBox.AddCheckBox(this, isChecked, alias);
+            return this;
+        }
+
+        /// <summary>
         /// Add fields to a word document proceeding from the paragraph this is called on.
         /// </summary>
         /// <param name="wordFieldType">The type of field to add.</param>

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -11,6 +11,7 @@ using RunProperties = DocumentFormat.OpenXml.Wordprocessing.RunProperties;
 using TabStop = DocumentFormat.OpenXml.Wordprocessing.TabStop;
 using Text = DocumentFormat.OpenXml.Wordprocessing.Text;
 using V = DocumentFormat.OpenXml.Vml;
+using W14 = DocumentFormat.OpenXml.Office2010.Word;
 
 namespace OfficeIMO.Word {
     public partial class WordParagraph : WordElement {
@@ -205,7 +206,7 @@ namespace OfficeIMO.Word {
         internal SimpleField _simpleField;
         internal BookmarkStart _bookmarkStart;
         internal readonly OfficeMath _officeMath;
-        internal readonly SdtRun _stdRun;
+        internal SdtRun _stdRun;
         internal readonly DocumentFormat.OpenXml.Math.Paragraph _mathParagraph;
 
         /// <summary>
@@ -401,6 +402,19 @@ namespace OfficeIMO.Word {
             }
         }
 
+        internal WordCheckBox CheckBox {
+            get {
+                if (_stdRun != null) {
+                    var check = _stdRun.SdtProperties?.GetFirstChild<W14.SdtContentCheckBox>();
+                    if (check != null) {
+                        return new WordCheckBox(_document, _paragraph, _stdRun);
+                    }
+                }
+
+                return null;
+            }
+        }
+
         public WordChart Chart {
             get {
                 if (_run != null) {
@@ -499,6 +513,16 @@ namespace OfficeIMO.Word {
         public bool IsStructuredDocumentTag {
             get {
                 if (this.StructuredDocumentTag != null) {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        public bool IsCheckBox {
+            get {
+                if (this.CheckBox != null) {
                     return true;
                 }
 


### PR DESCRIPTION
## Summary
- implement checkbox content control via new `WordCheckBox` class
- allow `WordParagraph` to create and detect checkbox controls
- provide advanced example mixing checkboxes with tables, lists, hyperlinks, and fields
- add a basic unit test covering checkbox creation and manipulation
- remove changelog and docs updates from prior commit

## Testing
- `dotnet test OfficeImo.sln --no-build --verbosity minimal` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6854651b435c832ead6025d08befb524