### PR TITLE
Validate text segments

### DIFF
--- a/OfficeIMO.Tests/Word.ReplaceTextWithHtml.cs
+++ b/OfficeIMO.Tests/Word.ReplaceTextWithHtml.cs
@@ -47,5 +47,38 @@ namespace OfficeIMO.Tests {
                 Assert.Single(document.EmbeddedDocuments);
             }
         }
+
+        [Fact]
+        public void Test_ReplaceTextWithHtmlFragment_BoundaryStart() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReplaceHtmlBoundaryStart.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("target middle");
+                var count = document.ReplaceTextWithHtmlFragment("target", "<html><p>Injected</p></html>");
+                Assert.Equal(1, count);
+                Assert.Single(document.EmbeddedDocuments);
+                Assert.Equal(" middle", document.Paragraphs[0].Text);
+                document.Save();
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Single(document.EmbeddedDocuments);
+            }
+        }
+
+        [Fact]
+        public void Test_ReplaceTextWithHtmlFragment_BoundaryEnd() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReplaceHtmlBoundaryEnd.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Some text");
+                document.AddParagraph("final target");
+                var count = document.ReplaceTextWithHtmlFragment("target", "<html><p>Injected</p></html>");
+                Assert.Equal(1, count);
+                Assert.Single(document.EmbeddedDocuments);
+                Assert.Equal("final ", document.Paragraphs[1].Text);
+                document.Save();
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Single(document.EmbeddedDocuments);
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordDocument.HtmlReplacement.cs
+++ b/OfficeIMO.Word/WordDocument.HtmlReplacement.cs
@@ -100,6 +100,10 @@ namespace OfficeIMO.Word {
         /// <param name="paragraphs">Paragraph list to operate on.</param>
         /// <param name="ts">Segment describing the text range to remove.</param>
         private static void RemoveTextSegment(List<WordParagraph> paragraphs, WordTextSegment ts) {
+            if (!IsSegmentValid(paragraphs, ts)) {
+                return;
+            }
+
             if (ts.BeginIndex == ts.EndIndex) {
                 var p = paragraphs[ts.BeginIndex];
                 var len = ts.EndChar - ts.BeginChar + 1;
@@ -114,5 +118,7 @@ namespace OfficeIMO.Word {
                 }
             }
         }
+
+        // Uses WordDocument.IsSegmentValid for validation
     }
 }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -846,7 +846,7 @@ namespace OfficeIMO.Word {
             if (foundList?.Count > 0) {
                 count += foundList.Count;
                 foreach (var ts in foundList) {
-                    if (ts == null)
+                    if (!IsSegmentValid(paragraphs, ts))
                         continue;
                     if (ts.BeginIndex == ts.EndIndex) {
                         var p = paragraphs[ts.BeginIndex];
@@ -997,6 +997,33 @@ namespace OfficeIMO.Word {
             }
 
             return list;
+        }
+
+        private static bool IsSegmentValid(List<WordParagraph> paragraphs, WordTextSegment ts) {
+            if (paragraphs == null || ts == null) {
+                return false;
+            }
+
+            if (ts.BeginIndex < 0 || ts.EndIndex < ts.BeginIndex || ts.EndIndex >= paragraphs.Count) {
+                return false;
+            }
+
+            var beginPara = paragraphs[ts.BeginIndex];
+            var endPara = paragraphs[ts.EndIndex];
+
+            if (beginPara == null || endPara == null) {
+                return false;
+            }
+
+            if (ts.BeginChar < 0 || ts.BeginChar >= beginPara.Text.Length) {
+                return false;
+            }
+
+            if (ts.EndChar < 0 || ts.EndChar >= endPara.Text.Length) {
+                return false;
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- guard segment indices before replacement operations
- check segments before replacements in text search
- test HTML replacement at document boundaries

## Testing
- `dotnet test OfficeImo.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686959d13dec832eb0895816c29d6afc