### PR TITLE
Fix advanced content control example

### DIFF
--- a/OfficeIMO.Tests/Word.ContentControlsAdvanced.cs
+++ b/OfficeIMO.Tests/Word.ContentControlsAdvanced.cs
@@ -1,12 +1,14 @@
-using System;
 using System.IO;
 using OfficeIMO.Word;
+using Xunit;
 
-namespace OfficeIMO.Examples.Word {
-    internal static partial class ContentControls {
-        internal static void Example_AdvancedContentControls(string folderPath, bool openWord) {
-            Console.WriteLine("[*] Advanced content control demo");
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_AdvancedContentControls() {
+            string folderPath = _directoryWithFiles;
             string filePath = Path.Combine(folderPath, "DocumentAdvancedContentControls.docx");
+
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var para1 = document.AddParagraph("Control 1:");
                 para1.AddStructuredDocumentTag("Alias1", "First", "Tag1");
@@ -17,16 +19,25 @@ namespace OfficeIMO.Examples.Word {
                 var para3 = document.AddParagraph("Control 3:");
                 para3.AddStructuredDocumentTag("Alias3", "Third", "Tag3");
 
-                document.Save(openWord);
+                document.Save(false);
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 var aliasControl = document.GetStructuredDocumentTagByAlias("Alias2");
+                Assert.NotNull(aliasControl);
                 aliasControl.Text = "Changed";
+
                 var tagControl = document.GetStructuredDocumentTagByTag("Tag3");
-                Console.WriteLine("Tag3 text before: " + tagControl.Text);
+                Assert.NotNull(tagControl);
                 tagControl.Text = "Modified";
-                document.Save(openWord);
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var aliasControl = document.GetStructuredDocumentTagByAlias("Alias2");
+                Assert.Equal("Changed", aliasControl.Text);
+                var tagControl = document.GetStructuredDocumentTagByTag("Tag3");
+                Assert.Equal("Modified", tagControl.Text);
             }
         }
     }


### PR DESCRIPTION
## Summary
- correct alias parameter order in advanced content controls example
- add regression test for advanced content control scenario

## Testing
- `dotnet build`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685af21a64c4832eb1e986053a2334f8