### PR TITLE
Improve page numbering API

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -90,6 +90,9 @@ namespace OfficeIMO.Examples {
             PageSettings.Example_PageOrientation(folderPath, false);
 
             PageNumbers.Example_PageNumbers1(folderPath, false);
+            PageNumbers.Example_PageNumbers2(folderPath, false);
+            PageNumbers.Example_PageNumbers3(folderPath, false);
+            PageNumbers.Example_PageNumbers4(folderPath, false);
 
             Sections.Example_BasicSections(folderPath, false);
             Sections.Example_BasicSections2(folderPath, false);

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example2.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example2.cs
@@ -1,0 +1,26 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class PageNumbers {
+        internal static void Example_PageNumbers2(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with custom page numbers 2");
+            string filePath = System.IO.Path.Combine(folderPath, "Document with PageNumbers2.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddHeadersAndFooters();
+
+                var table = document.Footer.Default.AddTable(1, 2, WordTableStyle.TableGrid);
+                table.WidthType = TableWidthUnitValues.Pct;
+                table.Width = WordTableGenerator.OneHundredPercentWidth;
+
+                table.Rows[0].Cells[0].AddParagraph("Confidential");
+                var para = table.Rows[0].Cells[1].AddParagraph();
+                para.ParagraphAlignment = JustificationValues.Right;
+                para.AddPageNumber(includeTotalPages: true, separator: " / ");
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example2.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example2.cs
@@ -12,7 +12,8 @@ namespace OfficeIMO.Examples.Word {
 
                 var table = document.Footer.Default.AddTable(1, 2, WordTableStyle.TableGrid);
                 table.WidthType = TableWidthUnitValues.Pct;
-                table.Width = WordTableGenerator.OneHundredPercentWidth;
+                // 5000 represents 100% when using Pct width
+                table.Width = 5000;
 
                 table.Rows[0].Cells[0].AddParagraph("Confidential");
                 var para = table.Rows[0].Cells[1].AddParagraph();

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example3.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example3.cs
@@ -1,0 +1,22 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class PageNumbers {
+        internal static void Example_PageNumbers3(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with custom page numbers 3");
+            string filePath = System.IO.Path.Combine(folderPath, "Document with PageNumbers3.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.Sections[0].AddPageNumbering(2, NumberFormatValues.LowerRoman);
+                document.AddHeadersAndFooters();
+
+                var para = document.Footer.Default.AddParagraph();
+                para.AddText("Page ");
+                para.AddPageNumber();
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example4.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example4.cs
@@ -1,0 +1,21 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class PageNumbers {
+        internal static void Example_PageNumbers4(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with custom page numbers 4");
+            string filePath = System.IO.Path.Combine(folderPath, "Document with PageNumbers4.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddHeadersAndFooters();
+
+                var para = document.Header.Default.AddParagraph();
+                para.ParagraphAlignment = JustificationValues.Center;
+                para.AddPageNumber();
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.PageNumbers.cs
+++ b/OfficeIMO.Tests/Word.PageNumbers.cs
@@ -1,0 +1,60 @@
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_AddingPageNumberToParagraph() {
+            string filePath = Path.Combine(_directoryWithFiles, "PageNumberParagraph.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddHeadersAndFooters();
+                var table = document.Footer.Default.AddTable(1, 2);
+                table.Rows[0].Cells[0].AddParagraph("Footer");
+                var para = table.Rows[0].Cells[1].AddParagraph();
+                para.AddPageNumber(includeTotalPages: true);
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.NotNull(document.ParagraphsFields);
+                var errors = document.ValidateDocument();
+                errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();
+                Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
+            }
+        }
+
+        [Fact]
+        public void Test_PageNumberSettings() {
+            string filePath = Path.Combine(_directoryWithFiles, "PageNumberSettings.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.Sections[0].AddPageNumbering(2, NumberFormatValues.LowerRoman);
+                document.AddHeadersAndFooters();
+                document.Footer.Default.AddParagraph().AddPageNumber();
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal(NumberFormatValues.LowerRoman, document.Sections[0].PageNumberType.Format.Value);
+                var errors = document.ValidateDocument();
+                errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();
+                Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
+            }
+        }
+
+        [Fact]
+        public void Test_PageNumberSeparator() {
+            string filePath = Path.Combine(_directoryWithFiles, "PageNumberSeparator.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddHeadersAndFooters();
+                var para = document.Footer.Default.AddParagraph();
+                para.AddPageNumber(includeTotalPages: true, separator: " / ");
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var errors = document.ValidateDocument();
+                errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();
+                Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.SectionProperties.cs
+++ b/OfficeIMO.Word/WordDocument.SectionProperties.cs
@@ -138,5 +138,26 @@ namespace OfficeIMO.Word {
             int? startNumber = null) {
             this.Sections[0].AddEndnoteProperties(numberingFormat, position, restartNumbering, startNumber);
         }
+
+        public PageNumberType PageNumberType {
+            get {
+                if (this.Sections.Count > 1) {
+                    Debug.WriteLine("This document contains more than 1 section. Consider using Sections[wantedSection].PageNumberType.");
+                }
+
+                return this.Sections[0].PageNumberType;
+            }
+            set {
+                if (this.Sections.Count > 1) {
+                    Debug.WriteLine("This document contains more than 1 section. Consider using Sections[wantedSection].PageNumberType.");
+                }
+
+                this.Sections[0].PageNumberType = value;
+            }
+        }
+
+        public void AddPageNumbering(int? startNumber = null, NumberFormatValues? format = null) {
+            this.Sections[0].AddPageNumbering(startNumber, format);
+        }
     }
 }

--- a/OfficeIMO.Word/WordHeaderFooter.Methods.cs
+++ b/OfficeIMO.Word/WordHeaderFooter.Methods.cs
@@ -44,6 +44,10 @@ namespace OfficeIMO.Word {
             return this.AddParagraph().AddField(wordFieldType, wordFieldFormat, advanced);
         }
 
+        public WordParagraph AddPageNumber(bool includeTotalPages = false, WordFieldFormat? format = null, string separator = " of ") {
+            return this.AddParagraph().AddPageNumber(includeTotalPages, format, separator);
+        }
+
         public WordTable AddTable(int rows, int columns, WordTableStyle tableStyle = WordTableStyle.TableGrid) {
             if (_footer != null) {
                 return new WordTable(_document, _footer, rows, columns, tableStyle);

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -310,6 +310,22 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Adds a page number field to the paragraph.
+        /// </summary>
+        /// <param name="includeTotalPages">If true adds a NUMPAGES field preceded by text " of ".</param>
+        /// <param name="format">Optional field format to apply.</param>
+        /// <param name="separator">Text inserted between the current page and total pages fields.</param>
+        /// <returns>The paragraph that this was called on.</returns>
+        public WordParagraph AddPageNumber(bool includeTotalPages = false, WordFieldFormat? format = null, string separator = " of ") {
+            this.AddField(WordFieldType.Page, format);
+            if (includeTotalPages) {
+                this.AddText(separator);
+                this.AddField(WordFieldType.NumPages, format);
+            }
+            return this;
+        }
+
+        /// <summary>
         /// Adds a mathematical equation represented as OMML XML.
         /// </summary>
         /// <param name="omml">Office Math Markup Language (OMML) fragment.</param>

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -155,6 +155,30 @@ namespace OfficeIMO.Word {
             return this;
         }
 
+        public WordSection AddPageNumbering(int? startNumber = null, NumberFormatValues? format = null) {
+            var existing = _sectionProperties.GetFirstChild<PageNumberType>();
+            existing?.Remove();
+
+            if (startNumber != null || format != null) {
+                var pageNumberType = new PageNumberType();
+                if (format != null) {
+                    pageNumberType.Format = format;
+                }
+                if (startNumber != null) {
+                    pageNumberType.Start = startNumber.Value;
+                }
+                var refNode = _sectionProperties.Elements<FooterReference>().Cast<OpenXmlElement>()
+                    .Concat(_sectionProperties.Elements<HeaderReference>()).LastOrDefault();
+                if (refNode != null) {
+                    _sectionProperties.InsertAfter(pageNumberType, refNode);
+                } else {
+                    _sectionProperties.InsertAt(pageNumberType, 0);
+                }
+            }
+
+            return this;
+        }
+
         /// <summary>
         /// Removes this section and all of its content from the document,
         /// cleaning up numbering and any unreferenced header and footer parts.

--- a/OfficeIMO.Word/WordSection.SectionProperties.cs
+++ b/OfficeIMO.Word/WordSection.SectionProperties.cs
@@ -65,7 +65,7 @@ namespace OfficeIMO.Word {
                 var existing = _sectionProperties.GetFirstChild<FootnoteProperties>();
                 existing?.Remove();
                 if (value != null) {
-                    _sectionProperties.Append(value);
+                    _sectionProperties.InsertAt(value, 0);
                 }
             }
         }
@@ -78,7 +78,32 @@ namespace OfficeIMO.Word {
                 var existing = _sectionProperties.GetFirstChild<EndnoteProperties>();
                 existing?.Remove();
                 if (value != null) {
-                    _sectionProperties.Append(value);
+                    var refNode = _sectionProperties.Elements<FooterReference>().Cast<OpenXmlElement>()
+                        .Concat(_sectionProperties.Elements<HeaderReference>()).LastOrDefault();
+                    if (refNode != null) {
+                        _sectionProperties.InsertAfter(value, refNode);
+                    } else {
+                        _sectionProperties.InsertAt(value, 0);
+                    }
+                }
+            }
+        }
+
+        public PageNumberType PageNumberType {
+            get {
+                return _sectionProperties.GetFirstChild<PageNumberType>();
+            }
+            set {
+                var existing = _sectionProperties.GetFirstChild<PageNumberType>();
+                existing?.Remove();
+                if (value != null) {
+                    var refNode = _sectionProperties.Elements<FooterReference>().Cast<OpenXmlElement>()
+                        .Concat(_sectionProperties.Elements<HeaderReference>()).LastOrDefault();
+                    if (refNode != null) {
+                        _sectionProperties.InsertAfter(value, refNode);
+                    } else {
+                        _sectionProperties.InsertAt(value, 0);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- allow customizing page number text separator
- expose header/footer page numbering overload
- insert section page number settings in schema-compliant order
- add validation tests for page numbering
- show separator usage in examples

## Testing
- `dotnet build OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Debug`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68579b1fda38832eb80bd437917b4d60