### PR TITLE
Add helpers for list creation and remote image embedding

### DIFF
--- a/OfficeIMO.Examples/Word/Images/Images.FromUrl.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.FromUrl.cs
@@ -1,0 +1,15 @@
+using System;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Images {
+        internal static void Example_AddImageFromUrl(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with image downloaded from URL");
+            string filePath = System.IO.Path.Combine(folderPath, "DocumentWithImageFromUrl.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddImageFromUrl("https://via.placeholder.com/150", 150, 150);
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Lists/Lists.CreateWithHelpers.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.CreateWithHelpers.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Lists {
+        internal static void Example_CreateListsWithHelpers(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with helper list methods");
+            string filePath = Path.Combine(folderPath, "DocumentWithHelperLists.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var bullets = document.CreateBulletList();
+                bullets.AddItem("Bullet 1");
+                bullets.AddItem("Bullet 2");
+
+                var numbers = document.CreateNumberedList();
+                numbers.AddItem("First");
+                numbers.AddItem("Second");
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.AddImageFromUrl.cs
+++ b/OfficeIMO.Tests/Word.AddImageFromUrl.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_AddImageFromUrl() {
+            var filePath = Path.Combine(_directoryWithFiles, "ImageFromUrl.docx");
+            string imagePath = Path.Combine(_directoryWithImages, "Kulek.jpg");
+
+            using var listener = new HttpListener();
+            listener.Prefixes.Add("http://localhost:54321/");
+            listener.Start();
+            var serverTask = Task.Run(() => {
+                var context = listener.GetContext();
+                var bytes = File.ReadAllBytes(imagePath);
+                context.Response.ContentType = "image/jpeg";
+                context.Response.ContentLength64 = bytes.Length;
+                context.Response.OutputStream.Write(bytes, 0, bytes.Length);
+                context.Response.OutputStream.Close();
+                listener.Stop();
+            });
+
+            using (var document = WordDocument.Create(filePath)) {
+                var img = document.AddImageFromUrl("http://localhost:54321/", 40, 40);
+                Assert.NotNull(img);
+                document.Save(false);
+            }
+
+            serverTask.Wait();
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Single(document.Images);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.ListHelpers.cs
+++ b/OfficeIMO.Tests/Word.ListHelpers.cs
@@ -1,0 +1,28 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_ListHelpers() {
+            var filePath = Path.Combine(_directoryWithFiles, "ListHelpers.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                var bullet = document.CreateBulletList();
+                bullet.AddItem("One");
+
+                var numbered = document.CreateNumberedList();
+                numbered.AddItem("First");
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(2, document.Lists.Count);
+                Assert.Equal("One", document.Lists[0].ListItems[0].Text);
+                Assert.Equal("First", document.Lists[1].ListItems[0].Text);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `CreateBulletList`, `CreateNumberedList`, and `AddImageFromUrl` helpers
- streamline Markdown and HTML converters to use new helpers
- include examples and tests for list helpers and downloading images

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68931762b3d0832eb5ec6b2bedb8f980