### PR TITLE
Refactor converters into partial classes

### DIFF
--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -1,0 +1,60 @@
+using AngleSharp.Dom;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html.Helpers;
+using System;
+using System.Collections.Generic;
+
+namespace OfficeIMO.Word.Html.Converters {
+    internal partial class HtmlToWordConverter {
+        private struct TextFormatting {
+            public bool Bold;
+            public bool Italic;
+            public bool Underline;
+
+            public TextFormatting(bool bold = false, bool italic = false, bool underline = false) {
+                Bold = bold;
+                Italic = italic;
+                Underline = underline;
+            }
+        }
+
+        private static void ApplyParagraphStyleFromCss(WordParagraph paragraph, IElement element) {
+            var style = CssStyleMapper.MapParagraphStyle(element.GetAttribute("style"));
+            if (style.HasValue) {
+                paragraph.Style = style.Value;
+            }
+        }
+
+        private static readonly System.Text.RegularExpressions.Regex _urlRegex = new(@"((?:https?|ftp)://[^\s]+)", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        private static void AddTextRun(WordParagraph paragraph, string text, TextFormatting formatting, HtmlToWordOptions options) {
+            int lastIndex = 0;
+            foreach (System.Text.RegularExpressions.Match match in _urlRegex.Matches(text)) {
+                if (match.Index > lastIndex) {
+                    var segment = text.Substring(lastIndex, match.Index - lastIndex);
+                    var run = paragraph.AddFormattedText(segment, formatting.Bold, formatting.Italic, formatting.Underline ? UnderlineValues.Single : null);
+                    if (!string.IsNullOrEmpty(options.FontFamily)) {
+                        run.SetFontFamily(options.FontFamily);
+                    }
+                }
+                var linkRun = paragraph.AddHyperLink(match.Value, new Uri(match.Value));
+                ApplyFormatting(linkRun, formatting, options);
+                lastIndex = match.Index + match.Length;
+            }
+            if (lastIndex < text.Length) {
+                var run = paragraph.AddFormattedText(text.Substring(lastIndex), formatting.Bold, formatting.Italic, formatting.Underline ? UnderlineValues.Single : null);
+                if (!string.IsNullOrEmpty(options.FontFamily)) {
+                    run.SetFontFamily(options.FontFamily);
+                }
+            }
+        }
+
+        private static void ApplyFormatting(WordParagraph run, TextFormatting formatting, HtmlToWordOptions options) {
+            if (formatting.Bold) run.SetBold();
+            if (formatting.Italic) run.SetItalic();
+            if (formatting.Underline) run.SetUnderline(UnderlineValues.Single);
+            if (!string.IsNullOrEmpty(options.FontFamily)) run.SetFontFamily(options.FontFamily);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -1,0 +1,36 @@
+using AngleSharp.Html.Dom;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Word.Html.Converters {
+    internal partial class HtmlToWordConverter {
+        private void ProcessImage(IHtmlImageElement img, WordDocument doc) {
+            var src = img.Source;
+            if (string.IsNullOrEmpty(src)) return;
+
+            double? width = img.DisplayWidth > 0 ? img.DisplayWidth : null;
+            double? height = img.DisplayHeight > 0 ? img.DisplayHeight : null;
+
+            if (src.StartsWith("data:image", StringComparison.OrdinalIgnoreCase)) {
+                var commaIndex = src.IndexOf(',');
+                if (commaIndex > 0) {
+                    var meta = src.Substring(5, commaIndex - 5); // e.g., image/png;base64
+                    var base64 = src.Substring(commaIndex + 1);
+                    var ext = "png";
+                    var parts = meta.Split(new[] { ';', '/' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length >= 2) {
+                        ext = parts[1];
+                    }
+                    doc.AddParagraph().AddImageFromBase64(base64, "image." + ext, width, height);
+                }
+            } else if (Uri.TryCreate(src, UriKind.Absolute, out var uri) && uri.IsFile) {
+                doc.AddParagraph().AddImage(uri.LocalPath, width, height);
+            } else if (File.Exists(src)) {
+                doc.AddParagraph().AddImage(src, width, height);
+            } else {
+                doc.AddImageFromUrl(src, width, height);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
@@ -1,0 +1,33 @@
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using OfficeIMO.Word;
+using System.Collections.Generic;
+
+namespace OfficeIMO.Word.Html.Converters {
+    internal partial class HtmlToWordConverter {
+        private void ProcessList(IElement element, WordDocument doc, WordSection section, HtmlToWordOptions options,
+            Stack<WordList> listStack, WordTableCell? cell, TextFormatting formatting) {
+            WordList list;
+            if (element.TagName.Equals("ul", StringComparison.OrdinalIgnoreCase)) {
+                list = cell != null ? cell.AddList(WordListStyle.Bulleted) : doc.AddListBulleted();
+            } else {
+                list = cell != null ? cell.AddList(WordListStyle.Headings111) : doc.AddListNumbered();
+            }
+            listStack.Push(list);
+            foreach (var li in element.Children.OfType<IHtmlListItemElement>()) {
+                ProcessListItem(li, doc, section, options, listStack, formatting, cell);
+            }
+            listStack.Pop();
+        }
+
+        private void ProcessListItem(IHtmlListItemElement element, WordDocument doc, WordSection section, HtmlToWordOptions options,
+            Stack<WordList> listStack, TextFormatting formatting, WordTableCell? cell) {
+            var list = listStack.Peek();
+            int level = listStack.Count - 1;
+            var paragraph = list.AddItem("", level);
+            foreach (var child in element.ChildNodes) {
+                ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -1,0 +1,39 @@
+using AngleSharp.Html.Dom;
+using OfficeIMO.Word;
+using System;
+using System.Collections.Generic;
+
+namespace OfficeIMO.Word.Html.Converters {
+    internal partial class HtmlToWordConverter {
+        private void ProcessTable(IHtmlTableElement tableElem, WordDocument doc, WordSection section, HtmlToWordOptions options,
+            Stack<WordList> listStack, WordTableCell? cell, WordParagraph? currentParagraph) {
+            int rows = tableElem.Rows.Length;
+            int cols = 0;
+            foreach (var r in tableElem.Rows) {
+                cols = Math.Max(cols, r.Cells.Length);
+            }
+            WordTable wordTable;
+            if (cell != null) {
+                wordTable = cell.AddTable(rows, cols);
+            } else if (currentParagraph != null) {
+                wordTable = currentParagraph.AddTableAfter(rows, cols);
+            } else {
+                var placeholder = section.AddParagraph("");
+                wordTable = placeholder.AddTableAfter(rows, cols);
+            }
+            for (int r = 0; r < rows; r++) {
+                var htmlRow = tableElem.Rows[r];
+                for (int c = 0; c < htmlRow.Cells.Length; c++) {
+                    var htmlCell = htmlRow.Cells[c];
+                    var wordCell = wordTable.Rows[r].Cells[c];
+                    if (wordCell.Paragraphs.Count == 1 && string.IsNullOrEmpty(wordCell.Paragraphs[0].Text)) {
+                        wordCell.Paragraphs[0].Remove();
+                    }
+                    foreach (var child in htmlCell.ChildNodes) {
+                        ProcessNode(child, doc, section, options, null, listStack, new TextFormatting(), wordCell);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -2,14 +2,14 @@ using AngleSharp;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using AngleSharp.Html.Parser;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
+using OfficeIMO.Word.Html.Helpers;
 using System;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.IO;
-using DocumentFormat.OpenXml.Wordprocessing;
-using OfficeIMO.Word.Html.Helpers;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace OfficeIMO.Word.Html.Converters {
     /// <summary>
@@ -22,7 +22,7 @@ namespace OfficeIMO.Word.Html.Converters {
     /// 3. Reuse existing OfficeIMO.Word helper methods and converters
     /// 4. Follow existing patterns in OfficeIMO.Word for consistency
     /// </summary>
-    internal class HtmlToWordConverter {
+    internal partial class HtmlToWordConverter {
         public async Task<WordDocument> ConvertAsync(string html, HtmlToWordOptions options) {
             if (html == null) throw new ArgumentNullException(nameof(html));
             options ??= new HtmlToWordOptions();
@@ -50,137 +50,103 @@ namespace OfficeIMO.Word.Html.Converters {
             return wordDoc;
         }
 
-        private struct TextFormatting {
-            public bool Bold;
-            public bool Italic;
-            public bool Underline;
-
-            public TextFormatting(bool bold = false, bool italic = false, bool underline = false) {
-                Bold = bold;
-                Italic = italic;
-                Underline = underline;
-            }
-        }
-
-        private static void ApplyParagraphStyleFromCss(WordParagraph paragraph, IElement element) {
-            var style = CssStyleMapper.MapParagraphStyle(element.GetAttribute("style"));
-            if (style.HasValue) {
-                paragraph.Style = style.Value;
-            }
-        }
-
         private void ProcessNode(INode node, WordDocument doc, WordSection section, HtmlToWordOptions options,
             WordParagraph? currentParagraph, Stack<WordList> listStack, TextFormatting formatting, WordTableCell? cell) {
             if (node is IElement element) {
                 switch (element.TagName.ToLowerInvariant()) {
                     case "section": {
-                        var newSection = doc.AddSection();
-                        foreach (var child in element.ChildNodes) {
-                            ProcessNode(child, doc, newSection, options, null, listStack, formatting, null);
+                            var newSection = doc.AddSection();
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, newSection, options, null, listStack, formatting, null);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case "h1":
                     case "h2":
                     case "h3":
                     case "h4":
                     case "h5":
                     case "h6": {
-                        int level = int.Parse(element.TagName.Substring(1));
-                        var paragraph = cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
-                        paragraph.Style = HeadingStyleMapper.GetHeadingStyleForLevel(level);
-                        ApplyParagraphStyleFromCss(paragraph, element);
-                        foreach (var child in element.ChildNodes) {
-                            ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);
+                            int level = int.Parse(element.TagName.Substring(1));
+                            var paragraph = cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
+                            paragraph.Style = HeadingStyleMapper.GetHeadingStyleForLevel(level);
+                            ApplyParagraphStyleFromCss(paragraph, element);
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case "p": {
-                        var paragraph = cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
-                        ApplyParagraphStyleFromCss(paragraph, element);
-                        foreach (var child in element.ChildNodes) {
-                            ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);
+                            var paragraph = cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
+                            ApplyParagraphStyleFromCss(paragraph, element);
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case "br": {
-                        currentParagraph ??= cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
-                        currentParagraph.AddBreak();
-                        break;
-                    }
+                            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
+                            currentParagraph.AddBreak();
+                            break;
+                        }
                     case "strong":
                     case "b": {
-                        var fmt = new TextFormatting(true, formatting.Italic, formatting.Underline);
-                        foreach (var child in element.ChildNodes) {
-                            ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
+                            var fmt = new TextFormatting(true, formatting.Italic, formatting.Underline);
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case "em":
                     case "i": {
-                        var fmt = new TextFormatting(formatting.Bold, true, formatting.Underline);
-                        foreach (var child in element.ChildNodes) {
-                            ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
-                        }
-                        break;
-                    }
-                    case "u": {
-                        var fmt = new TextFormatting(formatting.Bold, formatting.Italic, true);
-                        foreach (var child in element.ChildNodes) {
-                            ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
-                        }
-                        break;
-                    }
-                    case "a": {
-                        var href = element.GetAttribute("href");
-                        if (!string.IsNullOrEmpty(href)) {
-                            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
-                            var uri = new Uri(href, UriKind.RelativeOrAbsolute);
-                            var linkPara = currentParagraph.AddHyperLink(element.TextContent, uri);
-                            if (!string.IsNullOrEmpty(options.FontFamily)) {
-                                linkPara.SetFontFamily(options.FontFamily);
+                            var fmt = new TextFormatting(formatting.Bold, true, formatting.Underline);
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
                             }
+                            break;
                         }
-                        break;
-                    }
+                    case "u": {
+                            var fmt = new TextFormatting(formatting.Bold, formatting.Italic, true);
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
+                            }
+                            break;
+                        }
+                    case "a": {
+                            var href = element.GetAttribute("href");
+                            if (!string.IsNullOrEmpty(href)) {
+                                currentParagraph ??= cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
+                                var uri = new Uri(href, UriKind.RelativeOrAbsolute);
+                                var linkPara = currentParagraph.AddHyperLink(element.TextContent, uri);
+                                if (!string.IsNullOrEmpty(options.FontFamily)) {
+                                    linkPara.SetFontFamily(options.FontFamily);
+                                }
+                            }
+                            break;
+                        }
                     case "ul":
                     case "ol": {
-                        WordList list;
-                        if (element.TagName.Equals("ul", StringComparison.OrdinalIgnoreCase)) {
-                            list = cell != null ? cell.AddList(WordListStyle.Bulleted) : doc.AddListBulleted();
-                        } else {
-                            list = cell != null ? cell.AddList(WordListStyle.Headings111) : doc.AddListNumbered();
+                            ProcessList(element, doc, section, options, listStack, cell, formatting);
+                            break;
                         }
-                        listStack.Push(list);
-                        foreach (var li in element.Children.OfType<IHtmlListItemElement>()) {
-                            ProcessNode(li, doc, section, options, null, listStack, formatting, cell);
-                        }
-                        listStack.Pop();
-                        break;
-                    }
                     case "li": {
-                        var list = listStack.Peek();
-                        int level = listStack.Count - 1;
-                        var paragraph = list.AddItem("", level);
-                        foreach (var child in element.ChildNodes) {
-                            ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);
+                            ProcessListItem((IHtmlListItemElement)element, doc, section, options, listStack, formatting, cell);
+                            break;
                         }
-                        break;
-                    }
                     case "table": {
-                        ProcessTable((IHtmlTableElement)element, doc, section, options, listStack, cell, currentParagraph);
-                        break;
-                    }
-                    case "img": {
-                        ProcessImage((IHtmlImageElement)element, doc);
-                        break;
-                    }
-                    default: {
-                        foreach (var child in element.ChildNodes) {
-                            ProcessNode(child, doc, section, options, currentParagraph, listStack, formatting, cell);
+                            ProcessTable((IHtmlTableElement)element, doc, section, options, listStack, cell, currentParagraph);
+                            break;
                         }
-                        break;
-                    }
+                    case "img": {
+                            ProcessImage((IHtmlImageElement)element, doc);
+                            break;
+                        }
+                    default: {
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, formatting, cell);
+                            }
+                            break;
+                        }
                 }
             } else if (node is IText textNode) {
                 var text = textNode.Text;
@@ -189,96 +155,6 @@ namespace OfficeIMO.Word.Html.Converters {
                 }
                 currentParagraph ??= cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
                 AddTextRun(currentParagraph, text, formatting, options);
-            }
-        }
-
-        private static readonly System.Text.RegularExpressions.Regex _urlRegex = new(@"((?:https?|ftp)://[^\s]+)", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-
-        private static void AddTextRun(WordParagraph paragraph, string text, TextFormatting formatting, HtmlToWordOptions options) {
-            int lastIndex = 0;
-            foreach (System.Text.RegularExpressions.Match match in _urlRegex.Matches(text)) {
-                if (match.Index > lastIndex) {
-                    var segment = text.Substring(lastIndex, match.Index - lastIndex);
-                    var run = paragraph.AddFormattedText(segment, formatting.Bold, formatting.Italic, formatting.Underline ? UnderlineValues.Single : null);
-                    if (!string.IsNullOrEmpty(options.FontFamily)) {
-                        run.SetFontFamily(options.FontFamily);
-                    }
-                }
-                var linkRun = paragraph.AddHyperLink(match.Value, new Uri(match.Value));
-                ApplyFormatting(linkRun, formatting, options);
-                lastIndex = match.Index + match.Length;
-            }
-            if (lastIndex < text.Length) {
-                var run = paragraph.AddFormattedText(text.Substring(lastIndex), formatting.Bold, formatting.Italic, formatting.Underline ? UnderlineValues.Single : null);
-                if (!string.IsNullOrEmpty(options.FontFamily)) {
-                    run.SetFontFamily(options.FontFamily);
-                }
-            }
-        }
-
-        private static void ApplyFormatting(WordParagraph run, TextFormatting formatting, HtmlToWordOptions options) {
-            if (formatting.Bold) run.SetBold();
-            if (formatting.Italic) run.SetItalic();
-            if (formatting.Underline) run.SetUnderline(UnderlineValues.Single);
-            if (!string.IsNullOrEmpty(options.FontFamily)) run.SetFontFamily(options.FontFamily);
-        }
-
-        private void ProcessTable(IHtmlTableElement tableElem, WordDocument doc, WordSection section, HtmlToWordOptions options,
-            Stack<WordList> listStack, WordTableCell? cell, WordParagraph? currentParagraph) {
-            int rows = tableElem.Rows.Length;
-            int cols = 0;
-            foreach (var r in tableElem.Rows) {
-                cols = Math.Max(cols, r.Cells.Length);
-            }
-            WordTable wordTable;
-            if (cell != null) {
-                wordTable = cell.AddTable(rows, cols);
-            } else if (currentParagraph != null) {
-                wordTable = currentParagraph.AddTableAfter(rows, cols);
-            } else {
-                var placeholder = section.AddParagraph("");
-                wordTable = placeholder.AddTableAfter(rows, cols);
-            }
-            for (int r = 0; r < rows; r++) {
-                var htmlRow = tableElem.Rows[r];
-                for (int c = 0; c < htmlRow.Cells.Length; c++) {
-                    var htmlCell = htmlRow.Cells[c];
-                    var wordCell = wordTable.Rows[r].Cells[c];
-                    if (wordCell.Paragraphs.Count == 1 && string.IsNullOrEmpty(wordCell.Paragraphs[0].Text)) {
-                        wordCell.Paragraphs[0].Remove();
-                    }
-                    foreach (var child in htmlCell.ChildNodes) {
-                        ProcessNode(child, doc, section, options, null, listStack, new TextFormatting(), wordCell);
-                    }
-                }
-            }
-        }
-
-        private void ProcessImage(IHtmlImageElement img, WordDocument doc) {
-            var src = img.Source;
-            if (string.IsNullOrEmpty(src)) return;
-
-            double? width = img.DisplayWidth > 0 ? img.DisplayWidth : null;
-            double? height = img.DisplayHeight > 0 ? img.DisplayHeight : null;
-
-            if (src.StartsWith("data:image", StringComparison.OrdinalIgnoreCase)) {
-                var commaIndex = src.IndexOf(',');
-                if (commaIndex > 0) {
-                    var meta = src.Substring(5, commaIndex - 5); // e.g., image/png;base64
-                    var base64 = src.Substring(commaIndex + 1);
-                    var ext = "png";
-                    var parts = meta.Split(new[] { ';', '/' }, StringSplitOptions.RemoveEmptyEntries);
-                    if (parts.Length >= 2) {
-                        ext = parts[1];
-                    }
-                    doc.AddParagraph().AddImageFromBase64(base64, "image." + ext, width, height);
-                }
-            } else if (Uri.TryCreate(src, UriKind.Absolute, out var uri) && uri.IsFile) {
-                doc.AddParagraph().AddImage(uri.LocalPath, width, height);
-            } else if (File.Exists(src)) {
-                doc.AddParagraph().AddImage(src, width, height);
-            } else {
-                doc.AddImageFromUrl(src, width, height);
             }
         }
     }

--- a/OfficeIMO.Word.Html/OfficeIMO.Word.Html.csproj
+++ b/OfficeIMO.Word.Html/OfficeIMO.Word.Html.csproj
@@ -39,6 +39,13 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Compile Update="Converters/HtmlToWordConverter.Tables.cs" />
+        <Compile Update="Converters/HtmlToWordConverter.Lists.cs" />
+        <Compile Update="Converters/HtmlToWordConverter.Images.cs" />
+        <Compile Update="Converters/HtmlToWordConverter.Formatting.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="DocumentFormat.OpenXml" Version="[3.3.0,4.0.0)" />
         <PackageReference Include="AngleSharp" Version="1.3.0" />
     </ItemGroup>

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Inlines.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Inlines.cs
@@ -1,0 +1,88 @@
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+using System.Text;
+
+namespace OfficeIMO.Word.Markdown.Converters {
+    internal partial class MarkdownToWordConverter {
+        private static void ProcessInline(Inline? inline, WordParagraph paragraph, MarkdownToWordOptions options, WordDocument document) {
+            if (inline == null) {
+                return;
+            }
+
+            var buffer = new StringBuilder();
+
+            void Flush() {
+                if (buffer.Length > 0) {
+                    InlineRunHelper.AddInlineRuns(paragraph, buffer.ToString(), options.FontFamily);
+                    buffer.Clear();
+                }
+            }
+
+            for (var current = inline; current != null; current = current.NextSibling) {
+                if (current is LinkInline link) {
+                    Flush();
+                    if (link.IsImage) {
+                        AddImage(document, paragraph, link);
+                    } else {
+                        string label = BuildMarkdown(link.FirstChild);
+                        var hyperlink = paragraph.AddHyperLink(label, new Uri(link.Url, UriKind.RelativeOrAbsolute));
+                        if (!string.IsNullOrEmpty(options.FontFamily)) {
+                            hyperlink.SetFontFamily(options.FontFamily);
+                        }
+                    }
+                } else {
+                    buffer.Append(BuildMarkdown(current));
+                }
+            }
+            Flush();
+        }
+
+        private static void AddImage(WordDocument document, WordParagraph paragraph, LinkInline link) {
+            if (File.Exists(link.Url)) {
+                paragraph.AddImage(link.Url);
+            } else {
+                document.AddImageFromUrl(link.Url, 50, 50);
+            }
+        }
+
+        private static string BuildMarkdown(Inline? inline) {
+            if (inline == null) {
+                return string.Empty;
+            }
+
+            var sb = new StringBuilder();
+            for (var current = inline; current != null; current = current.NextSibling) {
+                switch (current) {
+                    case LiteralInline literal:
+                        sb.Append(literal.Content.ToString());
+                        break;
+                    case EmphasisInline emphasis:
+                        string marker = new('*', emphasis.DelimiterCount);
+                        sb.Append(marker);
+                        sb.Append(BuildMarkdown(emphasis.FirstChild));
+                        sb.Append(marker);
+                        break;
+                    case LineBreakInline:
+                        sb.Append('\n');
+                        break;
+                    case ContainerInline container:
+                        sb.Append(BuildMarkdown(container.FirstChild));
+                        break;
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private static string GetCodeBlockText(CodeBlock codeBlock) {
+            var sb = new StringBuilder();
+            foreach (var line in codeBlock.Lines.Lines) {
+                sb.AppendLine(line.Slice.ToString());
+            }
+            return sb.ToString().TrimEnd();
+        }
+    }
+}

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Lists.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Lists.cs
@@ -1,0 +1,21 @@
+using Markdig.Syntax;
+using OfficeIMO.Word;
+using System.Linq;
+
+namespace OfficeIMO.Word.Markdown.Converters {
+    internal partial class MarkdownToWordConverter {
+        private static void ProcessListBlock(ListBlock listBlock, WordDocument document, MarkdownToWordOptions options, int listLevel) {
+            var list = listBlock.IsOrdered ? document.AddListNumbered() : document.AddListBulleted();
+            foreach (ListItemBlock listItem in listBlock) {
+                var firstParagraph = listItem.FirstOrDefault() as ParagraphBlock;
+                if (firstParagraph != null) {
+                    var listParagraph = list.AddItem(string.Empty, listLevel);
+                    ProcessInline(firstParagraph.Inline, listParagraph, options, document);
+                }
+                foreach (var sub in listItem.Skip(1)) {
+                    ProcessBlock(sub, document, options, list, listLevel + 1);
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Tables.cs
@@ -1,0 +1,28 @@
+using Markdig.Extensions.Tables;
+using Markdig.Syntax;
+using OfficeIMO.Word;
+using System.Linq;
+
+namespace OfficeIMO.Word.Markdown.Converters {
+    internal partial class MarkdownToWordConverter {
+        private static void ProcessTable(Table table, WordDocument document, MarkdownToWordOptions options) {
+            int rows = table.Count();
+            int cols = table.ColumnDefinitions.Count;
+            var wordTable = document.AddTable(rows, cols);
+            int r = 0;
+            foreach (TableRow row in table) {
+                int c = 0;
+                foreach (TableCell cell in row) {
+                    var target = wordTable.Rows[r].Cells[c].Paragraphs[0];
+                    foreach (var cellBlock in cell) {
+                        if (cellBlock is ParagraphBlock pb) {
+                            ProcessInline(pb.Inline, target, options, document);
+                        }
+                    }
+                    c++;
+                }
+                r++;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
@@ -1,12 +1,9 @@
 using Markdig;
+using Markdig.Extensions.Tables;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using OfficeIMO.Word;
 using System;
-using System.IO;
-using System.Linq;
-using System.Text;
-using Markdig.Extensions.Tables;
 
 namespace OfficeIMO.Word.Markdown.Converters {
     /// <summary>
@@ -23,7 +20,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
     ///    - LinkInline -> paragraph.AddHyperLink()
     /// 4. Reuse existing OfficeIMO.Word functionality, don't recreate
     /// </summary>
-    internal class MarkdownToWordConverter {
+    internal partial class MarkdownToWordConverter {
         public WordDocument Convert(string markdown, MarkdownToWordOptions options) {
             if (markdown == null) {
                 throw new ArgumentNullException(nameof(markdown));
@@ -60,17 +57,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
                     ProcessInline(paragraphBlock.Inline, listItemParagraph, options, document);
                     break;
                 case ListBlock listBlock:
-                    var list = listBlock.IsOrdered ? document.AddListNumbered() : document.AddListBulleted();
-                    foreach (ListItemBlock listItem in listBlock) {
-                        var firstParagraph = listItem.FirstOrDefault() as ParagraphBlock;
-                        if (firstParagraph != null) {
-                            var listParagraph = list.AddItem(string.Empty, listLevel);
-                            ProcessInline(firstParagraph.Inline, listParagraph, options, document);
-                        }
-                        foreach (var sub in listItem.Skip(1)) {
-                            ProcessBlock(sub, document, options, list, listLevel + 1);
-                        }
-                    }
+                    ProcessListBlock(listBlock, document, options, listLevel);
                     break;
                 case QuoteBlock quote:
                     foreach (var sub in quote) {
@@ -97,104 +84,5 @@ namespace OfficeIMO.Word.Markdown.Converters {
                     break;
             }
         }
-
-        private static void ProcessTable(Table table, WordDocument document, MarkdownToWordOptions options) {
-            int rows = table.Count();
-            int cols = table.ColumnDefinitions.Count;
-            var wordTable = document.AddTable(rows, cols);
-            int r = 0;
-            foreach (TableRow row in table) {
-                int c = 0;
-                foreach (TableCell cell in row) {
-                    var target = wordTable.Rows[r].Cells[c].Paragraphs[0];
-                    foreach (var cellBlock in cell) {
-                        if (cellBlock is ParagraphBlock pb) {
-                            ProcessInline(pb.Inline, target, options, document);
-                        }
-                    }
-                    c++;
-                }
-                r++;
-            }
-        }
-
-        private static void ProcessInline(Inline? inline, WordParagraph paragraph, MarkdownToWordOptions options, WordDocument document) {
-            if (inline == null) {
-                return;
-            }
-
-            var buffer = new StringBuilder();
-
-            void Flush() {
-                if (buffer.Length > 0) {
-                    InlineRunHelper.AddInlineRuns(paragraph, buffer.ToString(), options.FontFamily);
-                    buffer.Clear();
-                }
-            }
-
-            for (var current = inline; current != null; current = current.NextSibling) {
-                if (current is LinkInline link) {
-                    Flush();
-                    if (link.IsImage) {
-                        AddImage(document, paragraph, link);
-                    } else {
-                        string label = BuildMarkdown(link.FirstChild);
-                        var hyperlink = paragraph.AddHyperLink(label, new Uri(link.Url, UriKind.RelativeOrAbsolute));
-                        if (!string.IsNullOrEmpty(options.FontFamily)) {
-                            hyperlink.SetFontFamily(options.FontFamily);
-                        }
-                    }
-                } else {
-                    buffer.Append(BuildMarkdown(current));
-                }
-            }
-            Flush();
-        }
-
-        private static void AddImage(WordDocument document, WordParagraph paragraph, LinkInline link) {
-            if (File.Exists(link.Url)) {
-                paragraph.AddImage(link.Url);
-            } else {
-                document.AddImageFromUrl(link.Url, 50, 50);
-            }
-        }
-
-        private static string BuildMarkdown(Inline? inline) {
-            if (inline == null) {
-                return string.Empty;
-            }
-
-            var sb = new StringBuilder();
-            for (var current = inline; current != null; current = current.NextSibling) {
-                switch (current) {
-                    case LiteralInline literal:
-                        sb.Append(literal.Content.ToString());
-                        break;
-                    case EmphasisInline emphasis:
-                        string marker = new('*', emphasis.DelimiterCount);
-                        sb.Append(marker);
-                        sb.Append(BuildMarkdown(emphasis.FirstChild));
-                        sb.Append(marker);
-                        break;
-                    case LineBreakInline:
-                        sb.Append('\n');
-                        break;
-                    case ContainerInline container:
-                        sb.Append(BuildMarkdown(container.FirstChild));
-                        break;
-                }
-            }
-
-            return sb.ToString();
-        }
-
-        private static string GetCodeBlockText(CodeBlock codeBlock) {
-            var sb = new StringBuilder();
-            foreach (var line in codeBlock.Lines.Lines) {
-                sb.AppendLine(line.Slice.ToString());
-            }
-            return sb.ToString().TrimEnd();
-        }
-
     }
 }

--- a/OfficeIMO.Word.Markdown/OfficeIMO.Word.Markdown.csproj
+++ b/OfficeIMO.Word.Markdown/OfficeIMO.Word.Markdown.csproj
@@ -36,6 +36,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="Converters/MarkdownToWordConverter.Tables.cs" />
+    <Compile Update="Converters/MarkdownToWordConverter.Lists.cs" />
+    <Compile Update="Converters/MarkdownToWordConverter.Inlines.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="System" />
     <Using Include="System.IO" />
     <Using Include="System.Linq" />

--- a/OfficeIMO.Word.Pdf/OfficeIMO.Word.Pdf.csproj
+++ b/OfficeIMO.Word.Pdf/OfficeIMO.Word.Pdf.csproj
@@ -14,6 +14,10 @@
   <ItemGroup>
     <ProjectReference Include="..\OfficeIMO.Word\OfficeIMO.Word.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="WordPdfConverterExtensions.Tables.cs" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="QuestPDF" Version="2025.7.0" />
   </ItemGroup>

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
@@ -1,51 +1,13 @@
+using DocumentFormat.OpenXml;
 using OfficeIMO.Word;
 using QuestPDF.Fluent;
 using QuestPDF.Infrastructure;
 using System;
 using System.Collections.Generic;
-using DocumentFormat.OpenXml;
 using W = DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word.Pdf {
     public static partial class WordPdfConverterExtensions {
-        static IContainer ApplyCellStyle(IContainer container, WordTableCell cell) {
-            if (!string.IsNullOrEmpty(cell.ShadingFillColorHex)) {
-                container = container.Background("#" + cell.ShadingFillColorHex);
-            }
-
-            WordTableCellBorder borders = cell.Borders;
-
-            List<string> colors = new() {
-                borders.TopColorHex,
-                borders.BottomColorHex,
-                borders.LeftColorHex,
-                borders.RightColorHex
-            };
-            colors.RemoveAll(string.IsNullOrEmpty);
-            if (colors.Count > 0 && colors.Distinct(StringComparer.OrdinalIgnoreCase).Count() == 1) {
-                container = container.BorderColor("#" + colors[0]);
-            }
-
-            if (HasBorder(borders.TopStyle)) {
-                container = container.BorderTop(GetBorderWidth(borders.TopSize));
-            }
-            if (HasBorder(borders.BottomStyle)) {
-                container = container.BorderBottom(GetBorderWidth(borders.BottomSize));
-            }
-            if (HasBorder(borders.LeftStyle)) {
-                container = container.BorderLeft(GetBorderWidth(borders.LeftSize));
-            }
-            if (HasBorder(borders.RightStyle)) {
-                container = container.BorderRight(GetBorderWidth(borders.RightSize));
-            }
-
-            return container;
-        }
-
-        static bool HasBorder(W.BorderValues? style) => style != null && style != W.BorderValues.Nil && style != W.BorderValues.None;
-
-        static float GetBorderWidth(UInt32Value size) => size != null ? size.Value / 8f : 1f;
-
         static IContainer RenderParagraph(IContainer container, WordParagraph paragraph, (int Level, string Marker)? marker) {
             if (paragraph == null) {
                 return container;

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Tables.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Tables.cs
@@ -1,0 +1,86 @@
+using DocumentFormat.OpenXml;
+using OfficeIMO.Word;
+using QuestPDF.Fluent;
+using QuestPDF.Infrastructure;
+using System;
+using System.Collections.Generic;
+using W = DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word.Pdf {
+    public static partial class WordPdfConverterExtensions {
+        private static IContainer RenderTable(IContainer container, WordTable table, Func<WordParagraph, (int Level, string Marker)?> getMarker) {
+            container.Table(tableContainer => {
+                TableLayout layout = TableLayoutCache.GetLayout(table);
+                tableContainer.ColumnsDefinition(columns => {
+                    foreach (float width in layout.ColumnWidths) {
+                        if (width > 0) {
+                            columns.ConstantColumn(width);
+                        } else {
+                            columns.RelativeColumn();
+                        }
+                    }
+                });
+
+                foreach (IReadOnlyList<WordTableCell> row in layout.Rows) {
+                    foreach (WordTableCell cell in row) {
+                        tableContainer.Cell().Element(cellContainer => {
+                            cellContainer = ApplyCellStyle(cellContainer, cell);
+
+                            cellContainer.Column(cellColumn => {
+                                foreach (WordParagraph paragraph in cell.Paragraphs) {
+                                    cellColumn.Item().Element(e => RenderParagraph(e, paragraph, getMarker(paragraph)));
+                                }
+
+                                foreach (WordTable nested in cell.NestedTables) {
+                                    cellColumn.Item().Element(e => RenderTable(e, nested, getMarker));
+                                }
+                            });
+
+                            return cellContainer;
+                        });
+                    }
+                }
+            });
+
+            return container;
+        }
+
+        private static IContainer ApplyCellStyle(IContainer container, WordTableCell cell) {
+            if (!string.IsNullOrEmpty(cell.ShadingFillColorHex)) {
+                container = container.Background("#" + cell.ShadingFillColorHex);
+            }
+
+            WordTableCellBorder borders = cell.Borders;
+
+            List<string> colors = new() {
+                borders.TopColorHex,
+                borders.BottomColorHex,
+                borders.LeftColorHex,
+                borders.RightColorHex
+            };
+            colors.RemoveAll(string.IsNullOrEmpty);
+            if (colors.Count > 0 && colors.Distinct(StringComparer.OrdinalIgnoreCase).Count() == 1) {
+                container = container.BorderColor("#" + colors[0]);
+            }
+
+            if (HasBorder(borders.TopStyle)) {
+                container = container.BorderTop(GetBorderWidth(borders.TopSize));
+            }
+            if (HasBorder(borders.BottomStyle)) {
+                container = container.BorderBottom(GetBorderWidth(borders.BottomSize));
+            }
+            if (HasBorder(borders.LeftStyle)) {
+                container = container.BorderLeft(GetBorderWidth(borders.LeftSize));
+            }
+            if (HasBorder(borders.RightStyle)) {
+                container = container.BorderRight(GetBorderWidth(borders.RightSize));
+            }
+
+            return container;
+        }
+
+        private static bool HasBorder(W.BorderValues? style) => style != null && style != W.BorderValues.Nil && style != W.BorderValues.None;
+
+        private static float GetBorderWidth(UInt32Value size) => size != null ? size.Value / 8f : 1f;
+    }
+}


### PR DESCRIPTION
## Summary
- split HtmlToWordConverter into partial files for formatting, images, lists, and tables
- split MarkdownToWordConverter into partial classes for lists, tables, and inline handling
- extract WordPdfConverterExtensions table rendering into its own partial class

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`
- `dotnet format OfficeIMO.Word.Html/OfficeIMO.Word.Html.csproj --no-restore` *(fails: Required references did not load for OfficeIMO.Word.Html)*
- `dotnet format OfficeIMO.Word.Markdown/OfficeIMO.Word.Markdown.csproj --no-restore` *(fails: Required references did not load for OfficeIMO.Word.Markdown)*
- `dotnet format OfficeIMO.Word.Pdf/OfficeIMO.Word.Pdf.csproj --no-restore` *(fails: Required references did not load for OfficeIMO.Word.Pdf)*

------
https://chatgpt.com/codex/tasks/task_e_68932746c254832ea8446a90f1003929