### PR TITLE
Fix MoveSectionProperties null check

### DIFF
--- a/OfficeIMO.Tests/Word.BasicDocument.cs
+++ b/OfficeIMO.Tests/Word.BasicDocument.cs
@@ -22,7 +22,11 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void Test_OpeningWordAndParagraphCountMatches() {
-            using (var document = WordDocument.Load(Path.Combine(_directoryDocuments, "BasicDocument.docx"))) {
+            string sourceFile = Path.Combine(_directoryDocuments, "BasicDocument.docx");
+            string filePath = Path.Combine(_directoryWithFiles, "BasicDocument.docx");
+            File.Copy(sourceFile, filePath, true);
+
+            using (var document = WordDocument.Load(filePath)) {
                 // There is only one Paragraph at the document level.
                 Assert.True(document.Paragraphs.Count == 12);
 
@@ -31,6 +35,8 @@ namespace OfficeIMO.Tests {
 
                 // This table has 12 Paragraphs.
                 //Assert.True(t0.Paragraphs.Count() == 12);
+
+                document.Save();
             }
         }
 

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1724,9 +1724,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         private void MoveSectionProperties() {
             var body = this._wordprocessingDocument.MainDocumentPart.Document.Body;
-            var sectionProperties = this._wordprocessingDocument.MainDocumentPart.Document.Body.Elements<SectionProperties>().Last();
-            body.RemoveChild(sectionProperties);
-            body.Append(sectionProperties);
+            var sectionProperties = body.Elements<SectionProperties>().LastOrDefault();
+            if (sectionProperties != null) {
+                body.RemoveChild(sectionProperties);
+                body.Append(sectionProperties);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- guard MoveSectionProperties against missing SectionProperties
- copy BasicDocument before loading to ensure Save works without section properties

## Testing
- `dotnet test -c Release -v minimal --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688bd3e0200c832eb1743d6ba6dda15f