### PR TITLE
feat: add shared formatting and traversal helpers

### DIFF
--- a/OfficeIMO.Examples/Converters/Shared/Shared.Helpers.cs
+++ b/OfficeIMO.Examples/Converters/Shared/Shared.Helpers.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Shared {
+    internal static partial class Shared {
+        public static void Example_SharedHelpers(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "SharedHelpers.docx");
+
+            using (var document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph(string.Empty);
+                paragraph.AddFormattedText("Hello", bold: true);
+                paragraph.AddFormattedText("World", italic: true);
+                document.Save();
+
+                foreach (var section in DocumentTraversal.EnumerateSections(document)) {
+                    foreach (var p in section.Paragraphs) {
+                        foreach (var run in FormattingHelper.GetFormattedRuns(p)) {
+                            if (!string.IsNullOrEmpty(run.Text)) {
+                                Console.WriteLine($"{run.Text} B:{run.Bold} I:{run.Italic}");
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Converters.Helpers.cs
+++ b/OfficeIMO.Tests/Converters.Helpers.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.Linq;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void FormattingHelper_GetsRunsWithFlags() {
+            using MemoryStream ms = new MemoryStream();
+            using (var document = WordDocument.Create(ms)) {
+                var paragraph = document.AddParagraph(string.Empty);
+                paragraph.AddFormattedText("Hello");
+                paragraph.AddFormattedText("Bold", bold: true);
+                paragraph.AddFormattedText("Italic", italic: true);
+                paragraph.AddHyperLink("Link", new Uri("https://example.com/"));
+                paragraph.AddImage(Path.Combine(_directoryWithImages, "EvotecLogo.png"));
+
+                document.Save();
+
+                var runs = FormattingHelper.GetFormattedRuns(paragraph).ToList();
+                Assert.Equal(5, runs.Count);
+                Assert.Contains(runs, r => r.Text == "Hello" && !r.Bold);
+                Assert.Contains(runs, r => r.Text == "Bold" && r.Bold);
+                Assert.Contains(runs, r => r.Text == "Italic" && r.Italic);
+                Assert.Contains(runs, r => r.Text == "Link" && r.Hyperlink == "https://example.com/");
+                Assert.Contains(runs, r => r.Image != null);
+            }
+        }
+
+        [Fact]
+        public void DocumentTraversal_ResolvesListMarkers() {
+            using MemoryStream ms = new MemoryStream();
+            using (var document = WordDocument.Create(ms)) {
+                var bullet = document.AddList(WordListStyle.Bulleted);
+                var bulletItem = bullet.AddItem("Bullet 1");
+                var ordered = document.AddList(WordListStyle.Headings111);
+                var orderedItem = ordered.AddItem("Number 1");
+
+                document.Save();
+
+                var bulletInfo = DocumentTraversal.GetListInfo(bulletItem);
+                Assert.NotNull(bulletInfo);
+                Assert.False(bulletInfo.Value.Ordered);
+
+                var orderedInfo = DocumentTraversal.GetListInfo(orderedItem);
+                Assert.True(orderedInfo.Value.Ordered);
+
+                var markers = DocumentTraversal.BuildListMarkers(document);
+                Assert.Equal("•", markers[bulletItem].Marker);
+                Assert.Equal("1.", markers[orderedItem].Marker);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Helpers.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Helpers.cs
@@ -1,7 +1,5 @@
 using OfficeIMO.Word;
 using QuestPDF.Helpers;
-using System;
-using System.Collections.Generic;
 
 namespace OfficeIMO.Word.Pdf {
     public static partial class WordPdfConverterExtensions {
@@ -17,28 +15,6 @@ namespace OfficeIMO.Word.Pdf {
                 WordPageSize.B5 => PageSizes.B5,
                 _ => PageSizes.A4
             };
-        }
-
-        private static Dictionary<WordParagraph, (int Level, string Marker)> BuildListMarkers(WordDocument document) {
-            Dictionary<WordParagraph, (int, string)> result = new();
-
-            foreach (WordList list in document.Lists) {
-                Dictionary<int, int> indices = new();
-                bool bullet = list.Style.ToString().IndexOf("Bullet", StringComparison.OrdinalIgnoreCase) >= 0;
-                foreach (WordParagraph item in list.ListItems) {
-                    int level = item.ListItemLevel ?? 0;
-                    if (!indices.ContainsKey(level)) {
-                        indices[level] = 1;
-                    }
-
-                    int index = indices[level];
-                    indices[level] = index + 1;
-                    string marker = bullet ? "•" : $"{index}.";
-                    result[item] = (level, marker);
-                }
-            }
-
-            return result;
         }
     }
 }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -40,7 +40,7 @@ public static partial class WordPdfConverterExtensions {
     private static Document CreatePdfDocument(WordDocument document, PdfSaveOptions? options) {
         QuestPDF.Settings.License = LicenseType.Community;
 
-        Dictionary<WordParagraph, (int Level, string Marker)> listMarkers = BuildListMarkers(document);
+        Dictionary<WordParagraph, (int Level, string Marker)> listMarkers = DocumentTraversal.BuildListMarkers(document);
 
         Document pdf = Document.Create(container => {
             foreach (WordSection section in document.Sections) {

--- a/OfficeIMO.Word/Converters/DocumentTraversal.cs
+++ b/OfficeIMO.Word/Converters/DocumentTraversal.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides helper methods for traversing documents and resolving list markers.
+    /// </summary>
+    public static class DocumentTraversal {
+        /// <summary>
+        /// Enumerates all sections within the document.
+        /// </summary>
+        public static IEnumerable<WordSection> EnumerateSections(WordDocument document) {
+            return document?.Sections ?? Enumerable.Empty<WordSection>();
+        }
+
+        /// <summary>
+        /// Resolves list information for the given paragraph.
+        /// </summary>
+        /// <param name="paragraph">Paragraph to inspect.</param>
+        /// <returns>Tuple containing list level and whether the list is ordered.</returns>
+        public static (int Level, bool Ordered)? GetListInfo(WordParagraph paragraph) {
+            if (paragraph == null || !paragraph.IsListItem) {
+                return null;
+            }
+
+            int level = paragraph.ListItemLevel ?? 0;
+            bool ordered = paragraph.ListStyle switch {
+                WordListStyle.Bulleted => false,
+                WordListStyle.BulletedChars => false,
+                _ => true,
+            };
+
+            return (level, ordered);
+        }
+
+        /// <summary>
+        /// Builds a lookup of list markers for all paragraphs in the document.
+        /// </summary>
+        public static Dictionary<WordParagraph, (int Level, string Marker)> BuildListMarkers(WordDocument document) {
+            Dictionary<WordParagraph, (int, string)> result = new();
+
+            foreach (WordList list in document.Lists) {
+                Dictionary<int, int> indices = new();
+                bool bullet = list.Style.ToString().IndexOf("Bullet", StringComparison.OrdinalIgnoreCase) >= 0;
+                foreach (WordParagraph item in list.ListItems) {
+                    int level = item.ListItemLevel ?? 0;
+                    if (!indices.ContainsKey(level)) {
+                        indices[level] = 1;
+                    }
+
+                    int index = indices[level];
+                    indices[level] = index + 1;
+                    string marker = bullet ? "•" : $"{index}.";
+                    result[item] = (level, marker);
+                }
+            }
+
+            return result;
+        }
+    }
+}
+

--- a/OfficeIMO.Word/Converters/FormattingHelper.cs
+++ b/OfficeIMO.Word/Converters/FormattingHelper.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides helpers for working with runs and their formatting.
+    /// </summary>
+    public static class FormattingHelper {
+        /// <summary>
+        /// Represents a run of text or image with associated formatting flags.
+        /// </summary>
+        public readonly struct FormattedRun {
+            public string? Text { get; }
+            public WordImage? Image { get; }
+            public bool Bold { get; }
+            public bool Italic { get; }
+            public bool Underline { get; }
+            public string? Hyperlink { get; }
+
+            public FormattedRun(string? text, WordImage? image, bool bold, bool italic, bool underline, string? hyperlink) {
+                Text = text;
+                Image = image;
+                Bold = bold;
+                Italic = italic;
+                Underline = underline;
+                Hyperlink = hyperlink;
+            }
+        }
+
+        /// <summary>
+        /// Enumerates runs within the paragraph and returns their text and formatting flags.
+        /// </summary>
+        public static IEnumerable<FormattedRun> GetFormattedRuns(WordParagraph paragraph) {
+            if (paragraph == null) {
+                yield break;
+            }
+
+            foreach (WordParagraph run in paragraph.GetRuns()) {
+                if (run.IsImage && run.Image != null) {
+                    yield return new FormattedRun(null, run.Image, false, false, false, null);
+                    continue;
+                }
+
+                string? text = run.Text;
+                if (string.IsNullOrEmpty(text)) {
+                    continue;
+                }
+
+                string? hyperlink = run.IsHyperLink && run.Hyperlink != null ? run.Hyperlink.Uri?.ToString() : null;
+                yield return new FormattedRun(text, null, run.Bold, run.Italic, run.Underline != null, hyperlink);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add DocumentTraversal helper for enumerating sections and resolving list markers
- add FormattingHelper for run-to-text conversion with formatting metadata
- refactor HTML, Markdown and PDF converters to use shared helpers
- include example and tests for new traversal and formatting logic

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68931ea50314832e90147d93706e7b29