### PR TITLE
Add XML docs to public API

### DIFF
--- a/OfficeIMO.Word/WordParagraph.Equality.cs
+++ b/OfficeIMO.Word/WordParagraph.Equality.cs
@@ -1,5 +1,10 @@
 namespace OfficeIMO.Word {
     public partial class WordParagraph : System.IEquatable<WordParagraph> {
+        /// <summary>
+        /// Determines whether the specified <see cref="WordParagraph"/> is equal to the current instance.
+        /// </summary>
+        /// <param name="other">The paragraph to compare with the current instance.</param>
+        /// <returns><c>true</c> if the paragraphs are equal; otherwise, <c>false</c>.</returns>
         public bool Equals(WordParagraph other) {
             if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
@@ -14,10 +19,19 @@ namespace OfficeIMO.Word {
             return true;
         }
 
+        /// <summary>
+        /// Determines whether the specified object is equal to the current instance.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current instance.</param>
+        /// <returns><c>true</c> if the objects are equal; otherwise, <c>false</c>.</returns>
         public override bool Equals(object obj) {
             return obj is WordParagraph other && Equals(other);
         }
 
+        /// <summary>
+        /// Serves as the default hash function.
+        /// </summary>
+        /// <returns>A hash code for the current object.</returns>
         public override int GetHashCode() {
             if (_paragraph != null) return _paragraph.GetHashCode();
             unchecked {
@@ -30,11 +44,23 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Determines whether two <see cref="WordParagraph"/> instances are equal.
+        /// </summary>
+        /// <param name="left">The left-hand instance.</param>
+        /// <param name="right">The right-hand instance.</param>
+        /// <returns><c>true</c> if the instances are equal; otherwise, <c>false</c>.</returns>
         public static bool operator ==(WordParagraph left, WordParagraph right) {
             if (left is null) return right is null;
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Determines whether two <see cref="WordParagraph"/> instances are not equal.
+        /// </summary>
+        /// <param name="left">The left-hand instance.</param>
+        /// <param name="right">The right-hand instance.</param>
+        /// <returns><c>true</c> if the instances are not equal; otherwise, <c>false</c>.</returns>
         public static bool operator !=(WordParagraph left, WordParagraph right) {
             return !(left == right);
         }

--- a/OfficeIMO.Word/WordParagraph.Run.cs
+++ b/OfficeIMO.Word/WordParagraph.Run.cs
@@ -6,6 +6,9 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
     public partial class WordParagraph {
+        /// <summary>
+        /// Gets a value indicating whether the paragraph contains no run element.
+        /// </summary>
         public bool IsEmpty {
             get {
                 if (_run == null) {
@@ -15,6 +18,9 @@ namespace OfficeIMO.Word {
                 return false;
             }
         }
+        /// <summary>
+        /// Gets a value indicating whether the paragraph contains a page break.
+        /// </summary>
         public bool IsPageBreak {
             get {
                 if (this.PageBreak != null) {
@@ -25,6 +31,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the paragraph contains a break element.
+        /// </summary>
         public bool IsBreak {
             get {
                 if (this.Break != null) {

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -5,6 +5,9 @@ using DocumentFormat.OpenXml;
 namespace OfficeIMO.Word {
     public partial class WordParagraph {
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the run is bold.
+        /// </summary>
         public bool Bold {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -38,6 +41,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the run is italic.
+        /// </summary>
         public bool Italic {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -64,6 +70,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the underline style for the run.
+        /// </summary>
         public UnderlineValues? Underline {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -94,6 +103,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether spelling and grammar checks are disabled.
+        /// </summary>
         public bool DoNotCheckSpellingOrGrammar {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -120,6 +132,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the character spacing value in twentieths of a point.
+        /// </summary>
         public int? Spacing {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -148,6 +163,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the run is struck through.
+        /// </summary>
         public bool Strike {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -174,6 +192,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the run has a double strikethrough.
+        /// </summary>
         public bool DoubleStrike {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -199,6 +220,9 @@ namespace OfficeIMO.Word {
                 }
             }
         }
+        /// <summary>
+        /// Gets or sets the font size in points.
+        /// </summary>
         public int? FontSize {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -228,6 +252,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the text color using <see cref="SixLabors.ImageSharp.Color"/>.
+        /// </summary>
         public SixLabors.ImageSharp.Color? Color {
             get {
                 if (ColorHex == "") {
@@ -243,6 +270,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the text color as a hexadecimal string.
+        /// </summary>
         public string ColorHex {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -271,6 +301,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the theme color applied to the run.
+        /// </summary>
         public ThemeColorValues? ThemeColor {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -302,6 +335,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the highlight color applied to the run.
+        /// </summary>
         public HighlightColorValues? Highlight {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -327,6 +363,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the capitalization style for the run.
+        /// </summary>
         public CapsStyle CapsStyle {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -404,6 +443,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the HighAnsi font family.
+        /// </summary>
         public string FontFamilyHighAnsi {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -434,6 +476,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the East Asia font family.
+        /// </summary>
         public string FontFamilyEastAsia {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -464,6 +509,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the complex script font family.
+        /// </summary>
         public string FontFamilyComplexScript {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -494,6 +542,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the character style applied to the run.
+        /// </summary>
         public WordCharacterStyles? CharacterStyle {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
@@ -521,6 +572,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the style identifier applied to the run.
+        /// </summary>
         public string CharacterStyleId {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;

--- a/OfficeIMO.Word/WordParagraph.RunPropertiesMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.RunPropertiesMethods.cs
@@ -2,69 +2,149 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
     public partial class WordParagraph {
+        /// <summary>
+        /// Sets the <see cref="WordParagraph.Bold"/> property.
+        /// </summary>
+        /// <param name="isBold">Whether the text should be bold.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetBold(bool isBold = true) {
             this.Bold = isBold;
             return this;
         }
+        /// <summary>
+        /// Sets the <see cref="WordParagraph.Italic"/> property.
+        /// </summary>
+        /// <param name="isItalic">Whether the text should be italic.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetItalic(bool isItalic = true) {
             this.Italic = isItalic;
             return this;
         }
+        /// <summary>
+        /// Sets the underline style for the text.
+        /// </summary>
+        /// <param name="underline">Underline style.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetUnderline(UnderlineValues underline) {
             this.Underline = underline;
             return this;
         }
+        /// <summary>
+        /// Sets the character spacing for the text.
+        /// </summary>
+        /// <param name="spacing">Spacing value in twentieths of a point.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetSpacing(int spacing) {
             this.Spacing = spacing;
             return this;
         }
+        /// <summary>
+        /// Enables or disables single strikethrough on the text.
+        /// </summary>
+        /// <param name="isStrike">Whether the text should be struck through.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetStrike(bool isStrike = true) {
             this.Strike = isStrike;
             return this;
         }
+        /// <summary>
+        /// Enables or disables double strikethrough on the text.
+        /// </summary>
+        /// <param name="isDoubleStrike">Whether the text should be double struck.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetDoubleStrike(bool isDoubleStrike = true) {
             this.DoubleStrike = isDoubleStrike;
             return this;
         }
+        /// <summary>
+        /// Sets the font size for the text.
+        /// </summary>
+        /// <param name="fontSize">Font size in points.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetFontSize(int fontSize) {
             this.FontSize = fontSize;
             return this;
         }
+        /// <summary>
+        /// Sets the font family for the text.
+        /// </summary>
+        /// <param name="fontFamily">Name of the font family.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetFontFamily(string fontFamily) {
             this.FontFamily = fontFamily;
             return this;
         }
+        /// <summary>
+        /// Sets the text color using a hexadecimal value.
+        /// </summary>
+        /// <param name="color">Color in hexadecimal format.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetColorHex(string color) {
             this.ColorHex = color;
             return this;
         }
+        /// <summary>
+        /// Sets the text color using <see cref="SixLabors.ImageSharp.Color"/>.
+        /// </summary>
+        /// <param name="color">The color to apply.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetColor(SixLabors.ImageSharp.Color color) {
             this.Color = color;
             return this;
         }
+        /// <summary>
+        /// Sets the paragraph alignment.
+        /// </summary>
+        /// <param name="alignment">Alignment value.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetAlignment(JustificationValues alignment) {
             this.ParagraphAlignment = alignment;
             return this;
         }
 
+        /// <summary>
+        /// Sets the highlight color for the text.
+        /// </summary>
+        /// <param name="highlight">Highlight color.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetHighlight(HighlightColorValues highlight) {
             this.Highlight = highlight;
             return this;
         }
+        /// <summary>
+        /// Sets the capitalization style for the text.
+        /// </summary>
+        /// <param name="capsStyle">Capitalization style.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetCapsStyle(CapsStyle capsStyle) {
             this.CapsStyle = capsStyle;
             return this;
         }
+        /// <summary>
+        /// Sets the paragraph text.
+        /// </summary>
+        /// <param name="text">The text content.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetText(string text) {
             this.Text = text;
             return this;
         }
+        /// <summary>
+        /// Sets the paragraph style.
+        /// </summary>
+        /// <param name="style">The style to apply.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetStyle(WordParagraphStyles style) {
             this.Style = style;
             return this;
         }
 
 
+        /// <summary>
+        /// Sets the paragraph style by identifier.
+        /// </summary>
+        /// <param name="styleId">The style identifier.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetStyleId(string styleId) {
             //Todo Check the styleId exist
             if (!string.IsNullOrEmpty(styleId)) {
@@ -79,11 +159,21 @@ namespace OfficeIMO.Word {
             return this;
         }
 
+        /// <summary>
+        /// Sets the character style for the run.
+        /// </summary>
+        /// <param name="style">Character style to apply.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetCharacterStyle(WordCharacterStyles style) {
             CharacterStyle = style;
             return this;
         }
 
+        /// <summary>
+        /// Sets the character style by identifier.
+        /// </summary>
+        /// <param name="styleId">The style identifier.</param>
+        /// <returns>The current paragraph instance.</returns>
         public WordParagraph SetCharacterStyleId(string styleId) {
             CharacterStyleId = styleId;
             return this;

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -9,10 +9,20 @@ using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
     public partial class WordSection {
+        /// <summary>
+        /// Updates the margins for this section.
+        /// </summary>
+        /// <param name="pageMargins">Margin values to apply.</param>
+        /// <returns>The current section.</returns>
         public WordSection SetMargins(WordMargin pageMargins) {
             return WordMargins.SetMargins(this, pageMargins);
         }
 
+        /// <summary>
+        /// Adds a new paragraph to the section.
+        /// </summary>
+        /// <param name="newRun">Whether to create a run within the paragraph.</param>
+        /// <returns>The created paragraph.</returns>
         public WordParagraph AddParagraph(bool newRun) {
             var wordParagraph = new WordParagraph(_document, newParagraph: true, newRun: newRun);
             if (this.Paragraphs.Count == 0) {
@@ -25,6 +35,11 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Adds a new paragraph containing the specified text.
+        /// </summary>
+        /// <param name="text">Text to place in the paragraph.</param>
+        /// <returns>The created paragraph.</returns>
         public WordParagraph AddParagraph(string text = "") {
             if (this.Paragraphs.Count == 0) {
                 WordParagraph paragraph = this._document.AddParagraph();
@@ -46,6 +61,12 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Adds a watermark to the section.
+        /// </summary>
+        /// <param name="watermarkStyle">Watermark style.</param>
+        /// <param name="textOrFilePath">Text or image file path.</param>
+        /// <returns>The created <see cref="WordWatermark"/> instance.</returns>
         public WordWatermark AddWatermark(WordWatermarkStyle watermarkStyle, string textOrFilePath) {
             // return new WordWatermark(this._document, this, this.Header.Default, watermarkStyle, text);
             return new WordWatermark(this._document, this, watermarkStyle, textOrFilePath);
@@ -60,33 +81,81 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Applies border settings to the section.
+        /// </summary>
+        /// <param name="wordBorder">Border preset to apply.</param>
+        /// <returns>The current section.</returns>
         public WordSection SetBorders(WordBorder wordBorder) {
             this.Borders.SetBorder(wordBorder);
 
             return this;
         }
 
+        /// <summary>
+        /// Inserts a horizontal line paragraph into the section.
+        /// </summary>
+        /// <param name="lineType">Border style of the line.</param>
+        /// <param name="color">Line color.</param>
+        /// <param name="size">Line width.</param>
+        /// <param name="space">Line spacing.</param>
+        /// <returns>The paragraph containing the line.</returns>
         public WordParagraph AddHorizontalLine(BorderValues? lineType = null, SixLabors.ImageSharp.Color? color = null, uint size = 12, uint space = 1) {
             lineType ??= BorderValues.Single;
             return this.AddParagraph("").AddHorizontalLine(lineType.Value, color, size, space);
         }
 
+        /// <summary>
+        /// Adds a hyperlink paragraph pointing to a URI.
+        /// </summary>
+        /// <param name="text">Display text.</param>
+        /// <param name="uri">Target URI.</param>
+        /// <param name="addStyle">Whether to apply hyperlink style.</param>
+        /// <param name="tooltip">Optional tooltip.</param>
+        /// <param name="history">Add to document history.</param>
+        /// <returns>The created paragraph.</returns>
         public WordParagraph AddHyperLink(string text, Uri uri, bool addStyle = false, string tooltip = "", bool history = true) {
             return this.AddParagraph("").AddHyperLink(text, uri, addStyle, tooltip, history);
         }
 
+        /// <summary>
+        /// Adds a hyperlink paragraph pointing to an internal anchor.
+        /// </summary>
+        /// <param name="text">Display text.</param>
+        /// <param name="anchor">Bookmark anchor name.</param>
+        /// <param name="addStyle">Whether to apply hyperlink style.</param>
+        /// <param name="tooltip">Optional tooltip.</param>
+        /// <param name="history">Add to document history.</param>
+        /// <returns>The created paragraph.</returns>
         public WordParagraph AddHyperLink(string text, string anchor, bool addStyle = false, string tooltip = "", bool history = true) {
             return this.AddParagraph("").AddHyperLink(text, anchor, addStyle, tooltip, history);
         }
 
+        /// <summary>
+        /// Adds default headers and footers to the section.
+        /// </summary>
         public void AddHeadersAndFooters() {
             WordHeadersAndFooters.AddHeadersAndFooters(this);
         }
 
+        /// <summary>
+        /// Adds a text box paragraph to the section.
+        /// </summary>
+        /// <param name="text">Initial text inside the text box.</param>
+        /// <param name="wrapTextImage">Wrapping style.</param>
+        /// <returns>The created <see cref="WordTextBox"/>.</returns>
         public WordTextBox AddTextBox(string text, WrapTextImage wrapTextImage = WrapTextImage.Square) {
             return AddParagraph(newRun: true).AddTextBox(text, wrapTextImage);
         }
 
+        /// <summary>
+        /// Configures footnote properties for the section.
+        /// </summary>
+        /// <param name="numberingFormat">Numbering format.</param>
+        /// <param name="position">Footnote position.</param>
+        /// <param name="restartNumbering">Restart numbering option.</param>
+        /// <param name="startNumber">Starting number.</param>
+        /// <returns>The current section.</returns>
         public WordSection AddFootnoteProperties(NumberFormatValues? numberingFormat = null,
             FootnotePositionValues? position = null,
             RestartNumberValues? restartNumbering = null,
@@ -121,6 +190,14 @@ namespace OfficeIMO.Word {
             return this;
         }
 
+        /// <summary>
+        /// Configures endnote properties for the section.
+        /// </summary>
+        /// <param name="numberingFormat">Numbering format.</param>
+        /// <param name="position">Endnote position.</param>
+        /// <param name="restartNumbering">Restart numbering option.</param>
+        /// <param name="startNumber">Starting number.</param>
+        /// <returns>The current section.</returns>
         public WordSection AddEndnoteProperties(NumberFormatValues? numberingFormat = null,
             EndnotePositionValues? position = null,
             RestartNumberValues? restartNumbering = null,
@@ -155,6 +232,12 @@ namespace OfficeIMO.Word {
             return this;
         }
 
+        /// <summary>
+        /// Adds or updates page numbering for the section.
+        /// </summary>
+        /// <param name="startNumber">Starting page number.</param>
+        /// <param name="format">Number format.</param>
+        /// <returns>The current section.</returns>
         public WordSection AddPageNumbering(int? startNumber = null, NumberFormatValues? format = null) {
             var existing = _sectionProperties.GetFirstChild<PageNumberType>();
             existing?.Remove();

--- a/OfficeIMO.Word/WordSection.SectionProperties.cs
+++ b/OfficeIMO.Word/WordSection.SectionProperties.cs
@@ -43,6 +43,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the number of columns in the section.
+        /// </summary>
         public int? ColumnCount {
             get {
                 Columns columns = _sectionProperties.GetFirstChild<Columns>();
@@ -66,6 +69,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the footnote properties for the section.
+        /// </summary>
         public FootnoteProperties FootnoteProperties {
             get {
                 return _sectionProperties.GetFirstChild<FootnoteProperties>();
@@ -79,6 +85,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the endnote properties for the section.
+        /// </summary>
         public EndnoteProperties EndnoteProperties {
             get {
                 return _sectionProperties.GetFirstChild<EndnoteProperties>();
@@ -98,6 +107,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets the page numbering configuration for the section.
+        /// </summary>
         public PageNumberType PageNumberType {
             get {
                 return _sectionProperties.GetFirstChild<PageNumberType>();

--- a/OfficeIMO.Word/WordSection.cs
+++ b/OfficeIMO.Word/WordSection.cs
@@ -109,22 +109,37 @@ namespace OfficeIMO.Word {
             get { return Paragraphs.Where(p => p.IsImage).ToList(); }
         }
 
+        /// <summary>
+        /// Provides a list of paragraphs that contain embedded objects.
+        /// </summary>
         public List<WordParagraph> ParagraphsEmbeddedObjects {
             get { return Paragraphs.Where(p => p.IsEmbeddedObject).ToList(); }
         }
 
+        /// <summary>
+        /// Provides a list of paragraphs that contain charts.
+        /// </summary>
         public List<WordParagraph> ParagraphsCharts {
             get { return Paragraphs.Where(p => p.IsChart).ToList(); }
         }
 
+        /// <summary>
+        /// Provides a list of paragraphs that contain end notes.
+        /// </summary>
         public List<WordParagraph> ParagraphsEndNotes {
             get { return Paragraphs.Where(p => p.IsEndNote).ToList(); }
         }
 
+        /// <summary>
+        /// Provides a list of paragraphs that contain foot notes.
+        /// </summary>
         public List<WordParagraph> ParagraphsFootNotes {
             get { return Paragraphs.Where(p => p.IsFootNote).ToList(); }
         }
 
+        /// <summary>
+        /// Provides a list of paragraphs that contain text boxes.
+        /// </summary>
         public List<WordParagraph> ParagraphsTextBoxes {
             get { return Paragraphs.Where(p => p.IsTextBox).ToList(); }
         }
@@ -136,6 +151,9 @@ namespace OfficeIMO.Word {
             get { return Paragraphs.Where(p => p.IsShape).ToList(); }
         }
 
+        /// <summary>
+        /// Gets all page break objects within the section.
+        /// </summary>
         public List<WordBreak> PageBreaks {
             get {
                 List<WordBreak> list = new List<WordBreak>();
@@ -147,6 +165,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets all charts contained in the section.
+        /// </summary>
         public List<WordChart> Charts {
             get {
                 List<WordChart> list = new List<WordChart>();
@@ -158,6 +179,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets all line breaks within the section.
+        /// </summary>
         public List<WordBreak> Breaks {
             get {
                 List<WordBreak> list = new List<WordBreak>();
@@ -183,6 +207,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets all embedded objects within the section.
+        /// </summary>
         public List<WordEmbeddedObject> EmbeddedObjects {
             get {
                 List<WordEmbeddedObject> list = new List<WordEmbeddedObject>();
@@ -193,6 +220,9 @@ namespace OfficeIMO.Word {
                 return list;
             }
         }
+        /// <summary>
+        /// Gets all bookmarks defined in the section.
+        /// </summary>
         public List<WordBookmark> Bookmarks {
             get {
                 List<WordBookmark> list = new List<WordBookmark>();
@@ -204,6 +234,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets all fields within the section.
+        /// </summary>
         public List<WordField> Fields {
             get {
                 List<WordField> list = new List<WordField>();
@@ -215,6 +248,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets all end notes within the section.
+        /// </summary>
         public List<WordEndNote> EndNotes {
             get {
                 List<WordEndNote> list = new List<WordEndNote>();
@@ -226,6 +262,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets all foot notes within the section.
+        /// </summary>
         public List<WordFootNote> FootNotes {
             get {
                 List<WordFootNote> list = new List<WordFootNote>();
@@ -237,6 +276,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets all hyperlinks within the section.
+        /// </summary>
         public List<WordHyperLink> HyperLinks {
             get {
                 List<WordHyperLink> list = new List<WordHyperLink>();
@@ -256,6 +298,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets all tab characters defined in the section.
+        /// </summary>
         public List<WordTabChar> Tabs {
             get {
                 List<WordTabChar> list = new List<WordTabChar>();
@@ -268,6 +313,9 @@ namespace OfficeIMO.Word {
         }
 
 
+        /// <summary>
+        /// Gets all text boxes within the section.
+        /// </summary>
         public List<WordTextBox> TextBoxes {
             get {
                 List<WordTextBox> list = new List<WordTextBox>();
@@ -295,6 +343,9 @@ namespace OfficeIMO.Word {
 
         }
 
+        /// <summary>
+        /// Gets all equations within the section.
+        /// </summary>
         public List<WordEquation> Equations {
             get {
                 List<WordEquation> list = new List<WordEquation>();
@@ -306,6 +357,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets all structured document tags within the section.
+        /// </summary>
         public List<WordStructuredDocumentTag> StructuredDocumentTags {
             get {
                 List<WordStructuredDocumentTag> list = new List<WordStructuredDocumentTag>();
@@ -317,6 +371,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets all checkbox content controls within the section.
+        /// </summary>
         public List<WordCheckBox> CheckBoxes {
             get {
                 List<WordCheckBox> list = new List<WordCheckBox>();
@@ -487,6 +544,9 @@ namespace OfficeIMO.Word {
             wordDocument.Sections.Add(this);
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the first page has different headers and footers.
+        /// </summary>
         public bool DifferentFirstPage {
             get {
                 var sectionProperties = _sectionProperties;
@@ -526,6 +586,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether odd and even pages use separate headers and footers.
+        /// </summary>
         public bool DifferentOddAndEvenPages {
             get {
                 var headerReference = WordHeadersAndFooters.GetHeaderReference(this._document, this, HeaderFooterValues.Even);
@@ -553,6 +616,9 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the gutter should be on the right for RTL pages.
+        /// </summary>
         public bool RtlGutter {
             get {
                 var sectionProperties = _sectionProperties;


### PR DESCRIPTION
## Summary
- document equality and run information for `WordParagraph`
- document property setters in `WordParagraph` run properties
- document helper methods for setting paragraph run properties
- document public APIs in `WordSection`

## Testing
- `dotnet test --no-build` *(failed: no output received)*

------
https://chatgpt.com/codex/tasks/task_e_685ba97c5bb4832e83ba0f5ecdd7d6dc