### PR TITLE
Add custom paragraph style examples

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -43,6 +43,9 @@ namespace OfficeIMO.Examples {
 
             Paragraphs.Example_BasicParagraphs(folderPath, false);
             Paragraphs.Example_BasicParagraphStyles(folderPath, false);
+            Paragraphs.Example_RegisterCustomParagraphStyle(folderPath, false);
+            Paragraphs.Example_MultipleCustomParagraphStyles(folderPath, false);
+            Paragraphs.Example_OverrideBuiltInParagraphStyle(folderPath, false);
             Paragraphs.Example_MultipleParagraphsViaDifferentWays(folderPath, false);
             Paragraphs.Example_BasicTabStops(folderPath, false);
 

--- a/OfficeIMO.Examples/Word/Paragraphs/Paragraphs.CustomStyles.cs
+++ b/OfficeIMO.Examples/Word/Paragraphs/Paragraphs.CustomStyles.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Color = SixLabors.ImageSharp.Color;
+using WColor = DocumentFormat.OpenXml.Wordprocessing.Color;
+
+internal static partial class Paragraphs {
+    internal static void Example_RegisterCustomParagraphStyle(string folderPath, bool openWord) {
+        Console.WriteLine("[*] Creating document with custom style");
+        string filePath = Path.Combine(folderPath, "CustomParagraphStyle.docx");
+
+        var custom = new Style { Type = StyleValues.Paragraph, StyleId = "MyStyle" };
+        custom.Append(new StyleName { Val = "MyStyle" });
+        var runProps = new StyleRunProperties();
+        runProps.Append(new RunFonts { Ascii = "Courier New" });
+        runProps.Append(new WColor { Val = Color.Red.ToHexColor() });
+        runProps.Append(new FontSize { Val = "28" });
+        custom.Append(runProps);
+
+        WordParagraphStyle.RegisterCustomStyle("MyStyle", custom);
+
+        using (WordDocument document = WordDocument.Create(filePath)) {
+            document.AddParagraph("Hello world").SetStyleId("MyStyle");
+            document.Save(openWord);
+        }
+    }
+
+    internal static void Example_MultipleCustomParagraphStyles(string folderPath, bool openWord) {
+        Console.WriteLine("[*] Creating document with multiple custom styles");
+        string filePath = Path.Combine(folderPath, "MultipleCustomParagraphStyles.docx");
+
+        var centeredRed = new Style { Type = StyleValues.Paragraph, StyleId = "CenteredRed" };
+        centeredRed.Append(new StyleName { Val = "CenteredRed" });
+        centeredRed.Append(new StyleParagraphProperties(new Justification { Val = JustificationValues.Center }));
+        var centeredRedRun = new StyleRunProperties();
+        centeredRedRun.Append(new WColor { Val = "FF0000" });
+        centeredRedRun.Append(new Bold());
+        centeredRed.Append(centeredRedRun);
+        WordParagraphStyle.RegisterCustomStyle("CenteredRed", centeredRed);
+
+        var greenIndented = new Style { Type = StyleValues.Paragraph, StyleId = "GreenIndented" };
+        greenIndented.Append(new StyleName { Val = "GreenIndented" });
+        greenIndented.Append(new StyleParagraphProperties(new Indentation { Left = "720" }));
+        var greenIndentedRun = new StyleRunProperties();
+        greenIndentedRun.Append(new WColor { Val = "00AA00" });
+        greenIndentedRun.Append(new Italic());
+        greenIndented.Append(greenIndentedRun);
+        WordParagraphStyle.RegisterCustomStyle("GreenIndented", greenIndented);
+
+        using (WordDocument document = WordDocument.Create(filePath)) {
+            document.AddParagraph("This paragraph is centered and red").SetStyleId("CenteredRed");
+            document.AddParagraph("This paragraph is indented and green").SetStyleId("GreenIndented");
+            document.Save(openWord);
+        }
+    }
+
+    internal static void Example_OverrideBuiltInParagraphStyle(string folderPath, bool openWord) {
+        Console.WriteLine("[*] Overriding built-in Normal style");
+        string filePath = Path.Combine(folderPath, "OverrideNormalStyle.docx");
+        var original = WordParagraphStyle.GetStyleDefinition(WordParagraphStyles.Normal);
+
+        var custom = new Style { Type = StyleValues.Paragraph, StyleId = "Normal" };
+        var run = new StyleRunProperties();
+        run.Append(new WColor { Val = "0000FF" });
+        run.Append(new Bold());
+        custom.Append(run);
+        WordParagraphStyle.OverrideBuiltInStyle(WordParagraphStyles.Normal, custom);
+
+        using (WordDocument document = WordDocument.Create(filePath)) {
+            document.AddParagraph("Paragraph with overridden Normal style");
+            document.Save(openWord);
+        }
+
+        WordParagraphStyle.OverrideBuiltInStyle(WordParagraphStyles.Normal, original);
+    }
+}


### PR DESCRIPTION
## Summary
- add multiple examples demonstrating custom paragraph styles and overriding built-in styles
- invoke these new samples in the example runner

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeImo.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685b140916bc832ebaa358d65cc7cf29