### PR TITLE
Add div style inheritance for HTML to Word conversion

### DIFF
--- a/OfficeIMO.Tests/Html.DivStyles.cs
+++ b/OfficeIMO.Tests/Html.DivStyles.cs
@@ -1,0 +1,27 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_DivStyles_TextAlign() {
+            string html = "<div style=\"text-align:center\"><p>Centered</p></div>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var paragraph = doc.Paragraphs[0];
+
+            Assert.Equal(JustificationValues.Center, paragraph.ParagraphAlignment);
+        }
+
+        [Fact]
+        public void HtmlToWord_DivStyles_Margins() {
+            string html = "<div style=\"margin-left:20pt;padding-left:10pt\"><p>Indented</p></div>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var paragraph = doc.Paragraphs[0];
+
+            Assert.Equal(30d, paragraph.IndentationBeforePoints);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -84,6 +84,23 @@ namespace OfficeIMO.Word.Html.Converters {
                             }
                             break;
                         }
+                    case "div": {
+                            var fmt = formatting;
+                            var divStyle = element.GetAttribute("style");
+                            if (!string.IsNullOrWhiteSpace(divStyle)) {
+                                ApplySpanStyles(element, ref fmt);
+                            }
+                            foreach (var child in element.ChildNodes) {
+                                if (!string.IsNullOrWhiteSpace(divStyle) && child is IElement childElement) {
+                                    var merged = MergeStyles(divStyle, childElement.GetAttribute("style"));
+                                    if (!string.IsNullOrEmpty(merged)) {
+                                        childElement.SetAttribute("style", merged);
+                                    }
+                                }
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
+                            }
+                            break;
+                        }
                     case "br": {
                             currentParagraph ??= cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
                             currentParagraph.AddBreak();


### PR DESCRIPTION
## Summary
- propagate `<div>` CSS styles to child elements
- support text alignment, margin, and padding CSS for paragraphs
- test div style inheritance for alignment and margins

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~DivStyles" -v n`

------
https://chatgpt.com/codex/tasks/task_e_68934ca7110c832e8cee72d18f23971b