### PR TITLE
Add cross-platform font resolver for converters

### DIFF
--- a/OfficeIMO.Examples/Html/Html.GenericFont.cs
+++ b/OfficeIMO.Examples/Html/Html.GenericFont.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using OfficeIMO.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlGenericFont(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlGenericFont.docx");
+            string html = "<p>Generic font sample.</p>";
+
+            using MemoryStream ms = new MemoryStream();
+            HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "monospace" });
+            File.WriteAllBytes(filePath, ms.ToArray());
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Examples/Markdown/Markdown.GenericFont.cs
+++ b/OfficeIMO.Examples/Markdown/Markdown.GenericFont.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using OfficeIMO.Markdown;
+
+namespace OfficeIMO.Examples.Markdown {
+    internal static partial class Markdown {
+        public static void Example_MarkdownGenericFont(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "MarkdownGenericFont.docx");
+            string markdown = "Generic font sample.";
+
+            using MemoryStream ms = new MemoryStream();
+            MarkdownToWordConverter.Convert(markdown, ms, new MarkdownToWordOptions { FontFamily = "monospace" });
+            File.WriteAllBytes(filePath, ms.ToArray());
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
@@ -220,12 +220,13 @@ namespace OfficeIMO.Html {
 
         private static Run CreateRun(string text, HtmlToWordOptions options) {
             Run run = new Run(new Text(text) { Space = SpaceProcessingModeValues.Preserve });
-            if (!string.IsNullOrEmpty(options.FontFamily)) {
+            var fontFamily = FontResolver.Resolve(options.FontFamily);
+            if (!string.IsNullOrEmpty(fontFamily)) {
                 RunProperties runProperties = run.RunProperties ??= new RunProperties();
                 runProperties.RunFonts = new RunFonts {
-                    Ascii = options.FontFamily,
-                    HighAnsi = options.FontFamily,
-                    ComplexScript = options.FontFamily
+                    Ascii = fontFamily,
+                    HighAnsi = fontFamily,
+                    ComplexScript = fontFamily
                 };
             }
             return run;

--- a/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
@@ -26,6 +26,7 @@ namespace OfficeIMO.Markdown {
             }
 
             options ??= new MarkdownToWordOptions();
+            var fontFamily = FontResolver.Resolve(options.FontFamily);
 
             using var document = WordDocument.Create();
             WordList? currentList = null;
@@ -43,7 +44,7 @@ namespace OfficeIMO.Markdown {
                     int level = line.TakeWhile(c => c == '#').Count();
                     string text = line.Substring(level).TrimStart();
                     var paragraph = document.AddParagraph();
-                    InlineRunHelper.AddInlineRuns(paragraph, text, options.FontFamily);
+                    InlineRunHelper.AddInlineRuns(paragraph, text, fontFamily);
                     paragraph.Style = level switch {
                         1 => WordParagraphStyles.Heading1,
                         2 => WordParagraphStyles.Heading2,
@@ -67,13 +68,13 @@ namespace OfficeIMO.Markdown {
                     }
 
                     var item = currentList.AddItem(string.Empty);
-                    InlineRunHelper.AddInlineRuns(item, text, options.FontFamily);
+                    InlineRunHelper.AddInlineRuns(item, text, fontFamily);
                     continue;
                 }
 
                 currentList = null;
                 var para = document.AddParagraph();
-                InlineRunHelper.AddInlineRuns(para, line, options.FontFamily);
+                InlineRunHelper.AddInlineRuns(para, line, fontFamily);
             }
 
             document.Save(output);

--- a/OfficeIMO.Tests/FontResolver.cs
+++ b/OfficeIMO.Tests/FontResolver.cs
@@ -1,0 +1,21 @@
+using System.Runtime.InteropServices;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class FontResolverTests {
+    [Fact]
+    public void Resolve_GenericFonts() {
+        string resolved = FontResolver.Resolve("monospace")!;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Equal("Consolas", resolved);
+        } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+            Assert.Equal("DejaVu Sans Mono", resolved);
+        } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+            Assert.Equal("Menlo", resolved);
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Html;
+using OfficeIMO.Word;
 using System;
 using System.IO;
 using Xunit;
@@ -113,5 +114,16 @@ public partial class Html {
 
         Assert.Contains("<img", roundTrip, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("data:image/png;base64", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Test_Html_FontResolver() {
+        string html = "<p>Hello</p>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "monospace" });
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeStyles = true });
+        Assert.Contains($"font-family:{FontResolver.Resolve("monospace")}", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/OfficeIMO.Tests/Markdown.MarkdownConverter.cs
+++ b/OfficeIMO.Tests/Markdown.MarkdownConverter.cs
@@ -1,6 +1,10 @@
 using OfficeIMO.Markdown;
 using System;
 using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -30,6 +34,18 @@ namespace OfficeIMO.Tests {
 
             Assert.Contains("- Item 1", roundTrip, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("1. First", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_Markdown_FontResolver() {
+            string md = "Hello";
+            using MemoryStream ms = new MemoryStream();
+            MarkdownToWordConverter.Convert(md, ms, new MarkdownToWordOptions { FontFamily = "monospace" });
+
+            ms.Position = 0;
+            using WordprocessingDocument doc = WordprocessingDocument.Open(ms, false);
+            RunFonts fonts = doc.MainDocumentPart!.Document.Body!.Descendants<RunFonts>().First();
+            Assert.Equal(FontResolver.Resolve("monospace"), fonts.Ascii);
         }
     }
 }

--- a/OfficeIMO.Word/Helpers/FontResolver.cs
+++ b/OfficeIMO.Word/Helpers/FontResolver.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace OfficeIMO.Word;
+
+/// <summary>
+/// Resolves generic font family names to platform specific fonts.
+/// </summary>
+public static class FontResolver {
+    private static readonly Dictionary<string, string> _windowsFonts = new(StringComparer.OrdinalIgnoreCase) {
+        { "serif", "Times New Roman" },
+        { "sans-serif", "Calibri" },
+        { "monospace", "Consolas" }
+    };
+
+    private static readonly Dictionary<string, string> _linuxFonts = new(StringComparer.OrdinalIgnoreCase) {
+        { "serif", "DejaVu Serif" },
+        { "sans-serif", "DejaVu Sans" },
+        { "monospace", "DejaVu Sans Mono" }
+    };
+
+    private static readonly Dictionary<string, string> _macFonts = new(StringComparer.OrdinalIgnoreCase) {
+        { "serif", "Times" },
+        { "sans-serif", "Helvetica" },
+        { "monospace", "Menlo" }
+    };
+
+    /// <summary>
+    /// Resolves the provided font family name to an actual installed font.
+    /// Generic families like <c>serif</c> or <c>monospace</c> are mapped to
+    /// platform specific fonts.
+    /// </summary>
+    /// <param name="fontFamily">The requested font family.</param>
+    /// <returns>The resolved font family or <paramref name="fontFamily"/> if no mapping exists.</returns>
+    public static string? Resolve(string? fontFamily) {
+        if (string.IsNullOrWhiteSpace(fontFamily)) {
+            return null;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            if (_windowsFonts.TryGetValue(fontFamily, out string value)) {
+                return value;
+            }
+        } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+            if (_linuxFonts.TryGetValue(fontFamily, out string value)) {
+                return value;
+            }
+        } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+            if (_macFonts.TryGetValue(fontFamily, out string value)) {
+                return value;
+            }
+        }
+
+        return fontFamily;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add FontResolver helper to map generic fonts to OS-specific families
- apply FontResolver in Markdown and HTML converters
- add tests and examples demonstrating generic font resolution

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6891bd7d53f8832e999527304e66dcc1