### PR TITLE
Preserve image alt text in HTML conversions

### DIFF
--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -237,6 +237,22 @@ public partial class Html {
     }
 
     [Fact]
+    public void Test_Html_ImageAlt_Preserved() {
+        string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
+        byte[] imageBytes = File.ReadAllBytes(assetPath);
+        string base64 = Convert.ToBase64String(imageBytes);
+        string html = $"<p><img src=\"data:image/png;base64,{base64}\" alt=\"Company logo\" /></p>";
+
+        var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+        Assert.Single(doc.Images);
+        Assert.Equal("Company logo", doc.Images[0].Description);
+
+        string roundTrip = doc.ToHtml();
+        Assert.Contains("alt=\"Company logo\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Test_Html_HorizontalRule_RoundTrip() {
         string html = "<p>Before</p><hr><p>After</p>";
 

--- a/OfficeIMO.Tests/Html.WordToHtml.cs
+++ b/OfficeIMO.Tests/Html.WordToHtml.cs
@@ -71,12 +71,16 @@ namespace OfficeIMO.Tests {
             doc.BuiltinDocumentProperties.Creator = "Tester";
 
             string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
-            doc.AddParagraph().AddImage(assetPath);
+            var paragraph = doc.AddParagraph();
+            paragraph.AddImage(assetPath, description: "Company logo");
+
+            Assert.Equal("Company logo", paragraph.Image.Description);
 
             string html = doc.ToHtml();
 
             Assert.Contains("data:image/png", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("content=\"Tester\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("alt=\"Company logo\"", html, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -11,6 +11,7 @@ namespace OfficeIMO.Word.Html.Converters {
 
             double? width = img.DisplayWidth > 0 ? img.DisplayWidth : null;
             double? height = img.DisplayHeight > 0 ? img.DisplayHeight : null;
+            var alt = img.AlternativeText;
 
             if (src.StartsWith("data:image", StringComparison.OrdinalIgnoreCase)) {
                 var commaIndex = src.IndexOf(',');
@@ -22,14 +23,15 @@ namespace OfficeIMO.Word.Html.Converters {
                     if (parts.Length >= 2) {
                         ext = parts[1];
                     }
-                    doc.AddParagraph().AddImageFromBase64(base64, "image." + ext, width, height);
+                    doc.AddParagraph().AddImageFromBase64(base64, "image." + ext, width, height, description: alt);
                 }
             } else if (Uri.TryCreate(src, UriKind.Absolute, out var uri) && uri.IsFile) {
-                doc.AddParagraph().AddImage(uri.LocalPath, width, height);
+                doc.AddParagraph().AddImage(uri.LocalPath, width, height, description: alt);
             } else if (File.Exists(src)) {
-                doc.AddParagraph().AddImage(src, width, height);
+                doc.AddParagraph().AddImage(src, width, height, description: alt);
             } else {
-                doc.AddImageFromUrl(src, width, height);
+                var image = doc.AddImageFromUrl(src, width, height);
+                image.Description = alt;
             }
         }
     }

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -90,6 +90,7 @@ namespace OfficeIMO.Word.Html.Converters {
                             src = $"data:{mime};base64,{Convert.ToBase64String(bytes)}";
                         }
                         img!.Source = src;
+                        img.AlternativeText = imgObj.Description ?? string.Empty;
                         parent.AppendChild(img);
                         continue;
                     }


### PR DESCRIPTION
## Summary
- carry over HTML `<img alt>` text to Word images
- render Word image descriptions as `<img alt>` in generated HTML
- test alt text round trip from HTML to Word to HTML

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6893c6f6c548832e91a448d492590421