### PR TITLE
Add blockquote conversion support

### DIFF
--- a/OfficeIMO.Examples/Word/BlockquoteExample.cs
+++ b/OfficeIMO.Examples/Word/BlockquoteExample.cs
@@ -1,0 +1,23 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static class BlockquoteExample {
+        public static void Example_BlockquoteRoundTrip(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Blockquote round-trip HTML <-> Word");
+
+            string html = "<blockquote>Quoted text</blockquote>";
+            using (WordDocument document = html.LoadFromHtml(new HtmlToWordOptions())) {
+                string docPath = Path.Combine(folderPath, "Blockquote.docx");
+                document.Save(docPath);
+                Console.WriteLine($"✓ Created: {docPath}");
+
+                string roundTrip = document.ToHtml();
+                Console.WriteLine("Round-trip HTML:");
+                Console.WriteLine(roundTrip);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -158,6 +158,19 @@ public partial class Html {
     }
 
     [Fact]
+    public void Test_Html_Blockquote_RoundTrip() {
+        string html = "<blockquote>Quoted text</blockquote>";
+
+        var doc = html.LoadFromHtml(new HtmlToWordOptions());
+        Assert.Equal("Quoted text", doc.Paragraphs[0].Text);
+        Assert.True(doc.Paragraphs[0].IndentationBefore > 0);
+
+        string roundTrip = doc.ToHtml();
+        Assert.Contains("<blockquote>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Quoted text", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Test_Html_Lists_Structure() {
         string html = "<ul><li>Item 1<ul><li>Sub 1</li></ul></li><li>Item 2</li></ul>";
 

--- a/OfficeIMO.Tests/Html.WordToHtml.cs
+++ b/OfficeIMO.Tests/Html.WordToHtml.cs
@@ -125,6 +125,18 @@ namespace OfficeIMO.Tests {
             Assert.Contains("<table style=\"width:100%;border:1px solid black;border-collapse:collapse\">", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("<td style=\"width:50%;text-align:center;border:1px solid black\">", html, StringComparison.OrdinalIgnoreCase);
         }
+
+        [Fact]
+        public void Test_WordToHtml_Blockquote() {
+            using var doc = WordDocument.Create();
+            var p = doc.AddParagraph("Quoted text");
+            p.IndentationBefore = 720;
+
+            string html = doc.ToHtml();
+
+            Assert.Contains("<blockquote>", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Quoted text", html, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -84,6 +84,16 @@ namespace OfficeIMO.Word.Html.Converters {
                             }
                             break;
                         }
+                    case "blockquote": {
+                            var paragraph = cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
+                            paragraph.SetStyleId("Quote");
+                            paragraph.IndentationBefore = 720;
+                            ApplyParagraphStyleFromCss(paragraph, element);
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);
+                            }
+                            break;
+                        }
                     case "div": {
                             var fmt = formatting;
                             var divStyle = element.GetAttribute("style");

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -138,7 +138,9 @@ namespace OfficeIMO.Word.Html.Converters {
 
             void AppendParagraph(IElement parent, WordParagraph para) {
                 int level = para.Style.HasValue ? HeadingStyleMapper.GetLevelForHeadingStyle(para.Style.Value) : 0;
-                var element = htmlDoc.CreateElement(level > 0 ? $"h{level}" : "p");
+                bool isBlockQuote = (!string.IsNullOrEmpty(para.StyleId) && (string.Equals(para.StyleId, "Quote", StringComparison.OrdinalIgnoreCase) || string.Equals(para.StyleId, "IntenseQuote", StringComparison.OrdinalIgnoreCase)))
+                    || (para.IndentationBefore.HasValue && para.IndentationBefore.Value > 0);
+                var element = htmlDoc.CreateElement(isBlockQuote ? "blockquote" : (level > 0 ? $"h{level}" : "p"));
                 AppendRuns(element, para);
                 parent.AppendChild(element);
             }

--- a/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
@@ -16,6 +16,18 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Gets the identifier of the paragraph style, if any.
+        /// </summary>
+        public string StyleId {
+            get {
+                if (_paragraphProperties != null && _paragraphProperties.ParagraphStyleId != null) {
+                    return _paragraphProperties.ParagraphStyleId.Val;
+                }
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Alignment aka Paragraph Alignment. This element specifies the paragraph alignment which shall be applied to text in this paragraph.
         /// If this element is omitted on a given paragraph, its value is determined by the setting previously set at any level of the style hierarchy (i.e.that previous setting remains unchanged). If this setting is never specified in the style hierarchy, then no alignment is applied to the paragraph.
         /// </summary>


### PR DESCRIPTION
## Summary
- handle HTML `<blockquote>` in HtmlToWordConverter
- emit blockquotes in WordToHtmlConverter when paragraphs are indented or styled
- expose paragraph style identifier and add example & tests for blockquotes

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6893bc3e03f0832ea27e3662eb46c510