### PR TITLE
Add HTML to Word and Word to HTML converters with round-trip tests

### DIFF
--- a/OfficeIMO.Examples/Html/Html.Conversion.cs
+++ b/OfficeIMO.Examples/Html/Html.Conversion.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using OfficeIMO.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlRoundTrip(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlRoundTrip.docx");
+            string html = "<p>Hello <b>world</b> and <i>universe</i>.</p>";
+
+            using (MemoryStream ms = new MemoryStream()) {
+                HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "Calibri" });
+                File.WriteAllBytes(filePath, ms.ToArray());
+
+                ms.Position = 0;
+                string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeStyles = true });
+                Console.WriteLine(roundTrip);
+            }
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/OfficeIMO.Examples.csproj
+++ b/OfficeIMO.Examples/OfficeIMO.Examples.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <ProjectReference Include="..\OfficeIMO.Excel\OfficeIMO.Excel.csproj" />
         <ProjectReference Include="..\OfficeIMO.Word\OfficeIMO.Word.csproj" />
+        <ProjectReference Include="..\OfficeIMO.Html\OfficeIMO.Html.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -3,6 +3,8 @@ using System.IO;
 using OfficeIMO.Examples.Excel;
 using OfficeIMO.Examples.Word;
 
+using HtmlExamples = OfficeIMO.Examples.Html.Html;
+
 namespace OfficeIMO.Examples {
     internal static class Program {
         private static void Setup(string path) {
@@ -277,6 +279,7 @@ namespace OfficeIMO.Examples {
             Macros.Example_ExtractAndRemoveMacro(templatesPath, folderPath, false);
             Macros.Example_ListAndRemoveMacro(templatesPath, folderPath, false);
 
+            HtmlExamples.Example_HtmlRoundTrip(folderPath, false);
             XmlSerialization.Example_XmlSerializationBasic(folderPath, false);
             XmlSerialization.Example_XmlSerializationAdvanced(folderPath, false);
         }

--- a/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Html {
+    /// <summary>
+    /// Converts simple HTML fragments into WordprocessingDocument instances.
+    /// </summary>
+    public static class HtmlToWordConverter {
+        /// <summary>
+        /// Converts provided HTML string into a DOCX document written to the specified stream.
+        /// </summary>
+        /// <param name="html">HTML content to convert. It should be a valid XHTML fragment.</param>
+        /// <param name="output">Stream where DOCX content will be written.</param>
+        /// <param name="options">Conversion options.</param>
+        public static void Convert(string html, Stream output, HtmlToWordOptions? options = null) {
+            if (html == null) {
+                throw new ArgumentNullException(nameof(html));
+            }
+            if (output == null) {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            options ??= new HtmlToWordOptions();
+
+            using WordprocessingDocument document = WordprocessingDocument.Create(output, WordprocessingDocumentType.Document, true);
+            MainDocumentPart mainPart = document.AddMainDocumentPart();
+            mainPart.Document = new Document(new Body());
+            Body body = mainPart.Document.Body;
+
+            // Wrap in a root element to allow multiple top-level paragraphs
+            XDocument xdoc = XDocument.Parse("<root>" + html + "</root>");
+
+            foreach (XElement paragraphElement in xdoc.Root!.Elements("p")) {
+                Paragraph paragraph = new Paragraph();
+                foreach (XNode node in paragraphElement.Nodes()) {
+                    if (node is XText textNode) {
+                        paragraph.Append(CreateRun(textNode.Value, options));
+                    } else if (node is XElement element) {
+                        paragraph.Append(CreateRunFromElement(element, options));
+                    }
+                }
+                body.Append(paragraph);
+            }
+
+            mainPart.Document.Save();
+        }
+
+        private static Run CreateRunFromElement(XElement element, HtmlToWordOptions options) {
+            string text = element.Value;
+            Run run = CreateRun(text, options);
+            RunProperties runProperties = run.RunProperties ??= new RunProperties();
+
+            switch (element.Name.LocalName.ToLowerInvariant()) {
+                case "b":
+                case "strong":
+                    runProperties.Bold = new Bold();
+                    break;
+                case "i":
+                case "em":
+                    runProperties.Italic = new Italic();
+                    break;
+                case "u":
+                    runProperties.Underline = new Underline { Val = UnderlineValues.Single };
+                    break;
+            }
+
+            return run;
+        }
+
+        private static Run CreateRun(string text, HtmlToWordOptions options) {
+            Run run = new Run(new Text(text) { Space = SpaceProcessingModeValues.Preserve });
+            if (!string.IsNullOrEmpty(options.FontFamily)) {
+                RunProperties runProperties = run.RunProperties ??= new RunProperties();
+                runProperties.RunFonts = new RunFonts {
+                    Ascii = options.FontFamily,
+                    HighAnsi = options.FontFamily,
+                    ComplexScript = options.FontFamily
+                };
+            }
+            return run;
+        }
+    }
+}

--- a/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Text;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Html {
+    /// <summary>
+    /// Converts WordprocessingDocument content into simple HTML fragments.
+    /// </summary>
+    public static class WordToHtmlConverter {
+        /// <summary>
+        /// Converts a DOCX contained in the provided stream into HTML.
+        /// </summary>
+        /// <param name="docxStream">Stream containing DOCX content.</param>
+        /// <param name="options">Conversion options.</param>
+        /// <returns>Generated HTML string.</returns>
+        public static string Convert(Stream docxStream, WordToHtmlOptions? options = null) {
+            if (docxStream == null) {
+                throw new ArgumentNullException(nameof(docxStream));
+            }
+
+            options ??= new WordToHtmlOptions();
+
+            using WordprocessingDocument document = WordprocessingDocument.Open(docxStream, false);
+            StringBuilder sb = new StringBuilder();
+            sb.Append("<html><body>");
+
+            foreach (Paragraph paragraph in document.MainDocumentPart!.Document.Body!.Elements<Paragraph>()) {
+                sb.Append("<p>");
+                foreach (Run run in paragraph.Elements<Run>()) {
+                    string text = run.InnerText;
+                    string encoded = System.Net.WebUtility.HtmlEncode(text);
+                    RunProperties? runProps = run.RunProperties;
+                    string result = encoded;
+
+                    if (options.IncludeStyles && runProps?.RunFonts?.Ascii != null) {
+                        result = $"<span style=\"font-family:{runProps.RunFonts.Ascii}\">{result}</span>";
+                    }
+
+                    if (runProps?.Underline != null && runProps.Underline.Val != UnderlineValues.None) {
+                        result = $"<u>{result}</u>";
+                    }
+                    if (runProps?.Italic != null) {
+                        result = $"<i>{result}</i>";
+                    }
+                    if (runProps?.Bold != null) {
+                        result = $"<b>{result}</b>";
+                    }
+
+                    sb.Append(result);
+                }
+                sb.Append("</p>");
+            }
+
+            sb.Append("</body></html>");
+            return sb.ToString();
+        }
+    }
+}

--- a/OfficeIMO.Html/OfficeIMO.Html.csproj
+++ b/OfficeIMO.Html/OfficeIMO.Html.csproj
@@ -1,0 +1,55 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>An Open Source cross-platform .NET library providing HTML conversion helpers.</Description>
+        <AssemblyName>OfficeIMO.Html</AssemblyName>
+        <AssemblyTitle>OfficeIMO.Html</AssemblyTitle>
+
+        <VersionPrefix>1.0.6</VersionPrefix>
+        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
+            netstandard2.0;net472;net8.0;net9.0
+        </TargetFrameworks>
+        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
+            net8.0;net9.0
+        </TargetFrameworks>
+        <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+        <Company>Evotec</Company>
+        <Authors>Przemyslaw Klys</Authors>
+
+        <PackageId>OfficeIMO.Html</PackageId>
+        <PackageTags>html;openxml;office;docx;net472;net8.0;net9.0</PackageTags>
+        <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <DelaySign>False</DelaySign>
+        <IsPublishable>True</IsPublishable>
+        <Copyright>(c) 2011 - 2024 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
+        <PackageIcon>OfficeIMO.png</PackageIcon>
+        <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
+        <DebugType>portable</DebugType>
+        <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
+        <GenerateDocumentationFile>True</GenerateDocumentationFile>
+        <LangVersion>Latest</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\Assets\OfficeIMO.png">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="DocumentFormat.OpenXml" Version="[3.3.0,4.0.0)" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="System" />
+        <Using Include="System.Text" />
+        <Using Include="System.Collections.Generic" />
+        <Using Include="System.Collections" />
+        <Using Include="System.Linq" />
+        <Using Include="System.IO" />
+        <Using Include="DocumentFormat.OpenXml" />
+    </ItemGroup>
+
+</Project>

--- a/OfficeIMO.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Html/Options/HtmlToWordOptions.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace OfficeIMO.Html {
+    /// <summary>
+    /// Options controlling HTML to Word conversion.
+    /// </summary>
+    public class HtmlToWordOptions {
+        /// <summary>
+        /// Optional font family applied to created runs.
+        /// </summary>
+        public string? FontFamily { get; set; }
+    }
+}

--- a/OfficeIMO.Html/Options/WordToHtmlOptions.cs
+++ b/OfficeIMO.Html/Options/WordToHtmlOptions.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace OfficeIMO.Html {
+    /// <summary>
+    /// Options controlling Word to HTML conversion.
+    /// </summary>
+    public class WordToHtmlOptions {
+        /// <summary>
+        /// When true, includes run font information as inline styles.
+        /// </summary>
+        public bool IncludeStyles { get; set; }
+    }
+}

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using OfficeIMO.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Html {
+    [Fact]
+    public void Test_Html_RoundTrip() {
+        string html = "<p>Hello <b>world</b> and <i>universe</i>.</p>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "Calibri" });
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeStyles = true });
+
+        Assert.Contains("<b>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("</b>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("world", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<i>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("</i>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("universe", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("font-family:Calibri", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/OfficeIMO.Tests/OfficeIMO.Tests.csproj
+++ b/OfficeIMO.Tests/OfficeIMO.Tests.csproj
@@ -30,6 +30,7 @@
     <ItemGroup>
         <ProjectReference Include="..\OfficeIMO.Word\OfficeIMO.Word.csproj" />
         <ProjectReference Include="..\OfficeIMO.Excel\OfficeIMO.Excel.csproj" />
+        <ProjectReference Include="..\OfficeIMO.Html\OfficeIMO.Html.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OfficeImo.sln
+++ b/OfficeImo.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.32014.148
@@ -130,42 +130,100 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{D545
 		.github\FUNDING.yml = .github\FUNDING.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Html", "OfficeIMO.Html\OfficeIMO.Html.csproj", "{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Debug|x64.Build.0 = Debug|Any CPU
+		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Debug|x86.Build.0 = Debug|Any CPU
 		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Release|x64.ActiveCfg = Release|Any CPU
+		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Release|x64.Build.0 = Release|Any CPU
+		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Release|x86.ActiveCfg = Release|Any CPU
+		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Release|x86.Build.0 = Release|Any CPU
 		{B437E21F-3A63-45C3-9098-7BA302AB7301}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B437E21F-3A63-45C3-9098-7BA302AB7301}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B437E21F-3A63-45C3-9098-7BA302AB7301}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B437E21F-3A63-45C3-9098-7BA302AB7301}.Debug|x64.Build.0 = Debug|Any CPU
+		{B437E21F-3A63-45C3-9098-7BA302AB7301}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B437E21F-3A63-45C3-9098-7BA302AB7301}.Debug|x86.Build.0 = Debug|Any CPU
 		{B437E21F-3A63-45C3-9098-7BA302AB7301}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B437E21F-3A63-45C3-9098-7BA302AB7301}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B437E21F-3A63-45C3-9098-7BA302AB7301}.Release|x64.ActiveCfg = Release|Any CPU
+		{B437E21F-3A63-45C3-9098-7BA302AB7301}.Release|x64.Build.0 = Release|Any CPU
+		{B437E21F-3A63-45C3-9098-7BA302AB7301}.Release|x86.ActiveCfg = Release|Any CPU
+		{B437E21F-3A63-45C3-9098-7BA302AB7301}.Release|x86.Build.0 = Release|Any CPU
 		{CC1AF4F4-1BA1-4639-8434-09E3F543DB09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CC1AF4F4-1BA1-4639-8434-09E3F543DB09}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC1AF4F4-1BA1-4639-8434-09E3F543DB09}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CC1AF4F4-1BA1-4639-8434-09E3F543DB09}.Debug|x64.Build.0 = Debug|Any CPU
+		{CC1AF4F4-1BA1-4639-8434-09E3F543DB09}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CC1AF4F4-1BA1-4639-8434-09E3F543DB09}.Debug|x86.Build.0 = Debug|Any CPU
 		{CC1AF4F4-1BA1-4639-8434-09E3F543DB09}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC1AF4F4-1BA1-4639-8434-09E3F543DB09}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC1AF4F4-1BA1-4639-8434-09E3F543DB09}.Release|x64.ActiveCfg = Release|Any CPU
+		{CC1AF4F4-1BA1-4639-8434-09E3F543DB09}.Release|x64.Build.0 = Release|Any CPU
+		{CC1AF4F4-1BA1-4639-8434-09E3F543DB09}.Release|x86.ActiveCfg = Release|Any CPU
+		{CC1AF4F4-1BA1-4639-8434-09E3F543DB09}.Release|x86.Build.0 = Release|Any CPU
 		{80B77D75-D25C-4168-B6A3-FA58DB118EF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{80B77D75-D25C-4168-B6A3-FA58DB118EF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80B77D75-D25C-4168-B6A3-FA58DB118EF8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{80B77D75-D25C-4168-B6A3-FA58DB118EF8}.Debug|x64.Build.0 = Debug|Any CPU
+		{80B77D75-D25C-4168-B6A3-FA58DB118EF8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{80B77D75-D25C-4168-B6A3-FA58DB118EF8}.Debug|x86.Build.0 = Debug|Any CPU
 		{80B77D75-D25C-4168-B6A3-FA58DB118EF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{80B77D75-D25C-4168-B6A3-FA58DB118EF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80B77D75-D25C-4168-B6A3-FA58DB118EF8}.Release|x64.ActiveCfg = Release|Any CPU
+		{80B77D75-D25C-4168-B6A3-FA58DB118EF8}.Release|x64.Build.0 = Release|Any CPU
+		{80B77D75-D25C-4168-B6A3-FA58DB118EF8}.Release|x86.ActiveCfg = Release|Any CPU
+		{80B77D75-D25C-4168-B6A3-FA58DB118EF8}.Release|x86.Build.0 = Release|Any CPU
 		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Debug|x64.Build.0 = Debug|Any CPU
+		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Debug|x86.Build.0 = Debug|Any CPU
 		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Release|x64.ActiveCfg = Release|Any CPU
+		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Release|x64.Build.0 = Release|Any CPU
+		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Release|x86.ActiveCfg = Release|Any CPU
+		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Release|x86.Build.0 = Release|Any CPU
+		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Debug|x64.Build.0 = Debug|Any CPU
+		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Debug|x86.Build.0 = Debug|Any CPU
+		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Release|x64.ActiveCfg = Release|Any CPU
+		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Release|x64.Build.0 = Release|Any CPU
+		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Release|x86.ActiveCfg = Release|Any CPU
+		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {DAC88AB0-9011-4EED-A7F3-F9E8C5958DBF}
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{B261C012-2D98-485E-AD5D-BD4CB31EE7E4} = {5A10AB86-32EA-42AE-A029-222CCE1E282C}
 		{AF836F5B-8CAB-4AF4-AEEB-3C4E718D9AFD} = {B261C012-2D98-485E-AD5D-BD4CB31EE7E4}
 		{3265256C-A216-4CA9-8D5E-940FE94C4901} = {B261C012-2D98-485E-AD5D-BD4CB31EE7E4}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DAC88AB0-9011-4EED-A7F3-F9E8C5958DBF}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add HtmlToWordConverter for mapping simple HTML structures to Word elements
- add WordToHtmlConverter for generating HTML from WordprocessingDocuments
- include example and round-trip unit test covering styling options
- reorganize converters under dedicated Html folder with separate option classes

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeImo.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_688f511a3a18832eb4c3a78fc60c5cb6