### PR TITLE
Add documentation comments

### DIFF
--- a/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.Create.cs
+++ b/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.Create.cs
@@ -5,7 +5,11 @@ using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class AdvancedDocument {
-
+        /// <summary>
+        /// Creates an advanced document showcasing various features.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the document.</param>
+        /// <param name="openWord">Whether to open Word after creation.</param>
         public static void Example_AdvancedWord(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating advanced document");
             string filePath = System.IO.Path.Combine(folderPath, "AdvancedDocument.docx");

--- a/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.Create02.cs
+++ b/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.Create02.cs
@@ -7,6 +7,11 @@ using Color = SixLabors.ImageSharp.Color;
 namespace OfficeIMO.Examples.Word {
     internal static partial class AdvancedDocument {
 
+        /// <summary>
+        /// Generates a second advanced document demonstrating additional scenarios.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the document.</param>
+        /// <param name="openWord">Whether to open Word after creation.</param>
         public static void Example_AdvancedWord2(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating advanced document");
             string filePath = System.IO.Path.Combine(folderPath, "AdvancedDocument2.docx");

--- a/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample1.cs
+++ b/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample1.cs
@@ -8,7 +8,10 @@ using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
     internal partial class CustomAndBuiltinProperties {
-
+        /// <summary>
+        /// Loads an existing document and displays its built-in and custom properties.
+        /// </summary>
+        /// <param name="openWord">Whether to open Word after loading the document.</param>
         public static void Example_LoadDocumentWithProperties(bool openWord = false) {
             Console.WriteLine("[*] Loading standard document to check properties");
 

--- a/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample2.cs
+++ b/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample2.cs
@@ -8,6 +8,10 @@ using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class CustomAndBuiltinProperties {
+        /// <summary>
+        /// Loads a document and prints basic property information.
+        /// </summary>
+        /// <param name="openWord">Whether to open Word after loading the document.</param>
         public static void Example_Load(bool openWord = false) {
             Console.WriteLine("[*] Loading basic document");
 

--- a/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample3.cs
+++ b/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample3.cs
@@ -8,6 +8,10 @@ using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
     internal partial class CustomAndBuiltinProperties {
+        /// <summary>
+        /// Creates a document and validates its properties and content.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the document.</param>
         public static void Example_ValidateDocument(string folderPath) {
             Console.WriteLine("[*] Creating standard document and validate it");
             string filePath = System.IO.Path.Combine(folderPath, "Basic Document for validation.docx");

--- a/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample4.cs
+++ b/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample4.cs
@@ -8,6 +8,9 @@ using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
     internal partial class CustomAndBuiltinProperties {
+        /// <summary>
+        /// Validates a document in memory before saving it to disk.
+        /// </summary>
         public static void Example_ValidateDocument_BeforeSave() {
             Console.WriteLine("[*] Creating standard document and validate it without saving");
             using (WordDocument document = WordDocument.Create()) {

--- a/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample5.cs
+++ b/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample5.cs
@@ -8,6 +8,11 @@ using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
     internal partial class CustomAndBuiltinProperties {
+        /// <summary>
+        /// Creates a basic document and sets a few built-in properties.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the document.</param>
+        /// <param name="openWord">Whether to open Word after creation.</param>
         public static void Example_BasicDocumentProperties(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating standard document with some properties and single paragraph");
             string filePath = System.IO.Path.Combine(folderPath, "BasicDocument.docx");

--- a/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample6.cs
+++ b/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample6.cs
@@ -7,6 +7,10 @@ using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
     internal partial class CustomAndBuiltinProperties {
+        /// <summary>
+        /// Reads a document and prints its custom properties.
+        /// </summary>
+        /// <param name="openWord">Whether to open the document after reading.</param>
         public static void Example_ReadWord(bool openWord) {
             Console.WriteLine("[*] Read Basic Word");
 

--- a/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample7.cs
+++ b/OfficeIMO.Examples/Word/BuiltinAndCustomProperties/CustomAndBuiltinProperties.Sample7.cs
@@ -9,6 +9,11 @@ using OfficeIMO.Word;
 namespace OfficeIMO.Examples.Word {
     internal static partial class CustomAndBuiltinProperties {
 
+        /// <summary>
+        /// Creates a document with a few custom properties set.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the document.</param>
+        /// <param name="openWord">Whether to open Word after creation.</param>
         public static void Example_BasicCustomProperties(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating standard document with custom properties");
             string filePath = System.IO.Path.Combine(folderPath, "Basic Document with custom properties.docx");

--- a/OfficeIMO.Examples/Word/DocumentVariables/DocumentVariables.Advanced.cs
+++ b/OfficeIMO.Examples/Word/DocumentVariables/DocumentVariables.Advanced.cs
@@ -4,6 +4,11 @@ using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class DocumentVariablesExamples {
+        /// <summary>
+        /// Shows how to work with advanced document variables.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the document.</param>
+        /// <param name="openWord">Whether to open the document after creation.</param>
         public static void Example_AdvancedDocumentVariables(string folderPath, bool openWord) {
             Console.WriteLine("[*] Working with document variables");
             string filePath = Path.Combine(folderPath, "AdvancedDocumentWithVariables.docx");

--- a/OfficeIMO.Examples/Word/DocumentVariables/DocumentVariables.Simple.cs
+++ b/OfficeIMO.Examples/Word/DocumentVariables/DocumentVariables.Simple.cs
@@ -4,6 +4,11 @@ using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class DocumentVariablesExamples {
+        /// <summary>
+        /// Creates a document with a few simple document variables.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the document.</param>
+        /// <param name="openWord">Whether to open the document after creation.</param>
         public static void Example_BasicDocumentVariables(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating document with variables");
             string filePath = Path.Combine(folderPath, "DocumentWithVariables.docx");

--- a/OfficeIMO.Examples/Word/LoadDocuments/LoadDocuments.Sample1.cs
+++ b/OfficeIMO.Examples/Word/LoadDocuments/LoadDocuments.Sample1.cs
@@ -7,6 +7,10 @@ using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class LoadDocuments {
+        /// <summary>
+        /// Loads an existing document from disk and prints some information.
+        /// </summary>
+        /// <param name="openWord">Whether to open the document after loading.</param>
         public static void LoadWordDocument_Sample1(bool openWord) {
             Console.WriteLine("[*] Load external Word Document - Sample 1");
 

--- a/OfficeIMO.Examples/Word/LoadDocuments/LoadDocuments.Sample2.cs
+++ b/OfficeIMO.Examples/Word/LoadDocuments/LoadDocuments.Sample2.cs
@@ -7,6 +7,10 @@ using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class LoadDocuments {
+        /// <summary>
+        /// Loads another sample document demonstrating read-only access.
+        /// </summary>
+        /// <param name="openWord">Whether to open the document after loading.</param>
         public static void LoadWordDocument_Sample2(bool openWord) {
             Console.WriteLine("[*] Load external Word Document - Sample 2");
 

--- a/OfficeIMO.Examples/Word/LoadDocuments/LoadDocuments.Sample3.cs
+++ b/OfficeIMO.Examples/Word/LoadDocuments/LoadDocuments.Sample3.cs
@@ -7,6 +7,10 @@ using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class LoadDocuments {
+        /// <summary>
+        /// Loads a document and enumerates its sections.
+        /// </summary>
+        /// <param name="openWord">Whether to open the document after loading.</param>
         public static void LoadWordDocument_Sample3(bool openWord) {
             Console.WriteLine("[*] Load external Word Document - Sample 3");
             string documentPaths = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "Templates");

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Remove.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Remove.cs
@@ -3,6 +3,11 @@ using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class Watermark {
+        /// <summary>
+        /// Removes all watermarks from a document.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the file.</param>
+        /// <param name="openWord">Whether to open the document after creation.</param>
         public static void Watermark_Remove(string folderPath, bool openWord) {
             Console.WriteLine("[*] Removing watermarks using RemoveWatermark");
             string filePath = System.IO.Path.Combine(folderPath, "Watermark Remove.docx");

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Sample1.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Sample1.cs
@@ -8,6 +8,11 @@ using SixLabors.ImageSharp;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class Watermark {
+        /// <summary>
+        /// Demonstrates how to create a document with a basic watermark.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the file.</param>
+        /// <param name="openWord">Whether to open the document after creation.</param>
         public static void Watermark_Sample1(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating standard document with Watermark 2");
             string filePath = System.IO.Path.Combine(folderPath, "Basic Document with Watermark 4.docx");

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Sample2.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Sample2.cs
@@ -8,6 +8,11 @@ using SixLabors.ImageSharp;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class Watermark {
+        /// <summary>
+        /// Creates a document and inserts a simple text watermark.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the generated file.</param>
+        /// <param name="openWord">Whether to open the document after creation.</param>
         public static void Watermark_Sample2(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating standard document with watermark");
             string filePath = System.IO.Path.Combine(folderPath, "Basic Document with watermark.docx");

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Sample3.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Sample3.cs
@@ -8,6 +8,11 @@ using SixLabors.ImageSharp;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class Watermark {
+        /// <summary>
+        /// Demonstrates adding a watermark to a document with multiple sections.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the document.</param>
+        /// <param name="openWord">Whether to open the document after creation.</param>
         public static void Watermark_Sample3(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating standard document with watermark");
             string filePath = System.IO.Path.Combine(folderPath, "Basic Document with watermark and sections.docx");

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.SampleImage1.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.SampleImage1.cs
@@ -2,6 +2,11 @@ using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class Watermark {
+        /// <summary>
+        /// Creates a document with an image watermark.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the file.</param>
+        /// <param name="openWord">Whether to open the document after creation.</param>
         public static void Watermark_SampleImage1(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating standard document with Watermark Image 1");
             var imagePaths = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "Images");

--- a/OfficeIMO.Word/WordBibliography.cs
+++ b/OfficeIMO.Word/WordBibliography.cs
@@ -12,6 +12,11 @@ namespace OfficeIMO.Word {
         private readonly WordprocessingDocument _wordDocument;
         private CustomXmlPart _part;
 
+        /// <summary>
+        /// Initializes a new instance responsible for managing bibliography sources.
+        /// </summary>
+        /// <param name="document">Parent document instance.</param>
+        /// <param name="create">If set to <c>true</c>, a new bibliography part is created.</param>
         public WordBibliography(WordDocument document, bool? create = null) {
             _document = document;
             _wordDocument = document._wordprocessingDocument;

--- a/OfficeIMO.Word/WordEndNote.cs
+++ b/OfficeIMO.Word/WordEndNote.cs
@@ -57,10 +57,8 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
-        /// Parent Paragraph is Paragraph/Run that has EndNote attached to it.
-        /// This provides ability to find proper Run that has EndNote
+        /// Parent paragraph containing the endnote reference.
         /// </summary>
-
         public WordParagraph ParentParagraph {
             get {
                 var previousRun = _run.PreviousSibling<Run>();

--- a/OfficeIMO.Word/WordMacro.cs
+++ b/OfficeIMO.Word/WordMacro.cs
@@ -151,6 +151,9 @@ namespace OfficeIMO.Word {
 
             /// <summary>Represents a directory entry inside the compound file.</summary>
             private class DirEntry {
+                /// <summary>
+                /// Name of the entry.
+                /// </summary>
                 public string Name = string.Empty;
                 /// <summary>
                 /// Directory entry type (0 = unknown, 1 = storage, 2 = stream, 5 = root).


### PR DESCRIPTION
## Summary
- add XML docs for Word macro parser class
- add constructor documentation for `WordBibliography`
- ensure comment placement for `WordEndNote` property
- add documentation comments to various Word example methods

## Testing
- `dotnet build --no-incremental`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686b8006adb4832e926bc267ca6f0c3d