### PR TITLE
Add AutoUpdateToc option

### DIFF
--- a/Docs/officeimo.word.worddocument.md
+++ b/Docs/officeimo.word.worddocument.md
@@ -67,6 +67,14 @@ Enable or disable tracking of comment changes.
 public bool TrackComments { get; set; }
 ```
 
+### **AutoUpdateToc**
+
+Flag the table of contents for update before saving when set to <code>true</code>.
+
+```csharp
+public bool AutoUpdateToc { get; set; }
+```
+
 ### **HasDocumentVariables**
 
 Indicates if the document contains any document variables.

--- a/OfficeIMO.Tests/Word.TOC.cs
+++ b/OfficeIMO.Tests/Word.TOC.cs
@@ -215,5 +215,19 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Test_AutoUpdateToc() {
+            string filePath = Path.Combine(_directoryWithFiles, "AutoUpdateToc.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.AddTableOfContent();
+                document.AutoUpdateToc = true;
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.True(document.Settings.UpdateFieldsOnOpen);
+            }
+        }
+
     }
 }

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -882,6 +882,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool AutoSave => _wordprocessingDocument.AutoSave;
 
+        /// <summary>
+        /// When <c>true</c> the table of contents is flagged to update before saving.
+        /// </summary>
+        public bool AutoUpdateToc { get; set; }
+
 
         // we expose them to help with integration
         /// <summary>
@@ -1704,6 +1709,9 @@ namespace OfficeIMO.Word {
         private void PreSaving() {
             MoveSectionProperties();
             SaveNumbering();
+            if (AutoUpdateToc && TableOfContent != null) {
+                TableOfContent.Update();
+            }
             _ = new WordCustomProperties(this, true);
             var settingsPart = _wordprocessingDocument.MainDocumentPart.DocumentSettingsPart;
             bool hasVariables = settingsPart?.Settings?.GetFirstChild<DocumentVariables>() != null;


### PR DESCRIPTION
## Summary
- add `AutoUpdateToc` bool property to WordDocument
- flag TOC for update automatically during save when `AutoUpdateToc` is true
- document the new property
- test that AutoUpdateToc sets UpdateFieldsOnOpen

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68696bc5eecc832ea2ec518f3201858e