### PR TITLE
Fix CS8632 warnings without nullable context

### DIFF
--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -622,7 +622,7 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private DocumentFormat.OpenXml.Drawing.Pictures.Picture? GetPicture() {
+        private DocumentFormat.OpenXml.Drawing.Pictures.Picture GetPicture() {
             if (_Image.Inline != null) {
                 return _Image.Inline.Graphic.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
             }
@@ -1868,7 +1868,7 @@ namespace OfficeIMO.Word {
             return anchor1;
         }
 
-        private Blip? GetBlip() {
+        private Blip GetBlip() {
             if (_Image.Inline != null) {
                 var picture = _Image.Inline.Graphic.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
                 return picture?.BlipFill?.Blip;
@@ -2088,15 +2088,15 @@ namespace OfficeIMO.Word {
             string relationshipId;
             var location = paragraph.Location();
             if (location.GetType() == typeof(Header)) {
-                var part = ((Header)location).HeaderPart;
+                var part = ((Header)location).HeaderPart!;
                 imagePart = part.AddImagePart(imagePartType.ToOpenXmlImagePartType());
                 relationshipId = part.GetIdOfPart(imagePart);
             } else if (location.GetType() == typeof(Footer)) {
-                var part = ((Footer)location).FooterPart;
+                var part = ((Footer)location).FooterPart!;
                 imagePart = part.AddImagePart(imagePartType.ToOpenXmlImagePartType());
                 relationshipId = part.GetIdOfPart(imagePart);
             } else if (location.GetType() == typeof(Document)) {
-                var part = document._wordprocessingDocument.MainDocumentPart;
+                var part = document._wordprocessingDocument.MainDocumentPart!;
                 imagePart = part.AddImagePart(imagePartType.ToOpenXmlImagePartType());
                 relationshipId = part.GetIdOfPart(imagePart);
             } else {

--- a/OfficeIMO.Word/WordShape.cs
+++ b/OfficeIMO.Word/WordShape.cs
@@ -195,7 +195,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Optional title of the shape.
         /// </summary>
-        public string? Title {
+        public string Title {
             get {
                 if (_rectangle != null) return _rectangle.Title?.Value;
                 if (_ellipse != null) return _ellipse.Title?.Value;
@@ -214,7 +214,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Alternative text description of the shape.
         /// </summary>
-        public string? Description {
+        public string Description {
             get {
                 if (_rectangle != null) return _rectangle.Alternate?.Value;
                 if (_ellipse != null) return _ellipse.Alternate?.Value;
@@ -251,7 +251,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Outline color in hex format. Null when not applicable.
         /// </summary>
-        public string? StrokeColorHex {
+        public string StrokeColorHex {
             get {
                 if (_rectangle != null) return _rectangle.StrokeColor?.Value;
                 if (_ellipse != null) return _ellipse.StrokeColor?.Value;
@@ -285,7 +285,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public double? StrokeWeight {
             get {
-                string? v = null;
+                string v = null;
                 if (_rectangle != null) v = _rectangle.StrokeWeight?.Value;
                 if (_ellipse != null) v ??= _ellipse.StrokeWeight?.Value;
                 if (_polygon != null) v ??= _polygon.StrokeWeight?.Value;
@@ -294,7 +294,7 @@ namespace OfficeIMO.Word {
                 return double.Parse(v.Replace("pt", string.Empty), CultureInfo.InvariantCulture);
             }
             set {
-                string? v = value != null ? $"{value.Value.ToString(CultureInfo.InvariantCulture)}pt" : null;
+                string v = value != null ? $"{value.Value.ToString(CultureInfo.InvariantCulture)}pt" : null;
                 if (_rectangle != null) _rectangle.StrokeWeight = v;
                 if (_ellipse != null) _ellipse.StrokeWeight = v;
                 if (_polygon != null) _polygon.StrokeWeight = v;
@@ -321,7 +321,7 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private string? GetStyle() {
+        private string GetStyle() {
             return _rectangle?.Style?.Value ?? _ellipse?.Style?.Value ?? _polygon?.Style?.Value;
         }
 
@@ -331,7 +331,7 @@ namespace OfficeIMO.Word {
             if (_polygon != null) _polygon.Style = style;
         }
 
-        private string? GetStyleValue(string name) {
+        private string GetStyleValue(string name) {
             var style = GetStyle();
             if (string.IsNullOrEmpty(style)) return null;
             foreach (var part in style.Split(';')) {


### PR DESCRIPTION
## Summary
- remove nullable annotations causing CS8632 from `WordImage` and `WordShape`
- assert OpenXml parts are not null when adding images

## Testing
- `dotnet build OfficeImo.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685be4869fb8832e8262b88337709632