### PR TITLE
Enable customizing list start numbering

### DIFF
--- a/Docs/custom-lists.md
+++ b/Docs/custom-lists.md
@@ -17,5 +17,15 @@ builder.AddItem("First");
 builder.AddItem("Fifth", 4);
 ```
 
+You can adjust where numbering begins using `StartNumberingValue` on a level:
+
+```csharp
+var numbered = document.AddCustomList();
+var level = new WordListLevel(WordListLevelKind.Decimal)
+    .SetStartNumberingValue(3);
+numbered.Numbering.AddLevel(level);
+numbered.AddItem("Starts at three");
+```
+
 See [`WordListLevelKind`](./officeimo.word.wordlistlevelkind.md) for the available bullet symbols.
 

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -67,6 +67,7 @@ namespace OfficeIMO.Examples {
             Lists.Example_CustomList1(folderPath, false);
             Lists.Example_BasicListsWithChangedStyling(folderPath, false);
             Lists.Example_CloneList(folderPath, false);
+            Lists.Example_ListStartNumber(folderPath, false);
 
             Tables.Example_BasicTables1(folderPath, false);
             Tables.Example_BasicTablesLoad1(folderPath, false);

--- a/OfficeIMO.Examples/Word/Lists/Lists.StartNumber.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.StartNumber.cs
@@ -1,0 +1,18 @@
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Lists {
+        internal static void Example_ListStartNumber(string folderPath, bool openWord) {
+            string filePath = System.IO.Path.Combine(folderPath, "Document list starting number.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var list = document.AddCustomList();
+                var level = new WordListLevel(WordListLevelKind.Decimal)
+                    .SetStartNumberingValue(3);
+                list.Numbering.AddLevel(level);
+                list.AddItem("Starts at three");
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.ListStartNumberValue.cs
+++ b/OfficeIMO.Tests/Word.ListStartNumberValue.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_ListLevelStartNumberingValue() {
+            var filePath = Path.Combine(_directoryWithFiles, "ListStartNumbering.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                var list = document.AddList(WordListStyle.Headings111);
+                list.Numbering.Levels[0].SetStartNumberingValue(5);
+                list.AddItem("First");
+                list.AddItem("Second");
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(5, document.Lists[0].Numbering.Levels[0].StartNumberingValue);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordListLevel.cs
+++ b/OfficeIMO.Word/WordListLevel.cs
@@ -58,6 +58,16 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Sets the starting number for this level.
+        /// </summary>
+        /// <param name="value">The starting number.</param>
+        /// <returns>The current <see cref="WordListLevel"/> instance.</returns>
+        public WordListLevel SetStartNumberingValue(int value) {
+            StartNumberingValue = value;
+            return this;
+        }
+
+        /// <summary>
         /// Gets or sets the text indentation (left indentation) in twentieths of a point.
         /// </summary>
         public int IndentationLeft {


### PR DESCRIPTION
## Summary
- add `SetStartNumberingValue` helper to `WordListLevel`
- document how to change numbering start values
- test starting value handling for lists
- show custom start number use in examples

## Testing
- `dotnet test --no-build -v q` *(fails: 3, passed: 312)*

------
https://chatgpt.com/codex/tasks/task_e_685b11090f1c832eb6c84e5106897b9c