### PR TITLE
Add watermark removal utilities

### DIFF
--- a/Docs/officeimo.word.worddocument.md
+++ b/Docs/officeimo.word.worddocument.md
@@ -48,6 +48,15 @@ Remove all comments from the document.
 public void RemoveAllComments()
 ```
 
+### **RemoveWatermark()**
+
+Removes all watermarks from the document including those in headers.
+Alternatively remove individual watermarks via the `Watermarks` collection.
+
+```csharp
+public void RemoveWatermark()
+```
+
 ## Properties
 
 ### **TrackComments**

--- a/Docs/officeimo.word.wordsection.md
+++ b/Docs/officeimo.word.wordsection.md
@@ -435,6 +435,15 @@ public WordWatermark AddWatermark(WordWatermarkStyle watermarkStyle, string text
 
 [WordWatermark](./officeimo.word.wordwatermark.md)<br>
 
+### **RemoveWatermark()**
+
+Removes all watermarks from the section including headers.
+Individual watermarks can be removed from the `Watermarks` collection.
+
+```csharp
+public void RemoveWatermark()
+```
+
 ### **SetBorders(WordBorder)**
 
 ```csharp

--- a/Docs/officeimo.word.wordwatermark.md
+++ b/Docs/officeimo.word.wordwatermark.md
@@ -39,3 +39,11 @@ public WordWatermark(WordDocument wordDocument, WordSection wordSection, WordHea
 `style` [WordWatermarkStyle](./officeimo.word.wordwatermarkstyle.md)<br>
 
 `text` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+
+### **Remove()**
+
+Remove this watermark from the document.
+
+```csharp
+public void Remove()
+```

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -171,6 +171,7 @@ namespace OfficeIMO.Examples {
             Watermark.Watermark_Sample1(folderPath, false);
             Watermark.Watermark_Sample3(folderPath, false);
             Watermark.Watermark_SampleImage1(folderPath, false);
+            Watermark.Watermark_Remove(folderPath, false);
 
             Embed.Example_EmbedFileHTML(folderPath, templatesPath, false);
             Embed.Example_EmbedFileRTF(folderPath, templatesPath, false);

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Remove.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Remove.cs
@@ -1,0 +1,30 @@
+using System;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Watermark {
+        public static void Watermark_Remove(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Removing watermarks using RemoveWatermark");
+            string filePath = System.IO.Path.Combine(folderPath, "Watermark Remove.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Test");
+                document.AddHeadersAndFooters();
+                document.DifferentFirstPage = true;
+                document.DifferentOddAndEvenPages = true;
+
+                document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Default");
+                document.Sections[0].Header.First.AddWatermark(WordWatermarkStyle.Text, "First");
+                document.Sections[0].Header.Even.AddWatermark(WordWatermarkStyle.Text, "Even");
+
+                Console.WriteLine("Watermarks before: " + document.Watermarks.Count);
+                foreach (var watermark in document.Watermarks.ToList()) {
+                    watermark.Remove();
+                }
+                Console.WriteLine("Watermarks after: " + document.Watermarks.Count);
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Watermark.cs
+++ b/OfficeIMO.Tests/Word.Watermark.cs
@@ -34,7 +34,7 @@ namespace OfficeIMO.Tests {
 
                 document.Settings.SetBackgroundColor(Color.Azure);
 
-                Assert.True(document.Watermarks.Count == 0);
+                Assert.True(document.Watermarks.Count == 2);
                 Assert.True(document.Header.Default.Watermarks.Count == 1); // this is actually first section's header.default
                 Assert.True(document.Sections[0].Header.Default.Watermarks.Count == 1);
                 Assert.True(document.Sections[1].Header.Default.Watermarks.Count == 1);
@@ -84,7 +84,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Sections[0].Header.Default.Watermarks[0].Stroked == true);
                 Assert.True(document.Sections[0].Header.Default.Watermarks[0].AllowInCell == false);
 
-                Assert.True(document.Watermarks.Count == 0);
+                Assert.True(document.Watermarks.Count == 3);
                 Assert.True(document.Header.Default.Watermarks.Count == 1); // this is actually first section's header.default
                 Assert.True(document.Sections[0].Header.Default.Watermarks.Count == 1);
                 Assert.True(document.Sections[1].Header.Default.Watermarks.Count == 1);
@@ -110,7 +110,7 @@ namespace OfficeIMO.Tests {
                 document.Settings.SetBackgroundColor(Color.Azure);
                 document.AddSection();
 
-                Assert.True(document.Watermarks.Count == 0);
+                Assert.True(document.Watermarks.Count == 2);
                 Assert.True(document.Header.Default.Watermarks.Count == 1); // this is actually first section's header.default
                 Assert.True(document.Sections[0].Header.Default.Watermarks.Count == 1);
                 Assert.True(document.Sections[1].Header.Default.Watermarks.Count == 1);
@@ -119,7 +119,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_CreatingWordDocumentWithWatermark2.docx"))) {
-                Assert.True(document.Watermarks.Count == 0);
+                Assert.True(document.Watermarks.Count == 2);
                 Assert.True(document.Header.Default.Watermarks.Count == 1); // this is actually first section's header.default
                 Assert.True(document.Sections[0].Header.Default.Watermarks.Count == 1);
                 Assert.True(document.Sections[1].Header.Default.Watermarks.Count == 1);
@@ -191,6 +191,33 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_CreatingWordDocumentWithWatermark2.docx"))) {
                 document.Save();
+            }
+        }
+
+        [Fact]
+        public void Test_RemoveWatermarkFromAllHeaders() {
+            string filePath = Path.Combine(_directoryWithFiles, "Test_RemoveWatermarkFromHeaders.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Test");
+                document.AddHeadersAndFooters();
+                document.DifferentFirstPage = true;
+                document.DifferentOddAndEvenPages = true;
+
+                document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Default");
+                document.Sections[0].Header.First.AddWatermark(WordWatermarkStyle.Text, "First");
+                document.Sections[0].Header.Even.AddWatermark(WordWatermarkStyle.Text, "Even");
+
+                Assert.True(document.Sections[0].Watermarks.Count == 3);
+
+                foreach (var watermark in document.Sections[0].Watermarks.ToList()) {
+                    watermark.Remove();
+                }
+
+                Assert.True(document.Sections[0].Watermarks.Count == 0);
+                Assert.True(document.Sections[0].Header.Default.Watermarks.Count == 0);
+                Assert.True(document.Sections[0].Header.First.Watermarks.Count == 0);
+                Assert.True(document.Sections[0].Header.Even.Watermarks.Count == 0);
             }
         }
     }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -230,6 +230,15 @@ namespace OfficeIMO.Word {
             embeddedDocument.Remove();
         }
 
+        /// <summary>
+        /// Removes all watermarks from the document including headers.
+        /// </summary>
+        public void RemoveWatermark() {
+            foreach (var section in this.Sections) {
+                section.RemoveWatermark();
+            }
+        }
+
 
         private int CombineRuns(WordHeaderFooter wordHeaderFooter) {
             int count = 0;

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -350,7 +350,8 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
-        /// Provides a list of all watermarks within the document from all the sections
+        /// Provides a list of all watermarks within the document from all the
+        /// sections, including watermarks defined in headers.
         /// </summary>
         public List<WordWatermark> Watermarks {
             get {

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -51,6 +51,15 @@ namespace OfficeIMO.Word {
             return new WordWatermark(this._document, this, watermarkStyle, textOrFilePath);
         }
 
+        /// <summary>
+        /// Removes all watermarks from this section including headers.
+        /// </summary>
+        public void RemoveWatermark() {
+            foreach (var watermark in Watermarks.ToList()) {
+                watermark.Remove();
+            }
+        }
+
         public WordSection SetBorders(WordBorder wordBorder) {
             this.Borders.SetBorder(wordBorder);
 

--- a/OfficeIMO.Word/WordSection.cs
+++ b/OfficeIMO.Word/WordSection.cs
@@ -314,12 +314,20 @@ namespace OfficeIMO.Word {
         public List<WordEmbeddedDocument> EmbeddedDocuments => GetEmbeddedDocumentsList();
 
         /// <summary>
-        /// Provides a list of all watermarks within the section
+        /// Provides a list of all watermarks within the section, including
+        /// any watermarks found in the section headers.
         /// </summary>
         public List<WordWatermark> Watermarks {
             get {
+                List<WordWatermark> list = new List<WordWatermark>();
                 var sdtBlockList = GetSdtBlockList();
-                return WordSection.ConvertStdBlockToWatermark(_document, sdtBlockList);
+                list.AddRange(WordSection.ConvertStdBlockToWatermark(_document, sdtBlockList));
+
+                if (Header.Default != null) list.AddRange(Header.Default.Watermarks);
+                if (Header.Even != null) list.AddRange(Header.Even.Watermarks);
+                if (Header.First != null) list.AddRange(Header.First.Watermarks);
+
+                return list;
             }
         }
 


### PR DESCRIPTION
## Summary
- detect watermarks inside headers when enumerating section watermarks
- add `RemoveWatermark` to `WordSection` and `WordDocument`
- update docs with the new API
- show usage in examples and call it from program
- cover removal of header watermarks with tests
- document breaking change in watermark enumeration

## Testing
- `dotnet test OfficeImo.sln --logger "console;verbosity=minimal"`

------
https://chatgpt.com/codex/tasks/task_e_6856b5b02710832eaffd909d9cb1914a