### PR TITLE
Add Word document comparison utility

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -279,6 +279,7 @@ namespace OfficeIMO.Examples {
 
             XmlSerialization.Example_XmlSerializationBasic(folderPath, false);
             XmlSerialization.Example_XmlSerializationAdvanced(folderPath, false);
+            CompareDocuments.Example_BasicComparison(folderPath, false);
         }
     }
 }

--- a/OfficeIMO.Examples/Word/CompareDocuments/CompareDocuments.Example1.cs
+++ b/OfficeIMO.Examples/Word/CompareDocuments/CompareDocuments.Example1.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class CompareDocuments {
+        internal static void Example_BasicComparison(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Comparing documents");
+
+            string sourcePath = Path.Combine(folderPath, "CompareSource.docx");
+            string targetPath = Path.Combine(folderPath, "CompareTarget.docx");
+
+            using (WordDocument doc = WordDocument.Create(sourcePath)) {
+                doc.AddParagraph("Hello");
+                doc.Save(false);
+            }
+
+            using (WordDocument doc = WordDocument.Create(targetPath)) {
+                doc.AddParagraph("Hello World");
+                doc.Save(false);
+            }
+
+            using WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath);
+            result.Save(openWord);
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Word.CompareDocuments.cs
+++ b/OfficeIMO.Tests/Word.CompareDocuments.cs
@@ -1,0 +1,167 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void CompareDetectsInsertedText() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "compare_source_insert.docx");
+            using (WordDocument doc = WordDocument.Create(sourcePath)) {
+                doc.AddParagraph("Hello");
+                doc.Save(false);
+            }
+
+            string targetPath = Path.Combine(_directoryWithFiles, "compare_target_insert.docx");
+            using (WordDocument doc = WordDocument.Create(targetPath)) {
+                doc.AddParagraph("Hello World");
+                doc.Save(false);
+            }
+
+            string resultPath;
+            using (WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath)) {
+                resultPath = result.FilePath;
+            }
+
+            using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
+            InsertedRun ins = word.MainDocumentPart.Document.Body.Descendants<InsertedRun>().FirstOrDefault();
+            Assert.NotNull(ins);
+            Assert.Equal(" World", ins.InnerText);
+        }
+
+        [Fact]
+        public void CompareDetectsDeletedText() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "compare_source_delete.docx");
+            using (WordDocument doc = WordDocument.Create(sourcePath)) {
+                doc.AddParagraph("Hello World");
+                doc.Save(false);
+            }
+
+            string targetPath = Path.Combine(_directoryWithFiles, "compare_target_delete.docx");
+            using (WordDocument doc = WordDocument.Create(targetPath)) {
+                doc.AddParagraph("Hello");
+                doc.Save(false);
+            }
+
+            string resultPath;
+            using (WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath)) {
+                resultPath = result.FilePath;
+            }
+
+            using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
+            DeletedRun del = word.MainDocumentPart.Document.Body.Descendants<DeletedRun>().FirstOrDefault();
+            Assert.NotNull(del);
+            Assert.Equal(" World", del.InnerText);
+        }
+
+        [Fact]
+        public void CompareDetectsFormattingChanges() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "compare_source_format.docx");
+            using (WordDocument doc = WordDocument.Create(sourcePath)) {
+                doc.AddParagraph("Hello");
+                doc.Save(false);
+            }
+
+            string targetPath = Path.Combine(_directoryWithFiles, "compare_target_format.docx");
+            using (WordDocument doc = WordDocument.Create(targetPath)) {
+                var p = doc.AddParagraph("Hello");
+                p.Bold = true;
+                doc.Save(false);
+            }
+
+            string resultPath;
+            using (WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath)) {
+                resultPath = result.FilePath;
+            }
+
+            using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
+            Run run = word.MainDocumentPart.Document.Body.Descendants<Run>().First();
+            Assert.NotNull(run.RunProperties);
+            Assert.NotNull(run.RunProperties.RunPropertiesChange);
+        }
+
+        [Fact]
+        public void CompareDetectsInsertedTableRow() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "compare_source_row_insert.docx");
+            using (WordDocument doc = WordDocument.Create(sourcePath)) {
+                WordTable table = doc.AddTable(1, 1);
+                table.Rows[0].Cells[0].Paragraphs[0].SetText("Row1");
+                doc.Save(false);
+            }
+
+            string targetPath = Path.Combine(_directoryWithFiles, "compare_target_row_insert.docx");
+            using (WordDocument doc = WordDocument.Create(targetPath)) {
+                WordTable table = doc.AddTable(2, 1);
+                table.Rows[0].Cells[0].Paragraphs[0].SetText("Row1");
+                table.Rows[1].Cells[0].Paragraphs[0].SetText("Row2");
+                doc.Save(false);
+            }
+
+            string resultPath;
+            using (WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath)) {
+                resultPath = result.FilePath;
+            }
+
+            using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
+            InsertedRun ins = word.MainDocumentPart.Document.Body.Descendants<InsertedRun>().FirstOrDefault(r => r.InnerText == "Row2");
+            Assert.NotNull(ins);
+        }
+
+        [Fact]
+        public void CompareDetectsDeletedTableRow() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "compare_source_row_delete.docx");
+            using (WordDocument doc = WordDocument.Create(sourcePath)) {
+                WordTable table = doc.AddTable(2, 1);
+                table.Rows[0].Cells[0].Paragraphs[0].SetText("Row1");
+                table.Rows[1].Cells[0].Paragraphs[0].SetText("Row2");
+                doc.Save(false);
+            }
+
+            string targetPath = Path.Combine(_directoryWithFiles, "compare_target_row_delete.docx");
+            using (WordDocument doc = WordDocument.Create(targetPath)) {
+                WordTable table = doc.AddTable(1, 1);
+                table.Rows[0].Cells[0].Paragraphs[0].SetText("Row1");
+                doc.Save(false);
+            }
+
+            string resultPath;
+            using (WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath)) {
+                resultPath = result.FilePath;
+            }
+
+            using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
+            DeletedRun del = word.MainDocumentPart.Document.Body.Descendants<DeletedRun>().FirstOrDefault(r => r.InnerText == "Row2");
+            Assert.NotNull(del);
+        }
+
+        [Fact]
+        public void CompareDetectsImageReplacement() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "compare_source_image.docx");
+            using (WordDocument doc = WordDocument.Create(sourcePath)) {
+                doc.AddParagraph().AddImage(Path.Combine(_directoryWithImages, "EvotecLogo.png"));
+                doc.Save(false);
+            }
+
+            string targetPath = Path.Combine(_directoryWithFiles, "compare_target_image.docx");
+            using (WordDocument doc = WordDocument.Create(targetPath)) {
+                doc.AddParagraph().AddImage(Path.Combine(_directoryWithImages, "snail.bmp"));
+                doc.Save(false);
+            }
+
+            string resultPath;
+            using (WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath)) {
+                resultPath = result.FilePath;
+            }
+
+            using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
+            InsertedRun ins = word.MainDocumentPart.Document.Body.Descendants<InsertedRun>().FirstOrDefault(r => r.InnerText == "[Image]");
+            DeletedRun del = word.MainDocumentPart.Document.Body.Descendants<DeletedRun>().FirstOrDefault(r => r.InnerText == "[Image]");
+            Assert.NotNull(ins);
+            Assert.NotNull(del);
+        }
+
+    }
+}

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Images.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Images.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+
+namespace OfficeIMO.Word {
+    public static partial class WordDocumentComparer {
+        private static void CompareImages(WordDocument source, WordDocument target, WordDocument result) {
+            var srcImages = source.GetImages();
+            var tgtImages = target.GetImages();
+            int count = System.Math.Min(srcImages.Count, tgtImages.Count);
+
+            for (int i = 0; i < count; i++) {
+                if (!srcImages[i].SequenceEqual(tgtImages[i])) {
+                    WordParagraph p = result.AddParagraph();
+                    p.AddDeletedText("[Image]", "Comparer");
+                    p.AddInsertedText("[Image]", "Comparer");
+                }
+            }
+
+            for (int i = count; i < tgtImages.Count; i++) {
+                WordParagraph p = result.AddParagraph();
+                p.AddInsertedText("[Image]", "Comparer");
+            }
+
+            for (int i = count; i < srcImages.Count; i++) {
+                WordParagraph p = result.AddParagraph();
+                p.AddDeletedText("[Image]", "Comparer");
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Paragraphs.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Paragraphs.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word {
+    public static partial class WordDocumentComparer {
+        private static void CompareParagraphs(WordDocument source, WordDocument target, WordDocument result) {
+            int count = Math.Min(source.Paragraphs.Count, target.Paragraphs.Count);
+
+            for (int i = 0; i < count; i++) {
+                CompareParagraph(source.Paragraphs[i], target.Paragraphs[i], result.Paragraphs[i]);
+            }
+
+            for (int i = count; i < target.Paragraphs.Count; i++) {
+                WordParagraph p = result.AddParagraph();
+                p.AddInsertedText(target.Paragraphs[i].Text, "Comparer");
+            }
+
+            for (int i = count; i < source.Paragraphs.Count; i++) {
+                WordParagraph p = result.AddParagraph();
+                p.AddDeletedText(source.Paragraphs[i].Text, "Comparer");
+            }
+        }
+
+        private static void CompareParagraph(WordParagraph source, WordParagraph target, WordParagraph result) {
+            var srcRuns = source._paragraph.Elements<Run>().ToList();
+            var tgtRuns = target._paragraph.Elements<Run>().ToList();
+            int runCount = Math.Min(srcRuns.Count, tgtRuns.Count);
+
+            result._paragraph.RemoveAllChildren();
+
+            for (int i = 0; i < runCount; i++) {
+                string srcText = srcRuns[i].InnerText;
+                string tgtText = tgtRuns[i].InnerText;
+
+                string common = GetCommonPrefix(srcText, tgtText);
+                if (!string.IsNullOrEmpty(common)) {
+                    result.AddText(common);
+                }
+
+                string deleted = srcText.Substring(common.Length);
+                if (!string.IsNullOrEmpty(deleted)) {
+                    result.AddDeletedText(deleted, "Comparer");
+                }
+
+                string inserted = tgtText.Substring(common.Length);
+                if (!string.IsNullOrEmpty(inserted)) {
+                    result.AddInsertedText(inserted, "Comparer");
+                }
+
+                Run resRun = result._paragraph.Elements<Run>().LastOrDefault();
+                ApplyFormattingChange(srcRuns[i], tgtRuns[i], resRun);
+            }
+
+            for (int i = runCount; i < tgtRuns.Count; i++) {
+                result.AddInsertedText(tgtRuns[i].InnerText, "Comparer");
+            }
+
+            for (int i = runCount; i < srcRuns.Count; i++) {
+                result.AddDeletedText(srcRuns[i].InnerText, "Comparer");
+            }
+        }
+
+        private static void ApplyFormattingChange(Run srcRun, Run tgtRun, Run resRun) {
+            if (srcRun == null || tgtRun == null || resRun == null) {
+                return;
+            }
+
+            string srcXml = srcRun.RunProperties?.OuterXml ?? string.Empty;
+            string tgtXml = tgtRun.RunProperties?.OuterXml ?? string.Empty;
+
+            if (srcXml != tgtXml) {
+                resRun.RunProperties = (RunProperties)tgtRun.RunProperties?.CloneNode(true) ?? new RunProperties();
+                resRun.RunProperties.RunPropertiesChange = new RunPropertiesChange() {
+                    Author = "Comparer",
+                    Date = DateTime.Now
+                };
+                resRun.RunProperties.RunPropertiesChange.Append((RunProperties)srcRun.RunProperties?.CloneNode(true) ?? new RunProperties());
+            }
+        }
+
+        private static string GetCommonPrefix(string a, string b) {
+            int len = Math.Min(a.Length, b.Length);
+            int i = 0;
+            while (i < len && a[i] == b[i]) {
+                i++;
+            }
+            return a.Substring(0, i);
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Tables.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Tables.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+
+namespace OfficeIMO.Word {
+    public static partial class WordDocumentComparer {
+        private static void CompareTables(WordDocument source, WordDocument target, WordDocument result) {
+            int count = Math.Min(source.Tables.Count, target.Tables.Count);
+
+            for (int i = 0; i < count; i++) {
+                CompareTable(source.Tables[i], target.Tables[i], result.Tables[i]);
+            }
+
+            for (int i = count; i < source.Tables.Count; i++) {
+                WordTable resTable = result.Tables[i];
+                WordTable srcTable = source.Tables[i];
+                for (int r = 0; r < srcTable.RowsCount; r++) {
+                    for (int c = 0; c < srcTable.Rows[r].CellsCount; c++) {
+                        string text = srcTable.Rows[r].Cells[c].Paragraphs.FirstOrDefault()?.Text ?? string.Empty;
+                        resTable.Rows[r].Cells[c].AddParagraph(removeExistingParagraphs: true).AddDeletedText(text, "Comparer");
+                    }
+                }
+            }
+
+            for (int i = count; i < target.Tables.Count; i++) {
+                WordTable tgtTable = target.Tables[i];
+                WordTable resTable = result.AddTable(tgtTable.RowsCount, tgtTable.Rows.First().CellsCount);
+                for (int r = 0; r < tgtTable.RowsCount; r++) {
+                    for (int c = 0; c < tgtTable.Rows[r].CellsCount; c++) {
+                        string text = tgtTable.Rows[r].Cells[c].Paragraphs.FirstOrDefault()?.Text ?? string.Empty;
+                        resTable.Rows[r].Cells[c].AddParagraph(removeExistingParagraphs: true).AddInsertedText(text, "Comparer");
+                    }
+                }
+            }
+        }
+
+        private static void CompareTable(WordTable source, WordTable target, WordTable result) {
+            int rowCount = Math.Min(source.RowsCount, target.RowsCount);
+
+            for (int i = 0; i < rowCount; i++) {
+                CompareTableRow(source.Rows[i], target.Rows[i], result.Rows[i]);
+            }
+
+            for (int i = rowCount; i < source.RowsCount; i++) {
+                WordTableRow srcRow = source.Rows[i];
+                WordTableRow resRow = result.Rows[i];
+                for (int c = 0; c < srcRow.CellsCount; c++) {
+                    string text = srcRow.Cells[c].Paragraphs.FirstOrDefault()?.Text ?? string.Empty;
+                    resRow.Cells[c].AddParagraph(removeExistingParagraphs: true).AddDeletedText(text, "Comparer");
+                }
+            }
+
+            for (int i = rowCount; i < target.RowsCount; i++) {
+                WordTableRow tgtRow = target.Rows[i];
+                WordTableRow resRow = result.AddRow(tgtRow.CellsCount);
+                for (int c = 0; c < tgtRow.CellsCount; c++) {
+                    string text = tgtRow.Cells[c].Paragraphs.FirstOrDefault()?.Text ?? string.Empty;
+                    resRow.Cells[c].AddParagraph(removeExistingParagraphs: true).AddInsertedText(text, "Comparer");
+                }
+            }
+        }
+
+        private static void CompareTableRow(WordTableRow source, WordTableRow target, WordTableRow result) {
+            int cellCount = Math.Min(source.CellsCount, target.CellsCount);
+
+            for (int i = 0; i < cellCount; i++) {
+                WordParagraph srcPara = source.Cells[i].Paragraphs.FirstOrDefault() ?? source.Cells[i].AddParagraph();
+                WordParagraph tgtPara = target.Cells[i].Paragraphs.FirstOrDefault() ?? target.Cells[i].AddParagraph();
+                WordParagraph resPara = result.Cells[i].Paragraphs.FirstOrDefault() ?? result.Cells[i].AddParagraph();
+                CompareParagraph(srcPara, tgtPara, resPara);
+            }
+
+            for (int i = cellCount; i < source.CellsCount; i++) {
+                string text = source.Cells[i].Paragraphs.FirstOrDefault()?.Text ?? string.Empty;
+                result.Cells[i].AddParagraph(removeExistingParagraphs: true).AddDeletedText(text, "Comparer");
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides simple comparison between two Word documents.
+    /// </summary>
+    public static partial class WordDocumentComparer {
+        /// <summary>
+        /// Compares two documents and produces a new document with revision marks.
+        /// </summary>
+        /// <param name="sourcePath">Path to the original document.</param>
+        /// <param name="targetPath">Path to the modified document.</param>
+        /// <returns>Document containing revision marks highlighting differences.</returns>
+        public static WordDocument Compare(string sourcePath, string targetPath) {
+            if (string.IsNullOrEmpty(sourcePath)) throw new ArgumentNullException(nameof(sourcePath));
+            if (string.IsNullOrEmpty(targetPath)) throw new ArgumentNullException(nameof(targetPath));
+
+            string resultPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".docx");
+            File.Copy(sourcePath, resultPath, true);
+
+            using (WordDocument source = WordDocument.Load(sourcePath))
+            using (WordDocument target = WordDocument.Load(targetPath))
+            using (WordDocument result = WordDocument.Load(resultPath)) {
+                CompareParagraphs(source, target, result);
+                CompareTables(source, target, result);
+                CompareImages(source, target, result);
+
+                result.Save(false);
+            }
+
+            return WordDocument.Load(resultPath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move `WordDocumentComparer` into dedicated folder with partial implementations for paragraphs, tables, and images
- extend comparison to tables and images, producing revision markers for structural changes
- add tests for table row insertions/deletions and image replacement detection

## Testing
- `dotnet build`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688f51146e14832e9355ae323f0ee888