### PR TITLE
Implement Word list style detection

### DIFF
--- a/OfficeIMO.Tests/Word.ListStyleDetection.cs
+++ b/OfficeIMO.Tests/Word.ListStyleDetection.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.Linq;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_ListStyleDetection() {
+            var filePath = Path.Combine(_directoryWithFiles, "ListStyleDetection.docx");
+            var styles = new[] {
+                WordListStyle.Bulleted,
+                WordListStyle.Headings111,
+                WordListStyle.ArticleSections
+            };
+
+            using (var document = WordDocument.Create(filePath)) {
+                foreach (var style in styles) {
+                    var list = document.AddList(style);
+                    list.AddItem("Item");
+                }
+                document.Save();
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(styles.Length, document.Lists.Count);
+                var detected = document.Lists.Select(l => l.Style).ToList();
+                foreach (var style in styles) {
+                    Assert.Contains(style, detected);
+                }
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Word/WordList.Private.cs
+++ b/OfficeIMO.Word/WordList.Private.cs
@@ -8,8 +8,15 @@ public partial class WordList : WordElement {
     /// Retrieves the <see cref="AbstractNum"/> associated with this list.
     /// </summary>
     private AbstractNum GetAbstractNum() {
-        return _document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart!.Numbering
-            .Elements<AbstractNum>().FirstOrDefault(a => a.AbstractNumberId.Value == _abstractId);
+        var numbering = _document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart!.Numbering;
+        if (_abstractId == 0) {
+            var instance = numbering.Elements<NumberingInstance>()
+                .FirstOrDefault(n => n.NumberID.Value == _numberId);
+            if (instance?.AbstractNumId?.Val != null) {
+                _abstractId = (int)instance.AbstractNumId.Val.Value;
+            }
+        }
+        return numbering.Elements<AbstractNum>().FirstOrDefault(a => a.AbstractNumberId.Value == _abstractId);
     }
 
     /// <summary>

--- a/OfficeIMO.Word/WordList.cs
+++ b/OfficeIMO.Word/WordList.cs
@@ -398,6 +398,11 @@ public partial class WordList : WordElement {
     }
 
     /// <summary>
+    /// Gets the list style or <see cref="WordListStyle.Custom"/> when the list does not match a built-in style.
+    /// </summary>
+    public WordListStyle Style => WordListStyles.MatchStyle(GetAbstractNum());
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="WordList"/> class.
     /// </summary>
     /// <param name="wordDocument">The Word document.</param>

--- a/OfficeIMO.Word/WordListStyle.cs
+++ b/OfficeIMO.Word/WordListStyle.cs
@@ -45,6 +45,32 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Attempts to match an <see cref="AbstractNum"/> to one of the built-in list styles.
+        /// </summary>
+        /// <param name="abstractNum">The abstract numbering definition to compare.</param>
+        /// <returns>The matching <see cref="WordListStyle"/> or <see cref="WordListStyle.Custom"/> when no match is found.</returns>
+        public static WordListStyle MatchStyle(AbstractNum abstractNum) {
+            if (abstractNum == null) throw new ArgumentNullException(nameof(abstractNum));
+
+            var templateCode = abstractNum.GetFirstChild<TemplateCode>()?.Val?.Value;
+            return templateCode switch {
+                "934E79A6" => WordListStyle.Bulleted,
+                "04090023" => WordListStyle.ArticleSections,
+                "04090025" => WordListStyle.Headings111,
+                "04090027" => WordListStyle.HeadingIA1,
+                "04090029" => WordListStyle.Chapters,
+                "04090021" => WordListStyle.BulletedChars,
+                "0409001D" => WordListStyle.Heading1ai,
+                "0409001F" => WordListStyle.Headings111Shifted,
+                "BB9E481E" => WordListStyle.LowerLetterWithBracket,
+                "73ECA528" => WordListStyle.LowerLetterWithDot,
+                "76643E8A" => WordListStyle.UpperLetterWithDot,
+                "76643E8C" => WordListStyle.UpperLetterWithBracket,
+                _ => WordListStyle.Custom
+            };
+        }
+
+        /// <summary>
         /// The next abstract number identifier stored to be used when creating new abstract numbers
         /// </summary>
         private static int nextAbstractNumberId;


### PR DESCRIPTION
## Summary
- add `WordListStyles.MatchStyle` to map `AbstractNum` instances to built‑in styles
- expose `WordList.Style` for detecting the style of an existing list
- resolve abstract numbering when loading lists so detection works
- add tests verifying that list styles are detected correctly

## Testing
- `dotnet test --verbosity minimal`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_685a7d6eb2e8832eaf64ecba41a2ab56