### PR TITLE
Fix ExcelDocument read-only open behavior

### DIFF
--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -48,6 +48,11 @@ namespace OfficeIMO.Excel {
         public string FilePath;
 
         /// <summary>
+        /// FileOpenAccess of the document
+        /// </summary>
+        public FileAccess FileOpenAccess => _spreadSheetDocument.FileOpenAccess;
+
+        /// <summary>
         /// Creates a new Excel document at the specified path.
         /// </summary>
         /// <param name="filePath">Path to the new file.</param>
@@ -90,9 +95,8 @@ namespace OfficeIMO.Excel {
             };
 
             FileMode fileMode = readOnly ? FileMode.Open : FileMode.OpenOrCreate;
-            var package = Package.Open(filePath, fileMode);
 
-            SpreadsheetDocument spreadSheetDocument = SpreadsheetDocument.Open(package, openSettings);
+            SpreadsheetDocument spreadSheetDocument = SpreadsheetDocument.Open(filePath, !readOnly, openSettings);
 
             document._spreadSheetDocument = spreadSheetDocument;
 

--- a/OfficeIMO.Tests/Excel.BasicDocuments.cs
+++ b/OfficeIMO.Tests/Excel.BasicDocuments.cs
@@ -71,5 +71,12 @@ namespace OfficeIMO.Tests {
                 document.Save();
             }
         }
+
+        [Fact]
+        public void Test_LoadingReadOnlyExcel() {
+            var filePath = Path.Combine(_directoryDocuments, "BasicExcel.xlsx");
+            using var document = ExcelDocument.Load(filePath, readOnly: true);
+            Assert.Equal(FileAccess.Read, document.FileOpenAccess);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- correct ExcelDocument.Load to open file with isEditable flag
- expose FileOpenAccess property
- add regression test verifying read-only mode is respected

## Testing
- `dotnet test OfficeImo.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688bd3cff724832e84ef22aedbc5c3ab