### PR TITLE
Add docs and xml table example

### DIFF
--- a/Docs/officeimo.word.wordparagraph.md
+++ b/Docs/officeimo.word.wordparagraph.md
@@ -1042,3 +1042,24 @@ public void RemoveCheckBox()
 public void SetCheckBoxValue(bool value)
 ```
 
+### **InsertTableAfter(WordParagraph, WordTable)**
+
+Insert an existing table after this paragraph.
+
+```csharp
+public WordTable InsertTableAfter(WordParagraph anchor, WordTable table)
+```
+
+```csharp
+var table = document.CreateTable(2, 2);
+document.InsertTableAfter(paragraph, table);
+```
+
+### **InsertParagraphAfter()**
+
+Insert a new paragraph after this paragraph.
+
+```csharp
+var inserted = paragraph.AddParagraphAfterSelf();
+```
+

--- a/OfficeIMO.Examples/Word/Tables/Tables.InsertTableAfterXml.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.InsertTableAfterXml.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Tables {
+        internal static void Example_InsertTableAfterWithXml(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Inserting table after paragraph and using XML roundtrip");
+            string filePath = Path.Combine(folderPath, "Example-InsertTableAfterXml.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var anchor = document.AddParagraph("Before table");
+                var toClone = document.AddParagraph("This paragraph will be cloned using XML");
+
+                // create table but do not insert
+                var table = document.CreateTable(2, 2);
+                table.Rows[0].Cells[0].Paragraphs[0].Text = "Cell";
+
+                // insert table after the first paragraph
+                document.InsertTableAfter(anchor, table);
+
+                // export paragraph to xml and re-import
+                string xml = toClone.ToXml();
+                document.AddParagraphFromXml(xml);
+
+                document.Save(openWord);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- document InsertParagraphAfter and InsertTableAfter usage
- add example inserting a table then cloning a paragraph via XML

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeImo.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685b9695c310832eb731076765d9bcf8