### PR TITLE
Add SaveAsPdf example and PDF tests

### DIFF
--- a/OfficeIMO.Examples/Word/Pdf/Pdf.SaveAsPdfRelative.cs
+++ b/OfficeIMO.Examples/Word/Pdf/Pdf.SaveAsPdfRelative.cs
@@ -1,0 +1,19 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Pdf {
+        public static void Example_SaveAsPdfRelative(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Saving document as PDF using relative path");
+            string docPath = Path.Combine(folderPath, "SaveAsPdfRelative.docx");
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddParagraph("Hello PDF");
+                string current = Directory.GetCurrentDirectory();
+                Directory.SetCurrentDirectory(folderPath);
+                document.SaveAsPdf("output.pdf");
+                Directory.SetCurrentDirectory(current);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Pdf/Pdf.SaveAsPdfRelative.cs
+++ b/OfficeIMO.Examples/Word/Pdf/Pdf.SaveAsPdfRelative.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using OfficeIMO.Pdf;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -8,7 +9,19 @@ namespace OfficeIMO.Examples.Word {
             Console.WriteLine("[*] Saving document as PDF using relative path");
             string docPath = Path.Combine(folderPath, "SaveAsPdfRelative.docx");
             using (WordDocument document = WordDocument.Create(docPath)) {
-                document.AddParagraph("Hello PDF");
+                document.AddParagraph("First paragraph");
+                document.AddParagraph("Second paragraph").Bold = true;
+
+                WordList list = document.AddList(WordListStyle.Bulleted);
+                list.AddItem("Bullet 1");
+                list.AddItem("Bullet 2");
+
+                WordTable table = document.AddTable(2, 2);
+                table.Rows[0].Cells[0].Paragraphs[0].Text = "A1";
+                table.Rows[0].Cells[1].Paragraphs[0].Text = "B1";
+                table.Rows[1].Cells[0].Paragraphs[0].Text = "A2";
+                table.Rows[1].Cells[1].Paragraphs[0].Text = "B2";
+
                 string current = Directory.GetCurrentDirectory();
                 Directory.SetCurrentDirectory(folderPath);
                 document.SaveAsPdf("output.pdf");

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdfRelative.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdfRelative.cs
@@ -1,0 +1,31 @@
+using OfficeIMO.Pdf;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_RelativePath() {
+        var docPath = Path.Combine(_directoryWithFiles, "RelativeSample.docx");
+        var previous = Directory.GetCurrentDirectory();
+        Directory.SetCurrentDirectory(_directoryWithFiles);
+        try {
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddParagraph("Hello PDF");
+                document.SaveAsPdf("output.pdf");
+            }
+        } finally {
+            Directory.SetCurrentDirectory(previous);
+        }
+
+        var pdfPath = Path.Combine(_directoryWithFiles, "output.pdf");
+        Assert.True(File.Exists(pdfPath));
+        byte[] bytes = File.ReadAllBytes(pdfPath);
+        Assert.True(bytes.Length > 100);
+        string header = System.Text.Encoding.ASCII.GetString(bytes, 0, 4);
+        Assert.Equal("%PDF", header);
+        string trailer = System.Text.Encoding.ASCII.GetString(bytes, bytes.Length - 5, 5);
+        Assert.Contains("EOF", trailer);
+    }
+}

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdfRelative.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdfRelative.cs
@@ -12,7 +12,19 @@ public partial class Word {
         Directory.SetCurrentDirectory(_directoryWithFiles);
         try {
             using (WordDocument document = WordDocument.Create(docPath)) {
-                document.AddParagraph("Hello PDF");
+                document.AddParagraph("First paragraph");
+                document.AddParagraph("Second paragraph").Bold = true;
+
+                WordList list = document.AddList(WordListStyle.Bulleted);
+                list.AddItem("Bullet 1");
+                list.AddItem("Bullet 2");
+
+                WordTable table = document.AddTable(2, 2);
+                table.Rows[0].Cells[0].Paragraphs[0].Text = "A1";
+                table.Rows[0].Cells[1].Paragraphs[0].Text = "B1";
+                table.Rows[1].Cells[0].Paragraphs[0].Text = "A2";
+                table.Rows[1].Cells[1].Paragraphs[0].Text = "B2";
+
                 document.SaveAsPdf("output.pdf");
             }
         } finally {


### PR DESCRIPTION
## Summary
- add example demonstrating `WordDocument.SaveAsPdf("output.pdf")`
- test PDF saving with relative path and validate output structure

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688fbcea268c832e8d8f1e192d352193