### PR TITLE
Implement row-level vertical merge helper

### DIFF
--- a/Docs/officeimo.word.wordtablerow.md
+++ b/Docs/officeimo.word.wordtablerow.md
@@ -117,3 +117,17 @@ Remove a row
 ```csharp
 public void Remove()
 ```
+
+### **MergeVertically(Int32, Int32, Boolean)**
+
+Merges cells starting from the provided column across subsequent rows.
+
+```csharp
+public void MergeVertically(int cellIndex, int rowsCount, bool copyParagraphs)
+```
+
+#### Parameters
+
+`cellIndex` [Int32](https://docs.microsoft.com/en-us/dotnet/api/system.int32)<br>
+`rowsCount` [Int32](https://docs.microsoft.com/en-us/dotnet/api/system.int32)<br>
+`copyParagraphs` [Boolean](https://docs.microsoft.com/en-us/dotnet/api/system.boolean)<br>

--- a/OfficeIMO.Tests/Word.Tables.cs
+++ b/OfficeIMO.Tests/Word.Tables.cs
@@ -557,6 +557,46 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_RowMergeVerticallyAddsProperties() {
+            string filePath = Path.Combine(_directoryWithFiles, "RowVerticalMerge.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable wordTable = document.AddTable(3, 3, WordTableStyle.PlainTable1);
+
+                wordTable.Rows[0].Cells[0].Paragraphs[0].Text = "Top";
+                wordTable.Rows[1].Cells[0].Paragraphs[0].Text = "Bottom";
+                wordTable.Rows[2].Cells[0].Paragraphs[0].Text = "Another";
+                wordTable.Rows[0].Cells[1].Paragraphs[0].Text = "A";
+                wordTable.Rows[1].Cells[1].Paragraphs[0].Text = "B";
+                wordTable.Rows[2].Cells[1].Paragraphs[0].Text = "C";
+
+                // simulate cells loaded without properties
+                wordTable.Rows[0].Cells[0].RemoveTableCellProperties();
+                wordTable.Rows[1].Cells[0].RemoveTableCellProperties();
+
+                wordTable.Rows[0].MergeVertically(0, 1, true);
+
+                Assert.Equal(MergedCellValues.Restart, wordTable.Rows[0].Cells[0].VerticalMerge);
+                Assert.Equal(MergedCellValues.Continue, wordTable.Rows[1].Cells[0].VerticalMerge);
+                Assert.Null(wordTable.Rows[2].Cells[0].VerticalMerge);
+                Assert.Equal("Top", wordTable.Rows[0].Cells[0].Paragraphs[0].Text);
+                Assert.Equal("Bottom", wordTable.Rows[0].Cells[0].Paragraphs[1].Text);
+                Assert.Equal("", wordTable.Rows[1].Cells[0].Paragraphs[0].Text);
+
+                document.Save();
+            }
+
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "RowVerticalMerge.docx"))) {
+                var wordTable = document.Tables[0];
+
+                Assert.Equal(MergedCellValues.Restart, wordTable.Rows[0].Cells[0].VerticalMerge);
+                Assert.Equal(MergedCellValues.Continue, wordTable.Rows[1].Cells[0].VerticalMerge);
+                Assert.Null(wordTable.Rows[2].Cells[0].VerticalMerge);
+
+                document.Save();
+            }
+        }
+
+        [Fact]
         public void Test_SplitVerticallyKeepsIndices() {
             string filePath = Path.Combine(_directoryWithFiles, "SplitVerticallyIndices.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {


### PR DESCRIPTION
## Summary
- add `MergeVertically` docs directly in `WordTableRow`
- test vertical row merges with more complex layout

## Testing
- `dotnet format --no-restore` *(fails: Required references did not load)*
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build --logger "console;verbosity=normal"` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_68592558108c832ea7522ba917ee2c96