### PR TITLE
Fix build warnings about XML comments

### DIFF
--- a/OfficeIMO.Word/WordPageSizes.cs
+++ b/OfficeIMO.Word/WordPageSizes.cs
@@ -54,6 +54,9 @@ namespace OfficeIMO.Word {
         B5
     }
 
+    /// <summary>
+    /// Provides helpers for manipulating Word page size and orientation.
+    /// </summary>
     public class WordPageSizes {
         private readonly WordSection _section;
         private readonly WordDocument _document;
@@ -288,6 +291,9 @@ namespace OfficeIMO.Word {
             throw new ArgumentOutOfRangeException(nameof(pageSize));
         }
 
+        /// <summary>
+        /// Gets the default A3 page size.
+        /// </summary>
         public static PageSize A3 {
             get {
                 return new PageSize() {
@@ -298,6 +304,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the default A4 page size.
+        /// </summary>
         public static PageSize A4 {
             get {
                 return new PageSize() {
@@ -308,6 +317,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the default A5 page size.
+        /// </summary>
         public static PageSize A5 {
             get {
                 return new PageSize() {
@@ -318,6 +330,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the default Executive page size.
+        /// </summary>
         public static PageSize Executive =>
             new PageSize() {
                 Width = (UInt32Value)10440U,
@@ -325,10 +340,25 @@ namespace OfficeIMO.Word {
                 Code = (UInt16Value)7U
             };
 
+        /// <summary>
+        /// Gets the default A6 page size.
+        /// </summary>
         public static PageSize A6 => new PageSize() { Width = (UInt32Value)5953U, Height = (UInt32Value)8391U, Code = (UInt16Value)70U };
+        /// <summary>
+        /// Gets the default B5 page size.
+        /// </summary>
         public static PageSize B5 => new PageSize() { Width = (UInt32Value)10318U, Height = (UInt32Value)14570U, Code = (UInt16Value)13U };
+        /// <summary>
+        /// Gets the default Statement page size.
+        /// </summary>
         public static PageSize Statement => new PageSize() { Width = (UInt32Value)7920U, Height = (UInt32Value)12240U, Code = (UInt16Value)6U };
+        /// <summary>
+        /// Gets the default Legal page size.
+        /// </summary>
         public static PageSize Legal => new PageSize() { Width = (UInt32Value)12240U, Height = (UInt32Value)20160U, Code = (UInt16Value)5U };
+        /// <summary>
+        /// Gets the default Letter page size.
+        /// </summary>
         public static PageSize Letter => new PageSize() { Width = (UInt32Value)12240U, Height = (UInt32Value)15840U, Code = (UInt16Value)1U };
     }
 }

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -15,6 +15,9 @@ using Ovml = DocumentFormat.OpenXml.Vml.Office;
 using V = DocumentFormat.OpenXml.Vml;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a paragraph within a Word document.
+    /// </summary>
     public partial class WordParagraph : WordElement {
         internal WordDocument _document;
         internal Paragraph _paragraph;
@@ -318,6 +321,12 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Initializes a new paragraph.
+        /// </summary>
+        /// <param name="document">Parent document.</param>
+        /// <param name="newParagraph">Create a new paragraph element.</param>
+        /// <param name="newRun">Create a new run inside the paragraph.</param>
         public WordParagraph(WordDocument document = null, bool newParagraph = true, bool newRun = true) {
             this._document = document;
 
@@ -342,11 +351,22 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Wraps an existing paragraph from the document.
+        /// </summary>
+        /// <param name="document">Parent document.</param>
+        /// <param name="paragraph">Paragraph to wrap.</param>
         public WordParagraph(WordDocument document, Paragraph paragraph) {
             this._document = document;
             this._paragraph = paragraph;
         }
 
+        /// <summary>
+        /// Wraps an existing paragraph and run from the document.
+        /// </summary>
+        /// <param name="document">Parent document.</param>
+        /// <param name="paragraph">Paragraph to wrap.</param>
+        /// <param name="run">Run within the paragraph.</param>
         public WordParagraph(WordDocument document, Paragraph paragraph, Run run) {
             _document = document;
             _paragraph = paragraph;
@@ -419,6 +439,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the checkbox contained in this paragraph, if present.
+        /// </summary>
         public WordCheckBox CheckBox {
             get {
                 if (_stdRun != null && _stdRun.SdtProperties?.Elements<DocumentFormat.OpenXml.Office2010.Word.SdtContentCheckBox>().Any() == true) {
@@ -429,6 +452,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the bookmark associated with this paragraph, if present.
+        /// </summary>
         public WordBookmark Bookmark {
             get {
                 if (_bookmarkStart != null) {
@@ -439,6 +465,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the mathematical equation contained in this paragraph, if any.
+        /// </summary>
         public WordEquation Equation {
             get {
                 if (_officeMath != null || _mathParagraph != null) {
@@ -449,6 +478,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the field contained in this paragraph, if any.
+        /// </summary>
         public WordField Field {
             get {
                 if (_simpleField != null || _runs != null) {
@@ -459,6 +491,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the chart contained in this paragraph, if present.
+        /// </summary>
         public WordChart Chart {
             get {
                 if (_run != null) {
@@ -480,6 +515,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the hyperlink contained in this paragraph, if present.
+        /// </summary>
         public WordHyperLink Hyperlink {
             get {
                 if (_hyperlink != null) {
@@ -490,6 +528,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the footnote associated with this paragraph, if any.
+        /// </summary>
         public WordFootNote FootNote {
             get {
                 if (_run != null && _runProperties != null) {
@@ -502,6 +543,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the endnote associated with this paragraph, if any.
+        /// </summary>
         public WordEndNote EndNote {
             get {
                 if (_run != null && _runProperties != null) {
@@ -716,6 +760,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets the line shape contained in this paragraph, if present.
+        /// </summary>
         public WordLine Line {
             get {
                 if (_run != null) {


### PR DESCRIPTION
## Summary
- remove warning suppression
- add XML docs for page sizes
- document key paragraph members

## Testing
- `dotnet build OfficeImo.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685b9289d8e4832ea04cb4da10b004a2