### PR TITLE
Add WordDocument#SaveAsByteArray

### DIFF
--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1490,6 +1490,38 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Save the document to a memory stream and return the stream's byte array.
+        /// </summary>
+        /// <returns>A byte array representing the saved Word document.</returns>
+        public byte[] SaveAsByteArray() {
+            if (FileOpenAccess == FileAccess.Read) {
+                throw new InvalidOperationException("Document is read only, and cannot be saved.");
+            }
+
+            PreSaving();
+
+            if (_wordprocessingDocument == null) {
+                throw new InvalidOperationException("Document couldn't be saved as WordDocument wasn't provided.");
+            }
+
+            try {
+                _wordprocessingDocument.Save();
+
+                using var memoryStream = new MemoryStream();
+                using (var clone = _wordprocessingDocument.Clone(memoryStream, true)) {
+                    CopyPackageProperties(_wordprocessingDocument.PackageProperties, clone.PackageProperties);
+                }
+
+                Helpers.MakeOpenOfficeCompatible(memoryStream);
+                memoryStream.Flush();
+
+                return memoryStream.ToArray();
+            } catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException) {
+                throw;
+            }
+        }
+
+        /// <summary>
         /// Asynchronously saves the document.
         /// </summary>
         /// <param name="filePath">Optional path to save to.</param>


### PR DESCRIPTION
Hi,

This pull request adds a new method, SaveAsByteArray(), to the WordDocument class.
I needed functionality to save a word document without saving it to disk i.e. for serverless APIs generating word documents, so I added a function that saves the document to a MemoryStream and returns the stream's byte array after flushing.

I've tested it locally like so, and it works:
```csharp
string filePath = @"C:\your\template.docx";
using (WordDocument document = WordDocument.Load(filePath))
{
    byte[] byteArray = document.SaveAsByteArray();
    File.WriteAllBytes("ByteArray.docx", byteArray);
}
```
Thanks.