### PR TITLE
Use shared heading style mapping in converters

### DIFF
--- a/OfficeIMO.Tests/Word.HeadingStyles.cs
+++ b/OfficeIMO.Tests/Word.HeadingStyles.cs
@@ -1,0 +1,38 @@
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Theory]
+    [InlineData(1, WordParagraphStyles.Heading1)]
+    [InlineData(2, WordParagraphStyles.Heading2)]
+    [InlineData(3, WordParagraphStyles.Heading3)]
+    [InlineData(4, WordParagraphStyles.Heading4)]
+    [InlineData(5, WordParagraphStyles.Heading5)]
+    [InlineData(6, WordParagraphStyles.Heading6)]
+    [InlineData(7, WordParagraphStyles.Heading7)]
+    [InlineData(8, WordParagraphStyles.Heading8)]
+    [InlineData(9, WordParagraphStyles.Heading9)]
+    [InlineData(0, WordParagraphStyles.Heading1)]
+    public void Test_GetHeadingStyleForLevel(int level, WordParagraphStyles expected) {
+        var style = HeadingStyleMapper.GetHeadingStyleForLevel(level);
+        Assert.Equal(expected, style);
+    }
+
+    [Theory]
+    [InlineData(WordParagraphStyles.Heading1, 1)]
+    [InlineData(WordParagraphStyles.Heading2, 2)]
+    [InlineData(WordParagraphStyles.Heading3, 3)]
+    [InlineData(WordParagraphStyles.Heading4, 4)]
+    [InlineData(WordParagraphStyles.Heading5, 5)]
+    [InlineData(WordParagraphStyles.Heading6, 6)]
+    [InlineData(WordParagraphStyles.Heading7, 7)]
+    [InlineData(WordParagraphStyles.Heading8, 8)]
+    [InlineData(WordParagraphStyles.Heading9, 9)]
+    [InlineData(WordParagraphStyles.Normal, 0)]
+    public void Test_GetLevelForHeadingStyle(WordParagraphStyles style, int expected) {
+        var level = HeadingStyleMapper.GetLevelForHeadingStyle(style);
+        Assert.Equal(expected, level);
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -61,19 +61,6 @@ namespace OfficeIMO.Word.Html.Converters {
             }
         }
 
-        private static WordParagraphStyles GetHeadingStyleForLevel(int level) => level switch {
-            1 => WordParagraphStyles.Heading1,
-            2 => WordParagraphStyles.Heading2,
-            3 => WordParagraphStyles.Heading3,
-            4 => WordParagraphStyles.Heading4,
-            5 => WordParagraphStyles.Heading5,
-            6 => WordParagraphStyles.Heading6,
-            7 => WordParagraphStyles.Heading7,
-            8 => WordParagraphStyles.Heading8,
-            9 => WordParagraphStyles.Heading9,
-            _ => WordParagraphStyles.Heading1
-        };
-
         private static void ApplyParagraphStyleFromCss(WordParagraph paragraph, IElement element) {
             var style = CssStyleMapper.MapParagraphStyle(element.GetAttribute("style"));
             if (style.HasValue) {
@@ -100,7 +87,7 @@ namespace OfficeIMO.Word.Html.Converters {
                     case "h6": {
                         int level = int.Parse(element.TagName.Substring(1));
                         var paragraph = cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
-                        paragraph.Style = GetHeadingStyleForLevel(level);
+                        paragraph.Style = HeadingStyleMapper.GetHeadingStyleForLevel(level);
                         ApplyParagraphStyleFromCss(paragraph, element);
                         foreach (var child in element.ChildNodes) {
                             ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -142,10 +142,8 @@ namespace OfficeIMO.Word.Html.Converters {
             }
 
             void AppendParagraph(IElement parent, WordParagraph para) {
-                var element = htmlDoc.CreateElement(
-                    para.Style >= WordParagraphStyles.Heading1 && para.Style <= WordParagraphStyles.Heading9
-                        ? $"h{para.Style.Value - WordParagraphStyles.Heading1 + 1}"
-                        : "p");
+                int level = para.Style.HasValue ? HeadingStyleMapper.GetLevelForHeadingStyle(para.Style.Value) : 0;
+                var element = htmlDoc.CreateElement(level > 0 ? $"h{level}" : "p");
                 AppendRuns(element, para);
                 parent.AppendChild(element);
             }

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
@@ -49,7 +49,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
                 case HeadingBlock heading:
                     var headingParagraph = document.AddParagraph(string.Empty);
                     ProcessInline(heading.Inline, headingParagraph, options);
-                    headingParagraph.Style = GetHeadingStyleForLevel(heading.Level);
+                    headingParagraph.Style = HeadingStyleMapper.GetHeadingStyleForLevel(heading.Level);
                     break;
                 case ParagraphBlock paragraphBlock when currentList == null:
                     var paragraph = document.AddParagraph(string.Empty);
@@ -197,17 +197,5 @@ namespace OfficeIMO.Word.Markdown.Converters {
             return sb.ToString().TrimEnd();
         }
 
-        private static WordParagraphStyles GetHeadingStyleForLevel(int level) => level switch {
-            1 => WordParagraphStyles.Heading1,
-            2 => WordParagraphStyles.Heading2,
-            3 => WordParagraphStyles.Heading3,
-            4 => WordParagraphStyles.Heading4,
-            5 => WordParagraphStyles.Heading5,
-            6 => WordParagraphStyles.Heading6,
-            7 => WordParagraphStyles.Heading7,
-            8 => WordParagraphStyles.Heading8,
-            9 => WordParagraphStyles.Heading9,
-            _ => WordParagraphStyles.Heading1
-        };
     }
 }

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.cs
@@ -50,8 +50,10 @@ namespace OfficeIMO.Word.Markdown.Converters {
         private string ConvertParagraph(WordParagraph paragraph) {
             var sb = new StringBuilder();
 
-            int? headingLevel = GetLevelForHeadingStyle(paragraph.Style);
-            if (headingLevel != null) {
+            int? headingLevel = paragraph.Style.HasValue
+                ? HeadingStyleMapper.GetLevelForHeadingStyle(paragraph.Style.Value)
+                : (int?)null;
+            if (headingLevel.HasValue && headingLevel.Value > 0) {
                 sb.Append(new string('#', headingLevel.Value)).Append(' ');
             }
 
@@ -163,17 +165,5 @@ namespace OfficeIMO.Word.Markdown.Converters {
             return sb.ToString();
         }
 
-        private static int? GetLevelForHeadingStyle(WordParagraphStyles? style) => style switch {
-            WordParagraphStyles.Heading1 => 1,
-            WordParagraphStyles.Heading2 => 2,
-            WordParagraphStyles.Heading3 => 3,
-            WordParagraphStyles.Heading4 => 4,
-            WordParagraphStyles.Heading5 => 5,
-            WordParagraphStyles.Heading6 => 6,
-            WordParagraphStyles.Heading7 => 7,
-            WordParagraphStyles.Heading8 => 8,
-            WordParagraphStyles.Heading9 => 9,
-            _ => (int?)null
-        };
     }
 }

--- a/OfficeIMO.Word/Converters/HeadingStyleMapper.cs
+++ b/OfficeIMO.Word/Converters/HeadingStyleMapper.cs
@@ -1,0 +1,33 @@
+namespace OfficeIMO.Word {
+    public static class HeadingStyleMapper {
+        public static WordParagraphStyles GetHeadingStyleForLevel(int level) {
+            return level switch {
+                1 => WordParagraphStyles.Heading1,
+                2 => WordParagraphStyles.Heading2,
+                3 => WordParagraphStyles.Heading3,
+                4 => WordParagraphStyles.Heading4,
+                5 => WordParagraphStyles.Heading5,
+                6 => WordParagraphStyles.Heading6,
+                7 => WordParagraphStyles.Heading7,
+                8 => WordParagraphStyles.Heading8,
+                9 => WordParagraphStyles.Heading9,
+                _ => WordParagraphStyles.Heading1,
+            };
+        }
+
+        public static int GetLevelForHeadingStyle(WordParagraphStyles style) {
+            return style switch {
+                WordParagraphStyles.Heading1 => 1,
+                WordParagraphStyles.Heading2 => 2,
+                WordParagraphStyles.Heading3 => 3,
+                WordParagraphStyles.Heading4 => 4,
+                WordParagraphStyles.Heading5 => 5,
+                WordParagraphStyles.Heading6 => 6,
+                WordParagraphStyles.Heading7 => 7,
+                WordParagraphStyles.Heading8 => 8,
+                WordParagraphStyles.Heading9 => 9,
+                _ => 0,
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add HeadingStyleMapper to convert between heading levels and WordParagraphStyles
- reuse mapper in HTML and Markdown converters
- test both conversion directions

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68931237c134832eb582a478a7406f4a