### PR TITLE
Handle strikethrough in Markdown conversions

### DIFF
--- a/OfficeIMO.Tests/Markdown.BasicBlocks.cs
+++ b/OfficeIMO.Tests/Markdown.BasicBlocks.cs
@@ -11,7 +11,7 @@ namespace OfficeIMO.Tests {
     public partial class Markdown {
         [Fact]
         public void MarkdownToWord_ConvertsVariousElements() {
-            string imagePath = Path.GetFullPath(Path.Combine("Assets", "OfficeIMO.png"));
+            string imagePath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png"));
             string md = $@"# Heading 1
 
 Paragraph with **bold** and *italic* and [link](https://example.com).

--- a/OfficeIMO.Tests/Markdown.Strikethrough.cs
+++ b/OfficeIMO.Tests/Markdown.Strikethrough.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Markdown {
+        [Fact]
+        public void Markdown_Strikethrough_RoundTrip() {
+            string md = "This is ~~strike~~ text";
+
+            var doc = md.LoadFromMarkdown(new MarkdownToWordOptions());
+            var paragraph = doc.Paragraphs[0];
+            var run = paragraph.GetRuns().First(r => r.Strike);
+
+            Assert.Equal("strike", run.Text);
+
+            string roundTrip = doc.ToMarkdown(new WordToMarkdownOptions());
+            Assert.Contains("~~strike~~", roundTrip);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- detect `~~` strikethrough emphasis when converting Markdown to Word and apply strike formatting
- preserve delimiter characters and improve image handling in Markdown inline processing
- add test covering Markdown strikethrough round-trip

## Testing
- `dotnet test --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6893c6ed0f40832e8ae56d4b2a5b676e