### PR TITLE
Add XML docs for WordParagraph properties

### DIFF
--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -51,6 +51,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this run is the last run within its parent container.
+        /// </summary>
         public bool IsLastRun {
             get {
                 if (_run != null) {
@@ -61,6 +64,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this run is the first run within its parent container.
+        /// </summary>
         public bool IsFirstRun {
             get {
                 if (_run != null) {
@@ -107,6 +113,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the first image associated with this run, if any.
+        /// </summary>
         public WordImage Image {
             get {
                 if (_run != null) {
@@ -133,6 +142,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the embedded object associated with this run, if any.
+        /// </summary>
         public WordEmbeddedObject EmbeddedObject {
             get {
                 if (_run != null) {


### PR DESCRIPTION
## Summary
- document run status properties in `WordParagraph`
- ensure doc build and tests succeed

## Testing
- `dotnet build OfficeImo.sln -p:GenerateDocumentationFile=true -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6857c1c6690c832eb00cb43c3bc475fe