### PR TITLE
Add helper for inline markdown runs

### DIFF
--- a/OfficeIMO.Examples/Word/Paragraphs/Paragraphs.InlineRunHelper.cs
+++ b/OfficeIMO.Examples/Word/Paragraphs/Paragraphs.InlineRunHelper.cs
@@ -1,0 +1,15 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+internal static partial class Paragraphs {
+    internal static void Example_InlineRunHelper(string folderPath, bool openWord) {
+        Console.WriteLine("[*] Creating document with inline runs");
+        string filePath = Path.Combine(folderPath, "InlineRunHelper.docx");
+        using (WordDocument document = WordDocument.Create(filePath)) {
+            var paragraph = document.AddParagraph();
+            InlineRunHelper.AddInlineRuns(paragraph, "Hello **world** and *universe*");
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
@@ -43,7 +43,7 @@ namespace OfficeIMO.Markdown {
                     int level = line.TakeWhile(c => c == '#').Count();
                     string text = line.Substring(level).TrimStart();
                     var paragraph = document.AddParagraph();
-                    AddInlineRuns(paragraph, text, options);
+                    InlineRunHelper.AddInlineRuns(paragraph, text, options.FontFamily);
                     paragraph.Style = level switch {
                         1 => WordParagraphStyles.Heading1,
                         2 => WordParagraphStyles.Heading2,
@@ -67,39 +67,18 @@ namespace OfficeIMO.Markdown {
                     }
 
                     var item = currentList.AddItem(string.Empty);
-                    AddInlineRuns(item, text, options);
+                    InlineRunHelper.AddInlineRuns(item, text, options.FontFamily);
                     continue;
                 }
 
                 currentList = null;
                 var para = document.AddParagraph();
-                AddInlineRuns(para, line, options);
+                InlineRunHelper.AddInlineRuns(para, line, options.FontFamily);
             }
 
             document.Save(output);
         }
-
-        private static void AddInlineRuns(WordParagraph paragraph, string text, MarkdownToWordOptions options) {
-            var regex = new Regex(@"(\*\*[^\*]+\*\*|\*[^\*]+\*|[^\*]+)", RegexOptions.Singleline);
-            foreach (Match match in regex.Matches(text)) {
-                string token = match.Value;
-                bool bold = token.StartsWith("**") && token.EndsWith("**");
-                bool italic = !bold && token.StartsWith("*") && token.EndsWith("*");
-                string value = bold ? token.Substring(2, token.Length - 4) :
-                               italic ? token.Substring(1, token.Length - 2) : token;
-
-                var run = paragraph.AddText(value);
-                if (!string.IsNullOrEmpty(options.FontFamily)) {
-                    run.SetFontFamily(options.FontFamily);
-                }
-                if (bold) {
-                    run.SetBold();
-                }
-                if (italic) {
-                    run.SetItalic();
-                }
-            }
-        }
+        
         public void Convert(Stream input, Stream output, IConversionOptions options) {
             if (input == null) {
                 throw new ArgumentNullException(nameof(input));

--- a/OfficeIMO.Tests/Word.InlineRunHelper.cs
+++ b/OfficeIMO.Tests/Word.InlineRunHelper.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void InlineRunHelperAddsBoldAndItalicRuns() {
+        using var document = WordDocument.Create();
+        var paragraph = document.AddParagraph();
+        InlineRunHelper.AddInlineRuns(paragraph, "Hello **world** and *universe*");
+
+        var runs = paragraph._paragraph.Elements<Run>().ToList();
+        Assert.Equal(4, runs.Count);
+        Assert.Equal("Hello ", runs[0].InnerText);
+        Assert.Null(runs[0].RunProperties?.Bold);
+        Assert.Equal("world", runs[1].InnerText);
+        Assert.NotNull(runs[1].RunProperties?.Bold);
+        Assert.Equal(" and ", runs[2].InnerText);
+        Assert.Null(runs[2].RunProperties?.Bold);
+        Assert.Equal("universe", runs[3].InnerText);
+        Assert.NotNull(runs[3].RunProperties?.Italic);
+        Assert.Null(runs[3].RunProperties?.Bold);
+    }
+}

--- a/OfficeIMO.Word/Helpers/InlineRunHelper.cs
+++ b/OfficeIMO.Word/Helpers/InlineRunHelper.cs
@@ -1,0 +1,37 @@
+using System.Text.RegularExpressions;
+
+namespace OfficeIMO.Word;
+
+/// <summary>
+/// Provides utilities for adding inline formatted runs.
+/// </summary>
+public static class InlineRunHelper {
+    private static readonly Regex _inlineRegex = new("(\\*\\*[^\\*]+\\*\\*|\\*[^\\*]+\\*|[^\\*]+)", RegexOptions.Singleline);
+
+    /// <summary>
+    /// Adds text runs to <paramref name="paragraph"/> parsing Markdown style bold and italic markers.
+    /// </summary>
+    /// <param name="paragraph">Paragraph to add runs to.</param>
+    /// <param name="text">Input text containing optional <c>**bold**</c> or <c>*italic*</c> markers.</param>
+    /// <param name="fontFamily">Optional font family for the runs.</param>
+    public static void AddInlineRuns(WordParagraph paragraph, string text, string? fontFamily = null) {
+        foreach (Match match in _inlineRegex.Matches(text)) {
+            string token = match.Value;
+            bool bold = token.StartsWith("**") && token.EndsWith("**");
+            bool italic = !bold && token.StartsWith("*") && token.EndsWith("*");
+            string value = bold ? token.Substring(2, token.Length - 4) :
+                           italic ? token.Substring(1, token.Length - 2) : token;
+
+            var run = paragraph.AddText(value);
+            if (!string.IsNullOrEmpty(fontFamily)) {
+                run.SetFontFamily(fontFamily);
+            }
+            if (bold) {
+                run.SetBold();
+            }
+            if (italic) {
+                run.SetItalic();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- factor out inline bold/italic parsing into new `InlineRunHelper`
- use helper in `MarkdownToWordConverter`
- add example and unit test for helper

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68911dc94a10832eb0eb96ba3c4aa790