### PR TITLE
Implement list conversion functionality

### DIFF
--- a/OfficeIMO.Tests/Word.ListConversion.cs
+++ b/OfficeIMO.Tests/Word.ListConversion.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_ConvertBulletToNumbered() {
+            var filePath = Path.Combine(_directoryWithFiles, "ConvertBulletToNumbered.docx");
+            int indent;
+            using (var document = WordDocument.Create(filePath)) {
+                var list = document.AddList(WordListStyle.Bulleted);
+                list.AddItem("One");
+                list.AddItem("Two");
+                indent = list.Numbering.Levels.First().IndentationLeft;
+                list.ConvertToNumbered();
+                Assert.Equal(NumberFormatValues.Decimal, list.Numbering.Levels.First()._level.NumberingFormat.Val.Value);
+                Assert.Equal(indent, list.Numbering.Levels.First().IndentationLeft);
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                var list = document.Lists.First();
+                Assert.Equal(new[] { "One", "Two" }, list.ListItems.Select(i => i.Text).ToArray());
+                Assert.Equal(NumberFormatValues.Decimal, list.Numbering.Levels.First()._level.NumberingFormat.Val.Value);
+                Assert.Equal(indent, list.Numbering.Levels.First().IndentationLeft);
+            }
+        }
+
+        [Fact]
+        public void Test_ConvertNumberedToBullet() {
+            var filePath = Path.Combine(_directoryWithFiles, "ConvertNumberedToBullet.docx");
+            int indent;
+            using (var document = WordDocument.Create(filePath)) {
+                var list = document.AddList(WordListStyle.Headings111);
+                list.AddItem("One");
+                list.AddItem("Two");
+                indent = list.Numbering.Levels.First().IndentationLeft;
+                list.ConvertToBulleted();
+                Assert.Equal(NumberFormatValues.Bullet, list.Numbering.Levels.First()._level.NumberingFormat.Val.Value);
+                Assert.Equal(indent, list.Numbering.Levels.First().IndentationLeft);
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                var list = document.Lists.First();
+                Assert.Equal(new[] { "One", "Two" }, list.ListItems.Select(i => i.Text).ToArray());
+                Assert.Equal(NumberFormatValues.Bullet, list.Numbering.Levels.First()._level.NumberingFormat.Val.Value);
+                Assert.Equal(indent, list.Numbering.Levels.First().IndentationLeft);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordList.Private.cs
+++ b/OfficeIMO.Word/WordList.Private.cs
@@ -1,6 +1,7 @@
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using DocumentFormat.OpenXml;
+using System.Linq;
 
 namespace OfficeIMO.Word;
 
@@ -309,6 +310,46 @@ public partial class WordList : WordElement {
         }
         level.Append(symbolProps);
         return level;
+    }
+
+    /// <summary>
+    /// Replaces the underlying abstract numbering definition while keeping the current numbering instance.
+    /// </summary>
+    /// <param name="newAbstract">The new abstract numbering definition.</param>
+    private void ReplaceAbstractNum(AbstractNum newAbstract) {
+        var numberingPart = _document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart!;
+        var numbering = numberingPart.Numbering;
+
+        var oldAbstract = numbering.Elements<AbstractNum>().FirstOrDefault(a => a.AbstractNumberId.Value == _abstractId);
+        if (oldAbstract == null) {
+            return;
+        }
+
+        // preserve indentation from existing levels
+        var oldLevels = oldAbstract.Elements<Level>().ToList();
+        var newLevels = newAbstract.Elements<Level>().ToList();
+        for (int i = 0; i < Math.Min(oldLevels.Count, newLevels.Count); i++) {
+            var oldIndent = oldLevels[i].GetFirstChild<PreviousParagraphProperties>()?.GetFirstChild<Indentation>();
+            if (oldIndent != null) {
+                var prev = newLevels[i].GetFirstChild<PreviousParagraphProperties>();
+                if (prev == null) {
+                    prev = new PreviousParagraphProperties();
+                    newLevels[i].Append(prev);
+                }
+                var indent = prev.GetFirstChild<Indentation>();
+                if (indent == null) {
+                    prev.Append((Indentation)oldIndent.CloneNode(true));
+                } else {
+                    indent.Left = oldIndent.Left;
+                    indent.Hanging = oldIndent.Hanging;
+                }
+            }
+        }
+
+        newAbstract.AbstractNumberId = _abstractId;
+        numbering.InsertAfter(newAbstract, oldAbstract);
+        oldAbstract.Remove();
+        numbering.Save();
     }
 
     private static char GetBulletSymbol(WordListLevelKind kind) {

--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -200,5 +200,19 @@ namespace OfficeIMO.Word {
             string finalColor = color?.ToHexColor() ?? colorHex;
             return AddListLevel(levelIndex, symbol, fontName, finalColor, fontSize);
         }
+
+        /// <summary>
+        /// Converts this list to a numbered style while preserving existing list items.
+        /// </summary>
+        public void ConvertToNumbered() {
+            ReplaceAbstractNum(WordListStyles.GetStyle(WordListStyle.Headings111));
+        }
+
+        /// <summary>
+        /// Converts this list to a bulleted style while preserving existing list items.
+        /// </summary>
+        public void ConvertToBulleted() {
+            ReplaceAbstractNum(WordListStyles.GetStyle(WordListStyle.Bulleted));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `ConvertToNumbered` and `ConvertToBulleted` to `WordList`
- implement helper `ReplaceAbstractNum`
- add tests for converting between bullet and numbered lists

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685b140f71c8832e8d88eeb60df0069c