### PR TITLE
Fix numbering part removal when shared

### DIFF
--- a/OfficeIMO.Tests/Word.Lists.cs
+++ b/OfficeIMO.Tests/Word.Lists.cs
@@ -831,4 +831,30 @@ public partial class Word {
             // verified only before saving.
         }
     }
+
+    [Fact]
+    public void Test_SharedNumberingListRemovalKeepsNumberingPart() {
+        var filePath = Path.Combine(_directoryWithFiles, "SharedNumbering.docx");
+
+        using (var document = WordDocument.Create(filePath)) {
+            var list1 = document.AddList(WordListStyle.Bulleted);
+            list1.AddItem("One");
+
+            var list2 = new WordList(document, list1._numberId);
+            list2.AddItem("Two");
+
+            list1.Remove();
+
+            Assert.Single(document.Lists);
+            Assert.Equal("Two", document.Lists[0].ListItems[0].Text);
+            Assert.NotNull(document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart);
+
+            document.Save(false);
+        }
+
+        using (var wordDoc = WordprocessingDocument.Open(filePath, false)) {
+            Assert.NotNull(wordDoc.MainDocumentPart.NumberingDefinitionsPart);
+            Assert.Equal(1, wordDoc.MainDocumentPart.NumberingDefinitionsPart.Numbering.Elements<NumberingInstance>().Count());
+        }
+    }
 }

--- a/OfficeIMO.Word/WordList.Private.cs
+++ b/OfficeIMO.Word/WordList.Private.cs
@@ -272,8 +272,14 @@ public partial class WordList : WordElement {
                 numberingProps.NumberingId.Val = newNumberId;
             }
             currentRef = after ? currentRef.InsertAfterSelf(clonedParagraph) : currentRef.InsertBeforeSelf(clonedParagraph);
+            var run = ((Paragraph)currentRef).GetFirstChild<Run>() ?? new Run();
+            if (run.Parent == null) ((Paragraph)currentRef).AppendChild(run);
+            var wp = new WordParagraph(_document, (Paragraph)currentRef, run);
+            wp.Text = item.Text;
+            wp._list = clonedList;
+            clonedList._listItems.Add(wp);
             if (firstInserted == null) {
-                firstInserted = new WordParagraph(_document, (Paragraph)currentRef);
+                firstInserted = wp;
             }
         }
 

--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -51,6 +51,8 @@ namespace OfficeIMO.Word {
             }
 
             var newParagraph = new WordParagraph(_document, paragraph, run);
+            newParagraph._list = this;
+            _listItems.Add(newParagraph);
             if (text != null) {
                 newParagraph.Text = text;
             }
@@ -62,25 +64,35 @@ namespace OfficeIMO.Word {
             return newParagraph;
         }
 
+        internal void RemoveItem(WordParagraph paragraph) {
+            _listItems.Remove(paragraph);
+        }
+
         public void Remove() {
+            foreach (var listItem in _listItems.ToList()) {
+                listItem.Remove();
+            }
+            _listItems.Clear();
+
             var numberingPart = _document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart;
             var numbering = numberingPart?.Numbering;
             if (numbering != null) {
-                var abstractNum = numbering.Elements<AbstractNum>().FirstOrDefault(a => a.AbstractNumberId.Value == _abstractId);
-                abstractNum?.Remove();
+                bool stillReferenced = _document.EnumerateAllParagraphs()
+                    .Any(p => p.IsListItem && p._listNumberId == _numberId);
 
-                var numberingInstance = numbering.Elements<NumberingInstance>().FirstOrDefault(n => n.NumberID.Value == _numberId);
-                numberingInstance?.Remove();
+                if (!stillReferenced) {
+                    var abstractNum = numbering.Elements<AbstractNum>().FirstOrDefault(a => a.AbstractNumberId.Value == _abstractId);
+                    abstractNum?.Remove();
 
-                if (!numbering.ChildElements.OfType<AbstractNum>().Any() &&
-                    !numbering.ChildElements.OfType<NumberingInstance>().Any() &&
-                    !numbering.ChildElements.OfType<NumberingPictureBullet>().Any()) {
-                    _document._wordprocessingDocument.MainDocumentPart.DeletePart(numberingPart);
+                    var numberingInstance = numbering.Elements<NumberingInstance>().FirstOrDefault(n => n.NumberID.Value == _numberId);
+                    numberingInstance?.Remove();
+
+                    if (!numbering.Elements<AbstractNum>().Any() &&
+                        !numbering.Elements<NumberingInstance>().Any() &&
+                        !numbering.Elements<NumberingPictureBullet>().Any()) {
+                        _document._wordprocessingDocument.MainDocumentPart.DeletePart(numberingPart);
+                    }
                 }
-            }
-
-            foreach (var listItem in ListItems.ToList()) {
-                listItem.Remove();
             }
         }
 
@@ -97,11 +109,14 @@ namespace OfficeIMO.Word {
         }
 
         public void Merge(WordList documentList) {
-            foreach (var item in documentList.ListItems) {
+            foreach (var item in documentList.ListItems.ToList()) {
                 var numberingProperties = item._paragraphProperties.NumberingProperties;
                 if (numberingProperties != null && numberingProperties.NumberingId != null) {
                     numberingProperties.NumberingId.Val = this._numberId;
                 }
+                documentList._listItems.Remove(item);
+                item._list = this;
+                _listItems.Add(item);
             }
             documentList.Remove();
         }

--- a/OfficeIMO.Word/WordList.cs
+++ b/OfficeIMO.Word/WordList.cs
@@ -2,6 +2,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using DocumentFormat.OpenXml;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace OfficeIMO.Word;
 
@@ -20,6 +21,8 @@ public partial class WordList : WordElement {
     private WordParagraph _wordParagraph;
     private readonly WordHeaderFooter _headerFooter;
 
+    private readonly List<WordParagraph> _listItems = new();
+
     /// <summary>
     /// Indicates whether the list is treated as a Table of Contents (TOC).
     /// </summary>
@@ -36,16 +39,9 @@ public partial class WordList : WordElement {
     /// </summary>
     public List<WordParagraph> ListItems {
         get {
-            List<WordParagraph> list = new List<WordParagraph>();
-
-            foreach (var paragraph in _document.EnumerateAllParagraphs()) {
-                if (paragraph.IsListItem && paragraph._listNumberId == _numberId) {
-                    list.Add(paragraph);
-                }
-            }
-
-            return list;
-
+            return _listItems;
+        }
+    }
 
             //if (_wordParagraph != null) {
             //    var list = new List<Paragraph>();
@@ -67,8 +63,6 @@ public partial class WordList : WordElement {
             //return _document.Paragraphs
             //    .Where(paragraph => paragraph.IsListItem && paragraph._listNumberId == _numberId)
             //    .ToList();
-        }
-    }
 
     /// <summary>
     /// Restarts numbering of a list after a break. Requires a list to be set to RestartNumbering overall.
@@ -305,6 +299,10 @@ public partial class WordList : WordElement {
         _wordprocessingDocument = wordDocument._wordprocessingDocument;
         //  _section = section;
         _numberId = numberId;
+        foreach (var p in _document.EnumerateAllParagraphs().Where(p => p.IsListItem && p._listNumberId == _numberId)) {
+            p._list = this;
+            _listItems.Add(p);
+        }
     }
 
     /// <summary>

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -126,6 +126,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <exception cref="InvalidOperationException"></exception>
         public void Remove() {
+            _list?.RemoveItem(this);
             if (_paragraph != null) {
                 if (this._paragraph.Parent != null) {
                     if (this.IsBookmark) {


### PR DESCRIPTION
## Summary
- track list items internally when creating lists
- ensure list removal checks for remaining paragraph references before deleting numbering definitions
- keep numbering references when merging or cloning lists
- add regression test for shared numbering removal

## Testing
- `dotnet build`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685b0afbbeb0832eb8111f3b604794aa