### PR TITLE
Add advanced watermark customization

### DIFF
--- a/OfficeIMO.Word/WordWatermark.cs
+++ b/OfficeIMO.Word/WordWatermark.cs
@@ -182,6 +182,176 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Horizontal offset (margin-left) of the watermark in points.
+        /// </summary>
+        public double? HorizontalOffset {
+            get {
+                var shape = _shape;
+                if (shape != null) {
+                    var style = shape.Style.Value;
+                    if (style != null) {
+                        var left = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-left:"));
+                        if (left != null) {
+                            var value = left.Split(':').LastOrDefault();
+                            if (value != null) {
+                                string stringValue = value.Replace("pt", "");
+                                return double.Parse(stringValue, CultureInfo.InvariantCulture);
+                            }
+                        }
+                    }
+                }
+                return null;
+            }
+            set {
+                var shape = _shape;
+                if (shape != null) {
+                    var style = shape.Style.Value;
+                    if (style != null) {
+                        var left = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-left:"));
+                        if (left != null) {
+                            shape.Style.Value = style.Replace(left, "margin-left:" + value + "pt");
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Vertical offset (margin-top) of the watermark in points.
+        /// </summary>
+        public double? VerticalOffset {
+            get {
+                var shape = _shape;
+                if (shape != null) {
+                    var style = shape.Style.Value;
+                    if (style != null) {
+                        var top = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-top:"));
+                        if (top != null) {
+                            var value = top.Split(':').LastOrDefault();
+                            if (value != null) {
+                                string stringValue = value.Replace("pt", "");
+                                return double.Parse(stringValue, CultureInfo.InvariantCulture);
+                            }
+                        }
+                    }
+                }
+                return null;
+            }
+            set {
+                var shape = _shape;
+                if (shape != null) {
+                    var style = shape.Style.Value;
+                    if (style != null) {
+                        var top = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-top:"));
+                        if (top != null) {
+                            shape.Style.Value = style.Replace(top, "margin-top:" + value + "pt");
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Font family used for text watermark.
+        /// </summary>
+        public string FontFamily {
+            get {
+                var shape = _shape;
+                if (shape != null) {
+                    var textPath = shape.GetFirstChild<V.TextPath>();
+                    if (textPath != null && textPath.Style != null) {
+                        var style = textPath.Style.Value;
+                        var family = style.Split(';').FirstOrDefault(c => c.StartsWith("font-family:"));
+                        if (family != null) {
+                            var value = family.Split(':').LastOrDefault();
+                            if (value != null) {
+                                return value.Trim('"');
+                            }
+                        }
+                    }
+                }
+                return null;
+            }
+            set {
+                var shape = _shape;
+                if (shape != null) {
+                    var textPath = shape.GetFirstChild<V.TextPath>();
+                    if (textPath != null) {
+                        var style = textPath.Style?.Value ?? string.Empty;
+                        var dict = style.Split(';', StringSplitOptions.RemoveEmptyEntries)
+                            .Select(p => p.Split(':'))
+                            .ToDictionary(p => p[0], p => p.Length > 1 ? p[1] : string.Empty);
+                        dict["font-family"] = "\"" + value + "\"";
+                        textPath.Style.Value = string.Join(";", dict.Select(kvp => $"{kvp.Key}:{kvp.Value}"));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Font size of text watermark in points.
+        /// </summary>
+        public double? FontSize {
+            get {
+                var shape = _shape;
+                if (shape != null) {
+                    var textPath = shape.GetFirstChild<V.TextPath>();
+                    if (textPath != null && textPath.Style != null) {
+                        var style = textPath.Style.Value;
+                        var size = style.Split(';').FirstOrDefault(c => c.StartsWith("font-size:"));
+                        if (size != null) {
+                            var value = size.Split(':').LastOrDefault();
+                            if (value != null) {
+                                string stringValue = value.Replace("pt", "");
+                                return double.Parse(stringValue, CultureInfo.InvariantCulture);
+                            }
+                        }
+                    }
+                }
+                return null;
+            }
+            set {
+                var shape = _shape;
+                if (shape != null) {
+                    var textPath = shape.GetFirstChild<V.TextPath>();
+                    if (textPath != null) {
+                        var style = textPath.Style?.Value ?? string.Empty;
+                        var dict = style.Split(';', StringSplitOptions.RemoveEmptyEntries)
+                            .Select(p => p.Split(':'))
+                            .ToDictionary(p => p[0], p => p.Length > 1 ? p[1] : string.Empty);
+                        dict["font-size"] = value + "pt";
+                        textPath.Style.Value = string.Join(";", dict.Select(kvp => $"{kvp.Key}:{kvp.Value}"));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Opacity of the watermark fill. Value should be between 0 and 1.
+        /// </summary>
+        public double? Opacity {
+            get {
+                var shape = _shape;
+                if (shape != null) {
+                    var fill = shape.GetFirstChild<V.Fill>();
+                    if (fill != null && fill.Opacity != null) {
+                        return double.Parse(fill.Opacity.Value, CultureInfo.InvariantCulture);
+                    }
+                }
+                return null;
+            }
+            set {
+                var shape = _shape;
+                if (shape != null) {
+                    var fill = shape.GetFirstChild<V.Fill>();
+                    if (fill != null && value != null) {
+                        fill.Opacity = value.Value.ToString(CultureInfo.InvariantCulture);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Get or Set if watermark is stroked.
         /// </summary>
         public bool Stroked {
@@ -234,14 +404,14 @@ namespace OfficeIMO.Word {
             }
             set {
                 if (value != null) {
-                    this.ColorHex = ColorNameResolver.GetColorName(value.Value); //value.Value.ToHex();
+                    this.ColorHex = value.Value.ToHexColor();
                 }
             }
         }
 
         /// <summary>
-        /// Gets or sets color of the watermark using hex value.
-        /// Setting colors using this property is not recommended because it doesn't actually accept hex values, but rather color names.
+        /// Gets or sets the fill color of the watermark.
+        /// The value can be a known color name or a hex value without the leading '#'.
         /// </summary>
         public string ColorHex {
             get {


### PR DESCRIPTION
## Summary
- enable hex color support when setting watermark color
- expose watermark font and placement options
- allow adjusting watermark opacity

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release -f net8.0 --verbosity minimal`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release -f net9.0 --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_685720921c64832ebf583159544901e4