### PR TITLE
Fix embedded document removal

### DIFF
--- a/OfficeIMO.Tests/Word.EmbeddedDocuments.cs
+++ b/OfficeIMO.Tests/Word.EmbeddedDocuments.cs
@@ -234,4 +234,39 @@ public partial class Word {
             Assert.Equal(ids.Count, ids.Distinct().Count());
         }
     }
+
+    [Fact]
+    public void Test_RemoveSpecificEmbeddedDocument() {
+        string filePath = Path.Combine(_directoryWithFiles, "RemoveSpecificEmbeddedDocument.docx");
+        string htmlFilePath = Path.Combine(_directoryDocuments, "SampleFileHTML.html");
+        string rtfFilePath = Path.Combine(_directoryDocuments, "SampleFileRTF.rtf");
+
+        using (var document = WordDocument.Create(filePath)) {
+            document.AddEmbeddedDocument(rtfFilePath);
+            document.AddEmbeddedDocument(htmlFilePath);
+
+            Assert.True(document.EmbeddedDocuments.Count == 2);
+
+            var listBefore = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            Assert.True(listBefore.Count() == 2);
+
+            document.EmbeddedDocuments[0].Remove();
+
+            Assert.True(document.EmbeddedDocuments.Count == 1);
+            Assert.True(document.EmbeddedDocuments[0].ContentType == "text/html");
+
+            var listAfter = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            Assert.True(listAfter.Count() == 1);
+
+            document.Save(false);
+        }
+
+        using (var document = WordDocument.Load(filePath)) {
+            Assert.True(document.EmbeddedDocuments.Count == 1);
+            Assert.True(document.EmbeddedDocuments[0].ContentType == "text/html");
+
+            var listAfter = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            Assert.True(listAfter.Count() == 1);
+        }
+    }
 }

--- a/OfficeIMO.Word/WordEmbeddedDocument.cs
+++ b/OfficeIMO.Word/WordEmbeddedDocument.cs
@@ -1,8 +1,8 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
 using System;
 using System.IO;
 using System.Text;
-using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
     /// <summary>
@@ -39,16 +39,12 @@ namespace OfficeIMO.Word {
             _altChunk.Remove();
 
             var list = _document._document.MainDocumentPart.AlternativeFormatImportParts;
-            AlternativeFormatImportPart itemToDelete = null;
             foreach (var item in list) {
                 var relationshipId = _document._wordprocessingDocument.MainDocumentPart.GetIdOfPart(item);
                 if (relationshipId == _id) {
-                    itemToDelete = item;
+                    _document._wordprocessingDocument.MainDocumentPart.DeletePart(item);
+                    break;
                 }
-            }
-
-            if (itemToDelete != null) {
-                _document._wordprocessingDocument.MainDocumentPart.DeletePart(itemToDelete);
             }
         }
 


### PR DESCRIPTION
## Summary
- exit loop early when removing embedded documents
- add unit test ensuring the targeted embedded part is deleted

## Testing
- `dotnet build --no-restore --verbosity minimal`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686959cc98a4832eb2ec2aa1a4e4e072