### PR TITLE
Fix Assert.Single analyzer warnings

### DIFF
--- a/OfficeIMO.Tests/Word.EmbeddedObjects.cs
+++ b/OfficeIMO.Tests/Word.EmbeddedObjects.cs
@@ -17,14 +17,14 @@ public partial class Word {
             document.AddParagraph("Add excel object");
             document.AddEmbeddedObject(excelFilePath, imageFilePath);
 
-            Assert.Equal(1, document.EmbeddedObjects.Count);
-            Assert.Equal(1, document.Sections[0].EmbeddedObjects.Count);
+            Assert.Single(document.EmbeddedObjects);
+            Assert.Single(document.Sections[0].EmbeddedObjects);
             document.Save();
         }
 
         using (var document = WordDocument.Load(filePath)) {
-            Assert.Equal(1, document.EmbeddedObjects.Count);
-            Assert.Equal(1, document.Sections[0].EmbeddedObjects.Count);
+            Assert.Single(document.EmbeddedObjects);
+            Assert.Single(document.Sections[0].EmbeddedObjects);
         }
     }
 
@@ -39,12 +39,12 @@ public partial class Word {
             var options = WordEmbeddedObjectOptions.Icon(iconPath, width: 32, height: 32);
             document.AddEmbeddedObject(excelFilePath, options);
 
-            Assert.Equal(1, document.EmbeddedObjects.Count);
+            Assert.Single(document.EmbeddedObjects);
             document.Save();
         }
 
         using (var document = WordDocument.Load(filePath)) {
-            Assert.Equal(1, document.EmbeddedObjects.Count);
+            Assert.Single(document.EmbeddedObjects);
         }
     }
 

--- a/OfficeIMO.Tests/Word.Equations.cs
+++ b/OfficeIMO.Tests/Word.Equations.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = WordDocument.Load(filePath)) {
-                Assert.Equal(1, document.Equations.Count);
+                Assert.Single(document.Equations);
             }
         }
 
@@ -28,7 +28,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = WordDocument.Load(filePath)) {
-                Assert.Equal(1, document.Equations.Count);
+                Assert.Single(document.Equations);
             }
         }
 
@@ -42,7 +42,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = WordDocument.Load(filePath)) {
-                Assert.Equal(1, document.Equations.Count);
+                Assert.Single(document.Equations);
             }
         }
     }


### PR DESCRIPTION
## Summary
- swap Assert.Equal(collection.Count) for Assert.Single where applicable

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68579bc7f278832ea06ff9c626f98fb5