### PR TITLE
Implement Markdown to Word conversion

### DIFF
--- a/OfficeIMO.Examples/Converters/Markdown/Markdown01_LoadFromMarkdown.cs
+++ b/OfficeIMO.Examples/Converters/Markdown/Markdown01_LoadFromMarkdown.cs
@@ -8,9 +8,10 @@ namespace OfficeIMO.Examples.Word.Converters {
         public static void Example(string folderPath, bool openWord) {
             Console.WriteLine("[*] Loading Markdown and converting to Word");
             
-            string markdown = @"# Main Title
+            string imagePath = Path.Combine(AppContext.BaseDirectory, "..", "Assets", "OfficeIMO.png");
+            string markdown = $@"# Main Title
 
-This is a paragraph with **bold** and *italic* text.
+This is a paragraph with **bold** and *italic* text and a [link](https://example.com).
 
 ## Features
 
@@ -27,6 +28,12 @@ var example = ""Hello World"";
 | Column 1 | Column 2 |
 |----------|----------|
 | Data 1   | Data 2   |
+
+> Quoted text
+
+---
+
+![Logo]({imagePath})
 ";
             
             var doc = markdown.LoadFromMarkdown();
@@ -42,4 +49,4 @@ var example = ""Hello World"";
             }
         }
     }
-}
+}

--- a/OfficeIMO.Tests/Markdown.BasicBlocks.cs
+++ b/OfficeIMO.Tests/Markdown.BasicBlocks.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Markdown {
+        [Fact]
+        public void MarkdownToWord_ConvertsVariousElements() {
+            string imagePath = Path.GetFullPath(Path.Combine("Assets", "OfficeIMO.png"));
+            string md = $@"# Heading 1
+
+Paragraph with **bold** and *italic* and [link](https://example.com).
+
+- Item 1
+- Item 2
+
+```c
+code
+```
+
+|A|B|
+|-|-|
+|1|2|
+
+> Quote line
+
+---
+
+![Alt]({imagePath})
+";
+            var doc = md.LoadFromMarkdown(new MarkdownToWordOptions { FontFamily = "Calibri" });
+
+            Assert.Equal(WordParagraphStyles.Heading1, doc.Paragraphs[0].Style);
+              var quoteParagraph = doc.Paragraphs.First(p => p.Text.Contains("Quote line"));
+              Assert.True(quoteParagraph.IndentationBefore > 0);
+
+            using MemoryStream ms = new();
+            doc.Save(ms);
+            ms.Position = 0;
+              using WordprocessingDocument docx = WordprocessingDocument.Open(ms, false);
+              var body = docx.MainDocumentPart!.Document.Body!;
+
+              var codeRun = body.Descendants<Run>().First(r => r.InnerText.Contains("code"));
+              Assert.Equal("Consolas", codeRun.RunProperties!.RunFonts!.Ascii);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- convert Markdown blocks to Word elements using Markdig advanced pipeline
- add example covering quotes, horizontal rules, and images
- add tests verifying basic Markdown to Word conversion

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68926aa268f8832ebd492db896ee6784