### PR TITLE
Standardize style option naming across converters

### DIFF
--- a/OfficeIMO.Examples/Html/Html.Conversion.cs
+++ b/OfficeIMO.Examples/Html/Html.Conversion.cs
@@ -21,7 +21,7 @@ namespace OfficeIMO.Examples.Html {
             wordStream.Position = 0;
             using MemoryStream htmlOutput = new MemoryStream();
             IWordConverter wordToHtml = ConverterRegistry.Resolve("word->html");
-            wordToHtml.Convert(wordStream, htmlOutput, new WordToHtmlOptions { IncludeStyles = true });
+            wordToHtml.Convert(wordStream, htmlOutput, new WordToHtmlOptions { IncludeFontStyles = true });
             string roundTrip = Encoding.UTF8.GetString(htmlOutput.ToArray());
             Console.WriteLine(roundTrip);
 

--- a/OfficeIMO.Examples/Html/Html.Headings.cs
+++ b/OfficeIMO.Examples/Html/Html.Headings.cs
@@ -21,7 +21,7 @@ namespace OfficeIMO.Examples.Html {
             wordStream.Position = 0;
             using MemoryStream htmlOutput = new MemoryStream();
             IWordConverter wordToHtml = ConverterRegistry.Resolve("word->html");
-            wordToHtml.Convert(wordStream, htmlOutput, new WordToHtmlOptions { IncludeStyles = true });
+            wordToHtml.Convert(wordStream, htmlOutput, new WordToHtmlOptions { IncludeFontStyles = true });
             string roundTrip = Encoding.UTF8.GetString(htmlOutput.ToArray());
             Console.WriteLine(roundTrip);
 

--- a/OfficeIMO.Examples/Html/Html.Lists.cs
+++ b/OfficeIMO.Examples/Html/Html.Lists.cs
@@ -21,7 +21,7 @@ namespace OfficeIMO.Examples.Html {
             wordStream.Position = 0;
             using MemoryStream htmlOutput = new MemoryStream();
             IWordConverter wordToHtml = ConverterRegistry.Resolve("word->html");
-            wordToHtml.Convert(wordStream, htmlOutput, new WordToHtmlOptions { PreserveListStyles = true });
+            wordToHtml.Convert(wordStream, htmlOutput, new WordToHtmlOptions { IncludeListStyles = true });
             string roundTrip = Encoding.UTF8.GetString(htmlOutput.ToArray());
             Console.WriteLine(roundTrip);
 

--- a/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
@@ -53,7 +53,7 @@ namespace OfficeIMO.Html {
                         if (listStack.Count == 0) {
                             for (int i = 0; i <= level; i++) {
                                 string tagOpen = ordered ? "<ol>" : "<ul>";
-                                if (options.PreserveListStyles) {
+                                if (options.IncludeListStyles) {
                                     string listStyle = ordered ? "decimal" : "disc";
                                     tagOpen = ordered ? $"<ol style=\"list-style-type:{listStyle}\">" : $"<ul style=\"list-style-type:{listStyle}\">";
                                 }
@@ -65,7 +65,7 @@ namespace OfficeIMO.Html {
                             if (level > currentLevel) {
                                 for (int i = currentLevel + 1; i <= level; i++) {
                                     string tagOpen = ordered ? "<ol>" : "<ul>";
-                                    if (options.PreserveListStyles) {
+                                    if (options.IncludeListStyles) {
                                         string listStyle = ordered ? "decimal" : "disc";
                                         tagOpen = ordered ? $"<ol style=\"list-style-type:{listStyle}\">" : $"<ul style=\"list-style-type:{listStyle}\">";
                                     }
@@ -82,7 +82,7 @@ namespace OfficeIMO.Html {
                                     var closing = listStack.Pop();
                                     sb.Append(closing.ordered ? "</ol>" : "</ul>");
                                     string tagOpen = ordered ? "<ol>" : "<ul>";
-                                    if (options.PreserveListStyles) {
+                                    if (options.IncludeListStyles) {
                                         string listStyle = ordered ? "decimal" : "disc";
                                         tagOpen = ordered ? $"<ol style=\"list-style-type:{listStyle}\">" : $"<ul style=\"list-style-type:{listStyle}\">";
                                     }
@@ -167,7 +167,7 @@ namespace OfficeIMO.Html {
                 RunProperties? runProps = run.RunProperties;
                 string result = encoded;
 
-                if (options.IncludeStyles && runProps?.RunFonts?.Ascii != null) {
+                if (options.IncludeFontStyles && runProps?.RunFonts?.Ascii != null) {
                     result = $"<span style=\"font-family:{runProps.RunFonts.Ascii}\">{result}</span>";
                 }
 

--- a/OfficeIMO.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Html/Options/HtmlToWordOptions.cs
@@ -7,8 +7,8 @@ namespace OfficeIMO.Html {
     /// </summary>
     public class HtmlToWordOptions : ConversionOptions {
         /// <summary>
-        /// When true, attempts to keep list styling information during conversion.
+        /// When true, attempts to include list styling information during conversion.
         /// </summary>
-        public bool PreserveListStyles { get; set; }
+        public bool IncludeListStyles { get; set; }
     }
 }

--- a/OfficeIMO.Html/Options/WordToHtmlOptions.cs
+++ b/OfficeIMO.Html/Options/WordToHtmlOptions.cs
@@ -9,11 +9,11 @@ namespace OfficeIMO.Html {
         /// <summary>
         /// When true, includes run font information as inline styles.
         /// </summary>
-        public bool IncludeStyles { get; set; }
+        public bool IncludeFontStyles { get; set; }
 
         /// <summary>
-        /// When set, retains list style information in generated HTML.
+        /// When set, includes list style information in generated HTML.
         /// </summary>
-        public bool PreserveListStyles { get; set; }
+        public bool IncludeListStyles { get; set; }
     }
 }

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -14,7 +14,7 @@ public partial class Html {
         HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "Calibri" });
 
         ms.Position = 0;
-        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeStyles = true });
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeFontStyles = true });
 
         Assert.Contains("<b>", roundTrip, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("</b>", roundTrip, StringComparison.OrdinalIgnoreCase);
@@ -32,7 +32,7 @@ public partial class Html {
         HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "Calibri" });
 
         ms.Position = 0;
-        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeStyles = true });
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeFontStyles = true });
 
         for (int i = 1; i <= 6; i++) {
             string tag = $"h{i}";
@@ -49,7 +49,7 @@ public partial class Html {
         HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
 
         ms.Position = 0;
-        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { PreserveListStyles = true });
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeListStyles = true });
 
         Assert.Contains("<ul", roundTrip, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("<ol", roundTrip, StringComparison.OrdinalIgnoreCase);
@@ -123,7 +123,7 @@ public partial class Html {
         HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "monospace" });
 
         ms.Position = 0;
-        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeStyles = true });
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeFontStyles = true });
         Assert.Contains($"font-family:{FontResolver.Resolve("monospace")}", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
## Summary
- rename `PreserveListStyles` -> `IncludeListStyles`
- rename `IncludeStyles` -> `IncludeFontStyles`
- update converters, examples, and tests to use new options

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6891d3d54400832ea29460cda42021c5