### PR TITLE
Support heading tags in HTML conversion

### DIFF
--- a/OfficeIMO.Examples/Html/Html.Headings.cs
+++ b/OfficeIMO.Examples/Html/Html.Headings.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using OfficeIMO.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlHeadings(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlHeadings.docx");
+            string html = "<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><h4>Heading 4</h4><h5>Heading 5</h5><h6>Heading 6</h6>";
+
+            using (MemoryStream ms = new MemoryStream()) {
+                HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "Calibri" });
+                File.WriteAllBytes(filePath, ms.ToArray());
+
+                ms.Position = 0;
+                string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeStyles = true });
+                Console.WriteLine(roundTrip);
+            }
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
 
 namespace OfficeIMO.Html {
     /// <summary>
@@ -34,13 +35,43 @@ namespace OfficeIMO.Html {
             // Wrap in a root element to allow multiple top-level paragraphs
             XDocument xdoc = XDocument.Parse("<root>" + html + "</root>");
 
-            foreach (XElement paragraphElement in xdoc.Root!.Elements("p")) {
+            foreach (XElement element in xdoc.Root!.Elements()) {
                 Paragraph paragraph = new Paragraph();
-                foreach (XNode node in paragraphElement.Nodes()) {
+                WordParagraphStyles? style = null;
+                switch (element.Name.LocalName.ToLowerInvariant()) {
+                    case "p":
+                        break;
+                    case "h1":
+                        style = WordParagraphStyles.Heading1;
+                        break;
+                    case "h2":
+                        style = WordParagraphStyles.Heading2;
+                        break;
+                    case "h3":
+                        style = WordParagraphStyles.Heading3;
+                        break;
+                    case "h4":
+                        style = WordParagraphStyles.Heading4;
+                        break;
+                    case "h5":
+                        style = WordParagraphStyles.Heading5;
+                        break;
+                    case "h6":
+                        style = WordParagraphStyles.Heading6;
+                        break;
+                    default:
+                        continue;
+                }
+
+                if (style.HasValue) {
+                    paragraph.ParagraphProperties = new ParagraphProperties(new ParagraphStyleId { Val = style.Value.ToString() });
+                }
+
+                foreach (XNode node in element.Nodes()) {
                     if (node is XText textNode) {
                         paragraph.Append(CreateRun(textNode.Value, options));
-                    } else if (node is XElement element) {
-                        paragraph.Append(CreateRunFromElement(element, options));
+                    } else if (node is XElement inlineElement) {
+                        paragraph.Append(CreateRunFromElement(inlineElement, options));
                     }
                 }
                 body.Append(paragraph);

--- a/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
 
 namespace OfficeIMO.Html {
     /// <summary>
@@ -27,7 +28,16 @@ namespace OfficeIMO.Html {
             sb.Append("<html><body>");
 
             foreach (Paragraph paragraph in document.MainDocumentPart!.Document.Body!.Elements<Paragraph>()) {
-                sb.Append("<p>");
+                string tag = "p";
+                string? styleId = paragraph.ParagraphProperties?.ParagraphStyleId?.Val?.Value;
+                if (styleId != null && Enum.TryParse(styleId, true, out WordParagraphStyles style)) {
+                    if (style >= WordParagraphStyles.Heading1 && style <= WordParagraphStyles.Heading6) {
+                        int level = (int)style - (int)WordParagraphStyles.Heading1 + 1;
+                        tag = $"h{level}";
+                    }
+                }
+
+                sb.Append('<').Append(tag).Append('>');
                 foreach (Run run in paragraph.Elements<Run>()) {
                     string text = run.InnerText;
                     string encoded = System.Net.WebUtility.HtmlEncode(text);
@@ -50,7 +60,7 @@ namespace OfficeIMO.Html {
 
                     sb.Append(result);
                 }
-                sb.Append("</p>");
+                sb.Append("</").Append(tag).Append('>');
             }
 
             sb.Append("</body></html>");

--- a/OfficeIMO.Html/OfficeIMO.Html.csproj
+++ b/OfficeIMO.Html/OfficeIMO.Html.csproj
@@ -43,6 +43,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\OfficeIMO.Word\OfficeIMO.Word.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Using Include="System" />
         <Using Include="System.Text" />
         <Using Include="System.Collections.Generic" />

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -23,4 +23,21 @@ public partial class Html {
         Assert.Contains("universe", roundTrip, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("font-family:Calibri", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public void Test_Html_Headings_RoundTrip() {
+        string html = "<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><h4>Heading 4</h4><h5>Heading 5</h5><h6>Heading 6</h6>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "Calibri" });
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeStyles = true });
+
+        for (int i = 1; i <= 6; i++) {
+            string tag = $"h{i}";
+            Assert.Contains("<" + tag + ">", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains($"Heading {i}", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("</" + tag + ">", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- parse heading tags into corresponding Word styles when converting HTML
- emit heading tags from Word heading styles when converting to HTML
- cover heading round-trip with tests and examples

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_688fc20944cc832e9f00b620ac93e163