### PR TITLE
Add async load/save methods

### DIFF
--- a/OfficeIMO.Examples/Excel/BasicExcelFunctionality.Async.cs
+++ b/OfficeIMO.Examples/Excel/BasicExcelFunctionality.Async.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using OfficeIMO.Excel;
+
+namespace OfficeIMO.Examples.Excel {
+    public class BasicExcelFunctionalityAsync {
+        public static async Task Example_ExcelAsync(string folderPath) {
+            Console.WriteLine("[*] Async example for ExcelDocument");
+            string filePath = Path.Combine(folderPath, "AsyncExcel.xlsx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Sheet1");
+                await document.SaveAsync();
+            }
+
+            using (var document = await ExcelDocument.LoadAsync(filePath)) {
+                Console.WriteLine($"Sheet count: {document.Sheets.Count}");
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -31,6 +31,7 @@ namespace OfficeIMO.Examples {
             BasicDocument.Example_BasicWordWithMarginsAndImage(folderPath, false);
             BasicDocument.Example_BasicWordWithLineSpacing(folderPath, false);
             BasicDocument.Example_BasicWordWithSomeParagraphs(folderPath, false);
+            BasicDocument.Example_BasicWordAsync(folderPath).GetAwaiter().GetResult();
 
             AdvancedDocument.Example_AdvancedWord(folderPath, false);
             AdvancedDocument.Example_AdvancedWord2(folderPath, false);
@@ -160,6 +161,7 @@ namespace OfficeIMO.Examples {
             BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);
             BasicExcelFunctionality.BasicExcel_Example2(folderPath, false);
             BasicExcelFunctionality.BasicExcel_Example3(false);
+            BasicExcelFunctionalityAsync.Example_ExcelAsync(folderPath).GetAwaiter().GetResult();
 
             BordersAndMargins.Example_BasicWordMarginsSizes(folderPath, false);
             BordersAndMargins.Example_BasicPageBorders1(folderPath, false);

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Async.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Async.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class BasicDocument {
+        public static async Task Example_BasicWordAsync(string folderPath) {
+            Console.WriteLine("[*] Async example for WordDocument");
+            string filePath = Path.Combine(folderPath, "AsyncWord.docx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+
+            using (var document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Async paragraph");
+                await document.SaveAsync();
+            }
+
+            using (var document = await WordDocument.LoadAsync(filePath)) {
+                Console.WriteLine($"Paragraph count: {document.Paragraphs.Count}");
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -102,6 +102,14 @@ namespace OfficeIMO.Excel {
             return document;
         }
 
+        /// <summary>
+        /// Asynchronously loads an Excel document from the specified path.
+        /// </summary>
+        /// <param name="filePath">Path to the Excel file.</param>
+        /// <param name="readOnly">Open the file in read-only mode.</param>
+        /// <param name="autoSave">Enable auto-save on dispose.</param>
+        /// <returns>Loaded <see cref="ExcelDocument"/> instance.</returns>
+        /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
         public static async Task<ExcelDocument> LoadAsync(string filePath, bool readOnly = false, bool autoSave = false) {
             if (filePath != null) {
                 if (!File.Exists(filePath)) {
@@ -196,8 +204,27 @@ namespace OfficeIMO.Excel {
             this.Save("", openExcel);
         }
 
-        public Task SaveAsync(string filePath, bool openExcel, CancellationToken cancellationToken = default) {
-            return Task.Run(() => Save(filePath, openExcel), cancellationToken);
+        /// <summary>
+        /// Asynchronously saves the document.
+        /// </summary>
+        /// <param name="filePath">Optional path to save to.</param>
+        /// <param name="openExcel">Whether to open Excel after saving.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public async Task SaveAsync(string filePath, bool openExcel, CancellationToken cancellationToken = default) {
+            _workBookPart.Workbook.Save();
+
+            if (!string.IsNullOrEmpty(filePath)) {
+                await using var fs = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096, true);
+                using (var clone = _spreadSheetDocument.Clone(fs)) {
+                }
+                await fs.FlushAsync(cancellationToken);
+                FilePath = filePath;
+            }
+
+            if (openExcel) {
+                Open(filePath, true);
+            }
         }
 
         public Task SaveAsync(CancellationToken cancellationToken = default) {

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -116,7 +116,7 @@ namespace OfficeIMO.Excel {
                     throw new FileNotFoundException("File doesn't exists", filePath);
                 }
             }
-            await using var fileStream = new FileStream(filePath, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite, FileShare.Read, 4096, true);
+            using var fileStream = new FileStream(filePath, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite, FileShare.Read, 4096, FileOptions.Asynchronous);
             var memoryStream = new MemoryStream();
             await fileStream.CopyToAsync(memoryStream);
             memoryStream.Seek(0, SeekOrigin.Begin);
@@ -215,7 +215,7 @@ namespace OfficeIMO.Excel {
             _workBookPart.Workbook.Save();
 
             if (!string.IsNullOrEmpty(filePath)) {
-                await using var fs = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096, true);
+                using var fs = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.Asynchronous);
                 using (var clone = _spreadSheetDocument.Clone(fs)) {
                 }
                 await fs.FlushAsync(cancellationToken);

--- a/OfficeIMO.Tests/Excel.Async.cs
+++ b/OfficeIMO.Tests/Excel.Async.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using System.Threading.Tasks;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public async Task Test_ExcelSaveLoadAsync() {
+            var filePath = Path.Combine(_directoryWithFiles, "AsyncExcel.xlsx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Sheet1");
+                await document.SaveAsync();
+            }
+
+            Assert.True(File.Exists(filePath));
+
+            using (var document = await ExcelDocument.LoadAsync(filePath)) {
+                Assert.True(document.Sheets.Count > 0);
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Async.cs
+++ b/OfficeIMO.Tests/Word.Async.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using System.Threading.Tasks;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public async Task Test_WordSaveLoadAsync() {
+            var filePath = Path.Combine(_directoryWithFiles, "AsyncWord.docx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+
+            using (var document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Async");
+                await document.SaveAsync();
+            }
+
+            Assert.True(File.Exists(filePath));
+
+            using (var document = await WordDocument.LoadAsync(filePath)) {
+                Assert.Single(document.Paragraphs);
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -586,7 +586,7 @@ namespace OfficeIMO.Word {
 
         public readonly Dictionary<string, WordCustomProperty> CustomDocumentProperties = new Dictionary<string, WordCustomProperty>();
         /// <summary>
-        /// Collection of document variables accessible via <see cref="DocVariable"/> fields.
+        /// Collection of document variables accessible via <see cref="WordField.DocVariable"/> fields.
         /// </summary>
         public Dictionary<string, string> DocumentVariables { get; } = new Dictionary<string, string>();
 
@@ -862,7 +862,7 @@ namespace OfficeIMO.Word {
                 }
             }
 
-            await using var fileStream = new FileStream(filePath, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite, FileShare.Read, 4096, true);
+            using var fileStream = new FileStream(filePath, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite, FileShare.Read, 4096, FileOptions.Asynchronous);
             var memoryStream = new MemoryStream();
             await fileStream.CopyToAsync(memoryStream);
             memoryStream.Seek(0, SeekOrigin.Begin);
@@ -1065,7 +1065,7 @@ namespace OfficeIMO.Word {
                     this._wordprocessingDocument.Save();
 
                     if (filePath != "") {
-                        await using var fs = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096, true);
+                        using var fs = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.Asynchronous);
                         using (var clone = this._wordprocessingDocument.Clone(fs)) {
                             CopyPackageProperties(_wordprocessingDocument.PackageProperties, clone.PackageProperties);
                         }

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -847,6 +847,14 @@ namespace OfficeIMO.Word {
             return word;
         }
 
+        /// <summary>
+        /// Asynchronously loads a <see cref="WordDocument"/> from the given file.
+        /// </summary>
+        /// <param name="filePath">Path to the file.</param>
+        /// <param name="readOnly">Open the document in read-only mode.</param>
+        /// <param name="autoSave">Enable auto-save on dispose.</param>
+        /// <returns>Loaded <see cref="WordDocument"/> instance.</returns>
+        /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
         public static async Task<WordDocument> LoadAsync(string filePath, bool readOnly = false, bool autoSave = false) {
             if (filePath != null) {
                 if (!File.Exists(filePath)) {
@@ -1040,6 +1048,12 @@ namespace OfficeIMO.Word {
             this.Save("", openWord);
         }
 
+        /// <summary>
+        /// Asynchronously saves the document.
+        /// </summary>
+        /// <param name="filePath">Optional path to save to.</param>
+        /// <param name="openWord">Whether to open Word after saving.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         public async Task SaveAsync(string filePath, bool openWord, CancellationToken cancellationToken = default) {
             if (FileOpenAccess == FileAccess.Read) {
                 throw new InvalidOperationException("Document is read only, and cannot be saved.");


### PR DESCRIPTION
## Summary
- implement basic async wrappers for `WordDocument` and `ExcelDocument`
- include async unit tests for Word and Excel

## Testing
- `dotnet test -consoleloggerparameters:DisableColor=true` *(fails: Assert.False() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_6857a6c6a9ec832e91b6214feb09a15a