### PR TITLE
Add image round-trip support in HTML converters

### DIFF
--- a/OfficeIMO.Examples/Html/Html.Images.cs
+++ b/OfficeIMO.Examples/Html/Html.Images.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using OfficeIMO.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlImages(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlImage.docx");
+            byte[] imageBytes = File.ReadAllBytes(Path.Combine("Assets", "OfficeIMO.png"));
+            string base64 = Convert.ToBase64String(imageBytes);
+            string html = $"<p><img src=\"data:image/png;base64,{base64}\" /></p>";
+
+            using (MemoryStream ms = new MemoryStream()) {
+                HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
+                File.WriteAllBytes(filePath, ms.ToArray());
+
+                ms.Position = 0;
+                string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions());
+                Console.WriteLine(roundTrip);
+            }
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -83,4 +83,35 @@ public partial class Html {
         Assert.True(tableCount >= 2);
         Assert.Contains("Inner", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public void Test_Html_Image_Base64_RoundTrip() {
+        string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
+        byte[] imageBytes = File.ReadAllBytes(assetPath);
+        string base64 = Convert.ToBase64String(imageBytes);
+        string html = $"<p><img src=\"data:image/png;base64,{base64}\" /></p>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions());
+
+        Assert.Contains("<img", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("data:image/png;base64", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Test_Html_Image_File_RoundTrip() {
+        string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
+        string uri = new Uri(assetPath).AbsoluteUri;
+        string html = $"<p><img src=\"{uri}\" /></p>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions());
+
+        Assert.Contains("<img", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("data:image/png;base64", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
## Summary
- support `<img>` tags in HtmlToWordConverter, downloading external or base64 images and embedding them in DOCX
- emit `<img>` elements with embedded base64 data in WordToHtmlConverter
- cover image round-trip scenarios with tests and example

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689074138f08832e9ce41da7db1dda1d