### PR TITLE
Add XML documentation for key Word types

### DIFF
--- a/OfficeIMO.Word/BuiltinDocumentProperties.cs
+++ b/OfficeIMO.Word/BuiltinDocumentProperties.cs
@@ -2,6 +2,9 @@
 using DocumentFormat.OpenXml.Packaging;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides access to the built-in document properties such as title, creator and keywords.
+    /// </summary>
     public class BuiltinDocumentProperties {
         private WordprocessingDocument _wordprocessingDocument;
         private WordDocument _document;
@@ -12,6 +15,9 @@ namespace OfficeIMO.Word {
 
             document.BuiltinDocumentProperties = this;
         }
+        /// <summary>
+        /// Gets or sets the creator of the document.
+        /// </summary>
         public string Creator {
             get {
                 return _wordprocessingDocument.PackageProperties.Creator;
@@ -20,6 +26,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.PackageProperties.Creator = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the title of the document.
+        /// </summary>
         public string Title {
             get {
                 return _wordprocessingDocument.PackageProperties.Title;
@@ -28,6 +37,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.PackageProperties.Title = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the document description.
+        /// </summary>
         public string Description {
             get {
                 return _wordprocessingDocument.PackageProperties.Description;
@@ -36,6 +48,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.PackageProperties.Description = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the category of the document.
+        /// </summary>
         public string Category {
             get {
                 return _wordprocessingDocument.PackageProperties.Category;
@@ -55,6 +70,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.PackageProperties.Keywords = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the document subject.
+        /// </summary>
         public string Subject {
             get {
                 return _wordprocessingDocument.PackageProperties.Subject;
@@ -63,6 +81,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.PackageProperties.Subject = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the document revision number.
+        /// </summary>
         public string Revision {
             get {
                 return _wordprocessingDocument.PackageProperties.Revision;
@@ -71,6 +92,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.PackageProperties.Revision = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the last user who modified the document.
+        /// </summary>
         public string LastModifiedBy {
             get {
                 return _wordprocessingDocument.PackageProperties.LastModifiedBy;
@@ -79,6 +103,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.PackageProperties.LastModifiedBy = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the document version.
+        /// </summary>
         public string Version {
             get {
                 return _wordprocessingDocument.PackageProperties.Version;
@@ -87,6 +114,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.PackageProperties.Version = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the creation date of the document.
+        /// </summary>
         public DateTime? Created {
             get {
                 return _wordprocessingDocument.PackageProperties.Created;
@@ -95,6 +125,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.PackageProperties.Created = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the last modification date of the document.
+        /// </summary>
         public DateTime? Modified {
             get {
                 return _wordprocessingDocument.PackageProperties.Modified;
@@ -103,6 +136,9 @@ namespace OfficeIMO.Word {
                 _wordprocessingDocument.PackageProperties.Modified = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the last print date of the document.
+        /// </summary>
         public DateTime? LastPrinted {
             get {
                 return _wordprocessingDocument.PackageProperties.LastPrinted;

--- a/OfficeIMO.Word/CustomImagePartType.cs
+++ b/OfficeIMO.Word/CustomImagePartType.cs
@@ -6,11 +6,34 @@ namespace OfficeIMO.Word;
 /// Enumeration of additional image types supported by the library.
 /// </summary>
 public enum CustomImagePartType {
+    /// <summary>
+    /// Bitmap image type.
+    /// </summary>
     Bmp,
+
+    /// <summary>
+    /// GIF image type.
+    /// </summary>
     Gif,
+
+    /// <summary>
+    /// JPEG image type.
+    /// </summary>
     Jpeg,
+
+    /// <summary>
+    /// PNG image type.
+    /// </summary>
     Png,
+
+    /// <summary>
+    /// TIFF image type.
+    /// </summary>
     Tiff,
+
+    /// <summary>
+    /// Enhanced metafile image type.
+    /// </summary>
     Emf
 }
 

--- a/OfficeIMO.Word/Enumerations.cs
+++ b/OfficeIMO.Word/Enumerations.cs
@@ -3,14 +3,43 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Defines custom property types available for Word documents.
+    /// </summary>
     public enum PropertyTypes : int {
+        /// <summary>
+        /// Property type is not defined.
+        /// </summary>
         Undefined,
+
+        /// <summary>
+        /// Represents a yes/no property type.
+        /// </summary>
         YesNo,
+
+        /// <summary>
+        /// Represents a text property type.
+        /// </summary>
         Text,
+
+        /// <summary>
+        /// Represents a date and time property type.
+        /// </summary>
         DateTime,
+
+        /// <summary>
+        /// Represents an integer number property type.
+        /// </summary>
         NumberInteger,
+
+        /// <summary>
+        /// Represents a double number property type.
+        /// </summary>
         NumberDouble
     }
+    /// <summary>
+    /// Specifies the capitalization style applied to text.
+    /// </summary>
     public enum CapsStyle {
         /// <summary>
         /// No caps, characters as written.
@@ -32,8 +61,19 @@ namespace OfficeIMO.Word {
     /// Shape types supported by <see cref="WordDocument.AddShape(ShapeType,double,double,string,string,double)"/>.
     /// </summary>
     public enum ShapeType {
+        /// <summary>
+        /// A rectangular shape.
+        /// </summary>
         Rectangle,
+
+        /// <summary>
+        /// An elliptical shape.
+        /// </summary>
         Ellipse,
+
+        /// <summary>
+        /// A straight line shape.
+        /// </summary>
         Line
     }
 

--- a/OfficeIMO.Word/ExtensionsHeadersAndFooters.cs
+++ b/OfficeIMO.Word/ExtensionsHeadersAndFooters.cs
@@ -7,6 +7,9 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Helper methods for adding and retrieving headers and footers in Word documents.
+    /// </summary>
     public static partial class WordHeadersAndFooters {
         /// <summary>
         /// Add default header and footers to section. You can control odd/even/first with DifferentOddAndEventPages/DifferentFirstPage properties.

--- a/OfficeIMO.Word/WordWatermark.cs
+++ b/OfficeIMO.Word/WordWatermark.cs
@@ -17,11 +17,24 @@ using DocumentFormat.OpenXml.Vml;
 using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Specifies the type of watermark to insert into a Word document.
+    /// </summary>
     public enum WordWatermarkStyle {
+        /// <summary>
+        /// Indicates a text watermark.
+        /// </summary>
         Text,
+
+        /// <summary>
+        /// Indicates an image watermark.
+        /// </summary>
         Image
     }
 
+    /// <summary>
+    /// Represents a watermark element within a Word document.
+    /// </summary>
     public class WordWatermark : WordElement {
         private WordDocument _document;
         private SdtBlock _sdtBlock;
@@ -29,6 +42,9 @@ namespace OfficeIMO.Word {
         private WordSection _section;
         //private WordParagraph _wordParagraph;
 
+        /// <summary>
+        /// Gets or sets the watermark text.
+        /// </summary>
         public string Text {
             get {
                 var paragraph = _sdtBlock.SdtContentBlock.ChildElements.OfType<Paragraph>().FirstOrDefault();
@@ -111,6 +127,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the width of the watermark in points.
+        /// </summary>
         public double? Width {
             get {
                 var shape = _shape;
@@ -146,6 +165,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the height of the watermark in points.
+        /// </summary>
         public double? Height {
             get {
                 var shape = _shape;
@@ -482,6 +504,13 @@ namespace OfficeIMO.Word {
             throw new ArgumentOutOfRangeException(nameof(style));
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WordWatermark"/> class for the specified section.
+        /// </summary>
+        /// <param name="wordDocument">The parent document.</param>
+        /// <param name="wordSection">The section to which the watermark should be added.</param>
+        /// <param name="style">The type of watermark to add.</param>
+        /// <param name="textOrFilePath">Text to use or path to the watermark image.</param>
         public WordWatermark(WordDocument wordDocument, WordSection wordSection, WordWatermarkStyle style, string textOrFilePath) {
             this._document = wordDocument;
             this._section = wordSection;
@@ -517,6 +546,14 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WordWatermark"/> class for the specified header.
+        /// </summary>
+        /// <param name="wordDocument">The parent document.</param>
+        /// <param name="wordSection">The section associated with the header.</param>
+        /// <param name="wordHeader">The header where the watermark will be placed.</param>
+        /// <param name="style">The type of watermark to add.</param>
+        /// <param name="textOrFilePath">Text to use or path to the watermark image.</param>
         public WordWatermark(WordDocument wordDocument, WordSection wordSection, WordHeader wordHeader, WordWatermarkStyle style, string textOrFilePath) {
             this._document = wordDocument;
             this._section = wordSection;
@@ -549,6 +586,11 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WordWatermark"/> class from an existing structured document tag.
+        /// </summary>
+        /// <param name="wordDocument">The parent document.</param>
+        /// <param name="sdtBlock">The structured document tag block representing the watermark.</param>
         public WordWatermark(WordDocument wordDocument, SdtBlock sdtBlock) {
             _document = wordDocument;
             _sdtBlock = sdtBlock;


### PR DESCRIPTION
## Summary
- add XML summaries for document property helpers
- document enum values for custom image part types
- provide documentation for enumeration members and shape types
- add summaries for watermark helpers and constructors
- document headers and footers extensions

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_685afb99cd5c832e89d99aff1fd6cbea