### PR TITLE
Add async conversion support across Word converters

### DIFF
--- a/OfficeIMO.Converters/IWordConverter.cs
+++ b/OfficeIMO.Converters/IWordConverter.cs
@@ -1,7 +1,9 @@
 using System.IO;
+using System.Threading.Tasks;
 
 namespace OfficeIMO.Converters {
     public interface IWordConverter {
         void Convert(Stream input, Stream output, IConversionOptions options);
+        Task ConvertAsync(Stream input, Stream output, IConversionOptions options);
     }
 }

--- a/OfficeIMO.Examples/Html/Html.ConverterInterface.Async.cs
+++ b/OfficeIMO.Examples/Html/Html.ConverterInterface.Async.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using OfficeIMO.Converters;
+using OfficeIMO.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static async Task Example_HtmlInterfaceAsync(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlInterfaceAsync.docx");
+            string html = "<p>Hello world</p>";
+            using MemoryStream input = new MemoryStream(Encoding.UTF8.GetBytes(html));
+            using MemoryStream output = new MemoryStream();
+            ConverterRegistry.Register("html->word", () => new HtmlToWordConverter());
+            IWordConverter converter = ConverterRegistry.Resolve("html->word");
+            await converter.ConvertAsync(input, output, new HtmlToWordOptions());
+            await File.WriteAllBytesAsync(filePath, output.ToArray());
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Markdown/Markdown.ConverterInterface.Async.cs
+++ b/OfficeIMO.Examples/Markdown/Markdown.ConverterInterface.Async.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using OfficeIMO.Converters;
+using OfficeIMO.Markdown;
+
+namespace OfficeIMO.Examples.Markdown {
+    internal static partial class Markdown {
+        public static async Task Example_MarkdownInterfaceAsync(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "MarkdownInterfaceAsync.docx");
+            string markdown = "# Title\nContent";
+            using MemoryStream input = new MemoryStream(Encoding.UTF8.GetBytes(markdown));
+            using MemoryStream output = new MemoryStream();
+            ConverterRegistry.Register("markdown->word", () => new MarkdownToWordConverter());
+            IWordConverter converter = ConverterRegistry.Resolve("markdown->word");
+            await converter.ConvertAsync(input, output, new MarkdownToWordOptions());
+            await File.WriteAllBytesAsync(filePath, output.ToArray());
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Pdf/Pdf.ConverterInterface.Async.cs
+++ b/OfficeIMO.Examples/Word/Pdf/Pdf.ConverterInterface.Async.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using OfficeIMO.Converters;
+using OfficeIMO.Pdf;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Pdf {
+        public static async Task Example_PdfInterfaceAsync(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Exporting to PDF via interface async");
+            string pdfPath = Path.Combine(folderPath, "ExportInterfaceAsync.pdf");
+            using WordDocument document = WordDocument.Create();
+            document.AddParagraph("Hello PDF");
+            using MemoryStream docStream = new MemoryStream();
+            document.Save(docStream);
+            docStream.Position = 0;
+            using MemoryStream pdfStream = new MemoryStream();
+            ConverterRegistry.Register("word->pdf", () => new WordPdfConverter());
+            IWordConverter converter = ConverterRegistry.Resolve("word->pdf");
+            await converter.ConvertAsync(docStream, pdfStream, new PdfSaveOptions());
+            await File.WriteAllBytesAsync(pdfPath, pdfStream.ToArray());
+        }
+    }
+}

--- a/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
+using System.Threading.Tasks;
 using OfficeIMO.Converters;
 
 namespace OfficeIMO.Html {
@@ -245,5 +246,20 @@ namespace OfficeIMO.Html {
             string html = reader.ReadToEnd();
             Convert(html, output, options as HtmlToWordOptions);
         }
+
+        public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options) {
+            if (input == null) {
+                throw new ConversionException($"{nameof(input)} cannot be null.");
+            }
+            using StreamReader reader = new StreamReader(
+                input,
+                Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: true,
+                bufferSize: 1024,
+                leaveOpen: true);
+            string html = await reader.ReadToEndAsync().ConfigureAwait(false);
+            Convert(html, output, options as HtmlToWordOptions);
+            await output.FlushAsync().ConfigureAwait(false);
+        }
     }
-}
+}

--- a/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using A = DocumentFormat.OpenXml.Drawing;
 using OfficeIMO.Converters;
 
@@ -193,6 +194,17 @@ namespace OfficeIMO.Html {
                 leaveOpen: true);
             writer.Write(html);
             writer.Flush();
+        }
+
+        public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options) {
+            string html = Convert(input, options as WordToHtmlOptions);
+            using StreamWriter writer = new StreamWriter(
+                output,
+                Encoding.UTF8,
+                bufferSize: 1024,
+                leaveOpen: true);
+            await writer.WriteAsync(html).ConfigureAwait(false);
+            await writer.FlushAsync().ConfigureAwait(false);
         }
     }
 }

--- a/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using OfficeIMO.Word;
 using OfficeIMO.Converters;
 
@@ -92,6 +93,21 @@ namespace OfficeIMO.Markdown {
                 leaveOpen: true);
             string markdown = reader.ReadToEnd();
             Convert(markdown, output, options as MarkdownToWordOptions);
+        }
+
+        public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options) {
+            if (input == null) {
+                throw new ConversionException($"{nameof(input)} cannot be null.");
+            }
+            using StreamReader reader = new StreamReader(
+                input,
+                Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: true,
+                bufferSize: 1024,
+                leaveOpen: true);
+            string markdown = await reader.ReadToEndAsync().ConfigureAwait(false);
+            Convert(markdown, output, options as MarkdownToWordOptions);
+            await output.FlushAsync().ConfigureAwait(false);
         }
     }
 }

--- a/OfficeIMO.Markdown/Converters/WordToMarkdownConverter.cs
+++ b/OfficeIMO.Markdown/Converters/WordToMarkdownConverter.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using DocumentFormat.OpenXml;
@@ -84,6 +85,17 @@ namespace OfficeIMO.Markdown {
                 leaveOpen: true);
             writer.Write(markdown);
             writer.Flush();
+        }
+
+        public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options) {
+            string markdown = Convert(input, options as WordToMarkdownOptions);
+            using StreamWriter writer = new StreamWriter(
+                output,
+                Encoding.UTF8,
+                bufferSize: 1024,
+                leaveOpen: true);
+            await writer.WriteAsync(markdown).ConfigureAwait(false);
+            await writer.FlushAsync().ConfigureAwait(false);
         }
     }
 }

--- a/OfficeIMO.Pdf/WordPdfConverter.cs
+++ b/OfficeIMO.Pdf/WordPdfConverter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.IO;
 using System;
+using System.Threading.Tasks;
 using DocumentFormat.OpenXml;
 using W = DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Converters;
@@ -19,6 +20,12 @@ public class WordPdfConverter : IWordConverter {
     public void Convert(Stream input, Stream output, IConversionOptions options) {
         using WordDocument document = WordDocument.Load(input);
         document.SaveAsPdf(output, options as PdfSaveOptions);
+    }
+
+    public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options) {
+        using WordDocument document = WordDocument.Load(input);
+        document.SaveAsPdf(output, options as PdfSaveOptions);
+        await output.FlushAsync().ConfigureAwait(false);
     }
 }
 

--- a/OfficeIMO.Tests/ConverterInterfaces.Async.cs
+++ b/OfficeIMO.Tests/ConverterInterfaces.Async.cs
@@ -1,0 +1,61 @@
+using OfficeIMO.Converters;
+using OfficeIMO.Markdown;
+using OfficeIMO.Html;
+using OfficeIMO.Pdf;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class ConverterInterfacesAsync {
+    [Fact]
+    public async Task MarkdownConverters_Work_With_Interface_Async() {
+        string markdown = "# Title\nSome text";
+        using MemoryStream input = new MemoryStream(Encoding.UTF8.GetBytes(markdown));
+        using MemoryStream wordStream = new MemoryStream();
+        IWordConverter mdToWord = new MarkdownToWordConverter();
+        await mdToWord.ConvertAsync(input, wordStream, new MarkdownToWordOptions());
+        Assert.True(wordStream.Length > 0);
+
+        wordStream.Position = 0;
+        using MemoryStream markdownStream = new MemoryStream();
+        IWordConverter wordToMd = new WordToMarkdownConverter();
+        await wordToMd.ConvertAsync(wordStream, markdownStream, new WordToMarkdownOptions());
+        string result = Encoding.UTF8.GetString(markdownStream.ToArray());
+        Assert.Contains("Title", result);
+    }
+
+    [Fact]
+    public async Task HtmlConverters_Work_With_Interface_Async() {
+        string html = "<p>Hello <b>world</b></p>";
+        using MemoryStream input = new MemoryStream(Encoding.UTF8.GetBytes(html));
+        using MemoryStream wordStream = new MemoryStream();
+        IWordConverter htmlToWord = new HtmlToWordConverter();
+        await htmlToWord.ConvertAsync(input, wordStream, new HtmlToWordOptions());
+        Assert.True(wordStream.Length > 0);
+
+        wordStream.Position = 0;
+        using MemoryStream htmlStream = new MemoryStream();
+        IWordConverter wordToHtml = new WordToHtmlConverter();
+        await wordToHtml.ConvertAsync(wordStream, htmlStream, new WordToHtmlOptions());
+        string roundTrip = Encoding.UTF8.GetString(htmlStream.ToArray());
+        Assert.Contains("<b>world</b>", roundTrip, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PdfConverter_Works_With_Interface_Async() {
+        using WordDocument document = WordDocument.Create();
+        document.AddParagraph("Hello PDF");
+        using MemoryStream docStream = new MemoryStream();
+        document.Save(docStream);
+        docStream.Position = 0;
+        using MemoryStream pdfStream = new MemoryStream();
+        IWordConverter converter = new WordPdfConverter();
+        await converter.ConvertAsync(docStream, pdfStream, new PdfSaveOptions());
+        Assert.True(pdfStream.Length > 0);
+    }
+}

--- a/OfficeIMO.Tests/ConverterRegistryTests.cs
+++ b/OfficeIMO.Tests/ConverterRegistryTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Text;
 using OfficeIMO.Converters;
 using OfficeIMO.Markdown;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -13,6 +14,16 @@ namespace OfficeIMO.Tests {
             using MemoryStream output = new MemoryStream();
             IWordConverter converter = ConverterRegistry.Resolve("markdown->word-test");
             converter.Convert(input, output, new MarkdownToWordOptions());
+            Assert.True(output.Length > 0);
+        }
+
+        [Fact]
+        public async Task RegisteredConverterCanBeResolvedAsync() {
+            ConverterRegistry.Register("markdown->word-test-async", () => new MarkdownToWordConverter());
+            using MemoryStream input = new MemoryStream(Encoding.UTF8.GetBytes("# Title"));
+            using MemoryStream output = new MemoryStream();
+            IWordConverter converter = ConverterRegistry.Resolve("markdown->word-test-async");
+            await converter.ConvertAsync(input, output, new MarkdownToWordOptions());
             Assert.True(output.Length > 0);
         }
 


### PR DESCRIPTION
## Summary
- define `ConvertAsync` on `IWordConverter`
- add async implementations for markdown, html, and pdf converters
- add examples and tests for async conversion

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6891db8cac5c832e89ea2ca57c3d806c