### PR TITLE
Refactor disposal in basic tests

### DIFF
--- a/OfficeIMO.Tests/Excel.BasicDocuments.cs
+++ b/OfficeIMO.Tests/Excel.BasicDocuments.cs
@@ -14,11 +14,12 @@ namespace OfficeIMO.Tests {
 
             Assert.False(path); // MUST BE FALSE
 
-            using var document = ExcelDocument.Create(filePath);
-            document.Save();
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.Save();
 
-            path = File.Exists(filePath);
-            Assert.True(path);
+                path = File.Exists(filePath);
+                Assert.True(path);
+            }
 
             File.Delete(filePath);
         }
@@ -26,44 +27,46 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void Test_CreatingExcel1() {
             var filePath = Path.Combine(_directoryWithFiles, "TestFileTemporary1.xlsx");
-            using var document = ExcelDocument.Create(filePath);
-            Assert.True(document.Sheets.Count == 0);
-            var sheet1 = document.AddWorkSheet("Test1");
-            var sheet2 = document.AddWorkSheet("Test2");
-            var sheet3 = document.AddWorkSheet("Test3");
+            using (var document = ExcelDocument.Create(filePath)) {
+                Assert.True(document.Sheets.Count == 0);
+                var sheet1 = document.AddWorkSheet("Test1");
+                var sheet2 = document.AddWorkSheet("Test2");
+                var sheet3 = document.AddWorkSheet("Test3");
 
-            Assert.True(document.Sheets.Count == 3);
-            Assert.True(document.Sheets[0].Name == "Test1");
-            Assert.True(document.Sheets[1].Name == "Test2");
-            Assert.True(document.Sheets[2].Name == "Test3");
-            document.Save(false);
+                Assert.True(document.Sheets.Count == 3);
+                Assert.True(document.Sheets[0].Name == "Test1");
+                Assert.True(document.Sheets[1].Name == "Test2");
+                Assert.True(document.Sheets[2].Name == "Test3");
+                document.Save(false);
+            }
         }
 
 
         [Fact]
         public void Test_CreatingExcel2() {
             var filePath = Path.Combine(_directoryWithFiles, "TestFileTemporary2.xlsx");
-            using var document = ExcelDocument.Create(filePath, "WorkSheet5");
-            Assert.True(document.Sheets.Count == 1);
-            ExcelSheet sheet = document.AddWorkSheet("Test");
-            Assert.True(document.Sheets.Count == 2);
-            Assert.True(document.Sheets[0].Name == "WorkSheet5");
-            Assert.True(document.Sheets[1].Name == "Test");
-            document.Save(false);
+            using (var document = ExcelDocument.Create(filePath, "WorkSheet5")) {
+                Assert.True(document.Sheets.Count == 1);
+                ExcelSheet sheet = document.AddWorkSheet("Test");
+                Assert.True(document.Sheets.Count == 2);
+                Assert.True(document.Sheets[0].Name == "WorkSheet5");
+                Assert.True(document.Sheets[1].Name == "Test");
+                document.Save(false);
+            }
         }
 
         [Fact]
         public void Test_OpeningExcel() {
-            using var document = ExcelDocument.Load(Path.Combine(_directoryDocuments, "BasicExcel.xlsx"));
+            using (var document = ExcelDocument.Load(Path.Combine(_directoryDocuments, "BasicExcel.xlsx"))) {
+                Assert.True(document.FilePath != null);
+                Assert.True(document.Sheets.Count == 4);
 
-            Assert.True(document.FilePath != null);
-            Assert.True(document.Sheets.Count == 4);
-
-            Assert.True(document.Sheets[0].Name == "Sheet1");
-            Assert.True(document.Sheets[1].Name == "Sheet2");
-            Assert.True(document.Sheets[2].Name == "DifferentTest");
-            Assert.True(document.Sheets[3].Name == "Sheet3");
-            document.Save();
+                Assert.True(document.Sheets[0].Name == "Sheet1");
+                Assert.True(document.Sheets[1].Name == "Sheet2");
+                Assert.True(document.Sheets[2].Name == "DifferentTest");
+                Assert.True(document.Sheets[3].Name == "Sheet3");
+                document.Save();
+            }
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.BasicDocuments.cs
+++ b/OfficeIMO.Tests/Excel.BasicDocuments.cs
@@ -14,12 +14,11 @@ namespace OfficeIMO.Tests {
 
             Assert.False(path); // MUST BE FALSE
 
-            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
-                document.Save();
+            using var document = ExcelDocument.Create(filePath);
+            document.Save();
 
-                path = File.Exists(filePath);
-                Assert.True(path);
-            }
+            path = File.Exists(filePath);
+            Assert.True(path);
 
             File.Delete(filePath);
         }
@@ -27,47 +26,44 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void Test_CreatingExcel1() {
             var filePath = Path.Combine(_directoryWithFiles, "TestFileTemporary1.xlsx");
-            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
-                Assert.True(document.Sheets.Count == 0);
-                var sheet1 = document.AddWorkSheet("Test1");
-                var sheet2 = document.AddWorkSheet("Test2");
-                var sheet3 = document.AddWorkSheet("Test3");
+            using var document = ExcelDocument.Create(filePath);
+            Assert.True(document.Sheets.Count == 0);
+            var sheet1 = document.AddWorkSheet("Test1");
+            var sheet2 = document.AddWorkSheet("Test2");
+            var sheet3 = document.AddWorkSheet("Test3");
 
-                Assert.True(document.Sheets.Count == 3);
-                Assert.True(document.Sheets[0].Name == "Test1");
-                Assert.True(document.Sheets[1].Name == "Test2");
-                Assert.True(document.Sheets[2].Name == "Test3");
-                document.Save(false);
-            }
+            Assert.True(document.Sheets.Count == 3);
+            Assert.True(document.Sheets[0].Name == "Test1");
+            Assert.True(document.Sheets[1].Name == "Test2");
+            Assert.True(document.Sheets[2].Name == "Test3");
+            document.Save(false);
         }
 
 
         [Fact]
         public void Test_CreatingExcel2() {
             var filePath = Path.Combine(_directoryWithFiles, "TestFileTemporary2.xlsx");
-            using (ExcelDocument document = ExcelDocument.Create(filePath, "WorkSheet5")) {
-                Assert.True(document.Sheets.Count == 1);
-                ExcelSheet sheet = document.AddWorkSheet("Test");
-                Assert.True(document.Sheets.Count == 2);
-                Assert.True(document.Sheets[0].Name == "WorkSheet5");
-                Assert.True(document.Sheets[1].Name == "Test");
-                document.Save(false);
-            }
+            using var document = ExcelDocument.Create(filePath, "WorkSheet5");
+            Assert.True(document.Sheets.Count == 1);
+            ExcelSheet sheet = document.AddWorkSheet("Test");
+            Assert.True(document.Sheets.Count == 2);
+            Assert.True(document.Sheets[0].Name == "WorkSheet5");
+            Assert.True(document.Sheets[1].Name == "Test");
+            document.Save(false);
         }
 
         [Fact]
         public void Test_OpeningExcel() {
-            using (ExcelDocument document = ExcelDocument.Load(Path.Combine(_directoryDocuments, "BasicExcel.xlsx"))) {
+            using var document = ExcelDocument.Load(Path.Combine(_directoryDocuments, "BasicExcel.xlsx"));
 
-                Assert.True(document.FilePath != null);
-                Assert.True(document.Sheets.Count == 4);
+            Assert.True(document.FilePath != null);
+            Assert.True(document.Sheets.Count == 4);
 
-                Assert.True(document.Sheets[0].Name == "Sheet1");
-                Assert.True(document.Sheets[1].Name == "Sheet2");
-                Assert.True(document.Sheets[2].Name == "DifferentTest");
-                Assert.True(document.Sheets[3].Name == "Sheet3");
-                document.Save();
-            }
+            Assert.True(document.Sheets[0].Name == "Sheet1");
+            Assert.True(document.Sheets[1].Name == "Sheet2");
+            Assert.True(document.Sheets[2].Name == "DifferentTest");
+            Assert.True(document.Sheets[3].Name == "Sheet3");
+            document.Save();
         }
     }
 }

--- a/OfficeIMO.Tests/Word.BasicDocument.cs
+++ b/OfficeIMO.Tests/Word.BasicDocument.cs
@@ -11,25 +11,27 @@ namespace OfficeIMO.Tests {
             File.Delete(filePath);
             Assert.False(path); // MUST BE FALSE
 
-            using var document = WordDocument.Create(filePath);
-            document.Save();
+            using (var document = WordDocument.Create(filePath)) {
+                document.Save();
 
-            path = File.Exists(filePath);
-            Assert.True(path);
+                path = File.Exists(filePath);
+                Assert.True(path);
+            }
             File.Delete(filePath);
         }
 
         [Fact]
         public void Test_OpeningWordAndParagraphCountMatches() {
-            using var document = WordDocument.Load(Path.Combine(_directoryDocuments, "BasicDocument.docx"));
-            // There is only one Paragraph at the document level.
-            Assert.True(document.Paragraphs.Count == 12);
+            using (var document = WordDocument.Load(Path.Combine(_directoryDocuments, "BasicDocument.docx"))) {
+                // There is only one Paragraph at the document level.
+                Assert.True(document.Paragraphs.Count == 12);
 
-            // There is only one Table in this document.
-            //Assert.True(document.Tables.Count() == 1);
+                // There is only one Table in this document.
+                //Assert.True(document.Tables.Count() == 1);
 
-            // This table has 12 Paragraphs.
-            //Assert.True(t0.Paragraphs.Count() == 12);
+                // This table has 12 Paragraphs.
+                //Assert.True(t0.Paragraphs.Count() == 12);
+            }
         }
 
         [Fact]
@@ -40,12 +42,13 @@ namespace OfficeIMO.Tests {
             foreach (var doc in docs) {
                 Console.WriteLine($"Processing document: {doc}");
 
-                using var document = WordDocument.Load(doc);
-                var allElements = document.Elements;
-                Assert.True(allElements.Count > 0, $"Document '{doc}' has no elements.");
+                using (var document = WordDocument.Load(doc)) {
+                    var allElements = document.Elements;
+                    Assert.True(allElements.Count > 0, $"Document '{doc}' has no elements.");
 
-                var allElementsByType = document.ElementsByType;
-                Assert.True(allElementsByType.Count > 0, $"Document '{doc}' has no elements by type.");
+                    var allElementsByType = document.ElementsByType;
+                    Assert.True(allElementsByType.Count > 0, $"Document '{doc}' has no elements by type.");
+                }
             }
         }
     }

--- a/OfficeIMO.Tests/Word.BasicDocument.cs
+++ b/OfficeIMO.Tests/Word.BasicDocument.cs
@@ -11,27 +11,25 @@ namespace OfficeIMO.Tests {
             File.Delete(filePath);
             Assert.False(path); // MUST BE FALSE
 
-            using (WordDocument document = WordDocument.Create(filePath)) {
-                document.Save();
+            using var document = WordDocument.Create(filePath);
+            document.Save();
 
-                path = File.Exists(filePath);
-                Assert.True(path);
-            }
+            path = File.Exists(filePath);
+            Assert.True(path);
             File.Delete(filePath);
         }
 
         [Fact]
         public void Test_OpeningWordAndParagraphCountMatches() {
-            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryDocuments, "BasicDocument.docx"))) {
-                // There is only one Paragraph at the document level.
-                Assert.True(document.Paragraphs.Count == 12);
+            using var document = WordDocument.Load(Path.Combine(_directoryDocuments, "BasicDocument.docx"));
+            // There is only one Paragraph at the document level.
+            Assert.True(document.Paragraphs.Count == 12);
 
-                // There is only one Table in this document.
-                //Assert.True(document.Tables.Count() == 1);
+            // There is only one Table in this document.
+            //Assert.True(document.Tables.Count() == 1);
 
-                // This table has 12 Paragraphs.
-                //Assert.True(t0.Paragraphs.Count() == 12);
-            }
+            // This table has 12 Paragraphs.
+            //Assert.True(t0.Paragraphs.Count() == 12);
         }
 
         [Fact]
@@ -42,13 +40,12 @@ namespace OfficeIMO.Tests {
             foreach (var doc in docs) {
                 Console.WriteLine($"Processing document: {doc}");
 
-                using (WordDocument document = WordDocument.Load(doc)) {
-                    var allElements = document.Elements;
-                    Assert.True(allElements.Count > 0, $"Document '{doc}' has no elements.");
+                using var document = WordDocument.Load(doc);
+                var allElements = document.Elements;
+                Assert.True(allElements.Count > 0, $"Document '{doc}' has no elements.");
 
-                    var allElementsByType = document.ElementsByType;
-                    Assert.True(allElementsByType.Count > 0, $"Document '{doc}' has no elements by type.");
-                }
+                var allElementsByType = document.ElementsByType;
+                Assert.True(allElementsByType.Count > 0, $"Document '{doc}' has no elements by type.");
             }
         }
     }


### PR DESCRIPTION
## Summary
- dispose WordDocument and ExcelDocument instances with `using var`

## Testing
- `dotnet test --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6856a5a624c4832eb7d2b716298bcb1a