### PR TITLE
Handle multiple field format switches

### DIFF
--- a/Docs/officeimo.word.wordfield.md
+++ b/Docs/officeimo.word.wordfield.md
@@ -23,12 +23,12 @@ public Nullable<WordFieldType> FieldType { get; }
 ### **FieldFormat**
 
 ```csharp
-public Nullable<WordFieldFormat> FieldFormat { get; }
+public IReadOnlyList<WordFieldFormat> FieldFormat { get; }
 ```
 
 #### Property Value
 
-[Nullable&lt;WordFieldFormat&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.nullable-1)<br>
+IReadOnlyList<WordFieldFormat><br>
 
 ### **Field**
 

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -183,6 +183,7 @@ namespace OfficeIMO.Examples {
             Fields.Example_CustomFormattedHeaderDate(folderPath, false);
             Fields.Example_FieldFormatRoman(folderPath, false);
             Fields.Example_FieldFormatAdvanced(folderPath, false);
+            Fields.Example_FieldWithMultipleSwitches(folderPath, false);
 
             Watermark.Watermark_Sample2(folderPath, false);
             Watermark.Watermark_Sample1(folderPath, false);

--- a/OfficeIMO.Examples/Word/Fields/Fields.MultipleSwitches.cs
+++ b/OfficeIMO.Examples/Word/Fields/Fields.MultipleSwitches.cs
@@ -1,0 +1,21 @@
+using System;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Fields {
+        internal static void Example_FieldWithMultipleSwitches(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating field with multiple format switches");
+            string filePath = System.IO.Path.Combine(folderPath, "FieldMultipleSwitchesExample.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph().AddField(WordFieldType.Page, WordFieldFormat.Caps);
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var field = document.Fields[0];
+                Console.WriteLine("Format switches: " + String.Join(", ", field.FieldFormat));
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Fields/Fields.cs
+++ b/OfficeIMO.Examples/Word/Fields/Fields.cs
@@ -15,7 +15,7 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Load(filePath)) {
                 foreach (var field in document.Fields) {
                     Console.WriteLine("...Type: " + field.FieldType);
-                    Console.WriteLine("...Format switch: " + field.FieldFormat);
+                    Console.WriteLine("...Format switch: " + String.Join(", ", field.FieldFormat));
                     Console.WriteLine("...Instruction: " + String.Join(" ", field.FieldInstructions));
                     Console.WriteLine("...Switches: " + String.Join(" ", field.FieldSwitches));
                 }

--- a/OfficeIMO.Tests/Word.Fields.cs
+++ b/OfficeIMO.Tests/Word.Fields.cs
@@ -38,12 +38,12 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Sections[0].ParagraphsFields[2].Field.Field == @" PAGE  \* Arabic  \* MERGEFORMAT ");
 
 
-                Assert.True(document.Fields[0].FieldFormat == WordFieldFormat.Caps);
+                Assert.Equal(new[] { WordFieldFormat.Caps, WordFieldFormat.Mergeformat }, document.Fields[0].FieldFormat);
                 Assert.True(document.Fields[0].FieldType == WordFieldType.Author);
-                Assert.True(document.Fields[1].FieldFormat == WordFieldFormat.Mergeformat);
+                Assert.Equal(new[] { WordFieldFormat.Mergeformat }, document.Fields[1].FieldFormat);
                 Assert.True(document.Fields[1].FieldType == WordFieldType.FileName);
 
-                //Assert.True(document.Fields[2].FieldFormat == WordFieldFormat.Arabic);
+                //Assert.Equal(new[] { WordFieldFormat.Arabic, WordFieldFormat.Mergeformat }, document.Fields[2].FieldFormat);
                 Assert.True(document.Fields[2].FieldType == WordFieldType.Page);
 
             }
@@ -145,11 +145,11 @@ namespace OfficeIMO.Tests {
                 document.AddParagraph("Our title is ").AddField(WordFieldType.Title, WordFieldFormat.Caps);
                 document.AddParagraph("Our author is ").AddField(WordFieldType.Author);
 
-                Assert.True(document.Fields[0].FieldFormat == WordFieldFormat.Mergeformat);
+                Assert.Equal(new[] { WordFieldFormat.Mergeformat }, document.Fields[0].FieldFormat);
                 Assert.True(document.Fields[0].FieldType == WordFieldType.Page);
-                Assert.True(document.Fields[1].FieldFormat == WordFieldFormat.Caps);
+                Assert.Equal(new[] { WordFieldFormat.Caps, WordFieldFormat.Mergeformat }, document.Fields[1].FieldFormat);
                 Assert.True(document.Fields[1].FieldType == WordFieldType.Title);
-                Assert.True(document.Fields[2].FieldFormat == WordFieldFormat.Mergeformat);
+                Assert.Equal(new[] { WordFieldFormat.Mergeformat }, document.Fields[2].FieldFormat);
                 Assert.True(document.Fields[2].FieldType == WordFieldType.Author);
 
                 Assert.True(document.Paragraphs.Count == 6);
@@ -159,11 +159,11 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "DocumentWithFields.docx"))) {
                 Assert.True(document.Paragraphs.Count == 6);
-                Assert.True(document.Fields[0].FieldFormat == WordFieldFormat.Mergeformat);
+                Assert.Equal(new[] { WordFieldFormat.Mergeformat }, document.Fields[0].FieldFormat);
                 Assert.True(document.Fields[0].FieldType == WordFieldType.Page);
-                Assert.True(document.Fields[1].FieldFormat == WordFieldFormat.Caps);
+                Assert.Equal(new[] { WordFieldFormat.Caps, WordFieldFormat.Mergeformat }, document.Fields[1].FieldFormat);
                 Assert.True(document.Fields[1].FieldType == WordFieldType.Title);
-                Assert.True(document.Fields[2].FieldFormat == WordFieldFormat.Mergeformat);
+                Assert.Equal(new[] { WordFieldFormat.Mergeformat }, document.Fields[2].FieldFormat);
                 Assert.True(document.Fields[2].FieldType == WordFieldType.Author);
 
                 var fieldTypes = (WordFieldType[])Enum.GetValues(typeof(WordFieldType));
@@ -191,18 +191,18 @@ namespace OfficeIMO.Tests {
                     foreach (var fieldTypeFormat in fieldTypesFormats) {
                         var paragraph = document.AddParagraph("field Type " + fieldType.ToString() + ": ").AddField(fieldType, fieldTypeFormat);
                         Assert.True(paragraph.Field.FieldType == fieldType, "FieldType matches");
-                        Assert.True(paragraph.Field.FieldFormat == fieldTypeFormat, "FieldTypeFormat matches");
+                        Assert.Contains(fieldTypeFormat, paragraph.Field.FieldFormat);
                     }
                 }
 
                 document.Save();
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "DocumentWithFields.docx"))) {
-                Assert.True(document.Fields[0].FieldFormat == WordFieldFormat.Mergeformat);
+                Assert.Equal(new[] { WordFieldFormat.Mergeformat }, document.Fields[0].FieldFormat);
                 Assert.True(document.Fields[0].FieldType == WordFieldType.Page);
-                Assert.True(document.Fields[1].FieldFormat == WordFieldFormat.Caps);
+                Assert.Equal(new[] { WordFieldFormat.Caps, WordFieldFormat.Mergeformat }, document.Fields[1].FieldFormat);
                 Assert.True(document.Fields[1].FieldType == WordFieldType.Title);
-                Assert.True(document.Fields[2].FieldFormat == WordFieldFormat.Mergeformat);
+                Assert.Equal(new[] { WordFieldFormat.Mergeformat }, document.Fields[2].FieldFormat);
                 Assert.True(document.Fields[2].FieldType == WordFieldType.Author);
 
                 document.Save();
@@ -226,9 +226,22 @@ namespace OfficeIMO.Tests {
 
                 Assert.Equal(2, document.Fields.Count);
                 Assert.Equal(WordFieldType.Ask, document.Fields[0].FieldType);
-                Assert.Equal(WordFieldFormat.FirstCap, document.Fields[0].FieldFormat);
+                Assert.Equal(new[] { WordFieldFormat.FirstCap, WordFieldFormat.Mergeformat }, document.Fields[0].FieldFormat);
                 Assert.Equal(instructions, document.Fields[0].FieldInstructions);
                 Assert.Equal(switches, document.Fields[0].FieldSwitches);
+            }
+        }
+
+        [Fact]
+        public void Test_FieldWithMultipleSwitches() {
+            string filePath = Path.Combine(_directoryWithFiles, "FieldMultipleSwitches.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph().AddField(WordFieldType.Page, WordFieldFormat.Caps);
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal(new[] { WordFieldFormat.Caps, WordFieldFormat.Mergeformat }, document.Fields[0].FieldFormat);
             }
         }
 
@@ -260,9 +273,9 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.Equal(3, document.Fields.Count);
-                Assert.Equal(WordFieldFormat.CardText, document.Fields[0].FieldFormat);
-                Assert.Equal(WordFieldFormat.Ordinal, document.Fields[1].FieldFormat);
-                Assert.Equal(WordFieldFormat.Hex, document.Fields[2].FieldFormat);
+                Assert.Equal(new[] { WordFieldFormat.CardText, WordFieldFormat.Mergeformat }, document.Fields[0].FieldFormat);
+                Assert.Equal(new[] { WordFieldFormat.Ordinal, WordFieldFormat.Mergeformat }, document.Fields[1].FieldFormat);
+                Assert.Equal(new[] { WordFieldFormat.Hex, WordFieldFormat.Mergeformat }, document.Fields[2].FieldFormat);
             }
         }
 
@@ -271,15 +284,15 @@ namespace OfficeIMO.Tests {
             using WordDocument document = WordDocument.Load(Path.Combine(_directoryDocuments, "partitionedFieldInstructions.docx"));
 
             Assert.Equal(WordFieldType.XE, document.Fields[0].FieldType);
-            Assert.Equal(WordFieldFormat.Lower, document.Fields[0].FieldFormat);
+            Assert.Empty(document.Fields[0].FieldFormat);
             Assert.Equal("\"Introduction\"", document.Fields[0].FieldInstructions.First());
 
             Assert.Equal(WordFieldType.XE, document.Fields[1].FieldType);
-            Assert.Equal(WordFieldFormat.Lower, document.Fields[1].FieldFormat);
+            Assert.Empty(document.Fields[1].FieldFormat);
             Assert.Equal("\"Header 1\"", document.Fields[1].FieldInstructions.First());
 
             Assert.Equal(WordFieldType.Ask, document.Fields[2].FieldType);
-            Assert.Equal(WordFieldFormat.Mergeformat, document.Fields[2].FieldFormat);
+            Assert.Equal(new[] { WordFieldFormat.Mergeformat }, document.Fields[2].FieldFormat);
             Assert.Equal("\"What is the weather today?\"", document.Fields[2].FieldInstructions.First());
             Assert.Equal("\\d \"fine\"", document.Fields[2].FieldSwitches.First());
         }

--- a/OfficeIMO.Tests/Word.PageNumbers.cs
+++ b/OfficeIMO.Tests/Word.PageNumbers.cs
@@ -153,7 +153,7 @@ namespace OfficeIMO.Tests {
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.Equal(NumberFormatValues.UpperRoman, document.Sections[0].PageNumberType.Format.Value);
-                Assert.Contains(document.Sections[0].Footer.Default.Fields, f => f.FieldType == WordFieldType.Page && f.FieldFormat == WordFieldFormat.Roman);
+                Assert.Contains(document.Sections[0].Footer.Default.Fields, f => f.FieldType == WordFieldType.Page && f.FieldFormat.Contains(WordFieldFormat.Roman));
                 var errors = document.ValidateDocument();
                 errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();
                 Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));

--- a/OfficeIMO.Word/WordField.cs
+++ b/OfficeIMO.Word/WordField.cs
@@ -118,13 +118,10 @@ namespace OfficeIMO.Word {
             }
         }
 
-        public WordFieldFormat? FieldFormat {
+        public IReadOnlyList<WordFieldFormat> FieldFormat {
             get {
                 var parser = new WordFieldParser(Field);
-                // TODO: How do handle several format switches - if they are even combinable? 
-                //       Since we expect mergeformat to appear, we ignore it by return the first format switch, 
-                //       because its manually added by the GenerateField method anyway, at the moment. 
-                return parser.FormatSwitches.FirstOrDefault();
+                return parser.FormatSwitches;
             }
         }
 

--- a/OfficeIMO.Word/WordSection.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordSection.PrivateMethods.cs
@@ -192,6 +192,7 @@ namespace OfficeIMO.Word {
                                 runList.Add(run);
                                 wordParagraph = new WordParagraph(document, paragraph, runList);
                                 list.Add(wordParagraph);
+                                runList = new List<Run>();
                             } else {
                                 runList.Add(run);
                             }


### PR DESCRIPTION
## Summary
- collect all field format switches when parsing fields
- expose all field format switches via `WordField.FieldFormat`
- document new return type for `FieldFormat`
- support multi-switch assertions in tests
- add test ensuring multiple format switches roundtrip
- output all field format switches in field example
- add example demonstrating the retrieved switches

## Testing
- `dotnet test OfficeImo.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68586f22df88832ebfc90da6178adacf