### PR TITLE
Add date picker and dropdown list controls

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -42,6 +42,10 @@ namespace OfficeIMO.Examples {
             ContentControls.Example_ContentControlsInTable(folderPath, false);
             CheckBoxes.Example_BasicCheckBox(folderPath, false);
 
+            DatePickers.Example_BasicDatePicker(folderPath, false);
+            DatePickers.Example_AdvancedDatePicker(folderPath, false);
+            DropDownLists.Example_BasicDropDownList(folderPath, false);
+            DropDownLists.Example_AdvancedDropDownList(folderPath, false);
             Paragraphs.Example_BasicParagraphs(folderPath, false);
             Paragraphs.Example_BasicParagraphStyles(folderPath, false);
             Paragraphs.Example_RegisterCustomParagraphStyle(folderPath, false);

--- a/OfficeIMO.Examples/Word/DatePickers/DatePickers.Advanced.cs
+++ b/OfficeIMO.Examples/Word/DatePickers/DatePickers.Advanced.cs
@@ -1,0 +1,18 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class DatePickers {
+        internal static void Example_AdvancedDatePicker(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Updating date picker in existing document");
+            string filePath = Path.Combine(folderPath, "DocumentWithDatePicker.docx");
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var picker = document.GetDatePickerByTag("DateTag");
+                Console.WriteLine($"Current date: {picker.Date}");
+                picker.Date = DateTime.Today.AddDays(1);
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/DatePickers/DatePickers.Basic.cs
+++ b/OfficeIMO.Examples/Word/DatePickers/DatePickers.Basic.cs
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class DatePickers {
+        internal static void Example_BasicDatePicker(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a date picker control");
+            string filePath = Path.Combine(folderPath, "DocumentWithDatePicker.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Date: ");
+                paragraph.AddDatePicker(DateTime.Today, "DateAlias", "DateTag");
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/DropDownLists/DropDownLists.Advanced.cs
+++ b/OfficeIMO.Examples/Word/DropDownLists/DropDownLists.Advanced.cs
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class DropDownLists {
+        internal static void Example_AdvancedDropDownList(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Reading dropdown list items");
+            string filePath = Path.Combine(folderPath, "DocumentWithDropDownList.docx");
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var list = document.GetDropDownListByTag("ListTag");
+                Console.WriteLine($"Item count: {list.Items.Count}");
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/DropDownLists/DropDownLists.Basic.cs
+++ b/OfficeIMO.Examples/Word/DropDownLists/DropDownLists.Basic.cs
@@ -1,0 +1,18 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class DropDownLists {
+        internal static void Example_BasicDropDownList(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a dropdown list control");
+            string filePath = Path.Combine(folderPath, "DocumentWithDropDownList.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var items = new List<string> { "One", "Two", "Three" };
+                document.AddParagraph("Choose: ").AddDropDownList(items, "ListAlias", "ListTag");
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.DatePicker.cs
+++ b/OfficeIMO.Tests/Word.DatePicker.cs
@@ -13,6 +13,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.Single(document.DatePickers);
                 Assert.Equal(DateTime.Today.Date, dp.Date?.Date);
+                Assert.Equal("DPTag", dp.Tag);
+                Assert.Equal("DP", dp.Alias);
 
                 document.Save(false);
                 Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
@@ -22,12 +24,19 @@ namespace OfficeIMO.Tests {
                 Assert.Single(document.DatePickers);
                 var picker = document.GetDatePickerByTag("DPTag");
                 Assert.NotNull(picker);
+                Assert.Equal("DP", document.GetDatePickerByAlias("DP")?.Alias);
                 picker.Date = DateTime.Today.AddDays(1);
                 document.Save(false);
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.Equal(DateTime.Today.AddDays(1).Date, document.DatePickers[0].Date?.Date);
+                document.DatePickers[0].Remove();
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Empty(document.DatePickers);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.DatePicker.cs
+++ b/OfficeIMO.Tests/Word.DatePicker.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_AddingDatePicker() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithDatePicker.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var dp = document.AddParagraph("Date:").AddDatePicker(DateTime.Today, "DP", "DPTag");
+
+                Assert.Single(document.DatePickers);
+                Assert.Equal(DateTime.Today.Date, dp.Date?.Date);
+
+                document.Save(false);
+                Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Single(document.DatePickers);
+                var picker = document.GetDatePickerByTag("DPTag");
+                Assert.NotNull(picker);
+                picker.Date = DateTime.Today.AddDays(1);
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal(DateTime.Today.AddDays(1).Date, document.DatePickers[0].Date?.Date);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.DropDownList.cs
+++ b/OfficeIMO.Tests/Word.DropDownList.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Collections.Generic;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_AddingDropDownList() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithDropDownList.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var items = new List<string> { "One", "Two" };
+                var ddl = document.AddParagraph("Choose:").AddDropDownList(items, "DDL", "DDLTag");
+
+                Assert.Single(document.DropDownLists);
+                Assert.Equal(2, ddl.Items.Count);
+
+                document.Save(false);
+                Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Single(document.DropDownLists);
+                var list = document.GetDropDownListByAlias("DDL");
+                Assert.NotNull(list);
+                document.Save(false);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.DropDownList.cs
+++ b/OfficeIMO.Tests/Word.DropDownList.cs
@@ -14,6 +14,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.Single(document.DropDownLists);
                 Assert.Equal(2, ddl.Items.Count);
+                Assert.Equal("DDL", ddl.Alias);
+                Assert.Equal("DDLTag", ddl.Tag);
 
                 document.Save(false);
                 Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
@@ -23,7 +25,17 @@ namespace OfficeIMO.Tests {
                 Assert.Single(document.DropDownLists);
                 var list = document.GetDropDownListByAlias("DDL");
                 Assert.NotNull(list);
+                Assert.Equal("DDLTag", document.GetDropDownListByTag("DDLTag")?.Tag);
                 document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                document.DropDownLists[0].Remove();
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Empty(document.DropDownLists);
             }
         }
     }

--- a/OfficeIMO.Word/WordDatePicker.cs
+++ b/OfficeIMO.Word/WordDatePicker.cs
@@ -1,0 +1,78 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+using System;
+using System.Linq;
+using System.Xml;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a date picker content control within a paragraph.
+    /// </summary>
+    public class WordDatePicker : WordElement {
+        private readonly WordDocument _document;
+        private readonly Paragraph _paragraph;
+        internal readonly SdtRun _sdtRun;
+
+        internal WordDatePicker(WordDocument document, Paragraph paragraph, SdtRun sdtRun) {
+            _document = document;
+            _paragraph = paragraph;
+            _sdtRun = sdtRun;
+        }
+
+        /// <summary>
+        /// Gets or sets the selected date.
+        /// </summary>
+        public DateTime? Date {
+            get {
+                var dp = _sdtRun.SdtProperties?.Elements<SdtContentDate>().FirstOrDefault();
+                if (dp?.FullDate != null) {
+                    return dp.FullDate.Value;
+                }
+                return null;
+            }
+            set {
+                var dp = _sdtRun.SdtProperties.Elements<SdtContentDate>().FirstOrDefault();
+                if (dp == null) {
+                    dp = new SdtContentDate();
+                    _sdtRun.SdtProperties.Append(dp);
+                }
+                dp.FullDate = value.HasValue ? new DateTimeValue(value.Value) : null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the alias associated with this date picker control.
+        /// </summary>
+        public string Alias {
+            get {
+                var sdtAlias = _sdtRun.SdtProperties.OfType<SdtAlias>().FirstOrDefault();
+                return sdtAlias?.Val;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the tag value for this date picker control.
+        /// </summary>
+        public string Tag {
+            get {
+                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                return tag?.Val;
+            }
+            set {
+                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                if (tag == null) {
+                    tag = new Tag();
+                    _sdtRun.SdtProperties.Append(tag);
+                }
+                tag.Val = value;
+            }
+        }
+
+        /// <summary>
+        /// Removes the date picker from the paragraph.
+        /// </summary>
+        public void Remove() {
+            _sdtRun.Remove();
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -595,6 +595,41 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Retrieves a date picker control by its tag value.
+        /// </summary>
+        /// <param name="tag">Tag value of the date picker.</param>
+        /// <returns>The matching <see cref="WordDatePicker"/> or <c>null</c>.</returns>
+        public WordDatePicker GetDatePickerByTag(string tag) {
+            return this.DatePickers.FirstOrDefault(dp => dp.Tag == tag);
+        }
+
+        /// <summary>
+        /// Retrieves a date picker control by its alias.
+        /// </summary>
+        /// <param name="alias">Alias of the date picker.</param>
+        /// <returns>The matching <see cref="WordDatePicker"/> or <c>null</c>.</returns>
+        public WordDatePicker GetDatePickerByAlias(string alias) {
+            return this.DatePickers.FirstOrDefault(dp => dp.Alias == alias);
+        }
+
+        /// <summary>
+        /// Retrieves a dropdown list control by its tag value.
+        /// </summary>
+        /// <param name="tag">Tag value of the dropdown list.</param>
+        /// <returns>The matching <see cref="WordDropDownList"/> or <c>null</c>.</returns>
+        public WordDropDownList GetDropDownListByTag(string tag) {
+            return this.DropDownLists.FirstOrDefault(dl => dl.Tag == tag);
+        }
+
+        /// <summary>
+        /// Retrieves a dropdown list control by its alias.
+        /// </summary>
+        /// <param name="alias">Alias of the dropdown list.</param>
+        /// <returns>The matching <see cref="WordDropDownList"/> or <c>null</c>.</returns>
+        public WordDropDownList GetDropDownListByAlias(string alias) {
+            return this.DropDownLists.FirstOrDefault(dl => dl.Alias == alias);
+        }
+        /// <summary>
         /// Removes an embedded document from the document.
         /// </summary>
         /// <param name="embeddedDocument">Embedded document to remove.</param>

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -207,6 +207,33 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Returns paragraphs that contain date picker controls.
+        /// </summary>
+        public List<WordParagraph> ParagraphsDatePickers {
+            get {
+                List<WordParagraph> list = new List<WordParagraph>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.ParagraphsDatePickers);
+                }
+
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Returns paragraphs that contain dropdown list controls.
+        /// </summary>
+        public List<WordParagraph> ParagraphsDropDownLists {
+            get {
+                List<WordParagraph> list = new List<WordParagraph>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.ParagraphsDropDownLists);
+                }
+
+                return list;
+            }
+        }
+        /// <summary>
         /// Returns paragraphs with embedded charts.
         /// </summary>
         public List<WordParagraph> ParagraphsCharts {
@@ -691,6 +718,31 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Collection of all date picker controls in the document.
+        /// </summary>
+        public List<WordDatePicker> DatePickers {
+            get {
+                List<WordDatePicker> list = new List<WordDatePicker>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.DatePickers);
+                }
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Collection of all dropdown list controls in the document.
+        /// </summary>
+        public List<WordDropDownList> DropDownLists {
+            get {
+                List<WordDropDownList> list = new List<WordDropDownList>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.DropDownLists);
+                }
+                return list;
+            }
+        }
         /// <summary>
         /// Collection of all equations in the document.
         /// </summary>

--- a/OfficeIMO.Word/WordDropDownList.cs
+++ b/OfficeIMO.Word/WordDropDownList.cs
@@ -1,0 +1,69 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a dropdown list content control within a paragraph.
+    /// </summary>
+    public class WordDropDownList : WordElement {
+        private readonly WordDocument _document;
+        private readonly Paragraph _paragraph;
+        internal readonly SdtRun _sdtRun;
+
+        internal WordDropDownList(WordDocument document, Paragraph paragraph, SdtRun sdtRun) {
+            _document = document;
+            _paragraph = paragraph;
+            _sdtRun = sdtRun;
+        }
+
+        /// <summary>
+        /// Gets the display texts of all list items.
+        /// </summary>
+        public IReadOnlyList<string> Items {
+            get {
+                var ddl = _sdtRun.SdtProperties?.Elements<SdtContentDropDownList>().FirstOrDefault();
+                if (ddl != null) {
+                    return ddl.Elements<ListItem>().Select(li => li.DisplayText?.Value ?? li.Value?.Value).ToList();
+                }
+                return new List<string>();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the tag value for this dropdown list control.
+        /// </summary>
+        public string Tag {
+            get {
+                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                return tag?.Val;
+            }
+            set {
+                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                if (tag == null) {
+                    tag = new Tag();
+                    _sdtRun.SdtProperties.Append(tag);
+                }
+                tag.Val = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the alias associated with this dropdown list control.
+        /// </summary>
+        public string Alias {
+            get {
+                var sdtAlias = _sdtRun.SdtProperties.OfType<SdtAlias>().FirstOrDefault();
+                return sdtAlias?.Val;
+            }
+        }
+
+        /// <summary>
+        /// Removes the dropdown list from the paragraph.
+        /// </summary>
+        public void Remove() {
+            _sdtRun.Remove();
+        }
+    }
+}

--- a/OfficeIMO.Word/WordHeaderFooter.Properties.cs
+++ b/OfficeIMO.Word/WordHeaderFooter.Properties.cs
@@ -112,6 +112,19 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Gets paragraphs that contain a date picker control.
+        /// </summary>
+        public List<WordParagraph> ParagraphsDatePickers {
+            get { return Paragraphs.Where(p => p.IsDatePicker).ToList(); }
+        }
+
+        /// <summary>
+        /// Gets paragraphs that contain a dropdown list control.
+        /// </summary>
+        public List<WordParagraph> ParagraphsDropDownLists {
+            get { return Paragraphs.Where(p => p.IsDropDownList).ToList(); }
+        }
+        /// <summary>
         /// Provides a list of paragraphs that contain Image
         /// </summary>
         public List<WordParagraph> ParagraphsImages {
@@ -232,6 +245,35 @@ namespace OfficeIMO.Word {
                 var paragraphs = Paragraphs.Where(p => p.IsCheckBox).ToList();
                 foreach (var paragraph in paragraphs) {
                     list.Add(paragraph.CheckBox);
+                }
+
+                return list;
+            }
+        }
+        /// <summary>
+        /// Gets the date pickers contained in the header or footer.
+        /// </summary>
+        public List<WordDatePicker> DatePickers {
+            get {
+                List<WordDatePicker> list = new List<WordDatePicker>();
+                var paragraphs = Paragraphs.Where(p => p.IsDatePicker).ToList();
+                foreach (var paragraph in paragraphs) {
+                    list.Add(paragraph.DatePicker);
+                }
+
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Gets the dropdown lists contained in the header or footer.
+        /// </summary>
+        public List<WordDropDownList> DropDownLists {
+            get {
+                List<WordDropDownList> list = new List<WordDropDownList>();
+                var paragraphs = Paragraphs.Where(p => p.IsDropDownList).ToList();
+                foreach (var paragraph in paragraphs) {
+                    list.Add(paragraph.DropDownList);
                 }
 
                 return list;

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -768,5 +768,76 @@ namespace OfficeIMO.Word {
                 this.CheckBox.IsChecked = value;
             }
         }
-    }
+        /// <summary>
+        /// Adds a date picker content control to the paragraph.
+        /// </summary>
+        /// <param name="date">Initial date value.</param>
+        /// <param name="alias">Optional alias for the control.</param>
+        /// <param name="tag">Optional tag for the control.</param>
+        /// <returns>The created <see cref="WordDatePicker"/> instance.</returns>
+        public WordDatePicker AddDatePicker(System.DateTime? date = null, string alias = null, string tag = null) {
+            var sdtRun = new SdtRun();
+
+            var props = new SdtProperties();
+            if (!string.IsNullOrEmpty(alias)) {
+                props.Append(new SdtAlias() { Val = alias });
+            }
+            if (!string.IsNullOrEmpty(tag)) {
+                props.Append(new Tag() { Val = tag });
+            }
+            props.Append(new SdtId() { Val = new DocumentFormat.OpenXml.Int32Value(new System.Random().Next(1, int.MaxValue)) });
+
+            var dateProp = new SdtContentDate();
+            if (date.HasValue) {
+                dateProp.FullDate = new DateTimeValue(date.Value);
+            }
+            props.Append(dateProp);
+
+            var content = new SdtContentRun(new Run());
+
+            sdtRun.Append(props);
+            sdtRun.Append(content);
+
+            this._paragraph.Append(sdtRun);
+
+            return new WordDatePicker(this._document, this._paragraph, sdtRun);
+        }
+
+        /// <summary>
+        /// Adds a dropdown list content control to the paragraph.
+        /// </summary>
+        /// <param name="items">Items to include in the list.</param>
+        /// <param name="alias">Optional alias for the control.</param>
+        /// <param name="tag">Optional tag for the control.</param>
+        /// <returns>The created <see cref="WordDropDownList"/> instance.</returns>
+        public WordDropDownList AddDropDownList(System.Collections.Generic.IEnumerable<string> items, string alias = null, string tag = null) {
+            var sdtRun = new SdtRun();
+
+            var props = new SdtProperties();
+            if (!string.IsNullOrEmpty(alias)) {
+                props.Append(new SdtAlias() { Val = alias });
+            }
+            if (!string.IsNullOrEmpty(tag)) {
+                props.Append(new Tag() { Val = tag });
+            }
+            props.Append(new SdtId() { Val = new DocumentFormat.OpenXml.Int32Value(new System.Random().Next(1, int.MaxValue)) });
+
+            var ddl = new SdtContentDropDownList();
+            if (items != null) {
+                foreach (var item in items) {
+                    ddl.Append(new ListItem() { DisplayText = item, Value = item });
+                }
+            }
+            props.Append(ddl);
+
+            var content = new SdtContentRun(new Run());
+
+            sdtRun.Append(props);
+            sdtRun.Append(content);
+
+            this._paragraph.Append(sdtRun);
+
+            return new WordDropDownList(this._document, this._paragraph, sdtRun);
+        }
+}
 }

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -461,6 +461,32 @@ namespace OfficeIMO.Word {
             }
         }
 
+
+        /// <summary>
+        /// Gets the date picker contained in this paragraph, if present.
+        /// </summary>
+        public WordDatePicker DatePicker {
+            get {
+                if (_stdRun != null && _stdRun.SdtProperties?.Elements<SdtContentDate>().Any() == true) {
+                    return new WordDatePicker(_document, _paragraph, _stdRun);
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the dropdown list contained in this paragraph, if present.
+        /// </summary>
+        public WordDropDownList DropDownList {
+            get {
+                if (_stdRun != null && _stdRun.SdtProperties?.Elements<SdtContentDropDownList>().Any() == true) {
+                    return new WordDropDownList(_document, _paragraph, _stdRun);
+                }
+
+                return null;
+            }
+        }
         /// <summary>
         /// Gets the bookmark associated with this paragraph, if present.
         /// </summary>
@@ -645,6 +671,32 @@ namespace OfficeIMO.Word {
             }
         }
 
+
+        /// <summary>
+        /// Gets a value indicating whether the paragraph contains a date picker control.
+        /// </summary>
+        public bool IsDatePicker {
+            get {
+                if (this.DatePicker != null) {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the paragraph contains a dropdown list control.
+        /// </summary>
+        public bool IsDropDownList {
+            get {
+                if (this.DropDownList != null) {
+                    return true;
+                }
+
+                return false;
+            }
+        }
         /// <summary>
         /// Gets a value indicating whether an image is found in the paragraph.
         /// </summary>

--- a/OfficeIMO.Word/WordSection.cs
+++ b/OfficeIMO.Word/WordSection.cs
@@ -112,6 +112,19 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Provides a list of paragraphs that contain date picker controls
+        /// </summary>
+        public List<WordParagraph> ParagraphsDatePickers {
+            get { return Paragraphs.Where(p => p.IsDatePicker).ToList(); }
+        }
+
+        /// <summary>
+        /// Provides a list of paragraphs that contain dropdown list controls
+        /// </summary>
+        public List<WordParagraph> ParagraphsDropDownLists {
+            get { return Paragraphs.Where(p => p.IsDropDownList).ToList(); }
+        }
+        /// <summary>
         /// Provides a list of paragraphs that contain Image
         /// </summary>
         public List<WordParagraph> ParagraphsImages {
@@ -394,6 +407,33 @@ namespace OfficeIMO.Word {
             }
         }
 
+        /// <summary>
+        /// Gets all date picker content controls within the section.
+        /// </summary>
+        public List<WordDatePicker> DatePickers {
+            get {
+                List<WordDatePicker> list = new List<WordDatePicker>();
+                var paragraphs = Paragraphs.Where(p => p.IsDatePicker).ToList();
+                foreach (var paragraph in paragraphs) {
+                    list.Add(paragraph.DatePicker);
+                }
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Gets all dropdown list content controls within the section.
+        /// </summary>
+        public List<WordDropDownList> DropDownLists {
+            get {
+                List<WordDropDownList> list = new List<WordDropDownList>();
+                var paragraphs = Paragraphs.Where(p => p.IsDropDownList).ToList();
+                foreach (var paragraph in paragraphs) {
+                    list.Add(paragraph.DropDownList);
+                }
+                return list;
+            }
+        }
         /// <summary>
         /// Exposes the footers available for this section.
         /// </summary>

--- a/OfficeIMO.Word/WordTable.Properties.cs
+++ b/OfficeIMO.Word/WordTable.Properties.cs
@@ -305,5 +305,40 @@ namespace OfficeIMO.Word {
                 return list;
             }
         }
-    }
+        /// <summary>
+        /// Gets all date picker content controls contained in the table.
+        /// </summary>
+        public List<WordDatePicker> DatePickers {
+            get {
+                List<WordDatePicker> list = new();
+                foreach (var row in this.Rows) {
+                    foreach (var cell in row.Cells) {
+                        var paragraphs = cell.Paragraphs.Where(p => p.IsDatePicker).ToList();
+                        foreach (var paragraph in paragraphs) {
+                            list.Add(paragraph.DatePicker);
+                        }
+                    }
+                }
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Gets all dropdown list content controls contained in the table.
+        /// </summary>
+        public List<WordDropDownList> DropDownLists {
+            get {
+                List<WordDropDownList> list = new();
+                foreach (var row in this.Rows) {
+                    foreach (var cell in row.Cells) {
+                        var paragraphs = cell.Paragraphs.Where(p => p.IsDropDownList).ToList();
+                        foreach (var paragraph in paragraphs) {
+                            list.Add(paragraph.DropDownList);
+                        }
+                    }
+                }
+                return list;
+            }
+        }
+}
 }

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ Here's a list of features currently supported (and probably a lot I forgot) and 
     - ☑️ Update control text
     - ☑️ Remove controls
     - ☑️ Checkbox form controls
+    - ☑️ Date picker form controls
+    - ☑️ Dropdown list form controls
+    - ❔ The Open XML specification defines additional types such as combo boxes, repeating sections, or picture controls, but these are not yet present in the repository.
 - ☑️ Shapes
     - ☑️ Add rectangles
     - ☑️ Add ellipses


### PR DESCRIPTION
## Summary
- implement WordDatePicker and WordDropDownList classes
- add AddDatePicker and AddDropDownList methods
- expose new controls via document, section, header/footer, table APIs
- add unit tests and example usages

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeImo.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685dac776900832e90d27b0105916d8f