### PR TITLE
Add list style detection example

### DIFF
--- a/Docs/Examples/ExamplesListStyleDetection/README.MD
+++ b/Docs/Examples/ExamplesListStyleDetection/README.MD
@@ -1,0 +1,23 @@
+## Detect list style for paragraphs
+
+This example shows how to determine the style of a paragraph that belongs to a list.
+
+```csharp
+using (WordDocument document = WordDocument.Create(filePath)) {
+    var bullet = document.AddList(WordListStyle.Bulleted);
+    bullet.AddItem("Bullet item");
+
+    var numbered = document.AddList(WordListStyle.Headings111);
+    numbered.AddItem("Numbered item");
+
+    document.Save();
+}
+
+using (WordDocument document = WordDocument.Load(filePath)) {
+    foreach (var paragraph in document.Paragraphs) {
+        if (paragraph.IsListItem) {
+            Console.WriteLine($"{paragraph.Text}: {paragraph.GetListStyle()}");
+        }
+    }
+}
+```

--- a/OfficeIMO.Examples/Word/Lists/Lists.DetectListStyle.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.DetectListStyle.cs
@@ -1,0 +1,31 @@
+using OfficeIMO.Word;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Lists {
+        internal static void Example_DetectListStyles(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Detecting list style for paragraphs");
+            string filePath = Path.Combine(folderPath, "ListStyleDetection.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var bulletList = document.AddList(WordListStyle.Bulleted);
+                bulletList.AddItem("Bullet item");
+
+                var numberedList = document.AddList(WordListStyle.Headings111);
+                numberedList.AddItem("Numbered item");
+
+                document.Save();
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                foreach (var paragraph in document.Paragraphs) {
+                    if (paragraph.IsListItem) {
+                        Console.WriteLine($"{paragraph.Text} -> {paragraph.GetListStyle()}");
+                    }
+                }
+                document.Save(openWord);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Lists.DetectListStyle example to show how to determine list style for paragraphs
- document example in new README under Docs/Examples/ExamplesListStyleDetection

## Testing
- `dotnet build OfficeImo.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685b16e77e80832ebeda65a3b0868f3a