### PR TITLE
Add unified paragraph enumerator

### DIFF
--- a/OfficeIMO.Tests/Word.ListItemsEnumerator.cs
+++ b/OfficeIMO.Tests/Word.ListItemsEnumerator.cs
@@ -1,0 +1,58 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_ListItemsFromBodyTablesHeadersFooters() {
+            var filePath = Path.Combine(_directoryWithFiles, "ListItemsEnumerator.docx");
+
+            using (var document = WordDocument.Create(filePath)) {
+                var bodyList = document.AddList(WordListStyle.Bulleted);
+                bodyList.AddItem("Body1");
+                bodyList.AddItem("Body2");
+
+                var table = document.AddTable(1, 1);
+                var tableList = table.Rows[0].Cells[0].AddList(WordListStyle.Bulleted);
+                tableList.AddItem("Table1");
+                tableList.AddItem("Table2");
+
+                document.AddHeadersAndFooters();
+                var headerList = document.Header.Default.AddList(WordListStyle.Bulleted);
+                headerList.AddItem("Header1");
+                headerList.AddItem("Header2");
+
+                var footerList = document.Footer.Default.AddList(WordListStyle.Bulleted);
+                footerList.AddItem("Footer1");
+                footerList.AddItem("Footer2");
+
+                Assert.Equal(4, document.Lists.Count);
+                Assert.Equal(2, bodyList.ListItems.Count);
+                Assert.Equal(2, tableList.ListItems.Count);
+                Assert.Equal(2, headerList.ListItems.Count);
+                Assert.Equal(2, footerList.ListItems.Count);
+
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(4, document.Lists.Count);
+
+                var bodyList = document.Lists.First(l => l.ListItems.First().Text == "Body1");
+                Assert.Equal(new[] { "Body1", "Body2" }, bodyList.ListItems.Select(i => i.Text).ToArray());
+
+                var tableList = document.Lists.First(l => l.ListItems.First().Text == "Table1");
+                Assert.Equal(new[] { "Table1", "Table2" }, tableList.ListItems.Select(i => i.Text).ToArray());
+
+                var headerList = document.Lists.First(l => l.ListItems.First().Text == "Header1");
+                Assert.Equal(new[] { "Header1", "Header2" }, headerList.ListItems.Select(i => i.Text).ToArray());
+
+                var footerList = document.Lists.First(l => l.ListItems.First().Text == "Footer1");
+                Assert.Equal(new[] { "Footer1", "Footer2" }, footerList.ListItems.Select(i => i.Text).ToArray());
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.Enumerators.cs
+++ b/OfficeIMO.Word/WordDocument.Enumerators.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Word {
+    public partial class WordDocument {
+        internal IEnumerable<WordParagraph> EnumerateAllParagraphs() {
+            foreach (var paragraph in this.Paragraphs) {
+                yield return paragraph;
+            }
+
+            foreach (var table in this.Tables) {
+                foreach (var paragraph in table.Paragraphs) {
+                    yield return paragraph;
+                }
+            }
+
+            foreach (var paragraph in EnumerateHeaderFooterParagraphs(this.Header.Default)) {
+                yield return paragraph;
+            }
+            foreach (var paragraph in EnumerateHeaderFooterParagraphs(this.Header.Even)) {
+                yield return paragraph;
+            }
+            foreach (var paragraph in EnumerateHeaderFooterParagraphs(this.Header.First)) {
+                yield return paragraph;
+            }
+            foreach (var paragraph in EnumerateHeaderFooterParagraphs(this.Footer.Default)) {
+                yield return paragraph;
+            }
+            foreach (var paragraph in EnumerateHeaderFooterParagraphs(this.Footer.Even)) {
+                yield return paragraph;
+            }
+            foreach (var paragraph in EnumerateHeaderFooterParagraphs(this.Footer.First)) {
+                yield return paragraph;
+            }
+        }
+
+        private static IEnumerable<WordParagraph> EnumerateHeaderFooterParagraphs(WordHeaderFooter headerFooter) {
+            if (headerFooter == null) yield break;
+
+            foreach (var paragraph in headerFooter.Paragraphs) {
+                yield return paragraph;
+            }
+
+            foreach (var table in headerFooter.Tables) {
+                foreach (var paragraph in table.Paragraphs) {
+                    yield return paragraph;
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordList.cs
+++ b/OfficeIMO.Word/WordList.cs
@@ -37,110 +37,13 @@ public partial class WordList : WordElement {
     public List<WordParagraph> ListItems {
         get {
             List<WordParagraph> list = new List<WordParagraph>();
-            foreach (var paragraph in _document.Paragraphs) {
-                if (paragraph.IsListItem == true && paragraph._listNumberId == _numberId) {
+
+            foreach (var paragraph in _document.EnumerateAllParagraphs()) {
+                if (paragraph.IsListItem && paragraph._listNumberId == _numberId) {
                     list.Add(paragraph);
                 }
             }
 
-            foreach (var table in _document.Tables) {
-                foreach (var paragraph in table.Paragraphs) {
-                    if (paragraph.IsListItem == true && paragraph._listNumberId == _numberId) {
-                        list.Add(paragraph);
-                    }
-                }
-            }
-
-            if (_document.Header.Default != null) {
-                foreach (var paragraph in _document.Header.Default.Paragraphs) {
-                    if (paragraph.IsListItem == true && paragraph._listNumberId == _numberId) {
-                        list.Add(paragraph);
-                    }
-                }
-                foreach (var table in _document.Header.Default.Tables) {
-                    foreach (var paragraph in table.Paragraphs) {
-                        if (paragraph.IsListItem == true && paragraph._listNumberId == _numberId) {
-                            list.Add(paragraph);
-                        }
-                    }
-                }
-            }
-
-            if (_document.Header.Even != null) {
-                foreach (var paragraph in _document.Header.Even.Paragraphs) {
-                    if (paragraph.IsListItem == true && paragraph._listNumberId == _numberId) {
-                        list.Add(paragraph);
-                    }
-                }
-                foreach (var table in _document.Header.Even.Tables) {
-                    foreach (var paragraph in table.Paragraphs) {
-                        if (paragraph.IsListItem == true && paragraph._listNumberId == _numberId) {
-                            list.Add(paragraph);
-                        }
-                    }
-                }
-            }
-
-            if (_document.Header.First != null) {
-                foreach (var paragraph in _document.Header.First.Paragraphs) {
-                    if (paragraph.IsListItem == true && paragraph._listNumberId == _numberId) {
-                        list.Add(paragraph);
-                    }
-                }
-                foreach (var table in _document.Header.First.Tables) {
-                    foreach (var paragraph in table.Paragraphs) {
-                        if (paragraph.IsListItem == true && paragraph._listNumberId == _numberId) {
-                            list.Add(paragraph);
-                        }
-                    }
-                }
-            }
-
-
-            if (_document.Footer.Default != null) {
-                foreach (var paragraph in _document.Footer.Default.Paragraphs) {
-                    if (paragraph.IsListItem == true && paragraph._listNumberId == _numberId) {
-                        list.Add(paragraph);
-                    }
-                }
-                foreach (var table in _document.Footer.Default.Tables) {
-                    foreach (var paragraph in table.Paragraphs) {
-                        if (paragraph.IsListItem == true && paragraph._listNumberId == _numberId) {
-                            list.Add(paragraph);
-                        }
-                    }
-                }
-            }
-
-            if (_document.Footer.Even != null) {
-                foreach (var paragraph in _document.Footer.Even.Paragraphs) {
-                    if (paragraph.IsListItem == true && paragraph._listNumberId == _numberId) {
-                        list.Add(paragraph);
-                    }
-                }
-                foreach (var table in _document.Footer.Even.Tables) {
-                    foreach (var paragraph in table.Paragraphs) {
-                        if (paragraph.IsListItem == true && paragraph._listNumberId == _numberId) {
-                            list.Add(paragraph);
-                        }
-                    }
-                }
-            }
-
-            if (_document.Footer.First != null) {
-                foreach (var paragraph in _document.Footer.First.Paragraphs) {
-                    if (paragraph.IsListItem == true && paragraph._listNumberId == _numberId) {
-                        list.Add(paragraph);
-                    }
-                }
-                foreach (var table in _document.Footer.First.Tables) {
-                    foreach (var paragraph in table.Paragraphs) {
-                        if (paragraph.IsListItem == true && paragraph._listNumberId == _numberId) {
-                            list.Add(paragraph);
-                        }
-                    }
-                }
-            }
             return list;
 
 


### PR DESCRIPTION
## Summary
- create `EnumerateAllParagraphs` helper on `WordDocument`
- replace duplicated loops in `WordList.ListItems`
- add tests for lists inside tables and headers/footers

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeImo.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685aa741f62c832ebf3f4e8291d7d547