### PR TITLE
Implement equation support

### DIFF
--- a/Docs/officeimo.word.worddocument.md
+++ b/Docs/officeimo.word.worddocument.md
@@ -123,3 +123,9 @@ Returns a read-only collection of all document variables.
 public IReadOnlyDictionary<string, string> GetDocumentVariables()
 ```
 
+### **AddEquation(String)**
+
+```csharp
+public WordParagraph AddEquation(string omml)
+```
+

--- a/Docs/officeimo.word.wordparagraph.md
+++ b/Docs/officeimo.word.wordparagraph.md
@@ -934,6 +934,20 @@ public WordParagraph AddField(WordFieldType wordFieldType, Nullable<WordFieldFor
 
 [WordParagraph](./officeimo.word.wordparagraph.md)<br>
 
+### **AddEquation(String)**
+
+```csharp
+public WordParagraph AddEquation(string omml)
+```
+
+#### Parameters
+
+`omml` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+
+#### Returns
+
+[WordParagraph](./officeimo.word.wordparagraph.md)<br>
+
 ### **AddHyperLink(String, Uri, Boolean, String, Boolean)**
 
 ```csharp

--- a/OfficeIMO.Examples/Word/Equations/Equations.BasicWord.cs
+++ b/OfficeIMO.Examples/Word/Equations/Equations.BasicWord.cs
@@ -1,0 +1,36 @@
+using System;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Equations {
+        internal static void Example_AddEquation(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with equation");
+            string filePath = System.IO.Path.Combine(folderPath, "EquationDocument.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                const string omml = "<m:oMathPara xmlns:m=\"http://schemas.openxmlformats.org/officeDocument/2006/math\"><m:oMath><m:r><m:t>x=1</m:t></m:r></m:oMath></m:oMathPara>";
+                document.AddEquation(omml);
+                document.Save(openWord);
+            }
+        }
+
+        internal static void Example_AddEquationExponent(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with exponent equation");
+            string filePath = System.IO.Path.Combine(folderPath, "EquationExponent.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                const string omml = "<m:oMathPara xmlns:m=\"http://schemas.openxmlformats.org/officeDocument/2006/math\"><m:oMath><m:sSup><m:e><m:r><m:t>x</m:t></m:r></m:e><m:sup><m:r><m:t>2</m:t></m:r></m:sup></m:sSup></m:oMath></m:oMathPara>";
+                document.AddEquation(omml);
+                document.Save(openWord);
+            }
+        }
+
+        internal static void Example_AddEquationIntegral(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with integral equation");
+            string filePath = System.IO.Path.Combine(folderPath, "EquationIntegral.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                const string omml = "<m:oMathPara xmlns:m=\"http://schemas.openxmlformats.org/officeDocument/2006/math\"><m:oMath><m:int><m:intPr/><m:e><m:r><m:t>x</m:t></m:r></m:e></m:int></m:oMath></m:oMathPara>";
+                document.AddEquation(omml);
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Equations.cs
+++ b/OfficeIMO.Tests/Word.Equations.cs
@@ -1,0 +1,49 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_CreatingWordDocumentWithEquation() {
+            var filePath = Path.Combine(_directoryWithFiles, "CreatedWithEquation.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                const string omml = "<m:oMathPara xmlns:m=\"http://schemas.openxmlformats.org/officeDocument/2006/math\"><m:oMath><m:r><m:t>x=1</m:t></m:r></m:oMath></m:oMathPara>";
+                document.AddEquation(omml);
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(1, document.Equations.Count);
+            }
+        }
+
+        [Fact]
+        public void Test_CreatingWordDocumentWithExponentEquation() {
+            var filePath = Path.Combine(_directoryWithFiles, "CreatedWithExponentEquation.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                const string omml = "<m:oMathPara xmlns:m=\"http://schemas.openxmlformats.org/officeDocument/2006/math\"><m:oMath><m:sSup><m:e><m:r><m:t>x</m:t></m:r></m:e><m:sup><m:r><m:t>2</m:t></m:r></m:sup></m:sSup></m:oMath></m:oMathPara>";
+                document.AddEquation(omml);
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(1, document.Equations.Count);
+            }
+        }
+
+        [Fact]
+        public void Test_CreatingWordDocumentWithIntegralEquation() {
+            var filePath = Path.Combine(_directoryWithFiles, "CreatedWithIntegralEquation.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                const string omml = "<m:oMathPara xmlns:m=\"http://schemas.openxmlformats.org/officeDocument/2006/math\"><m:oMath><m:int><m:intPr/><m:e><m:r><m:t>x</m:t></m:r></m:e></m:int></m:oMath></m:oMathPara>";
+                document.AddEquation(omml);
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(1, document.Equations.Count);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -204,6 +204,10 @@ namespace OfficeIMO.Word {
             return this.AddParagraph().AddField(wordFieldType, wordFieldFormat, advanced, parameters);
         }
 
+        public WordParagraph AddEquation(string omml) {
+            return this.AddParagraph().AddEquation(omml);
+        }
+
         public WordParagraph AddEmbeddedObject(string filePath, string imageFilePath, double? width = null, double? height = null) {
             return this.AddParagraph().AddEmbeddedObject(filePath, imageFilePath, width, height);
         }

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -7,6 +7,9 @@ using DocumentFormat.OpenXml.Packaging;
 using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Xml.Linq;
+using MathParagraph = DocumentFormat.OpenXml.Math.Paragraph;
+using OfficeMath = DocumentFormat.OpenXml.Math.OfficeMath;
 
 namespace OfficeIMO.Word {
     public partial class WordParagraph {
@@ -304,6 +307,32 @@ namespace OfficeIMO.Word {
         public WordParagraph AddField(WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, bool advanced = false, List<String> parameters = null) {
             var field = WordField.AddField(this, wordFieldType, wordFieldFormat, advanced, parameters);
             return this;
+        }
+
+        /// <summary>
+        /// Adds a mathematical equation represented as OMML XML.
+        /// </summary>
+        /// <param name="omml">Office Math Markup Language (OMML) fragment.</param>
+        /// <returns>The paragraph that this was called on.</returns>
+        public WordParagraph AddEquation(string omml) {
+            if (string.IsNullOrWhiteSpace(omml)) {
+                throw new ArgumentNullException(nameof(omml));
+            }
+
+            XElement x = XElement.Parse(omml);
+            WordParagraph paragraphWithEquation;
+
+            if (x.Name.LocalName == "oMath") {
+                var officeMath = new OfficeMath(omml);
+                _paragraph.Append(officeMath);
+                paragraphWithEquation = new WordParagraph(this._document, this._paragraph, officeMath);
+            } else {
+                var mathPara = new MathParagraph(omml);
+                _paragraph.Append(mathPara);
+                paragraphWithEquation = new WordParagraph(this._document, this._paragraph, mathPara);
+            }
+
+            return paragraphWithEquation;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- support AddEquation from OMML
- expose AddEquation on WordDocument
- document AddEquation API
- add example and unit test
- add more equation examples and tests

## Testing
- `dotnet build OfficeImo.sln -c Release --no-restore`
- `dotnet test OfficeImo.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685720d62dc8832e8057640ea2f91fee