### PR TITLE
Improve exception messages with paths

### DIFF
--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -84,7 +84,7 @@ namespace OfficeIMO.Excel {
         public static ExcelDocument Load(string filePath, bool readOnly = false, bool autoSave = false) {
             if (filePath != null) {
                 if (!File.Exists(filePath)) {
-                    throw new FileNotFoundException("File doesn't exists", filePath);
+                    throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
                 }
             }
             ExcelDocument document = new ExcelDocument();
@@ -117,7 +117,7 @@ namespace OfficeIMO.Excel {
         public static async Task<ExcelDocument> LoadAsync(string filePath, bool readOnly = false, bool autoSave = false) {
             if (filePath != null) {
                 if (!File.Exists(filePath)) {
-                    throw new FileNotFoundException("File doesn't exists", filePath);
+                    throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
                 }
             }
             using var fileStream = new FileStream(filePath, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite, FileShare.Read, 4096, FileOptions.Asynchronous);

--- a/OfficeIMO.Tests/Excel.LoadExceptions.cs
+++ b/OfficeIMO.Tests/Excel.LoadExceptions.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using System.Threading.Tasks;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_LoadMissingFile_ThrowsWithPath() {
+            string filePath = Path.Combine(_directoryWithFiles, "missing.xlsx");
+            var ex = Assert.Throws<FileNotFoundException>(() => ExcelDocument.Load(filePath));
+            Assert.Equal($"File '{filePath}' doesn't exist.", ex.Message);
+        }
+
+        [Fact]
+        public async Task Test_LoadAsyncMissingFile_ThrowsWithPath() {
+            string filePath = Path.Combine(_directoryWithFiles, "missingAsync.xlsx");
+            var ex = await Assert.ThrowsAsync<FileNotFoundException>(() => ExcelDocument.LoadAsync(filePath));
+            Assert.Equal($"File '{filePath}' doesn't exist.", ex.Message);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.LoadExceptions.cs
+++ b/OfficeIMO.Tests/Word.LoadExceptions.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_LoadMissingFile_ThrowsWithPath() {
+            string filePath = Path.Combine(_directoryWithFiles, "missing.docx");
+            var ex = Assert.Throws<FileNotFoundException>(() => WordDocument.Load(filePath));
+            Assert.Equal($"File '{filePath}' doesn't exist.", ex.Message);
+        }
+
+        [Fact]
+        public async Task Test_LoadAsyncMissingFile_ThrowsWithPath() {
+            string filePath = Path.Combine(_directoryWithFiles, "missingAsync.docx");
+            var ex = await Assert.ThrowsAsync<FileNotFoundException>(() => WordDocument.LoadAsync(filePath));
+            Assert.Equal($"File '{filePath}' doesn't exist.", ex.Message);
+        }
+
+        [Fact]
+        public void Test_AddMacroMissingFile_ThrowsWithPath() {
+            using var document = WordDocument.Create(Path.Combine(_directoryWithFiles, "macro.docm"));
+            string macroPath = Path.Combine(_directoryWithFiles, "missingMacro.bin");
+            var ex = Assert.Throws<FileNotFoundException>(() => WordMacro.AddMacro(document, macroPath));
+            Assert.Equal($"File '{macroPath}' doesn't exist.", ex.Message);
+        }
+
+        [Fact]
+        public void Test_EmbedFontMissingFile_ThrowsWithPath() {
+            using var document = WordDocument.Create(Path.Combine(_directoryWithFiles, "font.docx"));
+            string fontPath = Path.Combine(_directoryWithFiles, "missing.ttf");
+            var ex = Assert.Throws<FileNotFoundException>(() => document.EmbedFont(fontPath));
+            Assert.Equal($"Font file '{fontPath}' doesn't exist.", ex.Message);
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.Fonts.cs
+++ b/OfficeIMO.Word/WordDocument.Fonts.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Word {
         /// <param name="fontPath">Path to a TrueType/OpenType font file.</param>
         public void EmbedFont(string fontPath) {
             if (string.IsNullOrEmpty(fontPath)) throw new ArgumentNullException(nameof(fontPath));
-            if (!File.Exists(fontPath)) throw new FileNotFoundException("Font file not found", fontPath);
+            if (!File.Exists(fontPath)) throw new FileNotFoundException($"Font file '{fontPath}' doesn't exist.", fontPath);
 
             var mainPart = _wordprocessingDocument.MainDocumentPart;
             var fontTablePart = mainPart.FontTablePart ?? mainPart.AddNewPart<FontTablePart>();

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1277,7 +1277,7 @@ namespace OfficeIMO.Word {
         public static WordDocument Load(string filePath, bool readOnly = false, bool autoSave = false, bool overrideStyles = false) {
             if (filePath != null) {
                 if (!File.Exists(filePath)) {
-                    throw new FileNotFoundException("File doesn't exists", filePath);
+                    throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
                 }
             }
 
@@ -1321,7 +1321,7 @@ namespace OfficeIMO.Word {
         public static async Task<WordDocument> LoadAsync(string filePath, bool readOnly = false, bool autoSave = false, bool overrideStyles = false) {
             if (filePath != null) {
                 if (!File.Exists(filePath)) {
-                    throw new FileNotFoundException("File doesn't exists", filePath);
+                    throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
                 }
             }
 

--- a/OfficeIMO.Word/WordMacro.cs
+++ b/OfficeIMO.Word/WordMacro.cs
@@ -61,7 +61,7 @@ namespace OfficeIMO.Word {
         /// <param name="filePath">Path to a <c>vbaProject.bin</c> file.</param>
         internal static void AddMacro(WordDocument document, string filePath) {
             if (string.IsNullOrEmpty(filePath)) throw new ArgumentNullException(nameof(filePath));
-            if (!File.Exists(filePath)) throw new FileNotFoundException("File doesn't exist", filePath);
+            if (!File.Exists(filePath)) throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
 
             AddMacro(document, File.ReadAllBytes(filePath));
         }


### PR DESCRIPTION
## Summary
- improve file-not-found exception messages in ExcelDocument, WordDocument, WordMacro and font embedding
- add tests validating these messages for both Word and Excel

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688d06faf7b4832e92072dc297d3cc00