### PR TITLE
Add XML documentation to tests and examples

### DIFF
--- a/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample01.cs
+++ b/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample01.cs
@@ -5,7 +5,14 @@ using System.Text;
 using System.Threading.Tasks;
 using OfficeIMO.Word;
 
+/// <summary>
+/// Examples demonstrating document cleanup operations.
+/// </summary>
 internal static partial class CleanupDocuments {
+    /// <summary>
+    /// Loads a template and performs cleanup of redundant runs.
+    /// </summary>
+    /// <param name="openWord">Opens Word when <c>true</c>.</param>
     public static void CleanupDocuments_Sample01(bool openWord) {
         Console.WriteLine("[*] Load external Word Document - Sample 1");
         string documentPaths = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "Templates");

--- a/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample02.cs
+++ b/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample02.cs
@@ -2,7 +2,15 @@ using System;
 using System.IO;
 using OfficeIMO.Word;
 
+/// <summary>
+/// Additional document cleanup examples.
+/// </summary>
 internal static partial class CleanupDocuments {
+    /// <summary>
+    /// Creates a document, performs cleanup operations and reloads it.
+    /// </summary>
+    /// <param name="folderPath">Directory to create the file in.</param>
+    /// <param name="openWord">Opens Word when <c>true</c>.</param>
     public static void CleanupDocuments_Sample02(string folderPath, bool openWord) {
         string filePath = System.IO.Path.Combine(folderPath, "SimpleWordDocumentReadyToCleanup1.docx");
         using (WordDocument document = WordDocument.Create(filePath)) {

--- a/OfficeIMO.Examples/Word/SaveToStream/StreamCreateInProvidedStream.cs
+++ b/OfficeIMO.Examples/Word/SaveToStream/StreamCreateInProvidedStream.cs
@@ -3,7 +3,15 @@ using System.IO;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
+    /// <summary>
+    /// Examples for creating documents directly in provided streams.
+    /// </summary>
     internal static partial class SaveToStream {
+        /// <summary>
+        /// Creates a document in a <see cref="MemoryStream"/> and saves it to disk.
+        /// </summary>
+        /// <param name="folderPath">Directory to store the file.</param>
+        /// <param name="openWord">Opens Word when <c>true</c>.</param>
         public static void Example_CreateInProvidedStream(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating document directly in a memory stream");
             using var stream = new MemoryStream();
@@ -20,6 +28,11 @@ namespace OfficeIMO.Examples.Word {
             Helpers.Open(filePath, openWord);
         }
 
+        /// <summary>
+        /// Creates a document using a provided <see cref="FileStream"/>.
+        /// </summary>
+        /// <param name="folderPath">Directory to store the file.</param>
+        /// <param name="openWord">Opens Word when <c>true</c>.</param>
         public static void Example_CreateInProvidedStreamAdvanced(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating document using a FileStream");
             string filePath = Path.Combine(folderPath, "CreateInFileStream.docx");

--- a/OfficeIMO.Examples/Word/SaveToStream/StreamDocumentProperties.Create.cs
+++ b/OfficeIMO.Examples/Word/SaveToStream/StreamDocumentProperties.Create.cs
@@ -4,7 +4,15 @@ using OfficeIMO.Word;
 using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Examples.Word {
+    /// <summary>
+    /// Examples for creating documents in a stream and setting properties.
+    /// </summary>
     internal static partial class SaveToStream {
+        /// <summary>
+        /// Creates a document in memory, populates properties and writes it to disk.
+        /// </summary>
+        /// <param name="folderPath">Directory to store the file.</param>
+        /// <param name="openWord">Opens Word when <c>true</c>.</param>
         public static void Example_StreamDocumentProperties(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating document and saving to stream");
             string filePath = System.IO.Path.Combine(folderPath, "StreamDocumentProperties.docx");

--- a/OfficeIMO.Examples/Word/SaveToStream/StreamSaveAsByteArray.cs
+++ b/OfficeIMO.Examples/Word/SaveToStream/StreamSaveAsByteArray.cs
@@ -3,7 +3,15 @@ using System.IO;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
+    /// <summary>
+    /// Demonstrates saving documents directly to various stream types.
+    /// </summary>
     internal static partial class SaveToStream {
+        /// <summary>
+        /// Saves a document to a byte array and writes it to disk.
+        /// </summary>
+        /// <param name="folderPath">Directory to store the file.</param>
+        /// <param name="openWord">Opens Word when <c>true</c>.</param>
         public static void Example_SaveAsByteArray(string folderPath, bool openWord) {
             Console.WriteLine("[*] Saving document as a byte array");
             byte[] bytes;
@@ -17,6 +25,11 @@ namespace OfficeIMO.Examples.Word {
             Helpers.Open(filePath, openWord);
         }
 
+        /// <summary>
+        /// Saves a document to a <see cref="MemoryStream"/> and writes it to disk.
+        /// </summary>
+        /// <param name="folderPath">Directory to store the file.</param>
+        /// <param name="openWord">Opens Word when <c>true</c>.</param>
         public static void Example_SaveAsMemoryStream(string folderPath, bool openWord) {
             Console.WriteLine("[*] Saving document to a MemoryStream");
             using var document = WordDocument.Create();
@@ -31,6 +44,11 @@ namespace OfficeIMO.Examples.Word {
             Helpers.Open(filePath, openWord);
         }
 
+        /// <summary>
+        /// Clones a document into a provided <see cref="Stream"/> instance.
+        /// </summary>
+        /// <param name="folderPath">Directory to store the file.</param>
+        /// <param name="openWord">Opens Word when <c>true</c>.</param>
         public static void Example_SaveAsStream(string folderPath, bool openWord) {
             Console.WriteLine("[*] Cloning document into a provided stream");
             using var document = WordDocument.Create();

--- a/OfficeIMO.Examples/Word/XmlSerialization/XmlSerialization.Advanced.cs
+++ b/OfficeIMO.Examples/Word/XmlSerialization/XmlSerialization.Advanced.cs
@@ -3,7 +3,15 @@ using System.IO;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
+    /// <summary>
+    /// Example showcasing advanced XML serialization and editing.
+    /// </summary>
     internal static partial class XmlSerialization {
+        /// <summary>
+        /// Creates a document, exports a paragraph to XML, edits it and imports it back.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the file.</param>
+        /// <param name="openWord">Opens Word when <c>true</c>.</param>
         public static void Example_XmlSerializationAdvanced(string folderPath, bool openWord) {
             Console.WriteLine("[*] Demonstrating advanced XML manipulation");
             string filePath = Path.Combine(folderPath, "XmlSerializationAdvanced.docx");

--- a/OfficeIMO.Examples/Word/XmlSerialization/XmlSerialization.Basic.cs
+++ b/OfficeIMO.Examples/Word/XmlSerialization/XmlSerialization.Basic.cs
@@ -3,7 +3,15 @@ using System.IO;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
+    /// <summary>
+    /// Provides simple XML serialization examples.
+    /// </summary>
     internal static partial class XmlSerialization {
+        /// <summary>
+        /// Saves a paragraph to XML and re-inserts it into the document.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the file.</param>
+        /// <param name="openWord">Opens Word when <c>true</c>.</param>
         public static void Example_XmlSerializationBasic(string folderPath, bool openWord) {
             Console.WriteLine("[*] Demonstrating basic XML serialization");
             string filePath = Path.Combine(folderPath, "XmlSerializationBasic.docx");

--- a/OfficeIMO.Tests/Word.AddEmbeddedFragmentAfter.cs
+++ b/OfficeIMO.Tests/Word.AddEmbeddedFragmentAfter.cs
@@ -4,7 +4,13 @@ using Xunit;
 using System.IO;
 
 namespace OfficeIMO.Tests {
+    /// <summary>
+    /// Tests related to inserting HTML fragments after a paragraph.
+    /// </summary>
     public partial class Word {
+        /// <summary>
+        /// Adds an HTML fragment after an existing paragraph.
+        /// </summary>
         [Fact]
         public void Test_AddEmbeddedFragmentAfter() {
             string filePath = Path.Combine(_directoryWithFiles, "FragmentAfter.docx");

--- a/OfficeIMO.Tests/Word.CustomDocumentProperties.cs
+++ b/OfficeIMO.Tests/Word.CustomDocumentProperties.cs
@@ -4,7 +4,13 @@ using OfficeIMO.Word;
 using Xunit;
 
 namespace OfficeIMO.Tests {
+    /// <summary>
+    /// Tests related to custom document properties.
+    /// </summary>
     public partial class Word {
+        /// <summary>
+        /// Creates a document with custom properties and verifies values.
+        /// </summary>
         [Fact]
         public void Test_SimpleWordDocumentCreationWithCustomProperties() {
             string filePath = Path.Combine(_directoryWithFiles, "SimpleWordDocumentCreationWithProperties.docx");

--- a/OfficeIMO.Tests/Word.FootnoteEndnoteProperties.cs
+++ b/OfficeIMO.Tests/Word.FootnoteEndnoteProperties.cs
@@ -4,7 +4,13 @@ using OfficeIMO.Word;
 using Xunit;
 
 namespace OfficeIMO.Tests {
+    /// <summary>
+    /// Tests configuring footnote and endnote properties.
+    /// </summary>
     public partial class Word {
+        /// <summary>
+        /// Creates a document, sets footnote and endnote options, and reloads it.
+        /// </summary>
         [Fact]
         public void Test_FootnoteEndnotePropertiesRoundtrip() {
             string filePath = Path.Combine(_directoryWithFiles, "FootnoteEndnoteProperties.docx");

--- a/OfficeIMO.Tests/Word.Indentation.cs
+++ b/OfficeIMO.Tests/Word.Indentation.cs
@@ -3,7 +3,13 @@ using OfficeIMO.Word;
 using Xunit;
 
 namespace OfficeIMO.Tests {
+    /// <summary>
+    /// Tests paragraph indentation helpers.
+    /// </summary>
     public partial class Word {
+        /// <summary>
+        /// Validates indentation values set in points.
+        /// </summary>
         [Fact]
         public void Test_ParagraphIndentationPoints() {
             string filePath = Path.Combine(_directoryWithFiles, "DocumentWithIndentationPoints.docx");

--- a/OfficeIMO.Tests/Word.LineSpacing.cs
+++ b/OfficeIMO.Tests/Word.LineSpacing.cs
@@ -8,7 +8,13 @@ using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Tests;
 
+/// <summary>
+/// Tests adjusting line spacing settings on paragraphs.
+/// </summary>
 public partial class Word {
+    /// <summary>
+    /// Creates a document and verifies various line spacing options.
+    /// </summary>
     [Fact]
     public void Test_CreatingWordDocumentWithLineRules() {
         var filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithLineRules.docx");

--- a/OfficeIMO.Tests/Word.ListItemsEnumerator.cs
+++ b/OfficeIMO.Tests/Word.ListItemsEnumerator.cs
@@ -5,7 +5,13 @@ using OfficeIMO.Word;
 using Xunit;
 
 namespace OfficeIMO.Tests {
+    /// <summary>
+    /// Tests enumerating list items across different document parts.
+    /// </summary>
     public partial class Word {
+        /// <summary>
+        /// Creates lists in body, tables, headers and footers and enumerates them.
+        /// </summary>
         [Fact]
         public void Test_ListItemsFromBodyTablesHeadersFooters() {
             var filePath = Path.Combine(_directoryWithFiles, "ListItemsEnumerator.docx");

--- a/OfficeIMO.Tests/Word.Tables.Margins.cs
+++ b/OfficeIMO.Tests/Word.Tables.Margins.cs
@@ -6,7 +6,13 @@ using Color = SixLabors.ImageSharp.Color;
 using Xunit;
 
 namespace OfficeIMO.Tests {
+    /// <summary>
+    /// Tests table margin properties defined in centimeters.
+    /// </summary>
     public partial class Word {
+        /// <summary>
+        /// Verifies correct handling of table margins specified in centimeters.
+        /// </summary>
         [Fact]
         public void Test_TableMarginsWithCentimeters() {
             string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithTableMargins.docx");

--- a/OfficeIMO.Tests/Word.TablesBeforeAfter.cs
+++ b/OfficeIMO.Tests/Word.TablesBeforeAfter.cs
@@ -6,7 +6,13 @@ using Color = SixLabors.ImageSharp.Color;
 using Xunit;
 
 namespace OfficeIMO.Tests {
+    /// <summary>
+    /// Tests adding tables before and after paragraphs.
+    /// </summary>
     public partial class Word {
+        /// <summary>
+        /// Creates a document with tables inserted before and after content.
+        /// </summary>
         [Fact]
         public void Test_CreatingWordDocumentWithTablesAfterBefore() {
             string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithTablesAfterBefore.docx");


### PR DESCRIPTION
## Summary
- add missing XML comments for test classes and methods
- document sample methods in example projects

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_686b924dadd0832e953adb27f712104c