### PR TITLE
Fix watermark unit conversions

### DIFF
--- a/OfficeIMO.Tests/Word.Watermark.cs
+++ b/OfficeIMO.Tests/Word.Watermark.cs
@@ -237,5 +237,25 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Sections[0].Header.Default.Watermarks.Count == 1);
             }
         }
+
+        [Fact]
+        public void Test_WatermarkImageDimensions() {
+            string filePath = Path.Combine(_directoryWithFiles, "Test_WatermarkImageDimensions.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Test");
+                document.AddHeadersAndFooters();
+                var imagePath = Path.Combine(_directoryWithImages, "Kulek.jpg");
+                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Image, imagePath);
+                Assert.True(watermark.Width > 0);
+                Assert.True(watermark.Height > 0);
+                document.Save();
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var watermark = document.Sections[0].Header.Default.Watermarks[0];
+                Assert.True(watermark.Width > 0);
+                Assert.True(watermark.Height > 0);
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/Helpers.cs
+++ b/OfficeIMO.Word/Helpers.cs
@@ -6,6 +6,15 @@ using SixLabors.ImageSharp.Formats;
 
 namespace OfficeIMO.Word {
     public static partial class Helpers {
+        private const double PixelsPerInch = 96.0;
+
+        internal static double ConvertPixelsToPoints(double pixels) {
+            return pixels * 72 / PixelsPerInch;
+        }
+
+        internal static double ConvertPointsToPixels(double points) {
+            return points * PixelsPerInch / 72;
+        }
         /// <summary>
         /// Converts Color to Hex Color
         /// </summary>

--- a/OfficeIMO.Word/WordWatermark.cs
+++ b/OfficeIMO.Word/WordWatermark.cs
@@ -844,8 +844,10 @@ namespace OfficeIMO.Word {
             };
 
             var style = ImageShapeStyleHelper.GetStyle(shape1);
-            style["width"] = imageLocation.Width + "pt";
-            style["height"] = imageLocation.Height + "pt";
+            double widthPt = Helpers.ConvertPixelsToPoints(imageLocation.Width);
+            double heightPt = Helpers.ConvertPixelsToPoints(imageLocation.Height);
+            style["width"] = widthPt + "pt";
+            style["height"] = heightPt + "pt";
             ImageShapeStyleHelper.SetStyle(shape1, style);
 
             shape1.Append(imageData1);
@@ -875,8 +877,10 @@ namespace OfficeIMO.Word {
             };
 
             var style = ImageShapeStyleHelper.GetStyle(shape);
-            style["width"] = imageLocation.Width + "pt";
-            style["height"] = imageLocation.Height + "pt";
+            double widthPt = Helpers.ConvertPixelsToPoints(imageLocation.Width);
+            double heightPt = Helpers.ConvertPixelsToPoints(imageLocation.Height);
+            style["width"] = widthPt + "pt";
+            style["height"] = heightPt + "pt";
             ImageShapeStyleHelper.SetStyle(shape, style);
 
             shape.Append(imageData1);


### PR DESCRIPTION
## Summary
- replace pixel-to-point calculations with reusable helper
- use helper in watermark style code to avoid magic numbers

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6857c548902c832eb0db467c0595ff10