### PR TITLE
Add XML docs to selected Word helpers

### DIFF
--- a/OfficeIMO.Word/ApplicationProperties.cs
+++ b/OfficeIMO.Word/ApplicationProperties.cs
@@ -5,10 +5,17 @@ using DocumentFormat.OpenXml.ExtendedProperties;
 using DocumentFormat.OpenXml.Packaging;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides strongly typed access to the extended application properties
+    /// stored in the underlying <see cref="WordprocessingDocument"/>.
+    /// </summary>
     public class ApplicationProperties {
         private readonly WordprocessingDocument _wordprocessingDocument = null;
         private readonly WordDocument _document = null;
 
+        /// <summary>
+        /// Gets or sets the application name that created the document.
+        /// </summary>
         public string Application {
             get {
                 if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
@@ -28,6 +35,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Application.Text = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the version of the application that created the document.
+        /// </summary>
         public string ApplicationVersion {
             get {
                 if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
@@ -46,6 +56,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.ApplicationVersion.Text = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the total number of paragraphs in the document.
+        /// </summary>
         public string Paragraphs {
             get {
                 if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
@@ -64,6 +77,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Paragraphs.Text = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the total number of pages in the document.
+        /// </summary>
         public string Pages {
             get {
                 if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
@@ -82,6 +98,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Pages.Text = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the character count of the document.
+        /// </summary>
         public string Characters {
             get {
                 if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
@@ -100,6 +119,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Characters.Text = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the character count including spaces.
+        /// </summary>
         public string CharactersWithSpaces {
             get {
                 if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
@@ -118,6 +140,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.CharactersWithSpaces.Text = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the company associated with the document.
+        /// </summary>
         public string Company {
             get {
                 if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
@@ -136,6 +161,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Company.Text = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the digital signature information for the document.
+        /// </summary>
         public DigitalSignature DigitalSignature {
             get {
                 if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
@@ -154,6 +182,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.DigitalSignature = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the document security information.
+        /// </summary>
         public DocumentSecurity DocumentSecurity {
             get {
                 if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
@@ -435,6 +466,10 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance bound to the specified document.
+        /// </summary>
+        /// <param name="document">Parent document.</param>
         public ApplicationProperties(WordDocument document) {
             _document = document;
             _wordprocessingDocument = document._wordprocessingDocument;

--- a/OfficeIMO.Word/ColorNameResolver.cs
+++ b/OfficeIMO.Word/ColorNameResolver.cs
@@ -3,6 +3,10 @@ using System.Reflection;
 using SixLabors.ImageSharp;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides utilities for resolving <see cref="Color"/> instances to their
+    /// named equivalents.
+    /// </summary>
     public class ColorNameResolver {
         private static readonly Dictionary<Color, string> colorNameMap = new Dictionary<Color, string>();
 
@@ -16,6 +20,12 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Returns the standard color name for the specified <see cref="Color"/>,
+        /// or the RGBA value if no name exists.
+        /// </summary>
+        /// <param name="color">The color to resolve.</param>
+        /// <returns>The color name or RGBA string.</returns>
         public static string GetColorName(Color color) {
             if (colorNameMap.TryGetValue(color, out string colorName)) {
                 return colorName;

--- a/OfficeIMO.Word/CustomImagePartType.cs
+++ b/OfficeIMO.Word/CustomImagePartType.cs
@@ -2,6 +2,9 @@ using DocumentFormat.OpenXml.Packaging;
 
 namespace OfficeIMO.Word;
 
+/// <summary>
+/// Enumeration of additional image types supported by the library.
+/// </summary>
 public enum CustomImagePartType {
     Bmp,
     Gif,
@@ -11,7 +14,15 @@ public enum CustomImagePartType {
     Emf
 }
 
+/// <summary>
+/// Extension helpers for <see cref="CustomImagePartType"/> values.
+/// </summary>
 public static class CustomImagePartTypeExtensions {
+    /// <summary>
+    /// Converts the custom image part type to the Open XML content type string.
+    /// </summary>
+    /// <param name="customType">The custom image part type.</param>
+    /// <returns>The corresponding content type value.</returns>
     public static string ToOpenXmlImagePartType(this CustomImagePartType customType) {
         return customType switch {
             CustomImagePartType.Bmp => "image/bmp",

--- a/OfficeIMO.Word/Helpers.PackageFixer.cs
+++ b/OfficeIMO.Word/Helpers.PackageFixer.cs
@@ -3,7 +3,14 @@ using System.IO.Packaging;
 using System.IO;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Helper methods for manipulating Open XML packages.
+    /// </summary>
     public static partial class Helpers {
+        /// <summary>
+        /// Adjusts relationship targets so that the document can be opened by OpenOffice.
+        /// </summary>
+        /// <param name="filePath">Path to the document package.</param>
         public static void MakeOpenOfficeCompatible(string filePath) {
             using (Package package = Package.Open(filePath, FileMode.Open, FileAccess.ReadWrite)) {
                 // Fix relationships in /_rels/.rels
@@ -16,6 +23,10 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Adjusts relationship targets for a document provided as a stream.
+        /// </summary>
+        /// <param name="fileStream">Stream containing the document package.</param>
         public static void MakeOpenOfficeCompatible(Stream fileStream) {
             using (Package package = Package.Open(fileStream, FileMode.Open, FileAccess.ReadWrite)) {
                 // Fix relationships in /_rels/.rels
@@ -28,6 +39,12 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Updates relationships for the specified part if it exists in the package.
+        /// </summary>
+        /// <param name="package">Package to modify.</param>
+        /// <param name="partUri">URI of the relationships part.</param>
+        /// <param name="removeWordPrefix">Whether to remove the /word prefix from targets.</param>
         private static void FixPartIfExists(Package package, Uri partUri, bool removeWordPrefix) {
             if (package.PartExists(partUri)) {
                 PackagePart part = package.GetPart(partUri);
@@ -35,6 +52,11 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Fixes relationship targets in the specified relationships part.
+        /// </summary>
+        /// <param name="relsPart">Relationship part to process.</param>
+        /// <param name="removeWordPrefix">Whether to remove the /word prefix from targets.</param>
         private static void FixRelationships(PackagePart relsPart, bool removeWordPrefix) {
             using (Stream stream = relsPart.GetStream(FileMode.Open, FileAccess.ReadWrite)) {
                 var xml = System.Xml.Linq.XDocument.Load(stream);

--- a/OfficeIMO.Word/WordBackground.cs
+++ b/OfficeIMO.Word/WordBackground.cs
@@ -4,10 +4,16 @@ using System.Text;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents the document background settings.
+    /// </summary>
     public class WordBackground {
 
         internal WordDocument _document;
 
+        /// <summary>
+        /// Gets or sets the background color as a hex string.
+        /// </summary>
         public string Color {
             get {
                 if (_document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground != null) {
@@ -25,12 +31,21 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Creates a background manager for the specified document.
+        /// </summary>
+        /// <param name="document">Parent document.</param>
         public WordBackground(WordDocument document) {
             _document = document;
 
             _document.Background = this;
         }
 
+        /// <summary>
+        /// Creates a background with the specified color.
+        /// </summary>
+        /// <param name="document">Parent document.</param>
+        /// <param name="color">Initial color.</param>
         public WordBackground(WordDocument document, SixLabors.ImageSharp.Color color) {
             _document = document;
 
@@ -40,10 +55,20 @@ namespace OfficeIMO.Word {
 
             //DocumentBackground documentBackground2 = new DocumentBackground() { Color = "BF8F00", ThemeColor = ThemeColorValues.Accent4, ThemeShade = "BF" };
         }
+        /// <summary>
+        /// Sets the background color using a hex value.
+        /// </summary>
+        /// <param name="color">Hex color value.</param>
+        /// <returns>The current instance.</returns>
         public WordBackground SetColorHex(string color) {
             this.Color = color.Replace("#", ""); ;
             return this;
         }
+        /// <summary>
+        /// Sets the background color using a <see cref="SixLabors.ImageSharp.Color"/>.
+        /// </summary>
+        /// <param name="color">Color value.</param>
+        /// <returns>The current instance.</returns>
         public WordBackground SetColor(SixLabors.ImageSharp.Color color) {
             this.Color = color.ToHexColor();
             return this;

--- a/OfficeIMO.Word/WordBookmark.cs
+++ b/OfficeIMO.Word/WordBookmark.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 using System.Text;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a bookmark within a Word document.
+    /// </summary>
     public class WordBookmark : WordElement {
         private WordDocument _document;
         private Paragraph _paragraph;
@@ -25,27 +28,48 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the bookmark name.
+        /// </summary>
         public string Name {
             get => _bookmarkStart.Name;
             set => _bookmarkStart.Name = value;
         }
 
+        /// <summary>
+        /// Gets or sets the bookmark identifier.
+        /// </summary>
         public int Id {
             get => int.Parse(_bookmarkStart.Id);
             set => _bookmarkStart.Id = value.ToString();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WordBookmark"/> class.
+        /// </summary>
+        /// <param name="document">Parent document.</param>
+        /// <param name="paragraph">Paragraph containing the bookmark.</param>
+        /// <param name="bookmarkStart">Underlying bookmark start element.</param>
         public WordBookmark(WordDocument document, Paragraph paragraph, BookmarkStart bookmarkStart) {
             this._document = document;
             this._paragraph = paragraph;
             this._bookmarkStart = bookmarkStart;
         }
 
+        /// <summary>
+        /// Removes the bookmark from the document.
+        /// </summary>
         public void Remove() {
             this._bookmarkEnd.Remove();
             this._bookmarkStart.Remove();
         }
 
+        /// <summary>
+        /// Adds a bookmark to the specified paragraph.
+        /// </summary>
+        /// <param name="paragraph">Paragraph to contain the bookmark.</param>
+        /// <param name="bookmarkName">Name of the bookmark.</param>
+        /// <returns>The paragraph with the inserted bookmark.</returns>
         public static WordParagraph AddBookmark(WordParagraph paragraph, string bookmarkName) {
             BookmarkStart bms = new BookmarkStart() { Name = bookmarkName, Id = paragraph._document.BookmarkId.ToString() };
             BookmarkEnd bme = new BookmarkEnd() { Id = paragraph._document.BookmarkId.ToString() };


### PR DESCRIPTION
## Summary
- document ApplicationProperties and selected helpers
- add summaries for color utilities and bookmark features
- annotate package fixer helpers and background management

## Testing
- `dotnet build /p:GenerateDocumentationFile=true` *(fails: unable to resolve NuGet packages)*

------
https://chatgpt.com/codex/tasks/task_e_6857a798a440832e8c3737ae63f3edf8