### PR TITLE
Add markdown conversion project with tests and example

### DIFF
--- a/OfficeIMO.Examples/Markdown/Markdown.Conversion.cs
+++ b/OfficeIMO.Examples/Markdown/Markdown.Conversion.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using OfficeIMO.Markdown;
+
+namespace OfficeIMO.Examples.Markdown {
+    internal static partial class Markdown {
+        public static void Example_MarkdownRoundTrip(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "MarkdownRoundTrip.docx");
+            string markdown = "# Heading 1\n\nHello **world** and *universe*.";
+
+            using (MemoryStream ms = new MemoryStream()) {
+                MarkdownToWordConverter.Convert(markdown, ms, new MarkdownToWordOptions { FontFamily = "Calibri" });
+                File.WriteAllBytes(filePath, ms.ToArray());
+
+                ms.Position = 0;
+                string roundTrip = WordToMarkdownConverter.Convert(ms, new WordToMarkdownOptions());
+                Console.WriteLine(roundTrip);
+            }
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/OfficeIMO.Examples.csproj
+++ b/OfficeIMO.Examples/OfficeIMO.Examples.csproj
@@ -12,6 +12,7 @@
         <ProjectReference Include="..\OfficeIMO.Word\OfficeIMO.Word.csproj" />
         <ProjectReference Include="..\OfficeIMO.Pdf\OfficeIMO.Pdf.csproj" />
         <ProjectReference Include="..\OfficeIMO.Html\OfficeIMO.Html.csproj" />
+        <ProjectReference Include="..\OfficeIMO.Markdown\OfficeIMO.Markdown.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -4,6 +4,7 @@ using OfficeIMO.Examples.Excel;
 using OfficeIMO.Examples.Word;
 
 using HtmlExamples = OfficeIMO.Examples.Html.Html;
+using MarkdownExamples = OfficeIMO.Examples.Markdown.Markdown;
 
 namespace OfficeIMO.Examples {
     internal static class Program {
@@ -280,6 +281,7 @@ namespace OfficeIMO.Examples {
             Macros.Example_ListAndRemoveMacro(templatesPath, folderPath, false);
 
             HtmlExamples.Example_HtmlRoundTrip(folderPath, false);
+            MarkdownExamples.Example_MarkdownRoundTrip(folderPath, false);
             XmlSerialization.Example_XmlSerializationBasic(folderPath, false);
             XmlSerialization.Example_XmlSerializationAdvanced(folderPath, false);
             CompareDocuments.Example_BasicComparison(folderPath, false);

--- a/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Markdown {
+    /// <summary>
+    /// Converts Markdown text into a Word document without intermediate formats.
+    /// </summary>
+    public static class MarkdownToWordConverter {
+        /// <summary>
+        /// Converts Markdown content to DOCX and writes it to the provided stream.
+        /// </summary>
+        /// <param name="markdown">Markdown source text.</param>
+        /// <param name="output">Destination stream for the generated document.</param>
+        /// <param name="options">Optional conversion settings.</param>
+        public static void Convert(string markdown, Stream output, MarkdownToWordOptions? options = null) {
+            if (markdown == null) {
+                throw new ArgumentNullException(nameof(markdown));
+            }
+            if (output == null) {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            options ??= new MarkdownToWordOptions();
+
+            using var document = WordDocument.Create();
+            WordList? currentList = null;
+            bool currentListIsNumbered = false;
+
+            foreach (var raw in markdown.Replace("\r", string.Empty).Split('\n')) {
+                var line = raw.TrimEnd();
+                if (string.IsNullOrWhiteSpace(line)) {
+                    currentList = null;
+                    continue;
+                }
+
+                if (line.StartsWith("#")) {
+                    currentList = null;
+                    int level = line.TakeWhile(c => c == '#').Count();
+                    string text = line.Substring(level).TrimStart();
+                    var paragraph = document.AddParagraph();
+                    AddInlineRuns(paragraph, text, options);
+                    paragraph.Style = level switch {
+                        1 => WordParagraphStyles.Heading1,
+                        2 => WordParagraphStyles.Heading2,
+                        3 => WordParagraphStyles.Heading3,
+                        4 => WordParagraphStyles.Heading4,
+                        5 => WordParagraphStyles.Heading5,
+                        6 => WordParagraphStyles.Heading6,
+                        _ => WordParagraphStyles.Normal
+                    };
+                    continue;
+                }
+
+                var numberMatch = Regex.Match(line, @"^(\d+)\.\s+(.*)");
+                if (line.StartsWith("- ") || line.StartsWith("* ") || numberMatch.Success) {
+                    bool isNumbered = numberMatch.Success;
+                    string text = isNumbered ? numberMatch.Groups[2].Value : line.Substring(2).TrimStart();
+
+                    if (currentList == null || currentListIsNumbered != isNumbered) {
+                        currentList = document.AddList(isNumbered ? WordListStyle.ArticleSections : WordListStyle.Bulleted);
+                        currentListIsNumbered = isNumbered;
+                    }
+
+                    var item = currentList.AddItem(string.Empty);
+                    AddInlineRuns(item, text, options);
+                    continue;
+                }
+
+                currentList = null;
+                var para = document.AddParagraph();
+                AddInlineRuns(para, line, options);
+            }
+
+            document.Save(output);
+        }
+
+        private static void AddInlineRuns(WordParagraph paragraph, string text, MarkdownToWordOptions options) {
+            var regex = new Regex(@"(\*\*[^\*]+\*\*|\*[^\*]+\*|[^\*]+)", RegexOptions.Singleline);
+            foreach (Match match in regex.Matches(text)) {
+                string token = match.Value;
+                bool bold = token.StartsWith("**") && token.EndsWith("**");
+                bool italic = !bold && token.StartsWith("*") && token.EndsWith("*");
+                string value = bold ? token.Substring(2, token.Length - 4) :
+                               italic ? token.Substring(1, token.Length - 2) : token;
+
+                var run = paragraph.AddText(value);
+                if (!string.IsNullOrEmpty(options.FontFamily)) {
+                    run.SetFontFamily(options.FontFamily);
+                }
+                if (bold) {
+                    run.SetBold();
+                }
+                if (italic) {
+                    run.SetItalic();
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Markdown/Converters/WordToMarkdownConverter.cs
+++ b/OfficeIMO.Markdown/Converters/WordToMarkdownConverter.cs
@@ -1,0 +1,99 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using DocumentFormat.OpenXml;
+
+namespace OfficeIMO.Markdown {
+    /// <summary>
+    /// Converts Word documents into Markdown text without relying on HTML or external tools.
+    /// </summary>
+    public static class WordToMarkdownConverter {
+        /// <summary>
+        /// Converts a DOCX document from the provided stream into Markdown text.
+        /// </summary>
+        /// <param name="input">Stream containing DOCX content.</param>
+        /// <param name="options">Conversion options.</param>
+        /// <returns>Markdown representation of the document.</returns>
+        public static string Convert(Stream input, WordToMarkdownOptions? options = null) {
+            if (input == null) {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            options ??= new WordToMarkdownOptions();
+            StringBuilder sb = new StringBuilder();
+
+            using var word = WordprocessingDocument.Open(input, false);
+            var body = word.MainDocumentPart?.Document.Body;
+            if (body == null) return string.Empty;
+
+            foreach (var paragraph in body.Elements<Paragraph>()) {
+                string line = GetParagraphText(paragraph);
+                if (string.IsNullOrEmpty(line)) {
+                    continue;
+                }
+
+                var styleId = paragraph.ParagraphProperties?.ParagraphStyleId?.Val?.Value;
+                if (styleId != null && styleId.StartsWith("Heading", StringComparison.OrdinalIgnoreCase)) {
+                    if (int.TryParse(styleId.Substring("Heading".Length), out int level) && level > 0 && level <= 6) {
+                        sb.Append('#', level).Append(' ').Append(line).AppendLine();
+                        sb.AppendLine();
+                        continue;
+                    }
+                }
+
+                if (paragraph.ParagraphProperties?.NumberingProperties != null) {
+                    bool bullet = IsBullet(paragraph, word.MainDocumentPart!);
+                    sb.Append(bullet ? "- " : "1. ").Append(line).AppendLine();
+                    continue;
+                }
+
+                sb.AppendLine(line);
+                sb.AppendLine();
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+
+        private static string GetParagraphText(Paragraph paragraph) {
+            StringBuilder sb = new StringBuilder();
+            foreach (var run in paragraph.Elements<Run>()) {
+                var text = run.GetFirstChild<Text>()?.Text;
+                if (string.IsNullOrEmpty(text)) {
+                    continue;
+                }
+                bool bold = run.RunProperties?.Bold != null;
+                bool italic = run.RunProperties?.Italic != null;
+                if (bold) sb.Append("**").Append(text).Append("**");
+                else if (italic) sb.Append('*').Append(text).Append('*');
+                else sb.Append(text);
+            }
+            return sb.ToString();
+        }
+
+        private static bool IsBullet(Paragraph paragraph, MainDocumentPart mainPart) {
+            var numProps = paragraph.ParagraphProperties?.NumberingProperties;
+            if (numProps?.NumberingId == null || mainPart.NumberingDefinitionsPart?.Numbering == null) {
+                return false;
+            }
+
+            int id = (int)numProps.NumberingId.Val.Value;
+            var instance = mainPart.NumberingDefinitionsPart.Numbering
+                .Elements<NumberingInstance>()
+                .FirstOrDefault(n => n.NumberID != null && n.NumberID.Value == id);
+            if (instance == null) return false;
+
+            var abstractNum = mainPart.NumberingDefinitionsPart.Numbering
+                .Elements<AbstractNum>()
+                .FirstOrDefault(a => a.AbstractNumberId != null && a.AbstractNumberId.Value == instance.AbstractNumId.Val.Value);
+            if (abstractNum == null) return false;
+
+            int levelIndex = numProps.NumberingLevelReference?.Val ?? 0;
+            var level = abstractNum.Elements<Level>().FirstOrDefault(l => l.LevelIndex != null && l.LevelIndex.Value == levelIndex);
+            var format = level?.NumberingFormat?.Val;
+            return format != null && format == NumberFormatValues.Bullet;
+        }
+    }
+}

--- a/OfficeIMO.Markdown/OfficeIMO.Markdown.csproj
+++ b/OfficeIMO.Markdown/OfficeIMO.Markdown.csproj
@@ -1,0 +1,46 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>An Open Source cross-platform .NET library providing Markdown conversion helpers.</Description>
+    <AssemblyName>OfficeIMO.Markdown</AssemblyName>
+    <AssemblyTitle>OfficeIMO.Markdown</AssemblyTitle>
+    <VersionPrefix>1.0.6</VersionPrefix>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">netstandard2.0;net472;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net9.0</TargetFrameworks>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <PackageId>OfficeIMO.Markdown</PackageId>
+    <PackageTags>markdown;openxml;office;docx;net472;net8.0;net9.0</PackageTags>
+    <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <DelaySign>False</DelaySign>
+    <IsPublishable>True</IsPublishable>
+    <Copyright>(c) 2011 - 2024 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
+    <PackageIcon>OfficeIMO.png</PackageIcon>
+    <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
+    <DebugType>portable</DebugType>
+    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <LangVersion>Latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\Assets\OfficeIMO.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.Word\OfficeIMO.Word.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.IO" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Text" />
+    <Using Include="System.Text.RegularExpressions" />
+  </ItemGroup>
+
+</Project>

--- a/OfficeIMO.Markdown/Options/MarkdownToWordOptions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownToWordOptions.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace OfficeIMO.Markdown {
+    /// <summary>
+    /// Options controlling Markdown to Word conversion.
+    /// </summary>
+    public class MarkdownToWordOptions {
+        /// <summary>
+        /// Optional font family applied to created runs.
+        /// </summary>
+        public string? FontFamily { get; set; }
+
+        // Additional options may be added in the future.
+    }
+}

--- a/OfficeIMO.Markdown/Options/WordToMarkdownOptions.cs
+++ b/OfficeIMO.Markdown/Options/WordToMarkdownOptions.cs
@@ -1,0 +1,7 @@
+namespace OfficeIMO.Markdown {
+    /// <summary>
+    /// Placeholder for future Word to Markdown conversion options.
+    /// </summary>
+    public class WordToMarkdownOptions {
+    }
+}

--- a/OfficeIMO.Tests/Markdown.MarkdownConverter.cs
+++ b/OfficeIMO.Tests/Markdown.MarkdownConverter.cs
@@ -1,0 +1,22 @@
+using OfficeIMO.Markdown;
+using System;
+using System.IO;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Markdown {
+        [Fact]
+        public void Test_Markdown_RoundTrip() {
+            string md = "# Heading 1\n\nHello **world** and *universe*.";
+            using MemoryStream ms = new MemoryStream();
+            MarkdownToWordConverter.Convert(md, ms, new MarkdownToWordOptions { FontFamily = "Calibri" });
+
+            ms.Position = 0;
+            string roundTrip = WordToMarkdownConverter.Convert(ms, new WordToMarkdownOptions());
+
+            Assert.Contains("# Heading 1", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("**world**", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("*universe*", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/OfficeIMO.Tests/OfficeIMO.Tests.csproj
+++ b/OfficeIMO.Tests/OfficeIMO.Tests.csproj
@@ -32,6 +32,7 @@
         <ProjectReference Include="..\OfficeIMO.Excel\OfficeIMO.Excel.csproj" />
         <ProjectReference Include="..\OfficeIMO.Pdf\OfficeIMO.Pdf.csproj" />
         <ProjectReference Include="..\OfficeIMO.Html\OfficeIMO.Html.csproj" />
+        <ProjectReference Include="..\OfficeIMO.Markdown\OfficeIMO.Markdown.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OfficeImo.sln
+++ b/OfficeImo.sln
@@ -134,6 +134,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{D545
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Html", "OfficeIMO.Html\OfficeIMO.Html.csproj", "{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Markdown", "OfficeIMO.Markdown\OfficeIMO.Markdown.csproj", "{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -200,14 +202,14 @@ Global
 		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Debug|x86.Build.0 = Debug|Any CPU
 		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9D9952F0-776C-4E1D-BD5F-9D9FB3924633}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9D9952F0-776C-4E1D-BD5F-9D9FB3924633}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9D9952F0-776C-4E1D-BD5F-9D9FB3924633}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9D9952F0-776C-4E1D-BD5F-9D9FB3924633}.Release|Any CPU.Build.0 = Release|Any CPU
 		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Release|x64.ActiveCfg = Release|Any CPU
 		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Release|x64.Build.0 = Release|Any CPU
 		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Release|x86.ActiveCfg = Release|Any CPU
 		{91F78177-72D4-429C-A29E-1B28B37F7BC6}.Release|x86.Build.0 = Release|Any CPU
+		{9D9952F0-776C-4E1D-BD5F-9D9FB3924633}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D9952F0-776C-4E1D-BD5F-9D9FB3924633}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D9952F0-776C-4E1D-BD5F-9D9FB3924633}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D9952F0-776C-4E1D-BD5F-9D9FB3924633}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -220,6 +222,18 @@ Global
 		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Release|x64.Build.0 = Release|Any CPU
 		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Release|x86.ActiveCfg = Release|Any CPU
 		{1FAE812D-A40C-4AD2-98FD-69DAA91A41DC}.Release|x86.Build.0 = Release|Any CPU
+		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Debug|x64.Build.0 = Debug|Any CPU
+		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Debug|x86.Build.0 = Debug|Any CPU
+		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Release|x64.ActiveCfg = Release|Any CPU
+		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Release|x64.Build.0 = Release|Any CPU
+		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Release|x86.ActiveCfg = Release|Any CPU
+		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add OfficeIMO.Markdown project to convert Markdown <-> Word
- provide example and wire into examples program
- verify round-trip with new Markdown unit test
- implement direct Markdown conversion without HTML or external tools

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68905a23a89c832ebe4f04947cd94f95