### PR TITLE
Fix TopParent loop when no ancestor found

### DIFF
--- a/OfficeIMO.Tests/Word.Paragraphs.cs
+++ b/OfficeIMO.Tests/Word.Paragraphs.cs
@@ -510,5 +510,18 @@ namespace OfficeIMO.Tests {
                 Assert.Contains("has no parent", ex.Message);
             }
         }
+
+        [Fact]
+        public void Test_TopParentWithoutValidAncestorThrowsDetailedMessage() {
+            string filePath = Path.Combine(_directoryWithFiles, "TopParentInvalidChain.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var table = new Table();
+                var openXmlParagraph = new Paragraph();
+                table.Append(openXmlParagraph);
+                WordParagraph paragraph = new WordParagraph(document, openXmlParagraph);
+                var ex = Assert.Throws<InvalidOperationException>(() => _ = paragraph.TopParent);
+                Assert.Contains("Unsupported parent chain", ex.Message);
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -43,9 +43,12 @@ namespace OfficeIMO.Word {
                     return "footer";
                 }
                 var parent = test;
-                do {
+                while (!(parent is Header) && !(parent is Footer) && !(parent is Body)) {
                     parent = parent.Parent;
-                } while (!(parent is Header) && !(parent is Footer) && !(parent is Body));
+                    if (parent == null) {
+                        throw new InvalidOperationException($"Unsupported parent chain for paragraph with text '{Text}'.");
+                    }
+                }
                 if (parent is Body) {
                     return "body";
                 }


### PR DESCRIPTION
## Summary
- stop `TopParent` loop when `Parent` becomes null
- add regression test for missing ancestor case

## Testing
- `dotnet test OfficeImo.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688bd3d73edc832ebbc48defabdb8061