### PR TITLE
Add custom paragraph style registration

### DIFF
--- a/Docs/Examples/ExamplesCustomParagraphStyles/README.MD
+++ b/Docs/Examples/ExamplesCustomParagraphStyles/README.MD
@@ -1,0 +1,20 @@
+## Custom Paragraph Styles
+
+Custom paragraph styles can be registered globally before creating a document.
+
+```csharp
+var custom = new Style { Type = StyleValues.Paragraph, StyleId = "MyStyle" };
+WordParagraphStyle.RegisterCustomStyle("MyStyle", custom);
+
+using (WordDocument document = WordDocument.Create(filePath)) {
+    document.AddParagraph("Hello").SetStyleId("MyStyle");
+    document.Save();
+}
+```
+
+Built-in styles may also be replaced:
+
+```csharp
+var normal = new Style { Type = StyleValues.Paragraph, StyleId = "Normal" };
+WordParagraphStyle.OverrideBuiltInStyle(WordParagraphStyles.Normal, normal);
+```

--- a/Docs/officeimo.word.wordparagraphstyle.md
+++ b/Docs/officeimo.word.wordparagraphstyle.md
@@ -71,3 +71,24 @@ internal static WordParagraphStyles GetStyle(int level)
 #### Exceptions
 
 [ArgumentOutOfRangeException](https://docs.microsoft.com/en-us/dotnet/api/system.argumentoutofrangeexception)<br>
+
+### **RegisterCustomStyle(String, Style)**
+
+```csharp
+public static void RegisterCustomStyle(string styleId, Style styleDefinition)
+```
+
+Adds a new style definition keyed by the provided style identifier.
+
+#### Parameters
+
+`styleId` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+`styleDefinition` Style<br>
+
+### **OverrideBuiltInStyle(WordParagraphStyles, Style)**
+
+```csharp
+public static void OverrideBuiltInStyle(WordParagraphStyles style, Style styleDefinition)
+```
+
+Replaces the definition for a built-in style.

--- a/OfficeIMO.Tests/Word.ParagraphCustomStyles.cs
+++ b/OfficeIMO.Tests/Word.ParagraphCustomStyles.cs
@@ -1,0 +1,37 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_RegisterCustomParagraphStyle() {
+            var style = new Style { Type = StyleValues.Paragraph, StyleId = "MyStyle" };
+            WordParagraphStyle.RegisterCustomStyle("MyStyle", style);
+
+            string filePath = Path.Combine(_directoryWithFiles, "CustomParagraphStyle.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Text").SetStyleId("MyStyle");
+                document.Save();
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var styles = document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles;
+                Assert.NotNull(styles.Elements<Style>().FirstOrDefault(s => s.StyleId == "MyStyle"));
+            }
+        }
+
+        [Fact]
+        public void Test_OverrideBuiltInParagraphStyle() {
+            var original = WordParagraphStyle.GetStyleDefinition(WordParagraphStyles.Normal);
+            var custom = new Style { Type = StyleValues.Paragraph, StyleId = "Normal" };
+            WordParagraphStyle.OverrideBuiltInStyle(WordParagraphStyles.Normal, custom);
+
+            Assert.Equal(custom, WordParagraphStyle.GetStyleDefinition(WordParagraphStyles.Normal));
+
+            WordParagraphStyle.OverrideBuiltInStyle(WordParagraphStyles.Normal, original);
+        }
+    }
+}

--- a/OfficeIMO.Word/Parts/WordDocument.Parts.StyleDefinitions.cs
+++ b/OfficeIMO.Word/Parts/WordDocument.Parts.StyleDefinitions.cs
@@ -145,7 +145,13 @@ namespace OfficeIMO.Word {
             // TODO: load all styles to document, probably we should load those in use
             var listOfStyles = (WordParagraphStyles[])Enum.GetValues(typeof(WordParagraphStyles));
             foreach (var style in listOfStyles) {
-                styles1.Append(WordParagraphStyle.GetStyleDefinition(style));
+                var styleDef = WordParagraphStyle.GetStyleDefinition(style);
+                if (styleDef != null) {
+                    styles1.Append(styleDef);
+                }
+            }
+            foreach (var custom in WordParagraphStyle.CustomStyles) {
+                styles1.Append((Style)custom.CloneNode(true));
             }
             // TODO: load only needed character styles
             var listOfCharStyles = (WordCharacterStyles[])Enum.GetValues(typeof(WordCharacterStyles));

--- a/OfficeIMO.Word/WordParagraphStyle.cs
+++ b/OfficeIMO.Word/WordParagraphStyle.cs
@@ -21,7 +21,26 @@ namespace OfficeIMO.Word {
     }
 
     public static class WordParagraphStyle {
+        private static readonly Dictionary<string, Style> _customStyles = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<WordParagraphStyles, Style> _overrides = new();
+
+        internal static IEnumerable<Style> CustomStyles => _customStyles.Values;
+
+        public static void RegisterCustomStyle(string styleId, Style styleDefinition) {
+            if (string.IsNullOrWhiteSpace(styleId)) throw new ArgumentException("StyleId cannot be empty", nameof(styleId));
+            if (styleDefinition == null) throw new ArgumentNullException(nameof(styleDefinition));
+            _customStyles[styleId] = styleDefinition;
+        }
+
+        public static void OverrideBuiltInStyle(WordParagraphStyles style, Style styleDefinition) {
+            if (style == WordParagraphStyles.Custom) throw new ArgumentException("Cannot override custom style placeholder", nameof(style));
+            if (styleDefinition == null) throw new ArgumentNullException(nameof(styleDefinition));
+            _overrides[style] = styleDefinition;
+        }
+
         public static Style GetStyleDefinition(WordParagraphStyles style) {
+            if (_overrides.TryGetValue(style, out var overrideStyle)) return (Style) overrideStyle.CloneNode(true);
+            if (_customStyles.TryGetValue(style.ToStringStyle(), out var customStyle)) return (Style) customStyle.CloneNode(true);
             switch (style) {
                 case WordParagraphStyles.Normal: return StyleNormal;
                 case WordParagraphStyles.Heading1: return StyleHeading1;


### PR DESCRIPTION
## Summary
- enable registering custom paragraph styles
- allow overriding built‑in paragraph styles
- document the new APIs with an example
- test registering and overriding paragraph styles

## Testing
- `dotnet restore`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build --verbosity minimal` *(fails: The argument /workspace/OfficeIMO/OfficeIMO.VerifyTests/bin/Debug/net8.0/OfficeIMO.VerifyTests.dll is invalid. Please use the /help option to check the list of valid arguments.)*


------
https://chatgpt.com/codex/tasks/task_e_685b041d8d5c832ea5433f6ffccac4c2