### PR TITLE
Add summaries to WordCoverPage partials

### DIFF
--- a/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Austin.cs
+++ b/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Austin.cs
@@ -12,6 +12,9 @@ using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage {
 
         private SdtBlock CoverPageAustin {

--- a/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Banded.cs
+++ b/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Banded.cs
@@ -12,6 +12,9 @@ using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage {
 
         private SdtBlock CoverPageBanded {

--- a/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Element.cs
+++ b/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Element.cs
@@ -12,6 +12,9 @@ using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage {
 
         private static SdtBlock CoverPageElement {

--- a/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Facet.cs
+++ b/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Facet.cs
@@ -12,6 +12,9 @@ using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage {
 
         private SdtBlock CoverPageFacet {

--- a/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Grid.cs
+++ b/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Grid.cs
@@ -12,6 +12,9 @@ using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage {
 
         private SdtBlock CoverPageGrid {

--- a/OfficeIMO.Word/CoverPageStyles/WordCoverPage.IonDark.cs
+++ b/OfficeIMO.Word/CoverPageStyles/WordCoverPage.IonDark.cs
@@ -12,6 +12,9 @@ using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage {
 
         private static SdtBlock CoverPageIonDark {

--- a/OfficeIMO.Word/CoverPageStyles/WordCoverPage.IonLight.cs
+++ b/OfficeIMO.Word/CoverPageStyles/WordCoverPage.IonLight.cs
@@ -12,6 +12,9 @@ using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage {
 
         private static SdtBlock CoverPageIonLight {

--- a/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Retrospect.cs
+++ b/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Retrospect.cs
@@ -12,6 +12,9 @@ using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage {
 
         private static SdtBlock CoverPageRetrospect {

--- a/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Semaphore.cs
+++ b/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Semaphore.cs
@@ -12,6 +12,9 @@ using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage {
 
         private static SdtBlock CoverPageSemaphore {

--- a/OfficeIMO.Word/CoverPageStyles/WordCoverPage.SideLine.cs
+++ b/OfficeIMO.Word/CoverPageStyles/WordCoverPage.SideLine.cs
@@ -12,6 +12,9 @@ using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage {
 
         private static SdtBlock CoverPageSideLine {

--- a/OfficeIMO.Word/CoverPageStyles/WordCoverPage.SliceDark.cs
+++ b/OfficeIMO.Word/CoverPageStyles/WordCoverPage.SliceDark.cs
@@ -12,6 +12,9 @@ using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage {
 
         private static SdtBlock CoverPageSliceDark {

--- a/OfficeIMO.Word/CoverPageStyles/WordCoverPage.SliceLight.cs
+++ b/OfficeIMO.Word/CoverPageStyles/WordCoverPage.SliceLight.cs
@@ -12,6 +12,9 @@ using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage {
 
         private static SdtBlock CoverPageSliceLight {

--- a/OfficeIMO.Word/CoverPageStyles/WordCoverPage.ViewMaster.cs
+++ b/OfficeIMO.Word/CoverPageStyles/WordCoverPage.ViewMaster.cs
@@ -12,6 +12,9 @@ using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage {
 
         private static SdtBlock CoverPageViewMaster {

--- a/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Wisp.cs
+++ b/OfficeIMO.Word/CoverPageStyles/WordCoverPage.Wisp.cs
@@ -12,6 +12,9 @@ using Pic = DocumentFormat.OpenXml.Drawing.Pictures;
 using A14 = DocumentFormat.OpenXml.Office2010.Drawing;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     public partial class WordCoverPage {
 
         private static SdtBlock CoverPageWisp {

--- a/OfficeIMO.Word/WordCoverPage.Templates.cs
+++ b/OfficeIMO.Word/WordCoverPage.Templates.cs
@@ -13,6 +13,9 @@ using W14 = DocumentFormat.OpenXml.Office2010.Word;
 using W15 = DocumentFormat.OpenXml.Office2013.Word;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a cover page within a Word document.
+    /// </summary>
     // This file serves as a placeholder for the WordCoverPage class
     // All individual cover page templates have been moved to separate files
     public partial class WordCoverPage {


### PR DESCRIPTION
## Summary
- document WordCoverPage partial declarations with summary comments

## Testing
- `dotnet test --verbosity minimal`
- `dotnet build OfficeImo.sln -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_685bb83f579c832e9374fe5017bbefaa