### PR TITLE
I/O improvements

### DIFF
--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1496,14 +1496,6 @@ namespace OfficeIMO.Word {
                     throw new IOException($"Failed to save to '{filePath}'. The file is read-only.");
                 }
 
-                var directory = Path.GetDirectoryName(Path.GetFullPath(filePath));
-                if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory)) {
-                    var dirInfo = new DirectoryInfo(directory);
-                    if (dirInfo.Attributes.HasFlag(FileAttributes.ReadOnly)) {
-                        throw new IOException($"Failed to save to '{filePath}'. The directory is read-only.");
-                    }
-                }
-
                 using var fs = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite);
                 using (var clone = _wordprocessingDocument.Clone(fs)) {
                     CopyPackageProperties(_wordprocessingDocument.PackageProperties, clone.PackageProperties);


### PR DESCRIPTION
This library is very useful but I have had some odd I/O issues:

1. An exception saying the folder is read-only is thrown when saving with this code, even on Desktop:

```cs
using (var document = WordDocument.Create(filePath, WordprocessingDocumentType.Document, true))
{
    document.Save();
}
```

It works properly when using a FileStream to the same path.  
After investigating more, it seems that most folders on my system (and this has been reported frequently on the internet for Windows 8.1-11) are marked as mixed read-only like this: 

<img width="452" height="103" alt="Immagine 2025-07-19 124719" src="https://github.com/user-attachments/assets/3e07fe4b-d328-47fc-9e5a-5a92cf51f876" />

This does not prevent applications from creating files in the folder, it only means some files are read-only. Even if it was a full tick sign, new files are created as not read-only in Explorer because the attribute is not relevant for the folder itself.  
I think manual checks for the read-only attribute should be removed, leaving the underlying .NET IO APIs to deal with this.

2. When using a stream (either for loading or creating) the Save method as shown above does not work and the stream must be specified as argument. This can be confusing given that it's not consistent with the file paths behavior, so I changed the logic to keep track of the original stream.  

