### PR TITLE
Enable XML docs for OfficeIMO.Excel

### DIFF
--- a/OfficeIMO.Excel/OfficeIMO.Excel.csproj
+++ b/OfficeIMO.Excel/OfficeIMO.Excel.csproj
@@ -28,6 +28,7 @@
         <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
         <DebugType>portable</DebugType>
         <LangVersion>Latest</LangVersion>
+        <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <!--
       Turns off reference assembly generation
       See: https://docs.microsoft.com/en-us/dotnet/standard/assembly/reference-assemblies


### PR DESCRIPTION
## Summary
- ensure XML documentation is generated for OfficeIMO.Excel

## Testing
- `dotnet restore OfficeImo.sln`
- `dotnet build OfficeImo.sln -c Release --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685bae5864c0832eaf55e8abddaadf3f