### PR TITLE
Implement image watermark support

### DIFF
--- a/OfficeIMO.Tests/Word.Watermark.cs
+++ b/OfficeIMO.Tests/Word.Watermark.cs
@@ -220,5 +220,22 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Sections[0].Header.Even.Watermarks.Count == 0);
             }
         }
+
+        [Fact]
+        public void Test_CreatingWordDocumentWithImageWatermark() {
+            string filePath = Path.Combine(_directoryWithFiles, "Test_CreatingWordDocumentWithImageWatermark.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Test");
+                document.AddHeadersAndFooters();
+                var imagePath = Path.Combine(_directoryWithImages, "Kulek.jpg");
+                document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Image, imagePath);
+                document.Save();
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.True(document.Watermarks.Count == 1);
+                Assert.True(document.Sections[0].Header.Default.Watermarks.Count == 1);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- enable `WordWatermark` to handle image paths
- embed image data in watermark SDT blocks
- add regression test for image watermarks

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --framework net8.0 --filter "Test_CreatingWordDocumentWithImageWatermark" -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68571a87aa00832eab03eaf38d138831