### PR TITLE
feat: add converter registry

### DIFF
--- a/OfficeIMO.Converters/ConverterRegistry.cs
+++ b/OfficeIMO.Converters/ConverterRegistry.cs
@@ -1,0 +1,38 @@
+namespace OfficeIMO.Converters {
+    /// <summary>
+    /// Provides registration and resolution of <see cref="IWordConverter"/> instances by key.
+    /// </summary>
+    public static class ConverterRegistry {
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, System.Func<IWordConverter>> _converters = new(System.StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Registers a converter factory under the specified key.
+        /// </summary>
+        /// <param name="key">Key describing the conversion, e.g. "markdown->word".</param>
+        /// <param name="factory">Factory delegate creating a converter instance.</param>
+        public static void Register(string key, System.Func<IWordConverter> factory) {
+            if (string.IsNullOrWhiteSpace(key)) {
+                throw new System.ArgumentException("Key cannot be null or whitespace.", nameof(key));
+            }
+            if (factory == null) {
+                throw new System.ArgumentNullException(nameof(factory));
+            }
+            _converters[key] = factory;
+        }
+
+        /// <summary>
+        /// Resolves a converter registered under the given key.
+        /// </summary>
+        /// <param name="key">Key describing the conversion.</param>
+        /// <returns>An instance of <see cref="IWordConverter"/>.</returns>
+        public static IWordConverter Resolve(string key) {
+            if (key == null) {
+                throw new System.ArgumentNullException(nameof(key));
+            }
+            if (_converters.TryGetValue(key, out var factory)) {
+                return factory();
+            }
+            throw new System.InvalidOperationException($"Converter for key '{key}' is not registered.");
+        }
+    }
+}

--- a/OfficeIMO.Examples/Html/Html.Conversion.cs
+++ b/OfficeIMO.Examples/Html/Html.Conversion.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using OfficeIMO.Converters;
 using OfficeIMO.Html;
 
 namespace OfficeIMO.Examples.Html {
@@ -8,14 +9,21 @@ namespace OfficeIMO.Examples.Html {
             string filePath = Path.Combine(folderPath, "HtmlRoundTrip.docx");
             string html = "<p>Hello <b>world</b> and <i>universe</i>.</p>";
 
-            using (MemoryStream ms = new MemoryStream()) {
-                HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "Calibri" });
-                File.WriteAllBytes(filePath, ms.ToArray());
+            ConverterRegistry.Register("html->word", () => new HtmlToWordConverter());
+            ConverterRegistry.Register("word->html", () => new WordToHtmlConverter());
 
-                ms.Position = 0;
-                string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeStyles = true });
-                Console.WriteLine(roundTrip);
-            }
+            using MemoryStream htmlStream = new MemoryStream(Encoding.UTF8.GetBytes(html));
+            using MemoryStream wordStream = new MemoryStream();
+            IWordConverter htmlToWord = ConverterRegistry.Resolve("html->word");
+            htmlToWord.Convert(htmlStream, wordStream, new HtmlToWordOptions { FontFamily = "Calibri" });
+            File.WriteAllBytes(filePath, wordStream.ToArray());
+
+            wordStream.Position = 0;
+            using MemoryStream htmlOutput = new MemoryStream();
+            IWordConverter wordToHtml = ConverterRegistry.Resolve("word->html");
+            wordToHtml.Convert(wordStream, htmlOutput, new WordToHtmlOptions { IncludeStyles = true });
+            string roundTrip = Encoding.UTF8.GetString(htmlOutput.ToArray());
+            Console.WriteLine(roundTrip);
 
             if (openWord) {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });

--- a/OfficeIMO.Examples/Html/Html.ConverterInterface.cs
+++ b/OfficeIMO.Examples/Html/Html.ConverterInterface.cs
@@ -11,7 +11,8 @@ namespace OfficeIMO.Examples.Html {
             string html = "<p>Hello world</p>";
             using MemoryStream input = new MemoryStream(Encoding.UTF8.GetBytes(html));
             using MemoryStream output = new MemoryStream();
-            IWordConverter converter = new HtmlToWordConverter();
+            ConverterRegistry.Register("html->word", () => new HtmlToWordConverter());
+            IWordConverter converter = ConverterRegistry.Resolve("html->word");
             converter.Convert(input, output, new HtmlToWordOptions());
             File.WriteAllBytes(filePath, output.ToArray());
             if (openWord) {

--- a/OfficeIMO.Examples/Html/Html.GenericFont.cs
+++ b/OfficeIMO.Examples/Html/Html.GenericFont.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using OfficeIMO.Converters;
 using OfficeIMO.Html;
 
 namespace OfficeIMO.Examples.Html {
@@ -8,9 +9,12 @@ namespace OfficeIMO.Examples.Html {
             string filePath = Path.Combine(folderPath, "HtmlGenericFont.docx");
             string html = "<p>Generic font sample.</p>";
 
-            using MemoryStream ms = new MemoryStream();
-            HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "monospace" });
-            File.WriteAllBytes(filePath, ms.ToArray());
+            ConverterRegistry.Register("html->word", () => new HtmlToWordConverter());
+            using MemoryStream input = new MemoryStream(Encoding.UTF8.GetBytes(html));
+            using MemoryStream output = new MemoryStream();
+            IWordConverter converter = ConverterRegistry.Resolve("html->word");
+            converter.Convert(input, output, new HtmlToWordOptions { FontFamily = "monospace" });
+            File.WriteAllBytes(filePath, output.ToArray());
 
             if (openWord) {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });

--- a/OfficeIMO.Examples/Html/Html.Headings.cs
+++ b/OfficeIMO.Examples/Html/Html.Headings.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using OfficeIMO.Converters;
 using OfficeIMO.Html;
 
 namespace OfficeIMO.Examples.Html {
@@ -8,14 +9,21 @@ namespace OfficeIMO.Examples.Html {
             string filePath = Path.Combine(folderPath, "HtmlHeadings.docx");
             string html = "<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><h4>Heading 4</h4><h5>Heading 5</h5><h6>Heading 6</h6>";
 
-            using (MemoryStream ms = new MemoryStream()) {
-                HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "Calibri" });
-                File.WriteAllBytes(filePath, ms.ToArray());
+            ConverterRegistry.Register("html->word", () => new HtmlToWordConverter());
+            ConverterRegistry.Register("word->html", () => new WordToHtmlConverter());
 
-                ms.Position = 0;
-                string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeStyles = true });
-                Console.WriteLine(roundTrip);
-            }
+            using MemoryStream htmlStream = new MemoryStream(Encoding.UTF8.GetBytes(html));
+            using MemoryStream wordStream = new MemoryStream();
+            IWordConverter htmlToWord = ConverterRegistry.Resolve("html->word");
+            htmlToWord.Convert(htmlStream, wordStream, new HtmlToWordOptions { FontFamily = "Calibri" });
+            File.WriteAllBytes(filePath, wordStream.ToArray());
+
+            wordStream.Position = 0;
+            using MemoryStream htmlOutput = new MemoryStream();
+            IWordConverter wordToHtml = ConverterRegistry.Resolve("word->html");
+            wordToHtml.Convert(wordStream, htmlOutput, new WordToHtmlOptions { IncludeStyles = true });
+            string roundTrip = Encoding.UTF8.GetString(htmlOutput.ToArray());
+            Console.WriteLine(roundTrip);
 
             if (openWord) {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });

--- a/OfficeIMO.Examples/Html/Html.Lists.cs
+++ b/OfficeIMO.Examples/Html/Html.Lists.cs
@@ -1,3 +1,4 @@
+using OfficeIMO.Converters;
 using OfficeIMO.Html;
 using System;
 using System.IO;
@@ -8,14 +9,21 @@ namespace OfficeIMO.Examples.Html {
             string filePath = Path.Combine(folderPath, "HtmlLists.docx");
             string html = "<ul><li>Item 1<ul><li>Sub 1</li><li>Sub 2</li></ul></li><li>Item 2</li></ul><ol><li>First</li><li>Second</li></ol>";
 
-            using (MemoryStream ms = new MemoryStream()) {
-                HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
-                File.WriteAllBytes(filePath, ms.ToArray());
+            ConverterRegistry.Register("html->word", () => new HtmlToWordConverter());
+            ConverterRegistry.Register("word->html", () => new WordToHtmlConverter());
 
-                ms.Position = 0;
-                string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { PreserveListStyles = true });
-                Console.WriteLine(roundTrip);
-            }
+            using MemoryStream htmlStream = new MemoryStream(Encoding.UTF8.GetBytes(html));
+            using MemoryStream wordStream = new MemoryStream();
+            IWordConverter htmlToWord = ConverterRegistry.Resolve("html->word");
+            htmlToWord.Convert(htmlStream, wordStream, new HtmlToWordOptions());
+            File.WriteAllBytes(filePath, wordStream.ToArray());
+
+            wordStream.Position = 0;
+            using MemoryStream htmlOutput = new MemoryStream();
+            IWordConverter wordToHtml = ConverterRegistry.Resolve("word->html");
+            wordToHtml.Convert(wordStream, htmlOutput, new WordToHtmlOptions { PreserveListStyles = true });
+            string roundTrip = Encoding.UTF8.GetString(htmlOutput.ToArray());
+            Console.WriteLine(roundTrip);
 
             if (openWord) {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });

--- a/OfficeIMO.Examples/Markdown/Markdown.Conversion.cs
+++ b/OfficeIMO.Examples/Markdown/Markdown.Conversion.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using OfficeIMO.Converters;
 using OfficeIMO.Markdown;
 
 namespace OfficeIMO.Examples.Markdown {
@@ -8,14 +9,21 @@ namespace OfficeIMO.Examples.Markdown {
             string filePath = Path.Combine(folderPath, "MarkdownRoundTrip.docx");
             string markdown = "# Heading 1\n\nHello **world** and *universe*.";
 
-            using (MemoryStream ms = new MemoryStream()) {
-                MarkdownToWordConverter.Convert(markdown, ms, new MarkdownToWordOptions { FontFamily = "Calibri" });
-                File.WriteAllBytes(filePath, ms.ToArray());
+            ConverterRegistry.Register("markdown->word", () => new MarkdownToWordConverter());
+            ConverterRegistry.Register("word->markdown", () => new WordToMarkdownConverter());
 
-                ms.Position = 0;
-                string roundTrip = WordToMarkdownConverter.Convert(ms, new WordToMarkdownOptions { FontFamily = "Calibri" });
-                Console.WriteLine(roundTrip);
-            }
+            using MemoryStream markdownStream = new MemoryStream(Encoding.UTF8.GetBytes(markdown));
+            using MemoryStream wordStream = new MemoryStream();
+            IWordConverter mdToWord = ConverterRegistry.Resolve("markdown->word");
+            mdToWord.Convert(markdownStream, wordStream, new MarkdownToWordOptions { FontFamily = "Calibri" });
+            File.WriteAllBytes(filePath, wordStream.ToArray());
+
+            wordStream.Position = 0;
+            using MemoryStream markdownOutput = new MemoryStream();
+            IWordConverter wordToMd = ConverterRegistry.Resolve("word->markdown");
+            wordToMd.Convert(wordStream, markdownOutput, new WordToMarkdownOptions { FontFamily = "Calibri" });
+            string roundTrip = Encoding.UTF8.GetString(markdownOutput.ToArray());
+            Console.WriteLine(roundTrip);
 
             if (openWord) {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });

--- a/OfficeIMO.Examples/Markdown/Markdown.ConverterInterface.cs
+++ b/OfficeIMO.Examples/Markdown/Markdown.ConverterInterface.cs
@@ -11,7 +11,8 @@ namespace OfficeIMO.Examples.Markdown {
             string markdown = "# Title\nContent";
             using MemoryStream input = new MemoryStream(Encoding.UTF8.GetBytes(markdown));
             using MemoryStream output = new MemoryStream();
-            IWordConverter converter = new MarkdownToWordConverter();
+            ConverterRegistry.Register("markdown->word", () => new MarkdownToWordConverter());
+            IWordConverter converter = ConverterRegistry.Resolve("markdown->word");
             converter.Convert(input, output, new MarkdownToWordOptions());
             File.WriteAllBytes(filePath, output.ToArray());
             if (openWord) {

--- a/OfficeIMO.Examples/Markdown/Markdown.GenericFont.cs
+++ b/OfficeIMO.Examples/Markdown/Markdown.GenericFont.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using OfficeIMO.Converters;
 using OfficeIMO.Markdown;
 
 namespace OfficeIMO.Examples.Markdown {
@@ -8,9 +9,12 @@ namespace OfficeIMO.Examples.Markdown {
             string filePath = Path.Combine(folderPath, "MarkdownGenericFont.docx");
             string markdown = "Generic font sample.";
 
-            using MemoryStream ms = new MemoryStream();
-            MarkdownToWordConverter.Convert(markdown, ms, new MarkdownToWordOptions { FontFamily = "monospace" });
-            File.WriteAllBytes(filePath, ms.ToArray());
+            ConverterRegistry.Register("markdown->word", () => new MarkdownToWordConverter());
+            using MemoryStream input = new MemoryStream(Encoding.UTF8.GetBytes(markdown));
+            using MemoryStream output = new MemoryStream();
+            IWordConverter converter = ConverterRegistry.Resolve("markdown->word");
+            converter.Convert(input, output, new MarkdownToWordOptions { FontFamily = "monospace" });
+            File.WriteAllBytes(filePath, output.ToArray());
 
             if (openWord) {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });

--- a/OfficeIMO.Examples/Word/Pdf/Pdf.ConverterInterface.cs
+++ b/OfficeIMO.Examples/Word/Pdf/Pdf.ConverterInterface.cs
@@ -15,7 +15,8 @@ namespace OfficeIMO.Examples.Word {
             document.Save(docStream);
             docStream.Position = 0;
             using MemoryStream pdfStream = new MemoryStream();
-            IWordConverter converter = new WordPdfConverter();
+            ConverterRegistry.Register("word->pdf", () => new WordPdfConverter());
+            IWordConverter converter = ConverterRegistry.Resolve("word->pdf");
             converter.Convert(docStream, pdfStream, new PdfSaveOptions());
             File.WriteAllBytes(pdfPath, pdfStream.ToArray());
         }

--- a/OfficeIMO.Tests/ConverterRegistryTests.cs
+++ b/OfficeIMO.Tests/ConverterRegistryTests.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using System.Text;
+using OfficeIMO.Converters;
+using OfficeIMO.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class ConverterRegistryTests {
+        [Fact]
+        public void RegisteredConverterCanBeResolved() {
+            ConverterRegistry.Register("markdown->word-test", () => new MarkdownToWordConverter());
+            using MemoryStream input = new MemoryStream(Encoding.UTF8.GetBytes("# Title"));
+            using MemoryStream output = new MemoryStream();
+            IWordConverter converter = ConverterRegistry.Resolve("markdown->word-test");
+            converter.Convert(input, output, new MarkdownToWordOptions());
+            Assert.True(output.Length > 0);
+        }
+
+        [Fact]
+        public void ResolvingMissingConverterThrows() {
+            Assert.Throws<System.InvalidOperationException>(() => ConverterRegistry.Resolve("missing"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ConverterRegistry` to register and resolve converters by key
- update Markdown, HTML, and PDF examples to use the registry
- test converter registry behavior

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6891c8d6c74c832e918057001abed847