### PR TITLE
Improve docs for helper and table style classes

### DIFF
--- a/OfficeIMO.Word/BuiltinDocumentProperties.cs
+++ b/OfficeIMO.Word/BuiltinDocumentProperties.cs
@@ -9,6 +9,11 @@ namespace OfficeIMO.Word {
         private WordprocessingDocument _wordprocessingDocument;
         private WordDocument _document;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BuiltinDocumentProperties"/> class
+        /// for the specified <see cref="WordDocument"/>.
+        /// </summary>
+        /// <param name="document">The document whose built-in properties are exposed.</param>
         public BuiltinDocumentProperties(WordDocument document) {
             _document = document;
             _wordprocessingDocument = document._wordprocessingDocument;

--- a/OfficeIMO.Word/Helpers.cs
+++ b/OfficeIMO.Word/Helpers.cs
@@ -5,6 +5,9 @@ using DocumentFormat.OpenXml.Packaging;
 using SixLabors.ImageSharp.Formats;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides various utility methods used throughout the library.
+    /// </summary>
     public static partial class Helpers {
         private const double PixelsPerInch = 96.0;
 

--- a/OfficeIMO.Word/WordTableStyle.cs
+++ b/OfficeIMO.Word/WordTableStyle.cs
@@ -7,6 +7,9 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word;
 
+/// <summary>
+/// Exposes predefined Word table styles.
+/// </summary>
 public static partial class WordTableStyles {
     // All styles are now in individual files in the TableStyles folder
 }


### PR DESCRIPTION
## Summary
- document the static `Helpers` partial class
- document the `BuiltinDocumentProperties` constructor
- document the `WordTableStyles` partial class

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeImo.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685ba2221784832eb058bb81be756bb5