### PR TITLE
Fix issue in Basic Document example of the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,9 +280,9 @@ string filePath = System.IO.Path.Combine(
     "BasicDocument.docx");
 
 using (WordDocument document = WordDocument.Create(filePath)) {
-    document.Title = "This is my title";
-    document.Creator = "Przemysław Kłys";
-    document.Keywords = "word, docx, test";
+    document.BuiltinDocumentProperties.Title = "This is my title";
+    document.BuiltinDocumentProperties.Creator = "Przemysław Kłys";
+    document.BuiltinDocumentProperties.Keywords = "word, docx, test";
 
     var paragraph = document.AddParagraph("Basic paragraph");
     paragraph.ParagraphAlignment = JustificationValues.Center;


### PR DESCRIPTION
Hello,

I just needed to manipulate Word documents and decided to try the library (with the 1.0 yesterday I feel like it was a sign).
I noticed `BuiltinDocumentProperties` was missing from the first example so I just added that in there.

