### PR TITLE
Add stream-based saving features

### DIFF
--- a/OfficeIMO.Examples/Word/SaveToStream/StreamSaveAsByteArray.cs
+++ b/OfficeIMO.Examples/Word/SaveToStream/StreamSaveAsByteArray.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class SaveToStream {
+        public static void Example_SaveAsByteArray(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Saving document as a byte array");
+            byte[] bytes;
+            using (var document = WordDocument.Create()) {
+                document.AddParagraph("Saved to byte array");
+                bytes = document.SaveAsByteArray();
+            }
+
+            string filePath = Path.Combine(folderPath, "SaveAsByteArray.docx");
+            File.WriteAllBytes(filePath, bytes);
+            Helpers.Open(filePath, openWord);
+        }
+
+        public static void Example_SaveAsMemoryStream(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Saving document to a MemoryStream");
+            using var document = WordDocument.Create();
+            document.AddParagraph("Saved to memory stream");
+
+            using MemoryStream stream = document.SaveAsMemoryStream();
+
+            string filePath = Path.Combine(folderPath, "SaveAsMemoryStream.docx");
+            using (var file = new FileStream(filePath, FileMode.Create, FileAccess.Write)) {
+                stream.CopyTo(file);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+
+        public static void Example_SaveAsStream(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Cloning document into a provided stream");
+            using var document = WordDocument.Create();
+            document.AddParagraph("Cloned into stream");
+
+            using var stream = new MemoryStream();
+            using var cloned = document.SaveAs(stream);
+
+            string filePath = Path.Combine(folderPath, "SaveAsStream.docx");
+            using (var file = new FileStream(filePath, FileMode.Create, FileAccess.Write)) {
+                stream.Position = 0;
+                stream.CopyTo(file);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.SaveAsByteArray.cs
+++ b/OfficeIMO.Tests/Word.SaveAsByteArray.cs
@@ -1,0 +1,49 @@
+using System.IO;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_SaveAsByteArray() {
+            using var document = WordDocument.Create();
+            document.AddParagraph("Hello bytes");
+            byte[] data = document.SaveAsByteArray();
+
+            using var ms = new MemoryStream(data);
+            using var openXml = WordprocessingDocument.Open(ms, false);
+            Assert.NotNull(openXml.MainDocumentPart);
+            ms.Position = 0;
+            using var loaded = WordDocument.Load(ms);
+            Assert.Equal("Hello bytes", loaded.Paragraphs[0].Text);
+        }
+
+        [Fact]
+        public void Test_SaveAsMemoryStream() {
+            using var document = WordDocument.Create();
+            document.AddParagraph("Hello memory");
+
+            using MemoryStream ms = document.SaveAsMemoryStream();
+            using var openXml = WordprocessingDocument.Open(ms, false);
+            Assert.NotNull(openXml.MainDocumentPart);
+            ms.Position = 0;
+            using var loaded = WordDocument.Load(ms);
+            Assert.Equal("Hello memory", loaded.Paragraphs[0].Text);
+        }
+
+        [Fact]
+        public void Test_SaveAsStream() {
+            using var document = WordDocument.Create();
+            document.AddParagraph("Hello stream");
+
+            using var ms = new MemoryStream();
+            using var clone = document.SaveAs(ms);
+
+            Assert.Equal(string.Empty, document.FilePath);
+            Assert.Null(clone.FilePath);
+            Assert.Single(clone.Paragraphs);
+            Assert.Equal("Hello stream", clone.Paragraphs[0].Text);
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1535,6 +1535,35 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Save the document to a new <see cref="MemoryStream"/>.
+        /// </summary>
+        /// <returns>A memory stream containing the saved document.</returns>
+        public MemoryStream SaveAsMemoryStream() {
+            var stream = new MemoryStream();
+            Save(stream);
+            stream.Seek(0, SeekOrigin.Begin);
+            return stream;
+        }
+
+        /// <summary>
+        /// Clone the document to the specified stream and return a new instance loaded from it.
+        /// </summary>
+        /// <param name="outputStream">Target stream that must support reading and seeking.</param>
+        /// <returns>A new <see cref="WordDocument"/> loaded from <paramref name="outputStream"/>.</returns>
+        public WordDocument SaveAs(Stream outputStream) {
+            if (outputStream == null) {
+                throw new ArgumentNullException(nameof(outputStream));
+            }
+            if (!outputStream.CanSeek) {
+                throw new ArgumentException("Stream must support seeking", nameof(outputStream));
+            }
+
+            Save(outputStream);
+            outputStream.Seek(0, SeekOrigin.Begin);
+            return WordDocument.Load(outputStream);
+        }
+
+        /// <summary>
         /// Asynchronously saves the document.
         /// </summary>
         /// <param name="filePath">Optional path to save to.</param>

--- a/README.md
+++ b/README.md
@@ -327,6 +327,19 @@ using (WordDocument document = WordDocument.Create()) {
 }
 ```
 
+### Saving to byte arrays and streams
+
+`SaveAsByteArray` and `SaveAsMemoryStream` let you keep everything in memory. `SaveAs(Stream)` clones the document to a provided stream and returns a new instance loaded from it.
+
+```csharp
+using (WordDocument document = WordDocument.Create()) {
+    document.AddParagraph("In memory");
+    byte[] data = document.SaveAsByteArray();
+    using MemoryStream stream = document.SaveAsMemoryStream();
+    using var clone = document.SaveAs(stream);
+}
+```
+
 ### Basic Document with Headers/Footers (first, odd, even)
 
 This short example shows how to add headers and footers to a Word document.


### PR DESCRIPTION
## Summary
- add `SaveAsMemoryStream` and `SaveAs(Stream)` APIs
- document byte array and stream saving in README
- provide examples for new APIs
- test saving to byte arrays and streams

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeImo.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68698f52a75c832ea86dc6e376cdc4b2