### PR TITLE
Skip CodeQL for docs updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,18 @@ name: "CodeQL Advanced"
 on:
   push:
     branches: [ "master" ]
+    paths-ignore:
+      - '*.md'
+      - 'Docs/**'
+      - 'Examples/**'
+      - '.gitignore'
   pull_request:
     branches: [ "master" ]
+    paths-ignore:
+      - '*.md'
+      - 'Docs/**'
+      - 'Examples/**'
+      - '.gitignore'
   schedule:
     - cron: '23 3 * * 1'
 

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -12,6 +12,11 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - '*.md'
+      - 'Docs/**'
+      - 'Examples/**'
+      - '.gitignore'
 
 env:
   DOTNET_VERSION: |


### PR DESCRIPTION
## Summary
- avoid running CodeQL when only docs change
- skip dotnet tests when only docs change

## Testing
- `dotnet test OfficeImo.sln --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_6857a8b01f2c832eb9c95276bf052e45