### PR TITLE
Add start and type attributes support for HTML list conversion

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.ListStartAndType.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.ListStartAndType.cs
@@ -1,0 +1,22 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlListStartAndType(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlListStartAndType.docx");
+            string html = "<ol start=\"3\" type=\"I\"><li>Third</li><li>Fourth</li></ol><ul type=\"square\"><li>Square</li></ul>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            string roundTrip = doc.ToHtml(new WordToHtmlOptions());
+            Console.WriteLine(roundTrip);
+
+            doc.Save(filePath);
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -167,6 +167,25 @@ public partial class Html {
     }
 
     [Fact]
+    public void Test_Html_OrderedList_StartAndType() {
+        string html = "<ol start=\"5\" type=\"a\"><li>First</li><li>Second</li></ol>";
+
+        var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+        Assert.Equal(5, doc.Lists[0].Numbering.Levels[0].StartNumberingValue);
+        Assert.Equal(NumberFormatValues.LowerLetter, doc.Lists[0].Numbering.Levels[0]._level.NumberingFormat.Val.Value);
+    }
+
+    [Fact]
+    public void Test_Html_UnorderedList_Type() {
+        string html = "<ul type=\"circle\"><li>A</li><li>B</li></ul>";
+
+        var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+        Assert.Equal("o", doc.Lists[0].Numbering.Levels[0]._level.LevelText.Val);
+    }
+
+    [Fact]
     public void Test_Html_Table_Structure() {
         string html = "<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr></table>";
 

--- a/OfficeIMO.Tests/Html.WordToHtml.cs
+++ b/OfficeIMO.Tests/Html.WordToHtml.cs
@@ -89,7 +89,7 @@ namespace OfficeIMO.Tests {
 
             string html = doc.ToHtml();
 
-            Assert.Contains("<ol start=\"4\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<ol start=\"4\" type=\"1\"", html, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -101,7 +101,21 @@ namespace OfficeIMO.Tests {
 
             string html = doc.ToHtml(new WordToHtmlOptions { IncludeListStyles = true });
 
+            Assert.Contains("<ol type=\"I\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("list-style-type:upper-roman", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_BulletType() {
+            using var doc = WordDocument.Create();
+            var list = doc.AddList(WordListStyle.Bulleted);
+            list.Numbering.Levels[0]._level.LevelText.Val = "o";
+            list.AddItem("One");
+            list.AddItem("Two");
+
+            string html = doc.ToHtml();
+
+            Assert.Contains("<ul type=\"circle\"", html, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
@@ -1,5 +1,6 @@
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using System.Collections.Generic;
 
@@ -8,10 +9,40 @@ namespace OfficeIMO.Word.Html.Converters {
         private void ProcessList(IElement element, WordDocument doc, WordSection section, HtmlToWordOptions options,
             Stack<WordList> listStack, WordTableCell? cell, TextFormatting formatting) {
             WordList list;
-            if (element.TagName.Equals("ul", StringComparison.OrdinalIgnoreCase)) {
-                list = cell != null ? cell.AddList(WordListStyle.Bulleted) : doc.AddListBulleted();
-            } else {
+            bool ordered = element.TagName.Equals("ol", System.StringComparison.OrdinalIgnoreCase);
+            if (ordered) {
                 list = cell != null ? cell.AddList(WordListStyle.Headings111) : doc.AddListNumbered();
+                var level = list.Numbering.Levels[0];
+                var start = element.GetAttribute("start");
+                if (!string.IsNullOrEmpty(start) && int.TryParse(start, out int startVal)) {
+                    level.SetStartNumberingValue(startVal);
+                }
+                var type = element.GetAttribute("type");
+                if (!string.IsNullOrEmpty(type)) {
+                    var format = type switch {
+                        "a" => NumberFormatValues.LowerLetter,
+                        "A" => NumberFormatValues.UpperLetter,
+                        "i" => NumberFormatValues.LowerRoman,
+                        "I" => NumberFormatValues.UpperRoman,
+                        _ => NumberFormatValues.Decimal,
+                    };
+                    level._level.NumberingFormat = new NumberingFormat { Val = format };
+                }
+            } else {
+                list = cell != null ? cell.AddList(WordListStyle.Bulleted) : doc.AddListBulleted();
+                var type = element.GetAttribute("type")?.ToLowerInvariant();
+                if (!string.IsNullOrEmpty(type)) {
+                    var level = list.Numbering.Levels[0];
+                    switch (type) {
+                        case "circle":
+                            level._level.LevelText.Val = "o";
+                            break;
+                        case "square":
+                            level._level.LevelText.Val = "■";
+                            break;
+                        // disc is the default, nothing to change
+                    }
+                }
             }
             listStack.Push(list);
             foreach (var li in element.Children.OfType<IHtmlListItemElement>()) {

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -221,6 +221,33 @@ namespace OfficeIMO.Word.Html.Converters {
                 return null;
             }
 
+            string? GetListType(DocumentTraversal.ListInfo info) {
+                var format = info.NumberFormat;
+                if (format == NumberFormatValues.Decimal) {
+                    return "1";
+                }
+                if (format == NumberFormatValues.LowerLetter) {
+                    return "a";
+                }
+                if (format == NumberFormatValues.UpperLetter) {
+                    return "A";
+                }
+                if (format == NumberFormatValues.LowerRoman) {
+                    return "i";
+                }
+                if (format == NumberFormatValues.UpperRoman) {
+                    return "I";
+                }
+                if (format == NumberFormatValues.Bullet) {
+                    return info.LevelText switch {
+                        "o" or "◦" => "circle",
+                        "■" or "§" => "square",
+                        _ => "disc",
+                    };
+                }
+                return null;
+            }
+
             foreach (var section in DocumentTraversal.EnumerateSections(document)) {
                 foreach (var element in section.Elements) {
                     if (element is WordParagraph paragraph) {
@@ -237,6 +264,10 @@ namespace OfficeIMO.Word.Html.Converters {
                                 var listEl = htmlDoc.CreateElement(listTag);
                                 if (ordered && listInfo.Value.Start > 1) {
                                     listEl.SetAttribute("start", listInfo.Value.Start.ToString());
+                                }
+                                var typeAttr = GetListType(listInfo.Value);
+                                if (!string.IsNullOrEmpty(typeAttr)) {
+                                    listEl.SetAttribute("type", typeAttr);
                                 }
                                 if (options.IncludeListStyles) {
                                     var css = GetListStyle(listInfo.Value);


### PR DESCRIPTION
## Summary
- support `start` and `type` list attributes when importing HTML
- export Word lists with corresponding `start` and `type` attributes
- add example and tests for custom list numbering

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_6893bc3697d4832eabf5fdede647b8d9