### PR TITLE
Use QuestPDF list elements for nested lists

### DIFF
--- a/OfficeIMO.Examples/Word/Pdf/Pdf.Lists.cs
+++ b/OfficeIMO.Examples/Word/Pdf/Pdf.Lists.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using OfficeIMO.Pdf;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Pdf {
+        public static void Example_SaveAsPdfWithLists(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Saving document with nested lists as PDF");
+
+            string docPath = Path.Combine(folderPath, "SaveAsPdfWithLists.docx");
+            string pdfPath = Path.Combine(folderPath, "SaveAsPdfWithLists.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                WordList numberList = document.AddList(WordListStyle.Headings111);
+                WordParagraph first = numberList.AddItem("Item 1");
+                WordParagraph second = numberList.AddItem("Item 1.1");
+                second.ListItemLevel = 1;
+                WordParagraph third = numberList.AddItem("Item 1.1.1");
+                third.ListItemLevel = 2;
+
+                WordList bulletList = document.AddList(WordListStyle.Bulleted);
+                bulletList.AddItem("Bullet 1");
+                WordParagraph nested = bulletList.AddItem("Bullet 1.1");
+                nested.ListItemLevel = 1;
+
+                document.Save();
+                document.SaveAsPdf(pdfPath);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
@@ -214,6 +214,33 @@ public partial class Word {
         Assert.Contains("/URI (https://evotec.xyz", pdfContent);
     }
 
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_MultiLevelLists() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfMultiLevelLists.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfMultiLevelLists.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            WordList numberList = document.AddList(WordListStyle.Headings111);
+            WordParagraph first = numberList.AddItem("Item 1");
+            WordParagraph second = numberList.AddItem("Item 1.1");
+            second.ListItemLevel = 1;
+            WordParagraph third = numberList.AddItem("Item 1.1.1");
+            third.ListItemLevel = 2;
+            numberList.AddItem("Item 2");
+
+            WordList bulletList = document.AddList(WordListStyle.Bulleted);
+            bulletList.AddItem("Bullet 1");
+            WordParagraph bulletNested = bulletList.AddItem("Bullet 1.1");
+            bulletNested.ListItemLevel = 1;
+
+            document.Save();
+            document.SaveAsPdf(pdfPath);
+        }
+
+        Assert.True(File.Exists(pdfPath));
+        Assert.True(new FileInfo(pdfPath).Length > 0);
+    }
+
     private static int IndexOf(byte[] buffer, byte[] pattern, int start) {
         for (int i = start; i <= buffer.Length - pattern.Length; i++) {
             int j = 0;


### PR DESCRIPTION
## Summary
- render Word lists in PDFs using QuestPDF row-based list markers
- cover multi-level list export to PDF
- add example demonstrating list preservation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689057adfd70832e93f8e9bf6c011eb4