### PR TITLE
Add basic XML docs

### DIFF
--- a/OfficeIMO.Word/WordCustomProperty.cs
+++ b/OfficeIMO.Word/WordCustomProperty.cs
@@ -11,6 +11,9 @@ using DocumentFormat.OpenXml.VariantTypes;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a custom property value stored in a Word document.
+    /// </summary>
     public class WordCustomProperty {
         //public string Name;
         public Object Value;
@@ -64,30 +67,64 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Creates a custom property with the specified value and type.
+        /// </summary>
+        /// <param name="value">Property value.</param>
+        /// <param name="propertyType">Type of the property.</param>
         public WordCustomProperty(Object value, PropertyTypes propertyType) {
             this.PropertyType = propertyType;
             this.Value = value;
         }
+
+        /// <summary>
+        /// Creates a boolean custom property.
+        /// </summary>
+        /// <param name="value">Boolean value.</param>
         public WordCustomProperty(bool value) {
             this.PropertyType = PropertyTypes.YesNo;
             this.Value = value;
         }
+
+        /// <summary>
+        /// Creates a date/time custom property.
+        /// </summary>
+        /// <param name="value">Date/time value.</param>
         public WordCustomProperty(DateTime value) {
             this.PropertyType = PropertyTypes.DateTime;
             this.Value = value;
         }
+
+        /// <summary>
+        /// Creates a string custom property.
+        /// </summary>
+        /// <param name="value">Text value.</param>
         public WordCustomProperty(string value) {
             this.PropertyType = PropertyTypes.Text;
             this.Value = value;
         }
+
+        /// <summary>
+        /// Creates a double custom property.
+        /// </summary>
+        /// <param name="value">Numeric value.</param>
         public WordCustomProperty(double value) {
             this.PropertyType = PropertyTypes.NumberDouble;
             this.Value = value;
         }
+
+        /// <summary>
+        /// Creates an integer custom property.
+        /// </summary>
+        /// <param name="value">Integer value.</param>
         public WordCustomProperty(int value) {
             this.PropertyType = PropertyTypes.NumberInteger;
             this.Value = value;
         }
+
+        /// <summary>
+        /// Creates an empty custom property.
+        /// </summary>
         public WordCustomProperty() { }
 
         internal WordCustomProperty(CustomDocumentProperty customDocumentProperty) {

--- a/OfficeIMO.Word/WordHeaderFooter.Methods.cs
+++ b/OfficeIMO.Word/WordHeaderFooter.Methods.cs
@@ -7,12 +7,22 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
     public partial class WordHeaderFooter {
+        /// <summary>
+        /// Adds a new paragraph with the specified text to the header or footer.
+        /// </summary>
+        /// <param name="text">Paragraph text.</param>
+        /// <returns>The created <see cref="WordParagraph"/> instance.</returns>
         public WordParagraph AddParagraph(string text) {
             var paragraph = AddParagraph();
             paragraph.Text = text;
             return paragraph;
         }
 
+        /// <summary>
+        /// Creates an empty paragraph and appends it to the header or footer.
+        /// </summary>
+        /// <param name="newRun">Specifies whether a new run should be started.</param>
+        /// <returns>The created <see cref="WordParagraph"/> instance.</returns>
         public WordParagraph AddParagraph(bool newRun = false) {
             var wordParagraph = new WordParagraph(_document, newParagraph: true, newRun: newRun);
             if (_footer != null) {
@@ -23,31 +33,83 @@ namespace OfficeIMO.Word {
             return wordParagraph;
         }
 
+        /// <summary>
+        /// Adds a hyperlink pointing to an external URI.
+        /// </summary>
+        /// <param name="text">Display text for the hyperlink.</param>
+        /// <param name="uri">Destination URI.</param>
+        /// <param name="addStyle">Whether to apply hyperlink style.</param>
+        /// <param name="tooltip">Tooltip text for the link.</param>
+        /// <param name="history">Whether to mark the link as visited.</param>
+        /// <returns>The created <see cref="WordParagraph"/> instance.</returns>
         public WordParagraph AddHyperLink(string text, Uri uri, bool addStyle = false, string tooltip = "", bool history = true) {
             return this.AddParagraph().AddHyperLink(text, uri, addStyle, tooltip, history);
         }
 
+        /// <summary>
+        /// Adds an internal hyperlink to a bookmark within the document.
+        /// </summary>
+        /// <param name="text">Display text for the hyperlink.</param>
+        /// <param name="anchor">Bookmark to link to.</param>
+        /// <param name="addStyle">Whether to apply hyperlink style.</param>
+        /// <param name="tooltip">Tooltip text for the link.</param>
+        /// <param name="history">Whether to mark the link as visited.</param>
+        /// <returns>The created <see cref="WordParagraph"/> instance.</returns>
         public WordParagraph AddHyperLink(string text, string anchor, bool addStyle = false, string tooltip = "", bool history = true) {
             return this.AddParagraph().AddHyperLink(text, anchor, addStyle, tooltip, history);
         }
 
+        /// <summary>
+        /// Adds a horizontal line to the header or footer.
+        /// </summary>
+        /// <param name="lineType">Border style of the line.</param>
+        /// <param name="color">Color of the line.</param>
+        /// <param name="size">Thickness of the line.</param>
+        /// <param name="space">Spacing above and below the line.</param>
+        /// <returns>The created <see cref="WordParagraph"/> instance.</returns>
         public WordParagraph AddHorizontalLine(BorderValues? lineType = null, SixLabors.ImageSharp.Color? color = null, uint size = 12, uint space = 1) {
             lineType ??= BorderValues.Single;
             return this.AddParagraph().AddHorizontalLine(lineType.Value, color, size, space);
         }
 
+        /// <summary>
+        /// Adds a bookmark at the current location.
+        /// </summary>
+        /// <param name="bookmarkName">Name of the bookmark.</param>
+        /// <returns>The created <see cref="WordParagraph"/> instance.</returns>
         public WordParagraph AddBookmark(string bookmarkName) {
             return this.AddParagraph().AddBookmark(bookmarkName);
         }
 
+        /// <summary>
+        /// Adds a field to the header or footer.
+        /// </summary>
+        /// <param name="wordFieldType">Type of field to insert.</param>
+        /// <param name="wordFieldFormat">Optional field format.</param>
+        /// <param name="advanced">Whether to use advanced formatting.</param>
+        /// <returns>The created <see cref="WordParagraph"/> instance.</returns>
         public WordParagraph AddField(WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, bool advanced = false) {
             return this.AddParagraph().AddField(wordFieldType, wordFieldFormat, advanced);
         }
 
+        /// <summary>
+        /// Inserts a page number field.
+        /// </summary>
+        /// <param name="includeTotalPages">Include total pages in the display.</param>
+        /// <param name="format">Optional number format.</param>
+        /// <param name="separator">Separator used when total pages are included.</param>
+        /// <returns>The created <see cref="WordParagraph"/> instance.</returns>
         public WordParagraph AddPageNumber(bool includeTotalPages = false, WordFieldFormat? format = null, string separator = " of ") {
             return this.AddParagraph().AddPageNumber(includeTotalPages, format, separator);
         }
 
+        /// <summary>
+        /// Creates a table and appends it to the header or footer.
+        /// </summary>
+        /// <param name="rows">Number of rows.</param>
+        /// <param name="columns">Number of columns.</param>
+        /// <param name="tableStyle">Table style to apply.</param>
+        /// <returns>The created <see cref="WordTable"/>.</returns>
         public WordTable AddTable(int rows, int columns, WordTableStyle tableStyle = WordTableStyle.TableGrid) {
             if (_footer != null) {
                 return new WordTable(_document, _footer, rows, columns, tableStyle);
@@ -58,6 +120,11 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Creates a list with the specified style.
+        /// </summary>
+        /// <param name="style">List style to apply.</param>
+        /// <returns>The created <see cref="WordList"/>.</returns>
         public WordList AddList(WordListStyle style) {
             WordList wordList = new WordList(this._document, this);
             wordList.AddList(style);

--- a/OfficeIMO.Word/WordParagraph.Revisions.cs
+++ b/OfficeIMO.Word/WordParagraph.Revisions.cs
@@ -3,6 +3,13 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
     public partial class WordParagraph {
+        /// <summary>
+        /// Inserts revision text marked as added.
+        /// </summary>
+        /// <param name="text">Text to insert.</param>
+        /// <param name="author">Revision author.</param>
+        /// <param name="date">Revision date. Uses current date when null.</param>
+        /// <returns>The current <see cref="WordParagraph"/> instance.</returns>
         public WordParagraph AddInsertedText(string text, string author, DateTime? date = null) {
             VerifyRun();
             date ??= DateTime.Now;
@@ -15,6 +22,13 @@ namespace OfficeIMO.Word {
             return this;
         }
 
+        /// <summary>
+        /// Inserts revision text marked as deleted.
+        /// </summary>
+        /// <param name="text">Text to delete.</param>
+        /// <param name="author">Revision author.</param>
+        /// <param name="date">Revision date. Uses current date when null.</param>
+        /// <returns>The current <see cref="WordParagraph"/> instance.</returns>
         public WordParagraph AddDeletedText(string text, string author, DateTime? date = null) {
             VerifyRun();
             date ??= DateTime.Now;

--- a/OfficeIMO.Word/WordPositionInParagraph.cs
+++ b/OfficeIMO.Word/WordPositionInParagraph.cs
@@ -3,19 +3,24 @@ using System.Collections.Generic;
 using System.Text;
 
 namespace OfficeIMO.Word {
-
-    /**
-    * postion of a character in a paragrapho
-   * 1st ParagraphPositon
-   * 2nd TextPosition
-   * 3rd CharacterPosition 
-   */
+    /// <summary>
+    /// Represents a character position inside a paragraph.
+    /// </summary>
     internal class WordPositionInParagraph {
         private int posParagraph = 0, posText = 0, posChar = 0;
 
+        /// <summary>
+        /// Initializes a new instance with all positions set to zero.
+        /// </summary>
         public WordPositionInParagraph() {
         }
 
+        /// <summary>
+        /// Initializes a new instance with the specified positions.
+        /// </summary>
+        /// <param name="posRun">Paragraph index.</param>
+        /// <param name="posText">Text index.</param>
+        /// <param name="posChar">Character index.</param>
         public WordPositionInParagraph(int posRun, int posText, int posChar) {
             this.posParagraph = posRun;
             this.posChar = posChar;


### PR DESCRIPTION
## Summary
- add missing XML docs on `WordHeaderFooter` helper methods
- document paragraph revision helpers
- document custom property class
- document Word position helper
- run documentation generation to validate

## Testing
- `dotnet build -p:GenerateDocumentationFile=true`

------
https://chatgpt.com/codex/tasks/task_e_6857ae74fd48832e83ce2a9496f39b91