### PR TITLE
Fix stream disposal in ConvertDotXtoDocX

### DIFF
--- a/OfficeIMO.Tests/Word.Converter.cs
+++ b/OfficeIMO.Tests/Word.Converter.cs
@@ -17,4 +17,15 @@ public partial class Word {
             Assert.Contains(document.Paragraphs[56].Text, "Feel free to use and share the file according to the license above.");
         }
     }
+
+    [Fact]
+    public void Test_ConvertDotXtoDocX_ReleasesDocumentStream() {
+        string templatePath = Path.Combine(_directoryDocuments, "ExampleTemplate.dotx");
+        string outFilePath = Path.Combine(_directoryWithFiles, "ExampleTemplate_Cleanup.docx");
+
+        WordHelpers.ConvertDotXtoDocX(templatePath, outFilePath);
+
+        Assert.False(templatePath.IsFileLocked());
+        Assert.True(File.Exists(outFilePath));
+    }
 }


### PR DESCRIPTION
## Summary
- dispose `documentStream` in `ConvertDotXtoDocX`
- ensure template stream isn't locked after conversion

## Testing
- `dotnet test OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_686959ba134c832e9fb58678e7c3360d