### PR TITLE
Implement Word to Markdown conversion

### DIFF
--- a/OfficeIMO.Examples/Converters/Markdown/Markdown02_SaveAsMarkdown.cs
+++ b/OfficeIMO.Examples/Converters/Markdown/Markdown02_SaveAsMarkdown.cs
@@ -15,12 +15,15 @@ namespace OfficeIMO.Examples.Word.Converters {
             doc.AddParagraph("This is a regular paragraph with some text.");
             
             doc.AddParagraph("Features").Style = WordParagraphStyles.Heading2;
-            
+
             var paragraph = doc.AddParagraph("This has ");
             paragraph.AddText("bold text").Bold = true;
             paragraph.AddText(" and ");
             paragraph.AddText("italic text").Italic = true;
-            
+            paragraph.AddText(" plus a ");
+            paragraph.AddHyperLink("link", new Uri("https://example.com"));
+            paragraph.AddText(".");
+
             var list = doc.AddList(WordListStyle.Bulleted);
             list.AddItem("First item");
             list.AddItem("Second item");
@@ -31,6 +34,9 @@ namespace OfficeIMO.Examples.Word.Converters {
             table.Rows[0].Cells[1].Paragraphs[0].Text = "Header 2";
             table.Rows[1].Cells[0].Paragraphs[0].Text = "Data 1";
             table.Rows[1].Cells[1].Paragraphs[0].Text = "Data 2";
+
+            string imagePath = Path.Combine(AppContext.BaseDirectory, "..", "Assets", "OfficeIMO.png");
+            doc.AddParagraph().AddImage(imagePath);
             
             // Save as Markdown
             string outputPath = Path.Combine(folderPath, "SaveAsMarkdown.md");

--- a/OfficeIMO.Tests/Markdown.WordToMarkdown.cs
+++ b/OfficeIMO.Tests/Markdown.WordToMarkdown.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Markdown {
+        [Fact]
+        public void WordToMarkdown_ConvertsElements() {
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Heading").Style = WordParagraphStyles.Heading1;
+
+            var paragraph = doc.AddParagraph("This is ");
+            paragraph.AddText("bold").Bold = true;
+            paragraph.AddText(" and ");
+            paragraph.AddText("italic").Italic = true;
+
+            var list = doc.AddList(WordListStyle.Bulleted);
+            list.AddItem("Item 1");
+            list.AddItem("Item 2");
+
+            var linkParagraph = doc.AddParagraph("Visit ");
+            linkParagraph.AddHyperLink("OfficeIMO", new Uri("https://example.com"));
+
+            var table = doc.AddTable(2, 2);
+            table.Rows[0].Cells[0].Paragraphs[0].Text = "H1";
+            table.Rows[0].Cells[1].Paragraphs[0].Text = "H2";
+            table.Rows[1].Cells[0].Paragraphs[0].Text = "C1";
+            table.Rows[1].Cells[1].Paragraphs[0].Text = "C2";
+
+            string imagePath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png"));
+            doc.AddParagraph().AddImage(imagePath);
+
+            string markdown = doc.ToMarkdown(new WordToMarkdownOptions());
+
+            Assert.Contains("# Heading", markdown);
+            Assert.Contains("**bold**", markdown);
+            Assert.Contains("*italic*", markdown);
+            Assert.Contains("- Item 1", markdown);
+            Assert.Contains("[OfficeIMO](https://example.com/)", markdown);
+            Assert.Contains("| H1 | H2 |", markdown);
+            Assert.Contains("![", markdown);
+        }
+    }
+}
+

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.cs
@@ -1,9 +1,7 @@
 using OfficeIMO.Word;
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.IO;
 using System.Text;
-using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word.Markdown.Converters {
     /// <summary>
@@ -25,21 +23,157 @@ namespace OfficeIMO.Word.Markdown.Converters {
     /// </summary>
     internal class WordToMarkdownConverter {
         private readonly StringBuilder _output = new StringBuilder();
-        
+
         public string Convert(WordDocument document, WordToMarkdownOptions options) {
             if (document == null) throw new ArgumentNullException(nameof(document));
             options ??= new WordToMarkdownOptions();
-            
-            // TODO: Implement full Word to Markdown conversion
-            // For now, just extract basic text
-            
-            foreach (var paragraph in document.Paragraphs) {
-                if (!string.IsNullOrEmpty(paragraph.Text)) {
-                    _output.AppendLine(paragraph.Text);
+
+            foreach (var section in document.Sections) {
+                foreach (var paragraph in section.Paragraphs) {
+                    var text = ConvertParagraph(paragraph);
+                    if (!string.IsNullOrEmpty(text)) {
+                        _output.AppendLine(text);
+                    }
+                }
+
+                foreach (var table in section.Tables) {
+                    var tableText = ConvertTable(table);
+                    if (!string.IsNullOrEmpty(tableText)) {
+                        _output.AppendLine(tableText);
+                    }
                 }
             }
-            
+
             return _output.ToString().TrimEnd();
         }
+
+        private string ConvertParagraph(WordParagraph paragraph) {
+            var sb = new StringBuilder();
+
+            int? headingLevel = GetLevelForHeadingStyle(paragraph.Style);
+            if (headingLevel != null) {
+                sb.Append(new string('#', headingLevel.Value)).Append(' ');
+            }
+
+            if (paragraph.IsListItem) {
+                int level = paragraph.ListItemLevel ?? 0;
+                sb.Append(new string(' ', level * 2));
+                bool numbered = paragraph.ListStyle != WordListStyle.Bulleted &&
+                                paragraph.ListStyle != WordListStyle.BulletedChars;
+                sb.Append(numbered ? "1. " : "- ");
+            }
+
+            sb.Append(RenderRuns(paragraph));
+
+            return sb.ToString();
+        }
+
+        private string RenderRuns(WordParagraph paragraph) {
+            var sb = new StringBuilder();
+            foreach (var run in paragraph.GetRuns()) {
+                if (run.IsImage) {
+                    sb.Append(RenderImage(run.Image));
+                    continue;
+                }
+
+                string text = run.Text;
+                if (string.IsNullOrEmpty(text)) {
+                    continue;
+                }
+
+                if (run.Bold && run.Italic) {
+                    text = $"***{text}***";
+                } else if (run.Bold) {
+                    text = $"**{text}**";
+                } else if (run.Italic) {
+                    text = $"*{text}*";
+                }
+
+                if (run.IsHyperLink && run.Hyperlink != null && run.Hyperlink.Uri != null) {
+                    text = $"[{text}]({run.Hyperlink.Uri})";
+                }
+
+                sb.Append(text);
+            }
+
+            return sb.ToString();
+        }
+
+        private string RenderImage(WordImage image) {
+            if (image == null) {
+                return string.Empty;
+            }
+
+            string alt = !string.IsNullOrEmpty(image.Description)
+                ? image.Description
+                : (string.IsNullOrEmpty(image.FilePath) ? "" : Path.GetFileName(image.FilePath));
+
+            if (!string.IsNullOrEmpty(image.FilePath)) {
+                return $"![{alt}]({image.FilePath})";
+            }
+
+            byte[] bytes = image.GetBytes();
+            string base64 = System.Convert.ToBase64String(bytes);
+            string extension = string.IsNullOrEmpty(image.FilePath) ? null : Path.GetExtension(image.FilePath).ToLower();
+            string mime = extension switch {
+                ".jpg" => "image/jpeg",
+                ".jpeg" => "image/jpeg",
+                ".gif" => "image/gif",
+                ".bmp" => "image/bmp",
+                _ => "image/png"
+            };
+
+            return $"![{alt}](data:{mime};base64,{base64})";
+        }
+
+        private string ConvertTable(WordTable table) {
+            var sb = new StringBuilder();
+            var rows = table.Rows;
+            if (rows.Count == 0) return string.Empty;
+
+            sb.Append('|');
+            foreach (var cell in rows[0].Cells) {
+                sb.Append(' ').Append(GetCellText(cell)).Append(" |");
+            }
+            sb.AppendLine();
+
+            sb.Append('|');
+            for (int i = 0; i < rows[0].CellsCount; i++) {
+                sb.Append("---|");
+            }
+            sb.AppendLine();
+
+            for (int r = 1; r < rows.Count; r++) {
+                sb.Append('|');
+                foreach (var cell in rows[r].Cells) {
+                    sb.Append(' ').Append(GetCellText(cell)).Append(" |");
+                }
+                sb.AppendLine();
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+
+        private string GetCellText(WordTableCell cell) {
+            var sb = new StringBuilder();
+            foreach (var p in cell.Paragraphs) {
+                if (sb.Length > 0) sb.Append("<br>");
+                sb.Append(RenderRuns(p));
+            }
+            return sb.ToString();
+        }
+
+        private static int? GetLevelForHeadingStyle(WordParagraphStyles? style) => style switch {
+            WordParagraphStyles.Heading1 => 1,
+            WordParagraphStyles.Heading2 => 2,
+            WordParagraphStyles.Heading3 => 3,
+            WordParagraphStyles.Heading4 => 4,
+            WordParagraphStyles.Heading5 => 5,
+            WordParagraphStyles.Heading6 => 6,
+            WordParagraphStyles.Heading7 => 7,
+            WordParagraphStyles.Heading8 => 8,
+            WordParagraphStyles.Heading9 => 9,
+            _ => (int?)null
+        };
     }
 }

--- a/OfficeIMO.Word/WordParagraph.RunEnumerator.cs
+++ b/OfficeIMO.Word/WordParagraph.RunEnumerator.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides run enumeration helpers for <see cref="WordParagraph"/>.
+    /// </summary>
+    public partial class WordParagraph {
+        /// <summary>
+        /// Enumerates all runs within the paragraph, including runs nested in hyperlinks.
+        /// </summary>
+        public IEnumerable<WordParagraph> GetRuns() {
+            foreach (var element in _paragraph.ChildElements) {
+                if (element is Run runElement) {
+                    yield return new WordParagraph(_document, _paragraph, runElement);
+                } else if (element is Hyperlink hyperlink) {
+                    foreach (var childRun in hyperlink.Elements<Run>()) {
+                        var paragraph = new WordParagraph(_document, _paragraph, childRun) { _hyperlink = hyperlink };
+                        yield return paragraph;
+                    }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement Word to Markdown converter that handles headings, lists, hyperlinks, images and tables
- add run enumeration helper to expose paragraph runs and hyperlink runs
- provide example and tests for Word to Markdown conversion

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689271111ae4832e940c3e61cb7752e6