### PR TITLE
Use fallback fonts when requested family not installed

### DIFF
--- a/OfficeIMO.Examples/Word/Fonts/Fonts.FontFallback.cs
+++ b/OfficeIMO.Examples/Word/Fonts/Fonts.FontFallback.cs
@@ -1,0 +1,17 @@
+using OfficeIMO.Word;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Fonts {
+        public static void Example_FontResolverFallback(string folderPath) {
+            Console.WriteLine("[*] Demonstrating font resolver fallback");
+            string filePath = Path.Combine(folderPath, "DocumentFontFallback.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                string resolved = FontResolver.Resolve("MissingFont")!;
+                document.AddParagraph($"Paragraph using {resolved} font").SetFontFamily(resolved);
+                document.Save(false);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/FontResolver.cs
+++ b/OfficeIMO.Tests/FontResolver.cs
@@ -10,11 +10,24 @@ public class FontResolverTests {
         string resolved = FontResolver.Resolve("monospace")!;
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-            Assert.Equal("Consolas", resolved);
+            Assert.Contains(resolved, new[] { "Consolas", "Calibri" });
         } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-            Assert.Equal("DejaVu Sans Mono", resolved);
+            Assert.Contains(resolved, new[] { "DejaVu Sans Mono", "DejaVu Sans" });
         } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
-            Assert.Equal("Menlo", resolved);
+            Assert.Contains(resolved, new[] { "Menlo", "Helvetica" });
+        }
+    }
+
+    [Fact]
+    public void Resolve_FallbackFonts() {
+        string resolved = FontResolver.Resolve("DefinitelyMissingFont")!;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Equal("Calibri", resolved);
+        } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+            Assert.Equal("DejaVu Sans", resolved);
+        } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+            Assert.Equal("Helvetica", resolved);
         }
     }
 }

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -22,7 +22,7 @@ public partial class Html {
         Assert.Contains("<i>", roundTrip, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("</i>", roundTrip, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("universe", roundTrip, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("font-family:Calibri", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains($"font-family:{FontResolver.Resolve("Calibri")}", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/OfficeIMO.Word/OfficeIMO.Word.csproj
+++ b/OfficeIMO.Word/OfficeIMO.Word.csproj
@@ -64,6 +64,7 @@
     <ItemGroup>
         <PackageReference Include="DocumentFormat.OpenXml" Version="[3.3.0,4.0.0)" />
         <PackageReference Include="SixLabors.ImageSharp" Version="[2.1.10,3.0.0)" />
+        <PackageReference Include="System.Drawing.Common" Version="8.0.4" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">


### PR DESCRIPTION
## Summary
- add platform-specific fallback fonts and resolve helper to choose first available font
- reference System.Drawing.Common for font availability checks
- update tests and example to demonstrate font fallback behavior

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6891db9d0888832e895f95a7691f455e