### PR TITLE
Improve public API documentation

### DIFF
--- a/OfficeIMO.Word/WordFooter.cs
+++ b/OfficeIMO.Word/WordFooter.cs
@@ -6,22 +6,39 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides access to the footer instances associated with a
+    /// <see cref="WordDocument"/> section.
+    /// </summary>
     public class WordFooters {
+        /// <summary>
+        /// Gets or sets the default footer for the section.
+        /// </summary>
         public WordFooter Default {
             get;
             set;
         }
 
+        /// <summary>
+        /// Gets or sets the footer used for even pages.
+        /// </summary>
         public WordFooter Even {
             get;
             set;
         }
 
+        /// <summary>
+        /// Gets or sets the footer used for the first page.
+        /// </summary>
         public WordFooter First {
             get;
             set;
         }
     }
+    /// <summary>
+    /// Represents a footer in a Word document and allows manipulation
+    /// of its contents.
+    /// </summary>
     public partial class WordFooter : WordHeaderFooter {
         private readonly WordSection _section;
 
@@ -58,6 +75,11 @@ namespace OfficeIMO.Word {
             _section = section;
         }
 
+        /// <summary>
+        /// Adds a page number to this footer using the specified style.
+        /// </summary>
+        /// <param name="wordPageNumberStyle">Style of the page number to insert.</param>
+        /// <returns>The created <see cref="WordPageNumber"/> instance.</returns>
         public WordPageNumber AddPageNumber(WordPageNumberStyle wordPageNumberStyle) {
             var pageNumber = new WordPageNumber(_document, this, wordPageNumberStyle);
             return pageNumber;

--- a/OfficeIMO.Word/WordStructuredDocumentTag.cs
+++ b/OfficeIMO.Word/WordStructuredDocumentTag.cs
@@ -5,11 +5,17 @@ using System.Linq;
 using System.Text;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a structured document tag (content control) within a Word document.
+    /// </summary>
     public class WordStructuredDocumentTag : WordElement {
         private WordDocument _document;
         private Paragraph _paragraph;
         private SdtRun _stdRun;
 
+        /// <summary>
+        /// Gets the alias associated with this content control.
+        /// </summary>
         public string Alias {
             get {
                 var sdtAlias = _stdRun.SdtProperties.OfType<SdtAlias>().FirstOrDefault();
@@ -21,6 +27,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the tag value for this content control.
+        /// </summary>
         public string Tag {
             get {
                 var tag = _stdRun.SdtProperties.OfType<Tag>().FirstOrDefault();
@@ -36,6 +45,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the inner text of the content control.
+        /// </summary>
         public string Text {
             get {
                 var run = _stdRun.SdtContentRun.ChildElements.OfType<Run>().FirstOrDefault();
@@ -58,12 +70,21 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WordStructuredDocumentTag"/> class.
+        /// </summary>
+        /// <param name="document">Parent document.</param>
+        /// <param name="paragraph">Paragraph that contains the content control.</param>
+        /// <param name="stdRun">Underlying structured document run.</param>
         public WordStructuredDocumentTag(WordDocument document, Paragraph paragraph, SdtRun stdRun) {
             this._document = document;
             this._paragraph = paragraph;
             this._stdRun = stdRun;
         }
 
+        /// <summary>
+        /// Removes the structured document tag from the document.
+        /// </summary>
         public void Remove() {
             if (this._stdRun != null) {
                 this._stdRun.Remove();


### PR DESCRIPTION
## Summary
- document footer-related public API
- add docs for structured document tag helpers

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685aee318994832e85c7a1fc57ec63ce