### PR TITLE
Respect image dimensions for header/footer images

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -181,6 +181,7 @@ namespace OfficeIMO.Examples {
             Images.Example_ImageTransparencySimple(folderPath, false);
             Images.Example_ImageTransparencyAdvanced(folderPath, false);
             Images.Example_ImageNewFeatures(folderPath, false);
+            Word.Pdf.Example_HeaderFooterImages(folderPath, false);
 
             Background.Example_BackgroundImageSimple(folderPath, false);
             Background.Example_BackgroundImageAdvanced(folderPath, false);

--- a/OfficeIMO.Examples/Word/Pdf/Pdf.HeaderFooterImages.cs
+++ b/OfficeIMO.Examples/Word/Pdf/Pdf.HeaderFooterImages.cs
@@ -1,0 +1,23 @@
+using OfficeIMO.Pdf;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Pdf {
+        public static void Example_HeaderFooterImages(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with header and footer images and exporting to PDF");
+            string docPath = Path.Combine(folderPath, "PdfHeaderFooterImages.docx");
+            string pdfPath = Path.Combine(folderPath, "PdfHeaderFooterImages.pdf");
+            string imagePath = Path.Combine(Directory.GetCurrentDirectory(), "Images", "EvotecLogo.png");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddHeadersAndFooters();
+                document.Header.Default.AddParagraph().AddImage(imagePath, 50, 50);
+                document.Footer.Default.AddParagraph().AddImage(imagePath, 300, 300);
+                document.Save();
+                document.SaveAsPdf(pdfPath);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Pdf/WordPdfConverter.cs
+++ b/OfficeIMO.Pdf/WordPdfConverter.cs
@@ -191,7 +191,17 @@ public static class WordPdfConverter {
 
             container.Column(col => {
                 if (paragraph.Image != null) {
-                    col.Item().Image(paragraph.Image.GetBytes());
+                    col.Item().Element(imageContainer => {
+                        var img = paragraph.Image;
+                        var sized = imageContainer;
+                        if (img.Width.HasValue) {
+                            sized = sized.Width((float)(img.Width.Value * 72 / 96));
+                        }
+                        if (img.Height.HasValue) {
+                            sized = sized.Height((float)(img.Height.Value * 72 / 96));
+                        }
+                        sized.Image(img.GetBytes());
+                    });
                 }
 
                 string content = paragraph.IsHyperLink && paragraph.Hyperlink != null ? paragraph.Hyperlink.Text : paragraph.Text;

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
@@ -58,6 +58,23 @@ public partial class Word {
     }
 
     [Fact]
+    public void Test_WordDocument_SaveAsPdf_HeaderFooterImagesScaling() {
+        var docPath = Path.Combine(_directoryWithFiles, "PdfHeaderFooterImages.docx");
+        var pdfPath = Path.Combine(_directoryWithFiles, "PdfHeaderFooterImages.pdf");
+        string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            document.AddHeadersAndFooters();
+            document.Header.Default.AddParagraph().AddImage(imagePath, 20, 20);
+            document.Footer.Default.AddParagraph().AddImage(imagePath, 400, 400);
+            document.Save();
+            document.SaveAsPdf(pdfPath);
+        }
+
+        Assert.True(File.Exists(pdfPath));
+    }
+
+    [Fact]
     public void Test_WordDocument_SaveAsPdf_ToMemoryStream() {
         string docPath = Path.Combine(_directoryWithFiles, "PdfStreamSample.docx");
 


### PR DESCRIPTION
## Summary
- ensure PDF converter uses Word image width and height values when rendering
- add regression test for header/footer images of different sizes
- include header and footer image example

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6890741b2108832ea203133b8c3462f9