### PR TITLE
Switch alternative format import to UTF8

### DIFF
--- a/OfficeIMO.Tests/Word.EmbeddedDocumentsEncoding.cs
+++ b/OfficeIMO.Tests/Word.EmbeddedDocumentsEncoding.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void Test_EmbeddedHtmlFragmentWithUnicode() {
+        string filePath = Path.Combine(_directoryWithFiles, "EmbeddedUnicodeFragment.docx");
+        const string phrase = "Zażółć gęślą jaźń";
+        string html = $"<html><body><p>{phrase}</p></body></html>";
+
+        using (var document = WordDocument.Create(filePath)) {
+            document.AddEmbeddedFragment(html, WordAlternativeFormatImportPartType.Html);
+            document.Save(false);
+        }
+
+        using (var document = WordDocument.Load(filePath)) {
+            Assert.Single(document.EmbeddedDocuments);
+            AlternativeFormatImportPart part = document._document.MainDocumentPart.AlternativeFormatImportParts.First();
+            using var reader = new StreamReader(part.GetStream(), Encoding.UTF8);
+            string content = reader.ReadToEnd();
+            Assert.Contains(phrase, content);
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.HtmlReplacement.cs
+++ b/OfficeIMO.Word/WordDocument.HtmlReplacement.cs
@@ -85,7 +85,7 @@ namespace OfficeIMO.Word {
             string altChunkId = mainDocPart.GetIdOfPart(chunk);
             AltChunk altChunk = new AltChunk { Id = altChunkId };
 
-            using (MemoryStream ms = new MemoryStream(Encoding.ASCII.GetBytes(htmlContent))) {
+            using (MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(htmlContent))) {
                 chunk.FeedData(ms);
             }
 

--- a/OfficeIMO.Word/WordEmbeddedDocument.cs
+++ b/OfficeIMO.Word/WordEmbeddedDocument.cs
@@ -111,9 +111,9 @@ namespace OfficeIMO.Word {
             AltChunk altChunk = new AltChunk { Id = altChunkId };
 
             // if it's a fragment, we don't need to read the file
-            var documentContent = htmlFragment ? fileNameOrContent : File.ReadAllText(fileNameOrContent, Encoding.ASCII);
+            var documentContent = htmlFragment ? fileNameOrContent : File.ReadAllText(fileNameOrContent, Encoding.UTF8);
 
-            using (MemoryStream ms = new MemoryStream(Encoding.ASCII.GetBytes(documentContent))) {
+            using (MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(documentContent))) {
                 chunk.FeedData(ms);
             }
 


### PR DESCRIPTION
## Summary
- use UTF8 encoding when feeding AlternativeFormatImportPart
- test embedded HTML fragments with Unicode text

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686959c3b5b0832eac726a04980b4d63