### PR TITLE
Add summary for WordTableCellBorder

### DIFF
--- a/OfficeIMO.Word/WordTableCellBorder.cs
+++ b/OfficeIMO.Word/WordTableCellBorder.cs
@@ -5,6 +5,10 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents the border configuration for a <see cref="WordTableCell"/>
+    /// and allows customization of each border side.
+    /// </summary>
     public class WordTableCellBorder {
         private readonly WordTableCell _wordTableCell;
         private readonly WordTableRow _wordTableRow;


### PR DESCRIPTION
## Summary
- document `WordTableCellBorder` with a class-level `<summary>`

## Testing
- `dotnet restore OfficeImo.sln`
- `dotnet build OfficeImo.sln --no-restore -c Release`
- `dotnet test OfficeImo.sln --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_685bae4805fc832e8d884a76370d67a2