### PR TITLE
Fix AddStructuredDocumentTag parameter order

### DIFF
--- a/Docs/officeimo.word.wordparagraph.md
+++ b/Docs/officeimo.word.wordparagraph.md
@@ -998,14 +998,14 @@ public WordParagraph AddHyperLink(string text, string anchor, bool addStyle, str
 Adds a simple content control (structured document tag) to the paragraph.
 
 ```csharp
-public WordStructuredDocumentTag AddStructuredDocumentTag(string alias = null, string text = "", string tag = null)
+public WordStructuredDocumentTag AddStructuredDocumentTag(string text = "", string alias = null, string tag = null)
 ```
 
 #### Parameters
 
-`alias` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
-
 `text` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+
+`alias` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
 `tag` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
 
 #### Returns

--- a/OfficeIMO.Examples/Word/ContentControls/ContentControls.Example3.cs
+++ b/OfficeIMO.Examples/Word/ContentControls/ContentControls.Example3.cs
@@ -9,13 +9,13 @@ namespace OfficeIMO.Examples.Word {
             string filePath = Path.Combine(folderPath, "DocumentAdvancedContentControls.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var para1 = document.AddParagraph("Control 1:");
-                para1.AddStructuredDocumentTag(alias: "Alias1", text: "First", tag: "Tag1");
+                para1.AddStructuredDocumentTag(text: "First", alias: "Alias1", tag: "Tag1");
 
                 var para2 = document.AddParagraph("Control 2:");
-                para2.AddStructuredDocumentTag(alias: "Alias2", text: "Second", tag: "Tag2");
+                para2.AddStructuredDocumentTag(text: "Second", alias: "Alias2", tag: "Tag2");
 
                 var para3 = document.AddParagraph("Control 3:");
-                para3.AddStructuredDocumentTag(alias: "Alias3", text: "Third", tag: "Tag3");
+                para3.AddStructuredDocumentTag(text: "Third", alias: "Alias3", tag: "Tag3");
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/ContentControls/ContentControls.Example4.cs
+++ b/OfficeIMO.Examples/Word/ContentControls/ContentControls.Example4.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var table = document.AddTable(2, 2);
-                table.Rows[0].Cells[0].Paragraphs[0].AddStructuredDocumentTag(alias: "Alias1", text: "One", tag: "Tag1");
+                table.Rows[0].Cells[0].Paragraphs[0].AddStructuredDocumentTag(text: "One", alias: "Alias1", tag: "Tag1");
                 var cb = table.Rows[1].Cells[1].Paragraphs[0].AddCheckBox(false, "CheckAlias", "CheckTag");
                 document.Save(openWord);
             }

--- a/OfficeIMO.Tests/Word.ContentControlsAdvanced.cs
+++ b/OfficeIMO.Tests/Word.ContentControlsAdvanced.cs
@@ -11,13 +11,13 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var para1 = document.AddParagraph("Control 1:");
-                para1.AddStructuredDocumentTag("Alias1", "First", "Tag1");
+                para1.AddStructuredDocumentTag("First", "Alias1", "Tag1");
 
                 var para2 = document.AddParagraph("Control 2:");
-                para2.AddStructuredDocumentTag("Alias2", "Second", "Tag2");
+                para2.AddStructuredDocumentTag("Second", "Alias2", "Tag2");
 
                 var para3 = document.AddParagraph("Control 3:");
-                para3.AddStructuredDocumentTag("Alias3", "Third", "Tag3");
+                para3.AddStructuredDocumentTag("Third", "Alias3", "Tag3");
 
                 document.Save(false);
             }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -535,7 +535,7 @@ namespace OfficeIMO.Word {
         /// <param name="tag">Optional tag for the control.</param>
         /// <returns>The created <see cref="WordStructuredDocumentTag"/>.</returns>
         public WordStructuredDocumentTag AddStructuredDocumentTag(string text, string alias = null, string tag = null) {
-            return this.AddParagraph().AddStructuredDocumentTag(alias, text, tag);
+            return this.AddParagraph().AddStructuredDocumentTag(text, alias, tag);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -689,11 +689,11 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Adds a simple content control (structured document tag) to the paragraph.
         /// </summary>
-        /// <param name="alias">Optional alias for the content control.</param>
         /// <param name="text">Initial text of the control.</param>
+        /// <param name="alias">Optional alias for the content control.</param>
         /// <param name="tag">Optional tag for the content control.</param>
         /// <returns>The created <see cref="WordStructuredDocumentTag"/> instance.</returns>
-        public WordStructuredDocumentTag AddStructuredDocumentTag(string alias = null, string text = "", string tag = null) {
+        public WordStructuredDocumentTag AddStructuredDocumentTag(string text = "", string alias = null, string tag = null) {
             var sdtRun = new SdtRun();
 
             var sdtProperties = new SdtProperties();


### PR DESCRIPTION
## Summary
- standardize the AddStructuredDocumentTag signature to use `text, alias, tag`
- update tests and examples to match new parameter order
- regenerate WordParagraph API docs

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685da7053654832e8f236779444643d7