### PR TITLE
Add list style detection on WordParagraph

### DIFF
--- a/OfficeIMO.Tests/Word.ParagraphListStyle.cs
+++ b/OfficeIMO.Tests/Word.ParagraphListStyle.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using System.Linq;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_ParagraphListStyleDetection() {
+            var filePath = Path.Combine(_directoryWithFiles, "ParagraphListStyle.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                var bullet = document.AddList(WordListStyle.Bulleted);
+                bullet.AddItem("Bullet");
+
+                var numbered = document.AddList(WordListStyle.Headings111);
+                numbered.AddItem("Numbered");
+
+                var custom = document.AddCustomList();
+                custom.AddListLevel(1, WordBulletSymbol.Square, "Courier New", colorHex: "#FF0000");
+                custom.AddItem("Custom");
+
+                document.Save();
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                var bulletParagraph = document.Paragraphs.First(p => p.Text == "Bullet");
+                var numberedParagraph = document.Paragraphs.First(p => p.Text == "Numbered");
+                var customParagraph = document.Paragraphs.First(p => p.Text == "Custom");
+
+                Assert.Equal(WordListStyle.Bulleted, bulletParagraph.GetListStyle());
+                Assert.Equal(WordListStyle.Headings111, numberedParagraph.GetListStyle());
+                Assert.Equal(WordListStyle.Custom, customParagraph.GetListStyle());
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -202,6 +202,19 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the list style when this paragraph is part of a list.
+        /// </summary>
+        public WordListStyle? GetListStyle() {
+            if (!IsListItem) return null;
+
+            int? numberId = _listNumberId;
+            if (numberId == null || _document == null) return null;
+
+            var list = _document.Lists.FirstOrDefault(l => l._numberId == numberId);
+            return list?.Style;
+        }
+
 
         /// <summary>
         /// Gets or sets the paragraph style. Updating this to a heading style will flag the document to update the table of contents on open.


### PR DESCRIPTION
## Summary
- expose `GetListStyle()` on WordParagraph to resolve the parent list style
- test list style detection for bulleted, numbered and custom lists

## Testing
- `dotnet test OfficeImo.sln -c Release`
- `dotnet build OfficeImo.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_685af2ef1684832e9a8970276cbb402c