### PR TITLE
Fix AddListLevel start index

### DIFF
--- a/OfficeIMO.Tests/Word.AddCustomBulletList.cs
+++ b/OfficeIMO.Tests/Word.AddCustomBulletList.cs
@@ -56,5 +56,24 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("24", props.GetFirstChild<FontSize>()?.Val);
             }
         }
+
+        [Fact]
+        public void Test_CustomListStartingAtThirdLevel() {
+            var filePath = Path.Combine(_directoryWithFiles, "CustomListStartAt3.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                var list = document.AddCustomList()
+                    .AddListLevel(3, WordListLevelKind.BulletBlackCircle, "Arial");
+                list.AddItem("Level3", 2);
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                var list = document.Lists[0];
+                Assert.Equal(3, list.Numbering.Levels.Count);
+                Assert.Equal("●", list.Numbering.Levels[0].LevelText);
+                Assert.Equal("●", list.Numbering.Levels[1].LevelText);
+                Assert.Equal("●", list.Numbering.Levels[2].LevelText);
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -171,8 +171,12 @@ namespace OfficeIMO.Word {
                 }
             }
 
-            if (levelIndex > 1 && this.Numbering.Levels.Count == 0) {
-                levelIndex = 1;
+            if (currentCount == 0 && levelIndex > 1) {
+                var placeholder = CreateBulletLevel(symbol, fontName, colorHex, fontSize);
+                while (this.Numbering.Levels.Count < levelIndex - 1) {
+                    var clone = (Level)placeholder.CloneNode(true);
+                    this.Numbering.AddLevel(clone);
+                }
             }
 
             var newLevel = CreateBulletLevel(symbol, fontName, colorHex, fontSize);


### PR DESCRIPTION
## Summary
- create placeholder bullet levels for custom lists when starting at a higher level
- cover starting custom list at level 3 with a new test

## Testing
- `dotnet build OfficeImo.sln -c Release -v minimal`
- `dotnet test OfficeImo.sln -c Release --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685b03c66110832eb0c1efa8c9149211