### PR TITLE
Enable watermark positioning

### DIFF
--- a/Docs/officeimo.word.wordsection.md
+++ b/Docs/officeimo.word.wordsection.md
@@ -419,10 +419,10 @@ header or footer parts are removed as well.
 public void RemoveSection()
 ```
 
-### **AddWatermark(WordWatermarkStyle, String)**
+### **AddWatermark(WordWatermarkStyle, String, Nullable(Double), Nullable(Double), Double)**
 
 ```csharp
-public WordWatermark AddWatermark(WordWatermarkStyle watermarkStyle, string text)
+public WordWatermark AddWatermark(WordWatermarkStyle watermarkStyle, string text, double? horizontalOffset = null, double? verticalOffset = null, double scale = 1.0)
 ```
 
 #### Parameters
@@ -430,6 +430,9 @@ public WordWatermark AddWatermark(WordWatermarkStyle watermarkStyle, string text
 `watermarkStyle` [WordWatermarkStyle](./officeimo.word.wordwatermarkstyle.md)<br>
 
 `text` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+`horizontalOffset` [Nullable(Double)](https://docs.microsoft.com/en-us/dotnet/api/system.nullable-1)<br>
+`verticalOffset` [Nullable(Double)](https://docs.microsoft.com/en-us/dotnet/api/system.nullable-1)<br>
+`scale` [Double](https://docs.microsoft.com/en-us/dotnet/api/system.double)<br>
 
 #### Returns
 

--- a/Docs/officeimo.word.wordwatermark.md
+++ b/Docs/officeimo.word.wordwatermark.md
@@ -22,10 +22,10 @@ public string Text { get; set; }
 
 ## Constructors
 
-### **WordWatermark(WordDocument, WordSection, WordHeader, WordWatermarkStyle, String)**
+### **WordWatermark(WordDocument, WordSection, WordHeader, WordWatermarkStyle, String, Nullable(Double), Nullable(Double), Double)**
 
 ```csharp
-public WordWatermark(WordDocument wordDocument, WordSection wordSection, WordHeader wordHeader, WordWatermarkStyle style, string text)
+public WordWatermark(WordDocument wordDocument, WordSection wordSection, WordHeader wordHeader, WordWatermarkStyle style, string text, double? horizontalOffset = null, double? verticalOffset = null, double scale = 1.0)
 ```
 
 #### Parameters
@@ -39,6 +39,9 @@ public WordWatermark(WordDocument wordDocument, WordSection wordSection, WordHea
 `style` [WordWatermarkStyle](./officeimo.word.wordwatermarkstyle.md)<br>
 
 `text` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+`horizontalOffset` [Nullable(Double)](https://docs.microsoft.com/en-us/dotnet/api/system.nullable-1)<br>
+`verticalOffset` [Nullable(Double)](https://docs.microsoft.com/en-us/dotnet/api/system.nullable-1)<br>
+`scale` [Double](https://docs.microsoft.com/en-us/dotnet/api/system.double)<br>
 
 ### **Remove()**
 

--- a/OfficeIMO.Tests/Word.Watermark.cs
+++ b/OfficeIMO.Tests/Word.Watermark.cs
@@ -257,5 +257,28 @@ namespace OfficeIMO.Tests {
                 Assert.True(watermark.Height > 0);
             }
         }
+
+        [Fact]
+        public void Test_WatermarkOffsetsAndScale() {
+            string filePath = Path.Combine(_directoryWithFiles, "Test_WatermarkOffsetsAndScale.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Test");
+                document.AddHeadersAndFooters();
+                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Offset", 10, 20, 2.0);
+                Assert.Equal(10, watermark.HorizontalOffset);
+                Assert.Equal(20, watermark.VerticalOffset);
+                Assert.True(watermark.Width > 0);
+                Assert.True(watermark.Height > 0);
+                document.Save();
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var watermark = document.Sections[0].Header.Default.Watermarks[0];
+                Assert.Equal(10, watermark.HorizontalOffset);
+                Assert.Equal(20, watermark.VerticalOffset);
+                Assert.True(watermark.Width > 0);
+                Assert.True(watermark.Height > 0);
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordHeader.cs
+++ b/OfficeIMO.Word/WordHeader.cs
@@ -123,9 +123,12 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="watermarkStyle">Watermark style.</param>
         /// <param name="textOrFilePath">Text or image path for the watermark.</param>
+        /// <param name="horizontalOffset">Horizontal offset in points.</param>
+        /// <param name="verticalOffset">Vertical offset in points.</param>
+        /// <param name="scale">Scale factor for width and height.</param>
         /// <returns>The created <see cref="WordWatermark"/>.</returns>
-        public WordWatermark AddWatermark(WordWatermarkStyle watermarkStyle, string textOrFilePath) {
-            return new WordWatermark(this._document, this._section, this, watermarkStyle, textOrFilePath);
+        public WordWatermark AddWatermark(WordWatermarkStyle watermarkStyle, string textOrFilePath, double? horizontalOffset = null, double? verticalOffset = null, double scale = 1.0) {
+            return new WordWatermark(this._document, this._section, this, watermarkStyle, textOrFilePath, horizontalOffset, verticalOffset, scale);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -69,10 +69,13 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="watermarkStyle">Watermark style.</param>
         /// <param name="textOrFilePath">Text or image file path.</param>
+        /// <param name="horizontalOffset">Horizontal offset in points.</param>
+        /// <param name="verticalOffset">Vertical offset in points.</param>
+        /// <param name="scale">Scale factor for width and height.</param>
         /// <returns>The created <see cref="WordWatermark"/> instance.</returns>
-        public WordWatermark AddWatermark(WordWatermarkStyle watermarkStyle, string textOrFilePath) {
+        public WordWatermark AddWatermark(WordWatermarkStyle watermarkStyle, string textOrFilePath, double? horizontalOffset = null, double? verticalOffset = null, double scale = 1.0) {
             // return new WordWatermark(this._document, this, this.Header.Default, watermarkStyle, text);
-            return new WordWatermark(this._document, this, watermarkStyle, textOrFilePath);
+            return new WordWatermark(this._document, this, watermarkStyle, textOrFilePath, horizontalOffset, verticalOffset, scale);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordWatermark.cs
+++ b/OfficeIMO.Word/WordWatermark.cs
@@ -511,7 +511,10 @@ namespace OfficeIMO.Word {
         /// <param name="wordSection">The section to which the watermark should be added.</param>
         /// <param name="style">The type of watermark to add.</param>
         /// <param name="textOrFilePath">Text to use or path to the watermark image.</param>
-        public WordWatermark(WordDocument wordDocument, WordSection wordSection, WordWatermarkStyle style, string textOrFilePath) {
+        /// <param name="horizontalOffset">Horizontal offset in points.</param>
+        /// <param name="verticalOffset">Vertical offset in points.</param>
+        /// <param name="scale">Scale factor for width and height.</param>
+        public WordWatermark(WordDocument wordDocument, WordSection wordSection, WordWatermarkStyle style, string textOrFilePath, double? horizontalOffset = null, double? verticalOffset = null, double scale = 1.0) {
             this._document = wordDocument;
             this._section = wordSection;
 
@@ -544,6 +547,19 @@ namespace OfficeIMO.Word {
                 var imageLocation = WordImage.AddImageToLocation(wordDocument, wordParagraph, imageStream, fileName);
                 SetWatermarkImageData(imageLocation);
             }
+
+            if (horizontalOffset != null) {
+                this.HorizontalOffset = horizontalOffset.Value;
+            }
+
+            if (verticalOffset != null) {
+                this.VerticalOffset = verticalOffset.Value;
+            }
+
+            if (Math.Abs(scale - 1.0) > double.Epsilon) {
+                if (this.Width != null) this.Width = this.Width.Value * scale;
+                if (this.Height != null) this.Height = this.Height.Value * scale;
+            }
         }
 
         /// <summary>
@@ -554,7 +570,10 @@ namespace OfficeIMO.Word {
         /// <param name="wordHeader">The header where the watermark will be placed.</param>
         /// <param name="style">The type of watermark to add.</param>
         /// <param name="textOrFilePath">Text to use or path to the watermark image.</param>
-        public WordWatermark(WordDocument wordDocument, WordSection wordSection, WordHeader wordHeader, WordWatermarkStyle style, string textOrFilePath) {
+        /// <param name="horizontalOffset">Horizontal offset in points.</param>
+        /// <param name="verticalOffset">Vertical offset in points.</param>
+        /// <param name="scale">Scale factor for width and height.</param>
+        public WordWatermark(WordDocument wordDocument, WordSection wordSection, WordHeader wordHeader, WordWatermarkStyle style, string textOrFilePath, double? horizontalOffset = null, double? verticalOffset = null, double scale = 1.0) {
             this._document = wordDocument;
             this._section = wordSection;
 
@@ -583,6 +602,19 @@ namespace OfficeIMO.Word {
                 var wordParagraph = new WordParagraph(wordDocument, paragraph);
                 var imageLocation = WordImage.AddImageToLocation(wordDocument, wordParagraph, imageStream, fileName);
                 SetWatermarkImageData(imageLocation);
+            }
+
+            if (horizontalOffset != null) {
+                this.HorizontalOffset = horizontalOffset.Value;
+            }
+
+            if (verticalOffset != null) {
+                this.VerticalOffset = verticalOffset.Value;
+            }
+
+            if (Math.Abs(scale - 1.0) > double.Epsilon) {
+                if (this.Width != null) this.Width = this.Width.Value * scale;
+                if (this.Height != null) this.Height = this.Height.Value * scale;
             }
         }
 


### PR DESCRIPTION
## Summary
- extend `WordWatermark` constructors with optional offset and scale parameters
- expose new parameters through `AddWatermark` helpers
- document new overloads
- test watermark positioning and scaling

## Testing
- `dotnet restore OfficeImo.sln`
- `dotnet build OfficeImo.sln --no-restore`
- `dotnet test OfficeImo.sln --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68695a233fe0832eb28278424c192960