### PR TITLE
Add combo chart support

### DIFF
--- a/OfficeIMO.Examples/Word/Charts/Charts.Combo.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Combo.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Examples.Word {
             using WordDocument document = WordDocument.Create(filePath);
             List<string> categories = new() { "Food", "Housing", "Mix", "Data" };
             var comboChart = document.AddComboChart("Combo chart");
-            comboChart.AddCategories(categories);
+            comboChart.AddChartAxisX(categories);
             comboChart.AddBar("Sales", new List<int> { 10, 35, 18, 23 }, Color.Brown);
             comboChart.AddLine("Trend", new List<int> { 12, 30, 20, 25 }, Color.AliceBlue);
             comboChart.AddLegend(LegendPositionValues.Top);

--- a/OfficeIMO.Examples/Word/Charts/Charts.Combo.cs
+++ b/OfficeIMO.Examples/Word/Charts/Charts.Combo.cs
@@ -1,0 +1,32 @@
+using DocumentFormat.OpenXml.Drawing.Charts;
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Charts {
+        public static void Example_ComboChart(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a combo chart");
+            string filePath = System.IO.Path.Combine(folderPath, "ComboChart.docx");
+            using WordDocument document = WordDocument.Create(filePath);
+            List<string> categories = new() { "Food", "Housing", "Mix", "Data" };
+            var comboChart = document.AddComboChart("Combo chart");
+            comboChart.AddCategories(categories);
+            comboChart.AddBar("Sales", new List<int> { 10, 35, 18, 23 }, Color.Brown);
+            comboChart.AddLine("Trend", new List<int> { 12, 30, 20, 25 }, Color.AliceBlue);
+            comboChart.AddLegend(LegendPositionValues.Top);
+            document.Save(false);
+
+            var valid = document.ValidateDocument();
+            if (valid.Count > 0) {
+                Console.WriteLine("Document has validation errors:");
+                foreach (var error in valid) {
+                    Console.WriteLine(error.Id + ": " + error.Description);
+                }
+            } else {
+                Console.WriteLine("Document is valid.");
+            }
+
+            document.Open(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Charts.cs
+++ b/OfficeIMO.Tests/Word.Charts.cs
@@ -401,6 +401,10 @@ namespace OfficeIMO.Tests {
                 var barIds = bar.Elements<AxisId>().Select(a => a.Val.Value).ToList();
                 var lineIds = line.Elements<AxisId>().Select(a => a.Val.Value).ToList();
                 Assert.Equal(barIds, lineIds);
+                var seriesIdx = bar.Elements<BarChartSeries>().Select(s => s.Index.Val.Value)
+                    .Concat(line.Elements<LineChartSeries>().Select(s => s.Index.Val.Value))
+                    .ToList();
+                Assert.Equal(seriesIdx.Count, seriesIdx.Distinct().Count());
 
                 var validation = document.ValidateDocument();
                 var chartErrors = validation.Where(v => v.Description.Contains("chart")).ToList();

--- a/OfficeIMO.Tests/Word.Charts.cs
+++ b/OfficeIMO.Tests/Word.Charts.cs
@@ -384,7 +384,7 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var categories = new List<string> { "A", "B", "C" };
                 var chart = document.AddComboChart();
-                chart.AddCategories(categories);
+                chart.AddChartAxisX(categories);
                 chart.AddBar("Sales", new List<int> { 1, 2, 3 }, Color.Blue);
                 chart.AddLine("Trend", new List<int> { 3, 2, 1 }, Color.Red);
                 document.Save(false);

--- a/OfficeIMO.Tests/Word.Charts.cs
+++ b/OfficeIMO.Tests/Word.Charts.cs
@@ -377,5 +377,36 @@ namespace OfficeIMO.Tests {
                     Word.FormatValidationErrors(chartErrors));
             }
         }
+        [Fact]
+        public void Test_ComboChartBarAndLine() {
+            var filePath = Path.Combine(_directoryWithFiles, "ComboChart.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var categories = new List<string> { "A", "B", "C" };
+                var chart = document.AddComboChart();
+                chart.AddCategories(categories);
+                chart.AddBar("Sales", new List<int> { 1, 2, 3 }, Color.Blue);
+                chart.AddLine("Trend", new List<int> { 3, 2, 1 }, Color.Red);
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Single(document.Charts);
+                var part = document._wordprocessingDocument.MainDocumentPart.ChartParts.First();
+                var c = part.ChartSpace.GetFirstChild<Chart>();
+                var bar = c.PlotArea.GetFirstChild<BarChart>();
+                var line = c.PlotArea.GetFirstChild<LineChart>();
+                Assert.NotNull(bar);
+                Assert.NotNull(line);
+                var barIds = bar.Elements<AxisId>().Select(a => a.Val.Value).ToList();
+                var lineIds = line.Elements<AxisId>().Select(a => a.Val.Value).ToList();
+                Assert.Equal(barIds, lineIds);
+
+                var validation = document.ValidateDocument();
+                var chartErrors = validation.Where(v => v.Description.Contains("chart")).ToList();
+                Assert.True(chartErrors.Count == 0,
+                    Word.FormatValidationErrors(chartErrors));
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordChart.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordChart.PrivateMethods.cs
@@ -1,5 +1,6 @@
 using DocumentFormat.OpenXml.Drawing.Charts;
 using DocumentFormat.OpenXml;
+using System.Linq;
 
 namespace OfficeIMO.Word {
     public partial class WordChart {
@@ -216,6 +217,20 @@ namespace OfficeIMO.Word {
                 // since the title may have changed, we need to update it
                 UpdateTitle();
                 UpdateAxisTitles();
+            } else if (_chart.PlotArea.GetFirstChild<BarChart>() == null) {
+                var lineChart = _chart.PlotArea.GetFirstChild<LineChart>();
+                if (lineChart != null) {
+                    var ids = lineChart.Elements<AxisId>().ToList();
+                    var barChart = CreateBarChart(ids[0].Val, ids[1].Val);
+                    var catAxis = _chart.PlotArea.GetFirstChild<CategoryAxis>();
+                    if (catAxis != null) {
+                        _chart.PlotArea.InsertBefore(barChart, catAxis);
+                    } else {
+                        _chart.PlotArea.Append(barChart);
+                    }
+                } else {
+                    _chart = GenerateChartBar(_chart);
+                }
             }
         }
 
@@ -240,6 +255,20 @@ namespace OfficeIMO.Word {
                 // since the title may have changed, we need to update it
                 UpdateTitle();
                 UpdateAxisTitles();
+            } else if (_chart.PlotArea.GetFirstChild<LineChart>() == null) {
+                var barChart = _chart.PlotArea.GetFirstChild<BarChart>();
+                if (barChart != null) {
+                    var ids = barChart.Elements<AxisId>().ToList();
+                    var lineChart = CreateLineChart(ids[0].Val, ids[1].Val);
+                    var catAxis = _chart.PlotArea.GetFirstChild<CategoryAxis>();
+                    if (catAxis != null) {
+                        _chart.PlotArea.InsertBefore(lineChart, catAxis);
+                    } else {
+                        _chart.PlotArea.Append(lineChart);
+                    }
+                } else {
+                    _chart = GenerateLineChart(_chart);
+                }
             }
         }
 

--- a/OfficeIMO.Word/WordChart.PublicMethods.cs
+++ b/OfficeIMO.Word/WordChart.PublicMethods.cs
@@ -39,7 +39,9 @@ namespace OfficeIMO.Word {
 
         /// <summary>
         /// Add a line to a chart. Multiple lines can be added.
-        /// You cannot mix lines with pies or bars.
+        /// You cannot mix lines with pie charts. Lines can be combined with bar
+        /// series to create combo charts, but make sure to call
+        /// <see cref="AddChartAxisX"/> before adding either series.
         /// </summary>
         /// <param name="name"></param>
         /// <param name="values"></param>
@@ -54,10 +56,20 @@ namespace OfficeIMO.Word {
 
         }
 
+        /// <summary>
+        /// Sets the category labels for the X axis. This should be called
+        /// before adding bar or line series when creating a combo chart so that
+        /// both chart types share the same axis.
+        /// </summary>
         public void AddChartAxisX(List<string> categories) {
             Categories = categories;
         }
 
+        /// <summary>
+        /// Adds a bar series to the chart. When mixing bar and line series be
+        /// sure to call <see cref="AddChartAxisX"/> first so the categories are
+        /// shared across both chart types.
+        /// </summary>
         public void AddBar(string name, int values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsBar();
             var barChart = _chart.PlotArea.GetFirstChild<BarChart>();
@@ -67,6 +79,11 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Adds a bar series with multiple values. When used in a combo chart
+        /// with line series the categories must be set via
+        /// <see cref="AddChartAxisX"/> before calling this method.
+        /// </summary>
         public void AddBar<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsBar();
             var barChart = _chart.PlotArea.GetFirstChild<BarChart>();
@@ -76,6 +93,10 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Adds a bar series from an array of values. For combo charts ensure
+        /// <see cref="AddChartAxisX"/> has been called first.
+        /// </summary>
         public void AddBar(string name, int[] values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsBar();
             var barChart = _chart.PlotArea.GetFirstChild<BarChart>();

--- a/OfficeIMO.Word/WordChart.cs
+++ b/OfficeIMO.Word/WordChart.cs
@@ -1,7 +1,7 @@
 using DocumentFormat.OpenXml.Drawing.Charts;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
-
+using System.Threading;
 using AxisId = DocumentFormat.OpenXml.Drawing.Charts.AxisId;
 using Chart = DocumentFormat.OpenXml.Drawing.Charts.Chart;
 using ChartSpace = DocumentFormat.OpenXml.Drawing.Charts.ChartSpace;
@@ -10,7 +10,6 @@ using Formula = DocumentFormat.OpenXml.Drawing.Charts.Formula;
 using Legend = DocumentFormat.OpenXml.Drawing.Charts.Legend;
 using NumericValue = DocumentFormat.OpenXml.Drawing.Charts.NumericValue;
 using PlotArea = DocumentFormat.OpenXml.Drawing.Charts.PlotArea;
-using System.Threading;
 
 namespace OfficeIMO.Word {
     public partial class WordChart : WordElement {
@@ -61,57 +60,18 @@ namespace OfficeIMO.Word {
 
         private UInt32Value _index {
             get {
-                var ids = new List<UInt32Value>();
                 if (_chart != null) {
-                    var lineChart = _chart.PlotArea.GetFirstChild<LineChart>();
-                    var line3dChart = _chart.PlotArea.GetFirstChild<Line3DChart>();
-                    var barChart = _chart.PlotArea.GetFirstChild<BarChart>();
-                    var bar3dChart = _chart.PlotArea.GetFirstChild<Bar3DChart>();
-                    var pieChart = _chart.PlotArea.GetFirstChild<PieChart>();
-                    var pie3dChart = _chart.PlotArea.GetFirstChild<Pie3DChart>();
-                    var areaChart = _chart.PlotArea.GetFirstChild<AreaChart>();
-                    if (lineChart != null) {
-                        var series = lineChart.ChildElements.OfType<LineChartSeries>();
-                        foreach (var index in series) {
-                            ids.Add(index.Index.Val);
-                        }
-                    } else if (line3dChart != null) {
-                        var series = line3dChart.ChildElements.OfType<LineChartSeries>();
-                        foreach (var index in series) {
-                            ids.Add(index.Index.Val);
-                        }
-                    } else if (pieChart != null) {
-                        var series = pieChart.ChildElements.OfType<PieChartSeries>();
-                        foreach (var index in series) {
-                            ids.Add(index.Index.Val);
-                        }
-                    } else if (pie3dChart != null) {
-                        var series = pie3dChart.ChildElements.OfType<PieChartSeries>();
-                        foreach (var index in series) {
-                            ids.Add(index.Index.Val);
-                        }
-                    } else if (barChart != null) {
-                        var series = barChart.ChildElements.OfType<BarChartSeries>();
-                        foreach (var index in series) {
-                            ids.Add(index.Index.Val);
-                        }
-                    } else if (bar3dChart != null) {
-                        var series = bar3dChart.ChildElements.OfType<BarChartSeries>();
-                        foreach (var index in series) {
-                            ids.Add(index.Index.Val);
-                        }
-                    } else if (areaChart != null) {
-                        var series = areaChart.ChildElements.OfType<AreaChartSeries>();
-                        foreach (var index in series) {
-                            ids.Add(index.Index.Val);
-                        }
+                    var ids = _chart.PlotArea
+                        .Descendants<DocumentFormat.OpenXml.Drawing.Charts.Index>()
+                        .Select(i => i.Val)
+                        .ToList();
+
+                    if (ids.Count > 0) {
+                        return ids.Max() + 1U;
                     }
                 }
-                if (ids.Count > 0) {
-                    return ids.Max() + 1;
-                } else {
-                    return 0;
-                }
+
+                return 0U;
             }
         }
         private CategoryAxis AddCategoryAxis() {

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -73,7 +73,7 @@ namespace OfficeIMO.Word {
         /// .AddBar3D() to add a 3-D bar chart.
         /// .AddPie3D() to add a 3-D pie chart.
         /// .AddLine3D() to add a 3-D line chart.
-        /// You can't mix and match the types of charts.
+        /// You can't mix and match the types of charts, except bar and line which can coexist in a combo chart.
         /// </summary>
         /// <param name="title">The title.</param>
         /// <param name="roundedCorners">if set to <c>true</c> [rounded corners].</param>
@@ -84,6 +84,15 @@ namespace OfficeIMO.Word {
             var paragraph = this.AddParagraph();
             var chartInstance = new WordChart(this, paragraph, title, roundedCorners, width, height);
             return chartInstance;
+        }
+
+        /// <summary>
+        /// Creates a chart ready for combining bar and line series.
+        /// Use <see cref="WordChart.AddBar"/> and <see cref="WordChart.AddLine"/>
+        /// to add data.
+        /// </summary>
+        public WordChart AddComboChart(string title = "", bool roundedCorners = false, int width = 600, int height = 600) {
+            return AddChart(title, roundedCorners, width, height);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -90,7 +90,8 @@ namespace OfficeIMO.Word {
         /// Creates a chart ready for combining bar and line series.
         /// Use <see cref="WordChart.AddChartAxisX"/> to supply category labels
         /// and then <see cref="WordChart.AddBar"/> / <see cref="WordChart.AddLine"/>
-        /// to add data.
+        /// to add data. The call to <c>AddChartAxisX</c> must be performed
+        /// before adding any series so both chart types share the same axes.
         /// </summary>
         public WordChart AddComboChart(string title = "", bool roundedCorners = false, int width = 600, int height = 600) {
             return AddChart(title, roundedCorners, width, height);

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -88,7 +88,8 @@ namespace OfficeIMO.Word {
 
         /// <summary>
         /// Creates a chart ready for combining bar and line series.
-        /// Use <see cref="WordChart.AddBar"/> and <see cref="WordChart.AddLine"/>
+        /// Use <see cref="WordChart.AddChartAxisX"/> to supply category labels
+        /// and then <see cref="WordChart.AddBar"/> / <see cref="WordChart.AddLine"/>
         /// to add data.
         /// </summary>
         public WordChart AddComboChart(string title = "", bool roundedCorners = false, int width = 600, int height = 600) {

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -545,7 +545,8 @@ namespace OfficeIMO.Word {
         /// Creates a chart ready for combining bar and line series.
         /// Use <see cref="WordChart.AddChartAxisX"/> to supply category labels
         /// and then <see cref="WordChart.AddBar"/> / <see cref="WordChart.AddLine"/>
-        /// to add data.
+        /// to add data. <c>AddChartAxisX</c> must be called before adding any
+        /// series so that both chart types share the same axes.
         /// </summary>
         public WordChart AddComboChart(string title = "", bool roundedCorners = false, int width = 600, int height = 600) {
             return AddChart(title, roundedCorners, width, height);

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -528,7 +528,7 @@ namespace OfficeIMO.Word {
         /// .AddBar3D() to add a 3-D bar chart.
         /// .AddPie3D() to add a 3-D pie chart.
         /// .AddLine3D() to add a 3-D line chart.
-        /// You can't mix and match the types of charts.
+        /// You can't mix and match the types of charts, except bar and line which can coexist in a combo chart.
         /// </summary>
         /// <param name="title">The title.</param>
         /// <param name="roundedCorners">if set to <c>true</c> [rounded corners].</param>
@@ -539,6 +539,15 @@ namespace OfficeIMO.Word {
             var paragraph = this.AddParagraph();
             var chartInstance = new WordChart(this._document, paragraph, title, roundedCorners, width, height);
             return chartInstance;
+        }
+
+        /// <summary>
+        /// Creates a chart ready for combining bar and line series.
+        /// Use <see cref="WordChart.AddBar"/> and <see cref="WordChart.AddLine"/>
+        /// to add data.
+        /// </summary>
+        public WordChart AddComboChart(string title = "", bool roundedCorners = false, int width = 600, int height = 600) {
+            return AddChart(title, roundedCorners, width, height);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -543,7 +543,8 @@ namespace OfficeIMO.Word {
 
         /// <summary>
         /// Creates a chart ready for combining bar and line series.
-        /// Use <see cref="WordChart.AddBar"/> and <see cref="WordChart.AddLine"/>
+        /// Use <see cref="WordChart.AddChartAxisX"/> to supply category labels
+        /// and then <see cref="WordChart.AddBar"/> / <see cref="WordChart.AddLine"/>
         /// to add data.
         /// </summary>
         public WordChart AddComboChart(string title = "", bool roundedCorners = false, int width = 600, int height = 600) {

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Here's a list of features currently supported (and probably a lot I forgot) and 
         - ☑️ Pie and Pie 3D
         - ☑️ Bar and Bar 3D
         - ☑️ Line and Line 3D
+        - ☑️ Combo (Bar + Line)
         - ☑️ Area and Area 3D
         - ☑️ Scatter
         - ☑️ Radar

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Here's a list of features currently supported (and probably a lot I forgot) and 
     - ☑️ Add categories and legends
     - ☑️ Configure axes
     - ☑️ Add multiple series
+    - ⚠️ When mixing bar and line series call `AddChartAxisX` before adding
+      any data so both chart types share the same category axis.
 - ☑️ Lists
     - ☑️ Add lists
     - ☑️ Remove lists


### PR DESCRIPTION
## Summary
- allow mixing bar and line charts in `WordChart`
- add `AddComboChart` helpers on document and paragraph
- demonstrate combo chart usage in examples
- test combo chart generation
- document combo chart feature

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeImo.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685b879e51ec832e9df244bd6746e15d