### PR TITLE
Fix WordParagraph equality and tests

### DIFF
--- a/OfficeIMO.Tests/Word.Paragraphs.cs
+++ b/OfficeIMO.Tests/Word.Paragraphs.cs
@@ -145,13 +145,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(document.Sections[0].Paragraphs[0].TabStops.Count == document.Paragraphs[0].TabStops.Count);
 
-                /// TODO: Fix likeness - for some reason it doesn't work for TabStops which are not available at all
-                //var expectedParagraph1 = new Likeness<WordParagraph, WordParagraph>(document.Sections[0].Paragraphs[0]);
-                //Assert.True(expectedParagraph1.Equals(document.Paragraphs[2]) == true);
-                //expectedParagraph1.ShouldEqual(document.Paragraphs[0]);
-
-                //var expectedParagraph2 = new Likeness<WordParagraph, WordParagraph>(document.Sections[0].Paragraphs[2]);
-                //Assert.True(expectedParagraph2.Equals(document.Paragraphs[2]) == true);
+                Assert.True(document.Sections[0].Paragraphs[0] == document.Paragraphs[0]);
+                Assert.True(document.Sections[0].Paragraphs[2] == document.Paragraphs[2]);
 
                 Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Red, "1st paragraph color should be the same");
                 Assert.True(document.Paragraphs[0].ColorHex == SixLabors.ImageSharp.Color.Red.ToHexColor(), "1st paragraph color should be the same");
@@ -188,7 +183,7 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(document.Paragraphs[0].Text == "Basic paragraph - Page 1", "1st paragraph text doesn't match. Current: " + document.Paragraphs[0].Text);
                 Assert.True(document.Paragraphs[0].Text == document.Sections[0].Paragraphs[0].Text, "1st paragraph of 1st section should be the same 1");
-                //Assert.True(document.Paragraphs[0] == document.Sections[0].Paragraphs[0], "1st paragraph of 1st section should be the same 2");
+                Assert.True(document.Paragraphs[0] == document.Sections[0].Paragraphs[0]);
                 Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Red, "1st paragraph color should be the same");
                 Assert.True(document.Paragraphs[1].IsPageBreak == true, "2nd paragraph color should be the page break");
                 Assert.True(document.Paragraphs[2].Color == SixLabors.ImageSharp.Color.Yellow, "3rd paragraph color should be the same");
@@ -231,7 +226,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs[0].Strike == true, "Strike should be set");
                 Assert.True(document.Paragraphs[0].Text == "Basic paragraph - Page 1", "1st paragraph text doesn't match. Current: " + document.Paragraphs[0].Text);
                 Assert.True(document.Paragraphs[0].Text == document.Sections[0].Paragraphs[0].Text, "1st paragraph of 1st section should be the same 1");
-                //Assert.True(document.Paragraphs[0] == document.Sections[0].Paragraphs[0], "1st paragraph of 1st section should be the same 2");
+                Assert.True(document.Paragraphs[0] == document.Sections[0].Paragraphs[0]);
                 Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Red, "1st paragraph color should be the same");
                 Assert.True(document.Paragraphs[1].IsPageBreak == true, "2nd paragraph color should be the page break");
                 Assert.True(document.Paragraphs[2].Color == SixLabors.ImageSharp.Color.Yellow, "3rd paragraph color should be the same");
@@ -254,7 +249,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs[0].Strike == true, "Strike should be set");
                 Assert.True(document.Paragraphs[0].Text == "Basic paragraph - Page 1", "1st paragraph text doesn't match. Current: " + document.Paragraphs[0].Text);
                 Assert.True(document.Paragraphs[0].Text == document.Sections[0].Paragraphs[0].Text, "1st paragraph of 1st section should be the same 1");
-                //Assert.True(document.Paragraphs[0] == document.Sections[0].Paragraphs[0], "1st paragraph of 1st section should be the same 2");
+                Assert.True(document.Paragraphs[0] == document.Sections[0].Paragraphs[0]);
                 Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Red, "1st paragraph color should be the same");
                 Assert.True(document.Paragraphs[1].IsPageBreak == true, "2nd paragraph color should be the page break");
                 Assert.True(document.Paragraphs[2].Color == SixLabors.ImageSharp.Color.Yellow, "3rd paragraph color should be the same");

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -443,7 +443,7 @@ namespace OfficeIMO.Word {
                             if (replace) {
                                 p.Text = p.Text.Replace(oldText, newText);
                             }
-                            if (foundParagraphs.IndexOf(p) == -1) {
+                            if (!foundParagraphs.Any(fp => ReferenceEquals(fp._paragraph, p._paragraph))) {
                                 foundParagraphs.Add(p);
                             }
                         }
@@ -454,7 +454,7 @@ namespace OfficeIMO.Word {
                             if (beginPara != null && endPara != null) {
                                 beginPara.Text = beginPara.Text.Replace(beginPara.Text.Substring(ts.BeginChar), newText);
                                 endPara.Text = endPara.Text.Replace(endPara.Text.Substring(0, ts.EndChar + 1), "");
-                                if (foundParagraphs.IndexOf(beginPara) == -1) {
+                                if (!foundParagraphs.Any(fp => ReferenceEquals(fp._paragraph, beginPara._paragraph))) {
                                     foundParagraphs.Add(beginPara);
                                 }
                             }

--- a/OfficeIMO.Word/WordParagraph.Equality.cs
+++ b/OfficeIMO.Word/WordParagraph.Equality.cs
@@ -20,12 +20,14 @@ namespace OfficeIMO.Word {
 
         public override int GetHashCode() {
             if (_paragraph != null) return _paragraph.GetHashCode();
-            var hash = new System.HashCode();
-            hash.Add(Text);
-            foreach (var tab in TabStops) {
-                hash.Add(tab);
+            unchecked {
+                int hash = 17;
+                hash = hash * 31 + (Text != null ? Text.GetHashCode() : 0);
+                foreach (var tab in TabStops) {
+                    hash = hash * 31 + tab.GetHashCode();
+                }
+                return hash;
             }
-            return hash.ToHashCode();
         }
 
         public static bool operator ==(WordParagraph left, WordParagraph right) {

--- a/OfficeIMO.Word/WordParagraph.Equality.cs
+++ b/OfficeIMO.Word/WordParagraph.Equality.cs
@@ -1,0 +1,40 @@
+namespace OfficeIMO.Word {
+    public partial class WordParagraph : System.IEquatable<WordParagraph> {
+        public bool Equals(WordParagraph other) {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            if (ReferenceEquals(_paragraph, other._paragraph)) return true;
+
+            if (Text != other.Text) return false;
+            if (TabStops.Count != other.TabStops.Count) return false;
+            for (int i = 0; i < TabStops.Count; i++) {
+                if (!TabStops[i].Equals(other.TabStops[i])) return false;
+            }
+
+            return true;
+        }
+
+        public override bool Equals(object obj) {
+            return obj is WordParagraph other && Equals(other);
+        }
+
+        public override int GetHashCode() {
+            if (_paragraph != null) return _paragraph.GetHashCode();
+            var hash = new System.HashCode();
+            hash.Add(Text);
+            foreach (var tab in TabStops) {
+                hash.Add(tab);
+            }
+            return hash.ToHashCode();
+        }
+
+        public static bool operator ==(WordParagraph left, WordParagraph right) {
+            if (left is null) return right is null;
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(WordParagraph left, WordParagraph right) {
+            return !(left == right);
+        }
+    }
+}

--- a/OfficeIMO.Word/WordTabStop.cs
+++ b/OfficeIMO.Word/WordTabStop.cs
@@ -73,7 +73,13 @@ namespace OfficeIMO.Word {
         }
 
         public override int GetHashCode() {
-            return System.HashCode.Combine(Alignment, Leader, Position);
+            unchecked {
+                int hash = 17;
+                hash = hash * 31 + Alignment.GetHashCode();
+                hash = hash * 31 + Leader.GetHashCode();
+                hash = hash * 31 + Position.GetHashCode();
+                return hash;
+            }
         }
     }
 }

--- a/OfficeIMO.Word/WordTabStop.cs
+++ b/OfficeIMO.Word/WordTabStop.cs
@@ -2,7 +2,7 @@ using DocumentFormat.OpenXml.Wordprocessing;
 using Tabs = DocumentFormat.OpenXml.Wordprocessing.Tabs;
 
 namespace OfficeIMO.Word {
-    public class WordTabStop {
+    public class WordTabStop : System.IEquatable<WordTabStop> {
 
         private WordParagraph _paragraph { get; set; }
 
@@ -61,6 +61,19 @@ namespace OfficeIMO.Word {
             _tabs.Append(tabStop1);
             _tabStop = tabStop1;
             return this;
+        }
+
+        public bool Equals(WordTabStop other) {
+            if (other is null) return false;
+            return Alignment == other.Alignment && Leader == other.Leader && Position == other.Position;
+        }
+
+        public override bool Equals(object obj) {
+            return obj is WordTabStop other && Equals(other);
+        }
+
+        public override int GetHashCode() {
+            return System.HashCode.Combine(Alignment, Leader, Position);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add equality implementation for `WordParagraph` including tab stop checks
- implement `IEquatable` on `WordTabStop`
- enable paragraph equality assertions in tests

## Testing
- `dotnet test OfficeImo.sln --no-build --verbosity minimal` *(fails: Assert.True() Failure in Word tests)*

------
https://chatgpt.com/codex/tasks/task_e_685925627858832ea7181e1e521fa2de