### PR TITLE
Fix XML doc entity in WordEquation

### DIFF
--- a/OfficeIMO.Word/WordEquation.cs
+++ b/OfficeIMO.Word/WordEquation.cs
@@ -65,7 +65,7 @@ namespace OfficeIMO.Word {
 
         /// <summary>
         /// Removes the equation from the document by deleting the underlying
-        /// Open&nbsp;XML elements.
+        /// Open XML elements.
         /// </summary>
         public void Remove() {
             if (this._officeMath != null) {


### PR DESCRIPTION
## Summary
- fix a malformed XML entity in `WordEquation` documentation

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_685be4f9b518832ea1177893f2bfa805