### PR TITLE
Add ellipse, line, and polygon shapes

### DIFF
--- a/Docs/Examples/ExamplesShapes/README.MD
+++ b/Docs/Examples/ExamplesShapes/README.MD
@@ -1,0 +1,18 @@
+## Drawing VML Shapes
+
+`WordShape` exposes factory methods for creating simple VML shapes directly on a paragraph.
+
+```csharp
+using (WordDocument document = WordDocument.Create(filePath)) {
+    var paragraph = document.AddParagraph("Shapes demo");
+    // rectangle
+    paragraph.AddShape(100, 50, SixLabors.ImageSharp.Color.Red);
+    // ellipse
+    WordShape.AddEllipse(paragraph, 80, 40, SixLabors.ImageSharp.Color.Green);
+    // line
+    WordShape.AddLine(paragraph, 0, 60, 100, 60, SixLabors.ImageSharp.Color.Blue, 2);
+    // polygon
+    WordShape.AddPolygon(paragraph, "0,0 50,0 50,50 0,50", SixLabors.ImageSharp.Color.Yellow, SixLabors.ImageSharp.Color.Black);
+    document.Save();
+}
+```

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -205,6 +205,7 @@ namespace OfficeIMO.Examples {
 
             Shapes.Example_AddBasicShape(folderPath, false);
             Shapes.Example_AddLine(folderPath, false);
+            Shapes.Example_AddEllipseAndPolygon(folderPath, false);
             Shapes.Example_AddMultipleShapes(folderPath, false);
             Shapes.Example_RemoveShape(folderPath, false);
             Shapes.Example_LoadShapes(folderPath, false);

--- a/OfficeIMO.Examples/Word/Shapes/Shapes.Basic.cs
+++ b/OfficeIMO.Examples/Word/Shapes/Shapes.Basic.cs
@@ -1,5 +1,6 @@
 using System;
 using OfficeIMO.Word;
+using SixLabors.ImageSharp;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class Shapes {
@@ -9,7 +10,7 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var paragraph = document.AddParagraph("Paragraph with red rectangle");
-                paragraph.AddShape(100, 50, "#FF0000");
+                paragraph.AddShape(100, 50, Color.Red);
                 document.Save(openWord);
             }
         }

--- a/OfficeIMO.Examples/Word/Shapes/Shapes.EllipsePolygon.cs
+++ b/OfficeIMO.Examples/Word/Shapes/Shapes.EllipsePolygon.cs
@@ -1,0 +1,19 @@
+using System;
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Shapes {
+        internal static void Example_AddEllipseAndPolygon(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with ellipse and polygon shapes");
+            string filePath = System.IO.Path.Combine(folderPath, "DocumentWithEllipsePolygon.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Paragraph with shapes");
+                WordShape.AddEllipse(paragraph, 80, 40, Color.Red);
+                WordShape.AddPolygon(paragraph, "0,0 40,0 40,40 0,40", Color.Lime, Color.Blue);
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Shapes.cs
+++ b/OfficeIMO.Tests/Word.Shapes.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using OfficeIMO.Word;
+using SixLabors.ImageSharp;
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -9,7 +10,11 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "CreateDocumentWithShapes.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var paragraph = document.AddParagraph("Paragraph with shape");
-                var shape = paragraph.AddShape(100, 50, "#FF0000");
+                var shape = paragraph.AddShape(100, 50, Color.Red);
+
+                WordShape.AddEllipse(paragraph, 80, 40, Color.Lime);
+                WordShape.AddPolygon(paragraph, "0,0 50,0 50,50 0,50", Color.White, Color.Blue);
+                WordShape.AddLine(paragraph, 0, 60, 100, 60, Color.Red, 2);
 
                 Assert.True(document.Paragraphs.Count == 1);
                 Assert.NotNull(paragraph.Shape);
@@ -20,7 +25,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithShapes.docx"))) {
-                Assert.True(document.Paragraphs[0].Shape != null);
+                Assert.True(document.Paragraphs[0].IsShape);
                 Assert.Equal(100d, document.Paragraphs[0].Shape.Width, 1);
                 Assert.Equal(50d, document.Paragraphs[0].Shape.Height, 1);
             }

--- a/OfficeIMO.Tests/Word.ShapesAdvanced.cs
+++ b/OfficeIMO.Tests/Word.ShapesAdvanced.cs
@@ -1,0 +1,43 @@
+using System.IO;
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_EllipseAndPolygonShapes() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreateDocumentWithEllipsePolygon.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Paragraph with shapes");
+                var ellipse = WordShape.AddEllipse(paragraph, 40, 20, Color.Lime);
+                WordShape.AddPolygon(paragraph, "0,0 20,0 20,20 0,20", Color.Yellow, Color.Blue);
+
+                Assert.NotNull(ellipse);
+                Assert.Equal(40d, ellipse.Width, 1);
+                Assert.Equal(20d, ellipse.Height, 1);
+
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.True(document.Paragraphs[0].IsShape);
+                Assert.Equal(40d, document.Paragraphs[0].Shape.Width, 1);
+                Assert.Equal(20d, document.Paragraphs[0].Shape.Height, 1);
+            }
+        }
+        [Fact]
+        public void Test_LineShapeFactory() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreateDocumentWithLineFactory.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Line via factory");
+                WordShape.AddLine(paragraph, 0, 0, 50, 0, Color.Red, 1);
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.True(document.Paragraphs[0].IsShape);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -497,6 +497,13 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Add a rectangle shape to the paragraph using <see cref="SixLabors.ImageSharp.Color"/>.
+        /// </summary>
+        public WordShape AddShape(double widthPt, double heightPt, SixLabors.ImageSharp.Color fillColor) {
+            return AddShape(widthPt, heightPt, fillColor.ToHexColor());
+        }
+
+        /// <summary>
         /// Add a line shape to the paragraph.
         /// </summary>
         /// <param name="startXPt">Start X position in points.</param>

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -599,11 +599,16 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Returns a <see cref="WordShape"/> instance when the paragraph contains VML shapes.
+        /// </summary>
         public WordShape Shape {
             get {
                 if (_run != null) {
-                    var rectangle = _run.Descendants<V.Rectangle>().FirstOrDefault();
-                    if (rectangle != null) {
+                    if (_run.Descendants<V.Rectangle>().Any() ||
+                        _run.Descendants<V.Oval>().Any() ||
+                        _run.Descendants<V.Line>().Any() ||
+                        _run.Descendants<V.PolyLine>().Any()) {
                         return new WordShape(_document, _paragraph, _run);
                     }
                 }
@@ -633,6 +638,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Indicates whether the paragraph contains a VML shape.
+        /// </summary>
         public bool IsShape {
             get {
                 if (this.Shape != null) {

--- a/OfficeIMO.Word/WordShape.cs
+++ b/OfficeIMO.Word/WordShape.cs
@@ -1,22 +1,37 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 using V = DocumentFormat.OpenXml.Vml;
 
 namespace OfficeIMO.Word {
     /// <summary>
-    /// Represents simple rectangle shape inside a paragraph.
+    /// Represents simple VML shapes inside a paragraph.
     /// </summary>
     public class WordShape : WordElement {
+        /// <summary>Parent document.</summary>
         internal WordDocument _document;
+        /// <summary>Parent paragraph.</summary>
         internal WordParagraph _wordParagraph;
+        /// <summary>Run that hosts the shape.</summary>
         internal Run _run;
+        /// <summary>The rectangle element if present.</summary>
         internal V.Rectangle _rectangle;
+        /// <summary>The ellipse element if present.</summary>
+        internal V.Oval _ellipse;
+        /// <summary>The line element if present.</summary>
+        internal V.Line _line;
+        /// <summary>The polygon element if present.</summary>
+        internal V.PolyLine _polygon;
 
+        /// <summary>
+        /// Initializes a new rectangle shape and appends it to the paragraph.
+        /// </summary>
         internal WordShape(WordDocument document, WordParagraph paragraph, double widthPt, double heightPt, string fillColor = "#FFFFFF") {
             _document = document;
             _wordParagraph = paragraph;
+
             _rectangle = new V.Rectangle() {
                 Id = "Rectangle" + Guid.NewGuid().ToString("N"),
                 Style = $"width:{widthPt}pt;height:{heightPt}pt;mso-wrap-style:square",
@@ -31,11 +46,131 @@ namespace OfficeIMO.Word {
             _run.Append(pict);
         }
 
+        /// <summary>
+        /// Initializes a <see cref="WordShape"/> from existing run content.
+        /// </summary>
         internal WordShape(WordDocument document, Paragraph paragraph, Run run) {
             _document = document;
             _wordParagraph = new WordParagraph(document, paragraph, run);
             _run = run;
             _rectangle = run.Descendants<V.Rectangle>().FirstOrDefault();
+            _ellipse = run.Descendants<V.Oval>().FirstOrDefault();
+            _line = run.Descendants<V.Line>().FirstOrDefault();
+            _polygon = run.Descendants<V.PolyLine>().FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Adds an ellipse shape to the given paragraph.
+        /// </summary>
+        public static WordShape AddEllipse(WordParagraph paragraph, double widthPt, double heightPt, string fillColor = "#FFFFFF") {
+            var ellipse = new V.Oval() {
+                Id = "Ellipse" + Guid.NewGuid().ToString("N"),
+                Style = $"width:{widthPt}pt;height:{heightPt}pt;mso-wrap-style:square",
+                FillColor = fillColor,
+                Stroked = false
+            };
+
+            Picture pict = new Picture();
+            pict.Append(ellipse);
+
+            var run = paragraph.VerifyRun();
+            run.Append(pict);
+
+            return new WordShape(paragraph._document, paragraph._paragraph, run);
+        }
+
+        /// <summary>
+        /// Adds an ellipse shape using <see cref="SixLabors.ImageSharp.Color"/>.
+        /// </summary>
+        public static WordShape AddEllipse(WordParagraph paragraph, double widthPt, double heightPt, SixLabors.ImageSharp.Color fillColor) {
+            return AddEllipse(paragraph, widthPt, heightPt, fillColor.ToHexColor());
+        }
+
+        /// <summary>
+        /// Adds a line shape to the given paragraph.
+        /// </summary>
+        public static WordShape AddLine(WordParagraph paragraph, double startXPt, double startYPt, double endXPt, double endYPt, string color = "#000000", double strokeWeightPt = 1) {
+            var line = new V.Line() {
+                Id = "Line" + Guid.NewGuid().ToString("N"),
+                Style = "mso-wrap-style:square",
+                From = $"{startXPt}pt,{startYPt}pt",
+                To = $"{endXPt}pt,{endYPt}pt",
+                StrokeColor = color,
+                StrokeWeight = $"{strokeWeightPt}pt"
+            };
+
+            Picture pict = new Picture();
+            pict.Append(line);
+
+            var run = paragraph.VerifyRun();
+            run.Append(pict);
+
+            return new WordShape(paragraph._document, paragraph._paragraph, run);
+        }
+
+        /// <summary>
+        /// Adds a line shape using <see cref="SixLabors.ImageSharp.Color"/>.
+        /// </summary>
+        public static WordShape AddLine(WordParagraph paragraph, double startXPt, double startYPt, double endXPt, double endYPt, SixLabors.ImageSharp.Color color, double strokeWeightPt = 1) {
+            return AddLine(paragraph, startXPt, startYPt, endXPt, endYPt, color.ToHexColor(), strokeWeightPt);
+        }
+
+        /// <summary>
+        /// Adds a polygon shape to the given paragraph.
+        /// </summary>
+        public static WordShape AddPolygon(WordParagraph paragraph, string points, string fillColor = "#FFFFFF", string strokeColor = "#000000") {
+            var poly = new V.PolyLine() {
+                Id = "Polygon" + Guid.NewGuid().ToString("N"),
+                Style = "mso-wrap-style:square",
+                Points = points,
+                FillColor = fillColor,
+                StrokeColor = strokeColor
+            };
+
+            Picture pict = new Picture();
+            pict.Append(poly);
+
+            var run = paragraph.VerifyRun();
+            run.Append(pict);
+
+            return new WordShape(paragraph._document, paragraph._paragraph, run);
+        }
+
+        /// <summary>
+        /// Adds a polygon shape using <see cref="SixLabors.ImageSharp.Color"/> values.
+        /// </summary>
+        public static WordShape AddPolygon(WordParagraph paragraph, string points, SixLabors.ImageSharp.Color fillColor, SixLabors.ImageSharp.Color strokeColor) {
+            return AddPolygon(paragraph, points, fillColor.ToHexColor(), strokeColor.ToHexColor());
+        }
+
+        /// <summary>
+        /// Gets or sets the fill color as hexadecimal string.
+        /// </summary>
+        public string FillColorHex {
+            get {
+                if (_rectangle != null) return _rectangle.FillColor?.Value;
+                if (_ellipse != null) return _ellipse.FillColor?.Value;
+                if (_polygon != null) return _polygon.FillColor?.Value;
+                return string.Empty;
+            }
+            set {
+                if (_rectangle != null) _rectangle.FillColor = value;
+                if (_ellipse != null) _ellipse.FillColor = value;
+                if (_polygon != null) _polygon.FillColor = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the fill color using <see cref="SixLabors.ImageSharp.Color"/>.
+        /// </summary>
+        public SixLabors.ImageSharp.Color FillColor {
+            get {
+                var hex = FillColorHex;
+                if (string.IsNullOrEmpty(hex)) return SixLabors.ImageSharp.Color.Transparent;
+                if (!hex.StartsWith("#")) hex = "#" + hex;
+                return SixLabors.ImageSharp.Color.Parse(hex);
+            }
+            set => FillColorHex = value.ToHexColor();
         }
 
         /// <summary>
@@ -43,17 +178,17 @@ namespace OfficeIMO.Word {
         /// </summary>
         public double Width {
             get {
-            var style = _rectangle.Style?.Value;
-            if (style != null) {
-                foreach (var part in style.Split(';')) {
-                    var kv = part.Split(':');
-                    if (kv.Length == 2 && kv[0] == "width") {
-                        return double.Parse(kv[1].Replace("pt", ""), CultureInfo.InvariantCulture);
+                var style = _rectangle?.Style?.Value ?? _ellipse?.Style?.Value ?? _polygon?.Style?.Value;
+                if (style != null) {
+                    foreach (var part in style.Split(';')) {
+                        var kv = part.Split(':');
+                        if (kv.Length == 2 && kv[0] == "width") {
+                            return double.Parse(kv[1].Replace("pt", ""), CultureInfo.InvariantCulture);
+                        }
                     }
                 }
+                return 0;
             }
-            return 0;
-        }
         }
 
         /// <summary>
@@ -61,17 +196,17 @@ namespace OfficeIMO.Word {
         /// </summary>
         public double Height {
             get {
-            var style = _rectangle.Style?.Value;
-            if (style != null) {
-                foreach (var part in style.Split(';')) {
-                    var kv = part.Split(':');
-                    if (kv.Length == 2 && kv[0] == "height") {
-                        return double.Parse(kv[1].Replace("pt", ""), CultureInfo.InvariantCulture);
+                var style = _rectangle?.Style?.Value ?? _ellipse?.Style?.Value ?? _polygon?.Style?.Value;
+                if (style != null) {
+                    foreach (var part in style.Split(';')) {
+                        var kv = part.Split(':');
+                        if (kv.Length == 2 && kv[0] == "height") {
+                            return double.Parse(kv[1].Replace("pt", ""), CultureInfo.InvariantCulture);
+                        }
                     }
                 }
+                return 0;
             }
-            return 0;
-        }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- extend shape examples to cover ellipse and polygon
- expose new shape sample in example runner
- document VML shape factory usage
- detect shapes in paragraphs with documentation comments
- add tests for ellipse, polygon, and line factory methods
- support ImageSharp Color throughout shape APIs

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6856b57678c4832ebfd673788dec4b32