### PR TITLE
Implement axis title formatting

### DIFF
--- a/OfficeIMO.Word/WordChart.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordChart.PrivateMethods.cs
@@ -203,6 +203,7 @@ namespace OfficeIMO.Word {
 
                 // since the title may have changed, we need to update it
                 UpdateTitle();
+                UpdateAxisTitles();
             }
         }
 
@@ -214,6 +215,7 @@ namespace OfficeIMO.Word {
 
                 // since the title may have changed, we need to update it
                 UpdateTitle();
+                UpdateAxisTitles();
             }
         }
 
@@ -225,6 +227,7 @@ namespace OfficeIMO.Word {
 
                 // since the title may have changed, we need to update it
                 UpdateTitle();
+                UpdateAxisTitles();
             }
         }
 
@@ -236,6 +239,7 @@ namespace OfficeIMO.Word {
 
                 // since the title may have changed, we need to update it
                 UpdateTitle();
+                UpdateAxisTitles();
             }
         }
 
@@ -794,6 +798,7 @@ namespace OfficeIMO.Word {
                 _chart = GenerateScatterChart(_chart);
                 _chartPart.ChartSpace.Append(_chart);
                 UpdateTitle();
+                UpdateAxisTitles();
             }
         }
 
@@ -803,6 +808,7 @@ namespace OfficeIMO.Word {
                 _chart = GenerateRadarChart(_chart);
                 _chartPart.ChartSpace.Append(_chart);
                 UpdateTitle();
+                UpdateAxisTitles();
             }
         }
 
@@ -812,6 +818,7 @@ namespace OfficeIMO.Word {
                 _chart = GenerateArea3DChart(_chart);
                 _chartPart.ChartSpace.Append(_chart);
                 UpdateTitle();
+                UpdateAxisTitles();
             }
         }
 
@@ -821,6 +828,7 @@ namespace OfficeIMO.Word {
                 _chart = GenerateBar3DChart(_chart);
                 _chartPart.ChartSpace.Append(_chart);
                 UpdateTitle();
+                UpdateAxisTitles();
             }
         }
 

--- a/OfficeIMO.Word/WordChart.Properties.cs
+++ b/OfficeIMO.Word/WordChart.Properties.cs
@@ -36,6 +36,11 @@ namespace OfficeIMO.Word {
         /// Value axis ID for Line3D charts
         /// </summary>
         private UInt32Value _valAxisId;
+        private string _xAxisTitle;
+        private string _yAxisTitle;
+        private string _axisTitleFontName = "Calibri";
+        private int _axisTitleFontSize = 11;
+        private SixLabors.ImageSharp.Color _axisTitleColor = SixLabors.ImageSharp.Color.Black;
         //private string _id => _document._wordprocessingDocument.MainDocumentPart.GetIdOfPart(_chartPart);
 
         public BarGroupingValues? BarGrouping {

--- a/OfficeIMO.Word/WordChart.PublicMethods.cs
+++ b/OfficeIMO.Word/WordChart.PublicMethods.cs
@@ -211,5 +211,25 @@ namespace OfficeIMO.Word {
                 }
             }
         }
+
+        public WordChart SetXAxisTitle(string title) {
+            _xAxisTitle = title;
+            UpdateAxisTitles();
+            return this;
+        }
+
+        public WordChart SetYAxisTitle(string title) {
+            _yAxisTitle = title;
+            UpdateAxisTitles();
+            return this;
+        }
+
+        public WordChart SetAxisTitleFormat(string fontName, int fontSize, SixLabors.ImageSharp.Color color) {
+            _axisTitleFontName = fontName;
+            _axisTitleFontSize = fontSize;
+            _axisTitleColor = color;
+            UpdateAxisTitles();
+            return this;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add axis title format fields and setters to `WordChart`
- create axis title elements with specified font, size and color
- update chart creation to include axis titles when provided
- verify axis title styling in new unit test

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685916acf0c8832eb6c878fe0edc0cab