### PR TITLE
Implement RunStyle customization

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -45,6 +45,8 @@ namespace OfficeIMO.Examples {
             Paragraphs.Example_BasicParagraphStyles(folderPath, false);
             Paragraphs.Example_MultipleParagraphsViaDifferentWays(folderPath, false);
             Paragraphs.Example_BasicTabStops(folderPath, false);
+            Paragraphs.Example_RunCharacterStylesSimple(folderPath, false);
+            Paragraphs.Example_RunCharacterStylesAdvanced(folderPath, false);
 
             BasicDocument.Example_BasicDocument(folderPath, false);
             BasicDocument.Example_BasicDocumentSaveAs1(folderPath, false);

--- a/OfficeIMO.Examples/Word/Paragraphs/Paragraphs.RunCharacterStyles.cs
+++ b/OfficeIMO.Examples/Word/Paragraphs/Paragraphs.RunCharacterStyles.cs
@@ -1,0 +1,32 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+internal static partial class Paragraphs {
+
+        internal static void Example_RunCharacterStylesSimple(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with character styled paragraphs");
+            string filePath = System.IO.Path.Combine(folderPath, "ParagraphRunStylesSimple.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Styled paragraph");
+                paragraph.SetCharacterStyle(WordCharacterStyles.Heading1Char);
+                paragraph.AddText(" with hyperlink style").SetCharacterStyleId("Hyperlink");
+                document.Save(openWord);
+            }
+        }
+
+        internal static void Example_RunCharacterStylesAdvanced(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with all character styles");
+            string filePath = System.IO.Path.Combine(folderPath, "ParagraphRunStylesAdvanced.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                foreach (WordCharacterStyles style in Enum.GetValues(typeof(WordCharacterStyles))) {
+                    var para = document.AddParagraph(style.ToString());
+                    para.SetCharacterStyle(style);
+                }
+                var advanced = document.AddParagraph("Link example");
+                var run = advanced.AddText(" visit website");
+                run.SetCharacterStyleId("Hyperlink");
+                document.Save(openWord);
+            }
+        }
+}

--- a/OfficeIMO.Tests/Word.Paragraphs.cs
+++ b/OfficeIMO.Tests/Word.Paragraphs.cs
@@ -467,5 +467,26 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(document.Paragraphs[6].VerticalTextAlignment, VerticalPositionValues.Superscript);
             }
         }
+
+        [Fact]
+        public void Test_RunCharacterStyle() {
+            string filePath = Path.Combine(_directoryWithFiles, "RunCharacterStyle.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Styled text");
+                paragraph.SetCharacterStyle(WordCharacterStyles.Heading1Char);
+                var run = paragraph.AddText(" link");
+                run.SetCharacterStyleId("Hyperlink");
+
+                Assert.Equal(WordCharacterStyles.Heading1Char, paragraph.CharacterStyle);
+                Assert.Equal("Hyperlink", run.CharacterStyleId);
+
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var para = document.Paragraphs[0];
+                Assert.Equal(WordCharacterStyles.Heading1Char, para.CharacterStyle);
+                document.Save();
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -493,5 +493,56 @@ namespace OfficeIMO.Word {
                 }
             }
         }
+
+        public WordCharacterStyles? CharacterStyle {
+            get {
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                if (runProperties != null && runProperties.RunStyle != null) {
+                    return WordCharacterStyle.GetStyle(runProperties.RunStyle.Val);
+                }
+                return null;
+            }
+            set {
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
+                } else {
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
+
+                if (value == null) {
+                    if (runProperties.RunStyle != null) runProperties.RunStyle.Remove();
+                } else {
+                    if (runProperties.RunStyle == null) runProperties.RunStyle = new RunStyle();
+                    runProperties.RunStyle.Val = WordCharacterStyle.ToStringStyle(value.Value);
+                }
+            }
+        }
+
+        public string CharacterStyleId {
+            get {
+                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                return runProperties?.RunStyle?.Val;
+            }
+            set {
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
+                    runProperties = this.Hyperlink._runProperties;
+                } else {
+                    VerifyRunProperties();
+                    runProperties = _runProperties;
+                }
+
+                if (string.IsNullOrEmpty(value)) {
+                    if (runProperties.RunStyle != null) runProperties.RunStyle.Remove();
+                } else {
+                    if (runProperties.RunStyle == null) runProperties.RunStyle = new RunStyle();
+                    runProperties.RunStyle.Val = value;
+                }
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordParagraph.RunPropertiesMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.RunPropertiesMethods.cs
@@ -79,6 +79,16 @@ namespace OfficeIMO.Word {
             return this;
         }
 
+        public WordParagraph SetCharacterStyle(WordCharacterStyles style) {
+            CharacterStyle = style;
+            return this;
+        }
+
+        public WordParagraph SetCharacterStyleId(string styleId) {
+            CharacterStyleId = styleId;
+            return this;
+        }
+
         /// <summary>
         /// Set the vertical text alignment
         /// </summary>


### PR DESCRIPTION
## Summary
- allow editing RunStyle in `WordParagraph`
- expose `CharacterStyle` and `CharacterStyleId` APIs
- add helpers to update character style via `SetCharacterStyle` methods
- test run character style logic
- show how to use run character styles in examples

## Testing
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685b116fb48c832e8e2046941a709a69