### PR TITLE
Add XML docs for Word table style enum

### DIFF
--- a/OfficeIMO.Word/WordTableStyle.Enum.cs
+++ b/OfficeIMO.Word/WordTableStyle.Enum.cs
@@ -1,138 +1,246 @@
-﻿namespace OfficeIMO.Word;
+namespace OfficeIMO.Word;
 
+/// <summary>
+/// Predefined table styles available in Word.
+/// </summary>
 public enum WordTableStyle {
     // Plain Tables
+    /// <summary>Normal table style.</summary>
     TableNormal,
+    /// <summary>Grid table style.</summary>
     TableGrid,
+    /// <summary>Plain table style 1.</summary>
     PlainTable1,
+    /// <summary>Plain table style 2.</summary>
     PlainTable2,
+    /// <summary>Plain table style 3.</summary>
     PlainTable3,
+    /// <summary>Plain table style 4.</summary>
     PlainTable4,
+    /// <summary>Plain table style 5.</summary>
     PlainTable5,
 
     // Grid Tables - Line 1
+    /// <summary>Light grid table style 1.</summary>
     GridTable1Light,
+    /// <summary>Light grid table style 1 accent 1.</summary>
     GridTable1LightAccent1,
+    /// <summary>Light grid table style 1 accent 2.</summary>
     GridTable1LightAccent2,
+    /// <summary>Light grid table style 1 accent 3.</summary>
     GridTable1LightAccent3,
+    /// <summary>Light grid table style 1 accent 4.</summary>
     GridTable1LightAccent4,
+    /// <summary>Light grid table style 1 accent 5.</summary>
     GridTable1LightAccent5,
+    /// <summary>Light grid table style 1 accent 6.</summary>
     GridTable1LightAccent6,
 
     // Grid Tables - Line 2
+    /// <summary>Grid table style 2.</summary>
     GridTable2,
+    /// <summary>Grid table style 2 accent 1.</summary>
     GridTable2Accent1,
+    /// <summary>Grid table style 2 accent 2.</summary>
     GridTable2Accent2,
+    /// <summary>Grid table style 2 accent 3.</summary>
     GridTable2Accent3,
+    /// <summary>Grid table style 2 accent 4.</summary>
     GridTable2Accent4,
+    /// <summary>Grid table style 2 accent 5.</summary>
     GridTable2Accent5,
+    /// <summary>Grid table style 2 accent 6.</summary>
     GridTable2Accent6,
 
     // Grid Tables - Line 3
+    /// <summary>Grid table style 3.</summary>
     GridTable3,
+    /// <summary>Grid table style 3 accent 1.</summary>
     GridTable3Accent1,
+    /// <summary>Grid table style 3 accent 2.</summary>
     GridTable3Accent2,
+    /// <summary>Grid table style 3 accent 3.</summary>
     GridTable3Accent3,
+    /// <summary>Grid table style 3 accent 4.</summary>
     GridTable3Accent4,
+    /// <summary>Grid table style 3 accent 5.</summary>
     GridTable3Accent5,
+    /// <summary>Grid table style 3 accent 6.</summary>
     GridTable3Accent6,
 
     // Grid Tables - Line 4
+    /// <summary>Grid table style 4.</summary>
     GridTable4,
+    /// <summary>Grid table style 4 accent 1.</summary>
     GridTable4Accent1,
+    /// <summary>Grid table style 4 accent 2.</summary>
     GridTable4Accent2,
+    /// <summary>Grid table style 4 accent 3.</summary>
     GridTable4Accent3,
+    /// <summary>Grid table style 4 accent 4.</summary>
     GridTable4Accent4,
+    /// <summary>Grid table style 4 accent 5.</summary>
     GridTable4Accent5,
+    /// <summary>Grid table style 4 accent 6.</summary>
     GridTable4Accent6,
 
     // Grid Tables - Line 5
+    /// <summary>Dark grid table style 5.</summary>
     GridTable5Dark,
+    /// <summary>Dark grid table style 5 accent 1.</summary>
     GridTable5DarkAccent1,
+    /// <summary>Dark grid table style 5 accent 2.</summary>
     GridTable5DarkAccent2,
+    /// <summary>Dark grid table style 5 accent 3.</summary>
     GridTable5DarkAccent3,
+    /// <summary>Dark grid table style 5 accent 4.</summary>
     GridTable5DarkAccent4,
+    /// <summary>Dark grid table style 5 accent 5.</summary>
     GridTable5DarkAccent5,
+    /// <summary>Dark grid table style 5 accent 6.</summary>
     GridTable5DarkAccent6,
 
     // Grid Tables - Line 6
+    /// <summary>Colorful grid table style 6.</summary>
     GridTable6Colorful,
+    /// <summary>Colorful grid table style 6 accent 1.</summary>
     GridTable6ColorfulAccent1,
+    /// <summary>Colorful grid table style 6 accent 2.</summary>
     GridTable6ColorfulAccent2,
+    /// <summary>Colorful grid table style 6 accent 3.</summary>
     GridTable6ColorfulAccent3,
+    /// <summary>Colorful grid table style 6 accent 4.</summary>
     GridTable6ColorfulAccent4,
+    /// <summary>Colorful grid table style 6 accent 5.</summary>
     GridTable6ColorfulAccent5,
+    /// <summary>Colorful grid table style 6 accent 6.</summary>
     GridTable6ColorfulAccent6,
 
     // Grid Tables - Line 7
+    /// <summary>Colorful grid table style 7.</summary>
     GridTable7Colorful,
+    /// <summary>Colorful grid table style 7 accent 1.</summary>
     GridTable7ColorfulAccent1,
+    /// <summary>Colorful grid table style 7 accent 2.</summary>
     GridTable7ColorfulAccent2,
+    /// <summary>Colorful grid table style 7 accent 3.</summary>
     GridTable7ColorfulAccent3,
+    /// <summary>Colorful grid table style 7 accent 4.</summary>
     GridTable7ColorfulAccent4,
+    /// <summary>Colorful grid table style 7 accent 5.</summary>
     GridTable7ColorfulAccent5,
+    /// <summary>Colorful grid table style 7 accent 6.</summary>
     GridTable7ColorfulAccent6,
 
     // List Tables - Line 8
+    /// <summary>Light list table style 1.</summary>
     ListTable1Light,
+    /// <summary>Light list table style 1 accent 1.</summary>
     ListTable1LightAccent1,
+    /// <summary>Light list table style 1 accent 2.</summary>
     ListTable1LightAccent2,
+    /// <summary>Light list table style 1 accent 3.</summary>
     ListTable1LightAccent3,
+    /// <summary>Light list table style 1 accent 4.</summary>
     ListTable1LightAccent4,
+    /// <summary>Light list table style 1 accent 5.</summary>
     ListTable1LightAccent5,
+    /// <summary>Light list table style 1 accent 6.</summary>
     ListTable1LightAccent6,
 
     // List Tables - Line 9
+    /// <summary>List table style 2.</summary>
     ListTable2,
+    /// <summary>List table style 2 accent 1.</summary>
     ListTable2Accent1,
+    /// <summary>List table style 2 accent 2.</summary>
     ListTable2Accent2,
+    /// <summary>List table style 2 accent 3.</summary>
     ListTable2Accent3,
+    /// <summary>List table style 2 accent 4.</summary>
     ListTable2Accent4,
+    /// <summary>List table style 2 accent 5.</summary>
     ListTable2Accent5,
+    /// <summary>List table style 2 accent 6.</summary>
     ListTable2Accent6,
 
     // List Tables - Line 10
+    /// <summary>List table style 3.</summary>
     ListTable3,
+    /// <summary>List table style 3 accent 1.</summary>
     ListTable3Accent1,
+    /// <summary>List table style 3 accent 2.</summary>
     ListTable3Accent2,
+    /// <summary>List table style 3 accent 3.</summary>
     ListTable3Accent3,
+    /// <summary>List table style 3 accent 4.</summary>
     ListTable3Accent4,
+    /// <summary>List table style 3 accent 5.</summary>
     ListTable3Accent5,
+    /// <summary>List table style 3 accent 6.</summary>
     ListTable3Accent6,
 
     // List Tables - Line 11
+    /// <summary>List table style 4.</summary>
     ListTable4,
+    /// <summary>List table style 4 accent 1.</summary>
     ListTable4Accent1,
+    /// <summary>List table style 4 accent 2.</summary>
     ListTable4Accent2,
+    /// <summary>List table style 4 accent 3.</summary>
     ListTable4Accent3,
+    /// <summary>List table style 4 accent 4.</summary>
     ListTable4Accent4,
+    /// <summary>List table style 4 accent 5.</summary>
     ListTable4Accent5,
+    /// <summary>List table style 4 accent 6.</summary>
     ListTable4Accent6,
 
     // List Tables - Line 12
+    /// <summary>Dark list table style 5.</summary>
     ListTable5Dark,
+    /// <summary>Dark list table style 5 accent 1.</summary>
     ListTable5DarkAccent1,
+    /// <summary>Dark list table style 5 accent 2.</summary>
     ListTable5DarkAccent2,
+    /// <summary>Dark list table style 5 accent 3.</summary>
     ListTable5DarkAccent3,
+    /// <summary>Dark list table style 5 accent 4.</summary>
     ListTable5DarkAccent4,
+    /// <summary>Dark list table style 5 accent 5.</summary>
     ListTable5DarkAccent5,
+    /// <summary>Dark list table style 5 accent 6.</summary>
     ListTable5DarkAccent6,
 
     // List Tables - Line 13
+    /// <summary>Colorful list table style 6.</summary>
     ListTable6Colorful,
+    /// <summary>Colorful list table style 6 accent 1.</summary>
     ListTable6ColorfulAccent1,
+    /// <summary>Colorful list table style 6 accent 2.</summary>
     ListTable6ColorfulAccent2,
+    /// <summary>Colorful list table style 6 accent 3.</summary>
     ListTable6ColorfulAccent3,
+    /// <summary>Colorful list table style 6 accent 4.</summary>
     ListTable6ColorfulAccent4,
+    /// <summary>Colorful list table style 6 accent 5.</summary>
     ListTable6ColorfulAccent5,
+    /// <summary>Colorful list table style 6 accent 6.</summary>
     ListTable6ColorfulAccent6,
 
     // List Tables - Line 14
+    /// <summary>Colorful list table style 7.</summary>
     ListTable7Colorful,
+    /// <summary>Colorful list table style 7 accent 1.</summary>
     ListTable7ColorfulAccent1,
+    /// <summary>Colorful list table style 7 accent 2.</summary>
     ListTable7ColorfulAccent2,
+    /// <summary>Colorful list table style 7 accent 3.</summary>
     ListTable7ColorfulAccent3,
+    /// <summary>Colorful list table style 7 accent 4.</summary>
     ListTable7ColorfulAccent4,
+    /// <summary>Colorful list table style 7 accent 5.</summary>
     ListTable7ColorfulAccent5,
+    /// <summary>Colorful list table style 7 accent 6.</summary>
     ListTable7ColorfulAccent6,
 };


### PR DESCRIPTION
## Summary
- document WordTableStyle enum members with <summary> tags
- add summary for the WordTableStyle enum type

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685ba9723498832eaf5b6f8d658a8a48