### PR TITLE
Add summary tags for enum values

### DIFF
--- a/OfficeIMO.Word/Table/WordTableBorderSide.cs
+++ b/OfficeIMO.Word/Table/WordTableBorderSide.cs
@@ -4,10 +4,28 @@ namespace OfficeIMO.Word;
 /// Enum to represent border sides for tables
 /// </summary>
 public enum WordTableBorderSide {
+    /// <summary>
+    /// The top border of the table.
+    /// </summary>
     Top,
+    /// <summary>
+    /// The bottom border of the table.
+    /// </summary>
     Bottom,
+    /// <summary>
+    /// The left border of the table.
+    /// </summary>
     Left,
+    /// <summary>
+    /// The right border of the table.
+    /// </summary>
     Right,
+    /// <summary>
+    /// Horizontal borders between rows.
+    /// </summary>
     InsideHorizontal,
+    /// <summary>
+    /// Vertical borders between columns.
+    /// </summary>
     InsideVertical
 }

--- a/OfficeIMO.Word/WordAlternativeFormatImportPartType.cs
+++ b/OfficeIMO.Word/WordAlternativeFormatImportPartType.cs
@@ -4,7 +4,16 @@ namespace OfficeIMO.Word;
 /// Alternative format import part type
 /// </summary>
 public enum WordAlternativeFormatImportPartType {
+    /// <summary>
+    /// Rich Text Format content.
+    /// </summary>
     Rtf,
+    /// <summary>
+    /// HyperText Markup Language content.
+    /// </summary>
     Html,
+    /// <summary>
+    /// Plain text content.
+    /// </summary>
     TextPlain
 }

--- a/OfficeIMO.Word/WordCharacterStyle.cs
+++ b/OfficeIMO.Word/WordCharacterStyle.cs
@@ -6,15 +6,45 @@ namespace OfficeIMO.Word {
     /// Predefined character styles available in Word documents.
     /// </summary>
     public enum WordCharacterStyles {
+        /// <summary>
+        /// Default character formatting used for paragraphs.
+        /// </summary>
         DefaultParagraphFont,
+        /// <summary>
+        /// Character style associated with Heading 1 paragraphs.
+        /// </summary>
         Heading1Char,
+        /// <summary>
+        /// Character style associated with Heading 2 paragraphs.
+        /// </summary>
         Heading2Char,
+        /// <summary>
+        /// Character style associated with Heading 3 paragraphs.
+        /// </summary>
         Heading3Char,
+        /// <summary>
+        /// Character style associated with Heading 4 paragraphs.
+        /// </summary>
         Heading4Char,
+        /// <summary>
+        /// Character style associated with Heading 5 paragraphs.
+        /// </summary>
         Heading5Char,
+        /// <summary>
+        /// Character style associated with Heading 6 paragraphs.
+        /// </summary>
         Heading6Char,
+        /// <summary>
+        /// Character style associated with Heading 7 paragraphs.
+        /// </summary>
         Heading7Char,
+        /// <summary>
+        /// Character style associated with Heading 8 paragraphs.
+        /// </summary>
         Heading8Char,
+        /// <summary>
+        /// Character style associated with Heading 9 paragraphs.
+        /// </summary>
         Heading9Char,
     }
 

--- a/OfficeIMO.Word/WordCoverPage.cs
+++ b/OfficeIMO.Word/WordCoverPage.cs
@@ -4,20 +4,62 @@ namespace OfficeIMO.Word {
     /// <summary>
     /// Built-in cover page templates available for Word documents.
     /// </summary>
-    public enum CoverPageTemplate {
+public enum CoverPageTemplate {
+        /// <summary>
+        /// The "Austin" built-in template.
+        /// </summary>
         Austin,
+        /// <summary>
+        /// The "Banded" built-in template.
+        /// </summary>
         Banded,
+        /// <summary>
+        /// The "Facet" built-in template.
+        /// </summary>
         Facet,
+        /// <summary>
+        /// The "Grid" built-in template.
+        /// </summary>
         Grid,
+        /// <summary>
+        /// The "Ion (Dark)" built-in template.
+        /// </summary>
         IonDark,
+        /// <summary>
+        /// The "Ion (Light)" built-in template.
+        /// </summary>
         IonLight,
+        /// <summary>
+        /// The "Element" built-in template.
+        /// </summary>
         Element,
+        /// <summary>
+        /// The "Wisp" built-in template.
+        /// </summary>
         Wisp,
+        /// <summary>
+        /// The "View Master" built-in template.
+        /// </summary>
         ViewMaster,
+        /// <summary>
+        /// The "Slice (Light)" built-in template.
+        /// </summary>
         SliceLight,
+        /// <summary>
+        /// The "Slice (Dark)" built-in template.
+        /// </summary>
         SliceDark,
+        /// <summary>
+        /// The "Sideline" built-in template.
+        /// </summary>
         SideLine,
+        /// <summary>
+        /// The "Semaphore" built-in template.
+        /// </summary>
         Semaphore,
+        /// <summary>
+        /// The "Retrospect" built-in template.
+        /// </summary>
         Retrospect
     }
 

--- a/OfficeIMO.Word/WordField.cs
+++ b/OfficeIMO.Word/WordField.cs
@@ -154,6 +154,7 @@ namespace OfficeIMO.Word {
         UserInitials,
         /// <summary>UserName field code.</summary>
         UserName,
+        /// <summary>Index entry field code.</summary>
         XE
     }
 

--- a/OfficeIMO.Word/WordMargins.cs
+++ b/OfficeIMO.Word/WordMargins.cs
@@ -6,13 +6,34 @@ namespace OfficeIMO.Word {
     /// <summary>
     /// Predefined margin configurations available for a document section.
     /// </summary>
-    public enum WordMargin {
+public enum WordMargin {
+        /// <summary>
+        /// Standard one inch margins on all sides.
+        /// </summary>
         Normal,
+        /// <summary>
+        /// Mirrored inside and outside margins for book binding.
+        /// </summary>
         Mirrored,
+        /// <summary>
+        /// Slightly smaller left and right margins.
+        /// </summary>
         Moderate,
+        /// <summary>
+        /// Minimal margins on all sides.
+        /// </summary>
         Narrow,
+        /// <summary>
+        /// Extra wide margins on left and right.
+        /// </summary>
         Wide,
+        /// <summary>
+        /// Margin preset used by Word 2003.
+        /// </summary>
         Office2003Default,
+        /// <summary>
+        /// Custom margins not represented by other presets.
+        /// </summary>
         Unknown
     }
 


### PR DESCRIPTION
## Summary
- add summaries for `WordAlternativeFormatImportPartType` values
- document standard margin presets in `WordMargin`
- document character styles in `WordCharacterStyles`
- add border side summaries in `WordTableBorderSide`
- document built-in cover page templates
- add missing summary for `WordFieldType.XE`

## Testing
- `dotnet build -c Release`
- `dotnet test -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685bd864712c832e87b26a7c2e33d696