### PR TITLE
Ensure embedded document streams are disposed

### DIFF
--- a/OfficeIMO.Tests/Word.EmbeddedDocuments.cs
+++ b/OfficeIMO.Tests/Word.EmbeddedDocuments.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using OfficeIMO.Word;
 using Xunit;
 
@@ -233,5 +234,24 @@ public partial class Word {
 
             Assert.Equal(ids.Count, ids.Distinct().Count());
         }
+    }
+
+    [Fact]
+    public void Test_SaveEmbeddedDocument_DoesNotLockFile() {
+        string filePath = Path.Combine(_directoryWithFiles, "EmbeddedLockTest.docx");
+        string rtfFilePath = Path.Combine(_directoryDocuments, "SampleFileRTF.rtf");
+        string savedPath = Path.Combine(_directoryWithFiles, "EmbeddedOutput.rtf");
+
+        using (var document = WordDocument.Create(filePath)) {
+            document.AddEmbeddedDocument(rtfFilePath);
+            document.Save();
+        }
+
+        using (var document = WordDocument.Load(filePath)) {
+            document.EmbeddedDocuments[0].Save(savedPath);
+            Assert.False(savedPath.IsFileLocked());
+        }
+
+        File.Delete(savedPath);
     }
 }

--- a/OfficeIMO.Word/WordEmbeddedDocument.cs
+++ b/OfficeIMO.Word/WordEmbeddedDocument.cs
@@ -26,9 +26,8 @@ namespace OfficeIMO.Word {
         /// <param name="fileName">Target file path.</param>
         public void Save(string fileName) {
             using (FileStream stream = new FileStream(fileName, FileMode.Create)) {
-                var altStream = _altContent.GetStream();
+                using var altStream = _altContent.GetStream();
                 altStream.CopyTo(stream);
-                altStream.Close();
             }
         }
 


### PR DESCRIPTION
## Summary
- dispose alt chunk stream when saving embedded documents
- test that saving an embedded document doesn't keep the file locked

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686959beb074832ea44c5c46804a79cc