### PR TITLE
Use InvalidOperationException for invalid operations

### DIFF
--- a/OfficeIMO.Tests/Word.Save.cs
+++ b/OfficeIMO.Tests/Word.Save.cs
@@ -179,6 +179,20 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Test_SaveReadOnlyDocument_ThrowsInvalidOperationException() {
+            var filePath = Path.Combine(_directoryWithFiles, "ReadOnlyDocument.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Test");
+                document.Save();
+            }
+
+            using var readOnlyDocument = WordDocument.Load(filePath, readOnly: true);
+            Assert.Throws<InvalidOperationException>(() => readOnlyDocument.Save());
+            using var outputStream = new MemoryStream();
+            Assert.Throws<InvalidOperationException>(() => readOnlyDocument.Save(outputStream));
+        }
+
     }
 
 }

--- a/OfficeIMO.Word/WordDocument.HtmlReplacement.cs
+++ b/OfficeIMO.Word/WordDocument.HtmlReplacement.cs
@@ -75,7 +75,7 @@ namespace OfficeIMO.Word {
                 WordAlternativeFormatImportPartType.Rtf => AlternativeFormatImportPartType.Rtf,
                 WordAlternativeFormatImportPartType.Html => AlternativeFormatImportPartType.Html,
                 WordAlternativeFormatImportPartType.TextPlain => AlternativeFormatImportPartType.TextPlain,
-                _ => throw new Exception("Unsupported format type")
+                _ => throw new InvalidOperationException("Unsupported format type")
             };
 
             AlternativeFormatImportPart chunk = mainDocPart.AddAlternativeFormatImportPart(partTypeInfo);

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -851,11 +851,10 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="filePath"></param>
         /// <param name="openWord"></param>
-        /// <exception cref="Exception"></exception>
         /// <exception cref="InvalidOperationException"></exception>
         public void Save(string filePath, bool openWord) {
             if (FileOpenAccess == FileAccess.Read) {
-                throw new Exception("Document is read only, and cannot be saved.");
+                throw new InvalidOperationException("Document is read only, and cannot be saved.");
             }
             PreSaving();
 
@@ -935,10 +934,10 @@ namespace OfficeIMO.Word {
         /// Save the WordDocument to Stream
         /// </summary>
         /// <param name="outputStream"></param>
-        /// <exception cref="Exception"></exception>
+        /// <exception cref="InvalidOperationException"></exception>
         public void Save(Stream outputStream) {
             if (FileOpenAccess == FileAccess.Read) {
-                throw new Exception("Document is read only, and cannot be saved.");
+                throw new InvalidOperationException("Document is read only, and cannot be saved.");
             }
             PreSaving();
 

--- a/OfficeIMO.Word/WordEmbeddedDocument.cs
+++ b/OfficeIMO.Word/WordEmbeddedDocument.cs
@@ -64,7 +64,7 @@ namespace OfficeIMO.Word {
                 } else if (fileInfo.Extension == ".log" || fileInfo.Extension == ".txt") {
                     partType = WordAlternativeFormatImportPartType.TextPlain;
                 } else {
-                    throw new Exception("Only RTF and HTML files are supported for now :-)");
+                    throw new InvalidOperationException("Only RTF and HTML files are supported for now :-)");
                 }
             } else {
                 partType = alternativeFormatImportPartType.Value;
@@ -76,7 +76,7 @@ namespace OfficeIMO.Word {
                 WordAlternativeFormatImportPartType.Rtf => AlternativeFormatImportPartType.Rtf,
                 WordAlternativeFormatImportPartType.Html => AlternativeFormatImportPartType.Html,
                 WordAlternativeFormatImportPartType.TextPlain => AlternativeFormatImportPartType.TextPlain,
-                _ => throw new Exception("Unsupported format type")
+                _ => throw new InvalidOperationException("Unsupported format type")
             };
 
             AlternativeFormatImportPart chunk = mainDocPart.AddAlternativeFormatImportPart(partTypeInfo);

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -744,7 +744,7 @@ namespace OfficeIMO.Word {
                 imagePart = part.AddImagePart(imagePartType.ToOpenXmlImagePartType());
                 relationshipId = part.GetIdOfPart(imagePart);
             } else {
-                throw new Exception("Paragraph is not in document or header or footer. This is weird. Probably a bug.");
+                throw new InvalidOperationException("Paragraph is not in document or header or footer. This is weird. Probably a bug.");
             }
 
             imagePart.FeedData(imageStream);

--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -258,7 +258,7 @@ namespace OfficeIMO.Word {
                     }
                     runPropertiesBaseStyle.FontSize.Val = (value * 2).ToString();
                 } else {
-                    throw new Exception("Could not set font size. Styles not found.");
+                    throw new InvalidOperationException("Could not set font size. Styles not found.");
                 }
             }
         }
@@ -285,7 +285,7 @@ namespace OfficeIMO.Word {
                     }
                     runPropertiesBaseStyle.FontSizeComplexScript.Val = (value * 2).ToString();
                 } else {
-                    throw new Exception("Could not set font size complex script. Styles not found.");
+                    throw new InvalidOperationException("Could not set font size complex script. Styles not found.");
                 }
             }
         }
@@ -325,7 +325,7 @@ namespace OfficeIMO.Word {
                     runPropertiesBaseStyle.RunFonts.ComplexScript = value;
                     runPropertiesBaseStyle.RunFonts.ComplexScriptTheme = null;
                 } else {
-                    throw new Exception("Could not set font family. Styles not found.");
+                    throw new InvalidOperationException("Could not set font family. Styles not found.");
                 }
             }
         }
@@ -360,7 +360,7 @@ namespace OfficeIMO.Word {
                     }
                     runPropertiesBaseStyle.RunFonts.HighAnsiTheme = null;
                 } else {
-                    throw new Exception("Could not set font family. Styles not found.");
+                    throw new InvalidOperationException("Could not set font family. Styles not found.");
                 }
             }
         }
@@ -393,7 +393,7 @@ namespace OfficeIMO.Word {
                     }
                     runPropertiesBaseStyle.RunFonts.EastAsiaTheme = null;
                 } else {
-                    throw new Exception("Could not set font family. Styles not found.");
+                    throw new InvalidOperationException("Could not set font family. Styles not found.");
                 }
             }
         }
@@ -426,7 +426,7 @@ namespace OfficeIMO.Word {
                     }
                     runPropertiesBaseStyle.RunFonts.ComplexScriptTheme = null;
                 } else {
-                    throw new Exception("Could not set font family. Styles not found.");
+                    throw new InvalidOperationException("Could not set font family. Styles not found.");
                 }
             }
         }
@@ -453,7 +453,7 @@ namespace OfficeIMO.Word {
                     runPropertiesBaseStyle.Languages.Val = value;
                     //runPropertiesBaseStyle.Languages.EastAsia = value;
                 } else {
-                    throw new Exception("Could not set language. Styles not found.");
+                    throw new InvalidOperationException("Could not set language. Styles not found.");
                 }
             }
         }


### PR DESCRIPTION
## Summary
- throw `InvalidOperationException` in place of generic `Exception`
- adjust xmldoc exception tags
- add test for saving a read-only document

## Testing
- `dotnet restore` *(fails: domain not in allowlist)*
- `dotnet test --no-build` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6856a5873260832e8eabdf4472e5725b