### PR TITLE
Add custom bullet list helper

### DIFF
--- a/OfficeIMO.Tests/Word.AddCustomBulletList.cs
+++ b/OfficeIMO.Tests/Word.AddCustomBulletList.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_AddCustomBulletList() {
+            var filePath = Path.Combine(_directoryWithFiles, "CustomBulletList.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                var list = document.AddCustomBulletList('\u25A0', "Courier New", "#FF0000", 14);
+                list.AddItem("Item 1");
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                var list = document.Lists[0];
+                Assert.Equal("■", list.Numbering.Levels[0].LevelText);
+                Assert.Equal("Courier New", list.FontName);
+                Assert.Equal("ff0000", list.ColorHex);
+                Assert.Equal(14, list.FontSize);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -91,6 +91,18 @@ namespace OfficeIMO.Word {
             return wordList;
         }
 
+        /// <summary>
+        /// Adds a custom bullet list with formatting options.
+        /// </summary>
+        /// <param name="symbol">Bullet symbol.</param>
+        /// <param name="fontName">Font name for the symbol.</param>
+        /// <param name="colorHex">Hex color of the symbol.</param>
+        /// <param name="fontSize">Font size in points.</param>
+        /// <returns>The created <see cref="WordList"/>.</returns>
+        public WordList AddCustomBulletList(char symbol, string fontName, string colorHex, int? fontSize = null) {
+            return WordList.AddCustomBulletList(this, symbol, fontName, colorHex, fontSize);
+        }
+
         public WordList AddTableOfContentList(WordListStyle style) {
             WordList wordList = new WordList(this, true);
             wordList.AddList(style);

--- a/OfficeIMO.Word/WordList.cs
+++ b/OfficeIMO.Word/WordList.cs
@@ -663,6 +663,49 @@ public partial class WordList : WordElement {
         documentList.Remove();
     }
 
+    /// <summary>
+    /// Adds a custom bullet list with a single level using provided formatting.
+    /// </summary>
+    /// <param name="document">Target document.</param>
+    /// <param name="symbol">Bullet symbol.</param>
+    /// <param name="fontName">Font name for the symbol.</param>
+    /// <param name="colorHex">Hex color of the symbol.</param>
+    /// <param name="fontSize">Font size in points.</param>
+    /// <returns>The created <see cref="WordList"/>.</returns>
+    public static WordList AddCustomBulletList(WordDocument document, char symbol, string fontName, string colorHex, int? fontSize = null) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+
+        var list = document.AddList(WordListStyle.Custom);
+
+        var level = new Level();
+        level.Append(new StartNumberingValue() { Val = 1 });
+        level.Append(new NumberingFormat() { Val = NumberFormatValues.Bullet });
+        level.Append(new LevelText() { Val = symbol.ToString() });
+        level.Append(new LevelJustification() { Val = LevelJustificationValues.Left });
+
+        var prevProps = new PreviousParagraphProperties();
+        prevProps.Append(new Indentation() { Left = "720", Hanging = "360" });
+        level.Append(prevProps);
+
+        var symbolProps = new NumberingSymbolRunProperties();
+        if (!string.IsNullOrEmpty(fontName)) {
+            symbolProps.Append(new RunFonts { Ascii = fontName, HighAnsi = fontName });
+        }
+        if (!string.IsNullOrEmpty(colorHex)) {
+            symbolProps.Append(new DocumentFormat.OpenXml.Wordprocessing.Color { Val = colorHex.Replace("#", "").ToLowerInvariant() });
+        }
+        if (fontSize.HasValue) {
+            var size = (fontSize.Value * 2).ToString();
+            symbolProps.Append(new FontSize { Val = size });
+            symbolProps.Append(new FontSizeComplexScript { Val = size });
+        }
+        level.Append(symbolProps);
+
+        list.Numbering.AddLevel(level);
+
+        return list;
+    }
+
     private static void EnsureW15Namespace(Numbering numbering) {
         const string prefix = "w15";
         const string ns = "http://schemas.microsoft.com/office/word/2012/wordml";

--- a/README.md
+++ b/README.md
@@ -419,6 +419,10 @@ using (WordDocument document = WordDocument.Create(filePath)) {
 
     document.AddParagraph();
 
+    // create a custom bullet list
+    var custom = document.AddCustomBulletList('■', "Courier New", "#ff0000", 16);
+    custom.AddItem("Custom bullet item");
+
     var listNumbered = document.AddList(WordListStyle.Heading1ai);
     listNumbered.AddItem("Different list number 1");
     listNumbered.AddItem("Different list number 2", 1);


### PR DESCRIPTION
## Summary
- add `AddCustomBulletList` API for creating custom bullet lists
- integrate the helper with `WordDocument`
- document usage in README
- test custom bullet formatting

## Testing
- `dotnet restore OfficeImo.sln`
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeImo.sln -c Release --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_685a82a146f8832ebd8de83f4b28313b