### PR TITLE
chore: 🚀 update version prefix to `1.0.0`

### DIFF
--- a/Build/UpdateVersion.ps1
+++ b/Build/UpdateVersion.ps1
@@ -3,4 +3,4 @@
 $Path = "$PSScriptRoot\.."
 
 Get-ProjectVersion -Path "$Path" -ExcludeFolders @("$Path\Module\Artefacts") | Format-Table
-Set-ProjectVersion -Path "$Path" -NewVersion "0.0.24" -WhatIf:$false -Verbose -ExcludeFolders @("$Path\Module\Artefacts") | Format-Table
+Set-ProjectVersion -Path "$Path" -NewVersion "1.0.0" -WhatIf:$false -Verbose -ExcludeFolders @("$Path\Module\Artefacts") | Format-Table

--- a/OfficeIMO.Examples/OfficeIMO.Examples.csproj
+++ b/OfficeIMO.Examples/OfficeIMO.Examples.csproj
@@ -4,7 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <LangVersion>Latest</LangVersion>
-        <VersionPrefix>0.0.24</VersionPrefix>
+        <VersionPrefix>1.0.0</VersionPrefix>
     </PropertyGroup>
 
     <ItemGroup>

--- a/OfficeIMO.Excel/OfficeIMO.Excel.csproj
+++ b/OfficeIMO.Excel/OfficeIMO.Excel.csproj
@@ -6,10 +6,11 @@
         <AssemblyName>OfficeIMO.Excel</AssemblyName>
         <AssemblyTitle>OfficeIMO.Excel</AssemblyTitle>
 
-        <VersionPrefix>0.0.24</VersionPrefix>
+        <VersionPrefix>1.0.0</VersionPrefix>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             netstandard2.0;net472;net48;net8.0;net9.0</TargetFrameworks>
-        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
+        <TargetFrameworks
+            Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
             net8.0;net9.0</TargetFrameworks>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 
@@ -29,10 +30,6 @@
         <DebugType>portable</DebugType>
         <LangVersion>Latest</LangVersion>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
-        <!--
-      Turns off reference assembly generation
-      See: https://docs.microsoft.com/en-us/dotnet/standard/assembly/reference-assemblies
-    -->
         <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     </PropertyGroup>
 

--- a/OfficeIMO.Word/OfficeIMO.Word.csproj
+++ b/OfficeIMO.Word/OfficeIMO.Word.csproj
@@ -6,10 +6,11 @@
         <AssemblyName>OfficeIMO.Word</AssemblyName>
         <AssemblyTitle>OfficeIMO.Word</AssemblyTitle>
 
-        <VersionPrefix>0.0.24</VersionPrefix>
+        <VersionPrefix>1.0.0</VersionPrefix>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             netstandard2.0;net472;net8.0;net9.0</TargetFrameworks>
-        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
+        <TargetFrameworks
+            Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
             net8.0</TargetFrameworks>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <Company>Evotec</Company>
@@ -26,10 +27,6 @@
         <PackageIcon>OfficeIMO.png</PackageIcon>
         <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
         <DebugType>portable</DebugType>
-        <!--
-      Turns off reference assembly generation
-      See: https://docs.microsoft.com/en-us/dotnet/standard/assembly/reference-assemblies
-    -->
         <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
         <ApplicationIcon>OfficeIMO.ico</ApplicationIcon>
         <PackageReadmeFile>../README.md</PackageReadmeFile>
@@ -39,11 +36,13 @@
         <LangVersion>Latest</LangVersion>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
+    <PropertyGroup
+        Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
+    <PropertyGroup
+        Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
 


### PR DESCRIPTION
* Updated the `VersionPrefix` in project files for `OfficeIMO.Excel`, `OfficeIMO.Word`, and `OfficeIMO.Examples`.
* Changed the version in `UpdateVersion.ps1` to reflect the new versioning.