### PR TITLE
Fix footnote numbering continuation

### DIFF
--- a/OfficeIMO.Tests/Word.FootNotes.cs
+++ b/OfficeIMO.Tests/Word.FootNotes.cs
@@ -201,5 +201,24 @@ namespace OfficeIMO.Tests {
                 document.Save(false);
             }
         }
+
+        [Fact]
+        public void Test_FootnoteNumberingAcrossSections() {
+            string filePath = Path.Combine(_directoryWithFiles, "FootnoteNumberingSections.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddFootnoteProperties(restartNumbering: RestartNumberValues.EachSection);
+
+                document.AddParagraph("Section1").AddFootNote("fn1");
+                document.AddSection();
+                document.Sections[1].AddParagraph("Section2").AddFootNote("fn2");
+
+                document.Save();
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal(2, document.FootNotes.Count);
+                Assert.Null(document.Sections[1].FootnoteProperties?.NumberingRestart);
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordSection.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordSection.PrivateMethods.cs
@@ -627,6 +627,16 @@ namespace OfficeIMO.Word {
                         //    newSectionProperties.Append(element.CloneNode(true));
                         //} else if (element is SectionType) {
                         //    newSectionProperties.Append(element.CloneNode(true));
+                    } else if (element is FootnoteProperties footnoteProps) {
+                        var cloned = (FootnoteProperties)footnoteProps.CloneNode(true);
+                        cloned.RemoveAllChildren<NumberingRestart>();
+                        newSectionProperties.Append(cloned);
+                        footnoteProps.RemoveAllChildren<NumberingRestart>();
+                    } else if (element is EndnoteProperties endnoteProps) {
+                        var cloned = (EndnoteProperties)endnoteProps.CloneNode(true);
+                        cloned.RemoveAllChildren<NumberingRestart>();
+                        newSectionProperties.Append(cloned);
+                        endnoteProps.RemoveAllChildren<NumberingRestart>();
                     } else if (element is TitlePage) {
                         newSectionProperties.Append(element.CloneNode(true));
                         sectionProperties.RemoveChild(element);


### PR DESCRIPTION
## Summary
- keep footnote numbering continuous when copying SectionProperties
- add test covering numbering across section breaks

## Testing
- `dotnet restore`
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685a71e6618c832ebf107a81d00cd829