### PR TITLE
Add cancellation token support to async converters

### DIFF
--- a/OfficeIMO.Examples/Html/Html.ConverterInterface.Async.cs
+++ b/OfficeIMO.Examples/Html/Html.ConverterInterface.Async.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using OfficeIMO.Html;
 using OfficeIMO.Word;
@@ -14,7 +15,8 @@ namespace OfficeIMO.Examples.Html {
             using MemoryStream output = new MemoryStream();
             ConverterRegistry.Register("html->word", () => new HtmlToWordConverter());
             IWordConverter converter = ConverterRegistry.Resolve("html->word");
-            await converter.ConvertAsync(input, output, new HtmlToWordOptions());
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            await converter.ConvertAsync(input, output, new HtmlToWordOptions(), cts.Token);
             await File.WriteAllBytesAsync(filePath, output.ToArray());
             if (openWord) {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });

--- a/OfficeIMO.Examples/Markdown/Markdown.ConverterInterface.Async.cs
+++ b/OfficeIMO.Examples/Markdown/Markdown.ConverterInterface.Async.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using OfficeIMO.Markdown;
 using OfficeIMO.Word;
@@ -14,7 +15,8 @@ namespace OfficeIMO.Examples.Markdown {
             using MemoryStream output = new MemoryStream();
             ConverterRegistry.Register("markdown->word", () => new MarkdownToWordConverter());
             IWordConverter converter = ConverterRegistry.Resolve("markdown->word");
-            await converter.ConvertAsync(input, output, new MarkdownToWordOptions());
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            await converter.ConvertAsync(input, output, new MarkdownToWordOptions(), cts.Token);
             await File.WriteAllBytesAsync(filePath, output.ToArray());
             if (openWord) {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });

--- a/OfficeIMO.Examples/Word/Pdf/Pdf.ConverterInterface.Async.cs
+++ b/OfficeIMO.Examples/Word/Pdf/Pdf.ConverterInterface.Async.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using OfficeIMO.Pdf;
 using OfficeIMO.Word;
@@ -17,7 +18,8 @@ namespace OfficeIMO.Examples.Word {
             using MemoryStream pdfStream = new MemoryStream();
             ConverterRegistry.Register("word->pdf", () => new WordPdfConverter());
             IWordConverter converter = ConverterRegistry.Resolve("word->pdf");
-            await converter.ConvertAsync(docStream, pdfStream, new PdfSaveOptions());
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            await converter.ConvertAsync(docStream, pdfStream, new PdfSaveOptions(), cts.Token);
             await File.WriteAllBytesAsync(pdfPath, pdfStream.ToArray());
         }
     }

--- a/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
@@ -266,7 +266,13 @@ namespace OfficeIMO.Html {
                 detectEncodingFromByteOrderMarks: true,
                 bufferSize: 1024,
                 leaveOpen: true);
-            string html = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            string html;
+#if NET8_0_OR_GREATER
+            html = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+#else
+            html = await reader.ReadToEndAsync().ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+#endif
             Convert(html, output, options as HtmlToWordOptions, cancellationToken);
             await output.FlushAsync(cancellationToken).ConfigureAwait(false);
         }

--- a/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace OfficeIMO.Html {
@@ -21,7 +22,8 @@ namespace OfficeIMO.Html {
         /// <param name="html">HTML content to convert. It should be a valid XHTML fragment.</param>
         /// <param name="output">Stream where DOCX content will be written.</param>
         /// <param name="options">Conversion options.</param>
-        public static void Convert(string html, Stream output, HtmlToWordOptions? options = null) {
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        public static void Convert(string html, Stream output, HtmlToWordOptions? options = null, CancellationToken cancellationToken = default) {
             if (html == null) {
                 throw new ConversionException($"{nameof(html)} cannot be null.");
             }
@@ -45,13 +47,14 @@ namespace OfficeIMO.Html {
             XDocument xdoc = XDocument.Parse("<root>" + html + "</root>");
 
             foreach (XElement element in xdoc.Root!.Elements()) {
-                AppendBlockElement(body, element, options, 0, bulletNumberId, orderedNumberId, mainPart);
+                cancellationToken.ThrowIfCancellationRequested();
+                AppendBlockElement(body, element, options, 0, bulletNumberId, orderedNumberId, mainPart, cancellationToken);
             }
 
             mainPart.Document.Save();
         }
 
-        private static void AppendBlockElement(OpenXmlElement parent, XElement element, HtmlToWordOptions options, int level, int bulletNumberId, int orderedNumberId, MainDocumentPart mainPart) {
+        private static void AppendBlockElement(OpenXmlElement parent, XElement element, HtmlToWordOptions options, int level, int bulletNumberId, int orderedNumberId, MainDocumentPart mainPart, CancellationToken cancellationToken) {
             switch (element.Name.LocalName.ToLowerInvariant()) {
                 case "p":
                 case "h1":
@@ -60,20 +63,22 @@ namespace OfficeIMO.Html {
                 case "h4":
                 case "h5":
                 case "h6":
-                    parent.Append(CreateParagraph(element, options, mainPart));
+                    parent.Append(CreateParagraph(element, options, mainPart, cancellationToken));
                     break;
                 case "ul":
                     foreach (XElement li in element.Elements("li")) {
-                        AppendListItem(parent, li, options, level, bulletNumberId, bulletNumberId, orderedNumberId, mainPart);
+                        cancellationToken.ThrowIfCancellationRequested();
+                        AppendListItem(parent, li, options, level, bulletNumberId, bulletNumberId, orderedNumberId, mainPart, cancellationToken);
                     }
                     break;
                 case "ol":
                     foreach (XElement li in element.Elements("li")) {
-                        AppendListItem(parent, li, options, level, orderedNumberId, bulletNumberId, orderedNumberId, mainPart);
+                        cancellationToken.ThrowIfCancellationRequested();
+                        AppendListItem(parent, li, options, level, orderedNumberId, bulletNumberId, orderedNumberId, mainPart, cancellationToken);
                     }
                     break;
                 case "table":
-                    parent.Append(CreateTable(element, options, level, bulletNumberId, orderedNumberId, mainPart));
+                    parent.Append(CreateTable(element, options, level, bulletNumberId, orderedNumberId, mainPart, cancellationToken));
                     break;
                 case "img":
                     string? src = element.Attribute("src")?.Value;
@@ -86,7 +91,7 @@ namespace OfficeIMO.Html {
             }
         }
 
-        private static Paragraph CreateParagraph(XElement element, HtmlToWordOptions options, MainDocumentPart mainPart) {
+        private static Paragraph CreateParagraph(XElement element, HtmlToWordOptions options, MainDocumentPart mainPart, CancellationToken cancellationToken) {
             Paragraph paragraph = new Paragraph();
             WordParagraphStyles? style = null;
             switch (element.Name.LocalName.ToLowerInvariant()) {
@@ -115,6 +120,7 @@ namespace OfficeIMO.Html {
             }
 
             foreach (XNode node in element.Nodes()) {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (node is XText textNode) {
                     paragraph.Append(CreateRun(textNode.Value, options));
                 } else if (node is XElement inlineElement) {
@@ -132,7 +138,7 @@ namespace OfficeIMO.Html {
             return paragraph;
         }
 
-        private static void AppendListItem(OpenXmlElement parent, XElement li, HtmlToWordOptions options, int level, int numId, int bulletNumberId, int orderedNumberId, MainDocumentPart mainPart) {
+        private static void AppendListItem(OpenXmlElement parent, XElement li, HtmlToWordOptions options, int level, int numId, int bulletNumberId, int orderedNumberId, MainDocumentPart mainPart, CancellationToken cancellationToken) {
             Paragraph paragraph = new Paragraph();
             paragraph.ParagraphProperties = new ParagraphProperties(
                 new NumberingProperties(
@@ -141,13 +147,14 @@ namespace OfficeIMO.Html {
                 ));
 
             foreach (XNode node in li.Nodes()) {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (node is XText textNode) {
                     paragraph.Append(CreateRun(textNode.Value, options));
                 } else if (node is XElement el) {
                     if (el.Name.LocalName.Equals("ul", StringComparison.OrdinalIgnoreCase) || el.Name.LocalName.Equals("ol", StringComparison.OrdinalIgnoreCase)) {
                         // finalize current paragraph and process nested list
                         parent.Append(paragraph);
-                        AppendBlockElement(parent, el, options, level + 1, bulletNumberId, orderedNumberId, mainPart);
+                        AppendBlockElement(parent, el, options, level + 1, bulletNumberId, orderedNumberId, mainPart, cancellationToken);
                         paragraph = new Paragraph(); // prevent re-adding
                     } else if (el.Name.LocalName.Equals("img", StringComparison.OrdinalIgnoreCase)) {
                         string? src = el.Attribute("src")?.Value;
@@ -165,17 +172,20 @@ namespace OfficeIMO.Html {
             }
         }
 
-        private static Table CreateTable(XElement element, HtmlToWordOptions options, int level, int bulletNumberId, int orderedNumberId, MainDocumentPart mainPart) {
+        private static Table CreateTable(XElement element, HtmlToWordOptions options, int level, int bulletNumberId, int orderedNumberId, MainDocumentPart mainPart, CancellationToken cancellationToken) {
             List<List<Action<TableCell>>> structure = new();
 
             foreach (XElement tr in element.Elements("tr")) {
+                cancellationToken.ThrowIfCancellationRequested();
                 List<Action<TableCell>> row = new();
                 foreach (XElement cellEl in tr.Elements().Where(e => e.Name.LocalName.Equals("td", StringComparison.OrdinalIgnoreCase) || e.Name.LocalName.Equals("th", StringComparison.OrdinalIgnoreCase))) {
+                    cancellationToken.ThrowIfCancellationRequested();
                     row.Add(cell => {
                         bool hasBlock = false;
                         foreach (XNode node in cellEl.Nodes()) {
+                            cancellationToken.ThrowIfCancellationRequested();
                             if (node is XElement blockEl) {
-                                AppendBlockElement(cell, blockEl, options, level, bulletNumberId, orderedNumberId, mainPart);
+                                AppendBlockElement(cell, blockEl, options, level, bulletNumberId, orderedNumberId, mainPart, cancellationToken);
                                 hasBlock = true;
                             } else if (node is XText text) {
                                 Paragraph p = new Paragraph();
@@ -246,7 +256,7 @@ namespace OfficeIMO.Html {
             Convert(html, output, options as HtmlToWordOptions);
         }
 
-        public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options) {
+        public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options, CancellationToken cancellationToken = default) {
             if (input == null) {
                 throw new ConversionException($"{nameof(input)} cannot be null.");
             }
@@ -256,9 +266,9 @@ namespace OfficeIMO.Html {
                 detectEncodingFromByteOrderMarks: true,
                 bufferSize: 1024,
                 leaveOpen: true);
-            string html = await reader.ReadToEndAsync().ConfigureAwait(false);
-            Convert(html, output, options as HtmlToWordOptions);
-            await output.FlushAsync().ConfigureAwait(false);
+            string html = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            Convert(html, output, options as HtmlToWordOptions, cancellationToken);
+            await output.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using A = DocumentFormat.OpenXml.Drawing;
 
@@ -195,15 +196,15 @@ namespace OfficeIMO.Html {
             writer.Flush();
         }
 
-        public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options) {
+        public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options, CancellationToken cancellationToken = default) {
             string html = Convert(input, options as WordToHtmlOptions);
             using StreamWriter writer = new StreamWriter(
                 output,
                 Encoding.UTF8,
                 bufferSize: 1024,
                 leaveOpen: true);
-            await writer.WriteAsync(html).ConfigureAwait(false);
-            await writer.FlushAsync().ConfigureAwait(false);
+            await writer.WriteAsync(html.AsMemory(), cancellationToken).ConfigureAwait(false);
+            await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Html/Converters/WordToHtmlConverter.cs
@@ -203,8 +203,14 @@ namespace OfficeIMO.Html {
                 Encoding.UTF8,
                 bufferSize: 1024,
                 leaveOpen: true);
+#if NET8_0_OR_GREATER
             await writer.WriteAsync(html.AsMemory(), cancellationToken).ConfigureAwait(false);
             await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+#else
+            await writer.WriteAsync(html).ConfigureAwait(false);
+            await writer.FlushAsync().ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+#endif
         }
     }
 }

--- a/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
@@ -107,7 +107,13 @@ namespace OfficeIMO.Markdown {
                 detectEncodingFromByteOrderMarks: true,
                 bufferSize: 1024,
                 leaveOpen: true);
-            string markdown = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            string markdown;
+#if NET8_0_OR_GREATER
+            markdown = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+#else
+            markdown = await reader.ReadToEndAsync().ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+#endif
             Convert(markdown, output, options as MarkdownToWordOptions, cancellationToken);
             await output.FlushAsync(cancellationToken).ConfigureAwait(false);
         }

--- a/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using OfficeIMO.Word;
 
@@ -17,7 +18,8 @@ namespace OfficeIMO.Markdown {
         /// <param name="markdown">Markdown source text.</param>
         /// <param name="output">Destination stream for the generated document.</param>
         /// <param name="options">Optional conversion settings.</param>
-        public static void Convert(string markdown, Stream output, MarkdownToWordOptions? options = null) {
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        public static void Convert(string markdown, Stream output, MarkdownToWordOptions? options = null, CancellationToken cancellationToken = default) {
             if (markdown == null) {
                 throw new ConversionException($"{nameof(markdown)} cannot be null.");
             }
@@ -33,6 +35,7 @@ namespace OfficeIMO.Markdown {
             bool currentListIsNumbered = false;
 
             foreach (var raw in markdown.Replace("\r", string.Empty).Split('\n')) {
+                cancellationToken.ThrowIfCancellationRequested();
                 var line = raw.TrimEnd();
                 if (string.IsNullOrWhiteSpace(line)) {
                     currentList = null;
@@ -94,7 +97,7 @@ namespace OfficeIMO.Markdown {
             Convert(markdown, output, options as MarkdownToWordOptions);
         }
 
-        public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options) {
+        public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options, CancellationToken cancellationToken = default) {
             if (input == null) {
                 throw new ConversionException($"{nameof(input)} cannot be null.");
             }
@@ -104,9 +107,9 @@ namespace OfficeIMO.Markdown {
                 detectEncodingFromByteOrderMarks: true,
                 bufferSize: 1024,
                 leaveOpen: true);
-            string markdown = await reader.ReadToEndAsync().ConfigureAwait(false);
-            Convert(markdown, output, options as MarkdownToWordOptions);
-            await output.FlushAsync().ConfigureAwait(false);
+            string markdown = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            Convert(markdown, output, options as MarkdownToWordOptions, cancellationToken);
+            await output.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/OfficeIMO.Markdown/Converters/WordToMarkdownConverter.cs
+++ b/OfficeIMO.Markdown/Converters/WordToMarkdownConverter.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
@@ -86,15 +87,15 @@ namespace OfficeIMO.Markdown {
             writer.Flush();
         }
 
-        public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options) {
+        public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options, CancellationToken cancellationToken = default) {
             string markdown = Convert(input, options as WordToMarkdownOptions);
             using StreamWriter writer = new StreamWriter(
                 output,
                 Encoding.UTF8,
                 bufferSize: 1024,
                 leaveOpen: true);
-            await writer.WriteAsync(markdown).ConfigureAwait(false);
-            await writer.FlushAsync().ConfigureAwait(false);
+            await writer.WriteAsync(markdown.AsMemory(), cancellationToken).ConfigureAwait(false);
+            await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/OfficeIMO.Markdown/Converters/WordToMarkdownConverter.cs
+++ b/OfficeIMO.Markdown/Converters/WordToMarkdownConverter.cs
@@ -94,8 +94,14 @@ namespace OfficeIMO.Markdown {
                 Encoding.UTF8,
                 bufferSize: 1024,
                 leaveOpen: true);
+#if NET8_0_OR_GREATER
             await writer.WriteAsync(markdown.AsMemory(), cancellationToken).ConfigureAwait(false);
             await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+#else
+            await writer.WriteAsync(markdown).ConfigureAwait(false);
+            await writer.FlushAsync().ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+#endif
         }
     }
 }

--- a/OfficeIMO.Pdf/WordPdfConverter.cs
+++ b/OfficeIMO.Pdf/WordPdfConverter.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using OfficeIMO.Word;
 
@@ -12,10 +13,10 @@ namespace OfficeIMO.Pdf {
             document.SaveAsPdf(output, options as PdfSaveOptions);
         }
 
-        public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options) {
+        public async Task ConvertAsync(Stream input, Stream output, IConversionOptions options, CancellationToken cancellationToken = default) {
             using WordDocument document = WordDocument.Load(input);
             document.SaveAsPdf(output, options as PdfSaveOptions);
-            await output.FlushAsync().ConfigureAwait(false);
+            await output.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/OfficeIMO.Tests/ConverterCancellation.cs
+++ b/OfficeIMO.Tests/ConverterCancellation.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using OfficeIMO.Html;
+using OfficeIMO.Markdown;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class ConverterCancellation {
+        [Fact]
+        public async Task MarkdownToWordConverter_CancelledToken_Throws() {
+            using MemoryStream input = new MemoryStream(Encoding.UTF8.GetBytes("# Title\nContent"));
+            using MemoryStream output = new MemoryStream();
+            IWordConverter converter = new MarkdownToWordConverter();
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+                await converter.ConvertAsync(input, output, new MarkdownToWordOptions(), cts.Token));
+        }
+
+        [Fact]
+        public async Task HtmlToWordConverter_CancelledToken_Throws() {
+            using MemoryStream input = new MemoryStream(Encoding.UTF8.GetBytes("<p>test</p>"));
+            using MemoryStream output = new MemoryStream();
+            IWordConverter converter = new HtmlToWordConverter();
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+                await converter.ConvertAsync(input, output, new HtmlToWordOptions(), cts.Token));
+        }
+    }
+}

--- a/OfficeIMO.Word/Converters/IWordConverter.cs
+++ b/OfficeIMO.Word/Converters/IWordConverter.cs
@@ -1,9 +1,10 @@
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace OfficeIMO.Word {
     public interface IWordConverter {
         void Convert(Stream input, Stream output, IConversionOptions options);
-        Task ConvertAsync(Stream input, Stream output, IConversionOptions options);
+        Task ConvertAsync(Stream input, Stream output, IConversionOptions options, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
## Summary
- allow `IWordConverter.ConvertAsync` to take an optional `CancellationToken`
- honor cancellation tokens in Markdown and HTML conversion loops
- document token usage in async conversion examples and add cancellation tests

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln --no-build --filter ConverterCancellation`


------
https://chatgpt.com/codex/tasks/task_e_6891eb37675c832e8f4c731009f38f74