### PR TITLE
Add class-based paragraph style mapping for HTML converter

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.ClassStyles.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.ClassStyles.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlClassStyles(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlClassStyles.docx");
+            string html = "<p class=\"title\">Title</p><p>Content</p>";
+
+            var options = new HtmlToWordOptions();
+            options.ClassStyles["title"] = WordParagraphStyles.Heading1;
+            var doc = html.LoadFromHtml(options);
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.ClassStyles.cs
+++ b/OfficeIMO.Tests/Html.ClassStyles.cs
@@ -1,0 +1,25 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_ClassStyles_Paragraph() {
+            string html = "<p class=\"title\">Text</p>";
+            var options = new HtmlToWordOptions();
+            options.ClassStyles["title"] = WordParagraphStyles.Heading1;
+            var doc = html.LoadFromHtml(options);
+            Assert.Equal(WordParagraphStyles.Heading1, doc.Paragraphs[0].Style);
+        }
+
+        [Fact]
+        public void HtmlToWord_ClassStyles_ListItem() {
+            string html = "<ul><li class=\"special\">Item</li></ul>";
+            var options = new HtmlToWordOptions();
+            options.ClassStyles["special"] = WordParagraphStyles.Heading2;
+            var doc = html.LoadFromHtml(options);
+            Assert.Equal(WordParagraphStyles.Heading2, doc.Paragraphs[0].Style);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
@@ -56,6 +56,7 @@ namespace OfficeIMO.Word.Html.Converters {
             var list = listStack.Peek();
             int level = listStack.Count - 1;
             var paragraph = list.AddItem("", level);
+            ApplyClassStyle(element, paragraph, options);
             foreach (var child in element.ChildNodes) {
                 ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);
             }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -71,6 +71,7 @@ namespace OfficeIMO.Word.Html.Converters {
                             var paragraph = cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
                             paragraph.Style = HeadingStyleMapper.GetHeadingStyleForLevel(level);
                             ApplyParagraphStyleFromCss(paragraph, element);
+                            ApplyClassStyle(element, paragraph, options);
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);
                             }
@@ -79,6 +80,7 @@ namespace OfficeIMO.Word.Html.Converters {
                     case "p": {
                             var paragraph = cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
                             ApplyParagraphStyleFromCss(paragraph, element);
+                            ApplyClassStyle(element, paragraph, options);
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);
                             }
@@ -89,6 +91,7 @@ namespace OfficeIMO.Word.Html.Converters {
                             paragraph.SetStyleId("Quote");
                             paragraph.IndentationBefore = 720;
                             ApplyParagraphStyleFromCss(paragraph, element);
+                            ApplyClassStyle(element, paragraph, options);
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);
                             }
@@ -190,6 +193,20 @@ namespace OfficeIMO.Word.Html.Converters {
                 }
                 currentParagraph ??= cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
                 AddTextRun(currentParagraph, text, formatting, options);
+            }
+        }
+
+        private static void ApplyClassStyle(IElement element, WordParagraph paragraph, HtmlToWordOptions options) {
+            string? classAttr = element.GetAttribute("class");
+            if (string.IsNullOrWhiteSpace(classAttr)) {
+                return;
+            }
+
+            foreach (var cls in classAttr.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)) {
+                if (options.ClassStyles.TryGetValue(cls, out var style)) {
+                    paragraph.Style = style;
+                    break;
+                }
             }
         }
     }

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using OfficeIMO.Word;
 using DocumentFormat.OpenXml.Wordprocessing;
 
@@ -21,7 +22,12 @@ namespace OfficeIMO.Word.Html {
         /// Optional default page orientation applied when creating new documents.
         /// </summary>
         public PageOrientationValues? DefaultOrientation { get; set; }
-        
+
+        /// <summary>
+        /// Maps HTML class names to paragraph styles. Example: <code>ClassStyles["title"] = WordParagraphStyles.Heading1;</code>
+        /// </summary>
+        public Dictionary<string, WordParagraphStyles> ClassStyles { get; } = new Dictionary<string, WordParagraphStyles>(StringComparer.OrdinalIgnoreCase);
+
         /// <summary>
         /// When true, attempts to include list styling information during conversion.
         /// </summary>


### PR DESCRIPTION
## Summary
- allow specifying HTML class to Word style mappings in `HtmlToWordOptions`
- apply mapped styles when converting paragraphs and list items
- add example and tests for class-based styling

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6893c1b8d0e4832e8b345c1060e9dfbb