### PR TITLE
Add document variable support

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -58,6 +58,8 @@
 
 [WordDocument](./officeimo.word.worddocument.md)
 
+[WordDocumentVariables](./officeimo.word.worddocumentvariables.md)
+
 [WordEquation](./officeimo.word.wordequation.md)
 
 [WordField](./officeimo.word.wordfield.md)

--- a/Docs/officeimo.word.worddocument.md
+++ b/Docs/officeimo.word.worddocument.md
@@ -58,3 +58,51 @@ Enable or disable tracking of comment changes.
 public bool TrackComments { get; set; }
 ```
 
+### **HasDocumentVariables**
+
+Indicates if the document contains any document variables.
+
+```csharp
+public bool HasDocumentVariables { get; }
+```
+
+### **GetDocumentVariable(String)**
+
+Return the value of a document variable or <code>null</code> if the variable does not exist.
+
+```csharp
+public string GetDocumentVariable(string name)
+```
+
+### **SetDocumentVariable(String, String)**
+
+Sets the value of a document variable. Creates it if it does not exist.
+
+```csharp
+public void SetDocumentVariable(string name, string value)
+```
+
+### **RemoveDocumentVariable(String)**
+
+Remove the document variable with the specified name if present.
+
+```csharp
+public void RemoveDocumentVariable(string name)
+```
+
+### **RemoveDocumentVariableAt(Int32)**
+
+Remove the document variable at the given index.
+
+```csharp
+public void RemoveDocumentVariableAt(int index)
+```
+
+### **GetDocumentVariables()**
+
+Returns a read-only collection of all document variables.
+
+```csharp
+public IReadOnlyDictionary<string, string> GetDocumentVariables()
+```
+

--- a/Docs/officeimo.word.worddocument.md
+++ b/Docs/officeimo.word.worddocument.md
@@ -66,6 +66,14 @@ Indicates if the document contains any document variables.
 public bool HasDocumentVariables { get; }
 ```
 
+### **DocumentVariables**
+
+Collection of document variables.
+
+```csharp
+public Dictionary<string, string> DocumentVariables { get; }
+```
+
 ### **GetDocumentVariable(String)**
 
 Return the value of a document variable or <code>null</code> if the variable does not exist.

--- a/Docs/officeimo.word.worddocumentvariables.md
+++ b/Docs/officeimo.word.worddocumentvariables.md
@@ -1,0 +1,34 @@
+# WordDocumentVariables
+
+Namespace: OfficeIMO.Word
+
+```csharp
+public class WordDocumentVariables
+```
+
+Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) → [WordDocumentVariables](./officeimo.word.worddocumentvariables.md)
+
+## Constructors
+
+### **WordDocumentVariables(WordDocument, Nullable&lt;Boolean&gt;)**
+
+```csharp
+public WordDocumentVariables(WordDocument document, Nullable<bool> create)
+```
+
+#### Parameters
+
+`document` [WordDocument](./officeimo.word.worddocument.md)<br>
+
+`create` [Nullable&lt;Boolean&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.nullable-1)<br>
+
+## Methods
+
+### **LoadDocumentVariables()**
+
+Loads existing variables from the document.
+
+### **CreateDocumentVariables()**
+
+Writes the current variables into the document.
+

--- a/OfficeIMO.Examples/Word/DocumentVariables/DocumentVariables.Advanced.cs
+++ b/OfficeIMO.Examples/Word/DocumentVariables/DocumentVariables.Advanced.cs
@@ -16,7 +16,9 @@ namespace OfficeIMO.Examples.Word {
             }
             using (WordDocument document = WordDocument.Load(filePath, false)) {
                 document.SetDocumentVariable("Version", "2.0");
-                document.RemoveDocumentVariable("Date");
+                if (document.HasDocumentVariables) {
+                    document.RemoveDocumentVariableAt(0);
+                }
                 document.Save(openWord);
             }
         }

--- a/OfficeIMO.Examples/Word/DocumentVariables/DocumentVariables.Advanced.cs
+++ b/OfficeIMO.Examples/Word/DocumentVariables/DocumentVariables.Advanced.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class DocumentVariablesExamples {
+        public static void Example_AdvancedDocumentVariables(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Working with document variables");
+            string filePath = Path.Combine(folderPath, "AdvancedDocumentWithVariables.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.BuiltinDocumentProperties.Title = "Variables";
+                document.SetDocumentVariable("Project", "OfficeIMO");
+                document.SetDocumentVariable("Version", "1.0");
+                document.SetDocumentVariable("Date", DateTime.Today.ToShortDateString());
+                document.Save();
+            }
+            using (WordDocument document = WordDocument.Load(filePath, false)) {
+                document.SetDocumentVariable("Version", "2.0");
+                document.RemoveDocumentVariable("Date");
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/DocumentVariables/DocumentVariables.Simple.cs
+++ b/OfficeIMO.Examples/Word/DocumentVariables/DocumentVariables.Simple.cs
@@ -16,8 +16,8 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine($"Author: {document.GetDocumentVariable("Author")}");
                 Console.WriteLine($"Year: {document.GetDocumentVariable("Year")}");
                 if (document.HasDocumentVariables) {
-                    foreach (var variable in document.GetDocumentVariables()) {
-                        Console.WriteLine($"{variable.Key} -> {variable.Value}");
+                    foreach (var pair in document.DocumentVariables) {
+                        Console.WriteLine($"{pair.Key} -> {pair.Value}");
                     }
                 }
             }

--- a/OfficeIMO.Examples/Word/DocumentVariables/DocumentVariables.Simple.cs
+++ b/OfficeIMO.Examples/Word/DocumentVariables/DocumentVariables.Simple.cs
@@ -15,6 +15,11 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Load(filePath, false)) {
                 Console.WriteLine($"Author: {document.GetDocumentVariable("Author")}");
                 Console.WriteLine($"Year: {document.GetDocumentVariable("Year")}");
+                if (document.HasDocumentVariables) {
+                    foreach (var variable in document.GetDocumentVariables()) {
+                        Console.WriteLine($"{variable.Key} -> {variable.Value}");
+                    }
+                }
             }
         }
     }

--- a/OfficeIMO.Examples/Word/DocumentVariables/DocumentVariables.Simple.cs
+++ b/OfficeIMO.Examples/Word/DocumentVariables/DocumentVariables.Simple.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class DocumentVariablesExamples {
+        public static void Example_BasicDocumentVariables(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with variables");
+            string filePath = Path.Combine(folderPath, "DocumentWithVariables.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.SetDocumentVariable("Author", "OfficeIMO");
+                document.SetDocumentVariable("Year", DateTime.Now.Year.ToString());
+                document.Save(openWord);
+            }
+            using (WordDocument document = WordDocument.Load(filePath, false)) {
+                Console.WriteLine($"Author: {document.GetDocumentVariable("Author")}");
+                Console.WriteLine($"Year: {document.GetDocumentVariable("Year")}");
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.DocumentVariables.cs
+++ b/OfficeIMO.Tests/Word.DocumentVariables.cs
@@ -18,11 +18,15 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.GetDocumentVariable("AnotherVar") == "123");
                 document.SetDocumentVariable("TestVar", "Updated");
                 document.RemoveDocumentVariable("AnotherVar");
+                Assert.True(document.HasDocumentVariables);
                 document.Save();
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.True(document.GetDocumentVariable("TestVar") == "Updated");
                 Assert.False(document.DocumentVariables.ContainsKey("AnotherVar"));
+                document.RemoveDocumentVariableAt(0);
+                Assert.False(document.HasDocumentVariables);
+                document.Save();
             }
         }
     }

--- a/OfficeIMO.Tests/Word.DocumentVariables.cs
+++ b/OfficeIMO.Tests/Word.DocumentVariables.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_DocumentVariables() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithVariables.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.SetDocumentVariable("TestVar", "Value1");
+                document.SetDocumentVariable("AnotherVar", "123");
+                Assert.True(document.GetDocumentVariable("TestVar") == "Value1");
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.True(document.GetDocumentVariable("AnotherVar") == "123");
+                document.SetDocumentVariable("TestVar", "Updated");
+                document.RemoveDocumentVariable("AnotherVar");
+                document.Save();
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.True(document.GetDocumentVariable("TestVar") == "Updated");
+                Assert.False(document.DocumentVariables.ContainsKey("AnotherVar"));
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -565,7 +565,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Collection of document variables accessible via <see cref="DocVariable"/> fields.
         /// </summary>
-        public readonly Dictionary<string, string> DocumentVariables = new Dictionary<string, string>();
+        public Dictionary<string, string> DocumentVariables { get; } = new Dictionary<string, string>();
 
         public bool AutoSave => _wordprocessingDocument.AutoSave;
 

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1070,7 +1070,11 @@ namespace OfficeIMO.Word {
             MoveSectionProperties();
             SaveNumbering();
             _ = new WordCustomProperties(this, true);
-            _ = new WordDocumentVariables(this, true);
+            var settingsPart = _wordprocessingDocument.MainDocumentPart.DocumentSettingsPart;
+            bool hasVariables = settingsPart?.Settings?.GetFirstChild<DocumentVariables>() != null;
+            if (hasVariables || DocumentVariables.Count > 0) {
+                _ = new WordDocumentVariables(this, true);
+            }
         }
     }
 }

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -306,6 +306,31 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Gets the value of a document variable or <c>null</c> if the variable does not exist.
+        /// </summary>
+        /// <param name="name">Variable name.</param>
+        public string GetDocumentVariable(string name) {
+            return DocumentVariables.ContainsKey(name) ? DocumentVariables[name] : null;
+        }
+
+        /// <summary>
+        /// Sets the value of a document variable. Creates it if it does not exist.
+        /// </summary>
+        /// <param name="name">Variable name.</param>
+        /// <param name="value">Variable value.</param>
+        public void SetDocumentVariable(string name, string value) {
+            DocumentVariables[name] = value;
+        }
+
+        /// <summary>
+        /// Removes the document variable with the specified name if present.
+        /// </summary>
+        /// <param name="name">Variable name.</param>
+        public void RemoveDocumentVariable(string name) {
+            DocumentVariables.Remove(name);
+        }
+
+        /// <summary>
         /// Enable or disable tracking of comment changes.
         /// </summary>
         public bool TrackComments {
@@ -512,6 +537,10 @@ namespace OfficeIMO.Word {
         public BuiltinDocumentProperties BuiltinDocumentProperties;
 
         public readonly Dictionary<string, WordCustomProperty> CustomDocumentProperties = new Dictionary<string, WordCustomProperty>();
+        /// <summary>
+        /// Collection of document variables accessible via <see cref="DocVariable"/> fields.
+        /// </summary>
+        public readonly Dictionary<string, string> DocumentVariables = new Dictionary<string, string>();
 
         public bool AutoSave => _wordprocessingDocument.AutoSave;
 
@@ -663,6 +692,7 @@ namespace OfficeIMO.Word {
             var applicationProperties = new ApplicationProperties(this);
             var builtinDocumentProperties = new BuiltinDocumentProperties(this);
             var wordCustomProperties = new WordCustomProperties(this);
+            var wordDocumentVariables = new WordDocumentVariables(this);
             var wordBackground = new WordBackground(this);
             var compatibilitySettings = new WordCompatibilitySettings(this);
             //CustomDocumentProperties customDocumentProperties = new CustomDocumentProperties(this);
@@ -1040,6 +1070,7 @@ namespace OfficeIMO.Word {
             MoveSectionProperties();
             SaveNumbering();
             _ = new WordCustomProperties(this, true);
+            _ = new WordDocumentVariables(this, true);
         }
     }
 }

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -331,6 +331,31 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Removes the document variable at the specified index.
+        /// </summary>
+        /// <param name="index">Zero-based index of the variable to remove.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when index is out of range.</exception>
+        public void RemoveDocumentVariableAt(int index) {
+            if (index < 0 || index >= DocumentVariables.Count) {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+            string key = DocumentVariables.Keys.ElementAt(index);
+            DocumentVariables.Remove(key);
+        }
+
+        /// <summary>
+        /// Determines whether the document contains any document variables.
+        /// </summary>
+        public bool HasDocumentVariables => DocumentVariables.Count > 0;
+
+        /// <summary>
+        /// Returns a read-only view of all document variables.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> GetDocumentVariables() {
+            return new Dictionary<string, string>(DocumentVariables);
+        }
+
+        /// <summary>
         /// Enable or disable tracking of comment changes.
         /// </summary>
         public bool TrackComments {

--- a/OfficeIMO.Word/WordDocumentVariables.cs
+++ b/OfficeIMO.Word/WordDocumentVariables.cs
@@ -54,13 +54,28 @@ namespace OfficeIMO.Word {
 
             var settings = settingsPart.Settings;
             _variables = settings.GetFirstChild<DocumentVariables>();
+
+            if (_document.DocumentVariables.Count == 0) {
+                _variables?.Remove();
+                return;
+            }
+
             if (_variables == null) {
                 _variables = new DocumentVariables();
                 settings.Append(_variables);
             }
 
+            // remove variables not present in the dictionary
+            var toRemove = _variables.Elements<DocumentVariable>()
+                .Where(v => !_document.DocumentVariables.ContainsKey(v.Name))
+                .ToList();
+            foreach (var variable in toRemove) {
+                variable.Remove();
+            }
+
             foreach (var pair in _document.DocumentVariables) {
-                var existing = _variables.Elements<DocumentVariable>().FirstOrDefault(v => v.Name == pair.Key);
+                var existing = _variables.Elements<DocumentVariable>()
+                    .FirstOrDefault(v => v.Name == pair.Key);
                 if (existing != null) {
                     existing.Val = pair.Value;
                 } else {

--- a/OfficeIMO.Word/WordDocumentVariables.cs
+++ b/OfficeIMO.Word/WordDocumentVariables.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides access to document variables stored in the document settings.
+    /// </summary>
+    public class WordDocumentVariables {
+        private readonly WordprocessingDocument _wordprocessingDocument;
+        private readonly WordDocument _document;
+        private DocumentVariables _variables;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="WordDocumentVariables"/> and loads or creates document variables.
+        /// </summary>
+        /// <param name="document">Parent document.</param>
+        /// <param name="create">When set to <c>true</c> variables are written to the document.</param>
+        public WordDocumentVariables(WordDocument document, bool? create = null) {
+            _document = document;
+            _wordprocessingDocument = document._wordprocessingDocument;
+
+            if (create == true) {
+                CreateDocumentVariables();
+            } else {
+                LoadDocumentVariables();
+            }
+        }
+
+        private void LoadDocumentVariables() {
+            var settingsPart = _wordprocessingDocument.MainDocumentPart.DocumentSettingsPart;
+            if (settingsPart?.Settings != null) {
+                _variables = settingsPart.Settings.GetFirstChild<DocumentVariables>();
+                if (_variables != null) {
+                    foreach (var variable in _variables.Elements<DocumentVariable>()) {
+                        _document.DocumentVariables[variable.Name] = variable.Val;
+                    }
+                }
+            }
+        }
+
+        private void CreateDocumentVariables() {
+            var settingsPart = _wordprocessingDocument.MainDocumentPart.DocumentSettingsPart;
+            if (settingsPart == null) {
+                if (_document.FileOpenAccess == FileAccess.Read) {
+                    throw new ArgumentException("Document is read only!");
+                }
+                settingsPart = _wordprocessingDocument.MainDocumentPart.AddNewPart<DocumentSettingsPart>();
+                settingsPart.Settings = new Settings();
+            }
+
+            var settings = settingsPart.Settings;
+            _variables = settings.GetFirstChild<DocumentVariables>();
+            if (_variables == null) {
+                _variables = new DocumentVariables();
+                settings.Append(_variables);
+            }
+
+            foreach (var pair in _document.DocumentVariables) {
+                var existing = _variables.Elements<DocumentVariable>().FirstOrDefault(v => v.Name == pair.Key);
+                if (existing != null) {
+                    existing.Val = pair.Value;
+                } else {
+                    _variables.Append(new DocumentVariable { Name = pair.Key, Val = pair.Value });
+                }
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -390,8 +390,8 @@ using (WordDocument document = WordDocument.Create(filePath)) {
     document.SetDocumentVariable("Year", DateTime.Now.Year.ToString());
 
     if (document.HasDocumentVariables) {
-        foreach (var variable in document.GetDocumentVariables()) {
-            Console.WriteLine($"{variable.Key}: {variable.Value}");
+        foreach (var pair in document.DocumentVariables) {
+            Console.WriteLine($"{pair.Key}: {pair.Value}");
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -385,6 +385,10 @@ using (WordDocument document = WordDocument.Create(filePath)) {
     document.CustomDocumentProperties.Add("MyName", new WordCustomProperty("Some text"));
     document.CustomDocumentProperties.Add("IsTodayGreatDay", new WordCustomProperty(true));
 
+    // document variables available via DocVariable fields
+    document.SetDocumentVariable("Project", "OfficeIMO");
+    document.SetDocumentVariable("Year", DateTime.Now.Year.ToString());
+
     document.Save(openWord);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -389,6 +389,12 @@ using (WordDocument document = WordDocument.Create(filePath)) {
     document.SetDocumentVariable("Project", "OfficeIMO");
     document.SetDocumentVariable("Year", DateTime.Now.Year.ToString());
 
+    if (document.HasDocumentVariables) {
+        foreach (var variable in document.GetDocumentVariables()) {
+            Console.WriteLine($"{variable.Key}: {variable.Value}");
+        }
+    }
+
     document.Save(openWord);
 }
 ```


### PR DESCRIPTION
## Summary
- support DocVariable fields via new WordDocumentVariables helper
- expose DocumentVariables dictionary on `WordDocument`
- manage variables on load and save
- provide methods `GetDocumentVariable`, `SetDocumentVariable` and `RemoveDocumentVariable`
- document new API and add C# examples
- create basic unit test for document variables

## Testing
- `dotnet test` *(fails: Test Run Failed)*

------
https://chatgpt.com/codex/tasks/task_e_6856ba951c4c832eb0985f351f2eb8dd