### PR TITLE
Cache table layouts for Word PDF rendering

### DIFF
--- a/OfficeIMO.Pdf/OfficeIMO.Pdf.csproj
+++ b/OfficeIMO.Pdf/OfficeIMO.Pdf.csproj
@@ -21,4 +21,7 @@
     <Using Include="System.IO" />
     <Using Include="System.Linq" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="OfficeIMO.Tests" />
+  </ItemGroup>
 </Project>

--- a/OfficeIMO.Pdf/WordPdfConverterExtensions.TableLayoutCache.cs
+++ b/OfficeIMO.Pdf/WordPdfConverterExtensions.TableLayoutCache.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using OfficeIMO.Word;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Pdf {
+    internal sealed class TableLayout {
+        internal TableLayout(List<IReadOnlyList<WordTableCell>> rows, float[] columnWidths) {
+            Rows = rows;
+            ColumnWidths = columnWidths;
+        }
+
+        internal List<IReadOnlyList<WordTableCell>> Rows { get; }
+
+        internal float[] ColumnWidths { get; }
+    }
+
+    internal static class TableLayoutCache {
+        private static readonly ConditionalWeakTable<WordTable, TableLayout> _cache = new();
+
+        internal static TableLayout GetLayout(WordTable table) {
+            if (_cache.TryGetValue(table, out TableLayout layout)) {
+                return layout;
+            }
+
+            List<IReadOnlyList<WordTableCell>> rows = TableBuilder.Map(table).ToList();
+            int columnCount = rows.Max(r => r.Count);
+            float[] widths = new float[columnCount];
+
+            foreach (IReadOnlyList<WordTableCell> row in rows) {
+                for (int i = 0; i < row.Count; i++) {
+                    WordTableCell cell = row[i];
+                    if (cell.Width.HasValue && cell.WidthType == TableWidthUnitValues.Dxa) {
+                        float width = cell.Width.Value / 20f;
+                        if (width > widths[i]) {
+                            widths[i] = width;
+                        }
+                    }
+                }
+            }
+
+            layout = new TableLayout(rows, widths);
+            _cache.Add(table, layout);
+            return layout;
+        }
+    }
+}
+

--- a/OfficeIMO.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Pdf/WordPdfConverterExtensions.cs
@@ -119,15 +119,18 @@ public static partial class WordPdfConverterExtensions {
 
         IContainer RenderTable(IContainer container, WordTable table) {
             container.Table(tableContainer => {
-                var rows = TableBuilder.Map(table).ToList();
-                int columnCount = rows.Max(r => r.Count);
+                TableLayout layout = TableLayoutCache.GetLayout(table);
                 tableContainer.ColumnsDefinition(columns => {
-                    for (int i = 0; i < columnCount; i++) {
-                        columns.RelativeColumn();
+                    foreach (float width in layout.ColumnWidths) {
+                        if (width > 0) {
+                            columns.ConstantColumn(width);
+                        } else {
+                            columns.RelativeColumn();
+                        }
                     }
                 });
 
-                foreach (var row in rows) {
+                foreach (IReadOnlyList<WordTableCell> row in layout.Rows) {
                     foreach (WordTableCell cell in row) {
                         tableContainer.Cell().Element(cellContainer => {
                             cellContainer = ApplyCellStyle(cellContainer, cell);

--- a/OfficeIMO.Tests/Pdf/TableLayoutCacheTests.cs
+++ b/OfficeIMO.Tests/Pdf/TableLayoutCacheTests.cs
@@ -1,0 +1,23 @@
+using OfficeIMO.Pdf;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf {
+    public class TableLayoutCacheTests {
+        [Fact]
+        public void ColumnWidthsAreCachedPerTable() {
+            using WordDocument document = WordDocument.Create();
+            WordTable table = document.AddTable(2, 2);
+            table.Rows[0].Cells[0].Width = 1440;
+            table.Rows[1].Cells[0].Width = 1440;
+
+            TableLayout first = TableLayoutCache.GetLayout(table);
+            TableLayout second = TableLayoutCache.GetLayout(table);
+
+            Assert.Same(first, second);
+            Assert.Equal(2, first.ColumnWidths.Length);
+            Assert.Equal(72f, first.ColumnWidths[0]);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- cache table column widths to avoid repeated computation during PDF rendering
- use cached table layout when building QuestPDF tables
- expose Pdf internals for tests and add regression test for column caching

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689233ba9a48832ea8f334d6c0c7fa38