### PR TITLE
feat(pdf): render table borders and shading

### DIFF
--- a/OfficeIMO.Examples/Word/Pdf/Pdf.TableStyles.cs
+++ b/OfficeIMO.Examples/Word/Pdf/Pdf.TableStyles.cs
@@ -1,0 +1,36 @@
+using OfficeIMO.Pdf;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+using W = DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Pdf {
+        public static void Example_TableStyles(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating PDF with styled table");
+            string docPath = Path.Combine(folderPath, "StyledTable.docx");
+            string pdfPath = Path.Combine(folderPath, "StyledTable.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                WordTable table = document.AddTable(1, 1, WordTableStyle.TableGrid);
+                WordTableCell cell = table.Rows[0].Cells[0];
+                cell.Paragraphs[0].Text = "Styled";
+                cell.ShadingFillColorHex = "FFFF00";
+                cell.Borders.TopStyle = W.BorderValues.Single;
+                cell.Borders.BottomStyle = W.BorderValues.Single;
+                cell.Borders.LeftStyle = W.BorderValues.Single;
+                cell.Borders.RightStyle = W.BorderValues.Single;
+                cell.Borders.TopColorHex = "FF0000";
+                cell.Borders.BottomColorHex = "FF0000";
+                cell.Borders.LeftColorHex = "FF0000";
+                cell.Borders.RightColorHex = "FF0000";
+                cell.Borders.TopSize = 8;
+                cell.Borders.BottomSize = 8;
+                cell.Borders.LeftSize = 8;
+                cell.Borders.RightSize = 8;
+                document.Save();
+                document.SaveAsPdf(pdfPath);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.TableStyles.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.TableStyles.cs
@@ -1,0 +1,57 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Pdf;
+using OfficeIMO.Word;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_TableStyles() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfStyledTable.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfStyledTable.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            WordTable table = document.AddTable(1, 1);
+            WordTableCell cell = table.Rows[0].Cells[0];
+            cell.Paragraphs[0].Text = "Styled";
+            cell.ShadingFillColorHex = "FF0000";
+            cell.Borders.TopStyle = BorderValues.Single;
+            cell.Borders.BottomStyle = BorderValues.Single;
+            cell.Borders.LeftStyle = BorderValues.Single;
+            cell.Borders.RightStyle = BorderValues.Single;
+            cell.Borders.TopColorHex = "0000FF";
+            cell.Borders.BottomColorHex = "0000FF";
+            cell.Borders.LeftColorHex = "0000FF";
+            cell.Borders.RightColorHex = "0000FF";
+            cell.Borders.TopSize = 8;
+            cell.Borders.BottomSize = 8;
+            cell.Borders.LeftSize = 8;
+            cell.Borders.RightSize = 8;
+            document.Save();
+            document.SaveAsPdf(pdfPath);
+        }
+
+        byte[] bytes = File.ReadAllBytes(pdfPath);
+        byte[] startPattern = Encoding.ASCII.GetBytes("stream\n");
+        byte[] endPattern = Encoding.ASCII.GetBytes("\nendstream");
+        int start = IndexOf(bytes, startPattern, 0);
+        Assert.True(start >= 0, "stream marker not found");
+        start += startPattern.Length;
+        int end = IndexOf(bytes, endPattern, start);
+        Assert.True(end >= 0, "endstream marker not found");
+        int length = end - start;
+        int deflateLength = length - 6;
+        byte[] deflateData = new byte[deflateLength];
+        Array.Copy(bytes, start + 2, deflateData, 0, deflateLength);
+        using MemoryStream ms = new MemoryStream(deflateData);
+        using DeflateStream ds = new DeflateStream(ms, CompressionMode.Decompress);
+        using StreamReader reader = new StreamReader(ds, Encoding.GetEncoding("ISO-8859-1"));
+        string content = reader.ReadToEnd();
+        Assert.Contains("1 0 0 rg", content);
+        Assert.Contains("0 0 1 RG", content);
+    }
+}


### PR DESCRIPTION
## Summary
- add cell style mapping to render table borders and shading when exporting to PDF
- cover table styling in PDF conversion tests
- include PDF example demonstrating styled table
- ensure border color is set only when all sides share the same color

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68904e744e88832e8e361603af1036bf