### PR TITLE
Fix page break removal

### DIFF
--- a/OfficeIMO.Tests/Word.PageBreaks.cs
+++ b/OfficeIMO.Tests/Word.PageBreaks.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_RemovingPageBreakParagraph() {
+            string filePath = Path.Combine(_directoryWithFiles, "RemovePageBreakParagraph.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Paragraph 1");
+                document.AddPageBreak();
+                document.AddParagraph("Paragraph 2");
+
+                Assert.True(document.Paragraphs[1].IsPageBreak);
+
+                document.Paragraphs[1].Remove();
+
+                Assert.Equal(2, document.Paragraphs.Count);
+                Assert.Empty(document.PageBreaks);
+
+                document.Save(false);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -134,6 +134,11 @@ namespace OfficeIMO.Word {
 
                     if (this.IsBreak) {
                         this.Break.Remove();
+                        // Removing a break can also remove the entire paragraph.
+                        // When that happens there's nothing else to clean up.
+                        if (this._paragraph.Parent == null) {
+                            return;
+                        }
                     }
 
                     // break should cover this


### PR DESCRIPTION
## Summary
- handle the case where removing a break also removes its paragraph
- add regression test for removing page break paragraphs

## Testing
- `dotnet test ./OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_685afc49a2cc832eb16d1dbed8b593e0