### PR TITLE
Add transparency validation and tests

### DIFF
--- a/OfficeIMO.Tests/Word.Images.cs
+++ b/OfficeIMO.Tests/Word.Images.cs
@@ -408,6 +408,49 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(75000, alpha.Amount.Value);
             }
         }
+
+        [Fact]
+        public void Test_ImageTransparency50() {
+            var filePath = Path.Combine(_directoryWithFiles, "DocumentImageTransparency50.docx");
+            using var document = WordDocument.Create(filePath);
+
+            var paragraph = document.AddParagraph();
+            paragraph.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 50, 50);
+            paragraph.Image.Transparency = 50;
+
+            document.Save(false);
+
+            using (var reloaded = WordDocument.Load(filePath)) {
+                Assert.Equal(50, reloaded.Images[0].Transparency);
+            }
+
+            using (var doc = DocumentFormat.OpenXml.Packaging.WordprocessingDocument.Open(filePath, false)) {
+                var blip = doc.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Blip>().First();
+                var alpha = blip.GetFirstChild<DocumentFormat.OpenXml.Drawing.AlphaModulationFixed>();
+                Assert.Equal(50000, alpha.Amount.Value);
+            }
+        }
+
+        [Fact]
+        public void Test_ImageTransparencyNotSet() {
+            var filePath = Path.Combine(_directoryWithFiles, "DocumentImageTransparencyNone.docx");
+            using var document = WordDocument.Create(filePath);
+
+            var paragraph = document.AddParagraph();
+            paragraph.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 50, 50);
+
+            document.Save(false);
+
+            using (var reloaded = WordDocument.Load(filePath)) {
+                Assert.Null(reloaded.Images[0].Transparency);
+            }
+
+            using (var doc = DocumentFormat.OpenXml.Packaging.WordprocessingDocument.Open(filePath, false)) {
+                var blip = doc.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Blip>().First();
+                var alpha = blip.GetFirstChild<DocumentFormat.OpenXml.Drawing.AlphaModulationFixed>();
+                Assert.Null(alpha);
+            }
+        }
       
         [Fact]
         public void Test_ImageCropping() {

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -700,6 +700,9 @@ namespace OfficeIMO.Word {
                 return null;
             }
             set {
+                if (value is < 0 or > 100)
+                    throw new ArgumentOutOfRangeException(nameof(value), "Transparency must be between 0 and 100.");
+
                 var blip = GetBlip();
                 if (blip == null) return;
 


### PR DESCRIPTION
## Summary
- validate WordImage.Transparency range
- add tests for 50% transparency and none case

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68586f744648832e8e17daaaeb7e72a3