### PR TITLE
Handle strike and code in Markdown rendering

### DIFF
--- a/OfficeIMO.Examples/Converters/Markdown/Markdown02_SaveAsMarkdown.cs
+++ b/OfficeIMO.Examples/Converters/Markdown/Markdown02_SaveAsMarkdown.cs
@@ -20,6 +20,11 @@ namespace OfficeIMO.Examples.Word.Converters {
             paragraph.AddText("bold text").Bold = true;
             paragraph.AddText(" and ");
             paragraph.AddText("italic text").Italic = true;
+            paragraph.AddText(", ");
+            paragraph.AddText("strikethrough").Strike = true;
+            paragraph.AddText(", and inline ");
+            var codeFont = FontResolver.Resolve("monospace") ?? "Consolas";
+            paragraph.AddText("code").SetFontFamily(codeFont);
             paragraph.AddText(" plus a ");
             paragraph.AddHyperLink("link", new Uri("https://example.com"));
             paragraph.AddText(".");

--- a/OfficeIMO.Tests/Converters.Helpers.cs
+++ b/OfficeIMO.Tests/Converters.Helpers.cs
@@ -14,16 +14,21 @@ namespace OfficeIMO.Tests {
                 paragraph.AddFormattedText("Hello");
                 paragraph.AddFormattedText("Bold", bold: true);
                 paragraph.AddFormattedText("Italic", italic: true);
+                paragraph.AddFormattedText("Strike").Strike = true;
+                var codeRun = paragraph.AddFormattedText("Code");
+                codeRun.SetFontFamily(FontResolver.Resolve("monospace")!);
                 paragraph.AddHyperLink("Link", new Uri("https://example.com/"));
                 paragraph.AddImage(Path.Combine(_directoryWithImages, "EvotecLogo.png"));
 
                 document.Save();
 
                 var runs = FormattingHelper.GetFormattedRuns(paragraph).ToList();
-                Assert.Equal(5, runs.Count);
+                Assert.Equal(7, runs.Count);
                 Assert.Contains(runs, r => r.Text == "Hello" && !r.Bold);
                 Assert.Contains(runs, r => r.Text == "Bold" && r.Bold);
                 Assert.Contains(runs, r => r.Text == "Italic" && r.Italic);
+                Assert.Contains(runs, r => r.Text == "Strike" && r.Strike);
+                Assert.Contains(runs, r => r.Text == "Code" && r.Code);
                 Assert.Contains(runs, r => r.Text == "Link" && r.Hyperlink == "https://example.com/");
                 Assert.Contains(runs, r => r.Image != null);
             }

--- a/OfficeIMO.Tests/Markdown.WordToMarkdown.cs
+++ b/OfficeIMO.Tests/Markdown.WordToMarkdown.cs
@@ -15,6 +15,10 @@ namespace OfficeIMO.Tests {
             paragraph.AddText("bold").Bold = true;
             paragraph.AddText(" and ");
             paragraph.AddText("italic").Italic = true;
+            paragraph.AddText(" with ");
+            paragraph.AddText("strike").Strike = true;
+            paragraph.AddText(" and ");
+            paragraph.AddText("code").SetFontFamily(FontResolver.Resolve("monospace")!);
 
             var list = doc.AddList(WordListStyle.Bulleted);
             list.AddItem("Item 1");
@@ -37,6 +41,8 @@ namespace OfficeIMO.Tests {
             Assert.Contains("# Heading", markdown);
             Assert.Contains("**bold**", markdown);
             Assert.Contains("*italic*", markdown);
+            Assert.Contains("~~strike~~", markdown);
+            Assert.Contains("`code`", markdown);
             Assert.Contains("- Item 1", markdown);
             Assert.Contains("[OfficeIMO](https://example.com/)", markdown);
             Assert.Contains("| H1 | H2 |", markdown);

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.cs
@@ -90,6 +90,14 @@ namespace OfficeIMO.Word.Markdown.Converters {
                     text = $"*{text}*";
                 }
 
+                if (run.Strike) {
+                    text = $"~~{text}~~";
+                }
+
+                if (run.Code) {
+                    text = $"`{text}`";
+                }
+
                 if (!string.IsNullOrEmpty(run.Hyperlink)) {
                     text = $"[{text}]({run.Hyperlink})";
                 }

--- a/OfficeIMO.Word/Converters/FormattingHelper.cs
+++ b/OfficeIMO.Word/Converters/FormattingHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace OfficeIMO.Word {
@@ -14,14 +15,18 @@ namespace OfficeIMO.Word {
             public bool Bold { get; }
             public bool Italic { get; }
             public bool Underline { get; }
+            public bool Strike { get; }
+            public bool Code { get; }
             public string? Hyperlink { get; }
 
-            public FormattedRun(string? text, WordImage? image, bool bold, bool italic, bool underline, string? hyperlink) {
+            public FormattedRun(string? text, WordImage? image, bool bold, bool italic, bool underline, bool strike, bool code, string? hyperlink) {
                 Text = text;
                 Image = image;
                 Bold = bold;
                 Italic = italic;
                 Underline = underline;
+                Strike = strike;
+                Code = code;
                 Hyperlink = hyperlink;
             }
         }
@@ -36,7 +41,7 @@ namespace OfficeIMO.Word {
 
             foreach (WordParagraph run in paragraph.GetRuns()) {
                 if (run.IsImage && run.Image != null) {
-                    yield return new FormattedRun(null, run.Image, false, false, false, null);
+                    yield return new FormattedRun(null, run.Image, false, false, false, false, false, null);
                     continue;
                 }
 
@@ -46,7 +51,10 @@ namespace OfficeIMO.Word {
                 }
 
                 string? hyperlink = run.IsHyperLink && run.Hyperlink != null ? run.Hyperlink.Uri?.ToString() : null;
-                yield return new FormattedRun(text, null, run.Bold, run.Italic, run.Underline != null, hyperlink);
+                bool strike = run.Strike;
+                string? monospace = FontResolver.Resolve("monospace");
+                bool code = !string.IsNullOrEmpty(monospace) && string.Equals(run.FontFamily, monospace, StringComparison.OrdinalIgnoreCase);
+                yield return new FormattedRun(text, null, run.Bold, run.Italic, run.Underline != null, strike, code, hyperlink);
             }
         }
     }


### PR DESCRIPTION
## Summary
- expand formatted run tracking to include strikethrough and code flags
- render strike and inline code runs using `~~` and backticks in Markdown
- cover strike/code in tests and examples

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68934cf8d16c832ea59b8ec80549c6ad