### PR TITLE
Add WordDocumentStatistics class

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -56,6 +56,7 @@
 [WordMacros](./officeimo.word.wordmacros.md)
 
 [WordDocumentVariables](./officeimo.word.worddocumentvariables.md)
+[WordDocumentStatistics](./officeimo.word.worddocumentstatistics.md)
 
 [WordEquation](./officeimo.word.wordequation.md)
 

--- a/Docs/officeimo.word.worddocumentstatistics.md
+++ b/Docs/officeimo.word.worddocumentstatistics.md
@@ -1,0 +1,99 @@
+# WordDocumentStatistics
+
+Namespace: OfficeIMO.Word
+
+```csharp
+public class WordDocumentStatistics
+```
+
+Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) → [WordDocumentStatistics](./officeimo.word.worddocumentstatistics.md)
+
+## Properties
+
+### **Pages**
+
+```csharp
+public int Pages { get; }
+```
+
+Total number of pages in the document.
+
+### **Paragraphs**
+
+```csharp
+public int Paragraphs { get; }
+```
+
+Total number of paragraphs in the document.
+
+### **Words**
+
+```csharp
+public int Words { get; }
+```
+
+Total number of words in the document.
+
+### **Images**
+
+```csharp
+public int Images { get; }
+```
+
+Total number of images in the document.
+
+### **Tables**
+
+```csharp
+public int Tables { get; }
+```
+
+Total number of tables in the document.
+
+### **Charts**
+
+```csharp
+public int Charts { get; }
+```
+
+Total number of charts in the document.
+
+### **Shapes**
+
+```csharp
+public int Shapes { get; }
+```
+
+Total number of shapes in the document.
+
+### **Bookmarks**
+
+```csharp
+public int Bookmarks { get; }
+```
+
+Total number of bookmarks in the document.
+
+### **Lists**
+
+```csharp
+public int Lists { get; }
+```
+
+Total number of lists in the document.
+
+### **Characters**
+
+```csharp
+public int Characters { get; }
+```
+
+Total number of characters in the document.
+
+### **CharactersWithSpaces**
+
+```csharp
+public int CharactersWithSpaces { get; }
+```
+
+Total number of characters including spaces in the document.

--- a/OfficeIMO.Tests/Word.DocumentStatistics.cs
+++ b/OfficeIMO.Tests/Word.DocumentStatistics.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_WordDocumentStatisticsCounts() {
+            var filePath = Path.Combine(_directoryWithFiles, "DocumentStatistics.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.AddParagraph("This is first paragraph");
+                document.AddParagraph("Second paragraph with image");
+                document.Paragraphs[1].AddImage(Path.Combine(_directoryWithImages, "EvotecLogo.png"));
+
+                Assert.Equal(2, document.Statistics.Paragraphs);
+                Assert.Equal(1, document.Statistics.Images);
+                Assert.Equal(1, document.Statistics.Pages);
+                Assert.True(document.Statistics.Words >= 8);
+
+                Assert.Equal(0, document.Statistics.Tables);
+                Assert.Equal(0, document.Statistics.Charts);
+                Assert.Equal(0, document.Statistics.Shapes);
+                Assert.Equal(0, document.Statistics.Bookmarks);
+                Assert.Equal(0, document.Statistics.Lists);
+                Assert.True(document.Statistics.CharactersWithSpaces >= 50);
+                Assert.True(document.Statistics.Characters >= 40);
+
+                document.Save(false);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -873,6 +873,11 @@ namespace OfficeIMO.Word {
         public Dictionary<string, string> DocumentVariables { get; } = new Dictionary<string, string>();
 
         /// <summary>
+        /// Provides basic statistics for the document.
+        /// </summary>
+        public WordDocumentStatistics Statistics { get; internal set; }
+
+        /// <summary>
         /// Indicates whether the document is saved automatically.
         /// </summary>
         public bool AutoSave => _wordprocessingDocument.AutoSave;
@@ -1013,6 +1018,7 @@ namespace OfficeIMO.Word {
             //CustomDocumentProperties customDocumentProperties = new CustomDocumentProperties(word);
             WordSection wordSection = new WordSection(word, null);
             WordBackground wordBackground = new WordBackground(word);
+            WordDocumentStatistics statistics = new WordDocumentStatistics(word);
 
             // initialize abstract number id for lists to make sure those are unique
             WordListStyles.InitializeAbstractNumberId(word._wordprocessingDocument);
@@ -1112,6 +1118,7 @@ namespace OfficeIMO.Word {
             BuiltinDocumentProperties builtinDocumentProperties = new BuiltinDocumentProperties(word);
             WordSection wordSection = new WordSection(word, null);
             WordBackground wordBackground = new WordBackground(word);
+            WordDocumentStatistics statistics = new WordDocumentStatistics(word);
 
             WordListStyles.InitializeAbstractNumberId(word._wordprocessingDocument);
             WordListStyles.InitializeAbstractNumberId(word._wordprocessingDocument);
@@ -1131,6 +1138,7 @@ namespace OfficeIMO.Word {
             var wordCustomProperties = new WordCustomProperties(this);
             var wordDocumentVariables = new WordDocumentVariables(this);
             var wordBackground = new WordBackground(this);
+            var statistics = new WordDocumentStatistics(this);
             var compatibilitySettings = new WordCompatibilitySettings(this);
             //CustomDocumentProperties customDocumentProperties = new CustomDocumentProperties(this);
             // add a section that's assigned to top of the document

--- a/OfficeIMO.Word/WordDocumentStatistics.cs
+++ b/OfficeIMO.Word/WordDocumentStatistics.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Linq;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides basic statistics for a <see cref="WordDocument"/> such as page, paragraph,
+    /// word and image counts. Additional statistics like table or chart counts
+    /// are also available.
+    /// </summary>
+    public class WordDocumentStatistics {
+        private readonly WordDocument _document;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WordDocumentStatistics"/> class.
+        /// </summary>
+        /// <param name="document">Parent document.</param>
+        public WordDocumentStatistics(WordDocument document) {
+            _document = document;
+            document.Statistics = this;
+        }
+
+        /// <summary>
+        /// Gets the total number of pages in the document.
+        /// </summary>
+        public int Pages {
+            get {
+                var pagesText = _document.ApplicationProperties?.Pages;
+                if (!string.IsNullOrEmpty(pagesText) && int.TryParse(pagesText, out var pages)) {
+                    return pages;
+                }
+
+                return _document.ParagraphsPageBreaks.Count + _document.Sections.Count;
+            }
+        }
+
+        /// <summary>
+        /// Gets the total number of paragraphs in the document.
+        /// </summary>
+        public int Paragraphs => _document.Paragraphs.Count;
+
+        /// <summary>
+        /// Gets the total number of words in the document.
+        /// </summary>
+        public int Words {
+            get {
+                var wordsProp = _document.ApplicationProperties?.Words;
+                if (wordsProp != null && int.TryParse(wordsProp.Text, out var propertyWords)) {
+                    return propertyWords;
+                }
+
+                int count = 0;
+                foreach (var paragraph in _document.Paragraphs) {
+                    var text = paragraph.Text;
+                    if (!string.IsNullOrWhiteSpace(text)) {
+                        count += text.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Length;
+                    }
+                }
+
+                return count;
+            }
+        }
+
+        /// <summary>
+        /// Gets the total number of images in the document.
+        /// </summary>
+        public int Images => _document.Images.Count;
+
+        /// <summary>
+        /// Gets the total number of tables in the document.
+        /// </summary>
+        public int Tables => _document.TablesIncludingNestedTables.Count;
+
+        /// <summary>
+        /// Gets the total number of charts in the document.
+        /// </summary>
+        public int Charts => _document.Charts.Count;
+
+        /// <summary>
+        /// Gets the total number of shapes in the document.
+        /// </summary>
+        public int Shapes => _document.Shapes.Count;
+
+        /// <summary>
+        /// Gets the total number of bookmarks in the document.
+        /// </summary>
+        public int Bookmarks => _document.Bookmarks.Count;
+
+        /// <summary>
+        /// Gets the total number of lists in the document.
+        /// </summary>
+        public int Lists => _document.Lists.Count;
+
+        /// <summary>
+        /// Gets the total number of characters in the document (excluding spaces).
+        /// </summary>
+        public int Characters {
+            get {
+                var charText = _document.ApplicationProperties?.Characters;
+                if (!string.IsNullOrEmpty(charText) && int.TryParse(charText, out var chars)) {
+                    return chars;
+                }
+
+                return _document.Paragraphs.Sum(p => p.Text.Replace(" ", "").Length);
+            }
+        }
+
+        /// <summary>
+        /// Gets the total number of characters in the document including spaces.
+        /// </summary>
+        public int CharactersWithSpaces {
+            get {
+                var charText = _document.ApplicationProperties?.CharactersWithSpaces;
+                if (!string.IsNullOrEmpty(charText) && int.TryParse(charText, out var chars)) {
+                    return chars;
+                }
+
+                return _document.Paragraphs.Sum(p => p.Text.Length);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `WordDocumentStatistics` to compute page, paragraph, word and image counts
- expose statistics through `WordDocument`
- document `WordDocumentStatistics` and link in the docs index
- test statistics gathering
- extend statistics with table, chart, shape, bookmark, list and character counts

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeImo.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68695a472e3c832e8acf209353644cc3