### PR TITLE
Add font embedding support

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -22,6 +22,10 @@ namespace OfficeIMO.Examples {
             BasicDocument.Example_BasicWordWithBreaks(folderPath, false);
             BasicDocument.Example_BasicWordWithDefaultStyleChange(folderPath, false);
             BasicDocument.Example_BasicWordWithDefaultFontChange(folderPath, false);
+            Fonts.Example_EmbedFont(templatesPath, folderPath, false);
+            Fonts.Example_EmbeddedAndBuiltinFonts(templatesPath, folderPath, false);
+            Fonts.Example_EmbeddedFontStyle(templatesPath, folderPath, false);
+            Fonts.Example_EmbedFontWithStyle(templatesPath, folderPath, false);
             BasicDocument.Example_BasicLoadHamlet(templatesPath, folderPath, false);
             BasicDocument.Example_BasicWordWithPolishChars(folderPath, false);
             BasicDocument.Example_BasicWordWithNewLines(folderPath, false);

--- a/OfficeIMO.Examples/Word/Fonts/Fonts.EmbedFont.cs
+++ b/OfficeIMO.Examples/Word/Fonts/Fonts.EmbedFont.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Fonts {
+        public static void Example_EmbedFont(string templatesPath, string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with embedded font");
+            string filePath = Path.Combine(folderPath, "DocumentWithEmbeddedFont.docx");
+            string fontPath = Path.Combine(templatesPath, "DejaVuSans.ttf");
+            if (!File.Exists(fontPath)) {
+                Console.WriteLine($"Font file not found: {fontPath}");
+                return;
+            }
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("This document uses an embedded font.");
+                document.EmbedFont(fontPath);
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Fonts/Fonts.EmbedFontQuickStyle.cs
+++ b/OfficeIMO.Examples/Word/Fonts/Fonts.EmbedFontQuickStyle.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Fonts {
+        public static void Example_EmbedFontWithStyle(string templatesPath, string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with embedded font and auto style");
+            string filePath = Path.Combine(folderPath, "DocumentEmbeddedFontAutoStyle.docx");
+            string fontPath = Path.Combine(templatesPath, "DejaVuSans.ttf");
+            if (!File.Exists(fontPath)) {
+                Console.WriteLine($"Font file not found: {fontPath}");
+                return;
+            }
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.EmbedFont(fontPath, "DejaVuStyle", "DejaVu Style");
+
+                document.AddParagraph("Paragraph using registered style").SetStyleId("DejaVuStyle");
+                document.AddParagraph("Fallback paragraph");
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Fonts/Fonts.EmbeddedFontStyles.cs
+++ b/OfficeIMO.Examples/Word/Fonts/Fonts.EmbeddedFontStyles.cs
@@ -1,0 +1,34 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Fonts {
+        public static void Example_EmbeddedFontStyle(string templatesPath, string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document using embedded font in a custom style");
+            string filePath = Path.Combine(folderPath, "DocumentEmbeddedFontStyle.docx");
+            string fontPath = Path.Combine(templatesPath, "DejaVuSans.ttf");
+            if (!File.Exists(fontPath)) {
+                Console.WriteLine($"Font file not found: {fontPath}");
+                return;
+            }
+
+            var style = new Style { Type = StyleValues.Paragraph, StyleId = "EmbeddedStyle" };
+            style.Append(new StyleName { Val = "EmbeddedStyle" });
+            var runProps = new StyleRunProperties();
+            runProps.Append(new RunFonts { Ascii = "DejaVu Sans" });
+            style.Append(runProps);
+            WordParagraphStyle.RegisterCustomStyle("EmbeddedStyle", style);
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.EmbedFont(fontPath);
+
+                document.AddParagraph("Paragraph using custom embedded style").SetStyleId("EmbeddedStyle");
+                document.AddParagraph("Paragraph using builtin Times New Roman").SetFontFamily("Times New Roman");
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Fonts/Fonts.MixedFonts.cs
+++ b/OfficeIMO.Examples/Word/Fonts/Fonts.MixedFonts.cs
@@ -1,0 +1,34 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Fonts {
+        public static void Example_EmbeddedAndBuiltinFonts(string templatesPath, string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document mixing builtin and embedded fonts");
+            string filePath = Path.Combine(folderPath, "DocumentMixedFonts.docx");
+            string fontPath = Path.Combine(templatesPath, "DejaVuSans.ttf");
+            if (!File.Exists(fontPath)) {
+                Console.WriteLine($"Font file not found: {fontPath}");
+                return;
+            }
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.EmbedFont(fontPath);
+
+                document.AddParagraph("Paragraph in builtin Arial font.")
+                    .SetFontFamily("Arial");
+
+                document.AddParagraph("Paragraph in embedded DejaVu Sans font.")
+                    .SetFontFamily("DejaVu Sans");
+
+                var paragraph = document.AddParagraph("Mix of builtin and embedded fonts within one paragraph: ");
+                paragraph.AddText("Arial text, ").SetFontFamily("Arial");
+                paragraph.AddText("DejaVu text").SetFontFamily("DejaVu Sans");
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.FontEmbedding.cs
+++ b/OfficeIMO.Tests/Word.FontEmbedding.cs
@@ -1,0 +1,45 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_EmbeddedFontPresent() {
+            string fontPath = Path.Combine(_directoryWithFiles, "DummyFont.ttf");
+            File.WriteAllText(fontPath, "dummy");
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithEmbeddedFont.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Test");
+                document.EmbedFont(fontPath);
+                document.Save();
+            }
+
+            using var word = WordprocessingDocument.Open(filePath, false);
+            var fontTablePart = word.MainDocumentPart.FontTablePart;
+            Assert.NotNull(fontTablePart);
+            Assert.True(fontTablePart.FontParts.Any());
+            File.Delete(fontPath);
+        }
+
+        [Fact]
+        public void Test_EmbedFontWithStyleRegistersStyle() {
+            string fontPath = Path.Combine(_directoryWithFiles, "DummyFont.ttf");
+            File.WriteAllText(fontPath, "dummy");
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithFontStyle.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.EmbedFont(fontPath, "DejaVuStyle", "DejaVu Style");
+                document.AddParagraph("Test").SetStyleId("DejaVuStyle");
+                document.Save();
+            }
+
+            using var word = WordprocessingDocument.Open(filePath, false);
+            var styles = word.MainDocumentPart.StyleDefinitionsPart!.Styles;
+            Assert.NotNull(styles.Elements<Style>().FirstOrDefault(s => s.StyleId == "DejaVuStyle"));
+            File.Delete(fontPath);
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.Fonts.cs
+++ b/OfficeIMO.Word/WordDocument.Fonts.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word {
+    public partial class WordDocument {
+        /// <summary>
+        /// Embeds a font into the document.
+        /// </summary>
+        /// <param name="fontPath">Path to a TrueType/OpenType font file.</param>
+        public void EmbedFont(string fontPath) {
+            if (string.IsNullOrEmpty(fontPath)) throw new ArgumentNullException(nameof(fontPath));
+            if (!File.Exists(fontPath)) throw new FileNotFoundException("Font file not found", fontPath);
+
+            var mainPart = _wordprocessingDocument.MainDocumentPart;
+            var fontTablePart = mainPart.FontTablePart ?? mainPart.AddNewPart<FontTablePart>();
+            fontTablePart.Fonts ??= new Fonts();
+
+            var fontName = Path.GetFileNameWithoutExtension(fontPath);
+            var fontPart = fontTablePart.AddFontPart(FontPartType.FontTtf);
+            using (var fs = File.OpenRead(fontPath)) {
+                fontPart.FeedData(fs);
+            }
+            var relId = fontTablePart.GetIdOfPart(fontPart);
+
+            var font = fontTablePart.Fonts.Elements<Font>().FirstOrDefault(f => string.Equals(f.Name.Value, fontName, StringComparison.OrdinalIgnoreCase));
+            if (font == null) {
+                font = new Font { Name = fontName };
+                fontTablePart.Fonts.Append(font);
+            }
+
+            font.EmbedRegularFont = new EmbedRegularFont { Id = relId };
+        }
+
+        /// <summary>
+        /// Embeds a font and registers a paragraph style using that font.
+        /// </summary>
+        /// <param name="fontPath">Path to a TrueType/OpenType font file.</param>
+        /// <param name="styleId">Style identifier to register.</param>
+        /// <param name="styleName">Optional friendly name for the style.</param>
+        public void EmbedFont(string fontPath, string styleId, string styleName = null) {
+            EmbedFont(fontPath);
+            var fontName = Path.GetFileNameWithoutExtension(fontPath);
+            WordParagraphStyle.RegisterFontStyle(styleId, fontName, styleName);
+            var stylePart = _wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart;
+            if (stylePart != null) {
+                AddStyleDefinitions(stylePart, overrideExisting: false);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordParagraphStyle.cs
+++ b/OfficeIMO.Word/WordParagraphStyle.cs
@@ -78,6 +78,33 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Creates a simple paragraph style that uses the specified font and returns it.
+        /// </summary>
+        /// <param name="styleId">Identifier of the style.</param>
+        /// <param name="fontName">Font family to apply to runs.</param>
+        /// <param name="styleName">Optional friendly style name.</param>
+        /// <returns>The created style.</returns>
+        public static Style CreateFontStyle(string styleId, string fontName, string styleName = null) {
+            if (string.IsNullOrWhiteSpace(styleId)) throw new ArgumentException("StyleId cannot be empty", nameof(styleId));
+            if (string.IsNullOrWhiteSpace(fontName)) throw new ArgumentException("Font name cannot be empty", nameof(fontName));
+
+            var style = new Style { Type = StyleValues.Paragraph, StyleId = styleId };
+            style.Append(new StyleName { Val = styleName ?? styleId });
+            var runProps = new StyleRunProperties();
+            runProps.Append(new RunFonts { Ascii = fontName, HighAnsi = fontName, ComplexScript = fontName, EastAsia = fontName });
+            style.Append(runProps);
+            return style;
+        }
+
+        /// <summary>
+        /// Registers a paragraph style that applies the specified font to all runs.
+        /// </summary>
+        public static void RegisterFontStyle(string styleId, string fontName, string styleName = null) {
+            var style = CreateFontStyle(styleId, fontName, styleName);
+            RegisterCustomStyle(styleId, style);
+        }
+
+        /// <summary>
         /// Replaces a built-in style definition with a custom one.
         /// </summary>
         public static void OverrideBuiltInStyle(WordParagraphStyles style, Style styleDefinition) {


### PR DESCRIPTION
## Summary
- implement `CreateFontStyle` and `RegisterFontStyle` helpers
- overload `EmbedFont` to create a style while embedding
- provide quick style example using the new API
- test style registration when embedding fonts
- document automatic style registration
- remove binary font assets and create dummy fonts during tests
- skip examples if the font file is missing

## Testing
- `dotnet test OfficeImo.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687d29ffb6a4832e954a7f6b37cd8a0d