### PR TITLE
Improve table cell merge detection and examples

### DIFF
--- a/Docs/officeimo.word.wordtablecell.md
+++ b/Docs/officeimo.word.wordtablecell.md
@@ -52,6 +52,30 @@ public Nullable<MergedCellValues> VerticalMerge { get; set; }
 
 [Nullable&lt;MergedCellValues&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.nullable-1)<br>
 
+### **HasHorizontalMerge**
+
+Gets information whether the Table Cell participates in a horizontal merge
+
+```csharp
+public bool HasHorizontalMerge { get; }
+```
+
+#### Property Value
+
+[Boolean](https://docs.microsoft.com/en-us/dotnet/api/system.boolean)<br>
+
+### **HasVerticalMerge**
+
+Gets information whether the Table Cell participates in a vertical merge
+
+```csharp
+public bool HasVerticalMerge { get; }
+```
+
+#### Property Value
+
+[Boolean](https://docs.microsoft.com/en-us/dotnet/api/system.boolean)<br>
+
 ### **ShadingFillColorHex**
 
 Get or set the background color of the cell using hexadecimal color code.
@@ -157,7 +181,7 @@ public void MergeHorizontally(int cellsCount, bool copyParagraphs)
 
 ### **SplitHorizontally(Int32)**
 
-Splits (unmerge) cells that were merged
+Splits (unmerge) cells that were merged horizontally
 
 ```csharp
 public void SplitHorizontally(int cellsCount)
@@ -180,6 +204,18 @@ public void MergeVertically(int cellsCount, bool copyParagraphs)
 `cellsCount` [Int32](https://docs.microsoft.com/en-us/dotnet/api/system.int32)<br>
 
 `copyParagraphs` [Boolean](https://docs.microsoft.com/en-us/dotnet/api/system.boolean)<br>
+
+### **SplitVertically(Int32)**
+
+Splits (unmerge) cells that were merged vertically
+
+```csharp
+public void SplitVertically(int cellsCount)
+```
+
+#### Parameters
+
+`cellsCount` [Int32](https://docs.microsoft.com/en-us/dotnet/api/system.int32)<br>
 
 ### **AddTable(Int32, Int32, WordTableStyle, Boolean)**
 

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -82,6 +82,8 @@ namespace OfficeIMO.Examples {
             Tables.Example_BasicTables10_StylesModificationWithCentimeters(folderPath, false);
             Tables.Example_DifferentTableSizes(folderPath, false);
             Tables.Example_CloneTable(folderPath, false);
+            Tables.Example_SplitVertically(folderPath, false);
+            Tables.Example_SplitHorizontally(folderPath, false);
             PageSettings.Example_BasicSettings(folderPath, false);
             PageSettings.Example_PageOrientation(folderPath, false);
 

--- a/OfficeIMO.Examples/Word/Tables/Tables.SplitHorizontally.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.SplitHorizontally.cs
@@ -1,0 +1,27 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Tables {
+        internal static void Example_SplitHorizontally(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Tables - split horizontally merged cells");
+            string filePath = System.IO.Path.Combine(folderPath, "TablesSplitHorizontally.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(2, 4, WordTableStyle.PlainTable1);
+
+                table.Rows[0].Cells[0].Paragraphs[0].Text = "Col 1";
+                table.Rows[0].Cells[1].Paragraphs[0].Text = "Col 2";
+                table.Rows[0].Cells[2].Paragraphs[0].Text = "Col 3";
+                table.Rows[0].Cells[3].Paragraphs[0].Text = "Col 4";
+
+                table.Rows[0].Cells[1].MergeHorizontally(2, true);
+                Console.WriteLine($"Merged: {table.Rows[0].Cells[1].HasHorizontalMerge}");
+                table.Rows[0].Cells[1].SplitHorizontally(2);
+                Console.WriteLine($"Merged after split: {table.Rows[0].Cells[1].HasHorizontalMerge}");
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Tables/Tables.SplitVertically.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.SplitVertically.cs
@@ -1,0 +1,25 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Tables {
+        internal static void Example_SplitVertically(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Tables - split vertically merged cells");
+            string filePath = System.IO.Path.Combine(folderPath, "TablesSplitVertically.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(4, 2, WordTableStyle.PlainTable1);
+
+                table.Rows[0].Cells[0].Paragraphs[0].Text = "Row 1";
+                table.Rows[1].Cells[0].Paragraphs[0].Text = "Row 2";
+                table.Rows[2].Cells[0].Paragraphs[0].Text = "Row 3";
+                table.Rows[3].Cells[0].Paragraphs[0].Text = "Row 4";
+
+                table.Rows[0].Cells[0].MergeVertically(2, true);
+                table.Rows[0].Cells[0].SplitVertically(2);
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Tables.cs
+++ b/OfficeIMO.Tests/Word.Tables.cs
@@ -555,6 +555,93 @@ namespace OfficeIMO.Tests {
                 document.Save();
             }
         }
+
+        [Fact]
+        public void Test_SplitVerticallyKeepsIndices() {
+            string filePath = Path.Combine(_directoryWithFiles, "SplitVerticallyIndices.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(4, 2, WordTableStyle.PlainTable1);
+
+                table.Rows[0].Cells[0].MergeVertically(2, true);
+
+                Assert.True(table.Rows[0].Cells[0].HasVerticalMerge);
+                Assert.True(table.Rows[1].Cells[0].HasVerticalMerge);
+                Assert.True(table.Rows[2].Cells[0].HasVerticalMerge);
+
+                Assert.Equal(4, table.RowsCount);
+                foreach (var row in table.Rows) {
+                    Assert.Equal(2, row.CellsCount);
+                }
+
+                table.Rows[0].Cells[0].SplitVertically(2);
+
+                Assert.Equal(4, table.RowsCount);
+                foreach (var row in table.Rows) {
+                    Assert.Equal(2, row.CellsCount);
+                }
+
+                document.Save();
+            }
+
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "SplitVerticallyIndices.docx"))) {
+                var table = document.Tables[0];
+
+                Assert.Equal(4, table.RowsCount);
+                foreach (var row in table.Rows) {
+                    Assert.Equal(2, row.CellsCount);
+                }
+                Assert.False(table.Rows[0].Cells[0].HasVerticalMerge);
+                Assert.False(table.Rows[1].Cells[0].HasVerticalMerge);
+                Assert.False(table.Rows[2].Cells[0].HasVerticalMerge);
+
+                document.Save();
+            }
+        }
+
+        [Fact]
+        public void Test_SplitHorizontallyKeepsIndices() {
+            string filePath = Path.Combine(_directoryWithFiles, "SplitHorizontallyIndices.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(2, 4, WordTableStyle.PlainTable1);
+
+                table.Rows[0].Cells[1].MergeHorizontally(2, true);
+
+                Assert.Equal(2, table.RowsCount);
+                foreach (var row in table.Rows) {
+                    Assert.Equal(4, row.CellsCount);
+                }
+
+                Assert.True(table.Rows[0].Cells[1].HasHorizontalMerge);
+                Assert.True(table.Rows[0].Cells[2].HasHorizontalMerge);
+                Assert.True(table.Rows[0].Cells[3].HasHorizontalMerge);
+
+                table.Rows[0].Cells[1].SplitHorizontally(2);
+
+                foreach (var row in table.Rows) {
+                    Assert.Equal(4, row.CellsCount);
+                }
+
+                Assert.False(table.Rows[0].Cells[1].HasHorizontalMerge);
+                Assert.False(table.Rows[0].Cells[2].HasHorizontalMerge);
+                Assert.False(table.Rows[0].Cells[3].HasHorizontalMerge);
+
+                document.Save();
+            }
+
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "SplitHorizontallyIndices.docx"))) {
+                var table = document.Tables[0];
+
+                Assert.Equal(2, table.RowsCount);
+                foreach (var row in table.Rows) {
+                    Assert.Equal(4, row.CellsCount);
+                }
+                Assert.False(table.Rows[0].Cells[1].HasHorizontalMerge);
+                Assert.False(table.Rows[0].Cells[2].HasHorizontalMerge);
+                Assert.False(table.Rows[0].Cells[3].HasHorizontalMerge);
+
+                document.Save();
+            }
+        }
         [Fact]
         public void Test_CreatingWordDocumentWithTablesWithSections() {
             string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithTablesAndSections.docx");

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -67,6 +67,24 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Gets information whether the cell is part of a horizontal merge
+        /// </summary>
+        public bool HasHorizontalMerge {
+            get {
+                return _tableCellProperties?.HorizontalMerge != null;
+            }
+        }
+
+        /// <summary>
+        /// Gets information whether the cell is part of a vertical merge
+        /// </summary>
+        public bool HasVerticalMerge {
+            get {
+                return _tableCellProperties?.VerticalMerge != null;
+            }
+        }
+
+        /// <summary>
         /// Get or set the background color of the cell using hexadecimal color code.
         /// </summary>
         public string ShadingFillColorHex {

--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ Here's a list of features currently supported (and probably a lot I forgot) and 
     - ☑️ Remove cells
     - ☑️ Others
         - ☑️ Merge cells (vertically, horizontally)
-        - ◼️ Split cells (vertically)
+        - ☑️ Split cells (vertically)
         - ☑️ Split cells (horizontally)
+        - ☑️ Detect merged cells (vertically, horizontally)
         - ☑️ Nested tables
         - ☑️ Repeat header row on each page
         - ☑️ Control row page breaks


### PR DESCRIPTION
## Summary
- add `HasHorizontalMerge` and `HasVerticalMerge` properties to `WordTableCell`
- document new properties and improve horizontal split description
- add example demonstrating horizontal split
- exercise new properties in tests
- update README with merged cell detection feature

## Testing
- `dotnet test --no-build` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6855d2080028832ea4d3096506e77deb