### PR TITLE
feat: add nested markdown list support

### DIFF
--- a/OfficeIMO.Examples/Converters/Markdown/Markdown.TaskLists.cs
+++ b/OfficeIMO.Examples/Converters/Markdown/Markdown.TaskLists.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Markdown;
+
+namespace OfficeIMO.Examples.Markdown {
+    internal static partial class Markdown {
+        public static void Example_MarkdownTaskLists(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "MarkdownTaskLists.docx");
+            string markdown = "- [ ] Task 1\n- [x] Task 2\n  - [ ] Subtask";
+
+            var doc = markdown.LoadFromMarkdown(new MarkdownToWordOptions());
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Markdown.NestedLists.cs
+++ b/OfficeIMO.Tests/Markdown.NestedLists.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using OfficeIMO.Word.Markdown;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Markdown {
+        [Fact]
+        public void MarkdownToWord_NestedOrderedAndUnorderedLists() {
+            string md = "1. First\n   - Second\n     1. Third\n2. Fourth";
+
+            var doc = md.LoadFromMarkdown(new MarkdownToWordOptions());
+
+            var paragraphs = doc.Paragraphs.Where(p => p.IsListItem && !string.IsNullOrWhiteSpace(p.Text)).ToArray();
+            Assert.Equal(new[] {0, 1, 2, 0}, paragraphs.Select(p => p.ListItemLevel.GetValueOrDefault()).ToArray());
+            Assert.Equal(new[] {"First", "Second", "Third", "Fourth"}, paragraphs.Select(p => p.Text.Trim()).ToArray());
+        }
+
+        [Fact]
+        public void MarkdownToWord_TaskLists() {
+            string md = "- [ ] Task1\n- [x] Task2\n  - [ ] Subtask";
+
+            var doc = md.LoadFromMarkdown(new MarkdownToWordOptions());
+
+            Assert.Equal(new[] {false, true, false}, doc.CheckBoxes.Select(cb => cb.IsChecked).ToArray());
+
+            var taskParagraphs = doc.Paragraphs.Where(p => p.IsListItem && !string.IsNullOrWhiteSpace(p.Text)).ToArray();
+            Assert.Equal(new[] {0, 0, 1}, taskParagraphs.Select(p => p.ListItemLevel.GetValueOrDefault()).ToArray());
+            Assert.Equal(new[] {"Task1", "Task2", "Subtask"}, taskParagraphs.Select(p => p.Text.Trim()).ToArray());
+        }
+    }
+}

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Lists.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Lists.cs
@@ -1,19 +1,43 @@
+using Markdig.Extensions.TaskLists;
 using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
 using OfficeIMO.Word;
 using System.Linq;
 
 namespace OfficeIMO.Word.Markdown.Converters {
     internal partial class MarkdownToWordConverter {
-        private static void ProcessListBlock(ListBlock listBlock, WordDocument document, MarkdownToWordOptions options, int listLevel) {
-            var list = listBlock.IsOrdered ? document.AddListNumbered() : document.AddListBulleted();
+        private static void ProcessListBlock(ListBlock listBlock, WordDocument document, MarkdownToWordOptions options, WordList? currentList, int listLevel) {
+            var list = currentList ?? (listBlock.IsOrdered ? document.AddListNumbered() : document.AddListBulleted());
+
             foreach (ListItemBlock listItem in listBlock) {
                 var firstParagraph = listItem.FirstOrDefault() as ParagraphBlock;
+                ParagraphBlock? textParagraph = null;
                 if (firstParagraph != null) {
                     var listParagraph = list.AddItem(string.Empty, listLevel);
-                    ProcessInline(firstParagraph.Inline, listParagraph, options, document);
-                }
-                foreach (var sub in listItem.Skip(1)) {
-                    ProcessBlock(sub, document, options, list, listLevel + 1);
+                    var firstInline = firstParagraph.Inline?.FirstChild;
+                    if (firstInline is TaskList task) {
+                        listParagraph.AddCheckBox(task.Checked);
+                        if (task.NextSibling != null) {
+                            ProcessInline(task.NextSibling, listParagraph, options, document);
+                        } else {
+                            textParagraph = listItem.Skip(1).OfType<ParagraphBlock>().FirstOrDefault();
+                            if (textParagraph != null) {
+                                ProcessInline(textParagraph.Inline, listParagraph, options, document);
+                            }
+                        }
+                        listParagraph.Text = listParagraph.Text.TrimStart();
+                    } else {
+                        ProcessInline(firstParagraph.Inline, listParagraph, options, document);
+                    }
+
+                    int skip = textParagraph != null ? 2 : 1;
+                    foreach (var sub in listItem.Skip(skip)) {
+                        ProcessBlock(sub, document, options, list, listLevel + 1);
+                    }
+                } else {
+                    foreach (var sub in listItem) {
+                        ProcessBlock(sub, document, options, list, listLevel + 1);
+                    }
                 }
             }
         }

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
@@ -57,7 +57,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
                     ProcessInline(paragraphBlock.Inline, listItemParagraph, options, document);
                     break;
                 case ListBlock listBlock:
-                    ProcessListBlock(listBlock, document, options, listLevel);
+                    ProcessListBlock(listBlock, document, options, currentList, listLevel);
                     break;
                 case QuoteBlock quote:
                     foreach (var sub in quote) {


### PR DESCRIPTION
## Summary
- track list level and checkbox state when converting Markdown lists
- demonstrate task-list conversion in Markdown examples
- cover nested lists and task lists in tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68936d14047c832ea96fb40822e1d555