### PR TITLE
Add shape positioning and rotation

### DIFF
--- a/OfficeIMO.Tests/Word.Shapes.cs
+++ b/OfficeIMO.Tests/Word.Shapes.cs
@@ -11,6 +11,17 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var paragraph = document.AddParagraph("Paragraph with shape");
                 var shape = paragraph.AddShape(100, 50, Color.Red);
+                shape.Title = "Rectangle";
+                shape.Description = "My rectangle";
+                shape.Hidden = false;
+                shape.Stroked = true;
+                shape.StrokeColor = Color.Blue;
+                shape.StrokeWeight = 2;
+                shape.Left = 10;
+                shape.Top = 20;
+                shape.Rotation = 45;
+                shape.Width = 120;
+                shape.Height = 60;
 
                 WordShape.AddEllipse(paragraph, 80, 40, Color.Lime);
                 WordShape.AddPolygon(paragraph, "0,0 50,0 50,50 0,50", Color.White, Color.Blue);
@@ -18,16 +29,34 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(document.Paragraphs.Count == 1);
                 Assert.NotNull(paragraph.Shape);
-                Assert.Equal(100d, shape.Width, 1);
-                Assert.Equal(50d, shape.Height, 1);
+                Assert.Equal("Rectangle", shape.Title);
+                Assert.Equal("My rectangle", shape.Description);
+                Assert.False(shape.Hidden!.Value);
+                Assert.True(shape.Stroked!.Value);
+                Assert.Equal(Color.Blue.ToHexColor(), shape.StrokeColorHex);
+                Assert.Equal(2d, shape.StrokeWeight!.Value, 1);
+                Assert.Equal(120d, shape.Width, 1);
+                Assert.Equal(60d, shape.Height, 1);
+                Assert.Equal(10d, shape.Left!.Value, 1);
+                Assert.Equal(20d, shape.Top!.Value, 1);
+                Assert.Equal(45d, shape.Rotation!.Value, 1);
 
                 document.Save(false);
             }
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithShapes.docx"))) {
                 Assert.True(document.Paragraphs[0].IsShape);
-                Assert.Equal(100d, document.Paragraphs[0].Shape.Width, 1);
-                Assert.Equal(50d, document.Paragraphs[0].Shape.Height, 1);
+                Assert.Equal("Rectangle", document.Paragraphs[0].Shape.Title);
+                Assert.Equal("My rectangle", document.Paragraphs[0].Shape.Description);
+                Assert.False(document.Paragraphs[0].Shape.Hidden!.Value);
+                Assert.True(document.Paragraphs[0].Shape.Stroked!.Value);
+                Assert.Equal(Color.Blue.ToHexColor(), document.Paragraphs[0].Shape.StrokeColorHex);
+                Assert.Equal(2d, document.Paragraphs[0].Shape.StrokeWeight!.Value, 1);
+                Assert.Equal(120d, document.Paragraphs[0].Shape.Width, 1);
+                Assert.Equal(60d, document.Paragraphs[0].Shape.Height, 1);
+                Assert.Equal(10d, document.Paragraphs[0].Shape.Left!.Value, 1);
+                Assert.Equal(20d, document.Paragraphs[0].Shape.Top!.Value, 1);
+                Assert.Equal(45d, document.Paragraphs[0].Shape.Rotation!.Value, 1);
             }
         }
     }

--- a/OfficeIMO.Word/WordShape.cs
+++ b/OfficeIMO.Word/WordShape.cs
@@ -231,21 +231,20 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
-        /// Whether the shape is hidden.
+        /// Whether the shape is hidden. Stored as "visibility:hidden" in the style string.
         /// </summary>
         public bool? Hidden {
             get {
-                if (_rectangle?.Hidden != null) return _rectangle.Hidden.Value;
-                if (_ellipse?.Hidden != null) return _ellipse.Hidden.Value;
-                if (_polygon?.Hidden != null) return _polygon.Hidden.Value;
-                if (_line?.Hidden != null) return _line.Hidden.Value;
-                return null;
+                var v = GetStyleValue("visibility");
+                if (string.IsNullOrEmpty(v)) return null;
+                return v == "hidden";
             }
             set {
-                if (_rectangle != null) _rectangle.Hidden = value;
-                if (_ellipse != null) _ellipse.Hidden = value;
-                if (_polygon != null) _polygon.Hidden = value;
-                if (_line != null) _line.Hidden = value;
+                if (value == null) {
+                    RemoveStyleValue("visibility");
+                } else {
+                    SetStyleValue("visibility", value.Value ? "hidden" : "visible");
+                }
             }
         }
 
@@ -344,7 +343,7 @@ namespace OfficeIMO.Word {
 
         private void SetStyleValue(string name, string value) {
             var style = GetStyle() ?? string.Empty;
-            var parts = style.Split(';', StringSplitOptions.RemoveEmptyEntries).ToList();
+            var parts = style.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).ToList();
             bool updated = false;
             for (int i = 0; i < parts.Count; i++) {
                 var kv = parts[i].Split(':');
@@ -361,7 +360,7 @@ namespace OfficeIMO.Word {
         private void RemoveStyleValue(string name) {
             var style = GetStyle();
             if (string.IsNullOrEmpty(style)) return;
-            var parts = style.Split(';', StringSplitOptions.RemoveEmptyEntries).ToList();
+            var parts = style.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).ToList();
             parts.RemoveAll(p => p.Split(':').FirstOrDefault() == name);
             SetStyle(string.Join(";", parts));
         }

--- a/OfficeIMO.Word/WordShape.cs
+++ b/OfficeIMO.Word/WordShape.cs
@@ -174,21 +174,208 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Identifier of the shape.
+        /// </summary>
+        public string Id {
+            get {
+                if (_rectangle != null) return _rectangle.Id?.Value ?? string.Empty;
+                if (_ellipse != null) return _ellipse.Id?.Value ?? string.Empty;
+                if (_polygon != null) return _polygon.Id?.Value ?? string.Empty;
+                if (_line != null) return _line.Id?.Value ?? string.Empty;
+                return string.Empty;
+            }
+            set {
+                if (_rectangle != null) _rectangle.Id = value;
+                if (_ellipse != null) _ellipse.Id = value;
+                if (_polygon != null) _polygon.Id = value;
+                if (_line != null) _line.Id = value;
+            }
+        }
+
+        /// <summary>
+        /// Optional title of the shape.
+        /// </summary>
+        public string? Title {
+            get {
+                if (_rectangle != null) return _rectangle.Title?.Value;
+                if (_ellipse != null) return _ellipse.Title?.Value;
+                if (_polygon != null) return _polygon.Title?.Value;
+                if (_line != null) return _line.Title?.Value;
+                return null;
+            }
+            set {
+                if (_rectangle != null) _rectangle.Title = value;
+                if (_ellipse != null) _ellipse.Title = value;
+                if (_polygon != null) _polygon.Title = value;
+                if (_line != null) _line.Title = value;
+            }
+        }
+
+        /// <summary>
+        /// Alternative text description of the shape.
+        /// </summary>
+        public string? Description {
+            get {
+                if (_rectangle != null) return _rectangle.Alternate?.Value;
+                if (_ellipse != null) return _ellipse.Alternate?.Value;
+                if (_polygon != null) return _polygon.Alternate?.Value;
+                if (_line != null) return _line.Alternate?.Value;
+                return null;
+            }
+            set {
+                if (_rectangle != null) _rectangle.Alternate = value;
+                if (_ellipse != null) _ellipse.Alternate = value;
+                if (_polygon != null) _polygon.Alternate = value;
+                if (_line != null) _line.Alternate = value;
+            }
+        }
+
+        /// <summary>
+        /// Whether the shape is hidden.
+        /// </summary>
+        public bool? Hidden {
+            get {
+                if (_rectangle?.Hidden != null) return _rectangle.Hidden.Value;
+                if (_ellipse?.Hidden != null) return _ellipse.Hidden.Value;
+                if (_polygon?.Hidden != null) return _polygon.Hidden.Value;
+                if (_line?.Hidden != null) return _line.Hidden.Value;
+                return null;
+            }
+            set {
+                if (_rectangle != null) _rectangle.Hidden = value;
+                if (_ellipse != null) _ellipse.Hidden = value;
+                if (_polygon != null) _polygon.Hidden = value;
+                if (_line != null) _line.Hidden = value;
+            }
+        }
+
+        /// <summary>
+        /// Outline color in hex format. Null when not applicable.
+        /// </summary>
+        public string? StrokeColorHex {
+            get {
+                if (_rectangle != null) return _rectangle.StrokeColor?.Value;
+                if (_ellipse != null) return _ellipse.StrokeColor?.Value;
+                if (_polygon != null) return _polygon.StrokeColor?.Value;
+                if (_line != null) return _line.StrokeColor?.Value;
+                return null;
+            }
+            set {
+                if (_rectangle != null) _rectangle.StrokeColor = value;
+                if (_ellipse != null) _ellipse.StrokeColor = value;
+                if (_polygon != null) _polygon.StrokeColor = value;
+                if (_line != null) _line.StrokeColor = value;
+            }
+        }
+
+        /// <summary>
+        /// Outline color using <see cref="SixLabors.ImageSharp.Color"/>.
+        /// </summary>
+        public SixLabors.ImageSharp.Color StrokeColor {
+            get {
+                var hex = StrokeColorHex;
+                if (string.IsNullOrEmpty(hex)) return SixLabors.ImageSharp.Color.Transparent;
+                if (!hex.StartsWith("#")) hex = "#" + hex;
+                return SixLabors.ImageSharp.Color.Parse(hex);
+            }
+            set => StrokeColorHex = value.ToHexColor();
+        }
+
+        /// <summary>
+        /// Outline thickness in points.
+        /// </summary>
+        public double? StrokeWeight {
+            get {
+                string? v = null;
+                if (_rectangle != null) v = _rectangle.StrokeWeight?.Value;
+                if (_ellipse != null) v ??= _ellipse.StrokeWeight?.Value;
+                if (_polygon != null) v ??= _polygon.StrokeWeight?.Value;
+                if (_line != null) v ??= _line.StrokeWeight?.Value;
+                if (string.IsNullOrEmpty(v)) return null;
+                return double.Parse(v.Replace("pt", string.Empty), CultureInfo.InvariantCulture);
+            }
+            set {
+                string? v = value != null ? $"{value.Value.ToString(CultureInfo.InvariantCulture)}pt" : null;
+                if (_rectangle != null) _rectangle.StrokeWeight = v;
+                if (_ellipse != null) _ellipse.StrokeWeight = v;
+                if (_polygon != null) _polygon.StrokeWeight = v;
+                if (_line != null) _line.StrokeWeight = v;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the outline is drawn.
+        /// </summary>
+        public bool? Stroked {
+            get {
+                if (_rectangle?.Stroked != null) return _rectangle.Stroked.Value;
+                if (_ellipse?.Stroked != null) return _ellipse.Stroked.Value;
+                if (_polygon?.Stroked != null) return _polygon.Stroked.Value;
+                if (_line?.Stroked != null) return _line.Stroked.Value;
+                return null;
+            }
+            set {
+                if (_rectangle != null) _rectangle.Stroked = value;
+                if (_ellipse != null) _ellipse.Stroked = value;
+                if (_polygon != null) _polygon.Stroked = value;
+                if (_line != null) _line.Stroked = value;
+            }
+        }
+
+        private string? GetStyle() {
+            return _rectangle?.Style?.Value ?? _ellipse?.Style?.Value ?? _polygon?.Style?.Value;
+        }
+
+        private void SetStyle(string style) {
+            if (_rectangle != null) _rectangle.Style = style;
+            if (_ellipse != null) _ellipse.Style = style;
+            if (_polygon != null) _polygon.Style = style;
+        }
+
+        private string? GetStyleValue(string name) {
+            var style = GetStyle();
+            if (string.IsNullOrEmpty(style)) return null;
+            foreach (var part in style.Split(';')) {
+                var kv = part.Split(':');
+                if (kv.Length == 2 && kv[0] == name) return kv[1];
+            }
+            return null;
+        }
+
+        private void SetStyleValue(string name, string value) {
+            var style = GetStyle() ?? string.Empty;
+            var parts = style.Split(';', StringSplitOptions.RemoveEmptyEntries).ToList();
+            bool updated = false;
+            for (int i = 0; i < parts.Count; i++) {
+                var kv = parts[i].Split(':');
+                if (kv.Length == 2 && kv[0] == name) {
+                    parts[i] = $"{name}:{value}";
+                    updated = true;
+                    break;
+                }
+            }
+            if (!updated) parts.Add($"{name}:{value}");
+            SetStyle(string.Join(";", parts));
+        }
+
+        private void RemoveStyleValue(string name) {
+            var style = GetStyle();
+            if (string.IsNullOrEmpty(style)) return;
+            var parts = style.Split(';', StringSplitOptions.RemoveEmptyEntries).ToList();
+            parts.RemoveAll(p => p.Split(':').FirstOrDefault() == name);
+            SetStyle(string.Join(";", parts));
+        }
+
+        /// <summary>
         /// Width of the shape in points.
         /// </summary>
         public double Width {
             get {
-                var style = _rectangle?.Style?.Value ?? _ellipse?.Style?.Value ?? _polygon?.Style?.Value;
-                if (style != null) {
-                    foreach (var part in style.Split(';')) {
-                        var kv = part.Split(':');
-                        if (kv.Length == 2 && kv[0] == "width") {
-                            return double.Parse(kv[1].Replace("pt", ""), CultureInfo.InvariantCulture);
-                        }
-                    }
-                }
+                var v = GetStyleValue("width");
+                if (!string.IsNullOrEmpty(v)) return double.Parse(v.Replace("pt", string.Empty), CultureInfo.InvariantCulture);
                 return 0;
             }
+            set => SetStyleValue("width", $"{value.ToString(CultureInfo.InvariantCulture)}pt");
         }
 
         /// <summary>
@@ -196,16 +383,66 @@ namespace OfficeIMO.Word {
         /// </summary>
         public double Height {
             get {
-                var style = _rectangle?.Style?.Value ?? _ellipse?.Style?.Value ?? _polygon?.Style?.Value;
-                if (style != null) {
-                    foreach (var part in style.Split(';')) {
-                        var kv = part.Split(':');
-                        if (kv.Length == 2 && kv[0] == "height") {
-                            return double.Parse(kv[1].Replace("pt", ""), CultureInfo.InvariantCulture);
-                        }
-                    }
-                }
+                var v = GetStyleValue("height");
+                if (!string.IsNullOrEmpty(v)) return double.Parse(v.Replace("pt", string.Empty), CultureInfo.InvariantCulture);
                 return 0;
+            }
+            set => SetStyleValue("height", $"{value.ToString(CultureInfo.InvariantCulture)}pt");
+        }
+
+        /// <summary>
+        /// Left position of the shape in points. Returns null when not explicitly set.
+        /// </summary>
+        public double? Left {
+            get {
+                var v = GetStyleValue("margin-left");
+                if (string.IsNullOrEmpty(v)) return null;
+                return double.Parse(v.Replace("pt", string.Empty), CultureInfo.InvariantCulture);
+            }
+            set {
+                if (value == null) {
+                    RemoveStyleValue("margin-left");
+                } else {
+                    SetStyleValue("margin-left", $"{value.Value.ToString(CultureInfo.InvariantCulture)}pt");
+                    if (GetStyleValue("position") == null) SetStyleValue("position", "absolute");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Top position of the shape in points. Returns null when not explicitly set.
+        /// </summary>
+        public double? Top {
+            get {
+                var v = GetStyleValue("margin-top");
+                if (string.IsNullOrEmpty(v)) return null;
+                return double.Parse(v.Replace("pt", string.Empty), CultureInfo.InvariantCulture);
+            }
+            set {
+                if (value == null) {
+                    RemoveStyleValue("margin-top");
+                } else {
+                    SetStyleValue("margin-top", $"{value.Value.ToString(CultureInfo.InvariantCulture)}pt");
+                    if (GetStyleValue("position") == null) SetStyleValue("position", "absolute");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Rotation of the shape in degrees. Returns null when not set.
+        /// </summary>
+        public double? Rotation {
+            get {
+                var v = GetStyleValue("rotation");
+                if (string.IsNullOrEmpty(v)) return null;
+                return double.Parse(v, CultureInfo.InvariantCulture);
+            }
+            set {
+                if (value == null) {
+                    RemoveStyleValue("rotation");
+                } else {
+                    SetStyleValue("rotation", value.Value.ToString(CultureInfo.InvariantCulture));
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- implement advanced style handling for shapes
- expose ID, size, position and rotation APIs on `WordShape`
- test updated shape properties
- add title, description, visibility and outline properties

## Testing
- `dotnet restore`
- `dotnet test OfficeImo.sln --no-build -v n` *(fails: VSTestTask returned false)*

------
https://chatgpt.com/codex/tasks/task_e_6859224e19ac832e824fcde068fbc42a