### PR TITLE
Handle alignment and formatting in Markdown tables

### DIFF
--- a/OfficeIMO.Tests/Markdown.Tables.cs
+++ b/OfficeIMO.Tests/Markdown.Tables.cs
@@ -1,0 +1,27 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word.Markdown;
+using System.Linq;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Markdown {
+        [Fact]
+        public void MarkdownToWord_TableCellAlignmentAndFormatting() {
+            string md = "| Left | Center | Right |\n| :--- | :---: | ---: |\n| **Bold** | *Italic* | Normal |";
+            var doc = md.LoadFromMarkdown(new MarkdownToWordOptions { FontFamily = "Calibri" });
+            var table = doc.Tables[0];
+
+            var leftParagraph = table.Rows[1].Cells[0].Paragraphs[0];
+            var centerParagraph = table.Rows[1].Cells[1].Paragraphs[0];
+            var rightParagraph = table.Rows[1].Cells[2].Paragraphs[0];
+
+            Assert.Equal(JustificationValues.Left, leftParagraph.ParagraphAlignment);
+            Assert.Equal(JustificationValues.Center, centerParagraph.ParagraphAlignment);
+            Assert.Equal(JustificationValues.Right, rightParagraph.ParagraphAlignment);
+
+            Assert.True(leftParagraph.GetRuns().Any(r => r.Bold));
+            Assert.True(centerParagraph.GetRuns().Any(r => r.Italic));
+        }
+    }
+}
+

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Tables.cs
@@ -1,28 +1,90 @@
 using Markdig.Extensions.Tables;
 using Markdig.Syntax;
 using OfficeIMO.Word;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
-
-namespace OfficeIMO.Word.Markdown.Converters {
-    internal partial class MarkdownToWordConverter {
-        private static void ProcessTable(Table table, WordDocument document, MarkdownToWordOptions options) {
-            int rows = table.Count();
-            int cols = table.ColumnDefinitions.Count;
-            var wordTable = document.AddTable(rows, cols);
-            int r = 0;
-            foreach (TableRow row in table) {
-                int c = 0;
-                foreach (TableCell cell in row) {
-                    var target = wordTable.Rows[r].Cells[c].Paragraphs[0];
-                    foreach (var cellBlock in cell) {
-                        if (cellBlock is ParagraphBlock pb) {
-                            ProcessInline(pb.Inline, target, options, document);
-                        }
-                    }
-                    c++;
-                }
-                r++;
-            }
-        }
-    }
+using JustificationValues = DocumentFormat.OpenXml.Wordprocessing.JustificationValues;
+
+namespace OfficeIMO.Word.Markdown.Converters {
+    internal partial class MarkdownToWordConverter {
+        private static void ProcessTable(Table table, WordDocument document, MarkdownToWordOptions options) {
+            int rows = table.Count();
+            int cols = table.ColumnDefinitions.Count;
+            var wordTable = document.AddTable(rows, cols);
+            int r = 0;
+            foreach (TableRow row in table) {
+                var rowAlignments = GetRowAlignments(row);
+                int c = 0;
+                foreach (TableCell cell in row) {
+                    var wordCell = wordTable.Rows[r].Cells[c];
+                    JustificationValues? justification = null;
+                    if (rowAlignments != null && c < rowAlignments.Length) {
+                        justification = ToJustification(rowAlignments[c]);
+                    }
+                    if (justification == null && c < table.ColumnDefinitions.Count) {
+                        justification = ToJustification(table.ColumnDefinitions[c].Alignment);
+                    }
+                    int blockIndex = 0;
+                    foreach (var cellBlock in cell) {
+                        var paragraph = blockIndex == 0 ? wordCell.Paragraphs[0] : wordCell.AddParagraph();
+                        if (justification != null) {
+                            paragraph.SetAlignment(justification.Value);
+                        }
+                        if (cellBlock is ParagraphBlock pb) {
+                            ProcessInline(pb.Inline, paragraph, options, document);
+                        }
+                        blockIndex++;
+                    }
+                    if (blockIndex == 0) {
+                        var paragraph = wordCell.Paragraphs[0];
+                        if (justification != null) {
+                            paragraph.SetAlignment(justification.Value);
+                        }
+                    }
+                    c++;
+                }
+                r++;
+            }
+        }
+
+        private static TableColumnAlign?[]? GetRowAlignments(TableRow row) {
+            object data = row.GetData("alignment") ?? row.GetData("alignments");
+            if (data is IEnumerable enumerable) {
+                List<TableColumnAlign?> list = new List<TableColumnAlign?>();
+                foreach (var item in enumerable) {
+                    if (item is TableColumnAlign align) {
+                        list.Add(align);
+                    } else if (item is string str) {
+                        if (Enum.TryParse<TableColumnAlign>(str, true, out var parsed)) {
+                            list.Add(parsed);
+                        } else {
+                            list.Add(null);
+                        }
+                    } else {
+                        list.Add(null);
+                    }
+                }
+                return list.ToArray();
+            }
+            return null;
+        }
+
+        private static JustificationValues? ToJustification(TableColumnAlign? align) {
+            if (align == null) {
+                return null;
+            }
+
+            switch (align.Value) {
+                case TableColumnAlign.Left:
+                    return JustificationValues.Left;
+                case TableColumnAlign.Center:
+                    return JustificationValues.Center;
+                case TableColumnAlign.Right:
+                    return JustificationValues.Right;
+                default:
+                    return null;
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- support table row metadata for cell alignment
- process inline formatting inside markdown table cells
- add tests for aligned and formatted table cells

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68937675dff8832e8db5c9a53854a706