### PR TITLE
Fix missing XML comments

### DIFF
--- a/OfficeIMO.Word/FieldCodes/WordFieldCode.cs
+++ b/OfficeIMO.Word/FieldCodes/WordFieldCode.cs
@@ -2,9 +2,20 @@ using System;
 using System.Collections.Generic;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Base class for all field code representations. Derived types expose
+    /// specific parameters and the field type they represent.
+    /// </summary>
     public abstract class WordFieldCode {
+        /// <summary>
+        /// Gets the type of field represented by the derived class.
+        /// </summary>
         internal abstract WordFieldType FieldType { get; }
 
+        /// <summary>
+        /// Retrieves a list of parameter strings used to construct the field
+        /// code within the document.
+        /// </summary>
         internal abstract List<string> GetParameters();
     }
 }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -189,10 +189,21 @@ namespace OfficeIMO.Word {
             return WordList.AddCustomBulletList(this, kind, fontName, color, colorHex, fontSize);
         }
 
+        /// <summary>
+        /// Creates a bullet list where the bullet symbol is provided as an image.
+        /// </summary>
+        /// <param name="imageStream">Stream containing the image data.</param>
+        /// <param name="fileName">File name used to determine the image type.</param>
+        /// <returns>The created <see cref="WordList"/>.</returns>
         public WordList AddPictureBulletList(Stream imageStream, string fileName) {
             return WordList.AddPictureBulletList(this, imageStream, fileName);
         }
 
+        /// <summary>
+        /// Creates a bullet list where the bullet symbol is loaded from an image file.
+        /// </summary>
+        /// <param name="imagePath">Path to the image file.</param>
+        /// <returns>The created <see cref="WordList"/>.</returns>
         public WordList AddPictureBulletList(string imagePath) {
             return WordList.AddPictureBulletList(this, imagePath);
         }

--- a/OfficeIMO.Word/WordHeaderFooter.Properties.cs
+++ b/OfficeIMO.Word/WordHeaderFooter.Properties.cs
@@ -13,10 +13,23 @@ namespace OfficeIMO.Word {
     public partial class WordHeaderFooter {
         private protected HeaderFooterValues _type;
         private protected HeaderPart _headerPart;
+
+        /// <summary>
+        /// Underlying OpenXML header element associated with this header or footer.
+        /// </summary>
         protected internal Header _header;
+
+        /// <summary>
+        /// Underlying OpenXML footer element associated with this header or footer.
+        /// </summary>
         protected internal Footer _footer;
+
         protected private FooterPart _footerPart;
         private protected string _id;
+
+        /// <summary>
+        /// Parent <see cref="WordDocument"/> instance this header or footer belongs to.
+        /// </summary>
         protected WordDocument _document;
 
         /// <summary>

--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -239,6 +239,12 @@ namespace OfficeIMO.Word {
             return AddCustomBulletList(document, symbol, fontName, finalColor, fontSize);
         }
 
+        /// <summary>
+        /// Creates a list that does not contain any predefined levels. Levels can
+        /// be configured manually after creation.
+        /// </summary>
+        /// <param name="document">Parent document where the list will be added.</param>
+        /// <returns>The created <see cref="WordList"/>.</returns>
         public static WordList AddCustomList(WordDocument document) {
             if (document == null) throw new ArgumentNullException(nameof(document));
 

--- a/OfficeIMO.Word/WordSection.cs
+++ b/OfficeIMO.Word/WordSection.cs
@@ -55,10 +55,16 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Provides a list of paragraphs that contain hyperlinks.
+        /// </summary>
         public List<WordParagraph> ParagraphsHyperLinks {
             get { return Paragraphs.Where(p => p.IsHyperLink).ToList(); }
         }
 
+        /// <summary>
+        /// Provides a list of paragraphs that contain fields.
+        /// </summary>
         public List<WordParagraph> ParagraphsFields {
             get { return Paragraphs.Where(p => p.IsField).ToList(); }
         }


### PR DESCRIPTION
## Summary
- document base WordFieldCode
- document WordDocument.AddPictureBulletList methods
- document WordHeaderFooter private members
- document WordList.AddCustomList
- document hyperlink and field paragraph lists

## Testing
- `dotnet build OfficeImo.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_685bdc998bf0832ea663577570cec800