### PR TITLE
Fix Assert.Equal warnings

### DIFF
--- a/OfficeIMO.Tests/Word.Insertion.cs
+++ b/OfficeIMO.Tests/Word.Insertion.cs
@@ -43,7 +43,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = WordDocument.Load(filePath)) {
-                Assert.Equal(1, document.Tables.Count);
+                Assert.Single(document.Tables);
                 Assert.Equal("Test", document.Tables[0].Rows[0].Cells[0].Paragraphs[0].Text);
 
                 var body = document._document.Body;

--- a/OfficeIMO.Tests/Word.Lists.cs
+++ b/OfficeIMO.Tests/Word.Lists.cs
@@ -854,7 +854,7 @@ public partial class Word {
 
         using (var wordDoc = WordprocessingDocument.Open(filePath, false)) {
             Assert.NotNull(wordDoc.MainDocumentPart.NumberingDefinitionsPart);
-            Assert.Equal(1, wordDoc.MainDocumentPart.NumberingDefinitionsPart.Numbering.Elements<NumberingInstance>().Count());
+            Assert.Single(wordDoc.MainDocumentPart.NumberingDefinitionsPart.Numbering.Elements<NumberingInstance>());
         }
     }
 }

--- a/OfficeIMO.Tests/Word.MergeDocuments.cs
+++ b/OfficeIMO.Tests/Word.MergeDocuments.cs
@@ -141,7 +141,7 @@ namespace OfficeIMO.Tests {
         }
 
         using (var merged = WordDocument.Load(filePath1)) {
-            Assert.Equal(1, merged.Lists.Count);
+            Assert.Single(merged.Lists);
             Assert.Contains(merged.Paragraphs, p => p.Text == "Just text");
         }
     }


### PR DESCRIPTION
## Summary
- update tests to follow xunit analyzer guidance for collection size checks

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeImo.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685be53038c8832eb88170847f83697d