### PR TITLE
Add comment removal API

### DIFF
--- a/Docs/officeimo.word.wordcomment.md
+++ b/Docs/officeimo.word.wordcomment.md
@@ -157,3 +157,11 @@ public void Delete()
 ```
 
 Deletes the comment and removes its references from the document.
+
+### **Remove()**
+
+```csharp
+public void Remove()
+```
+
+Removes this comment from the document. Alias for `Delete()`.

--- a/Docs/officeimo.word.worddocument.md
+++ b/Docs/officeimo.word.worddocument.md
@@ -24,3 +24,37 @@ public void RemoveSection(int index)
 `index` [Int32](https://docs.microsoft.com/en-us/dotnet/api/system.int32)<br>
 
 
+### **RemoveComment(String)**
+
+Remove comment with the specified id. Alternatively you can call `Remove()` on a `WordComment` instance.
+
+```csharp
+public void RemoveComment(string commentId)
+```
+
+### **RemoveComment(WordComment)**
+
+Remove the specified comment object.
+
+```csharp
+public void RemoveComment(WordComment comment)
+```
+
+### **RemoveAllComments()**
+
+Remove all comments from the document.
+
+```csharp
+public void RemoveAllComments()
+```
+
+## Properties
+
+### **TrackComments**
+
+Enable or disable tracking of comment changes.
+
+```csharp
+public bool TrackComments { get; set; }
+```
+

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -148,6 +148,7 @@ namespace OfficeIMO.Examples {
             TOC.Example_BasicTOC2(folderPath, false);
 
             Comments.Example_PlayingWithComments(folderPath, false);
+            Comments.Example_RemoveCommentsAndTrack(folderPath, false);
 
             BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);
             BasicExcelFunctionality.BasicExcel_Example2(folderPath, false);

--- a/OfficeIMO.Examples/Word/Comments/Comments.Example2.cs
+++ b/OfficeIMO.Examples/Word/Comments/Comments.Example2.cs
@@ -1,0 +1,24 @@
+using System;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Comments {
+        internal static void Example_RemoveCommentsAndTrack(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Demonstrating comment lifecycle");
+            string filePath = System.IO.Path.Combine(folderPath, "Comments Lifecycle.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.TrackComments = true;
+                var paragraph = document.AddParagraph("Paragraph with comment");
+                paragraph.AddComment("John Doe", "JD", "My comment");
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                if (document.Comments.Count > 0) {
+                    document.Comments[0].Remove();
+                }
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Comments.cs
+++ b/OfficeIMO.Tests/Word.Comments.cs
@@ -16,11 +16,47 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_AddReadRemoveComment.docx"))) {
                 Assert.True(document.Comments.Count == 1);
                 var comment = document.Comments.First();
-                comment.Delete();
+                comment.Remove();
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_AddReadRemoveComment.docx"))) {
                 Assert.True(document.Comments.Count == 0);
+            }
+        }
+
+        [Fact]
+        public void Test_RemoveAllCommentsMethod() {
+            string filePath = Path.Combine(_directoryWithFiles, "Test_RemoveAllComments.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Paragraph");
+                document.Paragraphs[0].AddComment("John Doe", "JD", "First");
+                document.Paragraphs[0].AddComment("John Doe", "JD", "Second");
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_RemoveAllComments.docx"))) {
+                Assert.Equal(2, document.Comments.Count);
+                document.RemoveAllComments();
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_RemoveAllComments.docx"))) {
+                Assert.Empty(document.Comments);
+            }
+        }
+
+        [Fact]
+        public void Test_TrackCommentsViaDocumentProperty() {
+            string filePath = Path.Combine(_directoryWithFiles, "Test_TrackComments2.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.TrackComments = true;
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_TrackComments2.docx"))) {
+                Assert.True(document.TrackComments);
+                document.TrackComments = false;
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_TrackComments2.docx"))) {
+                Assert.False(document.TrackComments);
             }
         }
 

--- a/OfficeIMO.Word/WordComment.PublicMethods.cs
+++ b/OfficeIMO.Word/WordComment.PublicMethods.cs
@@ -70,5 +70,12 @@ namespace OfficeIMO.Word {
                 reference.Parent?.Remove();
             }
         }
+
+        /// <summary>
+        /// Removes this comment from the document. Alias for <see cref="Delete"/>.
+        /// </summary>
+        public void Remove() {
+            Delete();
+        }
     }
 }

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -280,6 +280,40 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Removes comment with the specified id.
+        /// </summary>
+        /// <param name="commentId">Id of the comment to remove.</param>
+        public void RemoveComment(string commentId) {
+            var comment = this.Comments.FirstOrDefault(c => c.Id == commentId);
+            comment?.Delete();
+        }
+
+        /// <summary>
+        /// Removes the specified comment from the document.
+        /// </summary>
+        /// <param name="comment">Comment instance to remove.</param>
+        public void RemoveComment(WordComment comment) {
+            comment?.Delete();
+        }
+
+        /// <summary>
+        /// Removes all comments from the document.
+        /// </summary>
+        public void RemoveAllComments() {
+            foreach (var comment in this.Comments.ToList()) {
+                comment.Delete();
+            }
+        }
+
+        /// <summary>
+        /// Enable or disable tracking of comment changes.
+        /// </summary>
+        public bool TrackComments {
+            get => this.Settings.TrackComments;
+            set => this.Settings.TrackComments = value;
+        }
+
+        /// <summary>
         /// Gets the lists in the document
         /// </summary>
         /// <value>

--- a/README.md
+++ b/README.md
@@ -137,11 +137,11 @@ Here's a list of features currently supported (and probably a lot I forgot) and 
     - ☑️ Read Bookmark
     - ☑️ Remove Bookmark
     - ☑️ Change Bookmark
-- ◼️ Comments
-    - ☑️ Add comments
-    - ☑️ Read comments
-    - ◼️ Remove comments
-    - ◼️ Track comments
+  - ◼️ Comments
+      - ☑️ Add comments
+      - ☑️ Read comments
+      - ☑️ Remove comments (single or all)
+      - ☑️ Track comments
 - ☑️ Fields
     - ☑️ Add Field
     - ☑️ Read Field


### PR DESCRIPTION
## Summary
- allow removing comments via `WordComment.Remove()`
- support removing a comment object from `WordDocument`
- demonstrate individual comment removal in examples
- document comment removal APIs and update README
- update unit tests for new removal method

## Testing
- `dotnet test` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6855d231a83c832e968f6664b3b738f2