### PR TITLE
Fix DigitalSignature part checks

### DIFF
--- a/OfficeIMO.Tests/Word.DigitalSignature.cs
+++ b/OfficeIMO.Tests/Word.DigitalSignature.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using DocumentFormat.OpenXml.ExtendedProperties;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_DigitalSignature_MissingPart_ReturnsNull() {
+            string tempFile = Path.GetTempFileName();
+            using (WordDocument document = WordDocument.Create(tempFile)) {
+                Assert.True(document.ApplicationProperties.DigitalSignature == null);
+            }
+        }
+
+        [Fact]
+        public void Test_DigitalSignature_PartDeleted_ReturnsNull() {
+            string tempFile = Path.GetTempFileName();
+            using (WordDocument document = WordDocument.Create(tempFile)) {
+                document.ApplicationProperties.DigitalSignature = new DigitalSignature();
+                Assert.True(document.ApplicationProperties.DigitalSignature != null);
+                document._wordprocessingDocument.DeletePart(document._wordprocessingDocument.ExtendedFilePropertiesPart);
+                Assert.True(document.ApplicationProperties.DigitalSignature == null);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/ApplicationProperties.cs
+++ b/OfficeIMO.Word/ApplicationProperties.cs
@@ -479,6 +479,9 @@ namespace OfficeIMO.Word {
         private void CreateExtendedFileProperties() {
             if (_wordprocessingDocument.ExtendedFilePropertiesPart == null) {
                 _wordprocessingDocument.AddExtendedFilePropertiesPart();
+            }
+
+            if (_wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
                 _wordprocessingDocument.ExtendedFilePropertiesPart.Properties = new Properties();
             }
         }


### PR DESCRIPTION
## Summary
- ensure `CreateExtendedFileProperties` creates the `Properties` node
- add tests verifying `DigitalSignature` access returns null when parts are absent

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685a71dd664c832e8b16f2078ed71902