### PR TITLE
Add missing XML docs to silence CS1591 warnings

### DIFF
--- a/OfficeIMO.Word/FieldCodes/WordFieldCode.cs
+++ b/OfficeIMO.Word/FieldCodes/WordFieldCode.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Base class for specific field code representations.
+    /// </summary>
     public abstract class WordFieldCode {
         internal abstract WordFieldType FieldType { get; }
 

--- a/OfficeIMO.Word/Parts/WordDocument.Parts.StyleDefinitions.cs
+++ b/OfficeIMO.Word/Parts/WordDocument.Parts.StyleDefinitions.cs
@@ -39,7 +39,8 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// This method is supposed to bring missing elements such as table styles to loaded document
         /// </summary>
-        /// <param name="styleDefinitionsPart"></param>
+        /// <param name="styleDefinitionsPart">Part to which styles should be added.</param>
+        /// <param name="overrideExisting">Replace styles when they already exist.</param>
         private static void AddStyleDefinitions(StyleDefinitionsPart styleDefinitionsPart, bool overrideExisting) {
             var styles = styleDefinitionsPart.Styles;
             AddTableStyles(styles, overrideExisting);

--- a/OfficeIMO.Word/Table/WordTableBorderSide.cs
+++ b/OfficeIMO.Word/Table/WordTableBorderSide.cs
@@ -4,10 +4,16 @@ namespace OfficeIMO.Word;
 /// Enum to represent border sides for tables
 /// </summary>
 public enum WordTableBorderSide {
+    /// <summary>Top border.</summary>
     Top,
+    /// <summary>Bottom border.</summary>
     Bottom,
+    /// <summary>Left border.</summary>
     Left,
+    /// <summary>Right border.</summary>
     Right,
+    /// <summary>Internal horizontal borders.</summary>
     InsideHorizontal,
+    /// <summary>Internal vertical borders.</summary>
     InsideVertical
 }

--- a/OfficeIMO.Word/WordAlternativeFormatImportPartType.cs
+++ b/OfficeIMO.Word/WordAlternativeFormatImportPartType.cs
@@ -4,7 +4,10 @@ namespace OfficeIMO.Word;
 /// Alternative format import part type
 /// </summary>
 public enum WordAlternativeFormatImportPartType {
+    /// <summary>Rich text format.</summary>
     Rtf,
+    /// <summary>HTML format.</summary>
     Html,
+    /// <summary>Plain text format.</summary>
     TextPlain
 }

--- a/OfficeIMO.Word/WordCharacterStyle.cs
+++ b/OfficeIMO.Word/WordCharacterStyle.cs
@@ -6,15 +6,25 @@ namespace OfficeIMO.Word {
     /// Predefined character styles available in Word documents.
     /// </summary>
     public enum WordCharacterStyles {
+        /// <summary>Default font of the paragraph.</summary>
         DefaultParagraphFont,
+        /// <summary>Character style for heading level 1.</summary>
         Heading1Char,
+        /// <summary>Character style for heading level 2.</summary>
         Heading2Char,
+        /// <summary>Character style for heading level 3.</summary>
         Heading3Char,
+        /// <summary>Character style for heading level 4.</summary>
         Heading4Char,
+        /// <summary>Character style for heading level 5.</summary>
         Heading5Char,
+        /// <summary>Character style for heading level 6.</summary>
         Heading6Char,
+        /// <summary>Character style for heading level 7.</summary>
         Heading7Char,
+        /// <summary>Character style for heading level 8.</summary>
         Heading8Char,
+        /// <summary>Character style for heading level 9.</summary>
         Heading9Char,
     }
 

--- a/OfficeIMO.Word/WordCoverPage.cs
+++ b/OfficeIMO.Word/WordCoverPage.cs
@@ -5,19 +5,33 @@ namespace OfficeIMO.Word {
     /// Built-in cover page templates available for Word documents.
     /// </summary>
     public enum CoverPageTemplate {
+        /// <summary>Template named Austin.</summary>
         Austin,
+        /// <summary>Template named Banded.</summary>
         Banded,
+        /// <summary>Template named Facet.</summary>
         Facet,
+        /// <summary>Template named Grid.</summary>
         Grid,
+        /// <summary>Template named IonDark.</summary>
         IonDark,
+        /// <summary>Template named IonLight.</summary>
         IonLight,
+        /// <summary>Template named Element.</summary>
         Element,
+        /// <summary>Template named Wisp.</summary>
         Wisp,
+        /// <summary>Template named ViewMaster.</summary>
         ViewMaster,
+        /// <summary>Template named SliceLight.</summary>
         SliceLight,
+        /// <summary>Template named SliceDark.</summary>
         SliceDark,
+        /// <summary>Template named SideLine.</summary>
         SideLine,
+        /// <summary>Template named Semaphore.</summary>
         Semaphore,
+        /// <summary>Template named Retrospect.</summary>
         Retrospect
     }
 

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -189,10 +189,21 @@ namespace OfficeIMO.Word {
             return WordList.AddCustomBulletList(this, kind, fontName, color, colorHex, fontSize);
         }
 
+        /// <summary>
+        /// Creates a bulleted list using the provided image stream as the bullet symbol.
+        /// </summary>
+        /// <param name="imageStream">Stream containing the bullet image.</param>
+        /// <param name="fileName">Image file name for metadata.</param>
+        /// <returns>The created <see cref="WordList"/>.</returns>
         public WordList AddPictureBulletList(Stream imageStream, string fileName) {
             return WordList.AddPictureBulletList(this, imageStream, fileName);
         }
 
+        /// <summary>
+        /// Creates a bulleted list using an image file as the bullet symbol.
+        /// </summary>
+        /// <param name="imagePath">Path to the image file.</param>
+        /// <returns>The created <see cref="WordList"/>.</returns>
         public WordList AddPictureBulletList(string imagePath) {
             return WordList.AddPictureBulletList(this, imagePath);
         }

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1065,9 +1065,10 @@ namespace OfficeIMO.Word {
         /// Load WordDocument from filePath
         /// </summary>
         /// <param name="filePath"></param>
-        /// <param name="readOnly"></param>
-        /// <param name="autoSave"></param>
-        /// <returns></returns>
+        /// <param name="readOnly">Open the document in read-only mode.</param>
+        /// <param name="autoSave">Enable auto-save when disposing.</param>
+        /// <param name="overrideStyles">When true, existing styles are overwritten.</param>
+        /// <returns>The loaded <see cref="WordDocument"/>.</returns>
         /// <exception cref="FileNotFoundException"></exception>
         public static WordDocument Load(string filePath, bool readOnly = false, bool autoSave = false, bool overrideStyles = false) {
             if (filePath != null) {
@@ -1110,6 +1111,7 @@ namespace OfficeIMO.Word {
         /// <param name="filePath">Path to the file.</param>
         /// <param name="readOnly">Open the document in read-only mode.</param>
         /// <param name="autoSave">Enable auto-save on dispose.</param>
+        /// <param name="overrideStyles">When true, existing styles are overwritten.</param>
         /// <returns>Loaded <see cref="WordDocument"/> instance.</returns>
         /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
         public static async Task<WordDocument> LoadAsync(string filePath, bool readOnly = false, bool autoSave = false, bool overrideStyles = false) {
@@ -1147,10 +1149,11 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Load WordDocument from stream
         /// </summary>
-        /// <param name="stream"></param>
-        /// <param name="readOnly"></param>
-        /// <param name="autoSave"></param>
-        /// <returns></returns>
+        /// <param name="stream">Stream containing the document.</param>
+        /// <param name="readOnly">Open the document in read-only mode.</param>
+        /// <param name="autoSave">Enable auto-save when disposing.</param>
+        /// <param name="overrideStyles">When true, existing styles are overwritten.</param>
+        /// <returns>The loaded <see cref="WordDocument"/>.</returns>
         public static WordDocument Load(Stream stream, bool readOnly = false, bool autoSave = false, bool overrideStyles = false) {
             var document = new WordDocument();
 
@@ -1467,6 +1470,9 @@ namespace OfficeIMO.Word {
             body.Append(sectionProperties);
         }
 
+        /// <summary>
+        /// Saves and releases all resources used by the document.
+        /// </summary>
         public void Dispose() {
             if (this._wordprocessingDocument.AutoSave) {
                 Save();

--- a/OfficeIMO.Word/WordField.PublicMethods.cs
+++ b/OfficeIMO.Word/WordField.PublicMethods.cs
@@ -55,6 +55,9 @@ namespace OfficeIMO.Word {
             return AddField(paragraph, fieldCode.FieldType, wordFieldFormat, customFormat, advanced, parameters);
         }
 
+        /// <summary>
+        /// Deletes the field from the document along with its runs.
+        /// </summary>
         public void Remove() {
             if (_runs != null) {
                 foreach (var run in _runs) {

--- a/OfficeIMO.Word/WordField.cs
+++ b/OfficeIMO.Word/WordField.cs
@@ -154,6 +154,7 @@ namespace OfficeIMO.Word {
         UserInitials,
         /// <summary>UserName field code.</summary>
         UserName,
+        /// <summary>Index entry field code.</summary>
         XE
     }
 

--- a/OfficeIMO.Word/WordHeaderFooter.Properties.cs
+++ b/OfficeIMO.Word/WordHeaderFooter.Properties.cs
@@ -13,10 +13,20 @@ namespace OfficeIMO.Word {
     public partial class WordHeaderFooter {
         private protected HeaderFooterValues _type;
         private protected HeaderPart _headerPart;
+        /// <summary>
+        /// Header element represented by this instance when applicable.
+        /// </summary>
         protected internal Header _header;
+
+        /// <summary>
+        /// Footer element represented by this instance when applicable.
+        /// </summary>
         protected internal Footer _footer;
         protected private FooterPart _footerPart;
         private protected string _id;
+        /// <summary>
+        /// Reference to the parent document that owns this header or footer.
+        /// </summary>
         protected WordDocument _document;
 
         /// <summary>

--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -236,6 +236,11 @@ namespace OfficeIMO.Word {
             return AddCustomBulletList(document, symbol, fontName, finalColor, fontSize);
         }
 
+        /// <summary>
+        /// Creates an empty custom list without any predefined levels.
+        /// </summary>
+        /// <param name="document">The parent document.</param>
+        /// <returns>The created <see cref="WordList"/>.</returns>
         public static WordList AddCustomList(WordDocument document) {
             if (document == null) throw new ArgumentNullException(nameof(document));
 
@@ -244,6 +249,13 @@ namespace OfficeIMO.Word {
             return list;
         }
 
+        /// <summary>
+        /// Creates a bulleted list using the specified image as the bullet symbol.
+        /// </summary>
+        /// <param name="document">The parent document.</param>
+        /// <param name="imageStream">Stream containing the bullet image.</param>
+        /// <param name="fileName">Name of the image file.</param>
+        /// <returns>The created <see cref="WordList"/>.</returns>
         public static WordList AddPictureBulletList(WordDocument document, Stream imageStream, string fileName) {
             if (document == null) throw new ArgumentNullException(nameof(document));
             if (imageStream == null) throw new ArgumentNullException(nameof(imageStream));
@@ -282,11 +294,26 @@ namespace OfficeIMO.Word {
             return list;
         }
 
+        /// <summary>
+        /// Creates a bulleted list using an image file as the bullet symbol.
+        /// </summary>
+        /// <param name="document">The parent document.</param>
+        /// <param name="imagePath">Path to the image file.</param>
+        /// <returns>The created <see cref="WordList"/>.</returns>
         public static WordList AddPictureBulletList(WordDocument document, string imagePath) {
             using var stream = new FileStream(imagePath, FileMode.Open, FileAccess.Read, FileShare.Read);
             return AddPictureBulletList(document, stream, System.IO.Path.GetFileName(imagePath));
         }
 
+        /// <summary>
+        /// Adds a bullet level to the list using a custom symbol.
+        /// </summary>
+        /// <param name="levelIndex">The one-based level index to add.</param>
+        /// <param name="symbol">Bullet character to use.</param>
+        /// <param name="fontName">Font name for the symbol.</param>
+        /// <param name="colorHex">Color of the symbol in hex format.</param>
+        /// <param name="fontSize">Optional symbol size in points.</param>
+        /// <returns>The current <see cref="WordList"/> instance.</returns>
         public WordList AddListLevel(int levelIndex, char symbol, string fontName, string colorHex, int? fontSize = null) {
             if (levelIndex < 1) throw new ArgumentOutOfRangeException(nameof(levelIndex));
 
@@ -312,11 +339,31 @@ namespace OfficeIMO.Word {
             return this;
         }
 
+        /// <summary>
+        /// Adds a bullet level using a predefined <see cref="WordBulletSymbol"/>.
+        /// </summary>
+        /// <param name="levelIndex">The one-based level index to add.</param>
+        /// <param name="symbol">Predefined symbol.</param>
+        /// <param name="fontName">Font name for the symbol.</param>
+        /// <param name="color">Optional color for the symbol.</param>
+        /// <param name="colorHex">Optional color as hex when <paramref name="color"/> is not provided.</param>
+        /// <param name="fontSize">Optional symbol size in points.</param>
+        /// <returns>The current <see cref="WordList"/> instance.</returns>
         public WordList AddListLevel(int levelIndex, WordBulletSymbol symbol, string fontName, SixLabors.ImageSharp.Color? color = null, string colorHex = null, int? fontSize = null) {
             string finalColor = color?.ToHexColor() ?? colorHex;
             return AddListLevel(levelIndex, (char)symbol, fontName, finalColor, fontSize);
         }
 
+        /// <summary>
+        /// Adds a bullet level using one of the predefined <see cref="WordListLevelKind"/> values.
+        /// </summary>
+        /// <param name="levelIndex">The one-based level index to add.</param>
+        /// <param name="kind">Specifies the symbol kind.</param>
+        /// <param name="fontName">Font name for the symbol.</param>
+        /// <param name="color">Optional color for the symbol.</param>
+        /// <param name="colorHex">Optional color as hex when <paramref name="color"/> is not provided.</param>
+        /// <param name="fontSize">Optional symbol size in points.</param>
+        /// <returns>The current <see cref="WordList"/> instance.</returns>
         public WordList AddListLevel(int levelIndex, WordListLevelKind kind, string fontName, SixLabors.ImageSharp.Color? color = null, string colorHex = null, int? fontSize = null) {
             char symbol = GetBulletSymbol(kind);
             string finalColor = color?.ToHexColor() ?? colorHex;

--- a/OfficeIMO.Word/WordMargins.cs
+++ b/OfficeIMO.Word/WordMargins.cs
@@ -7,12 +7,39 @@ namespace OfficeIMO.Word {
     /// Predefined margin configurations available for a document section.
     /// </summary>
     public enum WordMargin {
+        /// <summary>
+        /// Standard one inch margins on all sides.
+        /// </summary>
         Normal,
+
+        /// <summary>
+        /// Margins mirrored for odd and even pages when binding.
+        /// </summary>
         Mirrored,
+
+        /// <summary>
+        /// Slightly narrower left and right margins.
+        /// </summary>
         Moderate,
+
+        /// <summary>
+        /// Half inch margins on all sides.
+        /// </summary>
         Narrow,
+
+        /// <summary>
+        /// Wide margins for editing or notes.
+        /// </summary>
         Wide,
+
+        /// <summary>
+        /// Default margins used by Office 2003.
+        /// </summary>
         Office2003Default,
+
+        /// <summary>
+        /// Margin configuration is not recognized.
+        /// </summary>
         Unknown
     }
 

--- a/OfficeIMO.Word/WordSection.cs
+++ b/OfficeIMO.Word/WordSection.cs
@@ -55,10 +55,16 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Provides a list of paragraphs that contain hyperlinks.
+        /// </summary>
         public List<WordParagraph> ParagraphsHyperLinks {
             get { return Paragraphs.Where(p => p.IsHyperLink).ToList(); }
         }
 
+        /// <summary>
+        /// Provides a list of paragraphs that contain fields.
+        /// </summary>
         public List<WordParagraph> ParagraphsFields {
             get { return Paragraphs.Where(p => p.IsField).ToList(); }
         }


### PR DESCRIPTION
## Summary
- add XML comments for enumeration members like `WordMargin` and `CoverPageTemplate`
- document properties and methods in Word API classes
- include descriptions for additional enums and fields

## Testing
- `dotnet build OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_685bd86fcb30832e961f339d354cc96d