### PR TITLE
Fix row height persistence with AutoFit

### DIFF
--- a/Docs/officeimo.word.wordtable.md
+++ b/Docs/officeimo.word.wordtable.md
@@ -270,7 +270,7 @@ public List<int> ColumnWidth { get; set; }
 
 ### **RowHeight**
 
-Get or Set Table Row Height for 1st row
+Gets or sets the height for each row in the table.
 
 ```csharp
 public List<int> RowHeight { get; set; }
@@ -279,6 +279,7 @@ public List<int> RowHeight { get; set; }
 #### Property Value
 
 [List&lt;Int32&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1)<br>
+The collection contains the height of each row or `0` if the row has no explicit height set.
 
 ### **Cells**
 

--- a/Docs/officeimo.word.wordtablerow.md
+++ b/Docs/officeimo.word.wordtablerow.md
@@ -60,7 +60,8 @@ public int CellsCount { get; }
 
 ### **Height**
 
-Gets or sets height of a row
+Gets or sets the height of a row. The value is stored with
+`HeightRuleValues.Exact` to ensure it is preserved even when AutoFit is used.
 
 ```csharp
 public Nullable<int> Height { get; set; }

--- a/OfficeIMO.Tests/Word.Tables.cs
+++ b/OfficeIMO.Tests/Word.Tables.cs
@@ -1322,5 +1322,23 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Test_TableRowHeightWithAutoFit() {
+            string filePath = Path.Combine(_directoryWithFiles, "TableRowHeightAutoFit.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(2, 2);
+                table.Rows[0].Height = 500;
+                table.Rows[1].Height = 300;
+                table.AutoFitToWindow();
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                WordTable table = document.Tables[0];
+                Assert.Equal(500, table.Rows[0].Height);
+                Assert.Equal(300, table.Rows[1].Height);
+            }
+        }
+
     }
 }

--- a/OfficeIMO.Word/WordTable.Properties.cs
+++ b/OfficeIMO.Word/WordTable.Properties.cs
@@ -172,14 +172,16 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
-        /// Get or Set Table Row Height for 1st row
+        /// Get or set row heights for the table
         /// </summary>
         public List<int> RowHeight {
             get {
                 var listReturn = new List<int>();
-                // we assume the first row has the same widths as all rows, which may or may not be true
-                for (int rowIndex = 0; rowIndex >= this.Rows.Count; rowIndex++) {
-                    listReturn.Add(this.Rows[rowIndex].Height.Value);
+                for (int rowIndex = 0; rowIndex < this.Rows.Count; rowIndex++) {
+                    if (this.Rows[rowIndex].Height.HasValue)
+                        listReturn.Add(this.Rows[rowIndex].Height.Value);
+                    else
+                        listReturn.Add(0);
                 }
                 return listReturn;
             }

--- a/OfficeIMO.Word/WordTableRow.cs
+++ b/OfficeIMO.Word/WordTableRow.cs
@@ -54,10 +54,11 @@ namespace OfficeIMO.Word {
                     AddTableRowProperties();
                     var tableRowHeight = _tableRow.TableRowProperties.OfType<TableRowHeight>().FirstOrDefault();
                     if (tableRowHeight == null) {
-                        _tableRow.TableRowProperties.InsertAt(new TableRowHeight(), 0);
-                        tableRowHeight = _tableRow.TableRowProperties.OfType<TableRowHeight>().FirstOrDefault();
+                        tableRowHeight = new TableRowHeight();
+                        _tableRow.TableRowProperties.InsertAt(tableRowHeight, 0);
                     }
                     tableRowHeight.Val = (uint)value;
+                    tableRowHeight.HeightType = HeightRuleValues.Exact;
                 } else {
                     var tableRowHeight = _tableRow.TableRowProperties.OfType<TableRowHeight>().FirstOrDefault();
                     if (tableRowHeight != null) {


### PR DESCRIPTION
## Summary
- persist row heights even when AutoFit is used
- fix table RowHeight getter
- document row height behavior
- add regression test for row heights

## Testing
- `dotnet test OfficeImo.sln --verbosity minimal`
- `dotnet build OfficeImo.sln --no-restore --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_685a836e84a0832e990e6d82a532cc79