### PR TITLE
Implement UpdateFields for WordDocument

### DIFF
--- a/Docs/Examples/ExamplesUpdatingFields/README.MD
+++ b/Docs/Examples/ExamplesUpdatingFields/README.MD
@@ -1,0 +1,20 @@
+## Updating fields programmatically
+
+`WordDocument` allows two approaches to refresh fields like page numbers or table of contents.
+
+- `Settings.UpdateFieldsOnOpen` instructs Word to update fields when the document is opened.
+- `UpdateFields()` updates page numbers immediately and ensures the table of contents will refresh on open.
+
+```csharp
+using (WordDocument document = WordDocument.Create(filePath)) {
+    document.Settings.UpdateFieldsOnOpen = true; // ask Word to refresh fields
+
+    document.AddParagraph("Page 1").AddPageNumber(includeTotalPages: true);
+    document.AddPageBreak();
+    document.AddParagraph("Page 2");
+    document.AddTableOfContent();
+
+    document.UpdateFields();
+    document.Save();
+}
+```

--- a/Docs/officeimo.word.worddocument.md
+++ b/Docs/officeimo.word.worddocument.md
@@ -129,3 +129,13 @@ public IReadOnlyDictionary<string, string> GetDocumentVariables()
 public WordParagraph AddEquation(string omml)
 ```
 
+
+### **UpdateFields()**
+
+Updates page numbers and the total page count. If a table of contents exists it marks the document so Word refreshes fields when opened.
+
+```csharp
+public void UpdateFields()
+```
+
+Use this when you want fields refreshed before opening the file. Alternatively set `Settings.UpdateFieldsOnOpen` to rely on Word to update them.

--- a/Docs/officeimo.word.wordsettings.md
+++ b/Docs/officeimo.word.wordsettings.md
@@ -74,6 +74,7 @@ public Nullable<int> ZoomPercentage { get; set; }
 
 Tell Word to update fields when opening word.
  Without this option the document fields won't be refreshed until manual intervention.
+ For manual updates before opening the document see `WordDocument.UpdateFields`.
 
 ```csharp
 public bool UpdateFieldsOnOpen { get; set; }

--- a/OfficeIMO.Examples/Word/UpdateFields/UpdateFields.Example.cs
+++ b/OfficeIMO.Examples/Word/UpdateFields/UpdateFields.Example.cs
@@ -1,0 +1,24 @@
+using System;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class UpdateFieldsSample {
+        internal static void Example_UpdateFields(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Demonstrating UpdateFields vs UpdateFieldsOnOpen");
+            string filePath = System.IO.Path.Combine(folderPath, "Document with Updated Fields.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                // Option 1: update fields when the document is opened in Word
+                document.Settings.UpdateFieldsOnOpen = true;
+
+                document.AddParagraph("Page 1").AddPageNumber(includeTotalPages: true);
+                document.AddPageBreak();
+                document.AddParagraph("Page 2");
+                document.AddTableOfContent();
+
+                // Option 2: update fields immediately in code
+                document.UpdateFields();
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.UpdateFields.cs
+++ b/OfficeIMO.Tests/Word.UpdateFields.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using System.Linq;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_UpdateFieldsUpdatesPageNumbers() {
+            string filePath = Path.Combine(_directoryWithFiles, "UpdateFields.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Page 1").AddPageNumber(includeTotalPages: true);
+                document.AddPageBreak();
+                document.AddParagraph("Page 2");
+                document.AddTableOfContent();
+                document.UpdateFields();
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Contains("1", document.Fields.First(f => f.FieldType == WordFieldType.Page).Text);
+                Assert.True(document.Settings.UpdateFieldsOnOpen);
+                var errors = document.ValidateDocument();
+                errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();
+                Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.UpdateFields.cs
+++ b/OfficeIMO.Tests/Word.UpdateFields.cs
@@ -25,5 +25,52 @@ namespace OfficeIMO.Tests {
                 Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
             }
         }
+
+        [Fact]
+        public void Test_UpdateFieldsWithoutToc() {
+            string filePath = Path.Combine(_directoryWithFiles, "UpdateFieldsNoToc.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Page 1").AddPageNumber(includeTotalPages: true);
+                document.AddPageBreak();
+                document.AddParagraph("Page 2").AddPageNumber();
+                document.AddPageBreak();
+                document.AddParagraph("Page 3");
+                document.UpdateFields();
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var pages = document.Fields.Where(f => f.FieldType == WordFieldType.Page).Select(f => f.Text).ToList();
+                Assert.Equal(2, pages.Count);
+                Assert.Contains("1", pages);
+                Assert.Contains("2", pages);
+                string total = document.Fields.First(f => f.FieldType == WordFieldType.NumPages).Text;
+                Assert.Equal("3", total);
+                Assert.False(document.Settings.UpdateFieldsOnOpen);
+                var errors = document.ValidateDocument();
+                errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();
+                Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
+            }
+        }
+
+        [Fact]
+        public void Test_UpdateFieldsPreservesSettingWhenTocPresent() {
+            string filePath = Path.Combine(_directoryWithFiles, "UpdateFieldsToc.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Page 1").AddPageNumber(includeTotalPages: true);
+                document.AddPageBreak();
+                document.AddParagraph("Page 2");
+                document.AddTableOfContent();
+                document.UpdateFields();
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.True(document.Settings.UpdateFieldsOnOpen);
+                var errors = document.ValidateDocument();
+                errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();
+                Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -103,6 +103,30 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Iterates through document fields and updates values such as page numbers.
+        /// Also refreshes the table of contents if present.
+        /// </summary>
+        public void UpdateFields() {
+            int page = 1;
+            foreach (var paragraph in Paragraphs) {
+                var field = paragraph.Field;
+                if (field != null && field.FieldType == WordFieldType.Page) {
+                    field.Text = page.ToString();
+                }
+
+                if (paragraph.IsPageBreak) {
+                    page++;
+                }
+            }
+
+            foreach (var field in Fields.Where(f => f.FieldType == WordFieldType.NumPages)) {
+                field.Text = page.ToString();
+            }
+
+            TableOfContent?.Update();
+        }
+
+        /// <summary>
         /// Adds a table of contents to the current document.
         /// </summary>
         /// <param name="tableOfContentStyle">Optional style to use when creating the table of contents.</param>

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -103,8 +103,9 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
-        /// Iterates through document fields and updates values such as page numbers.
-        /// Also refreshes the table of contents if present.
+        /// Updates page and total page number fields.
+        /// When a table of contents is present the document is flagged to refresh
+        /// fields on open so Word can update the TOC.
         /// </summary>
         public void UpdateFields() {
             int page = 1;


### PR DESCRIPTION
## Summary
- add `UpdateFields` method to update page and total page numbers
- refresh TOC when updating fields
- test updated fields after saving

## Testing
- `dotnet test --framework net8.0 --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6857f9917bf8832ea1065a554c2af3c9