### PR TITLE
Add custom bullet color example

### DIFF
--- a/Docs/Examples/ExamplesCustomBulletLists/README.MD
+++ b/Docs/Examples/ExamplesCustomBulletLists/README.MD
@@ -1,0 +1,16 @@
+## Custom bullet lists with colors
+
+This example shows how to create bullet lists using `AddCustomBulletList` and set the bullet color and font.
+
+```csharp
+using (WordDocument document = WordDocument.Create(filePath)) {
+    var bulletList = document.AddCustomBulletList(WordListLevelKind.BulletDiamondSymbol, "Wingdings", Color.DarkRed, fontSize: 14);
+    bulletList.AddItem("Red bullet item");
+    bulletList.AddItem("Another item");
+
+    var second = document.AddCustomBulletList('o', "Calibri", "0000ff", fontSize: 12);
+    second.AddItem("Blue bullet item");
+    second.AddItem("Second blue item");
+    document.Save();
+}
+```

--- a/OfficeIMO.Examples/Word/Lists/Lists.CustomBulletColor.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.CustomBulletColor.cs
@@ -1,0 +1,23 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Color = SixLabors.ImageSharp.Color;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Lists {
+        internal static void Example_CustomBulletColor(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with custom bullet color");
+            string filePath = System.IO.Path.Combine(folderPath, "Document custom bullet color.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var bulletList = document.AddCustomBulletList(WordListLevelKind.BulletDiamondSymbol, "Wingdings", Color.DarkRed, fontSize: 14);
+                bulletList.AddItem("Red bullet item");
+                bulletList.AddItem("Another item");
+
+                var second = document.AddCustomBulletList('o', "Calibri", "0000ff", fontSize: 12);
+                second.AddItem("Blue bullet item");
+                second.AddItem("Second blue item");
+                document.Save(openWord);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Lists.CustomBulletColor example showing bullet lists with colored symbols
- document the sample in Docs/Examples/ExamplesCustomBulletLists

## Testing
- `dotnet build`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685b16f00954832e922e1f9479c412a8