### PR TITLE
Add WordDocument image extraction APIs

### DIFF
--- a/OfficeIMO.Tests/Word.Images.cs
+++ b/OfficeIMO.Tests/Word.Images.cs
@@ -590,6 +590,30 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Test_GetImagesMethods() {
+            var filePath = Path.Combine(_directoryDocuments, "DocumentWithImages.docx");
+            using var document = WordDocument.Load(filePath);
+
+            var bytes = document.GetImages();
+            Assert.Equal(document.Images.Count, bytes.Count);
+
+            for (int i = 0; i < bytes.Count; i++) {
+                var savePath = Path.Combine(_directoryWithFiles, $"extracted_{i}.bin");
+                File.WriteAllBytes(savePath, bytes[i]);
+                Assert.True(new FileInfo(savePath).Length > 0);
+            }
+
+            var streams = document.GetImageStreams();
+            Assert.Equal(document.Images.Count, streams.Count);
+            for (int i = 0; i < streams.Count; i++) {
+                var path2 = Path.Combine(_directoryWithFiles, $"stream_{i}.bin");
+                using var fs = new FileStream(path2, FileMode.Create);
+                streams[i].CopyTo(fs);
+                Assert.True(new FileInfo(path2).Length > 0);
+            }
+        }
+
     }
 
 }

--- a/OfficeIMO.Word/WordDocument.Images.cs
+++ b/OfficeIMO.Word/WordDocument.Images.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace OfficeIMO.Word {
+    public partial class WordDocument {
+        /// <summary>
+        /// Returns the bytes of all embedded images in the document.
+        /// Images linked externally are skipped.
+        /// </summary>
+        public IReadOnlyList<byte[]> GetImages() {
+            List<byte[]> images = new List<byte[]>();
+            foreach (var img in Images) {
+                try {
+                    images.Add(img.GetBytes());
+                } catch (InvalidOperationException) {
+                    // external image - skip
+                }
+            }
+            return images;
+        }
+
+        /// <summary>
+        /// Returns streams with data of all embedded images in the document.
+        /// Images linked externally are skipped.
+        /// </summary>
+        public IReadOnlyList<Stream> GetImageStreams() {
+            List<Stream> streams = new List<Stream>();
+            foreach (var img in Images) {
+                try {
+                    streams.Add(img.GetStream());
+                } catch (InvalidOperationException) {
+                    // external image - skip
+                }
+            }
+            return streams;
+        }
+    }
+}

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -1995,6 +1995,34 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Retrieves the image data as a new memory stream.
+        /// </summary>
+        /// <returns>A <see cref="Stream"/> containing the image bytes.</returns>
+        public Stream GetStream() {
+            if (_imagePart == null) {
+                throw new InvalidOperationException("Image is linked externally and cannot be extracted.");
+            }
+
+            MemoryStream ms = new MemoryStream();
+            using (var stream = _imagePart.GetStream()) {
+                stream.CopyTo(ms);
+            }
+            ms.Position = 0;
+            return ms;
+        }
+
+        /// <summary>
+        /// Retrieves the image data as a byte array.
+        /// </summary>
+        /// <returns>Bytes representing the image.</returns>
+        public byte[] GetBytes() {
+            using var stream = GetStream();
+            using var ms = new MemoryStream();
+            stream.CopyTo(ms);
+            return ms.ToArray();
+        }
+
+        /// <summary>
         /// Remove image from a Word Document
         /// </summary>
         public void Remove() {


### PR DESCRIPTION
## Summary
- add `GetStream` and `GetBytes` helpers to `WordImage`
- implement `WordDocument.GetImages()` and `GetImageStreams()` to return image data
- test extracting images and saving them to disk

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688d06b513f0832eb7cd01e2b3448602