### PR TITLE
Add missing XML docs to test classes

### DIFF
--- a/OfficeIMO.Examples/Excel/BasicExcelFunctionality.Async.cs
+++ b/OfficeIMO.Examples/Excel/BasicExcelFunctionality.Async.cs
@@ -4,7 +4,14 @@ using System.Threading.Tasks;
 using OfficeIMO.Excel;
 
 namespace OfficeIMO.Examples.Excel {
+    /// <summary>
+    /// Demonstrates asynchronous operations with <see cref="ExcelDocument"/>.
+    /// </summary>
     public class BasicExcelFunctionalityAsync {
+        /// <summary>
+        /// Creates a workbook, saves it and loads it asynchronously.
+        /// </summary>
+        /// <param name="folderPath">Path to the folder used for the workbook.</param>
         public static async Task Example_ExcelAsync(string folderPath) {
             Console.WriteLine("[*] Async example for ExcelDocument");
             string filePath = Path.Combine(folderPath, "AsyncExcel.xlsx");

--- a/OfficeIMO.Examples/Excel/BasicExcelFunctionality.cs
+++ b/OfficeIMO.Examples/Excel/BasicExcelFunctionality.cs
@@ -7,8 +7,16 @@ using OfficeIMO.Excel;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Excel {
+    /// <summary>
+    /// Contains basic examples demonstrating <see cref="ExcelDocument"/> usage.
+    /// </summary>
     public class BasicExcelFunctionality {
 
+        /// <summary>
+        /// Creates a simple workbook with three sheets.
+        /// </summary>
+        /// <param name="folderPath">Target folder for the workbook.</param>
+        /// <param name="openExcel">Opens the workbook after saving when set to <c>true</c>.</param>
         public static void BasicExcel_Example1(string folderPath, bool openExcel) {
             Console.WriteLine("[*] Excel - Creating standard Excel Document 1");
             string filePath = System.IO.Path.Combine(folderPath, "Basic Excel 1.xlsx");

--- a/OfficeIMO.Tests/Word.FieldParser_Should.cs
+++ b/OfficeIMO.Tests/Word.FieldParser_Should.cs
@@ -7,6 +7,9 @@ namespace OfficeIMO.Tests
 {
     public partial class Word
     {
+        /// <summary>
+        /// Unit tests related to <see cref="WordFieldParser"/> parsing logic.
+        /// </summary>
         public class FieldParser_Should
         {
 
@@ -16,6 +19,11 @@ namespace OfficeIMO.Tests
             [InlineData(@"BIBLIOGRAPHY \*arabic", 1)]
             [InlineData(@"BIBLIOGRAPHY \* ALPHABETICAL", 1)]
             [InlineData(@"Page \* FIRSTCAP \* MERGEFORMAT", 2)]
+            /// <summary>
+            /// Ensures format switches are correctly identified within field codes.
+            /// </summary>
+            /// <param name="FieldCodeString">Field code string under test.</param>
+            /// <param name="expected_amount_of_format_switches">Expected count of switches.</param>
             public void Test_IdentifyFormatSwitches(String FieldCodeString, int expected_amount_of_format_switches)
             {
                 var parser = new WordFieldParser(FieldCodeString);

--- a/OfficeIMO.VerifyTests/Word/AdvancedDocumentTests.cs
+++ b/OfficeIMO.VerifyTests/Word/AdvancedDocumentTests.cs
@@ -10,6 +10,9 @@ using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.VerifyTests.Word;
 
+/// <summary>
+/// Exercises advanced document features such as sections and headers.
+/// </summary>
 public class AdvancedDocumentTests : VerifyTestBase {
 
     private static async Task DoTest(WordprocessingDocument document) {

--- a/OfficeIMO.VerifyTests/Word/BasicDocumentTests.cs
+++ b/OfficeIMO.VerifyTests/Word/BasicDocumentTests.cs
@@ -9,6 +9,9 @@ using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.VerifyTests.Word;
 
+/// <summary>
+/// Provides baseline document generation tests.
+/// </summary>
 public class BasicDocumentTests : VerifyTestBase {
 
     private static async Task DoTest(WordprocessingDocument document) {

--- a/OfficeIMO.VerifyTests/Word/BookmarkTests.cs
+++ b/OfficeIMO.VerifyTests/Word/BookmarkTests.cs
@@ -7,6 +7,9 @@ using Xunit;
 
 namespace OfficeIMO.VerifyTests.Word;
 
+/// <summary>
+/// Tests bookmark creation and removal within documents.
+/// </summary>
 public class BookmarkTests : VerifyTestBase {
 
     private static async Task DoTest(WordprocessingDocument document) {

--- a/OfficeIMO.VerifyTests/Word/BordersAndMarginsTests.cs
+++ b/OfficeIMO.VerifyTests/Word/BordersAndMarginsTests.cs
@@ -9,6 +9,9 @@ using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.VerifyTests.Word;
 
+/// <summary>
+/// Verifies border and margin related functionality.
+/// </summary>
 public class BordersAndMarginsTests : VerifyTestBase {
 
     private static async Task DoTest(WordprocessingDocument document) {

--- a/OfficeIMO.VerifyTests/Word/ChartTests.cs
+++ b/OfficeIMO.VerifyTests/Word/ChartTests.cs
@@ -14,6 +14,9 @@ using Xunit;
 
 namespace OfficeIMO.VerifyTests.Word;
 
+/// <summary>
+/// Tests generating documents that contain charts.
+/// </summary>
 public class ChartTests : VerifyTestBase {
 
     private static async Task DoTest(WordprocessingDocument document) {

--- a/OfficeIMO.VerifyTests/Word/CommentTests.cs
+++ b/OfficeIMO.VerifyTests/Word/CommentTests.cs
@@ -7,6 +7,9 @@ using Xunit;
 
 namespace OfficeIMO.VerifyTests.Word;
 
+/// <summary>
+/// Tests adding and verifying comments in documents.
+/// </summary>
 public class CommentTests : VerifyTestBase {
 
     private static async Task DoTest(WordprocessingDocument document) {

--- a/OfficeIMO.VerifyTests/Word/CoverPageTests.cs
+++ b/OfficeIMO.VerifyTests/Word/CoverPageTests.cs
@@ -6,6 +6,9 @@ using Xunit;
 
 namespace OfficeIMO.VerifyTests.Word;
 
+/// <summary>
+/// Validates cover page functionality within generated documents.
+/// </summary>
 public class CoverPageTests : VerifyTestBase {
 
     private static async Task DoTest(WordprocessingDocument document) {

--- a/OfficeIMO.VerifyTests/Word/CustomAndBuiltinPropertiesTests.cs
+++ b/OfficeIMO.VerifyTests/Word/CustomAndBuiltinPropertiesTests.cs
@@ -10,6 +10,9 @@ using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.VerifyTests.Word;
 
+/// <summary>
+/// Verifies custom and built‑in document property handling.
+/// </summary>
 public class CustomAndBuiltinPropertiesTests : VerifyTestBase {
 
     private static async Task DoTest(WordprocessingDocument document) {

--- a/OfficeIMO.VerifyTests/Word/ImageRemoveTests.cs
+++ b/OfficeIMO.VerifyTests/Word/ImageRemoveTests.cs
@@ -10,6 +10,9 @@ using Xunit;
 
 namespace OfficeIMO.VerifyTests.Word;
 
+/// <summary>
+/// Tests removal of images and related cleanup.
+/// </summary>
 public class ImageRemoveTests : VerifyTestBase {
 
     private static async Task DoTest(WordprocessingDocument document) {


### PR DESCRIPTION
## Summary
- document missing API classes in tests and examples
- update example methods with comments

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686b661a92c8832ea5f0b75ddc450179