### PR TITLE
feat: centralize bullet detection across converters

### DIFF
--- a/OfficeIMO.Examples/Markdown/Markdown.Lists.cs
+++ b/OfficeIMO.Examples/Markdown/Markdown.Lists.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using OfficeIMO.Markdown;
+
+namespace OfficeIMO.Examples.Markdown {
+    internal static partial class Markdown {
+        public static void Example_MarkdownLists(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "MarkdownLists.docx");
+            string markdown = "- Item 1\n- Item 2\n\n1. First\n1. Second";
+
+            using (MemoryStream ms = new MemoryStream()) {
+                MarkdownToWordConverter.Convert(markdown, ms, new MarkdownToWordOptions());
+                File.WriteAllBytes(filePath, ms.ToArray());
+
+                ms.Position = 0;
+                string roundTrip = WordToMarkdownConverter.Convert(ms, new WordToMarkdownOptions());
+                Console.WriteLine(roundTrip);
+            }
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
@@ -32,7 +32,7 @@ namespace OfficeIMO.Html {
             StringBuilder sb = new StringBuilder();
             sb.Append("<html><body>");
 
-            Dictionary<int, bool> listTypes = GetListTypes(document);
+            Dictionary<int, bool> listTypes = ListParser.GetListTypes(document.MainDocumentPart!);
             AppendElements(document.MainDocumentPart!.Document.Body!.ChildElements, sb, options, listTypes, document.MainDocumentPart);
 
             sb.Append("</body></html>");
@@ -144,25 +144,6 @@ namespace OfficeIMO.Html {
             sb.Append("</table>");
         }
 
-        private static Dictionary<int, bool> GetListTypes(WordprocessingDocument document) {
-            NumberingDefinitionsPart? numberingPart = document.MainDocumentPart!.NumberingDefinitionsPart;
-            Dictionary<int, bool> listTypes = new Dictionary<int, bool>();
-            if (numberingPart?.Numbering != null) {
-                foreach (NumberingInstance instance in numberingPart.Numbering.Elements<NumberingInstance>()) {
-                    int id = instance.NumberID!.Value;
-                    int absId = instance.AbstractNumId!.Val!.Value;
-                    AbstractNum? abs = numberingPart.Numbering.Elements<AbstractNum>().FirstOrDefault(a => a.AbstractNumberId!.Value == absId);
-                    bool ordered = true;
-                    Level? lvl = abs?.Elements<Level>().FirstOrDefault(l => l.LevelIndex == 0);
-                    NumberFormatValues? format = lvl?.NumberingFormat?.Val;
-                    if (format == NumberFormatValues.Bullet) {
-                        ordered = false;
-                    }
-                    listTypes[id] = ordered;
-                }
-            }
-            return listTypes;
-        }
 
         private static void AppendRuns(StringBuilder sb, Paragraph paragraph, WordToHtmlOptions options, MainDocumentPart mainPart) {
             foreach (Run run in paragraph.Elements<Run>()) {

--- a/OfficeIMO.Tests/Markdown.MarkdownConverter.cs
+++ b/OfficeIMO.Tests/Markdown.MarkdownConverter.cs
@@ -18,5 +18,18 @@ namespace OfficeIMO.Tests {
             Assert.Contains("**world**", roundTrip, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("*universe*", roundTrip, StringComparison.OrdinalIgnoreCase);
         }
+
+        [Fact]
+        public void Test_Markdown_Lists_RoundTrip() {
+            string md = "- Item 1\n- Item 2\n\n1. First\n1. Second";
+            using MemoryStream ms = new MemoryStream();
+            MarkdownToWordConverter.Convert(md, ms, new MarkdownToWordOptions { FontFamily = "Calibri" });
+
+            ms.Position = 0;
+            string roundTrip = WordToMarkdownConverter.Convert(ms, new WordToMarkdownOptions());
+
+            Assert.Contains("- Item 1", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("1. First", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/OfficeIMO.Tests/Word.ListParser.cs
+++ b/OfficeIMO.Tests/Word.ListParser.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_ListParser_DetectsTypes() {
+            using MemoryStream ms = new MemoryStream();
+            using (var document = WordDocument.Create(ms)) {
+                var bullet = document.AddList(WordListStyle.Bulleted);
+                bullet.AddItem("Bullet 1");
+                var ordered = document.AddList(WordListStyle.Headings111);
+                ordered.AddItem("Number 1");
+                document.Save();
+            }
+            ms.Position = 0;
+            using var word = WordprocessingDocument.Open(ms, false);
+            var paragraphs = word.MainDocumentPart!.Document.Body!.Elements<DocumentFormat.OpenXml.Wordprocessing.Paragraph>().ToList();
+            Assert.True(ListParser.IsBullet(paragraphs[0], word.MainDocumentPart!));
+            Assert.True(ListParser.IsOrdered(paragraphs[1], word.MainDocumentPart!));
+        }
+    }
+}

--- a/OfficeIMO.Word/Helpers/ListParser.cs
+++ b/OfficeIMO.Word/Helpers/ListParser.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides helpers for detecting bullet and numbered lists within a document.
+    /// </summary>
+    public static class ListParser {
+        /// <summary>
+        /// Returns a dictionary describing list types keyed by numbering ID.
+        /// </summary>
+        /// <param name="mainPart">Main document part containing numbering definitions.</param>
+        /// <returns>
+        /// A dictionary where the key is a numbering ID and the value indicates whether the list is ordered (<c>true</c>)
+        /// or bulleted (<c>false</c>).
+        /// </returns>
+        public static Dictionary<int, bool> GetListTypes(MainDocumentPart mainPart) {
+            Dictionary<int, bool> listTypes = new();
+            NumberingDefinitionsPart? numberingPart = mainPart.NumberingDefinitionsPart;
+            if (numberingPart?.Numbering != null) {
+                foreach (NumberingInstance instance in numberingPart.Numbering.Elements<NumberingInstance>()) {
+                    int id = instance.NumberID!.Value;
+                    int absId = instance.AbstractNumId!.Val!.Value;
+                    AbstractNum? abs = numberingPart.Numbering.Elements<AbstractNum>()
+                        .FirstOrDefault(a => a.AbstractNumberId!.Value == absId);
+                    bool ordered = true;
+                    Level? lvl = abs?.Elements<Level>().FirstOrDefault(l => l.LevelIndex == 0);
+                    NumberFormatValues? format = lvl?.NumberingFormat?.Val;
+                    if (format == NumberFormatValues.Bullet) {
+                        ordered = false;
+                    }
+                    listTypes[id] = ordered;
+                }
+            }
+            return listTypes;
+        }
+
+        /// <summary>
+        /// Determines whether a paragraph belongs to a bulleted list.
+        /// </summary>
+        /// <param name="paragraph">Paragraph to evaluate.</param>
+        /// <param name="mainPart">Main document part.</param>
+        public static bool IsBullet(Paragraph paragraph, MainDocumentPart mainPart) {
+            var numProps = paragraph.ParagraphProperties?.NumberingProperties;
+            if (numProps?.NumberingId?.Val == null) {
+                return false;
+            }
+            int numId = numProps.NumberingId.Val.Value;
+            var listTypes = GetListTypes(mainPart);
+            return listTypes.TryGetValue(numId, out bool ordered) && !ordered;
+        }
+
+        /// <summary>
+        /// Determines whether a paragraph belongs to an ordered (numbered) list.
+        /// </summary>
+        /// <param name="paragraph">Paragraph to evaluate.</param>
+        /// <param name="mainPart">Main document part.</param>
+        public static bool IsOrdered(Paragraph paragraph, MainDocumentPart mainPart) {
+            var numProps = paragraph.ParagraphProperties?.NumberingProperties;
+            if (numProps?.NumberingId?.Val == null) {
+                return false;
+            }
+            int numId = numProps.NumberingId.Val.Value;
+            var listTypes = GetListTypes(mainPart);
+            return listTypes.TryGetValue(numId, out bool ordered) && ordered;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add shared `ListParser` helper to detect bullet and numbered lists
- switch HTML and Markdown converters to use `ListParser`
- cover list parsing with new tests and examples

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6891a4069408832e91f8686ed2c3340a