### PR TITLE
Add stream output for Word PDF conversion

### DIFF
--- a/OfficeIMO.Examples/Word/Pdf/Pdf.SaveAsPdf.cs
+++ b/OfficeIMO.Examples/Word/Pdf/Pdf.SaveAsPdf.cs
@@ -48,5 +48,21 @@ namespace OfficeIMO.Examples.Word {
                 document.SaveAsPdf(pdfPath);
             }
         }
+
+        public static void Example_SaveAsPdfInMemory(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document and exporting to in-memory PDF");
+            string docPath = Path.Combine(folderPath, "ExportToPdfInMemory.docx");
+            string pdfPath = Path.Combine(folderPath, "ExportToPdfInMemory.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddParagraph("Hello World");
+                document.Save();
+
+                using (MemoryStream pdfStream = new MemoryStream()) {
+                    document.SaveAsPdf(pdfStream);
+                    File.WriteAllBytes(pdfPath, pdfStream.ToArray());
+                }
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
@@ -50,4 +50,36 @@ public partial class Word {
 
         Assert.True(File.Exists(pdfPath));
     }
+
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_ToMemoryStream() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfStreamSample.docx");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            document.AddParagraph("Hello World");
+            document.Save();
+
+            using (MemoryStream pdfStream = new MemoryStream()) {
+                document.SaveAsPdf(pdfStream);
+                Assert.True(pdfStream.Length > 0);
+            }
+        }
+    }
+
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_ToFileStream() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfFileStreamSample.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfFileStreamSample.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            document.AddParagraph("Hello World");
+            document.Save();
+
+            using (FileStream fileStream = File.Create(pdfPath)) {
+                document.SaveAsPdf(fileStream);
+            }
+        }
+
+        Assert.True(File.Exists(pdfPath));
+    }
 }


### PR DESCRIPTION
## Summary
- allow saving Word documents to PDF via `Stream`
- demonstrate in-memory PDF generation example
- verify stream-based PDF output with new unit tests

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_688fc2272ce4832ea61b1ccbcfd42ccd