### PR TITLE
Add multi-column conditional formatting rules

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -103,6 +103,8 @@ namespace OfficeIMO.Examples {
             Tables.Example_CloneTable(folderPath, false);
             Tables.Example_SplitVertically(folderPath, false);
             Tables.Example_SplitHorizontally(folderPath, false);
+            Tables.Example_ConditionalFormattingValues(folderPath, false);
+            Tables.Example_ConditionalFormattingAdvanced(folderPath, false);
             PageSettings.Example_BasicSettings(folderPath, false);
             PageSettings.Example_PageOrientation(folderPath, false);
 

--- a/OfficeIMO.Examples/Word/Tables/Tables.Create12-ConditionalFormattingValues.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.Create12-ConditionalFormattingValues.cs
@@ -1,0 +1,45 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Tables {
+        internal static void Example_ConditionalFormattingValues(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating table with conditional formatting based on cell values");
+            string filePath = System.IO.Path.Combine(folderPath, "ConditionalFormattingValues.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(3, 2, WordTableStyle.PlainTable1);
+                table.Rows[0].Cells[0].Paragraphs[0].Text = "Name";
+                table.Rows[0].Cells[1].Paragraphs[0].Text = "Status";
+
+                table.Rows[1].Cells[0].Paragraphs[0].Text = "Task1";
+                table.Rows[1].Cells[1].Paragraphs[0].Text = "Done";
+                table.Rows[2].Cells[0].Paragraphs[0].Text = "Task2";
+                table.Rows[2].Cells[1].Paragraphs[0].Text = "Pending";
+
+                table.ConditionalFormatting(
+                    "Status",
+                    "Done",
+                    TextMatchType.Equals,
+                    matchFillColorHex: "92d050",
+                    noMatchFillColorHex: "ff0000",
+                    matchTextFormat: p => p.SetBold(),
+                    noMatchTextFormat: p => p.SetUnderline(UnderlineValues.Single));
+
+                table.ConditionalFormatting(
+                    new[] {
+                        ("Status", "Done", TextMatchType.Equals),
+                        ("Name", "Task1", TextMatchType.StartsWith)
+                    },
+                    matchAll: true,
+                    matchFillColorHex: "92d050",
+                    noMatchFillColorHex: "ff0000",
+                    highlightColumns: new[] { "Name" },
+                    matchTextFormat: p => p.SetBold(),
+                    noMatchTextFormat: p => p.SetUnderline(UnderlineValues.Single));
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Tables/Tables.Create13-ConditionalFormattingAdvanced.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.Create13-ConditionalFormattingAdvanced.cs
@@ -1,0 +1,73 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Color = SixLabors.ImageSharp.Color;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Tables {
+        internal static void Example_ConditionalFormattingAdvanced(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating table with advanced conditional formatting");
+            string filePath = System.IO.Path.Combine(folderPath, "ConditionalFormattingAdvanced.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(5, 2, WordTableStyle.PlainTable1);
+                table.Rows[0].Cells[0].Paragraphs[0].Text = "Name";
+                table.Rows[0].Cells[1].Paragraphs[0].Text = "Status";
+
+                table.Rows[1].Cells[0].Paragraphs[0].Text = "Task1";
+                table.Rows[1].Cells[1].Paragraphs[0].Text = "Done";
+
+                table.Rows[2].Cells[0].Paragraphs[0].Text = "Task2";
+                table.Rows[2].Cells[1].Paragraphs[0].Text = "Pending";
+
+                table.Rows[3].Cells[0].Paragraphs[0].Text = "Task3";
+                table.Rows[3].Cells[1].Paragraphs[0].Text = "Skipped";
+
+                table.Rows[4].Cells[0].Paragraphs[0].Text = "Task4";
+                table.Rows[4].Cells[1].Paragraphs[0].Text = "Done";
+
+                var builder = table.BeginConditionalFormatting();
+
+                // rule 1: mark done tasks green else red and format text
+                builder.AddRule(
+                    "Status",
+                    "Done",
+                    TextMatchType.Equals,
+                    Color.LightGreen,
+                    Color.Black,
+                    Color.LightPink,
+                    Color.Black,
+                    highlightColumns: new[] { "Name" },
+                    matchTextFormat: p => p.SetBold(),
+                    noMatchTextFormat: p => p.SetUnderline(UnderlineValues.Single));
+
+                // rule 2: highlight pending tasks using a color object
+                builder.AddRule(
+                    "Status",
+                    "Pending",
+                    TextMatchType.Equals,
+                    Color.Yellow,
+                    null,
+                    highlightColumns: new[] { "Name" },
+                    matchTextFormat: p => p.SetItalic());
+
+                // rule 3: highlight row when task is done and name starts with Task4
+                builder.AddRule(
+                    new[] {
+                        ("Status", "Done", TextMatchType.Equals),
+                        ("Name", "Task4", TextMatchType.StartsWith)
+                    },
+                    matchAll: true,
+                    Color.LightSkyBlue,
+                    highlightColumns: new[] { "Name" },
+                    matchTextFormat: p => {
+                        p.SetBold();
+                        p.SetUnderline(UnderlineValues.Single);
+                    });
+
+                builder.Apply();
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.ConditionalFormatting.cs
+++ b/OfficeIMO.Tests/Word.ConditionalFormatting.cs
@@ -1,0 +1,124 @@
+using System.IO;
+using OfficeIMO.Word;
+using Color = SixLabors.ImageSharp.Color;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_TableConditionalFormatting() {
+            string filePath = Path.Combine(_directoryWithFiles, "ConditionalFormatting.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(3, 2);
+                table.Rows[0].Cells[0].Paragraphs[0].Text = "Name";
+                table.Rows[0].Cells[1].Paragraphs[0].Text = "Status";
+
+                table.Rows[1].Cells[0].Paragraphs[0].Text = "Task1";
+                table.Rows[1].Cells[1].Paragraphs[0].Text = "Done";
+                table.Rows[2].Cells[0].Paragraphs[0].Text = "Task2";
+                table.Rows[2].Cells[1].Paragraphs[0].Text = "Pending";
+
+                table.ConditionalFormatting(
+                    "Status",
+                    "Done",
+                    TextMatchType.Equals,
+                    matchFillColorHex: "92d050",
+                    noMatchFillColorHex: "ff0000",
+                    matchTextFormat: p => p.SetBold(),
+                    noMatchTextFormat: p => p.SetUnderline(UnderlineValues.Single));
+
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                WordTable table = document.Tables[0];
+                Assert.Equal("92d050", table.Rows[1].Cells[1].ShadingFillColorHex);
+                Assert.Equal("ff0000", table.Rows[2].Cells[1].ShadingFillColorHex);
+                Assert.True(table.Rows[1].Cells[1].Paragraphs[0].Bold);
+                Assert.Equal(UnderlineValues.Single, table.Rows[2].Cells[1].Paragraphs[0].Underline);
+            }
+        }
+
+        [Fact]
+        public void Test_TableConditionalFormattingAdvanced() {
+            string filePath = Path.Combine(_directoryWithFiles, "ConditionalFormattingAdvanced.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(5, 2);
+                table.Rows[0].Cells[0].Paragraphs[0].Text = "Name";
+                table.Rows[0].Cells[1].Paragraphs[0].Text = "Status";
+
+                table.Rows[1].Cells[0].Paragraphs[0].Text = "Task1";
+                table.Rows[1].Cells[1].Paragraphs[0].Text = "Done";
+
+                table.Rows[2].Cells[0].Paragraphs[0].Text = "Task2";
+                table.Rows[2].Cells[1].Paragraphs[0].Text = "Pending";
+
+                table.Rows[3].Cells[0].Paragraphs[0].Text = "Task3";
+                table.Rows[3].Cells[1].Paragraphs[0].Text = "Skipped";
+
+                table.Rows[4].Cells[0].Paragraphs[0].Text = "Task4";
+                table.Rows[4].Cells[1].Paragraphs[0].Text = "Done";
+
+                var builder = table.BeginConditionalFormatting();
+                builder.AddRule(
+                    "Status",
+                    "Done",
+                    TextMatchType.Equals,
+                    Color.LightGreen,
+                    Color.Black,
+                    Color.LightPink,
+                    Color.Black,
+                    highlightColumns: new[] { "Name" },
+                    matchTextFormat: p => p.SetBold(),
+                    noMatchTextFormat: p => p.SetUnderline(UnderlineValues.Single));
+
+                builder.AddRule(
+                    "Status",
+                    "Pending",
+                    TextMatchType.Equals,
+                    Color.Yellow,
+                    null,
+                    highlightColumns: new[] { "Name" },
+                    matchTextFormat: p => p.SetItalic());
+
+                builder.AddRule(
+                    new[] {
+                        ("Status", "Done", TextMatchType.Equals),
+                        ("Name", "Task4", TextMatchType.StartsWith)
+                    },
+                    matchAll: true,
+                    Color.LightSkyBlue,
+                    highlightColumns: new[] { "Name" },
+                    matchTextFormat: p => {
+                        p.SetBold();
+                        p.SetUnderline(UnderlineValues.Single);
+                    });
+
+                builder.Apply();
+
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                WordTable table = document.Tables[0];
+                Assert.Equal("90ee90", table.Rows[1].Cells[1].ShadingFillColorHex);
+                Assert.Equal("ffff00", table.Rows[2].Cells[1].ShadingFillColorHex);
+                Assert.Equal("ffb6c1", table.Rows[3].Cells[1].ShadingFillColorHex);
+                Assert.Equal("90ee90", table.Rows[4].Cells[1].ShadingFillColorHex);
+
+                Assert.Equal("90ee90", table.Rows[1].Cells[0].ShadingFillColorHex);
+                Assert.Equal("ffff00", table.Rows[2].Cells[0].ShadingFillColorHex);
+                Assert.Equal("ffb6c1", table.Rows[3].Cells[0].ShadingFillColorHex);
+                Assert.Equal("87cefa", table.Rows[4].Cells[0].ShadingFillColorHex);
+
+                Assert.True(table.Rows[1].Cells[1].Paragraphs[0].Bold);
+                Assert.True(table.Rows[1].Cells[0].Paragraphs[0].Bold);
+                Assert.True(table.Rows[2].Cells[1].Paragraphs[0].Italic);
+                Assert.Equal(UnderlineValues.Single, table.Rows[3].Cells[1].Paragraphs[0].Underline);
+                Assert.True(table.Rows[4].Cells[0].Paragraphs[0].Bold);
+                Assert.Equal(UnderlineValues.Single, table.Rows[4].Cells[0].Paragraphs[0].Underline);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/Enumerations.cs
+++ b/OfficeIMO.Word/Enumerations.cs
@@ -77,4 +77,29 @@ namespace OfficeIMO.Word {
         Line
     }
 
+    /// <summary>
+    /// Specifies text matching behavior when applying conditional formatting.
+    /// </summary>
+    public enum TextMatchType {
+        /// <summary>
+        /// Text must exactly equal the provided value.
+        /// </summary>
+        Equals,
+
+        /// <summary>
+        /// Text must contain the provided value.
+        /// </summary>
+        Contains,
+
+        /// <summary>
+        /// Text must start with the provided value.
+        /// </summary>
+        StartsWith,
+
+        /// <summary>
+        /// Text must end with the provided value.
+        /// </summary>
+        EndsWith
+    }
+
 }

--- a/OfficeIMO.Word/Helpers.cs
+++ b/OfficeIMO.Word/Helpers.cs
@@ -42,6 +42,27 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Normalizes color input which may be a hex value or a named color.
+        /// Returns a lowercase hex string without '#'.
+        /// </summary>
+        internal static string NormalizeColor(string color) {
+            if (string.IsNullOrEmpty(color)) {
+                return null;
+            }
+
+            try {
+                var parsed = SixLabors.ImageSharp.Color.Parse(color);
+                return parsed.ToHexColor();
+            } catch {
+                if (!color.StartsWith("#")) {
+                    var parsedHex = SixLabors.ImageSharp.Color.Parse("#" + color);
+                    return parsedHex.ToHexColor();
+                }
+                throw;
+            }
+        }
+
+        /// <summary>
         /// Opens up any file using assigned Application
         /// </summary>
         /// <param name="filePath"></param>

--- a/OfficeIMO.Word/WordTable.ConditionalFormatting.cs
+++ b/OfficeIMO.Word/WordTable.ConditionalFormatting.cs
@@ -1,0 +1,383 @@
+using System;
+using System.Linq;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Word {
+    public partial class WordTable {
+        /// <summary>
+        /// Applies conditional formatting to cells based on text contained in a specific column.
+        /// </summary>
+        /// <param name="columnName">Header text of the column to evaluate.</param>
+        /// <param name="matchText">Text to compare against cell content.</param>
+        /// <param name="matchType">Comparison operator.</param>
+        /// <param name="matchFillColorHex">Background color applied when condition is met.</param>
+        /// <param name="matchFontColorHex">Font color applied when condition is met.</param>
+        /// <param name="noMatchFillColorHex">Background color applied when condition is not met.</param>
+        /// <param name="noMatchFontColorHex">Font color applied when condition is not met.</param>
+        /// <param name="ignoreCase">Whether comparison should ignore case.</param>
+        /// <param name="highlightColumns">Additional columns to apply the formatting to.</param>
+        /// <param name="matchTextFormat">Optional action applied to paragraphs when the condition is met.</param>
+        /// <param name="noMatchTextFormat">Optional action applied to paragraphs when the condition is not met.</param>
+        public void ConditionalFormatting(string columnName, string matchText, TextMatchType matchType,
+            string matchFillColorHex = null, string matchFontColorHex = null,
+            string noMatchFillColorHex = null, string noMatchFontColorHex = null,
+            bool ignoreCase = true, System.Collections.Generic.IEnumerable<string> highlightColumns = null,
+            Action<WordParagraph> matchTextFormat = null, Action<WordParagraph> noMatchTextFormat = null) {
+            if (string.IsNullOrEmpty(columnName)) throw new ArgumentException("Column name can't be empty", nameof(columnName));
+            if (matchText == null) matchText = string.Empty;
+
+            matchFillColorHex = Helpers.NormalizeColor(matchFillColorHex);
+            matchFontColorHex = Helpers.NormalizeColor(matchFontColorHex);
+            noMatchFillColorHex = Helpers.NormalizeColor(noMatchFillColorHex);
+            noMatchFontColorHex = Helpers.NormalizeColor(noMatchFontColorHex);
+
+            int headerIndex = -1;
+            System.Collections.Generic.Dictionary<string, int> headerMap = new System.Collections.Generic.Dictionary<string, int>(System.StringComparer.OrdinalIgnoreCase);
+            if (Rows.Count > 0) {
+                var headerRow = Rows[0];
+                for (int i = 0; i < headerRow.CellsCount; i++) {
+                    var text = headerRow.Cells[i].Paragraphs.FirstOrDefault()?.Text ?? string.Empty;
+                    headerMap[text] = i;
+                    if (string.Equals(text, columnName, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal)) {
+                        headerIndex = i;
+                    }
+                }
+            }
+            if (headerIndex == -1) {
+                throw new ArgumentException($"Column '{columnName}' was not found.", nameof(columnName));
+            }
+
+            var highlightIndices = new System.Collections.Generic.HashSet<int> { headerIndex };
+            if (highlightColumns != null) {
+                foreach (var col in highlightColumns) {
+                    if (string.IsNullOrEmpty(col)) continue;
+                    if (headerMap.TryGetValue(col, out int idx)) {
+                        highlightIndices.Add(idx);
+                    }
+                }
+            }
+
+            for (int r = 1; r < Rows.Count; r++) {
+                var cell = Rows[r].Cells[headerIndex];
+                var text = cell.Paragraphs.FirstOrDefault()?.Text ?? string.Empty;
+                bool isMatch = matchType switch {
+                    TextMatchType.Equals => string.Equals(text, matchText, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal),
+                    TextMatchType.Contains => text.IndexOf(matchText, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) >= 0,
+                    TextMatchType.StartsWith => text.StartsWith(matchText, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal),
+                    TextMatchType.EndsWith => text.EndsWith(matchText, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal),
+                    _ => false
+                };
+
+                foreach (int colIndex in highlightIndices) {
+                    var targetCell = Rows[r].Cells[colIndex];
+                    if (isMatch) {
+                        if (!string.IsNullOrEmpty(matchFillColorHex)) {
+                            targetCell.ShadingFillColorHex = matchFillColorHex;
+                        }
+                    } else {
+                        if (!string.IsNullOrEmpty(noMatchFillColorHex)) {
+                            targetCell.ShadingFillColorHex = noMatchFillColorHex;
+                        }
+                    }
+
+                    foreach (var p in targetCell.Paragraphs) {
+                        if (isMatch) {
+                            if (!string.IsNullOrEmpty(matchFontColorHex)) {
+                                p.ColorHex = matchFontColorHex;
+                            }
+                            matchTextFormat?.Invoke(p);
+                        } else {
+                            if (!string.IsNullOrEmpty(noMatchFontColorHex)) {
+                                p.ColorHex = noMatchFontColorHex;
+                            }
+                            noMatchTextFormat?.Invoke(p);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Applies conditional formatting to cells using <see cref="Color"/> parameters.
+        /// </summary>
+        /// <param name="columnName">Header text of the column to evaluate.</param>
+        /// <param name="matchText">Text to compare against cell content.</param>
+        /// <param name="matchType">Comparison operator.</param>
+        /// <param name="matchFillColor">Background color applied when condition is met.</param>
+        /// <param name="matchFontColor">Font color applied when condition is met.</param>
+        /// <param name="noMatchFillColor">Background color applied when condition is not met.</param>
+        /// <param name="noMatchFontColor">Font color applied when condition is not met.</param>
+        /// <param name="ignoreCase">Whether comparison should ignore case.</param>
+        /// <param name="highlightColumns">Additional columns to apply the formatting to.</param>
+        /// <param name="matchTextFormat">Optional action applied to paragraphs when the condition is met.</param>
+        /// <param name="noMatchTextFormat">Optional action applied to paragraphs when the condition is not met.</param>
+        public void ConditionalFormatting(string columnName, string matchText, TextMatchType matchType,
+            Color matchFillColor, Color? matchFontColor = null,
+            Color? noMatchFillColor = null, Color? noMatchFontColor = null,
+            bool ignoreCase = true, System.Collections.Generic.IEnumerable<string> highlightColumns = null,
+            Action<WordParagraph> matchTextFormat = null, Action<WordParagraph> noMatchTextFormat = null) =>
+            ConditionalFormatting(columnName, matchText, matchType,
+                matchFillColorHex: matchFillColor.ToHexColor(),
+                matchFontColorHex: matchFontColor?.ToHexColor(),
+                noMatchFillColorHex: noMatchFillColor?.ToHexColor(),
+                noMatchFontColorHex: noMatchFontColor?.ToHexColor(),
+                ignoreCase: ignoreCase, highlightColumns: highlightColumns,
+                matchTextFormat: matchTextFormat, noMatchTextFormat: noMatchTextFormat);
+
+        /// <summary>
+        /// Applies conditional formatting based on values in multiple columns.
+        /// </summary>
+        /// <param name="conditions">List of column/value conditions.</param>
+        /// <param name="matchAll">When true, all conditions must match; otherwise any condition can match.</param>
+        /// <param name="matchFillColorHex">Background color applied when conditions match.</param>
+        /// <param name="matchFontColorHex">Font color applied when conditions match.</param>
+        /// <param name="noMatchFillColorHex">Background color applied when conditions do not match.</param>
+        /// <param name="noMatchFontColorHex">Font color applied when conditions do not match.</param>
+        /// <param name="ignoreCase">Whether comparison should ignore case.</param>
+        /// <param name="highlightColumns">Columns to apply the formatting to. Defaults to the columns used in conditions.</param>
+        /// <param name="matchTextFormat">Optional action applied to paragraphs when conditions match.</param>
+        /// <param name="noMatchTextFormat">Optional action applied to paragraphs when conditions do not match.</param>
+        public void ConditionalFormatting(System.Collections.Generic.IEnumerable<(string ColumnName, string MatchText, TextMatchType MatchType)> conditions,
+            bool matchAll,
+            string matchFillColorHex = null, string matchFontColorHex = null,
+            string noMatchFillColorHex = null, string noMatchFontColorHex = null,
+            bool ignoreCase = true, System.Collections.Generic.IEnumerable<string> highlightColumns = null,
+            Action<WordParagraph> matchTextFormat = null, Action<WordParagraph> noMatchTextFormat = null) {
+            if (conditions == null) throw new ArgumentNullException(nameof(conditions));
+
+            var conditionList = conditions.ToList();
+            if (conditionList.Count == 0) throw new ArgumentException("At least one condition is required", nameof(conditions));
+
+            matchFillColorHex = Helpers.NormalizeColor(matchFillColorHex);
+            matchFontColorHex = Helpers.NormalizeColor(matchFontColorHex);
+            noMatchFillColorHex = Helpers.NormalizeColor(noMatchFillColorHex);
+            noMatchFontColorHex = Helpers.NormalizeColor(noMatchFontColorHex);
+
+            var headerMap = new System.Collections.Generic.Dictionary<string, int>(System.StringComparer.OrdinalIgnoreCase);
+            if (Rows.Count > 0) {
+                var headerRow = Rows[0];
+                for (int i = 0; i < headerRow.CellsCount; i++) {
+                    var text = headerRow.Cells[i].Paragraphs.FirstOrDefault()?.Text ?? string.Empty;
+                    headerMap[text] = i;
+                }
+            }
+            var condIndices = new System.Collections.Generic.List<(int Index, string MatchText, TextMatchType Type)>();
+            foreach (var c in conditionList) {
+                if (!headerMap.TryGetValue(c.ColumnName, out int idx)) {
+                    throw new ArgumentException($"Column '{c.ColumnName}' was not found.", nameof(conditions));
+                }
+                condIndices.Add((idx, c.MatchText ?? string.Empty, c.MatchType));
+            }
+
+            System.Collections.Generic.HashSet<int> highlightIndices;
+            if (highlightColumns != null) {
+                highlightIndices = new System.Collections.Generic.HashSet<int>();
+                foreach (var col in highlightColumns) {
+                    if (string.IsNullOrEmpty(col)) continue;
+                    if (headerMap.TryGetValue(col, out int idx)) {
+                        highlightIndices.Add(idx);
+                    }
+                }
+                if (highlightIndices.Count == 0) {
+                    highlightIndices.UnionWith(condIndices.Select(ci => ci.Index));
+                }
+            } else {
+                highlightIndices = new System.Collections.Generic.HashSet<int>(condIndices.Select(ci => ci.Index));
+            }
+
+            static bool Check(string cellText, string matchText, TextMatchType type, bool ic) => type switch {
+                TextMatchType.Equals => string.Equals(cellText, matchText, ic ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal),
+                TextMatchType.Contains => cellText.IndexOf(matchText, ic ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) >= 0,
+                TextMatchType.StartsWith => cellText.StartsWith(matchText, ic ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal),
+                TextMatchType.EndsWith => cellText.EndsWith(matchText, ic ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal),
+                _ => false
+            };
+
+            for (int r = 1; r < Rows.Count; r++) {
+                bool match = matchAll ? true : false;
+                foreach (var cond in condIndices) {
+                    var text = Rows[r].Cells[cond.Index].Paragraphs.FirstOrDefault()?.Text ?? string.Empty;
+                    bool condRes = Check(text, cond.MatchText, cond.Type, ignoreCase);
+                    if (matchAll) {
+                        match &= condRes;
+                        if (!match) break;
+                    } else {
+                        match |= condRes;
+                        if (match) break;
+                    }
+                }
+
+                foreach (int colIndex in highlightIndices) {
+                    var targetCell = Rows[r].Cells[colIndex];
+                    if (match) {
+                        if (!string.IsNullOrEmpty(matchFillColorHex)) {
+                            targetCell.ShadingFillColorHex = matchFillColorHex;
+                        }
+                    } else {
+                        if (!string.IsNullOrEmpty(noMatchFillColorHex)) {
+                            targetCell.ShadingFillColorHex = noMatchFillColorHex;
+                        }
+                    }
+
+                    foreach (var p in targetCell.Paragraphs) {
+                        if (match) {
+                            if (!string.IsNullOrEmpty(matchFontColorHex)) {
+                                p.ColorHex = matchFontColorHex;
+                            }
+                            matchTextFormat?.Invoke(p);
+                        } else {
+                            if (!string.IsNullOrEmpty(noMatchFontColorHex)) {
+                                p.ColorHex = noMatchFontColorHex;
+                            }
+                            noMatchTextFormat?.Invoke(p);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Applies conditional formatting based on values in multiple columns using <see cref="Color"/> parameters.
+        /// </summary>
+        /// <param name="conditions">List of column/value conditions.</param>
+        /// <param name="matchAll">When true, all conditions must match; otherwise any condition can match.</param>
+        /// <param name="matchFillColor">Background color applied when conditions match.</param>
+        /// <param name="matchFontColor">Font color applied when conditions match.</param>
+        /// <param name="noMatchFillColor">Background color applied when conditions do not match.</param>
+        /// <param name="noMatchFontColor">Font color applied when conditions do not match.</param>
+        /// <param name="ignoreCase">Whether comparison should ignore case.</param>
+        /// <param name="highlightColumns">Columns to apply the formatting to. Defaults to the columns used in conditions.</param>
+        /// <param name="matchTextFormat">Optional action applied to paragraphs when conditions match.</param>
+        /// <param name="noMatchTextFormat">Optional action applied to paragraphs when conditions do not match.</param>
+        public void ConditionalFormatting(System.Collections.Generic.IEnumerable<(string ColumnName, string MatchText, TextMatchType MatchType)> conditions,
+            bool matchAll,
+            Color matchFillColor, Color? matchFontColor = null,
+            Color? noMatchFillColor = null, Color? noMatchFontColor = null,
+            bool ignoreCase = true, System.Collections.Generic.IEnumerable<string> highlightColumns = null,
+            Action<WordParagraph> matchTextFormat = null, Action<WordParagraph> noMatchTextFormat = null) =>
+            ConditionalFormatting(conditions, matchAll,
+                matchFillColorHex: matchFillColor.ToHexColor(),
+                matchFontColorHex: matchFontColor?.ToHexColor(),
+                noMatchFillColorHex: noMatchFillColor?.ToHexColor(),
+                noMatchFontColorHex: noMatchFontColor?.ToHexColor(),
+                ignoreCase: ignoreCase, highlightColumns: highlightColumns,
+                matchTextFormat: matchTextFormat, noMatchTextFormat: noMatchTextFormat);
+
+        /// <summary>
+        /// Applies conditional formatting based on a custom row predicate.
+        /// </summary>
+        /// <param name="predicate">Condition evaluated for each data row.</param>
+        /// <param name="matchAction">Action executed when predicate is true.</param>
+        /// <param name="noMatchAction">Action executed when predicate is false.</param>
+        public void ConditionalFormatting(Func<WordTableRow, bool> predicate, Action<WordTableRow> matchAction, Action<WordTableRow> noMatchAction = null) {
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            if (matchAction == null) throw new ArgumentNullException(nameof(matchAction));
+
+            for (int r = 1; r < Rows.Count; r++) {
+                var row = Rows[r];
+                if (predicate(row)) {
+                    matchAction(row);
+                } else {
+                    noMatchAction?.Invoke(row);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Starts building conditional formatting rules using a fluent API.
+        /// </summary>
+        /// <returns>A new <see cref="WordTableConditionalFormattingBuilder"/>.</returns>
+        public WordTableConditionalFormattingBuilder BeginConditionalFormatting() => new WordTableConditionalFormattingBuilder(this);
+    }
+
+    /// <summary>
+    /// Provides a fluent API for defining and applying multiple conditional formatting rules.
+    /// </summary>
+    public class WordTableConditionalFormattingBuilder {
+        private readonly WordTable _table;
+        private readonly System.Collections.Generic.List<System.Action> _rules = new();
+
+        internal WordTableConditionalFormattingBuilder(WordTable table) {
+            _table = table ?? throw new System.ArgumentNullException(nameof(table));
+        }
+
+        /// <summary>
+        /// Adds a conditional formatting rule based on a column value.
+        /// </summary>
+        public WordTableConditionalFormattingBuilder AddRule(string columnName, string matchText, TextMatchType matchType,
+            string matchFillColorHex = null, string matchFontColorHex = null,
+            string noMatchFillColorHex = null, string noMatchFontColorHex = null,
+            bool ignoreCase = true, System.Collections.Generic.IEnumerable<string> highlightColumns = null,
+            Action<WordParagraph> matchTextFormat = null, Action<WordParagraph> noMatchTextFormat = null) {
+            _rules.Add(() => _table.ConditionalFormatting(columnName, matchText, matchType,
+                matchFillColorHex, matchFontColorHex, noMatchFillColorHex, noMatchFontColorHex,
+                ignoreCase, highlightColumns,
+                matchTextFormat, noMatchTextFormat));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a conditional formatting rule using <see cref="Color"/> parameters.
+        /// </summary>
+        public WordTableConditionalFormattingBuilder AddRule(string columnName, string matchText, TextMatchType matchType,
+            Color matchFillColor, Color? matchFontColor = null,
+            Color? noMatchFillColor = null, Color? noMatchFontColor = null,
+            bool ignoreCase = true, System.Collections.Generic.IEnumerable<string> highlightColumns = null,
+            Action<WordParagraph> matchTextFormat = null, Action<WordParagraph> noMatchTextFormat = null) {
+            _rules.Add(() => _table.ConditionalFormatting(columnName, matchText, matchType,
+                matchFillColor, matchFontColor, noMatchFillColor, noMatchFontColor,
+                ignoreCase, highlightColumns,
+                matchTextFormat, noMatchTextFormat));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a conditional formatting rule based on multiple column values.
+        /// </summary>
+        public WordTableConditionalFormattingBuilder AddRule(System.Collections.Generic.IEnumerable<(string ColumnName, string MatchText, TextMatchType MatchType)> conditions,
+            bool matchAll,
+            string matchFillColorHex = null, string matchFontColorHex = null,
+            string noMatchFillColorHex = null, string noMatchFontColorHex = null,
+            bool ignoreCase = true, System.Collections.Generic.IEnumerable<string> highlightColumns = null,
+            Action<WordParagraph> matchTextFormat = null, Action<WordParagraph> noMatchTextFormat = null) {
+            _rules.Add(() => _table.ConditionalFormatting(conditions, matchAll,
+                matchFillColorHex, matchFontColorHex, noMatchFillColorHex, noMatchFontColorHex,
+                ignoreCase, highlightColumns,
+                matchTextFormat, noMatchTextFormat));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a conditional formatting rule based on multiple column values using <see cref="Color"/> parameters.
+        /// </summary>
+        public WordTableConditionalFormattingBuilder AddRule(System.Collections.Generic.IEnumerable<(string ColumnName, string MatchText, TextMatchType MatchType)> conditions,
+            bool matchAll,
+            Color matchFillColor, Color? matchFontColor = null,
+            Color? noMatchFillColor = null, Color? noMatchFontColor = null,
+            bool ignoreCase = true, System.Collections.Generic.IEnumerable<string> highlightColumns = null,
+            Action<WordParagraph> matchTextFormat = null, Action<WordParagraph> noMatchTextFormat = null) {
+            _rules.Add(() => _table.ConditionalFormatting(conditions, matchAll,
+                matchFillColor, matchFontColor, noMatchFillColor, noMatchFontColor,
+                ignoreCase, highlightColumns,
+                matchTextFormat, noMatchTextFormat));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a conditional formatting rule using a predicate.
+        /// </summary>
+        public WordTableConditionalFormattingBuilder AddRule(System.Func<WordTableRow, bool> predicate, System.Action<WordTableRow> matchAction, System.Action<WordTableRow> noMatchAction = null) {
+            _rules.Add(() => _table.ConditionalFormatting(predicate, matchAction, noMatchAction));
+            return this;
+        }
+
+        /// <summary>
+        /// Applies all configured rules to the table.
+        /// </summary>
+        public void Apply() {
+            foreach (var rule in _rules) {
+                rule();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support multi-column conditions
- update examples to show multi-column rules
- enhance tests accordingly
- allow font formatting actions in conditional formatting rules

## Testing
- `dotnet build OfficeImo.sln -c Release -v minimal`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -f net8.0 -c Release --no-build --filter "FullyQualifiedName=OfficeIMO.Tests.Word.Test_TableConditionalFormatting" -v minimal`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -f net8.0 -c Release --no-build --filter "FullyQualifiedName=OfficeIMO.Tests.Word.Test_TableConditionalFormattingAdvanced" -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687d29f01b08832e807b6475e7f8a252