### PR TITLE
Add XML docs for various Word components

### DIFF
--- a/OfficeIMO.Word/ImageShapeStyle.cs
+++ b/OfficeIMO.Word/ImageShapeStyle.cs
@@ -4,18 +4,36 @@ using System.Linq;
 
 namespace OfficeIMO.Word;
 
+/// <summary>
+/// Represents style information for positioned images.
+/// </summary>
 public class ImageShapeStyle {
+    /// <summary>Gets or sets the CSS position property.</summary>
     public string Position { get; set; }
+    /// <summary>Gets or sets the left margin.</summary>
     public string MarginLeft { get; set; }
+    /// <summary>Gets or sets the top margin.</summary>
     public string MarginTop { get; set; }
+    /// <summary>Gets or sets the width.</summary>
     public string Width { get; set; }
+    /// <summary>Gets or sets the height.</summary>
     public string Height { get; set; }
+    /// <summary>Gets or sets the Z-index value.</summary>
     public string ZIndex { get; set; }
+    /// <summary>Gets or sets the horizontal position mode.</summary>
     public string MsoPositionHorizontal { get; set; }
+    /// <summary>Gets or sets the horizontal position relative to.</summary>
     public string MsoPositionHorizontalRelative { get; set; }
+    /// <summary>Gets or sets the vertical position mode.</summary>
     public string MsoPositionVertical { get; set; }
+    /// <summary>Gets or sets the vertical position relative to.</summary>
     public string MsoPositionVerticalRelative { get; set; }
 
+    /// <summary>
+    /// Parses a semicolon delimited style string into an <see cref="ImageShapeStyle"/> instance.
+    /// </summary>
+    /// <param name="styleString">The style string.</param>
+    /// <returns>A populated <see cref="ImageShapeStyle"/>.</returns>
     public static ImageShapeStyle FromString(string styleString) {
         var styleParts = styleString.Split(';')
             .Select(part => part.Split(':'))
@@ -35,6 +53,10 @@ public class ImageShapeStyle {
         return shapeStyle;
     }
 
+    /// <summary>
+    /// Serializes the instance to a style string.
+    /// </summary>
+    /// <returns>A semicolon delimited style string.</returns>
     public override string ToString() {
         var properties = typeof(ImageShapeStyle).GetProperties();
         var styleParts = new List<string>();
@@ -49,3 +71,4 @@ public class ImageShapeStyle {
         return string.Join(";", styleParts);
     }
 }
+

--- a/OfficeIMO.Word/WordBorders.cs
+++ b/OfficeIMO.Word/WordBorders.cs
@@ -5,6 +5,9 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Border presets that can be applied to a document section.
+    /// </summary>
     public enum WordBorder {
         None,
         Custom,
@@ -12,6 +15,9 @@ namespace OfficeIMO.Word {
         Shadow
     }
 
+    /// <summary>
+    /// Provides access to page border settings for a section.
+    /// </summary>
     public class WordBorders {
         private readonly WordDocument _document;
         private readonly WordSection _section;

--- a/OfficeIMO.Word/WordCharacterStyle.cs
+++ b/OfficeIMO.Word/WordCharacterStyle.cs
@@ -2,6 +2,9 @@
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Predefined character styles available in Word documents.
+    /// </summary>
     public enum WordCharacterStyles {
         DefaultParagraphFont,
         Heading1Char,
@@ -15,7 +18,15 @@ namespace OfficeIMO.Word {
         Heading9Char,
     }
 
+    /// <summary>
+    /// Helper methods for working with <see cref="WordCharacterStyles"/> values.
+    /// </summary>
     public static class WordCharacterStyle {
+        /// <summary>
+        /// Gets the <see cref="Style"/> definition for the specified character style.
+        /// </summary>
+        /// <param name="style">Character style to retrieve.</param>
+        /// <returns>The Open XML <see cref="Style"/> definition.</returns>
         public static Style GetStyleDefinition(WordCharacterStyles style) {
             switch (style) {
                 case WordCharacterStyles.DefaultParagraphFont: return DefaultParagraphFont;
@@ -33,6 +44,11 @@ namespace OfficeIMO.Word {
             throw new ArgumentOutOfRangeException(nameof(style));
         }
 
+        /// <summary>
+        /// Converts the style enumeration to its XML string representation.
+        /// </summary>
+        /// <param name="style">Style to convert.</param>
+        /// <returns>String identifier used in the document.</returns>
         public static string ToStringStyle(this WordCharacterStyles style) {
             switch (style) {
                 case WordCharacterStyles.DefaultParagraphFont: return "DefaultParagraphFont";
@@ -50,6 +66,11 @@ namespace OfficeIMO.Word {
             throw new ArgumentOutOfRangeException(nameof(style));
         }
 
+        /// <summary>
+        /// Converts the XML string identifier to its corresponding <see cref="WordCharacterStyles"/> value.
+        /// </summary>
+        /// <param name="style">String identifier.</param>
+        /// <returns>The matching enumeration value.</returns>
         public static WordCharacterStyles GetStyle(string style) {
             switch (style) {
                 case "DefaultParagraphFont": return WordCharacterStyles.DefaultParagraphFont;

--- a/OfficeIMO.Word/WordCoverPage.cs
+++ b/OfficeIMO.Word/WordCoverPage.cs
@@ -1,6 +1,9 @@
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Built-in cover page templates available for Word documents.
+    /// </summary>
     public enum CoverPageTemplate {
         Austin,
         Banded,
@@ -18,15 +21,28 @@ namespace OfficeIMO.Word {
         Retrospect
     }
 
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage : WordElement {
         private readonly WordDocument _document;
         private readonly SdtBlock _sdtBlock;
 
+        /// <summary>
+        /// Initializes a new instance from an existing structured document tag block.
+        /// </summary>
+        /// <param name="wordDocument">Parent document.</param>
+        /// <param name="sdtBlock">Structured document tag to wrap.</param>
         public WordCoverPage(WordDocument wordDocument, SdtBlock sdtBlock) {
             _document = wordDocument;
             _sdtBlock = sdtBlock;
         }
 
+        /// <summary>
+        /// Initializes a new instance using one of the predefined templates.
+        /// </summary>
+        /// <param name="wordDocument">Parent document.</param>
+        /// <param name="coverPageTemplate">Template to insert.</param>
         public WordCoverPage(WordDocument wordDocument, CoverPageTemplate coverPageTemplate) {
             _document = wordDocument;
             _sdtBlock = GetStyle(coverPageTemplate);

--- a/OfficeIMO.Word/WordCustomProperties.cs
+++ b/OfficeIMO.Word/WordCustomProperties.cs
@@ -9,11 +9,19 @@ using DocumentFormat.OpenXml.VariantTypes;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides access to custom document properties stored within a Word document.
+    /// </summary>
     public class WordCustomProperties {
         private WordprocessingDocument _wordprocessingDocument;
         private WordDocument _document;
         private Properties _customProperties;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WordCustomProperties"/> class.
+        /// </summary>
+        /// <param name="document">The parent document.</param>
+        /// <param name="create">When set to <c>true</c>, the custom properties part will be created if missing.</param>
         public WordCustomProperties(WordDocument document, bool? create = null) {
             _document = document;
             _wordprocessingDocument = document._wordprocessingDocument;
@@ -53,6 +61,13 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Adds a custom property to the document.
+        /// </summary>
+        /// <param name="name">Name of the property.</param>
+        /// <param name="value">Value to assign.</param>
+        /// <param name="propertyType">Type of the value.</param>
+        /// <returns>The created <see cref="CustomDocumentProperty"/>.</returns>
         public CustomDocumentProperty Add(string name, object value, PropertyTypes propertyType) {
             var newProp = new CustomDocumentProperty();
             bool propSet = false;

--- a/OfficeIMO.Word/WordDocument.HeadersAndFooters.cs
+++ b/OfficeIMO.Word/WordDocument.HeadersAndFooters.cs
@@ -18,6 +18,9 @@ namespace OfficeIMO.Word {
         //public readonly WordFooters Footer = new WordFooters();
         //public readonly WordHeaders Header = new WordHeaders();
 
+        /// <summary>
+        /// Gets the headers of the first section.
+        /// </summary>
         public WordHeaders Header {
             get {
                 if (this.Sections.Count > 1) {
@@ -26,6 +29,9 @@ namespace OfficeIMO.Word {
                 return this.Sections[0].Header;
             }
         }
+        /// <summary>
+        /// Gets the footers of the first section.
+        /// </summary>
         public WordFooters Footer {
             get {
                 if (this.Sections.Count > 1) {
@@ -35,6 +41,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the first page has different headers and footers.
+        /// </summary>
         public bool DifferentFirstPage {
             get {
                 if (this.Sections.Count > 1) {
@@ -84,6 +93,9 @@ namespace OfficeIMO.Word {
             //}
 
         }
+        /// <summary>
+        /// Gets or sets a value indicating whether odd and even pages use different headers and footers.
+        /// </summary>
         public bool DifferentOddAndEvenPages {
             get {
                 if (this.Sections.Count > 1) {

--- a/OfficeIMO.Word/WordSection.SectionProperties.cs
+++ b/OfficeIMO.Word/WordSection.SectionProperties.cs
@@ -6,11 +6,20 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides access to section property settings.
+    /// </summary>
     public partial class WordSection {
+        /// <summary>
+        /// Gets or sets the page orientation of the section.
+        /// </summary>
         public PageOrientationValues PageOrientation {
             get => WordPageSizes.GetOrientation(_sectionProperties);
             set => WordPageSizes.SetOrientation(_sectionProperties, value);
         }
+        /// <summary>
+        /// Gets or sets spacing between section columns.
+        /// </summary>
         public int? ColumnsSpace {
             get {
                 Columns columns = _sectionProperties.GetFirstChild<Columns>();


### PR DESCRIPTION
## Summary
- document WordCustomProperties and its Add method
- add docs for WordCharacterStyle helpers
- add cover page and section property summaries
- document page border and header/footer helpers
- add docs for ImageShapeStyle

## Testing
- `dotnet build OfficeImo.sln -property:GenerateDocumentationFile=true`

------
https://chatgpt.com/codex/tasks/task_e_6857b0dc68d4832eae7abd53f76ff9ea