### PR TITLE
Add XML docs for list, field, and document methods

### DIFF
--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1467,6 +1467,10 @@ namespace OfficeIMO.Word {
             body.Append(sectionProperties);
         }
 
+        /// <summary>
+        /// Closes the underlying <see cref="WordprocessingDocument"/> and
+        /// saves the document when <see cref="WordprocessingDocument.AutoSave"/> is enabled.
+        /// </summary>
         public void Dispose() {
             if (this._wordprocessingDocument.AutoSave) {
                 Save();

--- a/OfficeIMO.Word/WordField.PublicMethods.cs
+++ b/OfficeIMO.Word/WordField.PublicMethods.cs
@@ -55,6 +55,9 @@ namespace OfficeIMO.Word {
             return AddField(paragraph, fieldCode.FieldType, wordFieldFormat, customFormat, advanced, parameters);
         }
 
+        /// <summary>
+        /// Deletes all runs and simple field elements associated with this field.
+        /// </summary>
         public void Remove() {
             if (_runs != null) {
                 foreach (var run in _runs) {

--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -244,6 +244,13 @@ namespace OfficeIMO.Word {
             return list;
         }
 
+        /// <summary>
+        /// Creates a custom bullet list using an image as the bullet symbol.
+        /// </summary>
+        /// <param name="document">Parent document where the list will be added.</param>
+        /// <param name="imageStream">Stream containing the image data.</param>
+        /// <param name="fileName">File name used to determine the image type.</param>
+        /// <returns>The created <see cref="WordList"/>.</returns>
         public static WordList AddPictureBulletList(WordDocument document, Stream imageStream, string fileName) {
             if (document == null) throw new ArgumentNullException(nameof(document));
             if (imageStream == null) throw new ArgumentNullException(nameof(imageStream));
@@ -282,11 +289,26 @@ namespace OfficeIMO.Word {
             return list;
         }
 
+        /// <summary>
+        /// Creates a custom bullet list using an image file as the bullet symbol.
+        /// </summary>
+        /// <param name="document">Parent document where the list will be added.</param>
+        /// <param name="imagePath">Path to the image file.</param>
+        /// <returns>The created <see cref="WordList"/>.</returns>
         public static WordList AddPictureBulletList(WordDocument document, string imagePath) {
             using var stream = new FileStream(imagePath, FileMode.Open, FileAccess.Read, FileShare.Read);
             return AddPictureBulletList(document, stream, System.IO.Path.GetFileName(imagePath));
         }
 
+        /// <summary>
+        /// Adds a new bullet list level using a custom symbol character.
+        /// </summary>
+        /// <param name="levelIndex">Index of the level starting from 1.</param>
+        /// <param name="symbol">Character used for the bullet.</param>
+        /// <param name="fontName">Font name used for the symbol.</param>
+        /// <param name="colorHex">Bullet color specified as hex string.</param>
+        /// <param name="fontSize">Optional font size in points.</param>
+        /// <returns>The current <see cref="WordList"/>.</returns>
         public WordList AddListLevel(int levelIndex, char symbol, string fontName, string colorHex, int? fontSize = null) {
             if (levelIndex < 1) throw new ArgumentOutOfRangeException(nameof(levelIndex));
 
@@ -312,11 +334,31 @@ namespace OfficeIMO.Word {
             return this;
         }
 
+        /// <summary>
+        /// Adds a new bullet list level using a predefined <see cref="WordBulletSymbol"/>.
+        /// </summary>
+        /// <param name="levelIndex">Index of the level starting from 1.</param>
+        /// <param name="symbol">Predefined bullet symbol.</param>
+        /// <param name="fontName">Font name used for the symbol.</param>
+        /// <param name="color">Optional symbol color.</param>
+        /// <param name="colorHex">Optional color specified as hex string. Ignored when <paramref name="color"/> is provided.</param>
+        /// <param name="fontSize">Optional font size in points.</param>
+        /// <returns>The current <see cref="WordList"/>.</returns>
         public WordList AddListLevel(int levelIndex, WordBulletSymbol symbol, string fontName, SixLabors.ImageSharp.Color? color = null, string colorHex = null, int? fontSize = null) {
             string finalColor = color?.ToHexColor() ?? colorHex;
             return AddListLevel(levelIndex, (char)symbol, fontName, finalColor, fontSize);
         }
 
+        /// <summary>
+        /// Adds a new bullet list level using one of the predefined <see cref="WordListLevelKind"/> values.
+        /// </summary>
+        /// <param name="levelIndex">Index of the level starting from 1.</param>
+        /// <param name="kind">Determines which bullet symbol to use.</param>
+        /// <param name="fontName">Font name used for the symbol.</param>
+        /// <param name="color">Optional symbol color.</param>
+        /// <param name="colorHex">Optional color specified as hex string. Ignored when <paramref name="color"/> is provided.</param>
+        /// <param name="fontSize">Optional font size in points.</param>
+        /// <returns>The current <see cref="WordList"/>.</returns>
         public WordList AddListLevel(int levelIndex, WordListLevelKind kind, string fontName, SixLabors.ImageSharp.Color? color = null, string colorHex = null, int? fontSize = null) {
             char symbol = GetBulletSymbol(kind);
             string finalColor = color?.ToHexColor() ?? colorHex;


### PR DESCRIPTION
## Summary
- document Dispose() in WordDocument
- document picture bullet list helpers in WordList
- document AddListLevel overloads
- document WordField.Remove

## Testing
- `dotnet build OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_685bd8615a9c832e919780183c69f8ff