### PR TITLE
Fix PDF converter build errors

### DIFF
--- a/OfficeIMO.Examples/Word/Pdf/Pdf.SaveAsPdf.cs
+++ b/OfficeIMO.Examples/Word/Pdf/Pdf.SaveAsPdf.cs
@@ -1,8 +1,8 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Pdf;
+using OfficeIMO.Word;
 using System;
 using System.IO;
-using DocumentFormat.OpenXml.Wordprocessing;
-using OfficeIMO.Word;
-using OfficeIMO.Pdf;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class Pdf {
@@ -15,26 +15,32 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(docPath)) {
                 document.AddHeadersAndFooters();
                 document.Header.Default.AddParagraph("Example Header");
+                WordTable headerTable = document.Header.Default.AddTable(1, 1);
+                headerTable.Rows[0].Cells[0].Paragraphs[0].Text = "H1";
                 document.Footer.Default.AddParagraph("Example Footer");
+                WordTable footerTable = document.Footer.Default.AddTable(1, 1);
+                footerTable.Rows[0].Cells[0].Paragraphs[0].Text = "F1";
 
-                var heading = document.AddParagraph("Sample Heading");
+                WordParagraph heading = document.AddParagraph("Sample Heading");
                 heading.Style = WordParagraphStyles.Heading1;
 
-                var formatted = document.AddParagraph("Bold Italic Underlined Centered");
+                WordParagraph formatted = document.AddParagraph("Bold Italic Underlined Centered");
                 formatted.Bold = true;
                 formatted.Italic = true;
                 formatted.Underline = UnderlineValues.Single;
                 formatted.ParagraphAlignment = JustificationValues.Center;
 
-                var list = document.AddList(WordListStyle.ArticleSections);
+                WordList list = document.AddList(WordListStyle.ArticleSections);
                 list.AddItem("First Item");
                 list.AddItem("Second Item");
 
-                var table = document.AddTable(2, 2);
+                WordTable table = document.AddTable(2, 2);
                 table.Rows[0].Cells[0].Paragraphs[0].Text = "A1";
                 table.Rows[0].Cells[1].Paragraphs[0].Text = "B1";
                 table.Rows[1].Cells[0].Paragraphs[0].Text = "A2";
                 table.Rows[1].Cells[1].Paragraphs[0].Text = "B2";
+                WordTable nested = table.Rows[0].Cells[0].AddTable(1, 1);
+                nested.Rows[0].Cells[0].Paragraphs[0].Text = "N1";
 
                 document.AddParagraph().AddImage(imagePath, 50, 50);
 

--- a/OfficeIMO.Pdf/WordPdfConverter.cs
+++ b/OfficeIMO.Pdf/WordPdfConverter.cs
@@ -1,162 +1,184 @@
-using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using QuestPDF.Fluent;
 using QuestPDF.Helpers;
 using QuestPDF.Infrastructure;
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using W = DocumentFormat.OpenXml.Wordprocessing;
 
-namespace OfficeIMO.Pdf {
+namespace OfficeIMO.Pdf;
 
-    /// Provides extension methods for converting <see cref="WordDocument"/> instances to PDF files.
+/// <summary>
+/// Provides extension methods for converting <see cref="WordDocument"/> instances to PDF files.
+/// </summary>
+public static class WordPdfConverter {
+    /// <summary>
+    /// Saves the specified <see cref="WordDocument"/> as a PDF at the given <paramref name="path"/>.
     /// </summary>
-    public static class WordPdfConverter {
-        /// <summary>
-        /// Saves the specified <see cref="WordDocument"/> as a PDF at the given <paramref name="path"/>.
-        /// </summary>
-        /// <param name="document">The document to convert.</param>
-        /// <param name="path">The output PDF file path.</param>
-        public static void SaveAsPdf(this WordDocument document, string path) {
-            QuestPDF.Settings.License = LicenseType.Community;
-            var pdf = QuestPDF.Fluent.Document.Create(container => {
-                container.Page(page => {
-                    page.Margin(1, Unit.Centimetre);
+    /// <param name="document">The document to convert.</param>
+    /// <param name="path">The output PDF file path.</param>
+    public static void SaveAsPdf(this WordDocument document, string path) {
+        QuestPDF.Settings.License = LicenseType.Community;
 
-                    var headerParagraphs = document.Header?.Default?.Paragraphs ?? new List<WordParagraph>();
-                    if (headerParagraphs.Count > 0) {
-                        page.Header().Column(header => {
-                            foreach (var paragraph in headerParagraphs) {
-                                header.Item().Element(e => RenderParagraph(e, paragraph));
-                            }
-                        });
-                    }
-                    var footerParagraphs = document.Footer?.Default?.Paragraphs ?? new List<WordParagraph>();
-                    if (footerParagraphs.Count > 0) {
-                        page.Footer().Column(footer => {
-                            foreach (var paragraph in footerParagraphs) {
-                                footer.Item().Element(e => RenderParagraph(e, paragraph));
-                            }
-                        });
-                    page.Content().Column(column => {
-                        foreach (var paragraph in document.Paragraphs) {
-                            column.Item().Element(e => RenderParagraph(e, paragraph));
+        Dictionary<WordParagraph, string> listPrefixes = BuildListPrefixes(document);
 
-                        foreach (var list in document.Lists) {
-                            var index = 1;
-                            bool bullet = list.Style.ToString().IndexOf("Bullet", StringComparison.OrdinalIgnoreCase) >= 0;
-                            foreach (var item in list.ListItems) {
-                                var prefix = bullet ? "• " : $"{index++}. ";
-                                column.Item().Element(e => RenderParagraph(e, item, prefix));
-                            }
-                        }
-                        foreach (var table in document.Tables) {
-                            column.Item().Table(tableContainer => {
-                                var columnCount = table.Rows.Max(r => r.CellsCount);
-                                tableContainer.ColumnsDefinition(columns => {
-                                    for (int i = 0; i < columnCount; i++) {
-                                        columns.RelativeColumn();
-                                    }
-                                });
+        Document pdf = Document.Create(container => {
+            container.Page(page => {
+                page.Margin(1, Unit.Centimetre);
 
-                                foreach (var row in table.Rows) {
-                                    foreach (var cell in row.Cells) {
-                                        var firstParagraph = cell.Paragraphs.FirstOrDefault();
-                                        if (firstParagraph != null) {
-                                            tableContainer.Cell().Element(e => RenderParagraph(e, firstParagraph));
-                                        } else {
-                                            tableContainer.Cell();
-                                        }
-                            });
-                        }
-                        foreach (var image in document.Images) {
-                            column.Item().Image(image.GetBytes());
-                        }
+                WordHeaderFooter header = document.Header?.Default;
+                if (header != null && (header.Paragraphs.Count > 0 || header.Tables.Count > 0)) {
+                    page.Header().Column(col => {
+                        RenderElements(col, header.Paragraphs, header.Tables);
                     });
-
-            pdf.GeneratePdf(path);
-            static IContainer RenderParagraph(IContainer container, WordParagraph paragraph, string prefix = "") {
-                if (paragraph == null) {
-                    return container;
-                }
-                if (paragraph.ParagraphAlignment == JustificationValues.Center) {
-                    container = container.AlignCenter();
-                } else if (paragraph.ParagraphAlignment == JustificationValues.Right) {
-                    container = container.AlignRight();
-                } else if (paragraph.ParagraphAlignment == JustificationValues.Both) {
-                    container = container.AlignLeft();
                 }
 
-                container.Text(text => {
-                    var span = text.Span(prefix + paragraph.Text);
-                    if (paragraph.Bold) {
-                        span = span.Bold();
-                    }
-                    if (paragraph.Italic) {
-                        span = span.Italic();
-                    }
+                WordHeaderFooter footer = document.Footer?.Default;
+                if (footer != null && (footer.Paragraphs.Count > 0 || footer.Tables.Count > 0)) {
+                    page.Footer().Column(col => {
+                        RenderElements(col, footer.Paragraphs, footer.Tables);
+                    });
+                }
 
-                    if (paragraph.Underline != null) {
-                        span = span.Underline();
-                    }
-                    if (paragraph.Style.HasValue) {
-                        switch (paragraph.Style.Value) {
-                            case WordParagraphStyles.Heading1:
-                                span.FontSize(24);
-                                span.Bold();
-                                break;
-                            case WordParagraphStyles.Heading2:
-                                span.FontSize(20);
-                                span.Bold();
-                                break;
-                            case WordParagraphStyles.Heading3:
-                                span.FontSize(16);
-                                span.Bold();
-                                break;
-                            case WordParagraphStyles.Heading4:
-                                span.FontSize(14);
-                                span.Bold();
-                                break;
-                            case WordParagraphStyles.Heading5:
-                                span.FontSize(13);
-                                span.Bold();
-                                break;
-                            case WordParagraphStyles.Heading6:
-                                span.FontSize(12);
-                                span.Bold();
-                                break;
+                page.Content().Column(column => {
+                    foreach (WordElement element in document.Elements) {
+                        if (element is WordParagraph paragraph) {
+                            column.Item().Element(e => RenderParagraph(e, paragraph, GetPrefix(paragraph)));
+                        } else if (element is WordTable table) {
+                            column.Item().Element(e => RenderTable(e, table));
                         }
+                    }
                 });
-                return container;
+            });
+        });
+
+        pdf.GeneratePdf(path);
+
+        string GetPrefix(WordParagraph paragraph) {
+            if (listPrefixes.TryGetValue(paragraph, out string value)) {
+                return value;
             }
 
-                            span.Bold();
-                            break;
-                        case WordParagraphStyles.Heading2:
-                            span.FontSize(20);
-                            span.Bold();
-                            break;
-                        case WordParagraphStyles.Heading3:
-                            span.FontSize(16);
-                            span.Bold();
-                            break;
-                        case WordParagraphStyles.Heading4:
-                            span.FontSize(14);
-                            span.Bold();
-                            break;
-                        case WordParagraphStyles.Heading5:
-                            span.FontSize(13);
-                            span.Bold();
-                            break;
-                        case WordParagraphStyles.Heading6:
-                            span.FontSize(12);
-                            span.Bold();
-                            break;
+            return string.Empty;
+        }
+
+        void RenderElements(ColumnDescriptor column, IEnumerable<WordParagraph> paragraphs, IEnumerable<WordTable> tables) {
+            foreach (WordParagraph paragraph in paragraphs) {
+                column.Item().Element(e => RenderParagraph(e, paragraph, GetPrefix(paragraph)));
+            }
+
+            foreach (WordTable table in tables) {
+                column.Item().Element(e => RenderTable(e, table));
+            }
+        }
+
+        IContainer RenderTable(IContainer container, WordTable table) {
+            container.Table(tableContainer => {
+                int columnCount = table.Rows.Max(r => r.CellsCount);
+                tableContainer.ColumnsDefinition(columns => {
+                    for (int i = 0; i < columnCount; i++) {
+                        columns.RelativeColumn();
+                    }
+                });
+
+                foreach (WordTableRow row in table.Rows) {
+                    foreach (WordTableCell cell in row.Cells) {
+                        tableContainer.Cell().Column(cellColumn => {
+                            foreach (WordParagraph paragraph in cell.Paragraphs) {
+                                cellColumn.Item().Element(e => RenderParagraph(e, paragraph, GetPrefix(paragraph)));
+                            }
+
+                            foreach (WordTable nested in cell.NestedTables) {
+                                cellColumn.Item().Element(e => RenderTable(e, nested));
+                            }
+                        });
                     }
                 }
             });
 
             return container;
+        }
+
+        static IContainer RenderParagraph(IContainer container, WordParagraph paragraph, string prefix) {
+            if (paragraph == null) {
+                return container;
+            }
+
+            if (paragraph.ParagraphAlignment == W.JustificationValues.Center) {
+                container = container.AlignCenter();
+            } else if (paragraph.ParagraphAlignment == W.JustificationValues.Right) {
+                container = container.AlignRight();
+            } else if (paragraph.ParagraphAlignment == W.JustificationValues.Both) {
+                container = container.AlignLeft();
+            }
+
+            container.Column(col => {
+                if (paragraph.Image != null) {
+                    col.Item().Image(paragraph.Image.GetBytes());
+                }
+
+                if (!string.IsNullOrEmpty(paragraph.Text) || !string.IsNullOrEmpty(prefix)) {
+                    col.Item().Text(text => {
+                        TextSpanDescriptor span = text.Span(prefix + paragraph.Text);
+                        if (paragraph.Bold) {
+                            span = span.Bold();
+                        }
+                        if (paragraph.Italic) {
+                            span = span.Italic();
+                        }
+                        if (paragraph.Underline != null) {
+                            span = span.Underline();
+                        }
+                        if (paragraph.Style.HasValue) {
+                            switch (paragraph.Style.Value) {
+                                case WordParagraphStyles.Heading1:
+                                    span.FontSize(24).Bold();
+                                    break;
+                                case WordParagraphStyles.Heading2:
+                                    span.FontSize(20).Bold();
+                                    break;
+                                case WordParagraphStyles.Heading3:
+                                    span.FontSize(16).Bold();
+                                    break;
+                                case WordParagraphStyles.Heading4:
+                                    span.FontSize(14).Bold();
+                                    break;
+                                case WordParagraphStyles.Heading5:
+                                    span.FontSize(13).Bold();
+                                    break;
+                                case WordParagraphStyles.Heading6:
+                                    span.FontSize(12).Bold();
+                                    break;
+                            }
+                        }
+                    });
+                }
+            });
+
+            return container;
+        }
+
+        static Dictionary<WordParagraph, string> BuildListPrefixes(WordDocument document) {
+            Dictionary<WordParagraph, string> result = new Dictionary<WordParagraph, string>();
+
+            foreach (WordList list in document.Lists) {
+                Dictionary<int, int> indices = new Dictionary<int, int>();
+                bool bullet = list.Style.ToString().IndexOf("Bullet", System.StringComparison.OrdinalIgnoreCase) >= 0;
+                foreach (WordParagraph item in list.ListItems) {
+                    int level = item.ListItemLevel ?? 0;
+                    if (!indices.ContainsKey(level)) {
+                        indices[level] = 1;
+                    }
+
+                    int index = indices[level];
+                    indices[level] = index + 1;
+                    string prefix = bullet ? "• " : $"{index}. ";
+                    string indent = new string(' ', level * 2);
+                    result[item] = indent + prefix;
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
@@ -1,6 +1,6 @@
 using DocumentFormat.OpenXml.Wordprocessing;
-using OfficeIMO.Word;
 using OfficeIMO.Pdf;
+using OfficeIMO.Word;
 using Xunit;
 
 namespace OfficeIMO.Tests;
@@ -11,31 +11,37 @@ public partial class Word {
         var docPath = Path.Combine(_directoryWithFiles, "PdfSample.docx");
         var pdfPath = Path.Combine(_directoryWithFiles, "PdfSample.pdf");
 
-        using (var document = WordDocument.Create(docPath)) {
+        using (WordDocument document = WordDocument.Create(docPath)) {
             document.AddHeadersAndFooters();
             document.Header.Default.AddParagraph("Sample Header");
+            WordTable headerTable = document.Header.Default.AddTable(1, 1);
+            headerTable.Rows[0].Cells[0].Paragraphs[0].Text = "H1";
             document.Footer.Default.AddParagraph("Sample Footer");
+            WordTable footerTable = document.Footer.Default.AddTable(1, 1);
+            footerTable.Rows[0].Cells[0].Paragraphs[0].Text = "F1";
 
-            var heading = document.AddParagraph("Heading One");
+            WordParagraph heading = document.AddParagraph("Heading One");
             heading.Style = WordParagraphStyles.Heading1;
 
-            var formatted = document.AddParagraph("Centered Bold Italic Underlined");
+            WordParagraph formatted = document.AddParagraph("Centered Bold Italic Underlined");
             formatted.Bold = true;
             formatted.Italic = true;
             formatted.Underline = UnderlineValues.Single;
             formatted.ParagraphAlignment = JustificationValues.Center;
 
-            var list = document.AddList(WordListStyle.ArticleSections);
+            WordList list = document.AddList(WordListStyle.ArticleSections);
             list.AddItem("Numbered Item 1");
             list.AddItem("Numbered Item 2");
 
-            var table = document.AddTable(2, 2);
+            WordTable table = document.AddTable(2, 2);
             table.Rows[0].Cells[0].Paragraphs[0].Text = "A1";
             table.Rows[0].Cells[1].Paragraphs[0].Text = "B1";
             table.Rows[1].Cells[0].Paragraphs[0].Text = "A2";
             table.Rows[1].Cells[1].Paragraphs[0].Text = "B2";
+            WordTable nested = table.Rows[0].Cells[0].AddTable(1, 1);
+            nested.Rows[0].Cells[0].Paragraphs[0].Text = "N1";
 
-            var imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+            string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
             document.AddParagraph().AddImage(imagePath, 50, 50);
 
             document.Save();


### PR DESCRIPTION
## Summary
- Traverse document elements to render headers, footers, lists, images, and nested tables during PDF export
- Precompute list numbering and update tests and examples for nested table coverage

## Testing
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_688fabf58690832e8c408c5811101480