### PR TITLE
Add HTML table conversion support

### DIFF
--- a/OfficeIMO.Examples/Html/Html.Tables.cs
+++ b/OfficeIMO.Examples/Html/Html.Tables.cs
@@ -1,0 +1,25 @@
+using OfficeIMO.Html;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlTables(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlTables.docx");
+            string html = "<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td><table><tr><td>Nested</td></tr></table></td></tr></table>";
+
+            using (MemoryStream ms = new MemoryStream()) {
+                HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
+                File.WriteAllBytes(filePath, ms.ToArray());
+
+                ms.Position = 0;
+                string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions());
+                Console.WriteLine(roundTrip);
+            }
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -55,4 +55,32 @@ public partial class Html {
         Assert.Contains("Sub 1", roundTrip, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Second", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public void Test_Html_Table_RoundTrip() {
+        string html = "<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr></table>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions());
+
+        Assert.Contains("<table>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("A", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("D", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Test_Html_NestedTable_RoundTrip() {
+        string html = "<table><tr><td>Outer</td><td><table><tr><td>Inner</td></tr></table></td></tr></table>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions());
+
+        int tableCount = roundTrip.Split(new string[] { "<table>" }, StringSplitOptions.None).Length - 1;
+        Assert.True(tableCount >= 2);
+        Assert.Contains("Inner", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
## Summary
- map HTML table elements to Word table structures
- serialize Word table structures back into HTML
- verify table conversion with unit tests and example usage

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689059e36774832e862409397659b31a