### PR TITLE
Fix parallel test image access

### DIFF
--- a/OfficeIMO.Word/WordEmbeddedObject.cs
+++ b/OfficeIMO.Word/WordEmbeddedObject.cs
@@ -90,7 +90,7 @@ namespace OfficeIMO.Word {
 
         private EmbeddedObject ConvertFileToEmbeddedObject(WordDocument wordDocument, string fileName, string fileImage, double width, double height) {
             ImagePart imagePart = wordDocument._document.MainDocumentPart.AddImagePart(ImagePartType.Png);
-            using (FileStream stream = new FileStream(fileImage, FileMode.Open)) {
+            using (FileStream stream = new FileStream(fileImage, FileMode.Open, FileAccess.Read, FileShare.Read)) {
                 imagePart.FeedData(stream);
             }
             MainDocumentPart mainPart = wordDocument._document.MainDocumentPart;
@@ -103,7 +103,7 @@ namespace OfficeIMO.Word {
 
             EmbeddedPackagePart embeddedObjectPart = mainPart.AddEmbeddedPackagePart(contentType);
 
-            using (FileStream fileStream = new FileStream(fileName, FileMode.Open)) {
+            using (FileStream fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read)) {
                 embeddedObjectPart.FeedData(fileStream);
             }
 

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -1481,7 +1481,7 @@ namespace OfficeIMO.Word {
         public WordImage(WordDocument document, WordParagraph paragraph, string filePath, double? width, double? height, WrapTextImage wrapImage = WrapTextImage.InLineWithText, string description = "", ShapeTypeValues? shape = null, BlipCompressionValues? compressionQuality = null) {
             FilePath = filePath;
             var fileName = System.IO.Path.GetFileName(filePath);
-            using var imageStream = new FileStream(filePath, FileMode.Open);
+            using var imageStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
             shape ??= ShapeTypeValues.Rectangle; // Set default value if not provided
             compressionQuality ??= BlipCompressionValues.Print; // Set default value if not provided
             AddImage(document, paragraph, imageStream, fileName, width, height, shape.Value, compressionQuality.Value, description, wrapImage);

--- a/OfficeIMO.Word/WordWatermark.cs
+++ b/OfficeIMO.Word/WordWatermark.cs
@@ -501,7 +501,7 @@ namespace OfficeIMO.Word {
                 this._sdtBlock = GetStyle(style);
 
                 var fileName = System.IO.Path.GetFileName(textOrFilePath);
-                using var imageStream = new System.IO.FileStream(textOrFilePath, System.IO.FileMode.Open);
+                using var imageStream = new System.IO.FileStream(textOrFilePath, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.Read);
 
                 if (this._section.Paragraphs.Count == 0) {
                     this._document._document.Body.Append(_sdtBlock);
@@ -538,7 +538,7 @@ namespace OfficeIMO.Word {
                 this._sdtBlock = GetStyle(style);
 
                 var fileName = System.IO.Path.GetFileName(textOrFilePath);
-                using var imageStream = new System.IO.FileStream(textOrFilePath, System.IO.FileMode.Open);
+                using var imageStream = new System.IO.FileStream(textOrFilePath, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.Read);
 
                 wordHeader._header.Append(_sdtBlock);
 


### PR DESCRIPTION
## Summary
- open image files with shared read access

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --framework net8.0 --filter Test_ImageTransparency --no-build -v normal`

------
https://chatgpt.com/codex/tasks/task_e_685aed592744832e98686a1ca3754bb8