### PR TITLE
Render hyperlinks in PDF

### DIFF
--- a/OfficeIMO.Examples/Word/Pdf/Pdf.Hyperlinks.cs
+++ b/OfficeIMO.Examples/Word/Pdf/Pdf.Hyperlinks.cs
@@ -1,0 +1,21 @@
+using OfficeIMO.Pdf;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Pdf {
+        public static void Example_SaveAsPdfWithHyperlinks(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with hyperlinks and exporting to PDF");
+            string docPath = Path.Combine(folderPath, "HyperlinksToPdf.docx");
+            string pdfPath = Path.Combine(folderPath, "HyperlinksToPdf.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddParagraph("Visit ").AddHyperLink("OfficeIMO", new Uri("https://evotec.xyz"), addStyle: true);
+                document.AddParagraph("Contact ").AddHyperLink("Email", new Uri("mailto:kontakt@evotec.pl"), addStyle: true);
+                document.Save();
+                document.SaveAsPdf(pdfPath);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Pdf/WordPdfConverter.cs
+++ b/OfficeIMO.Pdf/WordPdfConverter.cs
@@ -148,45 +148,60 @@ public static class WordPdfConverter {
                     col.Item().Image(paragraph.Image.GetBytes());
                 }
 
-                if (!string.IsNullOrEmpty(paragraph.Text) || !string.IsNullOrEmpty(prefix)) {
+                string content = paragraph.IsHyperLink && paragraph.Hyperlink != null ? paragraph.Hyperlink.Text : paragraph.Text;
+                if (!string.IsNullOrEmpty(content) || !string.IsNullOrEmpty(prefix)) {
                     col.Item().Text(text => {
-                        TextSpanDescriptor span = text.Span(prefix + paragraph.Text);
-                        if (paragraph.Bold) {
-                            span = span.Bold();
+                        if (!string.IsNullOrEmpty(prefix)) {
+                            text.Span(prefix);
                         }
-                        if (paragraph.Italic) {
-                            span = span.Italic();
-                        }
-                        if (paragraph.Underline != null) {
-                            span = span.Underline();
-                        }
-                        if (paragraph.Style.HasValue) {
-                            switch (paragraph.Style.Value) {
-                                case WordParagraphStyles.Heading1:
-                                    span.FontSize(24).Bold();
-                                    break;
-                                case WordParagraphStyles.Heading2:
-                                    span.FontSize(20).Bold();
-                                    break;
-                                case WordParagraphStyles.Heading3:
-                                    span.FontSize(16).Bold();
-                                    break;
-                                case WordParagraphStyles.Heading4:
-                                    span.FontSize(14).Bold();
-                                    break;
-                                case WordParagraphStyles.Heading5:
-                                    span.FontSize(13).Bold();
-                                    break;
-                                case WordParagraphStyles.Heading6:
-                                    span.FontSize(12).Bold();
-                                    break;
-                            }
+
+                        if (paragraph.IsHyperLink && paragraph.Hyperlink != null) {
+                            ApplyFormatting(text.Hyperlink(content, paragraph.Hyperlink.Uri.ToString()));
+                        } else {
+                            ApplyFormatting(text.Span(content));
                         }
                     });
                 }
             });
 
             return container;
+        
+        void ApplyFormatting(TextSpanDescriptor span) {
+            if (paragraph.Bold) {
+                span = span.Bold();
+            }
+            if (paragraph.Italic) {
+                span = span.Italic();
+            }
+            if (paragraph.Underline != null) {
+                span = span.Underline();
+            }
+            if (!string.IsNullOrEmpty(paragraph.ColorHex)) {
+                span = span.FontColor("#" + paragraph.ColorHex);
+            }
+            if (paragraph.Style.HasValue) {
+                switch (paragraph.Style.Value) {
+                    case WordParagraphStyles.Heading1:
+                        span.FontSize(24).Bold();
+                        break;
+                    case WordParagraphStyles.Heading2:
+                        span.FontSize(20).Bold();
+                        break;
+                    case WordParagraphStyles.Heading3:
+                        span.FontSize(16).Bold();
+                        break;
+                    case WordParagraphStyles.Heading4:
+                        span.FontSize(14).Bold();
+                        break;
+                    case WordParagraphStyles.Heading5:
+                        span.FontSize(13).Bold();
+                        break;
+                    case WordParagraphStyles.Heading6:
+                        span.FontSize(12).Bold();
+                        break;
+                }
+            }
+        }
         }
     }
 

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
@@ -196,6 +196,24 @@ public partial class Word {
         Assert.True(System.Math.Abs(resultMarginCm - marginCm) < 0.1);
     }
 
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_Hyperlink() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfHyperlink.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfHyperlink.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            document.AddHyperLink("OfficeIMO", new Uri("https://evotec.xyz"), addStyle: true);
+            document.Save();
+
+            document.SaveAsPdf(pdfPath);
+        }
+
+        Assert.True(File.Exists(pdfPath));
+
+        string pdfContent = Encoding.ASCII.GetString(File.ReadAllBytes(pdfPath));
+        Assert.Contains("/URI (https://evotec.xyz", pdfContent);
+    }
+
     private static int IndexOf(byte[] buffer, byte[] pattern, int start) {
         for (int i = start; i <= buffer.Length - pattern.Length; i++) {
             int j = 0;


### PR DESCRIPTION
## Summary
- Detect `WordParagraph` hyperlinks during PDF conversion and render them as clickable links with full text and style
- Preserve bold, italic, underline and color styling when exporting to PDF
- Add example and unit test verifying hyperlink presence in generated PDFs

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688fd563c834832eae31654032a56870