### PR TITLE
Add XML docs to WordTableRow

### DIFF
--- a/OfficeIMO.Word/WordTableRow.cs
+++ b/OfficeIMO.Word/WordTableRow.cs
@@ -4,6 +4,9 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a row within a <see cref="WordTable"/> and exposes row level operations.
+    /// </summary>
     public class WordTableRow {
         internal readonly TableRow _tableRow;
 
@@ -68,7 +71,10 @@ namespace OfficeIMO.Word {
             }
         }
 
-
+        /// <summary>
+        /// Gets or sets a value indicating whether the row is allowed to break across pages.
+        /// When set to <c>false</c>, the row is kept intact on a single page.
+        /// </summary>
         public bool AllowRowToBreakAcrossPages {
             get {
                 if (_tableRow.TableRowProperties != null) {
@@ -133,6 +139,11 @@ namespace OfficeIMO.Word {
         private readonly WordTable _wordTable;
         private readonly WordDocument _document;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WordTableRow"/> class and creates an empty row.
+        /// </summary>
+        /// <param name="document">The parent <see cref="WordDocument"/>.</param>
+        /// <param name="wordTable">The table to which this row belongs.</param>
         public WordTableRow(WordDocument document, WordTable wordTable) {
             // Create a row.
             TableRow tableRow = new TableRow();
@@ -141,6 +152,12 @@ namespace OfficeIMO.Word {
             _wordTable = wordTable;
 
         }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WordTableRow"/> class from an existing <see cref="TableRow"/>.
+        /// </summary>
+        /// <param name="wordTable">The parent <see cref="WordTable"/>.</param>
+        /// <param name="row">The underlying Open XML table row.</param>
+        /// <param name="document">The parent <see cref="WordDocument"/>.</param>
         public WordTableRow(WordTable wordTable, TableRow row, WordDocument document) {
             _document = document;
             _tableRow = row;
@@ -151,6 +168,10 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Appends the specified <see cref="WordTableCell"/> to the end of this row.
+        /// </summary>
+        /// <param name="cell">The cell to append.</param>
         public void Add(WordTableCell cell) {
             _tableRow.Append(cell._tableCell);
         }


### PR DESCRIPTION
## Summary
- document `WordTableRow` class
- add comments for `AllowRowToBreakAcrossPages`
- document constructors
- document `Add` method

## Testing
- `dotnet build`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685a94b47294832e834b8b15a6607780