### PR TITLE
Fix list numbering when merging docs

### DIFF
--- a/OfficeIMO.Tests/Word.MergeDocuments.cs
+++ b/OfficeIMO.Tests/Word.MergeDocuments.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_MergingDocumentsWithSeparateLists() {
+            var filePath1 = Path.Combine(_directoryWithFiles, "MergeDoc1.docx");
+            var filePath2 = Path.Combine(_directoryWithFiles, "MergeDoc2.docx");
+
+            using (var doc1 = WordDocument.Create(filePath1)) {
+                var list1 = doc1.AddList(WordListStyle.Headings111);
+                list1.AddItem("Item 1");
+                list1.AddItem("Item 2");
+                doc1.Save();
+            }
+
+            using (var doc2 = WordDocument.Create(filePath2)) {
+                var list2 = doc2.AddList(WordListStyle.Headings111);
+                list2.AddItem("Second 1");
+                list2.AddItem("Second 2");
+                doc2.Save();
+            }
+
+            using (var doc1 = WordDocument.Load(filePath1))
+            using (var doc2 = WordDocument.Load(filePath2)) {
+                doc1.AppendDocument(doc2);
+                doc1.Save();
+            }
+
+            using (var merged = WordDocument.Load(filePath1)) {
+                Assert.Equal(2, merged.Lists.Count);
+                var numbering = merged._wordprocessingDocument.MainDocumentPart
+                    .NumberingDefinitionsPart!.Numbering;
+                var ids = numbering.Elements<NumberingInstance>()
+                    .Select(n => n.NumberID.Value).Distinct().ToList();
+                Assert.Equal(2, ids.Count);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.MergeDocuments.cs
+++ b/OfficeIMO.Tests/Word.MergeDocuments.cs
@@ -40,5 +40,110 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(2, ids.Count);
             }
         }
+    [Fact]
+
+    public void Test_MergingDocumentsWithNestedLists() {
+        var filePath1 = Path.Combine(_directoryWithFiles, "MergeDocNested1.docx");
+        var filePath2 = Path.Combine(_directoryWithFiles, "MergeDocNested2.docx");
+
+        using (var doc1 = WordDocument.Create(filePath1)) {
+            var list1 = doc1.AddList(WordListStyle.Headings111);
+            list1.AddItem("Item 1");
+            list1.AddItem("Item 1.1", 1);
+            doc1.Save();
+        }
+
+        using (var doc2 = WordDocument.Create(filePath2)) {
+            var list2 = doc2.AddList(WordListStyle.Headings111);
+            list2.AddItem("Item 2");
+            list2.AddItem("Item 2.1", 1);
+            doc2.Save();
+        }
+
+        using (var doc1 = WordDocument.Load(filePath1))
+        using (var doc2 = WordDocument.Load(filePath2)) {
+            doc1.AppendDocument(doc2);
+            doc1.Save();
+        }
+
+        using (var merged = WordDocument.Load(filePath1)) {
+            Assert.Equal(2, merged.Lists.Count);
+            var numbering = merged._wordprocessingDocument.MainDocumentPart
+                .NumberingDefinitionsPart!.Numbering;
+            var ids = numbering.Elements<NumberingInstance>()
+                .Select(n => n.NumberID.Value).Distinct().ToList();
+            Assert.Equal(2, ids.Count);
+            Assert.Equal(4, merged.Paragraphs.Count(p => p.IsListItem));
+        }
     }
+
+    [Fact]
+    public void Test_MergingDocumentsMultipleTimes() {
+        var filePath1 = Path.Combine(_directoryWithFiles, "MergeDocMulti1.docx");
+        var filePath2 = Path.Combine(_directoryWithFiles, "MergeDocMulti2.docx");
+        var filePath3 = Path.Combine(_directoryWithFiles, "MergeDocMulti3.docx");
+
+        using (var doc = WordDocument.Create(filePath1)) {
+            var list = doc.AddList(WordListStyle.Headings111);
+            list.AddItem("Item 1");
+            doc.Save();
+        }
+
+        using (var doc = WordDocument.Create(filePath2)) {
+            var list = doc.AddList(WordListStyle.Headings111);
+            list.AddItem("Item 2");
+            doc.Save();
+        }
+
+        using (var doc = WordDocument.Create(filePath3)) {
+            var list = doc.AddList(WordListStyle.Headings111);
+            list.AddItem("Item 3");
+            doc.Save();
+        }
+
+        using (var baseDoc = WordDocument.Load(filePath1))
+        using (var doc2 = WordDocument.Load(filePath2))
+        using (var doc3 = WordDocument.Load(filePath3)) {
+            baseDoc.AppendDocument(doc2);
+            baseDoc.AppendDocument(doc3);
+            baseDoc.Save();
+        }
+
+        using (var merged = WordDocument.Load(filePath1)) {
+            var numbering = merged._wordprocessingDocument.MainDocumentPart
+                .NumberingDefinitionsPart!.Numbering;
+            var ids = numbering.Elements<NumberingInstance>()
+                .Select(n => n.NumberID.Value).Distinct().ToList();
+            Assert.Equal(3, ids.Count);
+        }
+    }
+
+    [Fact]
+    public void Test_MergingDocumentWithoutLists() {
+        var filePath1 = Path.Combine(_directoryWithFiles, "MergeDocNoLists1.docx");
+        var filePath2 = Path.Combine(_directoryWithFiles, "MergeDocNoLists2.docx");
+
+        using (var doc1 = WordDocument.Create(filePath1)) {
+            var list = doc1.AddList(WordListStyle.Headings111);
+            list.AddItem("Item 1");
+            doc1.Save();
+        }
+
+        using (var doc2 = WordDocument.Create(filePath2)) {
+            doc2.AddParagraph("Just text");
+            doc2.Save();
+        }
+
+        using (var doc1 = WordDocument.Load(filePath1))
+        using (var doc2 = WordDocument.Load(filePath2)) {
+            doc1.AppendDocument(doc2);
+            doc1.Save();
+        }
+
+        using (var merged = WordDocument.Load(filePath1)) {
+            Assert.Equal(1, merged.Lists.Count);
+            Assert.Contains(merged.Paragraphs, p => p.Text == "Just text");
+        }
+    }
+}
 }

--- a/OfficeIMO.Word/WordDocument.Merge.cs
+++ b/OfficeIMO.Word/WordDocument.Merge.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using DocumentFormat.OpenXml;
+
+namespace OfficeIMO.Word {
+    public partial class WordDocument {
+        public void AppendDocument(WordDocument source) {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            var srcMain = source._wordprocessingDocument.MainDocumentPart;
+            var destMain = this._wordprocessingDocument.MainDocumentPart;
+            if (srcMain == null || destMain == null) return;
+
+            Numbering destNumbering;
+            if (destMain.NumberingDefinitionsPart == null) {
+                destNumbering = new Numbering();
+                destMain.AddNewPart<NumberingDefinitionsPart>().Numbering = destNumbering;
+            } else if (destMain.NumberingDefinitionsPart.Numbering == null) {
+                destNumbering = destMain.NumberingDefinitionsPart.Numbering = new Numbering();
+            } else {
+                destNumbering = destMain.NumberingDefinitionsPart.Numbering;
+            }
+
+            var srcNumbering = srcMain.NumberingDefinitionsPart?.Numbering;
+            Dictionary<int, int> numMap = new();
+            Dictionary<int, int> abstractMap = new();
+            if (srcNumbering != null) {
+                foreach (var abs in srcNumbering.Elements<AbstractNum>()) {
+                    int oldAbs = (int)abs.AbstractNumberId.Value;
+                    int newAbs = GetNextAbstractNumId(destNumbering);
+                    abstractMap[oldAbs] = newAbs;
+                    var cloneAbs = (AbstractNum)abs.CloneNode(true);
+                    cloneAbs.AbstractNumberId = newAbs;
+                    destNumbering.Append(cloneAbs);
+                }
+
+                foreach (var inst in srcNumbering.Elements<NumberingInstance>()) {
+                    int oldNum = (int)inst.NumberID.Value;
+                    int newNum = GetNextNumberingId(destNumbering);
+                    var cloneInst = (NumberingInstance)inst.CloneNode(true);
+                    cloneInst.NumberID = newNum;
+                    var absId = cloneInst.GetFirstChild<AbstractNumId>();
+                    if (absId != null && abstractMap.TryGetValue((int)absId.Val.Value, out var mapped)) {
+                        absId.Val = mapped;
+                    }
+                    destNumbering.Append(cloneInst);
+                    numMap[oldNum] = newNum;
+                }
+            }
+
+            foreach (var element in srcMain.Document.Body.ChildElements) {
+                var clone = element.CloneNode(true);
+                foreach (var numId in clone.Descendants<NumberingId>()) {
+                    if (numMap.TryGetValue((int)numId.Val.Value, out var mapped)) {
+                        numId.Val = mapped;
+                    }
+                }
+                destMain.Document.Body.Append(clone);
+            }
+        }
+
+        private static int GetNextAbstractNumId(Numbering numbering) {
+            var ids = numbering.ChildElements.OfType<AbstractNum>()
+                .Select(n => (int)n.AbstractNumberId.Value)
+                .ToList();
+            return ids.Count > 0 ? ids.Max() + 1 : 0;
+        }
+
+        private static int GetNextNumberingId(Numbering numbering) {
+            var ids = numbering.ChildElements.OfType<NumberingInstance>()
+                .Select(n => (int)n.NumberID.Value)
+                .ToList();
+            return ids.Count > 0 ? ids.Max() + 1 : 1;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure numbering IDs are unique when merging documents
- add test for merging documents containing lists

## Testing
- `dotnet test OfficeImo.sln --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685924e92480832e90a43ad24ac0a5fb