### PR TITLE
Support span styling in HTML converter

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.SpanStyles.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.SpanStyles.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlSpanStyles(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlSpanStyles.docx");
+            string html = "<p>Span with <span style=\"color:#ff0000;font-family:Arial;font-size:24px\">styled text</span></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.SpanStyles.cs
+++ b/OfficeIMO.Tests/Html.SpanStyles.cs
@@ -1,0 +1,20 @@
+using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
+using System.Linq;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_SpanStyles() {
+            string html = "<p><span style=\"color:#ff0000;font-family:Arial;font-size:24px\">Styled</span></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var run = doc.Paragraphs[0].GetRuns().First();
+
+            Assert.Equal("ff0000", run.ColorHex);
+            Assert.Equal("Arial", run.FontFamily);
+            Assert.Equal(24, run.FontSize);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -4,6 +4,8 @@ using OfficeIMO.Word;
 using OfficeIMO.Word.Html.Helpers;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 
 namespace OfficeIMO.Word.Html.Converters {
     internal partial class HtmlToWordConverter {
@@ -11,11 +13,17 @@ namespace OfficeIMO.Word.Html.Converters {
             public bool Bold;
             public bool Italic;
             public bool Underline;
+            public string? ColorHex;
+            public string? FontFamily;
+            public int? FontSize;
 
-            public TextFormatting(bool bold = false, bool italic = false, bool underline = false) {
+            public TextFormatting(bool bold = false, bool italic = false, bool underline = false, string? colorHex = null, string? fontFamily = null, int? fontSize = null) {
                 Bold = bold;
                 Italic = italic;
                 Underline = underline;
+                ColorHex = colorHex;
+                FontFamily = fontFamily;
+                FontSize = fontSize;
             }
         }
 
@@ -34,9 +42,7 @@ namespace OfficeIMO.Word.Html.Converters {
                 if (match.Index > lastIndex) {
                     var segment = text.Substring(lastIndex, match.Index - lastIndex);
                     var run = paragraph.AddFormattedText(segment, formatting.Bold, formatting.Italic, formatting.Underline ? UnderlineValues.Single : null);
-                    if (!string.IsNullOrEmpty(options.FontFamily)) {
-                        run.SetFontFamily(options.FontFamily);
-                    }
+                    ApplyFormatting(run, formatting, options);
                 }
                 var linkRun = paragraph.AddHyperLink(match.Value, new Uri(match.Value));
                 ApplyFormatting(linkRun, formatting, options);
@@ -44,9 +50,7 @@ namespace OfficeIMO.Word.Html.Converters {
             }
             if (lastIndex < text.Length) {
                 var run = paragraph.AddFormattedText(text.Substring(lastIndex), formatting.Bold, formatting.Italic, formatting.Underline ? UnderlineValues.Single : null);
-                if (!string.IsNullOrEmpty(options.FontFamily)) {
-                    run.SetFontFamily(options.FontFamily);
-                }
+                ApplyFormatting(run, formatting, options);
             }
         }
 
@@ -54,7 +58,91 @@ namespace OfficeIMO.Word.Html.Converters {
             if (formatting.Bold) run.SetBold();
             if (formatting.Italic) run.SetItalic();
             if (formatting.Underline) run.SetUnderline(UnderlineValues.Single);
-            if (!string.IsNullOrEmpty(options.FontFamily)) run.SetFontFamily(options.FontFamily);
+            if (!string.IsNullOrEmpty(formatting.ColorHex)) run.SetColorHex(formatting.ColorHex);
+            if (formatting.FontSize.HasValue) run.SetFontSize(formatting.FontSize.Value);
+            if (!string.IsNullOrEmpty(formatting.FontFamily)) {
+                run.SetFontFamily(formatting.FontFamily);
+            } else if (!string.IsNullOrEmpty(options.FontFamily)) {
+                run.SetFontFamily(options.FontFamily);
+            }
+        }
+
+        private static void ApplySpanStyles(IElement element, ref TextFormatting formatting) {
+            var style = element.GetAttribute("style");
+            if (string.IsNullOrWhiteSpace(style)) {
+                return;
+            }
+
+            foreach (var part in style.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
+                var pieces = part.Split(new[] { ':' }, 2);
+                if (pieces.Length != 2) {
+                    continue;
+                }
+                var name = pieces[0].Trim().ToLowerInvariant();
+                var value = pieces[1].Trim();
+                switch (name) {
+                    case "color":
+                        var color = NormalizeColor(value);
+                        if (color != null) {
+                            formatting.ColorHex = color;
+                        }
+                        break;
+                    case "font-family":
+                        formatting.FontFamily = value.Trim('"', '\'', ' ');
+                        break;
+                    case "font-size":
+                        if (TryParseFontSize(value, out int size)) {
+                            formatting.FontSize = size;
+                        }
+                        break;
+                }
+            }
+        }
+
+        private static bool TryParseFontSize(string value, out int size) {
+            size = 0;
+            if (string.IsNullOrWhiteSpace(value)) {
+                return false;
+            }
+            value = value.Trim().ToLowerInvariant();
+            string number = new(value.Where(c => char.IsDigit(c) || c == '.').ToArray());
+            if (!double.TryParse(number, NumberStyles.Number, CultureInfo.InvariantCulture, out double result)) {
+                return false;
+            }
+            if (value.EndsWith("em", StringComparison.Ordinal)) {
+                result *= 16;
+            }
+            size = (int)Math.Round(result);
+            return size > 0;
+        }
+
+        private static string? NormalizeColor(string value) {
+            if (string.IsNullOrWhiteSpace(value)) {
+                return null;
+            }
+            value = value.Trim();
+            if (value.StartsWith("#", StringComparison.Ordinal)) {
+                var hex = value.Substring(1);
+                if (hex.Length == 3) {
+                    hex = string.Concat(hex.Select(c => new string(c, 2)));
+                }
+                return hex.ToLowerInvariant();
+            }
+            if (value.StartsWith("rgb", StringComparison.OrdinalIgnoreCase)) {
+                int start = value.IndexOf('(');
+                int end = value.IndexOf(')');
+                if (start >= 0 && end > start) {
+                    var parts = value.Substring(start + 1, end - start - 1).Split(',');
+                    if (parts.Length >= 3 &&
+                        byte.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out byte r) &&
+                        byte.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out byte g) &&
+                        byte.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out byte b)) {
+                        var hex = string.Concat(r.ToString("X2"), g.ToString("X2"), b.ToString("X2"));
+                        return hex.ToLowerInvariant();
+                    }
+                }
+            }
+            return null;
         }
     }
 }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -112,6 +112,14 @@ namespace OfficeIMO.Word.Html.Converters {
                             }
                             break;
                         }
+                    case "span": {
+                            var fmt = formatting;
+                            ApplySpanStyles(element, ref fmt);
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
+                            }
+                            break;
+                        }
                     case "a": {
                             var href = element.GetAttribute("href");
                             if (!string.IsNullOrEmpty(href)) {


### PR DESCRIPTION
## Summary
- recognize `<span>` elements and apply inline color, font-family, and font-size styles to Word runs
- add example demonstrating span style conversion
- add tests verifying span style mapping to color, font family, and font size

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_689332e56c1c832e81a5befad90c5bd4