### PR TITLE
Fix XML comment referencing DocVariable

### DIFF
--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -735,7 +735,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public readonly Dictionary<string, WordCustomProperty> CustomDocumentProperties = new Dictionary<string, WordCustomProperty>();
         /// <summary>
-        /// Collection of document variables accessible via <see cref="WordField.DocVariable"/> fields.
+        /// Collection of document variables accessible via <see cref="WordFieldType.DocVariable"/> fields.
         /// </summary>
         public Dictionary<string, string> DocumentVariables { get; } = new Dictionary<string, string>();
 


### PR DESCRIPTION
## Summary
- fix incorrect XML comment referencing a non-existing `WordField.DocVariable`

## Testing
- `dotnet build OfficeImo.sln --configuration Release --no-restore`
- `dotnet test OfficeImo.sln --no-build --verbosity normal` *(fails: VSTestTask returned false)*

------
https://chatgpt.com/codex/tasks/task_e_685bef5227c8832ebbf0faf203623ddc