### PR TITLE
Enhance image feature support

### DIFF
--- a/OfficeIMO.Word/ImageFillMode.cs
+++ b/OfficeIMO.Word/ImageFillMode.cs
@@ -1,0 +1,11 @@
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Determines how an image fills its bounding box.
+    /// </summary>
+    public enum ImageFillMode {
+        /// <summary>Stretch the image to fill the area.</summary>
+        Stretch,
+        /// <summary>Tile the image to fill the area.</summary>
+        Tile
+    }
+}

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -62,6 +62,16 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Add an image that is stored outside the package.
+        /// </summary>
+        public WordParagraph AddImage(Uri imageUri, double width, double height, WrapTextImage wrapImageText = WrapTextImage.InLineWithText, string description = "") {
+            var wordImage = new WordImage(_document, this, imageUri, width, height, wrapImageText, description);
+            VerifyRun();
+            _run.Append(wordImage._Image);
+            return this;
+        }
+
+        /// <summary>
         /// Add image from a Base64 encoded string.
         /// </summary>
         public WordParagraph AddImageFromBase64(string base64String, string fileName, double? width = null, double? height = null, WrapTextImage wrapImageText = WrapTextImage.InLineWithText, string description = "") {


### PR DESCRIPTION
## Summary
- add `ImageFillMode` enum for tiling vs stretching images
- allow configuration of fill mode and local DPI
- enable adding images from external URIs
- ensure external images cannot be saved and relationships get cleaned

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f491aeb4832ea6dbada398771cdb