### PR TITLE
Add SaveAs method for WordDocument

### DIFF
--- a/Docs/officeimo.word.worddocument.md
+++ b/Docs/officeimo.word.worddocument.md
@@ -139,3 +139,24 @@ public void UpdateFields()
 ```
 
 Use this when you want fields refreshed before opening the file. Alternatively set `Settings.UpdateFieldsOnOpen` to rely on Word to update them.
+
+### **SaveAs(String, Nullable<Boolean>)**
+
+Creates a new file from the current document without changing the original `FilePath`.
+
+```csharp
+public WordDocument SaveAs(string filePath, bool openWord = false)
+```
+
+#### Parameters
+
+`filePath` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+Path to save the cloned document.
+
+`openWord` [Boolean](https://docs.microsoft.com/en-us/dotnet/api/system.boolean)<br>
+Open the document in Microsoft Word after saving.
+
+#### Returns
+
+[WordDocument](./officeimo.word.worddocument.md)<br>
+Newly loaded instance representing the saved file.

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.SaveAs.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.SaveAs.cs
@@ -39,7 +39,7 @@ namespace OfficeIMO.Examples.Word {
             // We're checking if the file is locked (it shouldn't be - yet)
             Console.WriteLine("File: " + filePathOutput + " is locked: " + filePathOutput.IsFileLocked());
 
-            document.Save(filePathOutput, false);
+            document.SaveAs(filePathOutput, false);
 
             // both files should not be locked
             Console.WriteLine("File: " + filePath + " is locked: " + filePath.IsFileLocked());
@@ -48,7 +48,7 @@ namespace OfficeIMO.Examples.Word {
             WordDocument document1 = WordDocument.Load(filePathOutput);
 
             document1.AddParagraph("This is my test in document 2");
-            document1.Save(filePathOutput2, openWord);
+            document1.SaveAs(filePathOutput2, openWord);
         }
 
 
@@ -63,7 +63,7 @@ namespace OfficeIMO.Examples.Word {
 
             document.AddParagraph("This is my test in document");
 
-            document.Save(filePath, openWord);
+            document.SaveAs(filePath, openWord);
         }
 
         public static void Example_BasicDocumentSaveAs3(string folderPath, bool openWord) {
@@ -79,15 +79,15 @@ namespace OfficeIMO.Examples.Word {
 
             document.AddParagraph("This is my test in document 1");
 
-            document.Save(filePath1);
+            document.SaveAs(filePath1);
 
             document.AddParagraph("This is my test in document 2");
 
-            document.Save(filePath2);
+            document.SaveAs(filePath2);
 
             document.AddParagraph("This is my test in document 3");
 
-            document.Save(filePath3, openWord);
+            document.SaveAs(filePath3, openWord);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/Paragraphs/Paragraphs.MultipleWays.cs
+++ b/OfficeIMO.Examples/Word/Paragraphs/Paragraphs.MultipleWays.cs
@@ -103,7 +103,7 @@ internal static partial class Paragraphs {
 
             Console.WriteLine("Found paragraphs in document: " + document.Paragraphs.Count);
 
-            document.Save(filePath, openWord);
+            document.SaveAs(filePath, openWord);
         }
     }
 

--- a/OfficeIMO.Examples/Word/Tables/Tables.Load2.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.Load2.cs
@@ -28,7 +28,7 @@ namespace OfficeIMO.Examples.Word {
                 wordTable = document.AddTable(3, 4, WordTableStyle.GridTable1LightAccent6);
                 wordTable.Rows[0].Cells[0].Paragraphs[0].Text = "Test 1";
 
-                document.Save(filePath2, openWord);
+                document.SaveAs(filePath2, openWord);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.SaveAsMethod.cs
+++ b/OfficeIMO.Tests/Word.SaveAsMethod.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_SaveAs_DoesNotChangeFilePath() {
+            var originalPath = Path.Combine(_directoryWithFiles, "SaveAsOriginal.docx");
+            var copyPath = Path.Combine(_directoryWithFiles, "SaveAsCopy.docx");
+
+            File.Delete(originalPath);
+            File.Delete(copyPath);
+
+            using (var document = WordDocument.Create(originalPath)) {
+                document.AddParagraph("Test");
+                document.Save();
+
+                Assert.Equal(originalPath, document.FilePath);
+
+                using var newDoc = document.SaveAs(copyPath);
+                Assert.Equal(originalPath, document.FilePath);
+                Assert.Equal(copyPath, newDoc.FilePath);
+                Assert.True(File.Exists(copyPath));
+                Assert.Single(newDoc.Paragraphs);
+            }
+
+            using var loaded = WordDocument.Load(copyPath);
+            Assert.Single(loaded.Paragraphs);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -249,6 +249,19 @@ using (WordDocument document = WordDocument.Create(filePath)) {
 }
 ```
 
+### Saving as a new document
+
+`SaveAs` clones the current document to a new path and returns a new `WordDocument` instance without changing the original `FilePath`.
+
+```csharp
+using (WordDocument document = WordDocument.Create()) {
+    document.AddParagraph("Some text");
+    using var copy = document.SaveAs(filePath);
+    // document.FilePath is still null
+    // copy.FilePath equals filePath
+}
+```
+
 ### Basic Document with Headers/Footers (first, odd, even)
 
 This short example shows how to add headers and footers to Word Document.


### PR DESCRIPTION
## Summary
- add a new `SaveAs` method to `WordDocument` that clones the current document without changing `FilePath`
- adjust examples to use the new API when saving under a new name
- document `SaveAs` in README and generated docs
- test `SaveAs` to ensure original `FilePath` remains unchanged and file loads

## Testing
- `dotnet test`
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_685b87c28ed0832ea3fac61b63e26886