### PR TITLE
Introduce ConversionException for converters

### DIFF
--- a/OfficeIMO.Converters/ConversionException.cs
+++ b/OfficeIMO.Converters/ConversionException.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace OfficeIMO.Converters {
+    [Serializable]
+    public class ConversionException : Exception {
+        public ConversionException() {
+        }
+
+        public ConversionException(string message) : base(message) {
+        }
+
+        public ConversionException(string message, Exception innerException) : base(message, innerException) {
+        }
+
+        protected ConversionException(SerializationInfo info, StreamingContext context) : base(info, context) {
+        }
+    }
+}
+

--- a/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
@@ -23,10 +23,10 @@ namespace OfficeIMO.Html {
         /// <param name="options">Conversion options.</param>
         public static void Convert(string html, Stream output, HtmlToWordOptions? options = null) {
             if (html == null) {
-                throw new ArgumentNullException(nameof(html));
+                throw new ConversionException($"{nameof(html)} cannot be null.");
             }
             if (output == null) {
-                throw new ArgumentNullException(nameof(output));
+                throw new ConversionException($"{nameof(output)} cannot be null.");
             }
 
             options ??= new HtmlToWordOptions();
@@ -234,7 +234,7 @@ namespace OfficeIMO.Html {
 
         public void Convert(Stream input, Stream output, IConversionOptions options) {
             if (input == null) {
-                throw new ArgumentNullException(nameof(input));
+                throw new ConversionException($"{nameof(input)} cannot be null.");
             }
             using StreamReader reader = new StreamReader(
                 input,

--- a/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
@@ -23,7 +23,7 @@ namespace OfficeIMO.Html {
         /// <returns>Generated HTML string.</returns>
         public static string Convert(Stream docxStream, WordToHtmlOptions? options = null) {
             if (docxStream == null) {
-                throw new ArgumentNullException(nameof(docxStream));
+                throw new ConversionException($"{nameof(docxStream)} cannot be null.");
             }
 
             options ??= new WordToHtmlOptions();

--- a/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
@@ -19,10 +19,10 @@ namespace OfficeIMO.Markdown {
         /// <param name="options">Optional conversion settings.</param>
         public static void Convert(string markdown, Stream output, MarkdownToWordOptions? options = null) {
             if (markdown == null) {
-                throw new ArgumentNullException(nameof(markdown));
+                throw new ConversionException($"{nameof(markdown)} cannot be null.");
             }
             if (output == null) {
-                throw new ArgumentNullException(nameof(output));
+                throw new ConversionException($"{nameof(output)} cannot be null.");
             }
 
             options ??= new MarkdownToWordOptions();
@@ -82,7 +82,7 @@ namespace OfficeIMO.Markdown {
         
         public void Convert(Stream input, Stream output, IConversionOptions options) {
             if (input == null) {
-                throw new ArgumentNullException(nameof(input));
+                throw new ConversionException($"{nameof(input)} cannot be null.");
             }
             using StreamReader reader = new StreamReader(
                 input,

--- a/OfficeIMO.Markdown/Converters/WordToMarkdownConverter.cs
+++ b/OfficeIMO.Markdown/Converters/WordToMarkdownConverter.cs
@@ -21,7 +21,7 @@ namespace OfficeIMO.Markdown {
         /// <returns>Markdown representation of the document.</returns>
         public static string Convert(Stream input, WordToMarkdownOptions? options = null) {
             if (input == null) {
-                throw new ArgumentNullException(nameof(input));
+                throw new ConversionException($"{nameof(input)} cannot be null.");
             }
 
             options ??= new WordToMarkdownOptions();

--- a/OfficeIMO.Tests/ConverterExceptions.cs
+++ b/OfficeIMO.Tests/ConverterExceptions.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using OfficeIMO.Converters;
+using OfficeIMO.Html;
+using OfficeIMO.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class ConverterExceptions {
+        [Fact]
+        public void HtmlToWordConverter_NullHtml_Throws() {
+            using MemoryStream ms = new MemoryStream();
+            Assert.Throws<ConversionException>(() => HtmlToWordConverter.Convert(null!, ms, new HtmlToWordOptions()));
+        }
+
+        [Fact]
+        public void HtmlToWordConverter_NullOutput_Throws() {
+            Assert.Throws<ConversionException>(() => HtmlToWordConverter.Convert("<p>test</p>", null!, new HtmlToWordOptions()));
+        }
+
+        [Fact]
+        public void WordToHtmlConverter_NullInput_Throws() {
+            Assert.Throws<ConversionException>(() => WordToHtmlConverter.Convert(null!));
+        }
+
+        [Fact]
+        public void MarkdownToWordConverter_NullMarkdown_Throws() {
+            using MemoryStream ms = new MemoryStream();
+            Assert.Throws<ConversionException>(() => MarkdownToWordConverter.Convert(null!, ms, new MarkdownToWordOptions()));
+        }
+
+        [Fact]
+        public void MarkdownToWordConverter_NullOutput_Throws() {
+            Assert.Throws<ConversionException>(() => MarkdownToWordConverter.Convert("test", null!, new MarkdownToWordOptions()));
+        }
+
+        [Fact]
+        public void WordToMarkdownConverter_NullInput_Throws() {
+            Assert.Throws<ConversionException>(() => WordToMarkdownConverter.Convert(null!));
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add custom `ConversionException` to share conversion-specific error type
- replace generic null checks in HTML and Markdown converters with `ConversionException`
- add tests confirming converters throw `ConversionException` for invalid inputs

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6891cc5d9a78832e81a3f963ed6a674a