### PR TITLE
Handle structured tags inside tables

### DIFF
--- a/Docs/Examples/ExamplesContentControls/README.MD
+++ b/Docs/Examples/ExamplesContentControls/README.MD
@@ -51,3 +51,19 @@ using (WordDocument document = WordDocument.Load(filePath)) {
     Console.WriteLine(tag.Text);
 }
 ```
+
+### Working with checkboxes
+
+```csharp
+using (WordDocument document = WordDocument.Create(filePath)) {
+    var para = document.AddParagraph("Accept:");
+    para.AddCheckBox(false, "Consent", "ConsentTag");
+    document.Save();
+}
+
+using (WordDocument document = WordDocument.Load(filePath)) {
+    var cb = document.GetCheckBoxByTag("ConsentTag");
+    cb.IsChecked = true;
+    Console.WriteLine(cb.Alias);
+}
+```

--- a/Docs/officeimo.word.wordcheckbox.md
+++ b/Docs/officeimo.word.wordcheckbox.md
@@ -20,6 +20,26 @@ public bool IsChecked { get; set; }
 
 [Boolean](https://docs.microsoft.com/en-us/dotnet/api/system.boolean)<br>
 
+### **Alias**
+
+```csharp
+public string Alias { get; }
+```
+
+#### Property Value
+
+[String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+
+### **Tag**
+
+```csharp
+public string Tag { get; set; }
+```
+
+#### Property Value
+
+[String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+
 ## Constructors
 
 ### **WordCheckBox(WordDocument, Paragraph, SdtRun)**

--- a/Docs/officeimo.word.wordparagraph.md
+++ b/Docs/officeimo.word.wordparagraph.md
@@ -1012,12 +1012,12 @@ public WordStructuredDocumentTag AddStructuredDocumentTag(string alias = null, s
 
 [WordStructuredDocumentTag](./officeimo.word.wordstructureddocumenttag.md)<br>
 
-### **AddCheckBox(Boolean, String)**
+### **AddCheckBox(Boolean, String, String)**
 
 Adds a checkbox content control to the paragraph.
 
 ```csharp
-public WordCheckBox AddCheckBox(bool isChecked = false, string alias = null)
+public WordCheckBox AddCheckBox(bool isChecked = false, string alias = null, string tag = null)
 ```
 
 #### Parameters
@@ -1025,6 +1025,7 @@ public WordCheckBox AddCheckBox(bool isChecked = false, string alias = null)
 `isChecked` [Boolean](https://docs.microsoft.com/en-us/dotnet/api/system.boolean)<br>
 
 `alias` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+`tag` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
 
 #### Returns
 

--- a/Docs/officeimo.word.wordtable.md
+++ b/Docs/officeimo.word.wordtable.md
@@ -341,6 +341,30 @@ public WordTable ParentTable { get; }
 
 [WordTable](./officeimo.word.wordtable.md)<br>
 
+### **StructuredDocumentTags**
+
+Returns structured document tags contained in the table
+
+```csharp
+public List<WordStructuredDocumentTag> StructuredDocumentTags { get; }
+```
+
+#### Property Value
+
+[List<WordStructuredDocumentTag>](./officeimo.word.wordstructureddocumenttag.md)<br>
+
+### **CheckBoxes**
+
+Returns checkbox content controls contained in the table
+
+```csharp
+public List<WordCheckBox> CheckBoxes { get; }
+```
+
+#### Property Value
+
+[List<WordCheckBox>](./officeimo.word.wordcheckbox.md)<br>
+
 ## Constructors
 
 ### **WordTable(WordDocument, TableCell, Int32, Int32, WordTableStyle)**

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -39,6 +39,7 @@ namespace OfficeIMO.Examples {
             ContentControls.Example_AddContentControl(folderPath, false);
             ContentControls.Example_MultipleContentControls(folderPath, false);
             ContentControls.Example_AdvancedContentControls(folderPath, false);
+            ContentControls.Example_ContentControlsInTable(folderPath, false);
             CheckBoxes.Example_BasicCheckBox(folderPath, false);
 
             Paragraphs.Example_BasicParagraphs(folderPath, false);

--- a/OfficeIMO.Examples/Word/CheckBoxes/CheckBoxes.Basic.cs
+++ b/OfficeIMO.Examples/Word/CheckBoxes/CheckBoxes.Basic.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var paragraph = document.AddParagraph("Accept terms:");
-                var checkBox = paragraph.AddCheckBox(true, "Terms");
+                var checkBox = paragraph.AddCheckBox(true, "Terms", "TermsTag");
                 Console.WriteLine($"Checkbox initially checked: {checkBox.IsChecked}");
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/ContentControls/ContentControls.Example4.cs
+++ b/OfficeIMO.Examples/Word/ContentControls/ContentControls.Example4.cs
@@ -1,0 +1,30 @@
+using OfficeIMO.Word;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class ContentControls {
+        internal static void Example_ContentControlsInTable(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Content controls inside a table");
+            string filePath = Path.Combine(folderPath, "DocumentContentControlsInTable.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var table = document.AddTable(2, 2);
+                table.Rows[0].Cells[0].Paragraphs[0].AddStructuredDocumentTag(alias: "Alias1", text: "One", tag: "Tag1");
+                var cb = table.Rows[1].Cells[1].Paragraphs[0].AddCheckBox(false, "CheckAlias", "CheckTag");
+                document.Save(openWord);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var table = document.Tables[0];
+                foreach (var control in table.StructuredDocumentTags) {
+                    Console.WriteLine($"SDT {control.Tag}: {control.Text}");
+                }
+                foreach (var checkBox in table.CheckBoxes) {
+                    Console.WriteLine($"CheckBox {checkBox.Tag}: alias={checkBox.Alias}");
+                }
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.CheckBox.cs
+++ b/OfficeIMO.Tests/Word.CheckBox.cs
@@ -8,7 +8,7 @@ namespace OfficeIMO.Tests {
         public void Test_AddingCheckBox() {
             string filePath = Path.Combine(_directoryWithFiles, "DocumentWithCheckBox.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
-                var checkBox = document.AddParagraph("Agree:").AddCheckBox(true);
+                var checkBox = document.AddParagraph("Agree:").AddCheckBox(true, "Agree", "AgreeTag");
 
                 Assert.Single(document.CheckBoxes);
                 Assert.True(checkBox.IsChecked);
@@ -20,13 +20,20 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.Single(document.CheckBoxes);
                 Assert.True(document.CheckBoxes[0].IsChecked);
+                Assert.Equal("AgreeTag", document.CheckBoxes[0].Tag);
+                Assert.Equal("Agree", document.CheckBoxes[0].Alias);
 
-                document.CheckBoxes[0].IsChecked = false;
+                var byTag = document.GetCheckBoxByTag("AgreeTag");
+                Assert.NotNull(byTag);
+                var byAlias = document.GetCheckBoxByAlias("Agree");
+                Assert.NotNull(byAlias);
+
+                byTag.IsChecked = false;
                 document.Save(false);
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.False(document.CheckBoxes[0].IsChecked);
+                Assert.False(document.GetCheckBoxByTag("AgreeTag").IsChecked);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.StructuredDocumentTagTable.cs
+++ b/OfficeIMO.Tests/Word.StructuredDocumentTagTable.cs
@@ -1,5 +1,6 @@
 using OfficeIMO.Word;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -21,6 +22,51 @@ namespace OfficeIMO.Tests {
                 Assert.Single(table.CheckBoxes);
                 Assert.Equal("TagCell", table.StructuredDocumentTags[0].Tag);
                 Assert.Equal("TagCheck", table.CheckBoxes[0].Tag);
+            }
+        }
+
+        [Fact]
+        public void Test_TableCheckBoxRetrievalByAliasAndTag() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentTableCheckBox.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var table = document.AddTable(1, 2);
+                table.Rows[0].Cells[0].Paragraphs[0].AddCheckBox(true, "Alias1", "Tag1");
+                table.Rows[0].Cells[1].Paragraphs[0].AddCheckBox(false, "Alias2", "Tag2");
+                document.Save(false);
+                Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var table = document.Tables[0];
+                Assert.Equal(2, table.CheckBoxes.Count);
+
+                var cb1 = table.CheckBoxes.First(cb => cb.Tag == "Tag1");
+                Assert.Equal("Alias1", cb1.Alias);
+                Assert.True(cb1.IsChecked);
+
+                var cb2 = table.CheckBoxes.First(cb => cb.Alias == "Alias2");
+                Assert.False(cb2.IsChecked);
+                Assert.Equal("Tag2", cb2.Tag);
+            }
+        }
+
+        [Fact]
+        public void Test_TableMultipleControlsCounts() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentTableMultipleControls.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var table = document.AddTable(2, 2);
+                table.Rows[0].Cells[0].Paragraphs[0].AddStructuredDocumentTag("One", "AliasSdt1", "TagSdt1");
+                table.Rows[0].Cells[1].Paragraphs[0].AddCheckBox(false, "AliasCB1", "TagCB1");
+                table.Rows[1].Cells[0].Paragraphs[0].AddCheckBox(true, "AliasCB2", "TagCB2");
+                table.Rows[1].Cells[1].Paragraphs[0].AddStructuredDocumentTag("Two", "AliasSdt2", "TagSdt2");
+                document.Save(false);
+                Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var table = document.Tables[0];
+                Assert.Equal(4, table.StructuredDocumentTags.Count);
+                Assert.Equal(2, table.CheckBoxes.Count);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.StructuredDocumentTagTable.cs
+++ b/OfficeIMO.Tests/Word.StructuredDocumentTagTable.cs
@@ -1,0 +1,27 @@
+using OfficeIMO.Word;
+using System.IO;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_StructuredDocumentTagInsideTable() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithTableContentControl.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var table = document.AddTable(1, 1);
+                table.Rows[0].Cells[0].Paragraphs[0].AddStructuredDocumentTag("Cell", "AliasCell", "TagCell");
+                var cb = table.Rows[0].Cells[0].Paragraphs[0].AddCheckBox(false, "AliasCheck", "TagCheck");
+                document.Save(false);
+                Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var table = document.Tables[0];
+                Assert.Equal(2, table.StructuredDocumentTags.Count);
+                Assert.Single(table.CheckBoxes);
+                Assert.Equal("TagCell", table.StructuredDocumentTags[0].Tag);
+                Assert.Equal("TagCheck", table.CheckBoxes[0].Tag);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordCheckBox.cs
+++ b/OfficeIMO.Word/WordCheckBox.cs
@@ -41,6 +41,34 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Gets the alias associated with this checkbox control.
+        /// </summary>
+        public string Alias {
+            get {
+                var sdtAlias = _sdtRun.SdtProperties.OfType<SdtAlias>().FirstOrDefault();
+                return sdtAlias?.Val;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the tag value for this checkbox control.
+        /// </summary>
+        public string Tag {
+            get {
+                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                return tag?.Val;
+            }
+            set {
+                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                if (tag == null) {
+                    tag = new Tag();
+                    _sdtRun.SdtProperties.Append(tag);
+                }
+                tag.Val = value;
+            }
+        }
+
+        /// <summary>
         /// Removes the checkbox from the paragraph.
         /// </summary>
         public void Remove() {

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -577,6 +577,24 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Retrieves a checkbox control by its tag value.
+        /// </summary>
+        /// <param name="tag">Tag value of the checkbox.</param>
+        /// <returns>The matching <see cref="WordCheckBox"/> or <c>null</c>.</returns>
+        public WordCheckBox GetCheckBoxByTag(string tag) {
+            return this.CheckBoxes.FirstOrDefault(cb => cb.Tag == tag);
+        }
+
+        /// <summary>
+        /// Retrieves a checkbox control by its alias.
+        /// </summary>
+        /// <param name="alias">Alias of the checkbox.</param>
+        /// <returns>The matching <see cref="WordCheckBox"/> or <c>null</c>.</returns>
+        public WordCheckBox GetCheckBoxByAlias(string alias) {
+            return this.CheckBoxes.FirstOrDefault(cb => cb.Alias == alias);
+        }
+
+        /// <summary>
         /// Removes an embedded document from the document.
         /// </summary>
         /// <param name="embeddedDocument">Embedded document to remove.</param>

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -723,13 +723,17 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="isChecked">Initial checked state.</param>
         /// <param name="alias">Optional alias for the control.</param>
+        /// <param name="tag">Optional tag for the control.</param>
         /// <returns>The created <see cref="WordCheckBox"/> instance.</returns>
-        public WordCheckBox AddCheckBox(bool isChecked = false, string alias = null) {
+        public WordCheckBox AddCheckBox(bool isChecked = false, string alias = null, string tag = null) {
             var sdtRun = new SdtRun();
 
             var props = new SdtProperties();
             if (!string.IsNullOrEmpty(alias)) {
                 props.Append(new SdtAlias() { Val = alias });
+            }
+            if (!string.IsNullOrEmpty(tag)) {
+                props.Append(new Tag() { Val = tag });
             }
             props.Append(new SdtId() { Val = new DocumentFormat.OpenXml.Int32Value(new Random().Next(1, int.MaxValue)) });
 

--- a/OfficeIMO.Word/WordTable.Properties.cs
+++ b/OfficeIMO.Word/WordTable.Properties.cs
@@ -269,5 +269,41 @@ namespace OfficeIMO.Word {
                 return null;
             }
         }
+
+        /// <summary>
+        /// Gets all structured document tags contained in the table.
+        /// </summary>
+        public List<WordStructuredDocumentTag> StructuredDocumentTags {
+            get {
+                List<WordStructuredDocumentTag> list = new();
+                foreach (var row in this.Rows) {
+                    foreach (var cell in row.Cells) {
+                        var paragraphs = cell.Paragraphs.Where(p => p.IsStructuredDocumentTag).ToList();
+                        foreach (var paragraph in paragraphs) {
+                            list.Add(paragraph.StructuredDocumentTag);
+                        }
+                    }
+                }
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Gets all checkbox content controls contained in the table.
+        /// </summary>
+        public List<WordCheckBox> CheckBoxes {
+            get {
+                List<WordCheckBox> list = new();
+                foreach (var row in this.Rows) {
+                    foreach (var cell in row.Cells) {
+                        var paragraphs = cell.Paragraphs.Where(p => p.IsCheckBox).ToList();
+                        foreach (var paragraph in paragraphs) {
+                            list.Add(paragraph.CheckBox);
+                        }
+                    }
+                }
+                return list;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add Alias and Tag properties to WordCheckBox
- expose StructuredDocumentTags and CheckBoxes collections on WordTable
- show example for content controls in table
- document new properties
- test retrieving structured tags from tables
- allow setting tag when adding checkboxes and add retrieval helpers

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_685d959d2ac8832e886d674f78435ae4