### PR TITLE
Add default page settings to conversion options

### DIFF
--- a/OfficeIMO.Examples/Markdown/Markdown.PageSettings.cs
+++ b/OfficeIMO.Examples/Markdown/Markdown.PageSettings.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Markdown;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Markdown {
+    internal static partial class Markdown {
+        public static void Example_MarkdownPageSettings(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "MarkdownPageSettings.docx");
+            string markdown = "Hello World";
+
+            using MemoryStream wordStream = new MemoryStream();
+            MarkdownToWordConverter.Convert(markdown, wordStream, new MarkdownToWordOptions {
+                DefaultOrientation = PageOrientationValues.Landscape,
+                DefaultPageSize = WordPageSize.A5
+            });
+
+            File.WriteAllBytes(filePath, wordStream.ToArray());
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Html/Converters/HtmlToWordConverter.cs
@@ -31,15 +31,16 @@ namespace OfficeIMO.Html {
 
             options ??= new HtmlToWordOptions();
 
-            using WordprocessingDocument document = WordprocessingDocument.Create(output, WordprocessingDocumentType.Document, true);
-            MainDocumentPart mainPart = document.AddMainDocumentPart();
-            mainPart.Document = new Document(new Body());
+            using var document = WordDocument.Create();
+            options.ApplyDefaults(document);
+            WordprocessingDocument wordDoc = document._wordprocessingDocument;
+            MainDocumentPart mainPart = wordDoc.MainDocumentPart;
             Body body = mainPart.Document.Body;
 
             // add numbering definitions for ordered and unordered lists using shared Word logic
             NumberingDefinitionsPart numberingPart = mainPart.AddNewPart<NumberingDefinitionsPart>();
             numberingPart.Numbering = new Numbering();
-            Numbering numbering = WordListStyles.CreateDefaultNumberingDefinitions(document, out int bulletNumberId, out int orderedNumberId);
+            Numbering numbering = WordListStyles.CreateDefaultNumberingDefinitions(wordDoc, out int bulletNumberId, out int orderedNumberId);
             numberingPart.Numbering = numbering;
 
             XDocument xdoc = XDocument.Parse("<root>" + html + "</root>");
@@ -49,6 +50,7 @@ namespace OfficeIMO.Html {
             }
 
             mainPart.Document.Save();
+            document.Save(output);
         }
 
         private static void AppendBlockElement(OpenXmlElement parent, XElement element, HtmlToWordOptions options, int level, int bulletNumberId, int orderedNumberId, MainDocumentPart mainPart) {

--- a/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Markdown/Converters/MarkdownToWordConverter.cs
@@ -29,6 +29,7 @@ namespace OfficeIMO.Markdown {
             var fontFamily = FontResolver.Resolve(options.FontFamily);
 
             using var document = WordDocument.Create();
+            options.ApplyDefaults(document);
             WordList? currentList = null;
             bool currentListIsNumbered = false;
 

--- a/OfficeIMO.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Pdf/WordPdfConverterExtensions.cs
@@ -48,16 +48,28 @@ public static class WordPdfConverterExtensions {
                 Unit unit = options?.MarginUnit ?? Unit.Centimetre;
                 page.Margin(margin, unit);
 
+                PageSize size = PageSizes.A4;
+                PdfPageOrientation? orientation = null;
                 if (options != null) {
-                    PageSize size = options.PageSize ?? PageSizes.A4;
-                    if (options.Orientation == PdfPageOrientation.Landscape) {
-                        size = size.Landscape();
-                    } else if (options.Orientation == PdfPageOrientation.Portrait) {
-                        size = size.Portrait();
+                    if (options.PageSize != null) {
+                        size = options.PageSize;
+                    } else if (options.DefaultPageSize.HasValue) {
+                        size = MapToPageSize(options.DefaultPageSize.Value);
                     }
 
-                    page.Size(size);
+                    orientation = options.Orientation;
+                    if (orientation == null && options.DefaultOrientation.HasValue) {
+                        orientation = options.DefaultOrientation == W.PageOrientationValues.Landscape ? PdfPageOrientation.Landscape : PdfPageOrientation.Portrait;
+                    }
                 }
+
+                if (orientation == PdfPageOrientation.Landscape) {
+                    size = size.Landscape();
+                } else if (orientation == PdfPageOrientation.Portrait) {
+                    size = size.Portrait();
+                }
+
+                page.Size(size);
 
                 WordHeaderFooter header = document.Header?.Default;
                 if (header != null && (header.Paragraphs.Count > 0 || header.Tables.Count > 0)) {
@@ -274,6 +286,20 @@ public static class WordPdfConverterExtensions {
         }
         }
 
+    }
+
+    private static PageSize MapToPageSize(WordPageSize pageSize) {
+        return pageSize switch {
+            WordPageSize.Letter => PageSizes.Letter,
+            WordPageSize.Legal => PageSizes.Legal,
+            WordPageSize.Executive => PageSizes.Executive,
+            WordPageSize.A3 => PageSizes.A3,
+            WordPageSize.A4 => PageSizes.A4,
+            WordPageSize.A5 => PageSizes.A5,
+            WordPageSize.A6 => PageSizes.A6,
+            WordPageSize.B5 => PageSizes.B5,
+            _ => PageSizes.A4
+        };
     }
 
     private static Dictionary<WordParagraph, (int Level, string Marker)> BuildListMarkers(WordDocument document) {

--- a/OfficeIMO.Tests/ConversionOptions.cs
+++ b/OfficeIMO.Tests/ConversionOptions.cs
@@ -1,6 +1,8 @@
 using OfficeIMO.Html;
 using OfficeIMO.Markdown;
 using OfficeIMO.Pdf;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
 using Xunit;
 
 namespace OfficeIMO.Tests;
@@ -22,5 +24,15 @@ public class ConversionOptionsTests {
     public void PdfSaveOptions_ExposeFontFamily() {
         var options = new PdfSaveOptions { FontFamily = "Times New Roman" };
         Assert.Equal("Times New Roman", options.FontFamily);
+    }
+
+    [Fact]
+    public void Options_ExposeDefaultPageSettings() {
+        var options = new HtmlToWordOptions {
+            DefaultOrientation = PageOrientationValues.Landscape,
+            DefaultPageSize = WordPageSize.A3
+        };
+        Assert.Equal(PageOrientationValues.Landscape, options.DefaultOrientation);
+        Assert.Equal(WordPageSize.A3, options.DefaultPageSize);
     }
 }

--- a/OfficeIMO.Tests/Html.PageSettings.cs
+++ b/OfficeIMO.Tests/Html.PageSettings.cs
@@ -1,0 +1,25 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using System.IO;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_Respects_DefaultPageSettings() {
+            string html = "<p>Hello</p>";
+            using MemoryStream ms = new MemoryStream();
+            var options = new HtmlToWordOptions {
+                DefaultOrientation = PageOrientationValues.Landscape,
+                DefaultPageSize = WordPageSize.A5
+            };
+            HtmlToWordConverter.Convert(html, ms, options);
+
+            ms.Position = 0;
+            using WordDocument doc = WordDocument.Load(ms);
+            Assert.Equal(PageOrientationValues.Landscape, doc.PageOrientation);
+            Assert.Equal(WordPageSize.A5, doc.PageSettings.PageSize);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Markdown.PageSettings.cs
+++ b/OfficeIMO.Tests/Markdown.PageSettings.cs
@@ -1,0 +1,25 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Markdown;
+using OfficeIMO.Word;
+using System.IO;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Markdown {
+        [Fact]
+        public void MarkdownToWord_Respects_DefaultPageSettings() {
+            string md = "Hello";
+            using MemoryStream ms = new MemoryStream();
+            var options = new MarkdownToWordOptions {
+                DefaultOrientation = PageOrientationValues.Landscape,
+                DefaultPageSize = WordPageSize.A5
+            };
+            MarkdownToWordConverter.Convert(md, ms, options);
+
+            ms.Position = 0;
+            using WordDocument doc = WordDocument.Load(ms);
+            Assert.Equal(PageOrientationValues.Landscape, doc.PageOrientation);
+            Assert.Equal(WordPageSize.A5, doc.PageSettings.PageSize);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Defaults.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Defaults.cs
@@ -1,0 +1,36 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Pdf;
+using OfficeIMO.Word;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void SaveAsPdf_Uses_DefaultPageSettings() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfDefaultSettings.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfDefaultSettings.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddParagraph("Hello World");
+                document.Save();
+                document.SaveAsPdf(pdfPath, new PdfSaveOptions {
+                    DefaultOrientation = PageOrientationValues.Landscape,
+                    DefaultPageSize = WordPageSize.A4
+                });
+            }
+
+            Assert.True(File.Exists(pdfPath));
+
+            string pdfContent = Encoding.ASCII.GetString(File.ReadAllBytes(pdfPath));
+            Match mediaBox = Regex.Match(pdfContent, @"/MediaBox\s*\[\s*0\s+0\s+(?<w>[0-9\.]+)\s+(?<h>[0-9\.]+)\s*\]");
+            Assert.True(mediaBox.Success, "MediaBox not found");
+            double width = double.Parse(mediaBox.Groups["w"].Value, CultureInfo.InvariantCulture);
+            double height = double.Parse(mediaBox.Groups["h"].Value, CultureInfo.InvariantCulture);
+            Assert.True(width > height);
+        }
+    }
+}

--- a/OfficeIMO.Word/Converters/ConversionOptions.cs
+++ b/OfficeIMO.Word/Converters/ConversionOptions.cs
@@ -1,3 +1,6 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+
 namespace OfficeIMO.Word {
     /// <summary>
     /// Base class for conversion option classes shared across OfficeIMO converters.
@@ -7,5 +10,33 @@ namespace OfficeIMO.Word {
         /// Optional font family applied to created runs during conversion.
         /// </summary>
         public string? FontFamily { get; set; }
+
+        /// <summary>
+        /// Optional default page size applied when creating new documents.
+        /// </summary>
+        public WordPageSize? DefaultPageSize { get; set; }
+
+        /// <summary>
+        /// Optional default page orientation applied when creating new documents.
+        /// </summary>
+        public PageOrientationValues? DefaultOrientation { get; set; }
+
+        /// <summary>
+        /// Applies default page settings to the provided document instance.
+        /// </summary>
+        /// <param name="document">Document to update.</param>
+        public void ApplyDefaults(WordDocument document) {
+            if (document == null) {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            if (DefaultPageSize.HasValue) {
+                document.PageSettings.PageSize = DefaultPageSize.Value;
+            }
+
+            if (DefaultOrientation.HasValue) {
+                document.PageOrientation = DefaultOrientation.Value;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow setting default page size and orientation through `ConversionOptions`
- apply default page settings in Markdown and HTML converters
- honor default page settings during PDF export
- cover default page settings with examples and tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6891ec9ffe78832e9199b7c3c4264ad5