### PR TITLE
Add CSS style mapping for HTML paragraph conversion

### DIFF
--- a/OfficeIMO.Examples/Html/Html.StyleAttributes.cs
+++ b/OfficeIMO.Examples/Html/Html.StyleAttributes.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using System.Text;
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlStyleAttributes(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlStyleAttributes.docx");
+            string html = "<p style=\"font-weight:bold;font-size:32px\">Heading 1</p>";
+
+            ConverterRegistry.Register("html->word", () => new HtmlToWordConverter());
+
+            using MemoryStream htmlStream = new MemoryStream(Encoding.UTF8.GetBytes(html));
+            using MemoryStream wordStream = new MemoryStream();
+            IWordConverter htmlToWord = ConverterRegistry.Resolve("html->word");
+            htmlToWord.Convert(htmlStream, wordStream, new HtmlToWordOptions());
+            File.WriteAllBytes(filePath, wordStream.ToArray());
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Html/Converters/HtmlToWordConverter.Blocks.cs
+++ b/OfficeIMO.Html/Converters/HtmlToWordConverter.Blocks.cs
@@ -1,6 +1,7 @@
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html.Helpers;
 using OfficeIMO.Word;
 using System;
 using System.Collections.Generic;
@@ -49,26 +50,28 @@ namespace OfficeIMO.Html {
 
         private static Paragraph CreateParagraph(XElement element, HtmlToWordOptions options, MainDocumentPart mainPart, CancellationToken cancellationToken) {
             Paragraph paragraph = new Paragraph();
-            WordParagraphStyles? style = null;
-            switch (element.Name.LocalName.ToLowerInvariant()) {
+            WordParagraphStyles? style = CssStyleMapper.MapParagraphStyle(element.Attribute("style")?.Value);
+            if (!style.HasValue) {
+                switch (element.Name.LocalName.ToLowerInvariant()) {
                 case "h1":
-                    style = WordParagraphStyles.Heading1;
-                    break;
+                        style = WordParagraphStyles.Heading1;
+                        break;
                 case "h2":
-                    style = WordParagraphStyles.Heading2;
-                    break;
+                        style = WordParagraphStyles.Heading2;
+                        break;
                 case "h3":
-                    style = WordParagraphStyles.Heading3;
-                    break;
+                        style = WordParagraphStyles.Heading3;
+                        break;
                 case "h4":
-                    style = WordParagraphStyles.Heading4;
-                    break;
+                        style = WordParagraphStyles.Heading4;
+                        break;
                 case "h5":
-                    style = WordParagraphStyles.Heading5;
-                    break;
+                        style = WordParagraphStyles.Heading5;
+                        break;
                 case "h6":
-                    style = WordParagraphStyles.Heading6;
-                    break;
+                        style = WordParagraphStyles.Heading6;
+                        break;
+                }
             }
 
             if (style.HasValue) {
@@ -96,11 +99,16 @@ namespace OfficeIMO.Html {
 
         private static void AppendListItem(OpenXmlElement parent, XElement li, HtmlToWordOptions options, int level, int numId, int bulletNumberId, int orderedNumberId, MainDocumentPart mainPart, CancellationToken cancellationToken) {
             Paragraph paragraph = new Paragraph();
-            paragraph.ParagraphProperties = new ParagraphProperties(
+            WordParagraphStyles? style = CssStyleMapper.MapParagraphStyle(li.Attribute("style")?.Value);
+            ParagraphProperties properties = new ParagraphProperties(
                 new NumberingProperties(
                     new NumberingLevelReference { Val = level },
                     new NumberingId { Val = numId }
                 ));
+            if (style.HasValue) {
+                properties.ParagraphStyleId = new ParagraphStyleId { Val = style.Value.ToString() };
+            }
+            paragraph.ParagraphProperties = properties;
 
             foreach (XNode node in li.Nodes()) {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/OfficeIMO.Html/Helpers/CssStyleMapper.cs
+++ b/OfficeIMO.Html/Helpers/CssStyleMapper.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Html.Helpers {
+    internal static class CssStyleMapper {
+        public static WordParagraphStyles? MapParagraphStyle(string? style) {
+            if (string.IsNullOrWhiteSpace(style)) {
+                return null;
+            }
+
+            Dictionary<string, string> properties = Parse(style);
+            if (properties.TryGetValue("font-weight", out string? weight) && weight.Equals("bold", StringComparison.OrdinalIgnoreCase)) {
+                if (properties.TryGetValue("font-size", out string? sizeValue) && TryParseFontSize(sizeValue, out double size)) {
+                    if (size >= 32) {
+                        return WordParagraphStyles.Heading1;
+                    }
+                    if (size >= 24) {
+                        return WordParagraphStyles.Heading2;
+                    }
+                    if (size >= 18) {
+                        return WordParagraphStyles.Heading3;
+                    }
+                    if (size >= 16) {
+                        return WordParagraphStyles.Heading4;
+                    }
+                    if (size >= 13) {
+                        return WordParagraphStyles.Heading5;
+                    }
+                    if (size >= 12) {
+                        return WordParagraphStyles.Heading6;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static Dictionary<string, string> Parse(string style) {
+            Dictionary<string, string> dict = new(StringComparer.OrdinalIgnoreCase);
+            foreach (string part in style.Split(';', StringSplitOptions.RemoveEmptyEntries)) {
+                string[] pieces = part.Split(':', 2);
+                if (pieces.Length == 2) {
+                    dict[pieces[0].Trim()] = pieces[1].Trim();
+                }
+            }
+            return dict;
+        }
+
+        private static bool TryParseFontSize(string value, out double size) {
+            size = 0;
+            value = value.Trim().ToLowerInvariant();
+
+            string number = new(value.Where(c => char.IsDigit(c) || c == '.').ToArray());
+            if (!double.TryParse(number, NumberStyles.Number, CultureInfo.InvariantCulture, out size)) {
+                return false;
+            }
+
+            if (value.EndsWith("em", StringComparison.Ordinal)) {
+                size *= 16; // approximate conversion
+            }
+
+            return size > 0;
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -1,146 +1,159 @@
-using OfficeIMO.Html;
-using OfficeIMO.Word;
-using System;
-using System.IO;
-using System.Linq;
-using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Wordprocessing;
-using Xunit;
-
-namespace OfficeIMO.Tests;
-
-public partial class Html {
-    [Fact]
-    public void Test_Html_RoundTrip() {
-        string html = "<p>Hello <b>world</b> and <i>universe</i>.</p>";
-        using MemoryStream ms = new MemoryStream();
-        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "Calibri" });
-
-        ms.Position = 0;
-        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeFontStyles = true });
-
-        Assert.Contains("<b>", roundTrip, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("</b>", roundTrip, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("world", roundTrip, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("<i>", roundTrip, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("</i>", roundTrip, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("universe", roundTrip, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains($"font-family:{FontResolver.Resolve("Calibri")}", roundTrip, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public void Test_Html_Headings_RoundTrip() {
-        string html = "<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><h4>Heading 4</h4><h5>Heading 5</h5><h6>Heading 6</h6>";
-        using MemoryStream ms = new MemoryStream();
-        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "Calibri" });
-
-        ms.Position = 0;
-        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeFontStyles = true });
-
-        for (int i = 1; i <= 6; i++) {
-            string tag = $"h{i}";
-            Assert.Contains("<" + tag + ">", roundTrip, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains($"Heading {i}", roundTrip, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("</" + tag + ">", roundTrip, StringComparison.OrdinalIgnoreCase);
-        }
-    }
-
-    [Fact]
-    public void Test_Html_Lists_RoundTrip() {
-        string html = "<ul><li>Item 1<ul><li>Sub 1</li><li>Sub 2</li></ul></li><li>Item 2</li></ul><ol><li>First</li><li>Second</li></ol>";
-        using MemoryStream ms = new MemoryStream();
-        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
-
-        ms.Position = 0;
-        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeListStyles = true });
-
-        Assert.Contains("<ul", roundTrip, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("<ol", roundTrip, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Sub 1", roundTrip, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Second", roundTrip, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public void Test_Html_Table_RoundTrip() {
-        string html = "<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr></table>";
-        using MemoryStream ms = new MemoryStream();
-        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
-
-        ms.Position = 0;
-        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions());
-
-        Assert.Contains("<table>", roundTrip, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("A", roundTrip, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("D", roundTrip, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public void Test_Html_NestedTable_RoundTrip() {
-        string html = "<table><tr><td>Outer</td><td><table><tr><td>Inner</td></tr></table></td></tr></table>";
-        using MemoryStream ms = new MemoryStream();
-        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
-
-        ms.Position = 0;
-        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions());
-
-        int tableCount = roundTrip.Split(new string[] { "<table>" }, StringSplitOptions.None).Length - 1;
-        Assert.True(tableCount >= 2);
-        Assert.Contains("Inner", roundTrip, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public void Test_Html_Image_Base64_RoundTrip() {
-        string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
-        byte[] imageBytes = File.ReadAllBytes(assetPath);
-        string base64 = Convert.ToBase64String(imageBytes);
-        string html = $"<p><img src=\"data:image/png;base64,{base64}\" /></p>";
-        using MemoryStream ms = new MemoryStream();
-        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
-
-        ms.Position = 0;
-        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions());
-
-        Assert.Contains("<img", roundTrip, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("data:image/png;base64", roundTrip, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public void Test_Html_Image_File_RoundTrip() {
-        string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
-        string uri = new Uri(assetPath).AbsoluteUri;
-        string html = $"<p><img src=\"{uri}\" /></p>";
-        using MemoryStream ms = new MemoryStream();
-        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
-
-        ms.Position = 0;
-        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions());
-
-        Assert.Contains("<img", roundTrip, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("data:image/png;base64", roundTrip, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public void Test_Html_FontResolver() {
-        string html = "<p>Hello</p>";
-        using MemoryStream ms = new MemoryStream();
-        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "monospace" });
-
-        ms.Position = 0;
-        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeFontStyles = true });
-        Assert.Contains($"font-family:{FontResolver.Resolve("monospace")}", roundTrip, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public void Test_Html_Urls_CreateHyperlinks() {
-        string html = "<p>Visit http://example.com</p>";
-        using MemoryStream ms = new MemoryStream();
-        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
-
-        ms.Position = 0;
-        using WordprocessingDocument doc = WordprocessingDocument.Open(ms, false);
-        var hyperlink = doc.MainDocumentPart!.Document.Body!.Descendants<Hyperlink>().FirstOrDefault();
-        Assert.NotNull(hyperlink);
-        var rel = doc.MainDocumentPart.HyperlinkRelationships.First();
-        Assert.StartsWith("http://example.com", rel.Uri.ToString());
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Html {
+    [Fact]
+    public void Test_Html_RoundTrip() {
+        string html = "<p>Hello <b>world</b> and <i>universe</i>.</p>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "Calibri" });
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeFontStyles = true });
+
+        Assert.Contains("<b>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("</b>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("world", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<i>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("</i>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("universe", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains($"font-family:{FontResolver.Resolve("Calibri")}", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Test_Html_Headings_RoundTrip() {
+        string html = "<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><h4>Heading 4</h4><h5>Heading 5</h5><h6>Heading 6</h6>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "Calibri" });
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeFontStyles = true });
+
+        for (int i = 1; i <= 6; i++) {
+            string tag = $"h{i}";
+            Assert.Contains("<" + tag + ">", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains($"Heading {i}", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("</" + tag + ">", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void Test_Html_Lists_RoundTrip() {
+        string html = "<ul><li>Item 1<ul><li>Sub 1</li><li>Sub 2</li></ul></li><li>Item 2</li></ul><ol><li>First</li><li>Second</li></ol>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeListStyles = true });
+
+        Assert.Contains("<ul", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<ol", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Sub 1", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Second", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Test_Html_Table_RoundTrip() {
+        string html = "<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr></table>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions());
+
+        Assert.Contains("<table>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("A", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("D", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Test_Html_NestedTable_RoundTrip() {
+        string html = "<table><tr><td>Outer</td><td><table><tr><td>Inner</td></tr></table></td></tr></table>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions());
+
+        int tableCount = roundTrip.Split(new string[] { "<table>" }, StringSplitOptions.None).Length - 1;
+        Assert.True(tableCount >= 2);
+        Assert.Contains("Inner", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Test_Html_Image_Base64_RoundTrip() {
+        string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
+        byte[] imageBytes = File.ReadAllBytes(assetPath);
+        string base64 = Convert.ToBase64String(imageBytes);
+        string html = $"<p><img src=\"data:image/png;base64,{base64}\" /></p>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions());
+
+        Assert.Contains("<img", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("data:image/png;base64", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Test_Html_Image_File_RoundTrip() {
+        string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
+        string uri = new Uri(assetPath).AbsoluteUri;
+        string html = $"<p><img src=\"{uri}\" /></p>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions());
+
+        Assert.Contains("<img", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("data:image/png;base64", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Test_Html_FontResolver() {
+        string html = "<p>Hello</p>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions { FontFamily = "monospace" });
+
+        ms.Position = 0;
+        string roundTrip = WordToHtmlConverter.Convert(ms, new WordToHtmlOptions { IncludeFontStyles = true });
+        Assert.Contains($"font-family:{FontResolver.Resolve("monospace")}", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Test_Html_Urls_CreateHyperlinks() {
+        string html = "<p>Visit http://example.com</p>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
+
+        ms.Position = 0;
+        using WordprocessingDocument doc = WordprocessingDocument.Open(ms, false);
+        var hyperlink = doc.MainDocumentPart!.Document.Body!.Descendants<Hyperlink>().FirstOrDefault();
+        Assert.NotNull(hyperlink);
+        var rel = doc.MainDocumentPart.HyperlinkRelationships.First();
+        Assert.StartsWith("http://example.com", rel.Uri.ToString());
+    }
+
+    [Fact]
+    public void Test_Html_InlineStyles_ParagraphStyle() {
+        string html = "<p style=\"font-weight:bold;font-size:32px\">Styled</p>";
+        using MemoryStream ms = new MemoryStream();
+        HtmlToWordConverter.Convert(html, ms, new HtmlToWordOptions());
+
+        ms.Position = 0;
+        using WordprocessingDocument doc = WordprocessingDocument.Open(ms, false);
+        Paragraph p = doc.MainDocumentPart!.Document.Body!.Elements<Paragraph>().First();
+        string styleId = p.ParagraphProperties?.ParagraphStyleId?.Val;
+        Assert.Equal(WordParagraphStyles.Heading1.ToString(), styleId);
     }
 }


### PR DESCRIPTION
## Summary
- map basic CSS inline styles to WordParagraphStyles
- apply mapped styles to paragraphs and list items during HTML conversion
- test and example for style attribute mapping

## Testing
- `dotnet test -c Release`
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_689233cfcc74832e825d952ee705cf6b