### PR TITLE
Add XML docs for WordTableOfContent

### DIFF
--- a/OfficeIMO.Word/WordTableOfContent.cs
+++ b/OfficeIMO.Word/WordTableOfContent.cs
@@ -1,11 +1,24 @@
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Defines template styles that can be used when generating a table of contents.
+    /// </summary>
     public enum TableOfContentStyle {
+        /// <summary>
+        /// Built-in layout with a heading followed by entries.
+        /// </summary>
         Template1,
+
+        /// <summary>
+        /// Alternative layout with the same structure but different identifiers.
+        /// </summary>
         Template2
     }
 
+    /// <summary>
+    /// Represents a table of contents within a Word document.
+    /// </summary>
     public class WordTableOfContent : WordElement {
         private readonly WordDocument _document;
         private readonly SdtBlock _sdtBlock;
@@ -16,6 +29,9 @@ namespace OfficeIMO.Word {
         /// </summary>
         public TableOfContentStyle Style { get; }
 
+        /// <summary>
+        /// Gets or sets the heading text displayed for the table of contents.
+        /// </summary>
         public string Text {
             get {
                 if (_sdtBlock != null) {
@@ -47,6 +63,10 @@ namespace OfficeIMO.Word {
                 }
             }
         }
+
+        /// <summary>
+        /// Gets or sets the text shown when the document has no entries for the table of contents.
+        /// </summary>
         public string TextNoContent {
             get {
                 if (_sdtBlock != null) {
@@ -87,6 +107,11 @@ namespace OfficeIMO.Word {
 
 
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WordTableOfContent"/> class and appends it to the document body.
+        /// </summary>
+        /// <param name="wordDocument">Parent document where the table of contents will be created.</param>
+        /// <param name="tableOfContentStyle">Template style used to generate the table of contents.</param>
         public WordTableOfContent(WordDocument wordDocument, TableOfContentStyle tableOfContentStyle) {
             this._document = wordDocument;
             this.Style = tableOfContentStyle;
@@ -101,12 +126,20 @@ namespace OfficeIMO.Word {
             //}
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WordTableOfContent"/> class using an existing structured document tag.
+        /// </summary>
+        /// <param name="wordDocument">Parent document that owns the table of contents.</param>
+        /// <param name="sdtBlock">Structured document tag representing the table of contents.</param>
         public WordTableOfContent(WordDocument wordDocument, SdtBlock sdtBlock) {
             this._document = wordDocument;
             this._sdtBlock = sdtBlock;
             this.Style = TableOfContentStyle.Template1;
         }
 
+        /// <summary>
+        /// Flags the document to update this table of contents when the file is opened.
+        /// </summary>
         public void Update() {
             this._document.Settings.UpdateFieldsOnOpen = true;
         }

--- a/OfficeIMO.Word/WordTableOfContent.cs
+++ b/OfficeIMO.Word/WordTableOfContent.cs
@@ -22,6 +22,10 @@ namespace OfficeIMO.Word {
     public class WordTableOfContent : WordElement {
         private readonly WordDocument _document;
         private readonly SdtBlock _sdtBlock;
+
+        /// <summary>
+        /// Exposes the underlying structured document tag for this table of contents.
+        /// </summary>
         internal SdtBlock SdtBlock => _sdtBlock;
 
         /// <summary>
@@ -159,6 +163,10 @@ namespace OfficeIMO.Word {
             return _document.RegenerateTableOfContent();
         }
 
+        /// <summary>
+        /// Returns a predefined structured document tag matching the chosen style.
+        /// </summary>
+        /// <param name="style">Template identifier to retrieve.</param>
         private static SdtBlock GetStyle(TableOfContentStyle style) {
             switch (style) {
                 case TableOfContentStyle.Template1: return Template1;
@@ -166,6 +174,9 @@ namespace OfficeIMO.Word {
             }
             throw new ArgumentOutOfRangeException(nameof(style));
         }
+        /// <summary>
+        /// Structured document tag implementing the default table-of-contents layout.
+        /// </summary>
         private static SdtBlock Template1 {
             get {
                 SdtBlock sdtBlock1 = new SdtBlock();
@@ -256,6 +267,9 @@ namespace OfficeIMO.Word {
 
             }
         }
+        /// <summary>
+        /// Alternative layout used for table-of-contents generation.
+        /// </summary>
         private static SdtBlock Template2 {
             get {
 


### PR DESCRIPTION
## Summary
- document `TableOfContentStyle` enum
- add summary comments for `WordTableOfContent`
- document members such as `Text`, `TextNoContent`, constructors and `Update`

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685bae7cfef8832e878ac2106402cfea