### PR TITLE
Improve InvalidOperationException messages for paragraphs

### DIFF
--- a/OfficeIMO.Tests/Word.Paragraphs.cs
+++ b/OfficeIMO.Tests/Word.Paragraphs.cs
@@ -488,5 +488,27 @@ namespace OfficeIMO.Tests {
                 document.Save();
             }
         }
+
+        [Fact]
+        public void Test_RemoveParagraphTwiceThrowsDetailedMessage() {
+            string filePath = Path.Combine(_directoryWithFiles, "RemoveParagraphTwice.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Test paragraph");
+                paragraph.Remove();
+                var ex = Assert.Throws<InvalidOperationException>(() => paragraph.Remove());
+                Assert.Contains("no longer has a parent", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void Test_TopParentOnRemovedParagraphThrowsDetailedMessage() {
+            string filePath = Path.Combine(_directoryWithFiles, "TopParentRemoved.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Another paragraph");
+                paragraph.Remove();
+                var ex = Assert.Throws<InvalidOperationException>(() => _ = paragraph.TopParent);
+                Assert.Contains("has no parent", ex.Message);
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -188,11 +188,11 @@ namespace OfficeIMO.Word {
                         }
                     }
                 } else {
-                    throw new InvalidOperationException("This shouldn't happen? Why? Oh why 1?");
+                    throw new InvalidOperationException($"Cannot remove paragraph because it no longer has a parent. Paragraph text: '{Text}'.");
                 }
             } else {
                 // this shouldn't happen
-                throw new InvalidOperationException("This shouldn't happen? Why? Oh why 2?");
+                throw new InvalidOperationException($"Cannot remove paragraph because it is not initialized in the document. Paragraph text: '{Text}'.");
             }
         }
 

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -30,6 +30,9 @@ namespace OfficeIMO.Word {
         internal string TopParent {
             get {
                 var test = _paragraph.Parent;
+                if (test == null) {
+                    throw new InvalidOperationException($"Paragraph with text '{Text}' has no parent.");
+                }
                 if (test is Body) {
                     return "body";
                 }
@@ -52,7 +55,7 @@ namespace OfficeIMO.Word {
                 if (parent is Header) {
                     return "header";
                 }
-                throw new InvalidOperationException("Please open an issue and describe your situation with Parent");
+                throw new InvalidOperationException($"Unsupported parent chain for paragraph with text '{Text}'.");
             }
         }
 


### PR DESCRIPTION
## Summary
- clarify paragraph removal exceptions with contextual details
- improve TopParent error message when parent is missing
- add tests covering the new exception messages

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686959d71e1c832ea05d7a98f8c16752