### PR TITLE
Fix numbering namespace handling

### DIFF
--- a/OfficeIMO.Word/WordList.cs
+++ b/OfficeIMO.Word/WordList.cs
@@ -661,10 +661,8 @@ public partial class WordList : WordElement {
     private static void EnsureW15Namespace(Numbering numbering) {
         const string prefix = "w15";
         const string ns = "http://schemas.microsoft.com/office/word/2012/wordml";
-        try {
+        if (numbering.LookupNamespace(prefix) == null) {
             numbering.AddNamespaceDeclaration(prefix, ns);
-        } catch (InvalidOperationException) {
-            // namespace already defined
         }
         if (numbering.MCAttributes == null) {
                 numbering.MCAttributes = new MarkupCompatibilityAttributes { Ignorable = prefix };

--- a/OfficeIMO.Word/WordList.cs
+++ b/OfficeIMO.Word/WordList.cs
@@ -1,6 +1,7 @@
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using DocumentFormat.OpenXml;
+using System.Linq;
 
 namespace OfficeIMO.Word;
 
@@ -221,6 +222,7 @@ public partial class WordList : WordElement {
         }
         set {
             var numbering = _document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart!.Numbering;
+            EnsureW15Namespace(numbering);
             var listAbstracts = numbering.ChildElements.OfType<AbstractNum>();
             foreach (var abstractInstance in listAbstracts) {
                 if (abstractInstance.AbstractNumberId == _abstractId) {
@@ -654,5 +656,25 @@ public partial class WordList : WordElement {
         }
         // Remove the other list
         documentList.Remove();
+    }
+
+    private static void EnsureW15Namespace(Numbering numbering) {
+        const string prefix = "w15";
+        const string ns = "http://schemas.microsoft.com/office/word/2012/wordml";
+        try {
+            numbering.AddNamespaceDeclaration(prefix, ns);
+        } catch (InvalidOperationException) {
+            // namespace already defined
+        }
+        if (numbering.MCAttributes == null) {
+                numbering.MCAttributes = new MarkupCompatibilityAttributes { Ignorable = prefix };
+        } else {
+            var ignorable = numbering.MCAttributes.Ignorable?.Value;
+            if (string.IsNullOrEmpty(ignorable)) {
+                numbering.MCAttributes.Ignorable = prefix;
+            } else if (!ignorable.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).Contains(prefix)) {
+                numbering.MCAttributes.Ignorable = ignorable + " " + prefix;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure `w15` namespace is declared when using `RestartNumberingAfterBreak`
- test that setting the property adds the missing namespace

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --framework net9.0 -v minimal` *(fails: The prefix "w15" is already defined in current node.)*

------
https://chatgpt.com/codex/tasks/task_e_6859414edfec832e8950ca0d9a9c6c30