### PR TITLE
Add XML docs to Word utilities

### DIFF
--- a/OfficeIMO.Word/WordFind.cs
+++ b/OfficeIMO.Word/WordFind.cs
@@ -3,17 +3,30 @@ using System.Collections.Generic;
 using System.Text;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents the results of a find and replace operation within a document.
+    /// </summary>
     public class WordFind {
+        /// <summary>Gets or sets the number of matches found.</summary>
         public int Found = 0;
+        /// <summary>Gets or sets the number of replacements performed.</summary>
         public int Replacements = 0;
 
+        /// <summary>Paragraphs containing matches.</summary>
         public List<WordParagraph> Paragraphs = new List<WordParagraph>();
+        /// <summary>Table cells containing matches.</summary>
         public List<WordParagraph> Tables = new List<WordParagraph>();
+        /// <summary>Header paragraphs containing matches when using the default header.</summary>
         public List<WordParagraph> HeaderDefault = new List<WordParagraph>();
+        /// <summary>Header paragraphs containing matches when using even page headers.</summary>
         public List<WordParagraph> HeaderEven = new List<WordParagraph>();
+        /// <summary>Header paragraphs containing matches when using the first page header.</summary>
         public List<WordParagraph> HeaderFirst = new List<WordParagraph>();
+        /// <summary>Footer paragraphs containing matches when using the default footer.</summary>
         public List<WordParagraph> FooterDefault = new List<WordParagraph>();
+        /// <summary>Footer paragraphs containing matches when using even page footers.</summary>
         public List<WordParagraph> FooterEven = new List<WordParagraph>();
+        /// <summary>Footer paragraphs containing matches when using the first page footer.</summary>
         public List<WordParagraph> FooterFirst = new List<WordParagraph>();
 
 
@@ -61,7 +74,19 @@ namespace OfficeIMO.Word {
 
 
 
+/// <summary>
+/// Provides helper string extensions used by the library.
+/// </summary>
 public static class StringExtensions {
+    /// <summary>
+    /// Replaces all occurrences of <paramref name="oldValue"/> with <paramref name="newValue"/> using the specified comparison type.
+    /// </summary>
+    /// <param name="str">Source string.</param>
+    /// <param name="oldValue">Value to search for.</param>
+    /// <param name="newValue">Value to replace with.</param>
+    /// <param name="comparisonType">String comparison type.</param>
+    /// <param name="count">Outputs the number of replacements performed.</param>
+    /// <returns>The resulting string after replacements.</returns>
     public static string FindAndReplace(this string str, string oldValue, string newValue, StringComparison comparisonType, ref int count) {
         List<string> list = new List<string>();
         // Check inputs.

--- a/OfficeIMO.Word/WordWrapTextImage.cs
+++ b/OfficeIMO.Word/WordWrapTextImage.cs
@@ -3,21 +3,40 @@ using System.Linq;
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Specifies the available options for how text should wrap around an image.
+    /// </summary>
     public enum WrapTextImage {
+        /// <summary>No wrapping is applied and the image is placed inline with the surrounding text.</summary>
         InLineWithText,
+        /// <summary>Wrap text around the image using a square boundary.</summary>
         Square,
+        /// <summary>Wrap text tightly around the outline of the image.</summary>
         Tight,
+        /// <summary>Allow text to flow through transparent regions of the image.</summary>
         Through,
+        /// <summary>Place text above and below the image leaving the sides clear.</summary>
         TopAndBottom,
+        /// <summary>Position the image behind the text.</summary>
         BehindText,
+        /// <summary>Position the image in front of the text.</summary>
         InFrontOfText,
     }
 
+    /// <summary>
+    /// Provides helper methods for configuring image wrap options on Wordprocessing elements.
+    /// </summary>
     public class WordWrapTextImage {
         private WordWrapTextImage(WrapTextImage wrapTextImage) {
 
         }
 
+        /// <summary>
+        /// Appends the appropriate wrapping element for the specified option to the given anchor.
+        /// </summary>
+        /// <param name="anchor">The anchor to which the wrapping should be applied.</param>
+        /// <param name="wrapImage">The desired wrapping option.</param>
+        /// <returns>The modified anchor.</returns>
         public static Anchor AppendWrapTextImage(Anchor anchor, WrapTextImage wrapImage) {
             if (wrapImage == WrapTextImage.Square) {
                 WrapSquare wrapSquare1 = new WrapSquare() {
@@ -47,6 +66,12 @@ namespace OfficeIMO.Word {
             return anchor;
         }
 
+        /// <summary>
+        /// Returns the currently applied wrapping option for the specified drawing.
+        /// </summary>
+        /// <param name="anchor">Anchor element associated with the drawing.</param>
+        /// <param name="inline">Inline element associated with the drawing.</param>
+        /// <returns>The wrap option or <c>null</c> if none can be determined.</returns>
         public static WrapTextImage? GetWrapTextImage(Anchor anchor, Inline inline) {
             if (anchor != null) {
                 var wrapSquare = anchor.OfType<WrapSquare>().FirstOrDefault();
@@ -78,6 +103,13 @@ namespace OfficeIMO.Word {
             return null;
         }
 
+        /// <summary>
+        /// Sets the wrapping option for the provided drawing.
+        /// </summary>
+        /// <param name="drawing">The drawing element to update.</param>
+        /// <param name="anchor">Anchor element associated with the drawing.</param>
+        /// <param name="inline">Inline element associated with the drawing.</param>
+        /// <param name="wrapImage">The desired wrapping option.</param>
         public static void SetWrapTextImage(DocumentFormat.OpenXml.Wordprocessing.Drawing drawing, Anchor anchor, Inline inline, WrapTextImage? wrapImage) {
             var currentWrap = GetWrapTextImage(anchor, inline);
             if (currentWrap == wrapImage) {
@@ -151,6 +183,9 @@ namespace OfficeIMO.Word {
         }
 
 
+        /// <summary>
+        /// Gets a <see cref="WrapTopBottom"/> instance used for top and bottom wrapping.
+        /// </summary>
         public static WrapTopBottom WrapTopBottom {
             get {
                 WrapTopBottom wrapTopBottom1 = new WrapTopBottom() {
@@ -162,6 +197,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets a <see cref="WrapThrough"/> instance used for through wrapping.
+        /// </summary>
         public static WrapThrough WrapThrough {
             get {
                 WrapThrough wrapThrough1 = new WrapThrough() { WrapText = WrapTextValues.BothSides };
@@ -184,6 +222,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets a <see cref="WrapTight"/> instance used for tight wrapping.
+        /// </summary>
         public static WrapTight WrapTight {
             get {
                 WrapTight wrapTight1 = new WrapTight() { WrapText = WrapTextValues.BothSides };


### PR DESCRIPTION
## Summary
- add documentation comments for `WordFind` and `StringExtensions`
- document `WrapTextImage` enum and `WordWrapTextImage` helper class

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685adef6e040832e8cb60aeb40794fad