### PR TITLE
Parse paragraph CSS for color and size

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.ParagraphStyles.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.ParagraphStyles.cs
@@ -6,7 +6,7 @@ namespace OfficeIMO.Examples.Html {
     internal static partial class Html {
         public static void Example_HtmlParagraphStyles(string folderPath, bool openWord) {
             string filePath = Path.Combine(folderPath, "HtmlParagraphStyles.docx");
-            string html = "<p style=\"color:#ff0000;background-color:#ffff00;font-size:24px\">Styled paragraph</p>";
+            string html = "<p style=\"color:red;background-color:cyan;font-size:24px\">Styled paragraph</p>";
 
             var doc = html.LoadFromHtml(new HtmlToWordOptions());
             doc.Save(filePath);

--- a/OfficeIMO.Examples/Converters/Html/Html.ParagraphStyles.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.ParagraphStyles.cs
@@ -1,0 +1,19 @@
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlParagraphStyles(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlParagraphStyles.docx");
+            string html = "<p style=\"color:#ff0000;background-color:#ffff00;font-size:24px\">Styled paragraph</p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.ParagraphStyles.cs
+++ b/OfficeIMO.Tests/Html.ParagraphStyles.cs
@@ -16,5 +16,17 @@ namespace OfficeIMO.Tests {
             Assert.Equal(24, paragraph.FontSize);
             Assert.Equal(HighlightColorValues.Yellow, paragraph.Highlight);
         }
+
+        [Fact]
+        public void HtmlToWord_ParagraphStyles_NamedAndRgbColors() {
+            string html = "<p style=\"color:red;background-color:rgb(0,255,255);font-size:20px\">Styled</p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var paragraph = doc.Paragraphs[0];
+
+            Assert.Equal("ff0000", paragraph.ColorHex);
+            Assert.Equal(20, paragraph.FontSize);
+            Assert.Equal(HighlightColorValues.Cyan, paragraph.Highlight);
+        }
     }
 }

--- a/OfficeIMO.Tests/Html.ParagraphStyles.cs
+++ b/OfficeIMO.Tests/Html.ParagraphStyles.cs
@@ -1,0 +1,20 @@
+using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_ParagraphStyles_ColorAndSize() {
+            string html = "<p style=\"color:#ff0000;background-color:#ffff00;font-size:24px\">Styled</p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var paragraph = doc.Paragraphs[0];
+
+            Assert.Equal("ff0000", paragraph.ColorHex);
+            Assert.Equal(24, paragraph.FontSize);
+            Assert.Equal(HighlightColorValues.Yellow, paragraph.Highlight);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- handle paragraph inline style attributes for color, background-color and font-size
- test paragraph style color and font-size conversion
- add HTML example for paragraph styles

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68933d2552c0832eaa47fe381254b033