### PR TITLE
Add style preservation during load

### DIFF
--- a/OfficeIMO.Tests/Word.ParagraphCustomStyles.cs
+++ b/OfficeIMO.Tests/Word.ParagraphCustomStyles.cs
@@ -1,5 +1,7 @@
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Collections.Generic;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using Xunit;
@@ -21,6 +23,10 @@ namespace OfficeIMO.Tests {
                 var styles = document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles;
                 Assert.NotNull(styles.Elements<Style>().FirstOrDefault(s => s.StyleId == "MyStyle"));
             }
+
+            var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static);
+            var dict = (IDictionary<string, Style>)field.GetValue(null)!;
+            dict.Clear();
         }
 
         [Fact]
@@ -32,6 +38,40 @@ namespace OfficeIMO.Tests {
             Assert.Equal(custom, WordParagraphStyle.GetStyleDefinition(WordParagraphStyles.Normal));
 
             WordParagraphStyle.OverrideBuiltInStyle(WordParagraphStyles.Normal, original);
+        }
+
+        [Fact]
+        public void Test_LoadDocumentWithExistingCustomStyle() {
+            var style = new Style { Type = StyleValues.Paragraph, StyleId = "MyStyle" };
+            style.Append(new StyleName { Val = "Original" });
+            WordParagraphStyle.RegisterCustomStyle("MyStyle", style);
+
+            string filePath = Path.Combine(_directoryWithFiles, "CustomStylePreserve.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Text").SetStyleId("MyStyle");
+                document.Save();
+            }
+
+            var updated = new Style { Type = StyleValues.Paragraph, StyleId = "MyStyle" };
+            updated.Append(new StyleName { Val = "Updated" });
+            WordParagraphStyle.RegisterCustomStyle("MyStyle", updated);
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var styles = document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles;
+                var loaded = styles.Elements<Style>().First(s => s.StyleId == "MyStyle");
+                Assert.Equal("Original", loaded.StyleName.Val);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath, overrideStyles: true)) {
+                var styles = document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles;
+                var loaded = styles.Elements<Style>().First(s => s.StyleId == "MyStyle");
+                Assert.Equal("Updated", loaded.StyleName.Val);
+            }
+
+            // cleanup
+            var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static);
+            var dict = (IDictionary<string, Style>)field.GetValue(null)!;
+            dict.Clear();
         }
     }
 }

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -874,7 +874,7 @@ namespace OfficeIMO.Word {
         /// <param name="autoSave"></param>
         /// <returns></returns>
         /// <exception cref="FileNotFoundException"></exception>
-        public static WordDocument Load(string filePath, bool readOnly = false, bool autoSave = false) {
+        public static WordDocument Load(string filePath, bool readOnly = false, bool autoSave = false, bool overrideStyles = false) {
             if (filePath != null) {
                 if (!File.Exists(filePath)) {
                     throw new FileNotFoundException("File doesn't exists", filePath);
@@ -894,7 +894,7 @@ namespace OfficeIMO.Word {
 
                 var wordDocument = WordprocessingDocument.Open(memoryStream, !readOnly, openSettings);
 
-                InitialiseStyleDefinitions(wordDocument, readOnly);
+                InitialiseStyleDefinitions(wordDocument, readOnly, overrideStyles);
 
                 word.FilePath = filePath;
                 word._wordprocessingDocument = wordDocument;
@@ -917,7 +917,7 @@ namespace OfficeIMO.Word {
         /// <param name="autoSave">Enable auto-save on dispose.</param>
         /// <returns>Loaded <see cref="WordDocument"/> instance.</returns>
         /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
-        public static async Task<WordDocument> LoadAsync(string filePath, bool readOnly = false, bool autoSave = false) {
+        public static async Task<WordDocument> LoadAsync(string filePath, bool readOnly = false, bool autoSave = false, bool overrideStyles = false) {
             if (filePath != null) {
                 if (!File.Exists(filePath)) {
                     throw new FileNotFoundException("File doesn't exists", filePath);
@@ -941,7 +941,7 @@ namespace OfficeIMO.Word {
                 _document = wordDocument.MainDocumentPart.Document
             };
 
-            InitialiseStyleDefinitions(wordDocument, readOnly);
+            InitialiseStyleDefinitions(wordDocument, readOnly, overrideStyles);
             word.LoadDocument();
             WordChart.InitializeAxisIdSeed(wordDocument);
             WordChart.InitializeDocPrIdSeed(wordDocument);
@@ -956,7 +956,7 @@ namespace OfficeIMO.Word {
         /// <param name="readOnly"></param>
         /// <param name="autoSave"></param>
         /// <returns></returns>
-        public static WordDocument Load(Stream stream, bool readOnly = false, bool autoSave = false) {
+        public static WordDocument Load(Stream stream, bool readOnly = false, bool autoSave = false, bool overrideStyles = false) {
             var document = new WordDocument();
 
             var openSettings = new OpenSettings {
@@ -964,7 +964,7 @@ namespace OfficeIMO.Word {
             };
 
             var wordDocument = WordprocessingDocument.Open(stream, !readOnly, openSettings);
-            InitialiseStyleDefinitions(wordDocument, readOnly);
+            InitialiseStyleDefinitions(wordDocument, readOnly, overrideStyles);
 
             document._wordprocessingDocument = wordDocument;
             document._document = wordDocument.MainDocumentPart.Document;
@@ -1230,13 +1230,13 @@ namespace OfficeIMO.Word {
 
         }
 
-        private static void InitialiseStyleDefinitions(WordprocessingDocument wordDocument, bool readOnly) {
+        private static void InitialiseStyleDefinitions(WordprocessingDocument wordDocument, bool readOnly, bool overrideStyles) {
             // if document is read only we shouldn't be doing any new styles, hopefully it doesn't break anything
             if (readOnly == false) {
                 var styleDefinitionsPart = wordDocument.MainDocumentPart.GetPartsOfType<StyleDefinitionsPart>()
                     .FirstOrDefault();
                 if (styleDefinitionsPart != null) {
-                    AddStyleDefinitions(styleDefinitionsPart);
+                    AddStyleDefinitions(styleDefinitionsPart, overrideStyles);
                 } else {
 
                     var styleDefinitionsPart1 = wordDocument.MainDocumentPart.AddNewPart<StyleDefinitionsPart>("rId1");


### PR DESCRIPTION
## Summary
- prevent overriding styles when loading documents
- allow overriding via new `overrideStyles` parameter
- preserve custom styles across loads
- test custom style preservation when loading

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeImo.sln --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_685b0f4449bc832e9824d7b7a01d3970