### PR TITLE
Enhance XML docs for public API

### DIFF
--- a/OfficeIMO.Excel/Helpers.cs
+++ b/OfficeIMO.Excel/Helpers.cs
@@ -1,22 +1,26 @@
 ﻿using System.Diagnostics;
 
 namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Provides helper methods used by <c>OfficeIMO.Excel</c> components.
+    /// </summary>
     public static partial class Helpers {
 
         /// <summary>
-        /// Converts Color to Hex Color
+        /// Converts a <see cref="SixLabors.ImageSharp.Color"/> to a hexadecimal
+        /// color string.
         /// </summary>
-        /// <param name="c"></param>
-        /// <returns></returns>
+        /// <param name="c">Color to convert.</param>
+        /// <returns>Hexadecimal representation of the color.</returns>
         public static string ToHexColor(this SixLabors.ImageSharp.Color c) {
             return c.ToHex().Remove(6);
         }
 
         /// <summary>
-        /// Opens up any file using assigned Application
+        /// Opens the specified file using the default application.
         /// </summary>
-        /// <param name="filePath"></param>
-        /// <param name="open"></param>
+        /// <param name="filePath">Path to the file to open.</param>
+        /// <param name="open">When <c>true</c>, the file is opened.</param>
         public static void Open(string filePath, bool open) {
             if (open) {
                 ProcessStartInfo startInfo = new ProcessStartInfo(filePath) {

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -10,6 +10,9 @@ using DocumentFormat.OpenXml.Validation;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides functionality for creating, loading and manipulating Word documents.
+    /// </summary>
     public partial class WordDocument : IDisposable {
         internal List<int> _listNumbersUsed = new List<int>();
         internal int? _tableOfContentIndex;
@@ -573,26 +576,55 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Collection of sections contained in the document.
+        /// </summary>
         public List<WordSection> Sections = new List<WordSection>();
 
+        /// <summary>
+        /// Path to the file backing this document.
+        /// </summary>
         public string FilePath { get; set; }
 
+        /// <summary>
+        /// Provides access to document settings.
+        /// </summary>
         public WordSettings Settings;
 
+        /// <summary>
+        /// Manages application related properties.
+        /// </summary>
         public ApplicationProperties ApplicationProperties;
+
+        /// <summary>
+        /// Provides access to built-in document properties.
+        /// </summary>
         public BuiltinDocumentProperties BuiltinDocumentProperties;
 
+        /// <summary>
+        /// Collection of custom document properties.
+        /// </summary>
         public readonly Dictionary<string, WordCustomProperty> CustomDocumentProperties = new Dictionary<string, WordCustomProperty>();
         /// <summary>
         /// Collection of document variables accessible via <see cref="DocVariable"/> fields.
         /// </summary>
         public Dictionary<string, string> DocumentVariables { get; } = new Dictionary<string, string>();
 
+        /// <summary>
+        /// Indicates whether the document is saved automatically.
+        /// </summary>
         public bool AutoSave => _wordprocessingDocument.AutoSave;
 
 
         // we expose them to help with integration
+        /// <summary>
+        /// Underlying Open XML word processing document.
+        /// </summary>
         public WordprocessingDocument _wordprocessingDocument;
+
+        /// <summary>
+        /// Root document element.
+        /// </summary>
         public Document _document;
         //public WordCustomProperties _customDocumentProperties;
 
@@ -1075,8 +1107,14 @@ namespace OfficeIMO.Word {
         internal WordSection _currentSection => this.Sections.Last();
 
 
+        /// <summary>
+        /// Provides access to the document background settings.
+        /// </summary>
         public WordBackground Background { get; set; }
 
+        /// <summary>
+        /// Indicates whether the document passes Open XML validation.
+        /// </summary>
         public bool DocumentIsValid {
             get {
                 if (DocumentValidationErrors.Count > 0) {
@@ -1087,12 +1125,20 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the list of validation errors for the document.
+        /// </summary>
         public List<ValidationErrorInfo> DocumentValidationErrors {
             get {
                 return ValidateDocument();
             }
         }
 
+        /// <summary>
+        /// Validates the document using the specified file format version.
+        /// </summary>
+        /// <param name="fileFormatVersions">File format version to validate against.</param>
+        /// <returns>List of validation errors.</returns>
         public List<ValidationErrorInfo> ValidateDocument(FileFormatVersions fileFormatVersions = FileFormatVersions.Microsoft365) {
             List<ValidationErrorInfo> listErrors = new List<ValidationErrorInfo>();
             OpenXmlValidator validator = new OpenXmlValidator(fileFormatVersions);
@@ -1102,6 +1148,9 @@ namespace OfficeIMO.Word {
             return listErrors;
         }
 
+        /// <summary>
+        /// Gets or sets compatibility settings for the document.
+        /// </summary>
         public WordCompatibilitySettings CompatibilitySettings { get; set; }
 
         internal void HeadingModified() {

--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -184,6 +184,10 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WordSettings"/> class for the specified document.
+        /// </summary>
+        /// <param name="document">Document whose settings are managed.</param>
         public WordSettings(WordDocument document) {
             if (document.FileOpenAccess != FileAccess.Read) {
                 var documentSettingsPart = document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart;
@@ -477,10 +481,21 @@ namespace OfficeIMO.Word {
                 _document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground.Color = value;
             }
         }
+        /// <summary>
+        /// Sets the background color using a hex value.
+        /// </summary>
+        /// <param name="backgroundColor">Hexadecimal color value.</param>
+        /// <returns>The current <see cref="WordSettings"/> instance.</returns>
         public WordSettings SetBackgroundColor(string backgroundColor) {
             this.BackgroundColor = backgroundColor;
             return this;
         }
+
+        /// <summary>
+        /// Sets the background color using a <see cref="SixLabors.ImageSharp.Color"/> value.
+        /// </summary>
+        /// <param name="backgroundColor">Color value.</param>
+        /// <returns>The current <see cref="WordSettings"/> instance.</returns>
         public WordSettings SetBackgroundColor(SixLabors.ImageSharp.Color backgroundColor) {
             this.BackgroundColor = backgroundColor.ToHexColor();
             return this;


### PR DESCRIPTION
## Summary
- expand documentation for Excel helpers
- document Word document metadata properties
- cover Word settings helpers with XML comments
- ensure doc build works

## Testing
- `dotnet build OfficeImo.sln /p:DocumentationFile=doc.xml`

------
https://chatgpt.com/codex/tasks/task_e_6857ab9ea59c832e9ff5562db61493c4