### PR TITLE
Handle merge exceptions

### DIFF
--- a/OfficeIMO.Tests/Word.EmbeddedDocumentFailures.cs
+++ b/OfficeIMO.Tests/Word.EmbeddedDocumentFailures.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using System.Linq;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void Test_AddEmbeddedDocument_MissingFile_CleansTemporaryPart() {
+        string filePath = Path.Combine(_directoryWithFiles, "MissingFileEmbed.docx");
+        using var document = WordDocument.Create(filePath);
+        string missingPath = Path.Combine(_directoryWithFiles, "does-not-exist.rtf");
+
+        Assert.Throws<FileNotFoundException>(() => document.AddEmbeddedDocument(missingPath));
+        Assert.Empty(document._document.MainDocumentPart.AlternativeFormatImportParts);
+    }
+}

--- a/OfficeIMO.Word/WordDocument.HtmlReplacement.cs
+++ b/OfficeIMO.Word/WordDocument.HtmlReplacement.cs
@@ -85,13 +85,18 @@ namespace OfficeIMO.Word {
             string altChunkId = mainDocPart.GetIdOfPart(chunk);
             AltChunk altChunk = new AltChunk { Id = altChunkId };
 
-            using (MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(htmlContent))) {
-                chunk.FeedData(ms);
+            try {
+                using (MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(htmlContent))) {
+                    chunk.FeedData(ms);
+                }
+
+                paragraph._paragraph.InsertAfterSelf(altChunk);
+
+                return new WordEmbeddedDocument(this, altChunk);
+            } catch {
+                mainDocPart.DeletePart(chunk);
+                throw;
             }
-
-            paragraph._paragraph.InsertAfterSelf(altChunk);
-
-            return new WordEmbeddedDocument(this, altChunk);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordEmbeddedDocument.cs
+++ b/OfficeIMO.Word/WordEmbeddedDocument.cs
@@ -106,21 +106,28 @@ namespace OfficeIMO.Word {
             string altChunkId = mainDocPart.GetIdOfPart(chunk);
             AltChunk altChunk = new AltChunk { Id = altChunkId };
 
-            // if it's a fragment, we don't need to read the file
-            var documentContent = htmlFragment ? fileNameOrContent : File.ReadAllText(fileNameOrContent, Encoding.UTF8);
+            try {
+                // if it's a fragment, we don't need to read the file
+                var documentContent = htmlFragment
+                    ? fileNameOrContent
+                    : File.ReadAllText(fileNameOrContent, Encoding.UTF8);
 
-            using (MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(documentContent))) {
-                chunk.FeedData(ms);
+                using (MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(documentContent))) {
+                    chunk.FeedData(ms);
+                }
+
+                _id = altChunkId;
+                _altChunk = altChunk;
+                _altContent = chunk;
+                _document = wordDocument;
+
+                mainDocPart.Document.Body.Append(altChunk);
+
+                mainDocPart.Document.Save();
+            } catch {
+                mainDocPart.DeletePart(chunk);
+                throw;
             }
-
-            _id = altChunkId;
-            _altChunk = altChunk;
-            _altContent = chunk;
-            _document = wordDocument;
-
-            mainDocPart.Document.Body.Append(altChunk);
-
-            mainDocPart.Document.Save();
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove leftover alternative parts on merge errors
- clean up when HTML fragment insertion fails
- cover merge failure scenario with new test

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68696c155310832eada1301dd9ee0c27