### PR TITLE
Fix unreachable code in WordListLevel

### DIFF
--- a/OfficeIMO.Word/WordListLevel.cs
+++ b/OfficeIMO.Word/WordListLevel.cs
@@ -633,7 +633,6 @@ public enum WordListLevelKind {
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(simplifiedListNumbers), simplifiedListNumbers, null);
-                    break;
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove unreachable `break` in `WordListLevel`'s switch statement

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeImo.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685be4e99ec8832ea174c46d5a881136