### PR TITLE
feat: add start and list style support for html lists

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.ListStartAndRoman.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.ListStartAndRoman.cs
@@ -1,0 +1,30 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlListStartAndRoman(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlListStartAndRoman.docx");
+
+            using var doc = WordDocument.Create();
+            var list = doc.AddList(WordListStyle.Headings111);
+            list.Numbering.Levels[0].SetStartNumberingValue(3);
+            list.AddItem("Third");
+            list.AddItem("Fourth");
+
+            var roman = doc.AddList(WordListStyle.HeadingIA1);
+            roman.AddItem("Intro");
+            roman.AddItem("Body");
+
+            string html = doc.ToHtml(new WordToHtmlOptions { IncludeListStyles = true });
+            Console.WriteLine(html);
+
+            doc.Save(filePath);
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.WordToHtml.cs
+++ b/OfficeIMO.Tests/Html.WordToHtml.cs
@@ -56,8 +56,8 @@ namespace OfficeIMO.Tests {
 
             string html = doc.ToHtml();
 
-            Assert.Contains("<ul>", html, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("<ol>", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<ul", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<ol", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Sub 1", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("<table>", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains(">A<", html, StringComparison.OrdinalIgnoreCase);
@@ -77,6 +77,31 @@ namespace OfficeIMO.Tests {
 
             Assert.Contains("data:image/png", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("content=\"Tester\"", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_ListStartAttribute() {
+            using var doc = WordDocument.Create();
+            var list = doc.AddList(WordListStyle.Headings111);
+            list.Numbering.Levels[0].SetStartNumberingValue(4);
+            list.AddItem("Four");
+            list.AddItem("Five");
+
+            string html = doc.ToHtml();
+
+            Assert.Contains("<ol start=\"4\"", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_RomanNumerals() {
+            using var doc = WordDocument.Create();
+            var list = doc.AddList(WordListStyle.HeadingIA1);
+            list.AddItem("Intro");
+            list.AddItem("Body");
+
+            string html = doc.ToHtml(new WordToHtmlOptions { IncludeListStyles = true });
+
+            Assert.Contains("list-style-type:upper-roman", html, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/OfficeIMO.Word/Converters/DocumentTraversal.cs
+++ b/OfficeIMO.Word/Converters/DocumentTraversal.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml.Wordprocessing;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,25 @@ namespace OfficeIMO.Word {
     /// Provides helper methods for traversing documents and resolving list markers.
     /// </summary>
     public static class DocumentTraversal {
+        /// <summary>
+        /// Describes list information for a paragraph.
+        /// </summary>
+        public readonly struct ListInfo {
+            public ListInfo(int level, bool ordered, int start, NumberFormatValues? format, string? text) {
+                Level = level;
+                Ordered = ordered;
+                Start = start;
+                NumberFormat = format;
+                LevelText = text;
+            }
+
+            public int Level { get; }
+            public bool Ordered { get; }
+            public int Start { get; }
+            public NumberFormatValues? NumberFormat { get; }
+            public string? LevelText { get; }
+        }
+
         /// <summary>
         /// Enumerates all sections within the document.
         /// </summary>
@@ -18,20 +38,32 @@ namespace OfficeIMO.Word {
         /// Resolves list information for the given paragraph.
         /// </summary>
         /// <param name="paragraph">Paragraph to inspect.</param>
-        /// <returns>Tuple containing list level and whether the list is ordered.</returns>
-        public static (int Level, bool Ordered)? GetListInfo(WordParagraph paragraph) {
+        /// <returns>List info for the paragraph or null when paragraph isn't a list item.</returns>
+        public static ListInfo? GetListInfo(WordParagraph paragraph) {
             if (paragraph == null || !paragraph.IsListItem) {
                 return null;
             }
 
             int level = paragraph.ListItemLevel ?? 0;
+            int start = 1;
+            NumberFormatValues? numberFormat = null;
+            string? levelText = null;
+
+            int? numberId = paragraph._listNumberId;
+            var list = numberId.HasValue ? paragraph._document?.Lists.FirstOrDefault(l => l._numberId == numberId) : null;
+            var wordLevel = list?.Numbering.Levels.FirstOrDefault(l => l._level.LevelIndex == level);
+            if (wordLevel != null) {
+                start = wordLevel.StartNumberingValue;
+                numberFormat = wordLevel._level.NumberingFormat?.Val;
+                levelText = wordLevel.LevelText;
+            }
+
             bool ordered = paragraph.ListStyle switch {
                 WordListStyle.Bulleted => false,
                 WordListStyle.BulletedChars => false,
                 _ => true,
             };
-
-            return (level, ordered);
+            return new ListInfo(level, ordered, start, numberFormat, levelText);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- capture list start and numbering format during traversal
- emit CSS list-style-type and start attribute when converting lists to HTML
- cover start values and roman numerals in unit tests and examples

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68934cc23adc832ea3e95791d3672a3f