### PR TITLE
Implement TrackChanges settings

### DIFF
--- a/OfficeIMO.Examples/Word/Revisions/Revisions.Example2.cs
+++ b/OfficeIMO.Examples/Word/Revisions/Revisions.Example2.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Revisions {
+        internal static void Example_TrackChangesToggle(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Demonstrating TrackChanges toggle");
+            string filePath = Path.Combine(folderPath, "TrackChangesToggle.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.TrackChanges = true;
+                document.AddParagraph("Tracking enabled");
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                document.TrackChanges = false;
+                document.AddParagraph("Tracking disabled");
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.TrackChanges.cs
+++ b/OfficeIMO.Tests/Word.TrackChanges.cs
@@ -1,0 +1,28 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_TrackChangesToggle() {
+            string filePath = Path.Combine(_directoryWithFiles, "Test_TrackChanges.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.TrackChanges = true;
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.True(document.TrackChanges);
+                Assert.True(document.Settings.TrackFormatting);
+                Assert.True(document.Settings.TrackMoves);
+                document.TrackChanges = false;
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.False(document.TrackChanges);
+                Assert.False(document.Settings.TrackFormatting);
+                Assert.False(document.Settings.TrackMoves);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -531,6 +531,18 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Enable or disable tracking of all revisions, moves and formatting changes.
+        /// </summary>
+        public bool TrackChanges {
+            get => this.Settings.TrackRevisions;
+            set {
+                this.Settings.TrackRevisions = value;
+                this.Settings.TrackFormatting = value;
+                this.Settings.TrackMoves = value;
+            }
+        }
+
+        /// <summary>
         /// Gets the lists in the document
         /// </summary>
         /// <value>

--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -596,9 +596,9 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
-        /// Enable or disable tracking of comments in the document.
+        /// Enable or disable tracking of revisions in the document.
         /// </summary>
-        public bool TrackComments {
+        public bool TrackRevisions {
             get {
                 var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
                 return settings.GetFirstChild<TrackRevisions>() != null;
@@ -612,6 +612,53 @@ namespace OfficeIMO.Word {
                     }
                 } else {
                     track?.Remove();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Enable or disable tracking of comments in the document.
+        /// Wrapper around <see cref="TrackRevisions"/> for backwards compatibility.
+        /// </summary>
+        public bool TrackComments {
+            get => TrackRevisions;
+            set => TrackRevisions = value;
+        }
+
+        /// <summary>
+        /// Enable or disable tracking of formatting changes.
+        /// </summary>
+        public bool TrackFormatting {
+            get {
+                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                return settings.GetFirstChild<DoNotTrackFormatting>() == null;
+            }
+            set {
+                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                var formatting = settings.GetFirstChild<DoNotTrackFormatting>();
+                if (value) {
+                    formatting?.Remove();
+                } else if (formatting == null) {
+                    settings.Append(new DoNotTrackFormatting());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Enable or disable tracking of move operations.
+        /// </summary>
+        public bool TrackMoves {
+            get {
+                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                return settings.GetFirstChild<DoNotTrackMoves>() == null;
+            }
+            set {
+                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                var moves = settings.GetFirstChild<DoNotTrackMoves>();
+                if (value) {
+                    moves?.Remove();
+                } else if (moves == null) {
+                    settings.Append(new DoNotTrackMoves());
                 }
             }
         }


### PR DESCRIPTION
## Summary
- expose `TrackRevisions`, `TrackFormatting`, and `TrackMoves` in `WordSettings`
- wrap them through new `WordDocument.TrackChanges` property
- add example for toggling track changes
- test persisting track changes across save/load

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeImo.sln --no-build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687d288c6188832e98fa74996b4f39f8