### PR TITLE
Unify list level enum across APIs

### DIFF
--- a/Docs/custom-lists.md
+++ b/Docs/custom-lists.md
@@ -5,17 +5,17 @@ OfficeIMO supports creating custom bullet lists using `AddCustomBulletList` and 
 allows you to manually configure each level.
 
 ```csharp
-var custom = document.AddCustomBulletList(WordBulletSymbol.Square, "Courier New", SixLabors.ImageSharp.Color.Red, fontSize: 16);
+var custom = document.AddCustomBulletList(WordListLevelKind.BulletSquareSymbol, "Courier New", SixLabors.ImageSharp.Color.Red, fontSize: 16);
 custom.AddItem("Custom bullet item");
 ```
 
 ```csharp
 var builder = document.AddCustomList()
-    .AddListLevel(1, WordBulletSymbol.Square, "Courier New", colorHex: "#FF0000", fontSize: 14)
-    .AddListLevel(5, WordBulletSymbol.BlackCircle, "Arial", colorHex: "#00FF00", fontSize: 10);
+    .AddListLevel(1, WordListLevelKind.BulletSquareSymbol, "Courier New", colorHex: "#FF0000", fontSize: 14)
+    .AddListLevel(5, WordListLevelKind.BulletBlackCircle, "Arial", colorHex: "#00FF00", fontSize: 10);
 builder.AddItem("First");
 builder.AddItem("Fifth", 4);
 ```
 
-See [`WordBulletSymbol`](./officeimo.word.wordbulletsymbol.md) for the available bullet symbols.
+See [`WordListLevelKind`](./officeimo.word.wordlistlevelkind.md) for the available bullet symbols.
 

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -92,7 +92,7 @@
 
 [WordListStyles](./officeimo.word.wordliststyles.md)
 
-[WordBulletSymbol](./officeimo.word.wordbulletsymbol.md)
+[WordListLevelKind](./officeimo.word.wordlistlevelkind.md)
 
 [Custom Lists](./custom-lists.md)
 

--- a/Docs/officeimo.word.wordlistlevelkind.md
+++ b/Docs/officeimo.word.wordlistlevelkind.md
@@ -1,0 +1,9 @@
+# WordListLevelKind
+
+Namespace: OfficeIMO.Word
+
+```csharp
+public enum WordListLevelKind
+```
+
+Enumeration combining bullet and numbering options for list levels.

--- a/OfficeIMO.Examples/Word/Lists/Lists.CreateCustom.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.CreateCustom.cs
@@ -46,28 +46,28 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine("Current levels count: " + wordList1.Numbering.Levels.Count);
 
                 // add custom levels
-                var level = new WordListLevel(SimplifiedListNumbers.BulletOpenCircle);
+                var level = new WordListLevel(WordListLevelKind.BulletOpenCircle);
                 wordList1.Numbering.AddLevel(level);
 
-                var level1 = new WordListLevel(SimplifiedListNumbers.BulletSolidRound);
+                var level1 = new WordListLevel(WordListLevelKind.BulletSolidRound);
                 wordList1.Numbering.AddLevel(level1);
 
-                var level2 = new WordListLevel(SimplifiedListNumbers.BulletSquare);
+                var level2 = new WordListLevel(WordListLevelKind.BulletSquare);
                 wordList1.Numbering.AddLevel(level2);
 
-                var level3 = new WordListLevel(SimplifiedListNumbers.BulletSquare2);
+                var level3 = new WordListLevel(WordListLevelKind.BulletSquare2);
                 wordList1.Numbering.AddLevel(level3);
 
-                var level4 = new WordListLevel(SimplifiedListNumbers.BulletClubs);
+                var level4 = new WordListLevel(WordListLevelKind.BulletClubs);
                 wordList1.Numbering.AddLevel(level4);
 
-                var level5 = new WordListLevel(SimplifiedListNumbers.BulletDiamond);
+                var level5 = new WordListLevel(WordListLevelKind.BulletDiamond);
                 wordList1.Numbering.AddLevel(level5);
 
-                var level6 = new WordListLevel(SimplifiedListNumbers.BulletCheckmark);
+                var level6 = new WordListLevel(WordListLevelKind.BulletCheckmark);
                 wordList1.Numbering.AddLevel(level6);
 
-                var level7 = new WordListLevel(SimplifiedListNumbers.BulletArrow);
+                var level7 = new WordListLevel(WordListLevelKind.BulletArrow);
                 wordList1.Numbering.AddLevel(level7);
 
                 Console.WriteLine("Current levels count: " + wordList1.Numbering.Levels.Count);
@@ -78,23 +78,23 @@ namespace OfficeIMO.Examples.Word {
                 // prefer AddCustomList over AddList(WordListStyle.Custom)
                 WordList wordList2 = document.AddCustomList();
                 // add levels
-                var level21 = new WordListLevel(SimplifiedListNumbers.Decimal);
+                var level21 = new WordListLevel(WordListLevelKind.Decimal);
                 wordList2.Numbering.AddLevel(level21);
-                var level22 = new WordListLevel(SimplifiedListNumbers.DecimalBracket);
+                var level22 = new WordListLevel(WordListLevelKind.DecimalBracket);
                 wordList2.Numbering.AddLevel(level22);
-                var level23 = new WordListLevel(SimplifiedListNumbers.DecimalDot);
+                var level23 = new WordListLevel(WordListLevelKind.DecimalDot);
                 wordList2.Numbering.AddLevel(level23);
-                var level24 = new WordListLevel(SimplifiedListNumbers.LowerLetter);
+                var level24 = new WordListLevel(WordListLevelKind.LowerLetter);
                 wordList2.Numbering.AddLevel(level24);
-                var level25 = new WordListLevel(SimplifiedListNumbers.LowerLetterBracket);
+                var level25 = new WordListLevel(WordListLevelKind.LowerLetterBracket);
                 wordList2.Numbering.AddLevel(level25);
-                var level26 = new WordListLevel(SimplifiedListNumbers.LowerLetterDot);
+                var level26 = new WordListLevel(WordListLevelKind.LowerLetterDot);
                 wordList2.Numbering.AddLevel(level26);
-                var level27 = new WordListLevel(SimplifiedListNumbers.UpperLetter);
+                var level27 = new WordListLevel(WordListLevelKind.UpperLetter);
                 wordList2.Numbering.AddLevel(level27);
-                var level28 = new WordListLevel(SimplifiedListNumbers.UpperLetterBracket);
+                var level28 = new WordListLevel(WordListLevelKind.UpperLetterBracket);
                 wordList2.Numbering.AddLevel(level28);
-                var level29 = new WordListLevel(SimplifiedListNumbers.UpperLetterDot);
+                var level29 = new WordListLevel(WordListLevelKind.UpperLetterDot);
                 wordList2.Numbering.AddLevel(level29);
 
                 // add items to the list
@@ -116,25 +116,25 @@ namespace OfficeIMO.Examples.Word {
 
                 // another custom list
                 WordList wordList3 = document.AddCustomList();
-                var level31 = new WordListLevel(SimplifiedListNumbers.UpperRoman);
+                var level31 = new WordListLevel(WordListLevelKind.UpperRoman);
                 wordList3.Numbering.AddLevel(level31);
-                var level32 = new WordListLevel(SimplifiedListNumbers.UpperRomanBracket);
+                var level32 = new WordListLevel(WordListLevelKind.UpperRomanBracket);
                 wordList3.Numbering.AddLevel(level32);
-                var level33 = new WordListLevel(SimplifiedListNumbers.UpperRomanDot);
+                var level33 = new WordListLevel(WordListLevelKind.UpperRomanDot);
                 wordList3.Numbering.AddLevel(level33);
-                var level34 = new WordListLevel(SimplifiedListNumbers.LowerRoman);
+                var level34 = new WordListLevel(WordListLevelKind.LowerRoman);
                 level34.StartNumberingValue = 4;
                 level34.LevelJustification = LevelJustificationValues.Right;
                 wordList3.Numbering.AddLevel(level34);
-                var level35 = new WordListLevel(SimplifiedListNumbers.LowerRomanBracket);
+                var level35 = new WordListLevel(WordListLevelKind.LowerRomanBracket);
                 wordList3.Numbering.AddLevel(level35);
-                var level36 = new WordListLevel(SimplifiedListNumbers.LowerRomanDot);
+                var level36 = new WordListLevel(WordListLevelKind.LowerRomanDot);
                 wordList3.Numbering.AddLevel(level36);
-                var level37 = new WordListLevel(SimplifiedListNumbers.DecimalBracket);
+                var level37 = new WordListLevel(WordListLevelKind.DecimalBracket);
                 wordList3.Numbering.AddLevel(level37);
-                var level38 = new WordListLevel(SimplifiedListNumbers.DecimalDot);
+                var level38 = new WordListLevel(WordListLevelKind.DecimalDot);
                 wordList3.Numbering.AddLevel(level38);
-                var level39 = new WordListLevel(SimplifiedListNumbers.Decimal);
+                var level39 = new WordListLevel(WordListLevelKind.Decimal);
                 wordList3.Numbering.AddLevel(level39);
 
 

--- a/OfficeIMO.Tests/Word.AddCustomBulletList.cs
+++ b/OfficeIMO.Tests/Word.AddCustomBulletList.cs
@@ -10,8 +10,8 @@ namespace OfficeIMO.Tests {
             var filePath = Path.Combine(_directoryWithFiles, "CustomBulletList.docx");
             using (var document = WordDocument.Create(filePath)) {
                 var list = document.AddCustomList()
-                    .AddListLevel(1, WordBulletSymbol.Square, "Courier New", SixLabors.ImageSharp.Color.Red, fontSize: 14)
-                    .AddListLevel(5, WordBulletSymbol.BlackCircle, "Arial", colorHex: "#00FF00", fontSize: 10);
+                    .AddListLevel(1, WordListLevelKind.BulletSquareSymbol, "Courier New", SixLabors.ImageSharp.Color.Red, fontSize: 14)
+                    .AddListLevel(5, WordListLevelKind.BulletBlackCircle, "Arial", colorHex: "#00FF00", fontSize: 10);
                 list.AddItem("Level1");
                 list.AddItem("Level5", 4);
                 document.Save(false);
@@ -40,7 +40,7 @@ namespace OfficeIMO.Tests {
         public void Test_AddCustomBulletList() {
             var filePath = Path.Combine(_directoryWithFiles, "CustomBulletSimple.docx");
             using (var document = WordDocument.Create(filePath)) {
-                var list = document.AddCustomBulletList(WordBulletSymbol.Diamond, "Wingdings", SixLabors.ImageSharp.Color.Blue, fontSize: 12);
+                var list = document.AddCustomBulletList(WordListLevelKind.BulletDiamondSymbol, "Wingdings", SixLabors.ImageSharp.Color.Blue, fontSize: 12);
                 list.AddItem("Item");
                 document.Save(false);
             }

--- a/OfficeIMO.Tests/Word.ParagraphListStyle.cs
+++ b/OfficeIMO.Tests/Word.ParagraphListStyle.cs
@@ -16,7 +16,7 @@ namespace OfficeIMO.Tests {
                 numbered.AddItem("Numbered");
 
                 var custom = document.AddCustomList();
-                custom.AddListLevel(1, WordBulletSymbol.Square, "Courier New", colorHex: "#FF0000");
+                custom.AddListLevel(1, WordListLevelKind.BulletSquareSymbol, "Courier New", colorHex: "#FF0000");
                 custom.AddItem("Custom");
 
                 document.Save();

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -121,6 +121,10 @@ namespace OfficeIMO.Word {
             return WordList.AddCustomBulletList(this, symbol, fontName, color, colorHex, fontSize);
         }
 
+        public WordList AddCustomBulletList(WordListLevelKind kind, string fontName, SixLabors.ImageSharp.Color? color = null, string colorHex = null, int? fontSize = null) {
+            return WordList.AddCustomBulletList(this, kind, fontName, color, colorHex, fontSize);
+        }
+
         /// <summary>
         /// Creates a custom list with no predefined levels for manual configuration.
         /// </summary>

--- a/OfficeIMO.Word/WordList.Private.cs
+++ b/OfficeIMO.Word/WordList.Private.cs
@@ -311,6 +311,25 @@ public partial class WordList : WordElement {
         return level;
     }
 
+    private static char GetBulletSymbol(WordListLevelKind kind) {
+        return kind switch {
+            WordListLevelKind.Bullet => '\u2022',
+            WordListLevelKind.BulletSquareSymbol => '\u25A0',
+            WordListLevelKind.BulletBlackCircle => '\u25CF',
+            WordListLevelKind.BulletDiamondSymbol => '\u25C6',
+            WordListLevelKind.BulletArrowSymbol => '\u25BA',
+            WordListLevelKind.BulletSolidRound => '·',
+            WordListLevelKind.BulletOpenCircle => 'o',
+            WordListLevelKind.BulletSquare2 => '■',
+            WordListLevelKind.BulletSquare => '§',
+            WordListLevelKind.BulletClubs => 'v',
+            WordListLevelKind.BulletArrow => 'Ø',
+            WordListLevelKind.BulletDiamond => '¨',
+            WordListLevelKind.BulletCheckmark => 'ü',
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), "Only bullet kinds are supported")
+        };
+    }
+
     private static void EnsureW15Namespace(Numbering numbering) {
         const string prefix = "w15";
         const string ns = "http://schemas.microsoft.com/office/word/2012/wordml";

--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -145,6 +145,12 @@ namespace OfficeIMO.Word {
             return AddCustomBulletList(document, (char)symbol, fontName, finalColor, fontSize);
         }
 
+        public static WordList AddCustomBulletList(WordDocument document, WordListLevelKind kind, string fontName, SixLabors.ImageSharp.Color? color = null, string colorHex = null, int? fontSize = null) {
+            char symbol = GetBulletSymbol(kind);
+            string finalColor = color?.ToHexColor() ?? colorHex;
+            return AddCustomBulletList(document, symbol, fontName, finalColor, fontSize);
+        }
+
         public static WordList AddCustomList(WordDocument document) {
             if (document == null) throw new ArgumentNullException(nameof(document));
 
@@ -177,6 +183,12 @@ namespace OfficeIMO.Word {
         public WordList AddListLevel(int levelIndex, WordBulletSymbol symbol, string fontName, SixLabors.ImageSharp.Color? color = null, string colorHex = null, int? fontSize = null) {
             string finalColor = color?.ToHexColor() ?? colorHex;
             return AddListLevel(levelIndex, (char)symbol, fontName, finalColor, fontSize);
+        }
+
+        public WordList AddListLevel(int levelIndex, WordListLevelKind kind, string fontName, SixLabors.ImageSharp.Color? color = null, string colorHex = null, int? fontSize = null) {
+            char symbol = GetBulletSymbol(kind);
+            string finalColor = color?.ToHexColor() ?? colorHex;
+            return AddListLevel(levelIndex, symbol, fontName, finalColor, fontSize);
         }
     }
 }

--- a/OfficeIMO.Word/WordListLevel.cs
+++ b/OfficeIMO.Word/WordListLevel.cs
@@ -3,8 +3,13 @@ using System.Linq;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
-    public enum SimplifiedListNumbers {
+    public enum WordListLevelKind {
         None,
+        Bullet,
+        BulletSquareSymbol,
+        BulletBlackCircle,
+        BulletDiamondSymbol,
+        BulletArrowSymbol,
         BulletSolidRound,
         BulletOpenCircle,
         BulletSquare,
@@ -128,9 +133,74 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="simplifiedListNumbers"></param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public WordListLevel(SimplifiedListNumbers simplifiedListNumbers) {
+        public WordListLevel(WordListLevelKind simplifiedListNumbers) {
             switch (simplifiedListNumbers) {
-                case SimplifiedListNumbers.BulletSolidRound:
+                case WordListLevelKind.Bullet:
+                    _level = new Level() {
+                        LevelIndex = 0,
+                        TemplateCode = "",
+                        StartNumberingValue = new StartNumberingValue() { Val = 1 },
+                        NumberingFormat = new NumberingFormat() { Val = NumberFormatValues.Bullet },
+                        LevelText = new LevelText() { Val = "\u2022" },
+                        LevelJustification = new LevelJustification() { Val = LevelJustificationValues.Left },
+                        PreviousParagraphProperties = new PreviousParagraphProperties() {
+                            Indentation = new Indentation() { Left = "720", Hanging = "360" }
+                        }
+                    };
+                    break;
+                case WordListLevelKind.BulletSquareSymbol:
+                    _level = new Level() {
+                        LevelIndex = 0,
+                        TemplateCode = "",
+                        StartNumberingValue = new StartNumberingValue() { Val = 1 },
+                        NumberingFormat = new NumberingFormat() { Val = NumberFormatValues.Bullet },
+                        LevelText = new LevelText() { Val = "\u25A0" },
+                        LevelJustification = new LevelJustification() { Val = LevelJustificationValues.Left },
+                        PreviousParagraphProperties = new PreviousParagraphProperties() {
+                            Indentation = new Indentation() { Left = "720", Hanging = "360" }
+                        }
+                    };
+                    break;
+                case WordListLevelKind.BulletBlackCircle:
+                    _level = new Level() {
+                        LevelIndex = 0,
+                        TemplateCode = "",
+                        StartNumberingValue = new StartNumberingValue() { Val = 1 },
+                        NumberingFormat = new NumberingFormat() { Val = NumberFormatValues.Bullet },
+                        LevelText = new LevelText() { Val = "\u25CF" },
+                        LevelJustification = new LevelJustification() { Val = LevelJustificationValues.Left },
+                        PreviousParagraphProperties = new PreviousParagraphProperties() {
+                            Indentation = new Indentation() { Left = "720", Hanging = "360" }
+                        }
+                    };
+                    break;
+                case WordListLevelKind.BulletDiamondSymbol:
+                    _level = new Level() {
+                        LevelIndex = 0,
+                        TemplateCode = "",
+                        StartNumberingValue = new StartNumberingValue() { Val = 1 },
+                        NumberingFormat = new NumberingFormat() { Val = NumberFormatValues.Bullet },
+                        LevelText = new LevelText() { Val = "\u25C6" },
+                        LevelJustification = new LevelJustification() { Val = LevelJustificationValues.Left },
+                        PreviousParagraphProperties = new PreviousParagraphProperties() {
+                            Indentation = new Indentation() { Left = "720", Hanging = "360" }
+                        }
+                    };
+                    break;
+                case WordListLevelKind.BulletArrowSymbol:
+                    _level = new Level() {
+                        LevelIndex = 0,
+                        TemplateCode = "",
+                        StartNumberingValue = new StartNumberingValue() { Val = 1 },
+                        NumberingFormat = new NumberingFormat() { Val = NumberFormatValues.Bullet },
+                        LevelText = new LevelText() { Val = "\u25BA" },
+                        LevelJustification = new LevelJustification() { Val = LevelJustificationValues.Left },
+                        PreviousParagraphProperties = new PreviousParagraphProperties() {
+                            Indentation = new Indentation() { Left = "720", Hanging = "360" }
+                        }
+                    };
+                    break;
+                case WordListLevelKind.BulletSolidRound:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -146,7 +216,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.BulletOpenCircle:
+                case WordListLevelKind.BulletOpenCircle:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -162,7 +232,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.BulletSquare2:
+                case WordListLevelKind.BulletSquare2:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -175,7 +245,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.BulletSquare:
+                case WordListLevelKind.BulletSquare:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -191,7 +261,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.BulletClubs:
+                case WordListLevelKind.BulletClubs:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -207,7 +277,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.BulletArrow:
+                case WordListLevelKind.BulletArrow:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -223,7 +293,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.BulletDiamond:
+                case WordListLevelKind.BulletDiamond:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -239,7 +309,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.BulletCheckmark:
+                case WordListLevelKind.BulletCheckmark:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -255,7 +325,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.Decimal:
+                case WordListLevelKind.Decimal:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -268,7 +338,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.DecimalBracket:
+                case WordListLevelKind.DecimalBracket:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -281,7 +351,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.DecimalDot:
+                case WordListLevelKind.DecimalDot:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -294,7 +364,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.LowerLetter:
+                case WordListLevelKind.LowerLetter:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -307,7 +377,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.LowerLetterBracket:
+                case WordListLevelKind.LowerLetterBracket:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -320,7 +390,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.LowerLetterDot:
+                case WordListLevelKind.LowerLetterDot:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -333,7 +403,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.UpperLetter:
+                case WordListLevelKind.UpperLetter:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -346,7 +416,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.UpperLetterBracket:
+                case WordListLevelKind.UpperLetterBracket:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -359,7 +429,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.UpperLetterDot:
+                case WordListLevelKind.UpperLetterDot:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -372,7 +442,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.LowerRoman:
+                case WordListLevelKind.LowerRoman:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -385,7 +455,7 @@ namespace OfficeIMO.Word {
                         },
                     };
                     break;
-                case SimplifiedListNumbers.LowerRomanBracket:
+                case WordListLevelKind.LowerRomanBracket:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -398,7 +468,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.LowerRomanDot:
+                case WordListLevelKind.LowerRomanDot:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -411,7 +481,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.UpperRoman:
+                case WordListLevelKind.UpperRoman:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -424,7 +494,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.UpperRomanBracket:
+                case WordListLevelKind.UpperRomanBracket:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -437,7 +507,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.UpperRomanDot:
+                case WordListLevelKind.UpperRomanDot:
                     _level = new Level() {
                         LevelIndex = 0,
                         TemplateCode = "",
@@ -450,7 +520,7 @@ namespace OfficeIMO.Word {
                         }
                     };
                     break;
-                case SimplifiedListNumbers.None:
+                case WordListLevelKind.None:
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(simplifiedListNumbers), simplifiedListNumbers, null);

--- a/README.md
+++ b/README.md
@@ -420,13 +420,13 @@ using (WordDocument document = WordDocument.Create(filePath)) {
     document.AddParagraph();
 
     // create a custom bullet list
-    var custom = document.AddCustomBulletList(WordBulletSymbol.Square, "Courier New", SixLabors.ImageSharp.Color.Red, fontSize: 16);
+    var custom = document.AddCustomBulletList(WordListLevelKind.BulletSquareSymbol, "Courier New", SixLabors.ImageSharp.Color.Red, fontSize: 16);
     custom.AddItem("Custom bullet item");
 
     // create a multi-level custom list
     var builder = document.AddCustomList()
-        .AddListLevel(1, WordBulletSymbol.Square, "Courier New", SixLabors.ImageSharp.Color.Red, fontSize: 14)
-        .AddListLevel(5, WordBulletSymbol.BlackCircle, "Arial", colorHex: "#00ff00", fontSize: 10);
+        .AddListLevel(1, WordListLevelKind.BulletSquareSymbol, "Courier New", SixLabors.ImageSharp.Color.Red, fontSize: 14)
+        .AddListLevel(5, WordListLevelKind.BulletBlackCircle, "Arial", colorHex: "#00ff00", fontSize: 10);
     builder.AddItem("First");
     builder.AddItem("Fifth", 4);
 


### PR DESCRIPTION
## Summary
- add new `WordListLevelKind` enum for bullets and numbering
- overload list APIs to use the new enum
- map bullet styles to characters in list helpers
- update examples, docs and tests to use `WordListLevelKind`

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_685af844a764832ead7657c4e7f16cf5