### PR TITLE
Implement mail merge helper

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -208,6 +208,9 @@ namespace OfficeIMO.Examples {
             Shapes.Example_AddMultipleShapes(folderPath, false);
             Shapes.Example_RemoveShape(folderPath, false);
             Shapes.Example_LoadShapes(folderPath, false);
+
+            MailMerge.Example_MailMergeSimple(folderPath, false);
+            MailMerge.Example_MailMergeAdvanced(folderPath, false);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/MailMerge/MailMerge.Advanced.cs
+++ b/OfficeIMO.Examples/Word/MailMerge/MailMerge.Advanced.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class MailMerge {
+        internal static void Example_MailMergeAdvanced(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Mail merge advanced");
+            string filePath = System.IO.Path.Combine(folderPath, "MailMergeAdvanced.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Hello ")
+                    .AddField(WordFieldType.MergeField, parameters: new List<string> { "\"FirstName\"" })
+                    .AddText(" ")
+                    .AddField(WordFieldType.MergeField, parameters: new List<string> { "\"LastName\"" })
+                    .AddText(",");
+
+                document.AddParagraph("Your balance is ")
+                    .AddField(WordFieldType.MergeField, parameters: new List<string> { "\"Balance\"" })
+                    .AddText(".");
+
+                var values = new Dictionary<string, string> {
+                    { "FirstName", "Jane" },
+                    { "LastName", "Doe" },
+                    { "Balance", "$200" }
+                };
+
+                WordMailMerge.Execute(document, values, removeFields: false);
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/MailMerge/MailMerge.Simple.cs
+++ b/OfficeIMO.Examples/Word/MailMerge/MailMerge.Simple.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class MailMerge {
+        internal static void Example_MailMergeSimple(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Mail merge simple");
+            string filePath = System.IO.Path.Combine(folderPath, "MailMergeSimple.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Dear ")
+                    .AddField(WordFieldType.MergeField, parameters: new List<string> { "\"FirstName\"" })
+                    .AddText(",");
+
+                document.AddParagraph("Your order number ")
+                    .AddField(WordFieldType.MergeField, parameters: new List<string> { "\"OrderId\"" })
+                    .AddText(" has been processed.");
+
+                var values = new Dictionary<string, string> {
+                    { "FirstName", "John" },
+                    { "OrderId", "12345" }
+                };
+
+                WordMailMerge.Execute(document, values);
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.MailMerge.cs
+++ b/OfficeIMO.Tests/Word.MailMerge.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_MailMerge_ReplacesFields() {
+            string filePath = Path.Combine(_directoryWithFiles, "MailMerge.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Hello ")
+                    .AddField(WordFieldType.MergeField, parameters: new List<string> { "\"Name\"" })
+                    .AddText("!");
+
+                var values = new Dictionary<string, string> { { "Name", "Alice" } };
+                WordMailMerge.Execute(document, values);
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                string xml = document._document.MainDocumentPart.Document.InnerText;
+                Assert.Contains("Alice", xml);
+                Assert.DoesNotContain("MERGEFIELD", xml);
+            }
+        }
+
+        [Fact]
+        public void Test_MailMerge_KeepFields() {
+            string filePath = Path.Combine(_directoryWithFiles, "MailMergeKeep.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Hello ")
+                    .AddField(WordFieldType.MergeField, parameters: new List<string> { "\"Name\"" })
+                    .AddText("!");
+
+                var values = new Dictionary<string, string> { { "Name", "Bob" } };
+                WordMailMerge.Execute(document, values, removeFields: false);
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Single(document.Fields);
+                Assert.Equal("Bob", document.Fields[0].Text);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordField.MailMerge.cs
+++ b/OfficeIMO.Word/WordField.MailMerge.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word {
+    public partial class WordField {
+        /// <summary>
+        /// Replaces the current field with plain text.
+        /// </summary>
+        /// <param name="text">Text to insert in place of the field.</param>
+        public void ReplaceWithText(string text) {
+            if (_simpleField != null) {
+                int index = _paragraph.ChildElements.ToList().IndexOf(_simpleField);
+                var run = new Run(new Text(text));
+                _paragraph.InsertAt(run, index);
+                _simpleField.Remove();
+                _runs.Clear();
+                _runs.Add(run);
+            } else if (_runs.Count > 0) {
+                int index = _paragraph.ChildElements.ToList().IndexOf(_runs[0]);
+                foreach (var r in _runs) {
+                    r.Remove();
+                }
+                var run = new Run(new Text(text));
+                _paragraph.InsertAt(run, index);
+                _runs.Clear();
+                _runs.Add(run);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordMailMerge.cs
+++ b/OfficeIMO.Word/WordMailMerge.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides basic mail merge capabilities by replacing <c>MERGEFIELD</c> fields with supplied values.
+    /// </summary>
+    public static class WordMailMerge {
+        /// <summary>
+        /// Replaces all MERGEFIELD fields in the given document with provided values.
+        /// </summary>
+        /// <param name="document">Document to update.</param>
+        /// <param name="values">Dictionary with field names and values.</param>
+        /// <param name="removeFields">Determines whether the field codes are removed after replacement.</param>
+        public static void Execute(WordDocument document, IDictionary<string, string> values, bool removeFields = true) {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+            if (values == null) throw new ArgumentNullException(nameof(values));
+
+            foreach (var field in document.Fields.Where(f => f.FieldType == WordFieldType.MergeField)) {
+                var parser = new WordFieldParser(field.Field);
+                if (parser.Instructions.Count == 0) continue;
+                var name = parser.Instructions[0].Trim().Trim('"');
+                if (values.TryGetValue(name, out var value)) {
+                    if (removeFields) {
+                        field.ReplaceWithText(value);
+                    } else {
+                        field.Text = value;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `WordMailMerge` helper for replacing MERGEFIELD data
- extend `WordField` with `ReplaceWithText` method
- showcase new helper in simple and advanced examples
- test mail merge behavior

## Testing
- `dotnet test OfficeImo.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6856b59456c4832e80312eabaab23a11