### PR TITLE
Improve FindAndReplace string comparison

### DIFF
--- a/OfficeIMO.Tests/Word.FindAndReplace.CaseSensitive.cs
+++ b/OfficeIMO.Tests/Word.FindAndReplace.CaseSensitive.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_FindAndReplace_CaseSensitive() {
+            string filePath = Path.Combine(_directoryWithFiles, "CaseSensitiveReplace.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Hello World");
+                document.AddParagraph("hello world");
+
+                var replacedCount = document.FindAndReplace("Hello World", "Bye", StringComparison.Ordinal);
+                Assert.Equal(1, replacedCount);
+                Assert.Equal("Bye", document.Paragraphs[0].Text);
+                Assert.Equal("hello world", document.Paragraphs[1].Text);
+
+                replacedCount = document.FindAndReplace("hello world", "Bye", StringComparison.OrdinalIgnoreCase);
+                Assert.Equal(1, replacedCount);
+
+                Assert.Equal("Bye", document.Paragraphs[1].Text);
+                document.Save(false);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -430,7 +430,7 @@ namespace OfficeIMO.Word {
             }
             List<WordParagraph> foundParagraphs = new List<WordParagraph>();
             var removeParas = new List<int>();
-            var foundList = SearchText(paragraphs, oldText, new WordPositionInParagraph() { Paragraph = 0 });
+            var foundList = SearchText(paragraphs, oldText, new WordPositionInParagraph() { Paragraph = 0 }, stringComparison);
 
             if (foundList?.Count > 0) {
                 count += foundList.Count;

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -441,7 +441,8 @@ namespace OfficeIMO.Word {
                         var p = paragraphs[ts.BeginIndex];
                         if (p != null) {
                             if (replace) {
-                                p.Text = p.Text.Replace(oldText, newText);
+                                int replaceCount = 0;
+                                p.Text = p.Text.FindAndReplace(oldText, newText, stringComparison, ref replaceCount);
                             }
                             if (foundParagraphs.IndexOf(p) == -1) {
                                 foundParagraphs.Add(p);


### PR DESCRIPTION
## Summary
- ensure `FindAndReplace` uses `StringComparison` when replacing text
- add unit test for case-sensitive replacements

## Testing
- `dotnet test OfficeImo.sln -f net9.0 --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_685924d598f0832e826651d5cb8803e4