### PR TITLE
feat: extend cleanup options

### DIFF
--- a/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample03.cs
+++ b/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample03.cs
@@ -1,0 +1,23 @@
+using System;
+using OfficeIMO.Word;
+
+/// <summary>
+/// Demonstrates cleanup operations on a newly created document.
+/// </summary>
+internal static partial class CleanupDocuments {
+    /// <summary>
+    /// Creates a document with redundant runs and applies cleanup.
+    /// </summary>
+    /// <param name="folderPath">Directory to create the file in.</param>
+    /// <param name="openWord">Opens Word when <c>true</c>.</param>
+    public static void CleanupDocuments_Sample03(string folderPath, bool openWord) {
+        string filePath = System.IO.Path.Combine(folderPath, "CleanupDocument.docx");
+        using (WordDocument document = WordDocument.Create(filePath)) {
+            WordParagraph p = document.AddParagraph("Hello");
+            p.SetBold();
+            p.AddText(" World").SetBold();
+            document.CleanupDocument();
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.CleanupOptions.cs
+++ b/OfficeIMO.Tests/Word.CleanupOptions.cs
@@ -1,0 +1,65 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void CleanupDocument_MergesRunsWithSameFormatting() {
+            string filePath = Path.Combine(_directoryWithFiles, "CleanupRuns.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordParagraph p = document.AddParagraph("Hello");
+                p.SetBold();
+                p.AddText(" World").SetBold();
+                Assert.Equal(2, p._paragraph.Elements<Run>().Count());
+                document.CleanupDocument();
+                Assert.Single(p._paragraph.Elements<Run>());
+                Assert.Equal("Hello World", p.Text);
+                document.Save(false);
+            }
+        }
+
+        [Fact]
+        public void CleanupDocument_RemovesEmptyRuns() {
+            string filePath = Path.Combine(_directoryWithFiles, "CleanupEmptyRuns.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordParagraph p = document.AddParagraph("Hello");
+                p._paragraph.AppendChild(new Run());
+                Assert.Equal(2, p._paragraph.Elements<Run>().Count());
+                document.CleanupDocument();
+                Assert.Single(p._paragraph.Elements<Run>());
+                document.Save(false);
+            }
+        }
+
+        [Fact]
+        public void CleanupDocument_RemovesRedundantRunProperties() {
+            string filePath = Path.Combine(_directoryWithFiles, "CleanupRunProperties.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordParagraph run = document.AddParagraph().AddText("Test");
+                run.SetBold();
+                run.SetBold(false);
+                Assert.NotNull(run._run.RunProperties);
+                document.CleanupDocument();
+                Assert.Null(run._paragraph.Elements<Run>().First().RunProperties);
+                document.Save(false);
+            }
+        }
+
+        [Fact]
+        public void CleanupDocument_RemovesEmptyParagraphs() {
+            string filePath = Path.Combine(_directoryWithFiles, "CleanupEmptyParagraphs.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Hello");
+                document.AddParagraph();
+                Assert.Equal(2, document.Paragraphs.Count);
+                document.CleanupDocument();
+                Assert.Single(document.Paragraphs);
+                Assert.Equal("Hello", document.Paragraphs.First().Text);
+                document.Save(false);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/DocumentCleanupOptions.cs
+++ b/OfficeIMO.Word/DocumentCleanupOptions.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Specifies document cleanup operations.
+    /// </summary>
+    [Flags]
+    public enum DocumentCleanupOptions {
+        /// <summary>
+        /// No cleanup.
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Merge consecutive runs that share identical formatting.
+        /// </summary>
+        MergeIdenticalRuns = 1,
+        /// <summary>
+        /// Remove runs with no text content.
+        /// </summary>
+        RemoveEmptyRuns = 2,
+        /// <summary>
+        /// Remove run properties that have no children.
+        /// </summary>
+        RemoveRedundantRunProperties = 4,
+        /// <summary>
+        /// Delete paragraphs that end up with no runs.
+        /// </summary>
+        RemoveEmptyParagraphs = 8,
+        /// <summary>
+        /// Perform all cleanup operations.
+        /// </summary>
+        All = MergeIdenticalRuns | RemoveEmptyRuns | RemoveRedundantRunProperties | RemoveEmptyParagraphs
+    }
+}

--- a/OfficeIMO.Word/WordDocument.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PrivateMethods.cs
@@ -77,4 +77,42 @@ public partial class WordDocument {
         }
         return count;
     }
+
+    private static int CleanupParagraph(Paragraph paragraph, DocumentCleanupOptions options) {
+        int count = 0;
+
+        if (options.HasFlag(DocumentCleanupOptions.RemoveEmptyRuns) || options.HasFlag(DocumentCleanupOptions.RemoveRedundantRunProperties)) {
+            foreach (var run in paragraph.Elements<Run>().ToList()) {
+                if (options.HasFlag(DocumentCleanupOptions.RemoveEmptyRuns) && IsRunEmpty(run)) {
+                    run.Remove();
+                    count++;
+                    continue;
+                }
+
+                if (options.HasFlag(DocumentCleanupOptions.RemoveRedundantRunProperties) && run.RunProperties != null && !run.RunProperties.ChildElements.Any()) {
+                    run.RunProperties.Remove();
+                    count++;
+                }
+            }
+        }
+
+        if (options.HasFlag(DocumentCleanupOptions.RemoveEmptyParagraphs) && IsParagraphEmpty(paragraph)) {
+            paragraph.Remove();
+            return count + 1;
+        }
+
+        if (options.HasFlag(DocumentCleanupOptions.MergeIdenticalRuns)) {
+            count += CombineIdenticalRuns(paragraph);
+        }
+
+        return count;
+    }
+
+    private static bool IsRunEmpty(Run run) {
+        return !run.ChildElements.OfType<Text>().Any() && run.ChildElements.All(e => e is RunProperties);
+    }
+
+    private static bool IsParagraphEmpty(Paragraph paragraph) {
+        return !paragraph.Elements<Run>().Any() && paragraph.ChildElements.All(e => e is ParagraphProperties);
+    }
 }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -755,57 +755,27 @@ namespace OfficeIMO.Word {
         /// It may impact on how your document looks like, please do extensive testing before using this feature.
         /// </summary>
         /// <returns></returns>
-        public int CleanupDocument() {
+        public int CleanupDocument(DocumentCleanupOptions options = DocumentCleanupOptions.All) {
             int count = 0;
 
-            foreach (var paragraph in this.Paragraphs) {
-                count += CombineIdenticalRuns(paragraph._paragraph);
-            }
-
-            foreach (var table in this.Tables) {
-                table.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
-            }
-
-            if (this.Header.Default != null) {
-                foreach (var p in this.Header.Default.Paragraphs) count += CombineIdenticalRuns(p._paragraph);
-                foreach (var table in this.Header.Default.Tables) {
-                    table.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+            if (_wordprocessingDocument?.MainDocumentPart?.Document?.Body != null) {
+                foreach (var paragraph in _wordprocessingDocument.MainDocumentPart.Document.Body.Descendants<Paragraph>().ToList()) {
+                    count += CleanupParagraph(paragraph, options);
                 }
             }
 
-            if (this.Header.Even != null) {
-                this.Header.Even.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
-                foreach (var table in this.Header.Even.Tables) {
-                    table.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
-                }
-            }
-            if (this.Header.First != null) {
-                this.Header.First.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
-                foreach (var table in this.Header.First.Tables) {
-                    table.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+            foreach (var header in _wordprocessingDocument?.MainDocumentPart?.HeaderParts ?? Enumerable.Empty<HeaderPart>()) {
+                foreach (var paragraph in header.Header.Descendants<Paragraph>().ToList()) {
+                    count += CleanupParagraph(paragraph, options);
                 }
             }
 
-            if (this.Footer.Default != null) {
-                this.Footer.Default.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
-                foreach (var table in this.Footer.Default.Tables) {
-                    table.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
+            foreach (var footer in _wordprocessingDocument?.MainDocumentPart?.FooterParts ?? Enumerable.Empty<FooterPart>()) {
+                foreach (var paragraph in footer.Footer.Descendants<Paragraph>().ToList()) {
+                    count += CleanupParagraph(paragraph, options);
                 }
             }
 
-            if (this.Footer.Even != null) {
-                this.Footer.Even.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
-                foreach (var table in this.Footer.Even.Tables) {
-                    table.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
-                }
-            }
-
-            if (this.Footer.First != null) {
-                this.Footer.First.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
-                foreach (var table in this.Footer.First.Tables) {
-                    table.Paragraphs.ForEach(p => count += CombineIdenticalRuns(p._paragraph));
-                }
-            }
             return count;
         }
 

--- a/OfficeIMO.Word/WordParagraph.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PrivateMethods.cs
@@ -142,41 +142,6 @@ namespace OfficeIMO.Word {
         //        }
         //    }
         //}
-
-        /// <summary>
-        /// Combines the identical runs.
-        /// </summary>
-        /// <param name="body"></param>
-        ///
-        ///
-        /// https://stackoverflow.com/questions/31056953/when-using-mergefield-fieldcodes-in-openxml-sdk-in-c-sharp-why-do-field-codes-di
-        public static void CombineIdenticalRuns(Body body) {
-
-            List<Run> runsToRemove = new List<Run>();
-
-            foreach (Paragraph para in body.Descendants<Paragraph>()) {
-                List<Run> runs = para.Elements<Run>().ToList();
-                for (int i = runs.Count - 2; i >= 0; i--) {
-                    Text text1 = runs[i].GetFirstChild<Text>();
-                    Text text2 = runs[i + 1].GetFirstChild<Text>();
-                    if (text1 != null && text2 != null) {
-                        string rPr1 = "";
-                        string rPr2 = "";
-                        if (runs[i].RunProperties != null) rPr1 = runs[i].RunProperties.OuterXml;
-                        if (runs[i + 1].RunProperties != null) rPr2 = runs[i + 1].RunProperties.OuterXml;
-                        if (rPr1 == rPr2) {
-                            text1.Text += text2.Text;
-                            runsToRemove.Add(runs[i + 1]);
-                        }
-                    }
-                }
-            }
-
-            foreach (Run run in runsToRemove) {
-                run.Remove();
-            }
-        }
-
         private List<string> ConvertStringToList(string text) {
             string[] splitStrings = { Environment.NewLine, "\r\n", "\n" };
             string[] textSplit = text.Split(splitStrings, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
## Summary
- add DocumentCleanupOptions flags to control cleanup behavior
- enhance CleanupDocument to remove empty content and merge runs across document parts
- cover cleanup scenarios with new example and unit tests

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688f51644af0832e9197603f0a87ac64