### PR TITLE
Handle horizontal rules in HTML conversion

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.HorizontalRules.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.HorizontalRules.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlHorizontalRules(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlHorizontalRules.docx");
+            string html = "<p>Before</p><hr><p>After</p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+
+            string roundTrip = doc.ToHtml();
+            Console.WriteLine(roundTrip);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -235,4 +235,19 @@ public partial class Html {
 
         Assert.Single(doc.Images);
     }
+
+    [Fact]
+    public void Test_Html_HorizontalRule_RoundTrip() {
+        string html = "<p>Before</p><hr><p>After</p>";
+
+        var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+        Assert.Equal(3, doc.Paragraphs.Count);
+        Assert.NotNull(doc.Paragraphs[1].Borders.BottomStyle);
+
+        string roundTrip = doc.ToHtml();
+        Assert.Contains("<hr", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Before", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("After", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/OfficeIMO.Tests/Html.WordToHtml.cs
+++ b/OfficeIMO.Tests/Html.WordToHtml.cs
@@ -151,6 +151,16 @@ namespace OfficeIMO.Tests {
             Assert.Contains("<blockquote>", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Quoted text", html, StringComparison.OrdinalIgnoreCase);
         }
+
+        [Fact]
+        public void Test_WordToHtml_HorizontalRule() {
+            using var doc = WordDocument.Create();
+            doc.AddHorizontalLine();
+
+            string html = doc.ToHtml();
+
+            Assert.Contains("<hr", html, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -116,6 +116,14 @@ namespace OfficeIMO.Word.Html.Converters {
                             currentParagraph.AddBreak();
                             break;
                         }
+                    case "hr": {
+                            if (cell != null) {
+                                cell.AddParagraph("", true).AddHorizontalLine();
+                            } else {
+                                section.AddParagraph("").AddHorizontalLine();
+                            }
+                            break;
+                        }
                     case "strong":
                     case "b": {
                             var fmt = new TextFormatting(true, formatting.Italic, formatting.Underline);

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -137,6 +137,12 @@ namespace OfficeIMO.Word.Html.Converters {
             }
 
             void AppendParagraph(IElement parent, WordParagraph para) {
+                if (para.Borders.BottomStyle != null && string.IsNullOrWhiteSpace(para.Text)) {
+                    var hr = htmlDoc.CreateElement("hr");
+                    parent.AppendChild(hr);
+                    return;
+                }
+
                 int level = para.Style.HasValue ? HeadingStyleMapper.GetLevelForHeadingStyle(para.Style.Value) : 0;
                 bool isBlockQuote = (!string.IsNullOrEmpty(para.StyleId) && (string.Equals(para.StyleId, "Quote", StringComparison.OrdinalIgnoreCase) || string.Equals(para.StyleId, "IntenseQuote", StringComparison.OrdinalIgnoreCase)))
                     || (para.IndentationBefore.HasValue && para.IndentationBefore.Value > 0);


### PR DESCRIPTION
## Summary
- support `<hr>` tags when converting HTML to Word by inserting horizontal lines
- emit `<hr>` elements when exporting Word paragraphs that are horizontal rules
- add tests and example for horizontal rule conversion

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6893c1c75c68832ead0f3334774079c1