### PR TITLE
Add repeating section content control

### DIFF
--- a/Docs/Examples/ExamplesContentControls/README.MD
+++ b/Docs/Examples/ExamplesContentControls/README.MD
@@ -67,3 +67,31 @@ using (WordDocument document = WordDocument.Load(filePath)) {
     Console.WriteLine(cb.Alias);
 }
 ```
+
+### Combo boxes
+
+```csharp
+using (WordDocument document = WordDocument.Create(filePath)) {
+    var items = new[] { "One", "Two" };
+    document.AddParagraph().AddComboBox(items, "Combo", "ComboTag");
+    document.Save();
+}
+```
+
+### Picture controls
+
+```csharp
+using (WordDocument document = WordDocument.Create(filePath)) {
+    document.AddParagraph().AddPictureControl(imagePath, 100, 100, "Pic", "PicTag");
+    document.Save();
+}
+```
+
+### Repeating sections
+
+```csharp
+using (WordDocument document = WordDocument.Create(filePath)) {
+    document.AddParagraph().AddRepeatingSection("Section", "RS", "RSTag");
+    document.Save();
+}
+```

--- a/OfficeIMO.Examples/Word/ComboBoxes/ComboBoxes.Basic.cs
+++ b/OfficeIMO.Examples/Word/ComboBoxes/ComboBoxes.Basic.cs
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class ComboBoxes {
+        internal static void Example_BasicComboBox(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a combo box control");
+            string filePath = Path.Combine(folderPath, "DocumentWithComboBox.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var items = new[] { "One", "Two", "Three" };
+                document.AddParagraph("Choose:").AddComboBox(items, "Combo", "ComboTag");
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/PictureControls/PictureControls.Basic.cs
+++ b/OfficeIMO.Examples/Word/PictureControls/PictureControls.Basic.cs
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class PictureControls {
+        internal static void Example_BasicPictureControl(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a picture content control");
+            string filePath = Path.Combine(folderPath, "DocumentWithPictureControl.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var imagePath = Path.Combine(folderPath, "Images", "Kulek.jpg");
+                document.AddParagraph().AddPictureControl(imagePath, 100, 100, "Pic", "PicTag");
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/RepeatingSections/RepeatingSections.Basic.cs
+++ b/OfficeIMO.Examples/Word/RepeatingSections/RepeatingSections.Basic.cs
@@ -1,0 +1,16 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class RepeatingSections {
+        internal static void Example_BasicRepeatingSection(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a repeating section control");
+            string filePath = Path.Combine(folderPath, "DocumentWithRepeatingSection.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph().AddRepeatingSection("Section", "RS", "RSTag");
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.ComboBox.cs
+++ b/OfficeIMO.Tests/Word.ComboBox.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_AddingComboBox() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithComboBox.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var items = new List<string> { "One", "Two" };
+                var cb = document.AddParagraph("Select:").AddComboBox(items, "CB", "CBTag");
+
+                Assert.Single(document.ComboBoxes);
+                Assert.Equal(2, cb.Items.Count);
+                Assert.Equal("CB", cb.Alias);
+                Assert.Equal("CBTag", cb.Tag);
+
+                document.Save(false);
+                Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Single(document.ComboBoxes);
+                var list = document.GetComboBoxByAlias("CB");
+                Assert.NotNull(list);
+                Assert.Equal("CBTag", document.GetComboBoxByTag("CBTag")?.Tag);
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                document.ComboBoxes[0].Remove();
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Empty(document.ComboBoxes);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.PictureControl.cs
+++ b/OfficeIMO.Tests/Word.PictureControl.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_AddingPictureControl() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithPictureControl.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var imagePath = Path.Combine(_directoryWithImages, "Kulek.jpg");
+                var pc = document.AddParagraph().AddPictureControl(imagePath, 100, 100, "PC", "PCTag");
+
+                Assert.Single(document.PictureControls);
+                Assert.Equal("PC", pc.Alias);
+                Assert.Equal("PCTag", pc.Tag);
+
+                document.Save(false);
+                Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Single(document.PictureControls);
+                var pic = document.GetPictureControlByAlias("PC");
+                Assert.NotNull(pic);
+                Assert.Equal("PCTag", document.GetPictureControlByTag("PCTag")?.Tag);
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                document.PictureControls[0].Remove();
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Empty(document.PictureControls);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.RepeatingSection.cs
+++ b/OfficeIMO.Tests/Word.RepeatingSection.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_AddingRepeatingSection() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithRepeatingSection.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var rs = document.AddParagraph().AddRepeatingSection("Section", "RS", "RSTag");
+
+                Assert.Single(document.RepeatingSections);
+                Assert.Equal("RS", rs.Alias);
+                Assert.Equal("RSTag", rs.Tag);
+
+                document.Save(false);
+                Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Single(document.RepeatingSections);
+                var control = document.GetRepeatingSectionByAlias("RS");
+                Assert.NotNull(control);
+                Assert.Equal("RSTag", document.GetRepeatingSectionByTag("RSTag")?.Tag);
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                document.RepeatingSections[0].Remove();
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Empty(document.RepeatingSections);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordComboBox.cs
+++ b/OfficeIMO.Word/WordComboBox.cs
@@ -1,0 +1,69 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a combo box content control within a paragraph.
+    /// </summary>
+    public class WordComboBox : WordElement {
+        private readonly WordDocument _document;
+        private readonly Paragraph _paragraph;
+        internal readonly SdtRun _sdtRun;
+
+        internal WordComboBox(WordDocument document, Paragraph paragraph, SdtRun sdtRun) {
+            _document = document;
+            _paragraph = paragraph;
+            _sdtRun = sdtRun;
+        }
+
+        /// <summary>
+        /// Gets the display texts of all combo box items.
+        /// </summary>
+        public IReadOnlyList<string> Items {
+            get {
+                var combo = _sdtRun.SdtProperties?.Elements<SdtContentComboBox>().FirstOrDefault();
+                if (combo != null) {
+                    return combo.Elements<ListItem>().Select(li => li.DisplayText?.Value ?? li.Value?.Value).ToList();
+                }
+                return new List<string>();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the tag value for this combo box control.
+        /// </summary>
+        public string Tag {
+            get {
+                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                return tag?.Val;
+            }
+            set {
+                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                if (tag == null) {
+                    tag = new Tag();
+                    _sdtRun.SdtProperties.Append(tag);
+                }
+                tag.Val = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the alias associated with this combo box control.
+        /// </summary>
+        public string Alias {
+            get {
+                var sdtAlias = _sdtRun.SdtProperties.OfType<SdtAlias>().FirstOrDefault();
+                return sdtAlias?.Val;
+            }
+        }
+
+        /// <summary>
+        /// Removes the combo box from the paragraph.
+        /// </summary>
+        public void Remove() {
+            _sdtRun.Remove();
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -539,6 +539,17 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Adds a new paragraph with a repeating section content control.
+        /// </summary>
+        /// <param name="sectionTitle">Optional title of the repeating section.</param>
+        /// <param name="alias">Optional alias for the control.</param>
+        /// <param name="tag">Optional tag for the control.</param>
+        /// <returns>The created <see cref="WordRepeatingSection"/>.</returns>
+        public WordRepeatingSection AddRepeatingSection(string sectionTitle = null, string alias = null, string tag = null) {
+            return this.AddParagraph().AddRepeatingSection(sectionTitle, alias, tag);
+        }
+
+        /// <summary>
         /// Embeds another document as an alternative format part.
         /// </summary>
         /// <param name="fileName">Path to the document.</param>
@@ -628,6 +639,48 @@ namespace OfficeIMO.Word {
         /// <returns>The matching <see cref="WordDropDownList"/> or <c>null</c>.</returns>
         public WordDropDownList GetDropDownListByAlias(string alias) {
             return this.DropDownLists.FirstOrDefault(dl => dl.Alias == alias);
+        }
+
+        /// <summary>
+        /// Retrieves a combo box control by its tag value.
+        /// </summary>
+        public WordComboBox GetComboBoxByTag(string tag) {
+            return this.ComboBoxes.FirstOrDefault(cb => cb.Tag == tag);
+        }
+
+        /// <summary>
+        /// Retrieves a combo box control by its alias.
+        /// </summary>
+        public WordComboBox GetComboBoxByAlias(string alias) {
+            return this.ComboBoxes.FirstOrDefault(cb => cb.Alias == alias);
+        }
+
+        /// <summary>
+        /// Retrieves a picture control by its tag value.
+        /// </summary>
+        public WordPictureControl GetPictureControlByTag(string tag) {
+            return this.PictureControls.FirstOrDefault(pc => pc.Tag == tag);
+        }
+
+        /// <summary>
+        /// Retrieves a picture control by its alias.
+        /// </summary>
+        public WordPictureControl GetPictureControlByAlias(string alias) {
+            return this.PictureControls.FirstOrDefault(pc => pc.Alias == alias);
+        }
+
+        /// <summary>
+        /// Retrieves a repeating section control by its tag value.
+        /// </summary>
+        public WordRepeatingSection GetRepeatingSectionByTag(string tag) {
+            return this.RepeatingSections.FirstOrDefault(rs => rs.Tag == tag);
+        }
+
+        /// <summary>
+        /// Retrieves a repeating section control by its alias.
+        /// </summary>
+        public WordRepeatingSection GetRepeatingSectionByAlias(string alias) {
+            return this.RepeatingSections.FirstOrDefault(rs => rs.Alias == alias);
         }
         /// <summary>
         /// Removes an embedded document from the document.

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -233,6 +233,48 @@ namespace OfficeIMO.Word {
                 return list;
             }
         }
+
+        /// <summary>
+        /// Returns paragraphs that contain combo box controls.
+        /// </summary>
+        public List<WordParagraph> ParagraphsComboBoxes {
+            get {
+                List<WordParagraph> list = new List<WordParagraph>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.ParagraphsComboBoxes);
+                }
+
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Returns paragraphs that contain picture controls.
+        /// </summary>
+        public List<WordParagraph> ParagraphsPictureControls {
+            get {
+                List<WordParagraph> list = new List<WordParagraph>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.ParagraphsPictureControls);
+                }
+
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Returns paragraphs that contain repeating section controls.
+        /// </summary>
+        public List<WordParagraph> ParagraphsRepeatingSections {
+            get {
+                List<WordParagraph> list = new List<WordParagraph>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.ParagraphsRepeatingSections);
+                }
+
+                return list;
+            }
+        }
         /// <summary>
         /// Returns paragraphs with embedded charts.
         /// </summary>
@@ -739,6 +781,45 @@ namespace OfficeIMO.Word {
                 List<WordDropDownList> list = new List<WordDropDownList>();
                 foreach (var section in this.Sections) {
                     list.AddRange(section.DropDownLists);
+                }
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Collection of all combo box controls in the document.
+        /// </summary>
+        public List<WordComboBox> ComboBoxes {
+            get {
+                List<WordComboBox> list = new List<WordComboBox>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.ComboBoxes);
+                }
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Collection of all picture controls in the document.
+        /// </summary>
+        public List<WordPictureControl> PictureControls {
+            get {
+                List<WordPictureControl> list = new List<WordPictureControl>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.PictureControls);
+                }
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Collection of all repeating section controls in the document.
+        /// </summary>
+        public List<WordRepeatingSection> RepeatingSections {
+            get {
+                List<WordRepeatingSection> list = new List<WordRepeatingSection>();
+                foreach (var section in this.Sections) {
+                    list.AddRange(section.RepeatingSections);
                 }
                 return list;
             }

--- a/OfficeIMO.Word/WordHeaderFooter.Properties.cs
+++ b/OfficeIMO.Word/WordHeaderFooter.Properties.cs
@@ -124,6 +124,13 @@ namespace OfficeIMO.Word {
         public List<WordParagraph> ParagraphsDropDownLists {
             get { return Paragraphs.Where(p => p.IsDropDownList).ToList(); }
         }
+
+        /// <summary>
+        /// Gets paragraphs that contain a repeating section control.
+        /// </summary>
+        public List<WordParagraph> ParagraphsRepeatingSections {
+            get { return Paragraphs.Where(p => p.IsRepeatingSection).ToList(); }
+        }
         /// <summary>
         /// Provides a list of paragraphs that contain Image
         /// </summary>
@@ -274,6 +281,21 @@ namespace OfficeIMO.Word {
                 var paragraphs = Paragraphs.Where(p => p.IsDropDownList).ToList();
                 foreach (var paragraph in paragraphs) {
                     list.Add(paragraph.DropDownList);
+                }
+
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Gets the repeating sections contained in the header or footer.
+        /// </summary>
+        public List<WordRepeatingSection> RepeatingSections {
+            get {
+                List<WordRepeatingSection> list = new List<WordRepeatingSection>();
+                var paragraphs = Paragraphs.Where(p => p.IsRepeatingSection).ToList();
+                foreach (var paragraph in paragraphs) {
+                    list.Add(paragraph.RepeatingSection);
                 }
 
                 return list;

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -905,7 +905,9 @@ namespace OfficeIMO.Word {
             this.AddImage(filePath, width, height);
             var newRun = this._paragraph.ChildElements[beforeCount] as Run;
             newRun?.Remove();
-            content.Append(newRun);
+            if (newRun != null) {
+                content.Append(newRun);
+            }
 
             sdtRun.Append(props);
             sdtRun.Append(content);

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -3,6 +3,7 @@ using System.IO;
 using DocumentFormat.OpenXml.Wordprocessing;
 using DocumentFormat.OpenXml;
 using W14 = DocumentFormat.OpenXml.Office2010.Word;
+using W15 = DocumentFormat.OpenXml.Office2013.Word;
 using DocumentFormat.OpenXml.Packaging;
 using System.Linq;
 using System.Collections.Generic;
@@ -838,6 +839,114 @@ namespace OfficeIMO.Word {
             this._paragraph.Append(sdtRun);
 
             return new WordDropDownList(this._document, this._paragraph, sdtRun);
+        }
+
+        /// <summary>
+        /// Adds a combo box content control to the paragraph.
+        /// </summary>
+        /// <param name="items">Items to include in the combo box.</param>
+        /// <param name="alias">Optional alias for the control.</param>
+        /// <param name="tag">Optional tag for the control.</param>
+        /// <returns>The created <see cref="WordComboBox"/> instance.</returns>
+        public WordComboBox AddComboBox(System.Collections.Generic.IEnumerable<string> items, string alias = null, string tag = null) {
+            var sdtRun = new SdtRun();
+
+            var props = new SdtProperties();
+            if (!string.IsNullOrEmpty(alias)) {
+                props.Append(new SdtAlias() { Val = alias });
+            }
+            if (!string.IsNullOrEmpty(tag)) {
+                props.Append(new Tag() { Val = tag });
+            }
+            props.Append(new SdtId() { Val = new DocumentFormat.OpenXml.Int32Value(new System.Random().Next(1, int.MaxValue)) });
+
+            var combo = new SdtContentComboBox();
+            if (items != null) {
+                foreach (var item in items) {
+                    combo.Append(new ListItem() { DisplayText = item, Value = item });
+                }
+            }
+            props.Append(combo);
+
+            var content = new SdtContentRun(new Run());
+
+            sdtRun.Append(props);
+            sdtRun.Append(content);
+
+            this._paragraph.Append(sdtRun);
+
+            return new WordComboBox(this._document, this._paragraph, sdtRun);
+        }
+
+        /// <summary>
+        /// Adds a picture content control containing an image to the paragraph.
+        /// </summary>
+        /// <param name="filePath">Image file path.</param>
+        /// <param name="width">Optional width of the image.</param>
+        /// <param name="height">Optional height of the image.</param>
+        /// <param name="alias">Optional alias for the control.</param>
+        /// <param name="tag">Optional tag for the control.</param>
+        /// <returns>The created <see cref="WordPictureControl"/> instance.</returns>
+        public WordPictureControl AddPictureControl(string filePath, double? width = null, double? height = null, string alias = null, string tag = null) {
+            var sdtRun = new SdtRun();
+
+            var props = new SdtProperties();
+            if (!string.IsNullOrEmpty(alias)) {
+                props.Append(new SdtAlias() { Val = alias });
+            }
+            if (!string.IsNullOrEmpty(tag)) {
+                props.Append(new Tag() { Val = tag });
+            }
+            props.Append(new SdtId() { Val = new DocumentFormat.OpenXml.Int32Value(new System.Random().Next(1, int.MaxValue)) });
+            props.Append(new SdtContentPicture());
+
+            var content = new SdtContentRun();
+            var beforeCount = this._paragraph.ChildElements.Count;
+            this.AddImage(filePath, width, height);
+            var newRun = this._paragraph.ChildElements[beforeCount] as Run;
+            newRun?.Remove();
+            content.Append(newRun);
+
+            sdtRun.Append(props);
+            sdtRun.Append(content);
+
+            this._paragraph.Append(sdtRun);
+
+            return new WordPictureControl(this._document, this._paragraph, sdtRun);
+        }
+
+        /// <summary>
+        /// Adds a repeating section content control to the paragraph.
+        /// </summary>
+        /// <param name="sectionTitle">Optional title of the repeating section.</param>
+        /// <param name="alias">Optional alias for the control.</param>
+        /// <param name="tag">Optional tag for the control.</param>
+        /// <returns>The created <see cref="WordRepeatingSection"/> instance.</returns>
+        public WordRepeatingSection AddRepeatingSection(string sectionTitle = null, string alias = null, string tag = null) {
+            var sdtRun = new SdtRun();
+
+            var props = new SdtProperties();
+            if (!string.IsNullOrEmpty(alias)) {
+                props.Append(new SdtAlias() { Val = alias });
+            }
+            if (!string.IsNullOrEmpty(tag)) {
+                props.Append(new Tag() { Val = tag });
+            }
+            props.Append(new SdtId() { Val = new DocumentFormat.OpenXml.Int32Value(new System.Random().Next(1, int.MaxValue)) });
+
+            string xml = "<w:sdt xmlns:w='http://schemas.openxmlformats.org/wordprocessingml/2006/main' xmlns:w15='http://schemas.microsoft.com/office/word/2012/wordml'>";
+            xml += "<w:sdtPr>";
+            if (!string.IsNullOrEmpty(alias)) xml += $"<w:alias w:val='{alias}'/>";
+            if (!string.IsNullOrEmpty(tag)) xml += $"<w:tag w:val='{tag}'/>";
+            xml += "<w15:repeatingSection" + (string.IsNullOrEmpty(sectionTitle) ? string.Empty : $" w15:sectionTitle='{sectionTitle}'") + "/>";
+            xml += "</w:sdtPr>";
+            xml += "<w:sdtContent><w15:repeatingSectionItem><w:sdt><w:sdtContent><w:r/></w:sdtContent></w:sdt></w15:repeatingSectionItem></w:sdtContent>";
+            xml += "</w:sdt>";
+
+            var newSdt = new SdtRun(xml);
+            this._paragraph.Append(newSdt);
+
+            return new WordRepeatingSection(this._document, this._paragraph, newSdt);
         }
 }
 }

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -6,6 +6,8 @@ using OfficeMath = DocumentFormat.OpenXml.Math.OfficeMath;
 using Paragraph = DocumentFormat.OpenXml.Wordprocessing.Paragraph;
 using ParagraphProperties = DocumentFormat.OpenXml.Wordprocessing.ParagraphProperties;
 using Picture = DocumentFormat.OpenXml.Wordprocessing.Picture;
+using SdtContentPicture = DocumentFormat.OpenXml.Wordprocessing.SdtContentPicture;
+using W15 = DocumentFormat.OpenXml.Office2013.Word;
 using Run = DocumentFormat.OpenXml.Wordprocessing.Run;
 using RunProperties = DocumentFormat.OpenXml.Wordprocessing.RunProperties;
 using TabStop = DocumentFormat.OpenXml.Wordprocessing.TabStop;
@@ -487,6 +489,45 @@ namespace OfficeIMO.Word {
                 return null;
             }
         }
+
+        /// <summary>
+        /// Gets the combo box contained in this paragraph, if present.
+        /// </summary>
+        public WordComboBox ComboBox {
+            get {
+                if (_stdRun != null && _stdRun.SdtProperties?.Elements<SdtContentComboBox>().Any() == true) {
+                    return new WordComboBox(_document, _paragraph, _stdRun);
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the picture content control contained in this paragraph, if present.
+        /// </summary>
+        public WordPictureControl PictureControl {
+            get {
+                if (_stdRun != null && _stdRun.SdtProperties?.Elements<SdtContentPicture>().Any() == true) {
+                    return new WordPictureControl(_document, _paragraph, _stdRun);
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the repeating section contained in this paragraph, if present.
+        /// </summary>
+        public WordRepeatingSection RepeatingSection {
+            get {
+                if (_stdRun != null && _stdRun.SdtProperties?.Elements<W15.SdtRepeatedSection>().Any() == true) {
+                    return new WordRepeatingSection(_document, _paragraph, _stdRun);
+                }
+
+                return null;
+            }
+        }
         /// <summary>
         /// Gets the bookmark associated with this paragraph, if present.
         /// </summary>
@@ -691,6 +732,45 @@ namespace OfficeIMO.Word {
         public bool IsDropDownList {
             get {
                 if (this.DropDownList != null) {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the paragraph contains a combo box control.
+        /// </summary>
+        public bool IsComboBox {
+            get {
+                if (this.ComboBox != null) {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the paragraph contains a picture control.
+        /// </summary>
+        public bool IsPictureControl {
+            get {
+                if (this.PictureControl != null) {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the paragraph contains a repeating section control.
+        /// </summary>
+        public bool IsRepeatingSection {
+            get {
+                if (this.RepeatingSection != null) {
                     return true;
                 }
 

--- a/OfficeIMO.Word/WordPictureControl.cs
+++ b/OfficeIMO.Word/WordPictureControl.cs
@@ -1,0 +1,55 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Office2010.Word;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a picture content control within a paragraph.
+    /// </summary>
+    public class WordPictureControl : WordElement {
+        private readonly WordDocument _document;
+        private readonly Paragraph _paragraph;
+        internal readonly SdtRun _sdtRun;
+
+        internal WordPictureControl(WordDocument document, Paragraph paragraph, SdtRun sdtRun) {
+            _document = document;
+            _paragraph = paragraph;
+            _sdtRun = sdtRun;
+        }
+
+        /// <summary>
+        /// Gets the alias associated with this picture control.
+        /// </summary>
+        public string Alias {
+            get {
+                var sdtAlias = _sdtRun.SdtProperties.OfType<SdtAlias>().FirstOrDefault();
+                return sdtAlias?.Val;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the tag value for this picture control.
+        /// </summary>
+        public string Tag {
+            get {
+                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                return tag?.Val;
+            }
+            set {
+                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                if (tag == null) {
+                    tag = new Tag();
+                    _sdtRun.SdtProperties.Append(tag);
+                }
+                tag.Val = value;
+            }
+        }
+
+        /// <summary>
+        /// Removes the picture control from the paragraph.
+        /// </summary>
+        public void Remove() {
+            _sdtRun.Remove();
+        }
+    }
+}

--- a/OfficeIMO.Word/WordRepeatingSection.cs
+++ b/OfficeIMO.Word/WordRepeatingSection.cs
@@ -1,0 +1,56 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+using W15 = DocumentFormat.OpenXml.Office2013.Word;
+using System.Linq;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents a repeating section content control within a paragraph.
+    /// </summary>
+    public class WordRepeatingSection : WordElement {
+        private readonly WordDocument _document;
+        private readonly Paragraph _paragraph;
+        internal readonly SdtRun _sdtRun;
+
+        internal WordRepeatingSection(WordDocument document, Paragraph paragraph, SdtRun sdtRun) {
+            _document = document;
+            _paragraph = paragraph;
+            _sdtRun = sdtRun;
+        }
+
+        /// <summary>
+        /// Gets the alias associated with this repeating section control.
+        /// </summary>
+        public string Alias {
+            get {
+                var sdtAlias = _sdtRun.SdtProperties.OfType<SdtAlias>().FirstOrDefault();
+                return sdtAlias?.Val;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the tag value for this repeating section control.
+        /// </summary>
+        public string Tag {
+            get {
+                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                return tag?.Val;
+            }
+            set {
+                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                if (tag == null) {
+                    tag = new Tag();
+                    _sdtRun.SdtProperties.Append(tag);
+                }
+                tag.Val = value;
+            }
+        }
+
+        /// <summary>
+        /// Removes the repeating section from the paragraph.
+        /// </summary>
+        public void Remove() {
+            _sdtRun.Remove();
+        }
+    }
+}

--- a/OfficeIMO.Word/WordSection.cs
+++ b/OfficeIMO.Word/WordSection.cs
@@ -124,6 +124,27 @@ namespace OfficeIMO.Word {
         public List<WordParagraph> ParagraphsDropDownLists {
             get { return Paragraphs.Where(p => p.IsDropDownList).ToList(); }
         }
+
+        /// <summary>
+        /// Provides a list of paragraphs that contain combo box controls
+        /// </summary>
+        public List<WordParagraph> ParagraphsComboBoxes {
+            get { return Paragraphs.Where(p => p.IsComboBox).ToList(); }
+        }
+
+        /// <summary>
+        /// Provides a list of paragraphs that contain picture controls
+        /// </summary>
+        public List<WordParagraph> ParagraphsPictureControls {
+            get { return Paragraphs.Where(p => p.IsPictureControl).ToList(); }
+        }
+
+        /// <summary>
+        /// Provides a list of paragraphs that contain repeating section controls
+        /// </summary>
+        public List<WordParagraph> ParagraphsRepeatingSections {
+            get { return Paragraphs.Where(p => p.IsRepeatingSection).ToList(); }
+        }
         /// <summary>
         /// Provides a list of paragraphs that contain Image
         /// </summary>
@@ -430,6 +451,48 @@ namespace OfficeIMO.Word {
                 var paragraphs = Paragraphs.Where(p => p.IsDropDownList).ToList();
                 foreach (var paragraph in paragraphs) {
                     list.Add(paragraph.DropDownList);
+                }
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Gets all combo box content controls within the section.
+        /// </summary>
+        public List<WordComboBox> ComboBoxes {
+            get {
+                List<WordComboBox> list = new List<WordComboBox>();
+                var paragraphs = Paragraphs.Where(p => p.IsComboBox).ToList();
+                foreach (var paragraph in paragraphs) {
+                    list.Add(paragraph.ComboBox);
+                }
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Gets all picture content controls within the section.
+        /// </summary>
+        public List<WordPictureControl> PictureControls {
+            get {
+                List<WordPictureControl> list = new List<WordPictureControl>();
+                var paragraphs = Paragraphs.Where(p => p.IsPictureControl).ToList();
+                foreach (var paragraph in paragraphs) {
+                    list.Add(paragraph.PictureControl);
+                }
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Gets all repeating section content controls within the section.
+        /// </summary>
+        public List<WordRepeatingSection> RepeatingSections {
+            get {
+                List<WordRepeatingSection> list = new List<WordRepeatingSection>();
+                var paragraphs = Paragraphs.Where(p => p.IsRepeatingSection).ToList();
+                foreach (var paragraph in paragraphs) {
+                    list.Add(paragraph.RepeatingSection);
                 }
                 return list;
             }

--- a/OfficeIMO.Word/WordTable.Properties.cs
+++ b/OfficeIMO.Word/WordTable.Properties.cs
@@ -340,5 +340,23 @@ namespace OfficeIMO.Word {
                 return list;
             }
         }
+
+        /// <summary>
+        /// Gets all repeating section content controls contained in the table.
+        /// </summary>
+        public List<WordRepeatingSection> RepeatingSections {
+            get {
+                List<WordRepeatingSection> list = new();
+                foreach (var row in this.Rows) {
+                    foreach (var cell in row.Cells) {
+                        var paragraphs = cell.Paragraphs.Where(p => p.IsRepeatingSection).ToList();
+                        foreach (var paragraph in paragraphs) {
+                            list.Add(paragraph.RepeatingSection);
+                        }
+                    }
+                }
+                return list;
+            }
+        }
 }
 }

--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ Here's a list of features currently supported (and probably a lot I forgot) and 
     - ☑️ Checkbox form controls
     - ☑️ Date picker form controls
     - ☑️ Dropdown list form controls
-    - ❔ The Open XML specification defines additional types such as combo boxes, repeating sections, or picture controls, but these are not yet present in the repository.
+    - ☑️ Combo box form controls
+    - ☑️ Picture form controls
+    - ☑️ Repeating section form controls
 - ☑️ Shapes
     - ☑️ Add rectangles
     - ☑️ Add ellipses


### PR DESCRIPTION
This pull request introduces new features for handling combo box controls, picture controls, and repeating section controls in Word documents. It includes methods for creating, retrieving, and managing these controls, as well as adding corresponding examples and unit tests. Below is a summary of the most important changes grouped by theme:

### New Features for Content Controls:
* Added support for combo box controls, including methods to create, retrieve by alias or tag, and remove them (`OfficeIMO.Word/WordComboBox.cs`, `OfficeIMO.Word/WordDocument.PublicMethods.cs`). [[1]](diffhunk://#diff-6691d22cd73c880d7d785a6d37c39d86fd5e6b00ddfafa9dfcdb038506eb8a8eR1-R69) [[2]](diffhunk://#diff-e577ba03277041388500f0977c2d71c115624ff28c8713f00ba2148ba599b219R643-R684)
* Introduced methods for creating and managing picture controls and repeating section controls, with similar retrieval and removal capabilities (`OfficeIMO.Word/WordDocument.PublicMethods.cs`). [[1]](diffhunk://#diff-e577ba03277041388500f0977c2d71c115624ff28c8713f00ba2148ba599b219R541-R551) [[2]](diffhunk://#diff-e577ba03277041388500f0977c2d71c115624ff28c8713f00ba2148ba599b219R643-R684)

### Document-Level Enhancements:
* Extended the `WordDocument` class to include collections for combo boxes, picture controls, and repeating sections, as well as methods to access paragraphs containing these controls (`OfficeIMO.Word/WordDocument.cs`). [[1]](diffhunk://#diff-22051952680789153ca03bb1059db72def2725396804d94a5fb6b2ea707ed3c9R236-R277) [[2]](diffhunk://#diff-22051952680789153ca03bb1059db72def2725396804d94a5fb6b2ea707ed3c9R788-R826)

### Examples and Documentation:
* Added examples demonstrating the creation of combo boxes, picture controls, and repeating sections in Word documents (`OfficeIMO.Examples/Word/ComboBoxes/ComboBoxes.Basic.cs`, `OfficeIMO.Examples/Word/PictureControls/PictureControls.Basic.cs`, `OfficeIMO.Examples/Word/RepeatingSections/RepeatingSections.Basic.cs`). [[1]](diffhunk://#diff-499d4dc04ae6666378d16263d8907eb2c9bdc3debf88856df93fc98c9decf87cR1-R17) [[2]](diffhunk://#diff-160e4787039800e1c0a613ba494a688280cb01e8047d88a1f59b9dc9f7e190b3R1-R17) [[3]](diffhunk://#diff-463c51beae202b4d29fefe34c255ba529e8d42095f281af29b33a59195388b98R1-R16)
* Updated the `README.MD` file with usage examples for these new controls (`Docs/Examples/ExamplesContentControls/README.MD`).

### Unit Tests:
* Added unit tests to validate the functionality of combo box, picture control, and repeating section features, including assertions for creation, retrieval, and removal (`OfficeIMO.Tests/Word.ComboBox.cs`, `OfficeIMO.Tests/Word.PictureControl.cs`, `OfficeIMO.Tests/Word.RepeatingSection.cs`). [[1]](diffhunk://#diff-d5919a1a260284671cdb0744243622a67de083e4262d109641d5421b94bbb6b8R1-R42) [[2]](diffhunk://#diff-4e900ba0d89bec6f17b8da491b8bf47b0d381e7086304cd8abb80354117b59a2R1-R40) [[3]](diffhunk://#diff-8c680be0c348e17d40aef9eed116797ad5e6ad4aa18bf2e9650b1a8263f636e3R1-R39)

### Header/Footer Enhancements:
* Enhanced the `WordHeaderFooter` class to support paragraphs and collections for repeating sections (`OfficeIMO.Word/WordHeaderFooter.Properties.cs`). [[1]](diffhunk://#diff-30de96ae8b9c9ec2b597c89af4e00026b0fdf9694b4a594d02ed92efec8bbb8fR127-R133) [[2]](diffhunk://#diff-30de96ae8b9c9ec2b597c89af4e00026b0fdf9694b4a594d02ed92efec8bbb8fR290-R304)