### PR TITLE
Implement WordImage coordinate support

### DIFF
--- a/OfficeIMO.Tests/Word.ImageCoordinates.cs
+++ b/OfficeIMO.Tests/Word.ImageCoordinates.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using DocumentFormat.OpenXml.Drawing.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_ImageLocation_Inline() {
+            var filePath = Path.Combine(_directoryWithFiles, "ImageLocationInline.docx");
+            using var document = WordDocument.Create(filePath);
+
+            var paragraph = document.AddParagraph();
+            paragraph.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 50, 50);
+
+            var loc = paragraph.Image.Location;
+            Assert.Equal(0, loc.X);
+            Assert.Equal(0, loc.Y);
+
+            document.Save(false);
+        }
+
+        [Fact]
+        public void Test_ImageLocation_Floating() {
+            var filePath = Path.Combine(_directoryWithFiles, "ImageLocationFloating.docx");
+            using var document = WordDocument.Create(filePath);
+
+            var paragraph = document.AddParagraph();
+            paragraph.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 50, 50, WrapTextImage.Square);
+            int offset = 914400;
+            paragraph.Image.horizontalPosition = new HorizontalPosition() {
+                RelativeFrom = HorizontalRelativePositionValues.Page,
+                PositionOffset = new PositionOffset { Text = offset.ToString() }
+            };
+            paragraph.Image.verticalPosition = new VerticalPosition() {
+                RelativeFrom = VerticalRelativePositionValues.Page,
+                PositionOffset = new PositionOffset { Text = offset.ToString() }
+            };
+
+            var loc = paragraph.Image.Location;
+            Assert.Equal(offset, loc.X);
+            Assert.Equal(offset, loc.Y);
+
+            document.Save(false);
+        }
+    }
+}

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -928,6 +928,26 @@ namespace OfficeIMO.Word {
             }
         }
 
+        public (int X, int Y) Location {
+            get {
+                if (_Image.Anchor != null) {
+                    var hPos = _Image.Anchor.HorizontalPosition;
+                    var vPos = _Image.Anchor.VerticalPosition;
+                    int x = 0;
+                    int y = 0;
+                    if (hPos?.PositionOffset != null) {
+                        int.TryParse(hPos.PositionOffset.Text, out x);
+                    }
+                    if (vPos?.PositionOffset != null) {
+                        int.TryParse(vPos.PositionOffset.Text, out y);
+                    }
+                    return (x, y);
+                }
+
+                return (0, 0);
+            }
+        }
+
         /// <summary>
         /// Indicates whether resizing should be relative to the original size.
         /// </summary>


### PR DESCRIPTION
## Summary
- expose `(int X, int Y) Location` property on `WordImage`
- verify inline images return zero coordinates
- verify floating images return set offsets

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685a8382e968832ead80dc09240ed6e6