### PR TITLE
Fix StructuredDocumentTag text setter

### DIFF
--- a/OfficeIMO.Word/WordStructuredDocumentTag.cs
+++ b/OfficeIMO.Word/WordStructuredDocumentTag.cs
@@ -61,12 +61,18 @@ namespace OfficeIMO.Word {
             }
             set {
                 var run = _stdRun.SdtContentRun.ChildElements.OfType<Run>().FirstOrDefault();
-                if (run != null) {
-                    var text = run.OfType<Text>().FirstOrDefault();
-                    if (text != null) {
-                        text.Text = value;
-                    }
+                if (run == null) {
+                    run = new Run();
+                    _stdRun.SdtContentRun.Append(run);
                 }
+
+                var text = run.OfType<Text>().FirstOrDefault();
+                if (text == null) {
+                    text = new Text { Space = SpaceProcessingModeValues.Preserve };
+                    run.Append(text);
+                }
+
+                text.Text = value;
             }
         }
 


### PR DESCRIPTION
## Summary
- allow setting text on empty structured document tags
- unit test for setting text on empty tags

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686959b62a78832e9fa5d1e92869841b