### PR TITLE
Add XML serialization helpers

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -78,6 +78,7 @@
 [WordHeadersAndFooters](./officeimo.word.wordheadersandfooters.md)
 
 [WordHelpers](./officeimo.word.wordhelpers.md)
+[WordXmlSerialization](./officeimo.word.wordxmlserialization.md)
 
 [WordHyperLink](./officeimo.word.wordhyperlink.md)
 

--- a/Docs/officeimo.word.wordxmlserialization.md
+++ b/Docs/officeimo.word.wordxmlserialization.md
@@ -1,0 +1,42 @@
+# WordXmlSerialization
+
+Namespace: OfficeIMO.Word
+
+```csharp
+public static class WordXmlExtensions
+```
+
+Provides helper methods to convert Word elements to and from raw XML.
+
+## Methods
+
+### **ToXml(WordParagraph)**
+
+```csharp
+public static string ToXml(this WordParagraph paragraph)
+```
+
+Returns the `OuterXml` of the underlying `Paragraph` element.
+
+### **AddParagraphFromXml(WordDocument, string)**
+
+```csharp
+public static WordParagraph AddParagraphFromXml(this WordDocument document, string xml)
+```
+
+Creates a paragraph from an XML string and appends it to the specified document.
+
+## Example
+
+```csharp
+using OfficeIMO.Word;
+
+using var doc = WordDocument.Create("example.docx");
+var p = doc.AddParagraph("Hello world");
+string xml = p.ToXml();
+
+// insert a copy of the paragraph
+var copy = doc.AddParagraphFromXml(xml);
+
+doc.Save(true);
+```

--- a/OfficeIMO.Tests/Word.XmlSerialization.cs
+++ b/OfficeIMO.Tests/Word.XmlSerialization.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_ParagraphXmlRoundTrip() {
+            string filePath = Path.Combine(_directoryWithFiles, "ParagraphXmlRoundTrip.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Example text");
+                string xml = paragraph.ToXml();
+
+                var cloned = document.AddParagraphFromXml(xml);
+
+                Assert.Equal(paragraph.ToXml(), cloned.ToXml());
+                Assert.Equal(2, document.Paragraphs.Count);
+                document.Save(false);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordXmlExtensions.cs
+++ b/OfficeIMO.Word/WordXmlExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides serialization helpers for Word elements.
+    /// </summary>
+    public static class WordXmlExtensions {
+        /// <summary>
+        /// Returns the raw Open XML string representing the paragraph.
+        /// </summary>
+        /// <param name="paragraph">Paragraph to convert.</param>
+        /// <returns>Outer XML of the underlying Open XML element.</returns>
+        public static string ToXml(this WordParagraph paragraph) {
+            if (paragraph == null) throw new ArgumentNullException(nameof(paragraph));
+            return paragraph._paragraph?.OuterXml ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="WordParagraph"/> from the provided XML string and appends it to the document.
+        /// </summary>
+        /// <param name="document">Target document.</param>
+        /// <param name="xml">XML string representing a paragraph.</param>
+        /// <returns>The inserted <see cref="WordParagraph"/>.</returns>
+        public static WordParagraph AddParagraphFromXml(this WordDocument document, string xml) {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+            if (string.IsNullOrWhiteSpace(xml)) throw new ArgumentException("Value cannot be null or empty.", nameof(xml));
+            var paragraph = new Paragraph(xml);
+            var wordParagraph = new WordParagraph(document, paragraph);
+            document.AddParagraph(wordParagraph);
+            return wordParagraph;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add extension methods for XML serialization
- document serialization helpers in docs
- test round-trip XML insertion

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_685b8a077440832eb0488ed11b85265d