### PR TITLE
Fix FinalDocument handling

### DIFF
--- a/OfficeIMO.Tests/Word.Settings.cs
+++ b/OfficeIMO.Tests/Word.Settings.cs
@@ -210,6 +210,24 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Theory]
+        [InlineData("1", true)]
+        [InlineData("0", false)]
+        [InlineData(null, false)]
+        public void Test_FinalDocument_CustomPropertyValues(string value, bool expected) {
+            string filePath = Path.Combine(_directoryWithFiles, $"Test_FinalDocument_Value_{expected}.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Test FinalDocument values");
+                if (value != null) {
+                    document.CustomDocumentProperties.Add("_MarkAsFinal", new WordCustomProperty(value));
+                }
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.True(document.Settings.FinalDocument == expected);
+            }
+        }
+
         [Fact]
         public void Test_Protection_ReadOnlyEnforced() {
             string filePath = Path.Combine(_directoryWithFiles, "Test_ReadOnlyEnforced.docx");

--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -554,19 +554,19 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool FinalDocument {
             get {
-                if (_document.CustomDocumentProperties.ContainsKey("_MarkAsFinal")) {
-                    // key exists in dictionary
-                    var markFinalProperty = _document.CustomDocumentProperties["_MarkAsFinal"];
-                    return markFinalProperty != null && (bool)markFinalProperty.Value;
-                } else {
-                    return false;
+                if (_document.CustomDocumentProperties.TryGetValue("_MarkAsFinal", out var markFinalProperty)) {
+                    if (markFinalProperty?.Value != null) {
+                        return markFinalProperty.Value.ToString() == "1";
+                    }
                 }
+                return false;
             }
             set {
+                string newValue = value ? "1" : "0";
                 if (_document.CustomDocumentProperties.ContainsKey("_MarkAsFinal")) {
-                    _document.CustomDocumentProperties["_MarkAsFinal"].Value = value;
+                    _document.CustomDocumentProperties["_MarkAsFinal"].Value = newValue;
                 } else {
-                    _document.CustomDocumentProperties.Add("_MarkAsFinal", new WordCustomProperty(value));
+                    _document.CustomDocumentProperties.Add("_MarkAsFinal", new WordCustomProperty(newValue));
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure WordSettings.FinalDocument checks for string `"1"`
- persist `_MarkAsFinal` as string values
- test FinalDocument parsing for `"1"`, `"0"`, and missing property

## Testing
- `dotnet test OfficeImo.sln -v minimal`
- `dotnet build OfficeImo.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688d07119404832e8fc0eaf13c015c46