### PR TITLE
Add tag support for Word content controls

### DIFF
--- a/Docs/Examples/ExamplesContentControls/README.MD
+++ b/Docs/Examples/ExamplesContentControls/README.MD
@@ -17,3 +17,37 @@ using (WordDocument document = WordDocument.Load(filePath)) {
     Console.WriteLine($"Tag text: {loaded.Text}");
 }
 ```
+
+### Multiple controls
+
+```csharp
+using (WordDocument document = WordDocument.Create(filePath)) {
+    document.AddStructuredDocumentTag("First", "Alias1", "Tag1");
+    document.AddStructuredDocumentTag("Second", "Alias2", "Tag2");
+    document.AddStructuredDocumentTag("Third", "Alias3", "Tag3");
+    document.Save();
+}
+
+using (WordDocument document = WordDocument.Load(filePath)) {
+    foreach (var control in document.StructuredDocumentTags) {
+        Console.WriteLine(control.Tag + ": " + control.Text);
+    }
+}
+```
+
+### Advanced retrieval
+
+```csharp
+using (WordDocument document = WordDocument.Create(filePath)) {
+    document.AddStructuredDocumentTag("First", "Alias1", "Tag1");
+    document.AddStructuredDocumentTag("Second", "Alias2", "Tag2");
+    document.Save();
+}
+
+using (WordDocument document = WordDocument.Load(filePath)) {
+    var alias = document.GetStructuredDocumentTagByAlias("Alias2");
+    alias.Text = "Updated";
+    var tag = document.GetStructuredDocumentTagByTag("Tag1");
+    Console.WriteLine(tag.Text);
+}
+```

--- a/Docs/Examples/ExamplesContentControls/README.MD
+++ b/Docs/Examples/ExamplesContentControls/README.MD
@@ -1,14 +1,19 @@
 ## Using Content Controls (Structured Document Tags)
 
 `OfficeIMO` allows inserting and editing simple content controls.
-The example below creates a document with a single control and updates its text.
+The example below creates a document with a single control, assigns a tag and updates its text.
 
 ```csharp
 using (WordDocument document = WordDocument.Create(filePath)) {
-    var sdt = document.AddStructuredDocumentTag("Sample text", "ExampleAlias");
+    var sdt = document.AddStructuredDocumentTag("Sample text", "ExampleAlias", "ExampleTag");
 
     // change the text later
     sdt.Text = "Updated text";
     document.Save();
+}
+
+using (WordDocument document = WordDocument.Load(filePath)) {
+    var loaded = document.GetStructuredDocumentTagByTag("ExampleTag");
+    Console.WriteLine($"Tag text: {loaded.Text}");
 }
 ```

--- a/Docs/officeimo.word.wordparagraph.md
+++ b/Docs/officeimo.word.wordparagraph.md
@@ -978,12 +978,12 @@ public WordParagraph AddHyperLink(string text, string anchor, bool addStyle, str
 
 [WordParagraph](./officeimo.word.wordparagraph.md)<br>
 
-### **AddStructuredDocumentTag(String, String)**
+### **AddStructuredDocumentTag(String, String, String)**
 
 Adds a simple content control (structured document tag) to the paragraph.
 
 ```csharp
-public WordStructuredDocumentTag AddStructuredDocumentTag(string alias = null, string text = "")
+public WordStructuredDocumentTag AddStructuredDocumentTag(string alias = null, string text = "", string tag = null)
 ```
 
 #### Parameters
@@ -991,6 +991,7 @@ public WordStructuredDocumentTag AddStructuredDocumentTag(string alias = null, s
 `alias` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
 
 `text` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+`tag` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
 
 #### Returns
 

--- a/Docs/officeimo.word.wordstructureddocumenttag.md
+++ b/Docs/officeimo.word.wordstructureddocumenttag.md
@@ -20,6 +20,16 @@ public string Alias { get; }
 
 [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
 
+### **Tag**
+
+```csharp
+public string Tag { get; set; }
+```
+
+#### Property Value
+
+[String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+
 ### **Text**
 
 ```csharp

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -36,6 +36,8 @@ namespace OfficeIMO.Examples {
             AdvancedDocument.Example_AdvancedWord2(folderPath, false);
 
             ContentControls.Example_AddContentControl(folderPath, false);
+            ContentControls.Example_MultipleContentControls(folderPath, false);
+            ContentControls.Example_AdvancedContentControls(folderPath, false);
             CheckBoxes.Example_BasicCheckBox(folderPath, false);
 
             Paragraphs.Example_BasicParagraphs(folderPath, false);

--- a/OfficeIMO.Examples/Word/ContentControls/ContentControls.Example1.cs
+++ b/OfficeIMO.Examples/Word/ContentControls/ContentControls.Example1.cs
@@ -8,7 +8,7 @@ namespace OfficeIMO.Examples.Word {
             Console.WriteLine("[*] Creating document with a content control");
             string filePath = Path.Combine(folderPath, "DocumentWithContentControl.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
-                var control = document.AddStructuredDocumentTag("Sample text", "ExampleAlias");
+                var control = document.AddStructuredDocumentTag("Sample text", "ExampleAlias", "ExampleTag");
 
                 Console.WriteLine($"Alias: {control.Alias}");
                 Console.WriteLine($"Text: {control.Text}");
@@ -18,7 +18,8 @@ namespace OfficeIMO.Examples.Word {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Console.WriteLine($"Loaded text: {document.StructuredDocumentTags[0].Text}");
+                var loaded = document.GetStructuredDocumentTagByTag("ExampleTag");
+                Console.WriteLine($"Loaded text: {loaded.Text}");
                 document.Save(openWord);
             }
         }

--- a/OfficeIMO.Examples/Word/ContentControls/ContentControls.Example2.cs
+++ b/OfficeIMO.Examples/Word/ContentControls/ContentControls.Example2.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class ContentControls {
+        internal static void Example_MultipleContentControls(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with multiple content controls");
+            string filePath = Path.Combine(folderPath, "DocumentWithMultipleContentControls.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddStructuredDocumentTag("First", "Alias1", "Tag1");
+                document.AddStructuredDocumentTag("Second", "Alias2", "Tag2");
+                document.AddStructuredDocumentTag("Third", "Alias3", "Tag3");
+                Console.WriteLine("Controls: " + document.StructuredDocumentTags.Count);
+                document.Save(openWord);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                foreach (var control in document.StructuredDocumentTags) {
+                    Console.WriteLine(control.Tag + ": " + control.Text);
+                }
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/ContentControls/ContentControls.Example3.cs
+++ b/OfficeIMO.Examples/Word/ContentControls/ContentControls.Example3.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class ContentControls {
+        internal static void Example_AdvancedContentControls(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Advanced content control demo");
+            string filePath = Path.Combine(folderPath, "DocumentAdvancedContentControls.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var para1 = document.AddParagraph("Control 1:");
+                para1.AddStructuredDocumentTag("First", "Alias1", "Tag1");
+
+                var para2 = document.AddParagraph("Control 2:");
+                para2.AddStructuredDocumentTag("Second", "Alias2", "Tag2");
+
+                var para3 = document.AddParagraph("Control 3:");
+                para3.AddStructuredDocumentTag("Third", "Alias3", "Tag3");
+
+                document.Save(openWord);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var aliasControl = document.GetStructuredDocumentTagByAlias("Alias2");
+                aliasControl.Text = "Changed";
+                var tagControl = document.GetStructuredDocumentTagByTag("Tag3");
+                Console.WriteLine("Tag3 text before: " + tagControl.Text);
+                tagControl.Text = "Modified";
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.StructuredDocumentTag.cs
+++ b/OfficeIMO.Tests/Word.StructuredDocumentTag.cs
@@ -31,5 +31,31 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Changed", document.StructuredDocumentTags[0].Text);
             }
         }
+
+        [Fact]
+        public void Test_StructuredDocumentTagWithTag() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithContentControlTag.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var sdt = document.AddStructuredDocumentTag("Hello", "Alias1", "Tag1");
+
+                Assert.Equal("Tag1", sdt.Tag);
+                document.Save(false);
+                Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var loaded = document.GetStructuredDocumentTagByTag("Tag1");
+                Assert.NotNull(loaded);
+                Assert.Equal("Hello", loaded.Text);
+
+                loaded.Text = "Updated";
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal("Updated", document.StructuredDocumentTags[0].Text);
+                Assert.Equal("Tag1", document.StructuredDocumentTags[0].Tag);
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Word.StructuredDocumentTag.cs
+++ b/OfficeIMO.Tests/Word.StructuredDocumentTag.cs
@@ -57,5 +57,29 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Tag1", document.StructuredDocumentTags[0].Tag);
             }
         }
+
+        [Fact]
+        public void Test_StructuredDocumentTagGetByAlias() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithContentControlAlias.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var sdt = document.AddStructuredDocumentTag("Hello", "Alias100", "Tag100");
+
+                Assert.NotNull(document.GetStructuredDocumentTagByAlias("Alias100"));
+                document.Save(false);
+                Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var alias = document.GetStructuredDocumentTagByAlias("Alias100");
+                Assert.NotNull(alias);
+                alias.Text = "Updated";
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal("Updated", document.StructuredDocumentTags[0].Text);
+                Assert.Equal("Tag100", document.StructuredDocumentTags[0].Tag);
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Drawing.Charts;
@@ -216,9 +217,10 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="text">Initial text of the control.</param>
         /// <param name="alias">Optional alias for the control.</param>
+        /// <param name="tag">Optional tag for the control.</param>
         /// <returns>The created <see cref="WordStructuredDocumentTag"/>.</returns>
-        public WordStructuredDocumentTag AddStructuredDocumentTag(string text, string alias = null) {
-            return this.AddParagraph().AddStructuredDocumentTag(alias, text);
+        public WordStructuredDocumentTag AddStructuredDocumentTag(string text, string alias = null, string tag = null) {
+            return this.AddParagraph().AddStructuredDocumentTag(alias, text, tag);
         }
 
         public WordEmbeddedDocument AddEmbeddedDocument(string fileName, WordAlternativeFormatImportPartType? type = null) {
@@ -227,6 +229,14 @@ namespace OfficeIMO.Word {
 
         public WordEmbeddedDocument AddEmbeddedFragment(string htmlContent, WordAlternativeFormatImportPartType type) {
             return new WordEmbeddedDocument(this, htmlContent, type, true);
+        }
+
+        public WordStructuredDocumentTag GetStructuredDocumentTagByTag(string tag) {
+            return this.StructuredDocumentTags.FirstOrDefault(sdt => sdt.Tag == tag);
+        }
+
+        public WordStructuredDocumentTag GetStructuredDocumentTagByAlias(string alias) {
+            return this.StructuredDocumentTags.FirstOrDefault(sdt => sdt.Alias == alias);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -548,13 +548,17 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="alias">Optional alias for the content control.</param>
         /// <param name="text">Initial text of the control.</param>
+        /// <param name="tag">Optional tag for the content control.</param>
         /// <returns>The created <see cref="WordStructuredDocumentTag"/> instance.</returns>
-        public WordStructuredDocumentTag AddStructuredDocumentTag(string alias = null, string text = "") {
+        public WordStructuredDocumentTag AddStructuredDocumentTag(string alias = null, string text = "", string tag = null) {
             var sdtRun = new SdtRun();
 
             var sdtProperties = new SdtProperties();
             if (!string.IsNullOrEmpty(alias)) {
                 sdtProperties.Append(new SdtAlias() { Val = alias });
+            }
+            if (!string.IsNullOrEmpty(tag)) {
+                sdtProperties.Append(new Tag() { Val = tag });
             }
             sdtProperties.Append(new SdtId() { Val = new DocumentFormat.OpenXml.Int32Value(new Random().Next(1, int.MaxValue)) });
 

--- a/OfficeIMO.Word/WordStructuredDocumentTag.cs
+++ b/OfficeIMO.Word/WordStructuredDocumentTag.cs
@@ -21,6 +21,21 @@ namespace OfficeIMO.Word {
             }
         }
 
+        public string Tag {
+            get {
+                var tag = _stdRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                return tag?.Val;
+            }
+            set {
+                var tag = _stdRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                if (tag == null) {
+                    tag = new Tag();
+                    _stdRun.SdtProperties.Append(tag);
+                }
+                tag.Val = value;
+            }
+        }
+
         public string Text {
             get {
                 var run = _stdRun.SdtContentRun.ChildElements.OfType<Run>().FirstOrDefault();

--- a/README.md
+++ b/README.md
@@ -304,13 +304,18 @@ using (WordDocument document = WordDocument.Create(filePath)) {
 
 ### Adding a Content Control
 
-This example shows how to add and update a simple content control.
+This example shows how to add and update a simple content control and then retrieve it by tag.
 
 ```csharp
 using (WordDocument document = WordDocument.Create(filePath)) {
-    var sdt = document.AddStructuredDocumentTag("Hello", "MyAlias");
+    var sdt = document.AddStructuredDocumentTag("Hello", "MyAlias", "MyTag");
     sdt.Text = "Changed";
     document.Save(true);
+}
+
+using (WordDocument document = WordDocument.Load(filePath)) {
+    var tag = document.GetStructuredDocumentTagByTag("MyTag");
+    Console.WriteLine(tag.Text);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,40 @@ using (WordDocument document = WordDocument.Create(filePath)) {
 
 using (WordDocument document = WordDocument.Load(filePath)) {
     var tag = document.GetStructuredDocumentTagByTag("MyTag");
+Console.WriteLine(tag.Text);
+}
+```
+
+### Multiple Content Controls
+
+```csharp
+using (WordDocument document = WordDocument.Create(filePath)) {
+    document.AddStructuredDocumentTag("First", "Alias1", "Tag1");
+    document.AddStructuredDocumentTag("Second", "Alias2", "Tag2");
+    document.AddStructuredDocumentTag("Third", "Alias3", "Tag3");
+    document.Save(true);
+}
+
+using (WordDocument document = WordDocument.Load(filePath)) {
+    foreach (var control in document.StructuredDocumentTags) {
+        Console.WriteLine(control.Tag + ": " + control.Text);
+    }
+}
+```
+
+### Advanced Content Control Usage
+
+```csharp
+using (WordDocument document = WordDocument.Create(filePath)) {
+    document.AddStructuredDocumentTag("First", "Alias1", "Tag1");
+    document.AddStructuredDocumentTag("Second", "Alias2", "Tag2");
+    document.Save(true);
+}
+
+using (WordDocument document = WordDocument.Load(filePath)) {
+    var alias = document.GetStructuredDocumentTagByAlias("Alias2");
+    alias.Text = "Updated";
+    var tag = document.GetStructuredDocumentTagByTag("Tag1");
     Console.WriteLine(tag.Text);
 }
 ```


### PR DESCRIPTION
## Summary
- support tagging structured document tags
- expose methods to find content controls by alias or tag
- update examples and docs
- include new unit test for tagging

## Testing
- `dotnet test --no-restore --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685721015104832e9dd0558804259132