### PR TITLE
Support internal bookmark links in PDF conversion

### DIFF
--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
@@ -231,6 +231,26 @@ public partial class Word {
         Assert.Contains("/URI (https://evotec.xyz", pdfContent);
     }
 
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_BookmarkLink() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfBookmarkLink.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfBookmarkLink.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            var target = document.AddParagraph("Bookmark target");
+            target.AddBookmark("TargetBookmark");
+            document.AddHyperLink("Go to bookmark", "TargetBookmark");
+            document.Save();
+
+            document.SaveAsPdf(pdfPath);
+        }
+
+        Assert.True(File.Exists(pdfPath));
+
+        string pdfContent = Encoding.ASCII.GetString(File.ReadAllBytes(pdfPath));
+        Assert.Contains("/Dest /0#20|#20TargetBookmark", pdfContent);
+    }
+
     private static int IndexOf(byte[] buffer, byte[] pattern, int start) {
         for (int i = start; i <= buffer.Length - pattern.Length; i++) {
             int j = 0;

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
@@ -13,6 +13,19 @@ namespace OfficeIMO.Word.Pdf {
                 return container;
             }
 
+            if (paragraph.Bookmark != null) {
+                container = container.Section(paragraph.Bookmark.Name);
+            }
+
+            if (paragraph.IsHyperLink && paragraph.Hyperlink != null) {
+                var link = paragraph.Hyperlink;
+                if (!string.IsNullOrEmpty(link.Anchor)) {
+                    container = container.SectionLink(link.Anchor);
+                } else if (link.Uri != null) {
+                    container = container.Hyperlink(link.Uri.ToString());
+                }
+            }
+
             if (paragraph.ParagraphAlignment == W.JustificationValues.Center) {
                 container = container.AlignCenter();
             } else if (paragraph.ParagraphAlignment == W.JustificationValues.Right) {
@@ -46,20 +59,12 @@ namespace OfficeIMO.Word.Pdf {
                             }
                             row.ConstantItem(indentSize).Text(marker.Value.Marker);
                             row.RelativeItem().Text(text => {
-                                if (paragraph.IsHyperLink && paragraph.Hyperlink != null) {
-                                    ApplyFormatting(text.Hyperlink(content, paragraph.Hyperlink.Uri.ToString()));
-                                } else {
-                                    ApplyFormatting(text.Span(content));
-                                }
+                                ApplyFormatting(text.Span(content));
                             });
                         });
                     } else {
                         col.Item().Text(text => {
-                            if (paragraph.IsHyperLink && paragraph.Hyperlink != null) {
-                                ApplyFormatting(text.Hyperlink(content, paragraph.Hyperlink.Uri.ToString()));
-                            } else {
-                                ApplyFormatting(text.Span(content));
-                            }
+                            ApplyFormatting(text.Span(content));
                         });
                     }
                 }
@@ -127,9 +132,13 @@ namespace OfficeIMO.Word.Pdf {
                 return container;
             }
 
-            container.Text(text => {
-                text.Hyperlink(link.Text, link.Uri.ToString());
-            });
+            if (!string.IsNullOrEmpty(link.Anchor)) {
+                container = container.SectionLink(link.Anchor);
+            } else if (link.Uri != null) {
+                container = container.Hyperlink(link.Uri.ToString());
+            }
+
+            container.Text(link.Text);
 
             return container;
         }


### PR DESCRIPTION
## Summary
- ensure QuestPDF uses link elements when rendering hyperlinks
- detect Word bookmarks and expose them as PDF sections
- add PDF test for bookmark link rendering

## Testing
- `dotnet test`
- `dotnet build OfficeIMO.Word.Pdf/OfficeIMO.Word.Pdf.csproj -f net472` *(fails: The reference assemblies for .NETFramework,Version=v4.7.2 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_689333004758832e9e5e147458d7ac41