### PR TITLE
Handle SDT blocks in document body

### DIFF
--- a/OfficeIMO.Tests/Word.StructuredDocumentTagBody.cs
+++ b/OfficeIMO.Tests/Word.StructuredDocumentTagBody.cs
@@ -1,0 +1,42 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using System.IO;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_StructuredDocumentTagInBody() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithBodySdt.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var block = new SdtBlock(
+                    new SdtProperties(
+                        new SdtAlias { Val = "AliasBody" },
+                        new Tag { Val = "TagBody" },
+                        new SdtId { Val = 1 }
+                    ),
+                    new SdtContentBlock(
+                        new Paragraph(new Run(new Text("Body text") { Space = SpaceProcessingModeValues.Preserve }))
+                    )
+                );
+                document._wordprocessingDocument.MainDocumentPart.Document.Body.Append(block);
+                document.Save(false);
+                Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Single(document.StructuredDocumentTags);
+                var sdt = document.StructuredDocumentTags[0];
+                Assert.Equal("TagBody", sdt.Tag);
+                Assert.Equal("Body text", sdt.Text);
+                sdt.Text = "Updated";
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Single(document.StructuredDocumentTags);
+                Assert.Equal("Updated", document.StructuredDocumentTags[0].Text);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.StructuredDocumentTagBody.cs
+++ b/OfficeIMO.Tests/Word.StructuredDocumentTagBody.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using System.IO;

--- a/OfficeIMO.Word/WordSection.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordSection.PrivateMethods.cs
@@ -121,15 +121,14 @@ namespace OfficeIMO.Word {
                 return new WordCoverPage(document, sdtBlock);
             } else if (docPartGallery != null && docPartGallery.Val == "Table of Contents") {
                 return new WordTableOfContent(document, sdtBlock);
-            } else {
-                var watermark = ConvertStdBlockToWatermark(document, sdtBlock);
-                if (watermark != null) {
-                    return watermark;
-                } else {
-                    Debug.WriteLine("Please implement me! " + docPartGallery.Val);
-                }
             }
-            return null;
+
+            var watermark = ConvertStdBlockToWatermark(document, sdtBlock);
+            if (watermark != null) {
+                return watermark;
+            }
+
+            return new WordStructuredDocumentTag(document, sdtBlock);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordSection.cs
+++ b/OfficeIMO.Word/WordSection.cs
@@ -432,6 +432,15 @@ namespace OfficeIMO.Word {
                 foreach (var paragraph in paragraphs) {
                     list.Add(paragraph.StructuredDocumentTag);
                 }
+
+                var sdtBlocks = GetSdtBlockList();
+                foreach (var block in sdtBlocks) {
+                    var element = ConvertStdBlockToWordElements(_document, block);
+                    if (element is WordStructuredDocumentTag sdt) {
+                        list.Add(sdt);
+                    }
+                }
+
                 return list;
             }
         }


### PR DESCRIPTION
## Summary
- extend `WordStructuredDocumentTag` to support `SdtBlock`
- interpret unrecognized body-level `<w:sdt>` elements as structured document tags
- expose SDT blocks through `StructuredDocumentTags` on sections
- add regression test for body level content control

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6880902dc68c832ebc41491a5e10ce8d