### PR TITLE
Fix XML cref and obsolete call

### DIFF
--- a/OfficeIMO.Tests/Word.Macros.cs
+++ b/OfficeIMO.Tests/Word.Macros.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Tests {
             vba.AddStream("_VBA_PROJECT").SetData(new byte[0]);
             vba.AddStream("Module1").SetData(System.Text.Encoding.UTF8.GetBytes("test"));
             cf.RootStorage.AddStream("PROJECT").SetData(new byte[0]);
-            cf.Save(path);
+            cf.SaveAs(path);
             cf.Close();
             return path;
         }

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1469,7 +1469,7 @@ namespace OfficeIMO.Word {
 
         /// <summary>
         /// Closes the underlying <see cref="WordprocessingDocument"/> and
-        /// saves the document when <see cref="WordprocessingDocument.AutoSave"/> is enabled.
+        /// saves the document when <see cref="DocumentFormat.OpenXml.Packaging.OpenXmlPackage.AutoSave"/> is enabled.
         /// </summary>
         public void Dispose() {
             if (this._wordprocessingDocument.AutoSave) {


### PR DESCRIPTION
## Summary
- fix cref to reference OpenXmlPackage.AutoSave property
- replace obsolete `CompoundFile.Save` with `SaveAs`

## Testing
- `dotnet build OfficeImo.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685be4c11eb0832e8b66618205b4c4dc