### PR TITLE
Improve VML handling

### DIFF
--- a/OfficeIMO.Examples/Word/Images/Images.DrawingVsVml.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.DrawingVsVml.cs
@@ -16,6 +16,7 @@ namespace OfficeIMO.Examples.Word {
                 doc.AddParagraph().AddImage(img);
                 doc.AddShapeDrawing(ShapeType.Ellipse, 40, 40);
                 doc.AddShapeDrawing(ShapeType.Rectangle, 60, 30);
+                doc.AddShapeDrawing(ShapeType.RoundedRectangle, 50, 30);
                 doc.AddTextBox("Text");
                 doc.Save(false);
             }
@@ -25,6 +26,7 @@ namespace OfficeIMO.Examples.Word {
                 doc.AddImageVml(img);
                 doc.AddShape(ShapeType.Ellipse, 40, 40, Color.Red, Color.Blue);
                 doc.AddShape(ShapeType.Rectangle, 60, 30, Color.Green, Color.Black);
+                doc.AddShape(ShapeType.RoundedRectangle, 50, 30, Color.Yellow, Color.Black, 1, arcSize: 0.3);
                 doc.AddTextBoxVml("Text");
                 doc.Save(false);
             }

--- a/OfficeIMO.Examples/Word/Images/Images.DrawingVsVml.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.DrawingVsVml.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Images {
+        internal static void Example_DrawingVsVml(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating DrawingML and VML sample documents");
+
+            string assets = Path.Combine(Directory.GetCurrentDirectory(), "Assets");
+            string img = Path.Combine(assets, "OfficeIMO.png");
+
+            string drawingFile = Path.Combine(folderPath, "DrawingVsVml.Drawing.docx");
+            using (WordDocument doc = WordDocument.Create(drawingFile)) {
+                doc.AddParagraph().AddImage(img);
+                doc.AddShapeDrawing(ShapeType.Ellipse, 40, 40);
+                doc.AddShapeDrawing(ShapeType.Rectangle, 60, 30);
+                doc.AddTextBox("Text");
+                doc.Save(false);
+            }
+
+            string vmlFile = Path.Combine(folderPath, "DrawingVsVml.Vml.docx");
+            using (WordDocument doc = WordDocument.Create(vmlFile)) {
+                doc.AddImageVml(img);
+                doc.AddShape(ShapeType.Ellipse, 40, 40, Color.Red, Color.Blue);
+                doc.AddShape(ShapeType.Rectangle, 60, 30, Color.Green, Color.Black);
+                doc.AddTextBoxVml("Text");
+                doc.Save(false);
+            }
+
+            using (WordDocument doc = WordDocument.Load(drawingFile)) {
+                Console.WriteLine($"DrawingML -> Images: {doc.Images.Count}, Shapes: {doc.Shapes.Count}, TextBoxes: {doc.TextBoxes.Count}");
+            }
+
+            using (WordDocument doc = WordDocument.Load(vmlFile)) {
+                Console.WriteLine($"VML -> Images: {doc.Images.Count}, Shapes: {doc.Shapes.Count}, TextBoxes: {doc.TextBoxes.Count}");
+            }
+
+            if (openWord) {
+                Console.WriteLine("OpenWord flag is set but opening is not implemented in this environment.");
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Examples/Word/Shapes/Shapes.SectionAndHeader.cs
+++ b/OfficeIMO.Examples/Word/Shapes/Shapes.SectionAndHeader.cs
@@ -1,0 +1,24 @@
+using System;
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Shapes {
+        internal static void Example_AddShapesInSectionAndHeader(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with shapes in section and header");
+            string filePath = System.IO.Path.Combine(folderPath, "DocumentWithSectionAndHeaderShapes.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var section = document.Sections[0];
+                section.AddShape(ShapeType.Rectangle, 50, 25, Color.Red, Color.Black);
+                section.AddShapeDrawing(ShapeType.Ellipse, 40, 40);
+
+                section.AddHeadersAndFooters();
+                section.Header.Default.AddShape(ShapeType.Rectangle, 30, 20, Color.Blue, Color.Black);
+                section.Header.Default.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Shapes/Shapes.SectionAndHeader.cs
+++ b/OfficeIMO.Examples/Word/Shapes/Shapes.SectionAndHeader.cs
@@ -11,10 +11,12 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var section = document.Sections[0];
                 section.AddShape(ShapeType.Rectangle, 50, 25, Color.Red, Color.Black);
+                section.AddShape(ShapeType.RoundedRectangle, 40, 20, Color.Yellow, Color.Purple, 1, arcSize: 0.3);
                 section.AddShapeDrawing(ShapeType.Ellipse, 40, 40);
 
                 section.AddHeadersAndFooters();
                 section.Header.Default.AddShape(ShapeType.Rectangle, 30, 20, Color.Blue, Color.Black);
+                section.Header.Default.AddShape(ShapeType.RoundedRectangle, 25, 15, Color.Green, Color.Black, 1, arcSize: 0.3);
                 section.Header.Default.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
 
                 document.Save(openWord);

--- a/OfficeIMO.Tests/Word.DrawingVsVml.cs
+++ b/OfficeIMO.Tests/Word.DrawingVsVml.cs
@@ -16,12 +16,13 @@ namespace OfficeIMO.Tests {
                 doc.AddParagraph().AddImage(img);
                 doc.AddShapeDrawing(ShapeType.Ellipse, 40, 40);
                 doc.AddShapeDrawing(ShapeType.Rectangle, 60, 30);
+                doc.AddShapeDrawing(ShapeType.RoundedRectangle, 50, 30);
                 doc.AddTextBox("Text");
                 doc.Save(false);
             }
             using (WordDocument doc = WordDocument.Load(drawingFile)) {
                 Assert.Single(doc.Images);
-                Assert.Equal(2, doc.Shapes.Count);
+                Assert.Equal(3, doc.Shapes.Count);
                 Assert.Single(doc.TextBoxes);
             }
 
@@ -30,12 +31,13 @@ namespace OfficeIMO.Tests {
                 doc.AddImageVml(img);
                 doc.AddShape(ShapeType.Ellipse, 40, 40, Color.Red, Color.Blue);
                 doc.AddShape(ShapeType.Rectangle, 60, 30, Color.Green, Color.Black);
+                doc.AddShape(ShapeType.RoundedRectangle, 50, 30, Color.Yellow, Color.Black, 1, arcSize: 0.3);
                 doc.AddTextBoxVml("Text");
                 doc.Save(false);
             }
             using (WordDocument doc = WordDocument.Load(vmlFile)) {
                 Assert.Single(doc.Images);
-                Assert.Equal(2, doc.Shapes.Count);
+                Assert.Equal(3, doc.Shapes.Count);
                 Assert.Single(doc.TextBoxes);
             }
         }

--- a/OfficeIMO.Tests/Word.DrawingVsVml.cs
+++ b/OfficeIMO.Tests/Word.DrawingVsVml.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using OfficeIMO.Word;
+using Color = SixLabors.ImageSharp.Color;
+using Xunit;
+using Path = System.IO.Path;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_DrawingVsVmlCounts() {
+            string assets = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../..", "Assets"));
+            string img = Path.Combine(assets, "OfficeIMO.png");
+
+            string drawingFile = Path.Combine(_directoryWithFiles, "DrawingCounts.docx");
+            using (WordDocument doc = WordDocument.Create(drawingFile)) {
+                doc.AddParagraph().AddImage(img);
+                doc.AddShapeDrawing(ShapeType.Ellipse, 40, 40);
+                doc.AddShapeDrawing(ShapeType.Rectangle, 60, 30);
+                doc.AddTextBox("Text");
+                doc.Save(false);
+            }
+            using (WordDocument doc = WordDocument.Load(drawingFile)) {
+                Assert.Single(doc.Images);
+                Assert.Equal(2, doc.Shapes.Count);
+                Assert.Single(doc.TextBoxes);
+            }
+
+            string vmlFile = Path.Combine(_directoryWithFiles, "VmlCounts.docx");
+            using (WordDocument doc = WordDocument.Create(vmlFile)) {
+                doc.AddImageVml(img);
+                doc.AddShape(ShapeType.Ellipse, 40, 40, Color.Red, Color.Blue);
+                doc.AddShape(ShapeType.Rectangle, 60, 30, Color.Green, Color.Black);
+                doc.AddTextBoxVml("Text");
+                doc.Save(false);
+            }
+            using (WordDocument doc = WordDocument.Load(vmlFile)) {
+                Assert.Single(doc.Images);
+                Assert.Equal(2, doc.Shapes.Count);
+                Assert.Single(doc.TextBoxes);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Word.Shapes.cs
+++ b/OfficeIMO.Tests/Word.Shapes.cs
@@ -123,5 +123,29 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(Color.Yellow.ToHexColor(), document.Shapes[0].FillColorHex);
             }
         }
+
+        [Fact]
+        public void Test_ShapesInSectionAndHeader() {
+            string filePath = Path.Combine(_directoryWithFiles, "SectionHeaderShapes.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var section = document.Sections[0];
+                section.AddShape(ShapeType.Rectangle, 40, 20, Color.Red, Color.Black);
+                section.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
+
+                section.AddHeadersAndFooters();
+                section.Header.Default.AddShape(ShapeType.Rectangle, 30, 15, Color.Blue, Color.Black);
+                section.Header.Default.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
+
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var section = document.Sections[0];
+                Assert.Equal(2, document.Shapes.Count);
+                Assert.Equal(2, section.Shapes.Count);
+                Assert.True(section.Header.Default.Paragraphs[0].IsShape);
+                Assert.True(section.Header.Default.Paragraphs[1].IsShape);
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Word.Shapes.cs
+++ b/OfficeIMO.Tests/Word.Shapes.cs
@@ -130,10 +130,12 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var section = document.Sections[0];
                 section.AddShape(ShapeType.Rectangle, 40, 20, Color.Red, Color.Black);
+                section.AddShape(ShapeType.RoundedRectangle, 30, 15, Color.Yellow, Color.Black, 1, arcSize: 0.3);
                 section.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
 
                 section.AddHeadersAndFooters();
                 section.Header.Default.AddShape(ShapeType.Rectangle, 30, 15, Color.Blue, Color.Black);
+                section.Header.Default.AddShape(ShapeType.RoundedRectangle, 25, 15, Color.Green, Color.Black, 1, arcSize: 0.3);
                 section.Header.Default.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
 
                 document.Save(false);
@@ -141,10 +143,28 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 var section = document.Sections[0];
-                Assert.Equal(2, document.Shapes.Count);
-                Assert.Equal(2, section.Shapes.Count);
+                Assert.Equal(3, document.Shapes.Count);
+                Assert.Equal(3, section.Shapes.Count);
                 Assert.True(section.Header.Default.Paragraphs[0].IsShape);
                 Assert.True(section.Header.Default.Paragraphs[1].IsShape);
+                Assert.True(section.Header.Default.Paragraphs[2].IsShape);
+            }
+        }
+
+        [Fact]
+        public void Test_AddRoundedRectangleShape() {
+            string filePath = Path.Combine(_directoryWithFiles, "RoundedRectangleShape.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var shape = document.AddShape(ShapeType.RoundedRectangle, 60, 30, Color.Lime, Color.Black, 1, arcSize: 0.3);
+                Assert.True(document.Paragraphs[0].IsShape);
+                Assert.NotNull(shape.ArcSize);
+                Assert.InRange(shape.ArcSize!.Value, 0.29, 0.31);
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.True(document.Paragraphs[0].IsShape);
+                Assert.InRange(document.Paragraphs[0].Shape.ArcSize!.Value, 0.29, 0.31);
             }
         }
     }

--- a/OfficeIMO.Word/Enumerations.cs
+++ b/OfficeIMO.Word/Enumerations.cs
@@ -74,6 +74,11 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// A straight line shape.
         /// </summary>
-        Line
+        Line,
+
+        /// <summary>
+        /// A rectangle with rounded corners.
+        /// </summary>
+        RoundedRectangle
     }
 }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -139,6 +139,15 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Inserts a VML image into the document.
+        /// </summary>
+        public WordImage AddImageVml(string filePathImage, double? width = null, double? height = null) {
+            var paragraph = AddParagraph();
+            paragraph.AddImageVml(filePathImage, width, height);
+            return paragraph.Image;
+        }
+
+        /// <summary>
         /// Adds the chart to the document. The type of chart is determined by the type of data passed in.
         /// You can use multiple:
         /// .AddBar() to add a bar chart
@@ -434,6 +443,14 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Inserts a VML text box into the document.
+        /// </summary>
+        public WordTextBox AddTextBoxVml(string text) {
+            var paragraph = this.AddParagraph();
+            return paragraph.AddTextBoxVml(text);
+        }
+
+        /// <summary>
         /// Adds a basic shape to the document in a new paragraph.
         /// </summary>
         /// <param name="shapeType">Type of shape to create.</param>
@@ -455,6 +472,17 @@ namespace OfficeIMO.Word {
         public WordShape AddShape(ShapeType shapeType, double widthPt, double heightPt,
             SixLabors.ImageSharp.Color fillColor, SixLabors.ImageSharp.Color strokeColor, double strokeWeightPt = 1) {
             return AddShape(shapeType, widthPt, heightPt, fillColor.ToHexColor(), strokeColor.ToHexColor(), strokeWeightPt);
+        }
+
+        /// <summary>
+        /// Adds a DrawingML shape to the document in a new paragraph.
+        /// </summary>
+        /// <param name="shapeType">Type of shape to create.</param>
+        /// <param name="widthPt">Width in points.</param>
+        /// <param name="heightPt">Height in points.</param>
+        public WordShape AddShapeDrawing(ShapeType shapeType, double widthPt, double heightPt) {
+            var paragraph = AddParagraph();
+            return paragraph.AddShapeDrawing(shapeType, widthPt, heightPt);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -459,19 +459,20 @@ namespace OfficeIMO.Word {
         /// <param name="fillColor">Fill color in hex format.</param>
         /// <param name="strokeColor">Stroke color in hex format.</param>
         /// <param name="strokeWeightPt">Stroke weight in points.</param>
+        /// <param name="arcSize">Corner roundness fraction for rounded rectangles.</param>
         /// <returns>The created <see cref="WordShape"/>.</returns>
         public WordShape AddShape(ShapeType shapeType, double widthPt, double heightPt,
-            string fillColor = "#FFFFFF", string strokeColor = "#000000", double strokeWeightPt = 1) {
+            string fillColor = "#FFFFFF", string strokeColor = "#000000", double strokeWeightPt = 1, double arcSize = 0.25) {
             var paragraph = AddParagraph();
-            return paragraph.AddShape(shapeType, widthPt, heightPt, fillColor, strokeColor, strokeWeightPt);
+            return paragraph.AddShape(shapeType, widthPt, heightPt, fillColor, strokeColor, strokeWeightPt, arcSize);
         }
 
         /// <summary>
         /// Adds a basic shape to the document using <see cref="SixLabors.ImageSharp.Color"/> values.
         /// </summary>
         public WordShape AddShape(ShapeType shapeType, double widthPt, double heightPt,
-            SixLabors.ImageSharp.Color fillColor, SixLabors.ImageSharp.Color strokeColor, double strokeWeightPt = 1) {
-            return AddShape(shapeType, widthPt, heightPt, fillColor.ToHexColor(), strokeColor.ToHexColor(), strokeWeightPt);
+            SixLabors.ImageSharp.Color fillColor, SixLabors.ImageSharp.Color strokeColor, double strokeWeightPt = 1, double arcSize = 0.25) {
+            return AddShape(shapeType, widthPt, heightPt, fillColor.ToHexColor(), strokeColor.ToHexColor(), strokeWeightPt, arcSize);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordHeader.cs
+++ b/OfficeIMO.Word/WordHeader.cs
@@ -168,17 +168,18 @@ namespace OfficeIMO.Word {
         /// <param name="fillColor">Fill color in hex format.</param>
         /// <param name="strokeColor">Stroke color in hex format.</param>
         /// <param name="strokeWeightPt">Stroke weight in points.</param>
+        /// <param name="arcSize">Corner roundness fraction for rounded rectangles.</param>
         public WordShape AddShape(ShapeType shapeType, double widthPt, double heightPt,
-            string fillColor = "#FFFFFF", string strokeColor = "#000000", double strokeWeightPt = 1) {
-            return AddParagraph(newRun: true).AddShape(shapeType, widthPt, heightPt, fillColor, strokeColor, strokeWeightPt);
+            string fillColor = "#FFFFFF", string strokeColor = "#000000", double strokeWeightPt = 1, double arcSize = 0.25) {
+            return AddParagraph(newRun: true).AddShape(shapeType, widthPt, heightPt, fillColor, strokeColor, strokeWeightPt, arcSize);
         }
 
         /// <summary>
         /// Adds a VML shape to the header using <see cref="SixLabors.ImageSharp.Color"/> values.
         /// </summary>
         public WordShape AddShape(ShapeType shapeType, double widthPt, double heightPt,
-            SixLabors.ImageSharp.Color fillColor, SixLabors.ImageSharp.Color strokeColor, double strokeWeightPt = 1) {
-            return AddShape(shapeType, widthPt, heightPt, fillColor.ToHexColor(), strokeColor.ToHexColor(), strokeWeightPt);
+            SixLabors.ImageSharp.Color fillColor, SixLabors.ImageSharp.Color strokeColor, double strokeWeightPt = 1, double arcSize = 0.25) {
+            return AddShape(shapeType, widthPt, heightPt, fillColor.ToHexColor(), strokeColor.ToHexColor(), strokeWeightPt, arcSize);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordHeader.cs
+++ b/OfficeIMO.Word/WordHeader.cs
@@ -141,5 +141,22 @@ namespace OfficeIMO.Word {
             WordTextBox wordTextBox = new WordTextBox(this._document, this, text, wrapTextImage);
             return wordTextBox;
         }
+
+        /// <summary>
+        /// Adds a VML text box to the header.
+        /// </summary>
+        public WordTextBox AddTextBoxVml(string text) {
+            var paragraph = AddParagraph(newRun: true);
+            return paragraph.AddTextBoxVml(text);
+        }
+
+        /// <summary>
+        /// Adds a VML image to the header.
+        /// </summary>
+        public WordImage AddImageVml(string filePathImage, double? width = null, double? height = null) {
+            var paragraph = AddParagraph(newRun: true);
+            paragraph.AddImageVml(filePathImage, width, height);
+            return paragraph.Image;
+        }
     }
 }

--- a/OfficeIMO.Word/WordHeader.cs
+++ b/OfficeIMO.Word/WordHeader.cs
@@ -158,5 +158,37 @@ namespace OfficeIMO.Word {
             paragraph.AddImageVml(filePathImage, width, height);
             return paragraph.Image;
         }
+
+        /// <summary>
+        /// Adds a VML shape to the header.
+        /// </summary>
+        /// <param name="shapeType">Type of shape to create.</param>
+        /// <param name="widthPt">Width in points or line end X.</param>
+        /// <param name="heightPt">Height in points or line end Y.</param>
+        /// <param name="fillColor">Fill color in hex format.</param>
+        /// <param name="strokeColor">Stroke color in hex format.</param>
+        /// <param name="strokeWeightPt">Stroke weight in points.</param>
+        public WordShape AddShape(ShapeType shapeType, double widthPt, double heightPt,
+            string fillColor = "#FFFFFF", string strokeColor = "#000000", double strokeWeightPt = 1) {
+            return AddParagraph(newRun: true).AddShape(shapeType, widthPt, heightPt, fillColor, strokeColor, strokeWeightPt);
+        }
+
+        /// <summary>
+        /// Adds a VML shape to the header using <see cref="SixLabors.ImageSharp.Color"/> values.
+        /// </summary>
+        public WordShape AddShape(ShapeType shapeType, double widthPt, double heightPt,
+            SixLabors.ImageSharp.Color fillColor, SixLabors.ImageSharp.Color strokeColor, double strokeWeightPt = 1) {
+            return AddShape(shapeType, widthPt, heightPt, fillColor.ToHexColor(), strokeColor.ToHexColor(), strokeWeightPt);
+        }
+
+        /// <summary>
+        /// Adds a DrawingML shape to the header.
+        /// </summary>
+        /// <param name="shapeType">Type of shape to create.</param>
+        /// <param name="widthPt">Width in points.</param>
+        /// <param name="heightPt">Height in points.</param>
+        public WordShape AddShapeDrawing(ShapeType shapeType, double widthPt, double heightPt) {
+            return AddParagraph(newRun: true).AddShapeDrawing(shapeType, widthPt, heightPt);
+        }
     }
 }

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -8,6 +8,7 @@ using DocumentFormat.OpenXml.Wordprocessing;
 using System.Linq;
 using Anchor = DocumentFormat.OpenXml.Drawing.Wordprocessing.Anchor;
 using ShapeProperties = DocumentFormat.OpenXml.Drawing.Pictures.ShapeProperties;
+using V = DocumentFormat.OpenXml.Vml;
 
 #nullable enable annotations
 using DocumentFormat.OpenXml.Office2010.Word.Drawing;
@@ -57,6 +58,9 @@ namespace OfficeIMO.Word {
         private int? _luminanceContrast;
         private int? _tintAmount;
         private int? _tintHue;
+
+        internal V.Shape _vmlShape;
+        internal V.ImageData _vmlImageData;
 
         /// <summary>
         /// Get or set the Image's horizontal position.
@@ -1960,6 +1964,15 @@ namespace OfficeIMO.Word {
                     _useLocalDpi = ext?.GetFirstChild<DocumentFormat.OpenXml.Office2010.Drawing.UseLocalDpi>()?.Val?.Value;
                 }
             }
+        }
+
+        /// <summary>
+        /// Wraps an existing VML image as a WordImage.
+        /// </summary>
+        internal WordImage(WordDocument document, DocumentFormat.OpenXml.Wordprocessing.Paragraph paragraph, DocumentFormat.OpenXml.Wordprocessing.Run run, V.Shape shape) {
+            _document = document;
+            _vmlShape = shape;
+            _vmlImageData = shape.GetFirstChild<V.ImageData>();
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Xml.Linq;
 using MathParagraph = DocumentFormat.OpenXml.Math.Paragraph;
 using OfficeMath = DocumentFormat.OpenXml.Math.OfficeMath;
+using V = DocumentFormat.OpenXml.Vml;
 
 namespace OfficeIMO.Word {
     /// <summary>
@@ -674,6 +675,61 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Adds a legacy VML text box to the paragraph.
+        /// </summary>
+        public WordTextBox AddTextBoxVml(string text) {
+            var run = this.VerifyRun();
+            var shape = new V.Shape() {
+                Id = "TextBox" + Guid.NewGuid().ToString("N"),
+                Style = "mso-wrap-style:square"
+            };
+
+            var textbox = new V.TextBox();
+            var content = new TextBoxContent(new Paragraph(new Run(new Text(text))));
+            textbox.Append(content);
+            shape.Append(textbox);
+
+            Picture pict = new Picture();
+            pict.Append(shape);
+            run.Append(pict);
+
+            return new WordTextBox(this._document, this._paragraph, run);
+        }
+
+        /// <summary>
+        /// Adds a legacy VML image to the paragraph.
+        /// </summary>
+        public WordParagraph AddImageVml(string filePathImage, double? width = null, double? height = null) {
+            var run = this.VerifyRun();
+            var mainPart = _document._wordprocessingDocument.MainDocumentPart;
+
+            var imagePart = mainPart.AddImagePart(ImagePartType.Png);
+            using (var fs = File.OpenRead(filePathImage)) {
+                imagePart.FeedData(fs);
+            }
+            var relId = mainPart.GetIdOfPart(imagePart);
+
+            string style = "mso-wrap-style:square";
+            if (width.HasValue) style = $"width:{width}pt;" + style;
+            if (height.HasValue) style = $"height:{height}pt;" + style;
+
+            var shape = new V.Shape() {
+                Id = "Image" + Guid.NewGuid().ToString("N"),
+                Style = style,
+                Type = "#_x0000_t75"
+            };
+            var imageData = new V.ImageData() {
+                RelationshipId = relId,
+                Title = Path.GetFileName(filePathImage)
+            };
+            shape.Append(imageData);
+            Picture pict = new Picture();
+            pict.Append(shape);
+            run.Append(pict);
+            return this;
+        }
+
+        /// <summary>
         /// Add a rectangle shape to the paragraph.
         /// </summary>
         /// <param name="widthPt">Width in points.</param>
@@ -729,6 +785,16 @@ namespace OfficeIMO.Word {
         public WordShape AddShape(ShapeType shapeType, double widthPt, double heightPt,
             SixLabors.ImageSharp.Color fillColor, SixLabors.ImageSharp.Color strokeColor, double strokeWeightPt = 1) {
             return AddShape(shapeType, widthPt, heightPt, fillColor.ToHexColor(), strokeColor.ToHexColor(), strokeWeightPt);
+        }
+
+        /// <summary>
+        /// Adds a DrawingML shape to the paragraph.
+        /// </summary>
+        /// <param name="shapeType">Type of shape to create.</param>
+        /// <param name="widthPt">Width in points.</param>
+        /// <param name="heightPt">Height in points.</param>
+        public WordShape AddShapeDrawing(ShapeType shapeType, double widthPt, double heightPt) {
+            return WordShape.AddDrawingShape(this, shapeType, widthPt, heightPt);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -756,8 +756,9 @@ namespace OfficeIMO.Word {
         /// <param name="fillColor">Fill color in hex format.</param>
         /// <param name="strokeColor">Stroke color in hex format.</param>
         /// <param name="strokeWeightPt">Stroke weight in points.</param>
+        /// <param name="arcSize">Corner roundness fraction for rounded rectangles.</param>
         public WordShape AddShape(ShapeType shapeType, double widthPt, double heightPt,
-            string fillColor = "#FFFFFF", string strokeColor = "#000000", double strokeWeightPt = 1) {
+            string fillColor = "#FFFFFF", string strokeColor = "#000000", double strokeWeightPt = 1, double arcSize = 0.25) {
             WordShape shape;
             switch (shapeType) {
                 case ShapeType.Rectangle:
@@ -765,6 +766,9 @@ namespace OfficeIMO.Word {
                     break;
                 case ShapeType.Ellipse:
                     shape = WordShape.AddEllipse(this, widthPt, heightPt, fillColor);
+                    break;
+                case ShapeType.RoundedRectangle:
+                    shape = WordShape.AddRoundedRectangle(this, widthPt, heightPt, fillColor, arcSize);
                     break;
                 case ShapeType.Line:
                     shape = WordShape.AddLine(this, 0, 0, widthPt, heightPt, strokeColor, strokeWeightPt);
@@ -783,8 +787,8 @@ namespace OfficeIMO.Word {
         /// Adds a basic shape to the paragraph using <see cref="SixLabors.ImageSharp.Color"/> values.
         /// </summary>
         public WordShape AddShape(ShapeType shapeType, double widthPt, double heightPt,
-            SixLabors.ImageSharp.Color fillColor, SixLabors.ImageSharp.Color strokeColor, double strokeWeightPt = 1) {
-            return AddShape(shapeType, widthPt, heightPt, fillColor.ToHexColor(), strokeColor.ToHexColor(), strokeWeightPt);
+            SixLabors.ImageSharp.Color fillColor, SixLabors.ImageSharp.Color strokeColor, double strokeWeightPt = 1, double arcSize = 0.25) {
+            return AddShape(shapeType, widthPt, heightPt, fillColor.ToHexColor(), strokeColor.ToHexColor(), strokeWeightPt, arcSize);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -155,6 +155,22 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Adds a VML text box paragraph to the section.
+        /// </summary>
+        public WordTextBox AddTextBoxVml(string text) {
+            return AddParagraph(newRun: true).AddTextBoxVml(text);
+        }
+
+        /// <summary>
+        /// Adds a VML image to the section.
+        /// </summary>
+        public WordImage AddImageVml(string filePathImage, double? width = null, double? height = null) {
+            var paragraph = AddParagraph(newRun: true);
+            paragraph.AddImageVml(filePathImage, width, height);
+            return paragraph.Image;
+        }
+
+        /// <summary>
         /// Inserts a SmartArt diagram into this section.
         /// </summary>
         /// <param name="type">Layout type of the SmartArt.</param>

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -179,17 +179,18 @@ namespace OfficeIMO.Word {
         /// <param name="fillColor">Fill color in hex format.</param>
         /// <param name="strokeColor">Stroke color in hex format.</param>
         /// <param name="strokeWeightPt">Stroke weight in points.</param>
+        /// <param name="arcSize">Corner roundness fraction for rounded rectangles.</param>
         public WordShape AddShape(ShapeType shapeType, double widthPt, double heightPt,
-            string fillColor = "#FFFFFF", string strokeColor = "#000000", double strokeWeightPt = 1) {
-            return AddParagraph(newRun: true).AddShape(shapeType, widthPt, heightPt, fillColor, strokeColor, strokeWeightPt);
+            string fillColor = "#FFFFFF", string strokeColor = "#000000", double strokeWeightPt = 1, double arcSize = 0.25) {
+            return AddParagraph(newRun: true).AddShape(shapeType, widthPt, heightPt, fillColor, strokeColor, strokeWeightPt, arcSize);
         }
 
         /// <summary>
         /// Adds a VML shape to the section using <see cref="SixLabors.ImageSharp.Color"/> values.
         /// </summary>
         public WordShape AddShape(ShapeType shapeType, double widthPt, double heightPt,
-            SixLabors.ImageSharp.Color fillColor, SixLabors.ImageSharp.Color strokeColor, double strokeWeightPt = 1) {
-            return AddShape(shapeType, widthPt, heightPt, fillColor.ToHexColor(), strokeColor.ToHexColor(), strokeWeightPt);
+            SixLabors.ImageSharp.Color fillColor, SixLabors.ImageSharp.Color strokeColor, double strokeWeightPt = 1, double arcSize = 0.25) {
+            return AddShape(shapeType, widthPt, heightPt, fillColor.ToHexColor(), strokeColor.ToHexColor(), strokeWeightPt, arcSize);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -171,6 +171,38 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Adds a VML shape to the section.
+        /// </summary>
+        /// <param name="shapeType">Type of shape to create.</param>
+        /// <param name="widthPt">Width in points or line end X.</param>
+        /// <param name="heightPt">Height in points or line end Y.</param>
+        /// <param name="fillColor">Fill color in hex format.</param>
+        /// <param name="strokeColor">Stroke color in hex format.</param>
+        /// <param name="strokeWeightPt">Stroke weight in points.</param>
+        public WordShape AddShape(ShapeType shapeType, double widthPt, double heightPt,
+            string fillColor = "#FFFFFF", string strokeColor = "#000000", double strokeWeightPt = 1) {
+            return AddParagraph(newRun: true).AddShape(shapeType, widthPt, heightPt, fillColor, strokeColor, strokeWeightPt);
+        }
+
+        /// <summary>
+        /// Adds a VML shape to the section using <see cref="SixLabors.ImageSharp.Color"/> values.
+        /// </summary>
+        public WordShape AddShape(ShapeType shapeType, double widthPt, double heightPt,
+            SixLabors.ImageSharp.Color fillColor, SixLabors.ImageSharp.Color strokeColor, double strokeWeightPt = 1) {
+            return AddShape(shapeType, widthPt, heightPt, fillColor.ToHexColor(), strokeColor.ToHexColor(), strokeWeightPt);
+        }
+
+        /// <summary>
+        /// Adds a DrawingML shape to the section.
+        /// </summary>
+        /// <param name="shapeType">Type of shape to create.</param>
+        /// <param name="widthPt">Width in points.</param>
+        /// <param name="heightPt">Height in points.</param>
+        public WordShape AddShapeDrawing(ShapeType shapeType, double widthPt, double heightPt) {
+            return AddParagraph(newRun: true).AddShapeDrawing(shapeType, widthPt, heightPt);
+        }
+
+        /// <summary>
         /// Inserts a SmartArt diagram into this section.
         /// </summary>
         /// <param name="type">Layout type of the SmartArt.</param>

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -2,6 +2,7 @@ using DocumentFormat.OpenXml.Drawing.Wordprocessing;
 using DocumentFormat.OpenXml.Office2010.Word.DrawingShape;
 using DocumentFormat.OpenXml.Wordprocessing;
 using Graphic = DocumentFormat.OpenXml.Drawing.Graphic;
+using V = DocumentFormat.OpenXml.Vml;
 
 namespace OfficeIMO.Word {
     /// <summary>
@@ -12,6 +13,7 @@ namespace OfficeIMO.Word {
         private readonly WordParagraph _wordParagraph;
         private readonly WordHeaderFooter _headerFooter;
         private Run _run => _wordParagraph._run;
+        private V.TextBox _vmlTextBox;
 
         /// <summary>
         /// Add a new text box to the document
@@ -38,6 +40,7 @@ namespace OfficeIMO.Word {
         public WordTextBox(WordDocument wordDocument, Paragraph paragraph, Run run) {
             _document = wordDocument;
             _wordParagraph = new WordParagraph(wordDocument, paragraph, run);
+            _vmlTextBox = run.Descendants<V.TextBox>().FirstOrDefault();
         }
 
         /// <summary>
@@ -82,6 +85,14 @@ namespace OfficeIMO.Word {
             get {
                 if (_textBoxInfo2 != null) {
                     return _textBoxInfo2.Descendants<Run>().Select(run => new WordParagraph(_document, _paragraph, run)).ToList();
+                }
+                if (_vmlTextBox != null) {
+                    var content = _vmlTextBox.Descendants<DocumentFormat.OpenXml.Wordprocessing.TextBoxContent>().FirstOrDefault();
+                    if (content != null) {
+                        return content.Descendants<Run>()
+                            .Select(run => new WordParagraph(_document, run.Ancestors<Paragraph>().FirstOrDefault(), run))
+                            .ToList();
+                    }
                 }
                 return new List<WordParagraph>();
             }


### PR DESCRIPTION
## Summary
- handle VML images and text boxes separately from DrawingML
- add APIs to insert legacy VML images and text boxes
- introduce AddShapeDrawing to create DrawingML shapes without exposing OpenXML
- broaden VML shape recognition to include rounded rectangles and generic shapes
- cover multiple shape types in example and regression test

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68934a0827a8832e8a5713eb7da70970