### PR TITLE
Add image transparency

### DIFF
--- a/Docs/Examples/ExamplesImageTransparencyAdvanced/README.MD
+++ b/Docs/Examples/ExamplesImageTransparencyAdvanced/README.MD
@@ -1,0 +1,11 @@
+## Modifying transparency of an existing image
+
+This advanced example loads a document, locates an image and updates its transparency.
+
+```csharp
+using (WordDocument document = WordDocument.Load(filePath)) {
+    var image = document.Images[0];
+    image.Transparency = 75; // make the image mostly transparent
+    document.Save();
+}
+```

--- a/Docs/Examples/ExamplesImageTransparencySimple/README.MD
+++ b/Docs/Examples/ExamplesImageTransparencySimple/README.MD
@@ -1,0 +1,12 @@
+## Setting image transparency
+
+This example demonstrates how to create a document with an image and apply a simple transparency value.
+
+```csharp
+using (WordDocument document = WordDocument.Create(filePath)) {
+    var paragraph = document.AddParagraph();
+    var image = paragraph.AddImage("image.png", 100, 100);
+    image.Transparency = 30; // 30% transparent
+    document.Save();
+}
+```

--- a/Docs/officeimo.word.wordimage.md
+++ b/Docs/officeimo.word.wordimage.md
@@ -140,6 +140,16 @@ public int Rotation { get; set; }
 
 [Int32](https://docs.microsoft.com/en-us/dotnet/api/system.int32)<br>
 
+### **Transparency**
+
+```csharp
+public Nullable<int> Transparency { get; set; }
+```
+
+#### Property Value
+
+[Nullable<int>](https://docs.microsoft.com/en-us/dotnet/api/system.nullable-1)<br>
+
 ### **Wrap**
 
 ```csharp

--- a/Docs/officeimo.word.wordimage.md
+++ b/Docs/officeimo.word.wordimage.md
@@ -150,6 +150,17 @@ public Nullable<int> Transparency { get; set; }
 
 [Nullable<int>](https://docs.microsoft.com/en-us/dotnet/api/system.nullable-1)<br>
 
+The value should be between `0` (fully opaque) and `100` (fully transparent).
+When set, the underlying XML contains an `a:alphaModFix` element that reflects
+the transparency percentage.
+
+#### Example
+
+```csharp
+var image = paragraph.AddImage("image.png", 100, 100);
+image.Transparency = 50; // half transparent
+```
+
 ### **Wrap**
 
 ```csharp

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -152,6 +152,8 @@ namespace OfficeIMO.Examples {
             Images.Example_ReadWordWithImagesAndDiffWraps();
             Images.Example_AddingFixedImages(folderPath, false);
             Images.Example_AddingImagesSampleToTable(folderPath, false);
+            Images.Example_ImageTransparencySimple(folderPath, false);
+            Images.Example_ImageTransparencyAdvanced(folderPath, false);
 
             PageBreaks.Example_PageBreaks(folderPath, false);
             PageBreaks.Example_PageBreaks1(folderPath, false);

--- a/OfficeIMO.Examples/Word/Images/Images.Transparency.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.Transparency.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Images {
+        internal static void Example_ImageTransparencySimple(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Adding image with transparency");
+            string filePath = Path.Combine(folderPath, "ImageTransparencySimple.docx");
+            string imagePaths = Path.Combine(Directory.GetCurrentDirectory(), "Images");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph();
+                paragraph.AddImage(Path.Combine(imagePaths, "Kulek.jpg"), 100, 100);
+                paragraph.Image.Transparency = 30;
+                document.Save(openWord);
+            }
+        }
+
+        internal static void Example_ImageTransparencyAdvanced(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Modifying transparency in existing document");
+            string templatesPath = Path.Combine(Directory.GetCurrentDirectory(), "Templates");
+            string filePath = Path.Combine(folderPath, "ImageTransparencyAdvanced.docx");
+            File.Copy(Path.Combine(templatesPath, "BasicDocumentWithImages.docx"), filePath, true);
+
+            using (WordDocument document = WordDocument.Load(filePath, false)) {
+                document.Images[0].Transparency = 75;
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Images.cs
+++ b/OfficeIMO.Tests/Word.Images.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using DocumentFormat.OpenXml.Drawing;
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
+using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Word;
 using Xunit;
 
@@ -384,6 +385,26 @@ namespace OfficeIMO.Tests {
 
             Assert.Single(document.Images);
             document.Save(false);
+        }
+
+        [Fact]
+        public void Test_ImageTransparency() {
+            var filePath = Path.Combine(_directoryWithFiles, "DocumentImageTransparency.docx");
+            using var document = WordDocument.Create(filePath);
+
+            var paragraph = document.AddParagraph();
+            paragraph.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 50, 50);
+            paragraph.Image.Transparency = 25;
+
+            document.Save(false);
+
+            using var reloaded = WordDocument.Load(filePath);
+            Assert.Equal(25, reloaded.Images[0].Transparency);
+
+            using var doc = DocumentFormat.OpenXml.Packaging.WordprocessingDocument.Open(filePath, false);
+            var blip = doc.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Blip>().First();
+            var alpha = blip.GetFirstChild<DocumentFormat.OpenXml.Drawing.AlphaModulationFixed>();
+            Assert.Equal(75000, alpha.Amount.Value);
         }
 
     }

--- a/OfficeIMO.Tests/Word.Images.cs
+++ b/OfficeIMO.Tests/Word.Images.cs
@@ -398,13 +398,15 @@ namespace OfficeIMO.Tests {
 
             document.Save(false);
 
-            using var reloaded = WordDocument.Load(filePath);
-            Assert.Equal(25, reloaded.Images[0].Transparency);
+            using (var reloaded = WordDocument.Load(filePath)) {
+                Assert.Equal(25, reloaded.Images[0].Transparency);
+            }
 
-            using var doc = DocumentFormat.OpenXml.Packaging.WordprocessingDocument.Open(filePath, false);
-            var blip = doc.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Blip>().First();
-            var alpha = blip.GetFirstChild<DocumentFormat.OpenXml.Drawing.AlphaModulationFixed>();
-            Assert.Equal(75000, alpha.Amount.Value);
+            using (var doc = DocumentFormat.OpenXml.Packaging.WordprocessingDocument.Open(filePath, false)) {
+                var blip = doc.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Blip>().First();
+                var alpha = blip.GetFirstChild<DocumentFormat.OpenXml.Drawing.AlphaModulationFixed>();
+                Assert.Equal(75000, alpha.Amount.Value);
+            }
         }
       
         [Fact]

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -475,6 +475,38 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Gets or sets the image transparency percentage (0-100).
+        /// </summary>
+        public int? Transparency {
+            get {
+                var blip = GetBlip();
+                if (blip != null) {
+                    var alpha = blip.GetFirstChild<AlphaModulationFixed>();
+                    if (alpha != null) {
+                        return (int)((100000 - alpha.Amount.Value) / 1000);
+                    }
+                }
+                return null;
+            }
+            set {
+                var blip = GetBlip();
+                if (blip == null) return;
+
+                var alpha = blip.GetFirstChild<AlphaModulationFixed>();
+                if (value == null) {
+                    alpha?.Remove();
+                    return;
+                }
+
+                if (alpha == null) {
+                    alpha = new AlphaModulationFixed();
+                    blip.Append(alpha);
+                }
+                alpha.Amount = 100000 - value.Value * 1000;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the image's wrap text.
         /// </summary>
         public WrapTextImage? WrapText {
@@ -653,6 +685,20 @@ namespace OfficeIMO.Word {
             anchor1.Append(relativeHeight1);
 
             return anchor1;
+        }
+
+        private Blip? GetBlip() {
+            if (_Image.Inline != null) {
+                var picture = _Image.Inline.Graphic.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
+                return picture?.BlipFill?.Blip;
+            } else if (_Image.Anchor != null) {
+                var anchorGraphic = _Image.Anchor.OfType<Graphic>().FirstOrDefault();
+                if (anchorGraphic != null && anchorGraphic.GraphicData != null) {
+                    var picture = anchorGraphic.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
+                    return picture?.BlipFill?.Blip;
+                }
+            }
+            return null;
         }
 
         public WordImage(WordDocument document, Drawing drawing) {


### PR DESCRIPTION
## Summary
- extend WordImage with Transparency property
- set alpha values in XML when transparency is set
- test image transparency persistence
- document new WordImage.Transparency property

## Testing
- `dotnet test OfficeImo.sln --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6857f9539a40832e8f8411a46f9dbef2