### PR TITLE
Add formatted text helper and run enumeration

### DIFF
--- a/OfficeIMO.Examples/Word/Paragraphs/Paragraphs.AddFormattedText.cs
+++ b/OfficeIMO.Examples/Word/Paragraphs/Paragraphs.AddFormattedText.cs
@@ -1,0 +1,18 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+internal static partial class Paragraphs {
+
+    internal static void Example_AddFormattedText(string folderPath, bool openWord) {
+        Console.WriteLine("[*] Creating document with AddFormattedText");
+        string filePath = System.IO.Path.Combine(folderPath, "AddFormattedText.docx");
+        using (WordDocument document = WordDocument.Create(filePath)) {
+            var paragraph = document.AddParagraph(string.Empty);
+            paragraph.AddFormattedText("Bold", bold: true);
+            paragraph.AddFormattedText(" Italic", italic: true);
+            paragraph.AddFormattedText(" Underlined", underline: UnderlineValues.Single);
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.AddFormattedText.cs
+++ b/OfficeIMO.Tests/Word.AddFormattedText.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void AddFormattedTextCreatesRunsWithFormatting() {
+            using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "FormattedText.docx"));
+            var paragraph = document.AddParagraph("Hello");
+            paragraph.AddFormattedText(" bold", bold: true);
+            paragraph.AddFormattedText(" italic", italic: true);
+            paragraph.AddFormattedText(" underline", underline: UnderlineValues.Single);
+            paragraph.AddHyperLink(" link", new Uri("https://example.com"));
+
+            var runs = paragraph.GetRuns().ToList();
+            Assert.Equal(5, runs.Count);
+            Assert.Equal("Hello", runs[0].Text);
+            Assert.True(runs[1].Bold);
+            Assert.True(runs[2].Italic);
+            Assert.Equal(UnderlineValues.Single, runs[3].Underline);
+            Assert.True(runs[4].IsHyperLink);
+
+            document.Save(false);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -207,16 +207,21 @@ namespace OfficeIMO.Word.Html.Converters {
             int lastIndex = 0;
             foreach (System.Text.RegularExpressions.Match match in _urlRegex.Matches(text)) {
                 if (match.Index > lastIndex) {
-                    var run = paragraph.AddText(text.Substring(lastIndex, match.Index - lastIndex));
-                    ApplyFormatting(run, formatting, options);
+                    var segment = text.Substring(lastIndex, match.Index - lastIndex);
+                    var run = paragraph.AddFormattedText(segment, formatting.Bold, formatting.Italic, formatting.Underline ? UnderlineValues.Single : null);
+                    if (!string.IsNullOrEmpty(options.FontFamily)) {
+                        run.SetFontFamily(options.FontFamily);
+                    }
                 }
                 var linkRun = paragraph.AddHyperLink(match.Value, new Uri(match.Value));
                 ApplyFormatting(linkRun, formatting, options);
                 lastIndex = match.Index + match.Length;
             }
             if (lastIndex < text.Length) {
-                var run = paragraph.AddText(text.Substring(lastIndex));
-                ApplyFormatting(run, formatting, options);
+                var run = paragraph.AddFormattedText(text.Substring(lastIndex), formatting.Bold, formatting.Italic, formatting.Underline ? UnderlineValues.Single : null);
+                if (!string.IsNullOrEmpty(options.FontFamily)) {
+                    run.SetFontFamily(options.FontFamily);
+                }
             }
         }
 

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
@@ -87,7 +87,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
                 case CodeBlock codeBlock:
                     var codeParagraph = document.AddParagraph(string.Empty);
                     var codeText = GetCodeBlockText(codeBlock);
-                    var run = codeParagraph.AddText(codeText);
+                    var run = codeParagraph.AddFormattedText(codeText);
                     run.SetFontFamily("Consolas");
                     break;
                 case Table table:

--- a/OfficeIMO.Word/Helpers/InlineRunHelper.cs
+++ b/OfficeIMO.Word/Helpers/InlineRunHelper.cs
@@ -29,7 +29,7 @@ public static class InlineRunHelper {
                 foreach (Match urlMatch in _urlRegex.Matches(value)) {
                     if (urlMatch.Index > lastIndex) {
                         var textPart = value.Substring(lastIndex, urlMatch.Index - lastIndex);
-                        var textRun = paragraph.AddText(textPart);
+                        var textRun = paragraph.AddFormattedText(textPart);
                         if (!string.IsNullOrEmpty(fontFamily)) {
                             textRun.SetFontFamily(fontFamily);
                         }
@@ -45,21 +45,15 @@ public static class InlineRunHelper {
                 }
 
                 if (lastIndex < value.Length) {
-                    var tailRun = paragraph.AddText(value.Substring(lastIndex));
+                    var tailRun = paragraph.AddFormattedText(value.Substring(lastIndex));
                     if (!string.IsNullOrEmpty(fontFamily)) {
                         tailRun.SetFontFamily(fontFamily);
                     }
                 }
             } else {
-                var run = paragraph.AddText(value);
+                var run = paragraph.AddFormattedText(value, bold, italic);
                 if (!string.IsNullOrEmpty(fontFamily)) {
                     run.SetFontFamily(fontFamily);
-                }
-                if (bold) {
-                    run.SetBold();
-                }
-                if (italic) {
-                    run.SetItalic();
                 }
             }
         }

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -32,6 +32,28 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Adds formatted text to the paragraph and applies basic run properties.
+        /// </summary>
+        /// <param name="text">Text to insert.</param>
+        /// <param name="bold">Whether the text should be bold.</param>
+        /// <param name="italic">Whether the text should be italic.</param>
+        /// <param name="underline">Optional underline style.</param>
+        /// <returns>The run containing the formatted text.</returns>
+        public WordParagraph AddFormattedText(string text, bool bold = false, bool italic = false, UnderlineValues? underline = null) {
+            var run = AddText(text);
+            if (bold) {
+                run.SetBold();
+            }
+            if (italic) {
+                run.SetItalic();
+            }
+            if (underline != null) {
+                run.SetUnderline(underline.Value);
+            }
+            return run;
+        }
+
+        /// <summary>
         /// Add image from file with ability to provide width and height of the image
         /// The image will be resized given new dimensions
         /// </summary>


### PR DESCRIPTION
## Summary
- add `AddFormattedText` to insert text runs with optional bold/italic/underline
- update inline helpers and converters to build runs via new API and expose run enumeration
- demonstrate and test formatted run usage with `GetRuns`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6893084f0624832eadef1c2acc79322c