### PR TITLE
Fix default section margins

### DIFF
--- a/OfficeIMO.Tests/Word.Margins.cs
+++ b/OfficeIMO.Tests/Word.Margins.cs
@@ -113,6 +113,25 @@ namespace OfficeIMO.Tests {
             }
 
         }
+
+        [Fact]
+        public void Test_DefaultMarginsWhenAddingSection() {
+            using var document = WordDocument.Create();
+
+            Assert.Equal(WordMargin.Normal, document.Sections[0].Margins.Type);
+            Assert.Equal<UInt32>(1440U, document.Sections[0].Margins.Left);
+            Assert.Equal<UInt32>(1440U, document.Sections[0].Margins.Right);
+            Assert.Equal(1440, document.Sections[0].Margins.Top);
+            Assert.Equal(1440, document.Sections[0].Margins.Bottom);
+
+            var section = document.AddSection();
+
+            Assert.Equal(WordMargin.Normal, section.Margins.Type);
+            Assert.Equal<UInt32>(1440U, section.Margins.Left);
+            Assert.Equal<UInt32>(1440U, section.Margins.Right);
+            Assert.Equal(1440, section.Margins.Top);
+            Assert.Equal(1440, section.Margins.Bottom);
+        }
     }
 
 }

--- a/OfficeIMO.Word/WordMargins.cs
+++ b/OfficeIMO.Word/WordMargins.cs
@@ -32,7 +32,7 @@ namespace OfficeIMO.Word {
                     return pageMargin.Left;
                 }
 
-                return null;
+                return WordMargins.Normal.Left;
             }
             set {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -55,7 +55,7 @@ namespace OfficeIMO.Word {
                     return pageMargin.Right;
                 }
 
-                return null;
+                return WordMargins.Normal.Right;
             }
             set {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -78,7 +78,7 @@ namespace OfficeIMO.Word {
                     return pageMargin.Top;
                 }
 
-                return null;
+                return WordMargins.Normal.Top;
             }
             set {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -101,7 +101,7 @@ namespace OfficeIMO.Word {
                     return pageMargin.Bottom;
                 }
 
-                return null;
+                return WordMargins.Normal.Bottom;
             }
             set {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -177,7 +177,7 @@ namespace OfficeIMO.Word {
                     return pageMargin.Header;
                 }
 
-                return null;
+                return WordMargins.Normal.Header;
             }
             set {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -200,7 +200,7 @@ namespace OfficeIMO.Word {
                     return pageMargin.Footer;
                 }
 
-                return null;
+                return WordMargins.Normal.Footer;
             }
             set {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -220,7 +220,7 @@ namespace OfficeIMO.Word {
                     return pageMargin.Gutter;
                 }
 
-                return null;
+                return WordMargins.Normal.Gutter;
             }
             set {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -277,7 +277,7 @@ namespace OfficeIMO.Word {
                     return WordMargin.Unknown;
                 }
 
-                return null;
+                return WordMargin.Normal;
             }
             set => SetMargins(value);
         }


### PR DESCRIPTION
## Summary
- return 1-inch margin defaults when no margins are set
- return WordMargin.Normal when margin type is undefined
- test that newly added sections keep normal margins

## Testing
- `dotnet test OfficeImo.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_685a839b23f8832ea17a94f4e658fee6