### PR TITLE
Clamp TOC AddItem levels

### DIFF
--- a/Docs/officeimo.word.wordlist.md
+++ b/Docs/officeimo.word.wordlist.md
@@ -128,6 +128,9 @@ public WordParagraph AddItem(string text, int level)
 
 `level` [Int32](https://docs.microsoft.com/en-us/dotnet/api/system.int32)<br>
 
+When the list is used as a table of contents, values outside the range 0-8 are
+automatically clamped to that range.
+
 #### Returns
 
 [WordParagraph](./officeimo.word.wordparagraph.md)<br>

--- a/OfficeIMO.Tests/Word.TOC.cs
+++ b/OfficeIMO.Tests/Word.TOC.cs
@@ -197,5 +197,23 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Test_TocListLevelClamping() {
+            string filePath = Path.Combine(_directoryWithFiles, "TocLevelClamp.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                var tocList = document.AddTableOfContentList(WordListStyle.Headings111);
+                tocList.AddItem("First", -2);
+                tocList.AddItem("Last", 10);
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                var list = document.Lists[0];
+                Assert.Equal(2, list.ListItems.Count);
+                Assert.Equal(WordParagraphStyles.Heading1, list.ListItems[0].Style);
+                Assert.Equal(WordParagraphStyles.Heading9, list.ListItems[1].Style);
+            }
+        }
+
     }
 }

--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -16,11 +16,17 @@ namespace OfficeIMO.Word {
             run.Append(new RunProperties());
             run.Append(new Text { Space = SpaceProcessingModeValues.Preserve });
 
+            var levelIndex = level;
+            if (_isToc || IsToc) {
+                if (levelIndex < 0) levelIndex = 0;
+                else if (levelIndex > 8) levelIndex = 8;
+            }
+
             var paragraphProperties = new ParagraphProperties();
             paragraphProperties.Append(new ParagraphStyleId { Val = "ListParagraph" });
             paragraphProperties.Append(
                 new NumberingProperties(
-                    new NumberingLevelReference { Val = level },
+                    new NumberingLevelReference { Val = levelIndex },
                     new NumberingId { Val = _numberId }
                 ));
             paragraph.Append(paragraphProperties);
@@ -56,7 +62,7 @@ namespace OfficeIMO.Word {
             }
 
             if (_isToc || IsToc) {
-                newParagraph.Style = WordParagraphStyle.GetStyle(level);
+                newParagraph.Style = WordParagraphStyle.GetStyle(levelIndex);
             }
 
             return newParagraph;


### PR DESCRIPTION
## Summary
- clamp level values when creating TOC list items
- document TOC level clamping behaviour
- test clamping of TOC list levels

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685b06e42edc832eac2029a43fab2bc5