### PR TITLE
Render tracked changes as visible markup

### DIFF
--- a/OfficeIMO.Examples/Word/Revisions/Revisions.Example3.cs
+++ b/OfficeIMO.Examples/Word/Revisions/Revisions.Example3.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Revisions {
+        internal static void Example_ConvertRevisionsToMarkup(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Demonstrating converting revisions to markup");
+            string filePath = Path.Combine(folderPath, "TrackedChangesMarkup.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph();
+                paragraph.AddInsertedText("Inserted text", "Codex");
+                paragraph.AddDeletedText("Deleted text", "Codex");
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                document.ConvertRevisionsToMarkup();
+                document.Save(openWord);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Word.Revisions.cs
+++ b/OfficeIMO.Tests/Word.Revisions.cs
@@ -70,5 +70,37 @@ namespace OfficeIMO.Tests {
                 Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
             }
         }
+
+        [Fact]
+        public void Test_ConvertRevisionsToMarkup_PreservesTextWithFormatting() {
+            string filePath = Path.Combine(_directoryWithFiles, "TrackedChangesMarkup.docx");
+            File.Delete(filePath);
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph();
+                paragraph.AddInsertedText("Added", "Codex");
+                paragraph.AddDeletedText("Removed", "Codex");
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                document.ConvertRevisionsToMarkup();
+
+                Assert.DoesNotContain(document._document.Body.Descendants<InsertedRun>(), r => r.InnerText == "Added");
+                Assert.DoesNotContain(document._document.Body.Descendants<DeletedRun>(), r => r.InnerText == "Removed");
+
+                var insertedRun = document._document.Body.Descendants<Run>().FirstOrDefault(r => r.InnerText == "Added");
+                Assert.NotNull(insertedRun);
+                Assert.NotNull(insertedRun.RunProperties);
+                Assert.NotNull(insertedRun.RunProperties.Underline);
+                Assert.Equal("0000FF", insertedRun.RunProperties.Color?.Val);
+
+                var deletedRun = document._document.Body.Descendants<Run>().FirstOrDefault(r => r.InnerText == "Removed");
+                Assert.NotNull(deletedRun);
+                Assert.NotNull(deletedRun.RunProperties);
+                Assert.NotNull(deletedRun.RunProperties.Strike);
+                Assert.Equal("FF0000", deletedRun.RunProperties.Color?.Val);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `ConvertRevisionsToMarkup` to render insertions and deletions with visible formatting
- document conversion example for revisions
- test that inserted and deleted text are marked up correctly

## Testing
- `dotnet test -v minimal`
- `dotnet build -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_688f515c9174832eb52d3ef0da9e486a