### PR TITLE
Add example and test for saving to original stream

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -236,6 +236,7 @@ namespace OfficeIMO.Examples {
             SaveToStream.Example_StreamDocumentProperties(folderPath, false);
             SaveToStream.Example_CreateInProvidedStream(folderPath, false);
             SaveToStream.Example_CreateInProvidedStreamAdvanced(folderPath, false);
+            SaveToStream.Example_SaveToOriginalStream(folderPath, false);
 
             Protect.Example_FinalDocument(folderPath, false);
             Protect.Example_ReadOnlyEnforced(folderPath, false);

--- a/OfficeIMO.Examples/Word/SaveToStream/StreamSaveToOriginalStream.cs
+++ b/OfficeIMO.Examples/Word/SaveToStream/StreamSaveToOriginalStream.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    /// <summary>
+    /// Demonstrates saving back to the original stream when no file path is provided.
+    /// </summary>
+    internal static partial class SaveToStream {
+        public static void Example_SaveToOriginalStream(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Saving document back to the original stream");
+            using var stream = new MemoryStream();
+            using (var document = WordDocument.Create(stream)) {
+                document.AddParagraph("Stream paragraph");
+                document.Save();
+            }
+
+            string filePath = Path.Combine(folderPath, "SaveToOriginalStream.docx");
+            using (var file = new FileStream(filePath, FileMode.Create, FileAccess.Write)) {
+                stream.Position = 0;
+                stream.CopyTo(file);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Save.cs
+++ b/OfficeIMO.Tests/Word.Save.cs
@@ -224,6 +224,24 @@ namespace OfficeIMO.Tests {
             var paragraph = Assert.Single(loadedDoc.Paragraphs);
             Assert.Equal("Stream paragraph", paragraph.Text);
         }
+
+        [Fact]
+        public void Test_SaveWithoutFilePath_UsesOriginalStream() {
+            using var stream = new MemoryStream();
+            using (var document = WordDocument.Create(stream)) {
+                document.AddParagraph("Hello original stream");
+                document.Save();
+            }
+
+            using (var openXmlDoc = WordprocessingDocument.Open(stream, false)) {
+                Assert.NotNull(openXmlDoc.MainDocumentPart);
+            }
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using var loadedDoc = WordDocument.Load(stream);
+            var paragraph = Assert.Single(loadedDoc.Paragraphs);
+            Assert.Equal("Hello original stream", paragraph.Text);
+        }
        
         [Fact]
         public void Test_SaveReadOnlyDocument_ThrowsInvalidOperationException() {


### PR DESCRIPTION
## Summary
- add `Example_SaveToOriginalStream` in examples demonstrating saving a document back to its stream
- call the new example from the main program
- test that `WordDocument.Save()` writes back to the original stream when no file path is specified

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687d171df654832ebddad4409a39044c