### PR TITLE
Add XML docs for WordChart API

### DIFF
--- a/OfficeIMO.Word/WordChart.Properties.cs
+++ b/OfficeIMO.Word/WordChart.Properties.cs
@@ -3,6 +3,10 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Partial class containing property definitions and helper fields for
+    /// <see cref="WordChart"/>.
+    /// </summary>
     public partial class WordChart {
         private const long EnglishMetricUnitsPerInch = 914400;
         private const long PixelsPerInch = 96;
@@ -43,6 +47,9 @@ namespace OfficeIMO.Word {
         private SixLabors.ImageSharp.Color _axisTitleColor = SixLabors.ImageSharp.Color.Black;
         //private string _id => _document._wordprocessingDocument.MainDocumentPart.GetIdOfPart(_chartPart);
 
+        /// <summary>
+        /// Gets or sets the bar grouping mode for bar charts.
+        /// </summary>
         public BarGroupingValues? BarGrouping {
             get {
                 if (_chartPart != null) {
@@ -71,6 +78,9 @@ namespace OfficeIMO.Word {
                 }
             }
         }
+        /// <summary>
+        /// Gets or sets the bar direction (row or column) for bar charts.
+        /// </summary>
         public BarDirectionValues? BarDirection {
             get {
                 if (_chartPart != null) {
@@ -101,6 +111,9 @@ namespace OfficeIMO.Word {
                 }
             }
         }
+        /// <summary>
+        /// Gets or sets whether the chart frame uses rounded corners.
+        /// </summary>
         public bool RoundedCorners {
             get {
                 var roundedCorners = _chartPart.ChartSpace.GetFirstChild<RoundedCorners>();

--- a/OfficeIMO.Word/WordChart.PublicMethods.cs
+++ b/OfficeIMO.Word/WordChart.PublicMethods.cs
@@ -1,10 +1,24 @@
 using DocumentFormat.OpenXml.Drawing.Charts;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Partial class containing public methods for building chart content.
+    /// </summary>
     public partial class WordChart {
+        /// <summary>
+        /// Sets the category labels used by subsequent chart series.
+        /// </summary>
+        /// <param name="categories">List of category names.</param>
         public void AddCategories(List<string> categories) {
             Categories = categories;
         }
+        /// <summary>
+        /// Adds a single value to a pie chart.
+        /// </summary>
+        /// <typeparam name="T">Numeric type representing the value.</typeparam>
+        /// <param name="category">Category label.</param>
+        /// <param name="value">Data value for the slice.</param>
+        /// <returns>The current <see cref="WordChart"/> instance.</returns>
         public WordChart AddPie<T>(string category, T value) {
             // if value is a list we need to throw as not supported
             if (!(value is int || value is double || value is float)) {
@@ -16,6 +30,13 @@ namespace OfficeIMO.Word {
             return this;
         }
 
+        /// <summary>
+        /// Adds a single value to a 3D pie chart.
+        /// </summary>
+        /// <typeparam name="T">Numeric type representing the value.</typeparam>
+        /// <param name="category">Category label.</param>
+        /// <param name="value">Data value for the slice.</param>
+        /// <returns>The current <see cref="WordChart"/> instance.</returns>
         public WordChart AddPie3D<T>(string category, T value) {
             if (!(value is int || value is double || value is float)) {
                 throw new NotSupportedException("Value must be of type int, double, or float");
@@ -26,6 +47,13 @@ namespace OfficeIMO.Word {
             return this;
         }
 
+        /// <summary>
+        /// Adds a line series to the chart from an array of integer values.
+        /// </summary>
+        /// <typeparam name="T">Unused generic parameter.</typeparam>
+        /// <param name="name">Series name.</param>
+        /// <param name="values">Values for the series.</param>
+        /// <param name="color">Line color.</param>
         public void AddChartLine<T>(string name, int[] values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsLine();
             if (_chart != null) {
@@ -106,6 +134,13 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Adds an area chart series using the provided values.
+        /// </summary>
+        /// <typeparam name="T">Numeric type of the data values.</typeparam>
+        /// <param name="name">Series name.</param>
+        /// <param name="values">Values for the series.</param>
+        /// <param name="color">Fill color for the series.</param>
         public void AddArea<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsArea();
             if (_chart != null) {
@@ -117,6 +152,13 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Adds an area chart series using an array of integer values.
+        /// </summary>
+        /// <typeparam name="T">Unused generic parameter.</typeparam>
+        /// <param name="name">Series name.</param>
+        /// <param name="values">Data values.</param>
+        /// <param name="color">Fill color for the series.</param>
         public void AddArea<T>(string name, int[] values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsArea();
             if (_chart != null) {
@@ -128,6 +170,13 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Adds a scatter chart series with separate X and Y values.
+        /// </summary>
+        /// <param name="name">Series name.</param>
+        /// <param name="xValues">Values plotted on the X axis.</param>
+        /// <param name="yValues">Values plotted on the Y axis.</param>
+        /// <param name="color">Color of the series.</param>
         public void AddScatter(string name, List<double> xValues, List<double> yValues, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsScatter();
             if (_chart != null) {
@@ -139,6 +188,13 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Adds a radar chart series.
+        /// </summary>
+        /// <typeparam name="T">Numeric type of the values.</typeparam>
+        /// <param name="name">Series name.</param>
+        /// <param name="values">Values for the series.</param>
+        /// <param name="color">Color of the series.</param>
         public void AddRadar<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsRadar();
             if (_chart != null) {
@@ -149,6 +205,13 @@ namespace OfficeIMO.Word {
                 }
             }
         }
+        /// <summary>
+        /// Adds a 3D bar chart series.
+        /// </summary>
+        /// <typeparam name="T">Numeric type of the data values.</typeparam>
+        /// <param name="name">Series name.</param>
+        /// <param name="values">Series data values.</param>
+        /// <param name="color">Color of the bars.</param>
         public void AddBar3D<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsBar3D();
             if (_chart != null) {
@@ -202,6 +265,13 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Adds a 3D area chart series.
+        /// </summary>
+        /// <typeparam name="T">Numeric type of the data values.</typeparam>
+        /// <param name="name">Series name.</param>
+        /// <param name="values">Series data values.</param>
+        /// <param name="color">Series color.</param>
         public void AddArea3D<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsArea3D();
             if (_chart != null) {
@@ -213,6 +283,10 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Adds a legend to the chart at the specified position.
+        /// </summary>
+        /// <param name="legendPosition">Desired legend position.</param>
         public void AddLegend(LegendPositionValues legendPosition) {
             if (_chart != null) {
                 Legend legend = new Legend();
@@ -233,18 +307,35 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Sets the title displayed on the X axis.
+        /// </summary>
+        /// <param name="title">Axis title text.</param>
+        /// <returns>The current <see cref="WordChart"/> instance.</returns>
         public WordChart SetXAxisTitle(string title) {
             _xAxisTitle = title;
             UpdateAxisTitles();
             return this;
         }
 
+        /// <summary>
+        /// Sets the title displayed on the Y axis.
+        /// </summary>
+        /// <param name="title">Axis title text.</param>
+        /// <returns>The current <see cref="WordChart"/> instance.</returns>
         public WordChart SetYAxisTitle(string title) {
             _yAxisTitle = title;
             UpdateAxisTitles();
             return this;
         }
 
+        /// <summary>
+        /// Defines font formatting for axis titles.
+        /// </summary>
+        /// <param name="fontName">Font family name.</param>
+        /// <param name="fontSize">Font size in points.</param>
+        /// <param name="color">Text color.</param>
+        /// <returns>The current <see cref="WordChart"/> instance.</returns>
         public WordChart SetAxisTitleFormat(string fontName, int fontSize, SixLabors.ImageSharp.Color color) {
             _axisTitleFontName = fontName;
             _axisTitleFontSize = fontSize;

--- a/OfficeIMO.Word/WordChart.cs
+++ b/OfficeIMO.Word/WordChart.cs
@@ -12,6 +12,10 @@ using NumericValue = DocumentFormat.OpenXml.Drawing.Charts.NumericValue;
 using PlotArea = DocumentFormat.OpenXml.Drawing.Charts.PlotArea;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides functionality for creating and manipulating charts within a
+    /// <see cref="WordDocument"/>.
+    /// </summary>
     public partial class WordChart : WordElement {
         private static int _axisIdSeed = 148921728;
         private static int _docPrIdSeed = 1;
@@ -44,12 +48,27 @@ namespace OfficeIMO.Word {
             }
             _axisIdSeed = (int)max;
         }
+        /// <summary>
+        /// Initializes a <see cref="WordChart"/> instance from an existing drawing.
+        /// </summary>
+        /// <param name="document">Parent document that owns the chart.</param>
+        /// <param name="paragraph">Paragraph containing the chart.</param>
+        /// <param name="drawing">Existing drawing element with chart data.</param>
         public WordChart(WordDocument document, WordParagraph paragraph, Drawing drawing) {
             _document = document;
             _drawing = drawing;
             _paragraph = paragraph;
         }
 
+        /// <summary>
+        /// Creates a new chart and inserts it into the specified paragraph.
+        /// </summary>
+        /// <param name="document">Parent document that will contain the chart.</param>
+        /// <param name="paragraph">Paragraph where the chart will be placed.</param>
+        /// <param name="title">Optional chart title.</param>
+        /// <param name="roundedCorners">Specifies whether the chart frame should have rounded corners.</param>
+        /// <param name="width">Initial chart width in pixels.</param>
+        /// <param name="height">Initial chart height in pixels.</param>
         public WordChart(WordDocument document, WordParagraph paragraph, string title = "", bool roundedCorners = false, int width = 600, int height = 600) {
             _document = document;
             _paragraph = paragraph;


### PR DESCRIPTION
## Summary
- document `WordChart` partial class definitions
- add XML comments for constructors and chart manipulation methods
- describe public properties such as `BarGrouping`, `BarDirection` and `RoundedCorners`

## Testing
- `dotnet build OfficeImo.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685ba1ba66b0832ea6c5180042a80a90