### PR TITLE
Expose page number paragraph

### DIFF
--- a/OfficeIMO.Tests/Word.PageNumbers.cs
+++ b/OfficeIMO.Tests/Word.PageNumbers.cs
@@ -74,5 +74,25 @@ namespace OfficeIMO.Tests {
                 }
             }
         }
+
+        [Fact]
+        public void Test_PageNumberWithCustomText() {
+            string filePath = Path.Combine(_directoryWithFiles, "PageNumberCustomText.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddHeadersAndFooters();
+                var pageNumber = document.Header.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                pageNumber.Paragraphs.Last().AddText(" custom");
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var headerPart = document._wordprocessingDocument.MainDocumentPart.HeaderParts.First();
+                string text = headerPart.Header.InnerText;
+                Assert.Contains("custom", text);
+                var errors = document.ValidateDocument();
+                errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue").ToList();
+                Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordPageNumber.cs
+++ b/OfficeIMO.Word/WordPageNumber.cs
@@ -70,6 +70,20 @@ namespace OfficeIMO.Word {
                 this._wordParagraph.ParagraphAlignment = value;
             }
         }
+
+        /// <summary>
+        /// Gets the primary paragraph containing the page number field.
+        /// </summary>
+        public WordParagraph Paragraph {
+            get { return _wordParagraph; }
+        }
+
+        /// <summary>
+        /// Gets all paragraphs that make up the page number content.
+        /// </summary>
+        public IReadOnlyList<WordParagraph> Paragraphs {
+            get { return _listParagraphs; }
+        }
         public WordPageNumber(WordDocument wordDocument, WordHeader wordHeader, WordPageNumberStyle wordPageNumberStyle) {
             this._document = wordDocument;
             this._wordHeader = wordHeader;


### PR DESCRIPTION
## Summary
- expose WordPageNumber paragraphs so that callers can customize the content
- test custom text appended to a page number

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6857c4c3be34832e868b6137076904c0