### PR TITLE
Improve shape vs text box detection

### DIFF
--- a/OfficeIMO.Examples/Word/Shapes/Shapes.ShapeAlternateContentFallback.cs
+++ b/OfficeIMO.Examples/Word/Shapes/Shapes.ShapeAlternateContentFallback.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using DocumentFormat.OpenXml;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Shapes {
+        internal static void Example_ShapeInAlternateContentFallback(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with shape inside AlternateContent fallback");
+            string filePath = System.IO.Path.Combine(folderPath, "ShapeInAlternateContentFallback.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddShapeDrawing(ShapeType.Rectangle, 40, 40);
+                document.Save(false);
+            }
+            using (WordprocessingDocument word = WordprocessingDocument.Open(filePath, true)) {
+                var run = word.MainDocumentPart.Document.Body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
+                var drawing = run.Descendants<Drawing>().First();
+                var fallbackDrawing = (Drawing)drawing.CloneNode(true);
+                drawing.Remove();
+                var choice = new AlternateContentChoice() { Requires = "wps" };
+                choice.Append(new Run(new Text("placeholder")));
+                var fallback = new AlternateContentFallback();
+                fallback.Append(fallbackDrawing);
+                var alt = new AlternateContent();
+                alt.Append(choice);
+                alt.Append(fallback);
+                run.Append(alt);
+                word.MainDocumentPart.Document.Save();
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Console.WriteLine($"Shapes count: {document.Shapes.Count}");
+                Console.WriteLine($"TextBoxes count: {document.TextBoxes.Count}");
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Shapes/Shapes.ShapeChoiceFallbackTextBox.cs
+++ b/OfficeIMO.Examples/Word/Shapes/Shapes.ShapeChoiceFallbackTextBox.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using DocumentFormat.OpenXml;
+using Wps = DocumentFormat.OpenXml.Office2010.Word.DrawingShape;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Shapes {
+        internal static void Example_ShapeChoiceFallbackTextBox(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with shape in choice and text box in fallback");
+            string filePath = Path.Combine(folderPath, "ShapeChoiceFallbackTextBox.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddShapeDrawing(ShapeType.Rectangle, 40, 40);
+                document.AddTextBox("Text");
+                document.Save(false);
+            }
+            using (WordprocessingDocument word = WordprocessingDocument.Open(filePath, true)) {
+                var body = word.MainDocumentPart.Document.Body;
+                var shapeRun = body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any() && !r.Descendants<Wps.TextBoxInfo2>().Any());
+                var textBoxRun = body.Descendants<Run>().First(r => r.Descendants<Wps.TextBoxInfo2>().Any());
+                var shapeDrawing = shapeRun.Descendants<Drawing>().First();
+                var textBoxDrawing = textBoxRun.Descendants<Drawing>().First();
+                shapeDrawing.Remove();
+                var choice = new AlternateContentChoice() { Requires = "wps" };
+                choice.Append(shapeDrawing);
+                var fallback = new AlternateContentFallback();
+                fallback.Append((Drawing)textBoxDrawing.CloneNode(true));
+                var alt = new AlternateContent();
+                alt.Append(choice);
+                alt.Append(fallback);
+                shapeRun.Append(alt);
+                textBoxRun.Remove();
+                word.MainDocumentPart.Document.Save();
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Console.WriteLine($"Shapes count: {document.Shapes.Count}");
+                Console.WriteLine($"TextBoxes count: {document.TextBoxes.Count}");
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Shapes/Shapes.ShapeWithText.cs
+++ b/OfficeIMO.Examples/Word/Shapes/Shapes.ShapeWithText.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using V = DocumentFormat.OpenXml.Vml;
+using SixLabors.ImageSharp;
+using Color = SixLabors.ImageSharp.Color;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Shapes {
+        internal static void Example_ShapeWithTextRecognizedAsTextBox(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with ellipse shape that contains text");
+            string filePath = System.IO.Path.Combine(folderPath, "ShapeWithText.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddShape(ShapeType.Ellipse, 40, 40, Color.Red, Color.Blue);
+                document.Save(false);
+            }
+            using (WordprocessingDocument word = WordprocessingDocument.Open(filePath, true)) {
+                var oval = word.MainDocumentPart.Document.Body.Descendants<V.Oval>().First();
+                var textBox = new V.TextBox();
+                textBox.Append(new TextBoxContent(new Paragraph(new Run(new Text("Text")))));
+                oval.Append(textBox);
+                word.MainDocumentPart.Document.Save();
+            }
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Console.WriteLine($"Shapes count: {document.Shapes.Count}");
+                Console.WriteLine($"TextBoxes count: {document.TextBoxes.Count}");
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.ShapeTextBoxRecognition.cs
+++ b/OfficeIMO.Tests/Word.ShapeTextBoxRecognition.cs
@@ -1,0 +1,125 @@
+using System.IO;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using V = DocumentFormat.OpenXml.Vml;
+using Wps = DocumentFormat.OpenXml.Office2010.Word.DrawingShape;
+using Xunit;
+using Color = SixLabors.ImageSharp.Color;
+using Path = System.IO.Path;
+using System.Linq;
+using DocumentFormat.OpenXml;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_VmlEllipseWithTextRecognizedAsTextBoxOnly() {
+            string filePath = Path.Combine(_directoryWithFiles, "EllipseShapeWithText.docx");
+            using (WordDocument doc = WordDocument.Create(filePath)) {
+                doc.AddShape(ShapeType.Ellipse, 40, 40, Color.Red, Color.Blue);
+                doc.Save(false);
+            }
+            using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
+                var oval = wDoc.MainDocumentPart.Document.Body.Descendants<V.Oval>().First();
+                var textBox = new V.TextBox();
+                textBox.Append(new TextBoxContent(new Paragraph(new Run(new Text("Text")))));
+                oval.Append(textBox);
+                wDoc.MainDocumentPart.Document.Save();
+            }
+            using (WordDocument doc = WordDocument.Load(filePath)) {
+                Assert.Empty(doc.Shapes);
+                Assert.Single(doc.TextBoxes);
+            }
+        }
+
+        [Fact]
+        public void Test_AlternateContentShapeNotTreatedAsTextBox() {
+            string filePath = Path.Combine(_directoryWithFiles, "ShapeWrappedInAlternateContent.docx");
+            using (WordDocument doc = WordDocument.Create(filePath)) {
+                doc.AddShapeDrawing(ShapeType.Rectangle, 40, 40);
+                doc.Save(false);
+            }
+            using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
+                var run = wDoc.MainDocumentPart.Document.Body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
+                var drawing = run.Descendants<Drawing>().First();
+                drawing.Remove();
+                var choice = new AlternateContentChoice() { Requires = "wps" };
+                choice.Append(drawing);
+                var alt = new AlternateContent();
+                alt.Append(choice);
+                run.Append(alt);
+                wDoc.MainDocumentPart.Document.Save();
+            }
+            using (WordDocument doc = WordDocument.Load(filePath)) {
+                Assert.Single(doc.Shapes);
+                Assert.Empty(doc.TextBoxes);
+            }
+        }
+
+        [Fact]
+        public void Test_AlternateContentFallbackShapeDetected() {
+            string filePath = Path.Combine(_directoryWithFiles, "ShapeInAlternateContentFallback.docx");
+            using (WordDocument doc = WordDocument.Create(filePath)) {
+                doc.AddShapeDrawing(ShapeType.Rectangle, 40, 40);
+                doc.Save(false);
+            }
+            using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
+                var run = wDoc.MainDocumentPart.Document.Body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
+                var drawing = run.Descendants<Drawing>().First();
+                var fallbackDrawing = (Drawing)drawing.CloneNode(true);
+                drawing.Remove();
+                var choice = new AlternateContentChoice() { Requires = "wps" };
+                choice.Append(new Run(new Text("placeholder")));
+                var fallback = new AlternateContentFallback();
+                fallback.Append(fallbackDrawing);
+                var alt = new AlternateContent();
+                alt.Append(choice);
+                alt.Append(fallback);
+                run.Append(alt);
+                wDoc.MainDocumentPart.Document.Save();
+            }
+            using (WordDocument doc = WordDocument.Load(filePath)) {
+                Assert.Single(doc.Shapes);
+                Assert.Empty(doc.TextBoxes);
+            }
+        }
+
+        [Fact]
+        public void Test_AlternateContentChoiceShapeFallbackTextBox() {
+            string filePath = Path.Combine(_directoryWithFiles, "ShapeChoiceFallbackTextBox.docx");
+            using (WordDocument doc = WordDocument.Create(filePath)) {
+                doc.AddShapeDrawing(ShapeType.Rectangle, 40, 40);
+                doc.AddTextBox("Text");
+                doc.Save(false);
+            }
+            using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
+                var body = wDoc.MainDocumentPart.Document.Body;
+                var shapeRun = body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any() && !r.Descendants<Wps.TextBoxInfo2>().Any());
+                var textBoxRun = body.Descendants<Run>().First(r => r.Descendants<Wps.TextBoxInfo2>().Any());
+                var shapeDrawing = shapeRun.Descendants<Drawing>().First();
+                var textBoxDrawing = textBoxRun.Descendants<Drawing>().First();
+                shapeDrawing.Remove();
+                var choice = new AlternateContentChoice() { Requires = "wps" };
+                choice.Append(shapeDrawing);
+                var fallback = new AlternateContentFallback();
+                fallback.Append((Drawing)textBoxDrawing.CloneNode(true));
+                var alt = new AlternateContent();
+                alt.Append(choice);
+                alt.Append(fallback);
+                shapeRun.Append(alt);
+                textBoxRun.Remove();
+                var document = wDoc.MainDocumentPart.Document;
+                if (document.LookupNamespace("wps") == null) {
+                    document.AddNamespaceDeclaration("wps", "http://schemas.microsoft.com/office/word/2010/wordprocessingShape");
+                }
+                document.MCAttributes = new MarkupCompatibilityAttributes() { Ignorable = "wps" };
+                document.Save();
+            }
+            using (WordDocument doc = WordDocument.Load(filePath)) {
+                Assert.Single(doc.Shapes);
+                Assert.Empty(doc.TextBoxes);
+            }
+        }
+
+    }
+}

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -938,7 +938,24 @@ namespace OfficeIMO.Word {
                     // Legacy text boxes wrapped in AlternateContent (Word 2007)
                     var ac = _run.ChildElements.OfType<AlternateContent>().FirstOrDefault();
                     if (ac != null) {
-                        return new WordTextBox(_document, _paragraph, _run);
+                        var choice = ac.ChildElements.OfType<AlternateContentChoice>().FirstOrDefault();
+                        if (choice != null) {
+                            bool choiceHasTextBox = choice.Descendants<Wps.TextBoxInfo2>().Any() || choice.Descendants<V.TextBox>().Any();
+                            bool choiceHasShape = choice.Descendants<Wps.WordprocessingShape>().Any() ||
+                                choice.Descendants<V.Shape>().Any(s => !s.Descendants<V.ImageData>().Any() && !s.Descendants<V.TextBox>().Any());
+                            if (choiceHasTextBox) {
+                                return new WordTextBox(_document, _paragraph, _run);
+                            }
+                            if (choiceHasShape) {
+                                return null;
+                            }
+                        }
+                        var fallback = ac.ChildElements.OfType<AlternateContentFallback>().FirstOrDefault();
+                        if (fallback != null) {
+                            if (fallback.Descendants<Wps.TextBoxInfo2>().Any() || fallback.Descendants<V.TextBox>().Any()) {
+                                return new WordTextBox(_document, _paragraph, _run);
+                            }
+                        }
                     }
 
                     // VML text boxes
@@ -956,6 +973,9 @@ namespace OfficeIMO.Word {
         public WordShape Shape {
             get {
                 if (_run != null) {
+                    if (TextBox != null) {
+                        return null;
+                    }
                     // VML shapes
                     if (_run.Descendants<V.Rectangle>().Any() ||
                         _run.Descendants<V.RoundRectangle>().Any() ||
@@ -968,6 +988,21 @@ namespace OfficeIMO.Word {
 
                     // DrawingML shapes (non-pictures and not text boxes)
                     var drawing = _run.ChildElements.OfType<Drawing>().FirstOrDefault();
+                    if (drawing == null) {
+                        var ac = _run.ChildElements.OfType<AlternateContent>().FirstOrDefault();
+                        if (ac != null) {
+                            var choice = ac.ChildElements.OfType<AlternateContentChoice>().FirstOrDefault();
+                            if (choice != null) {
+                                drawing = choice.Descendants<Drawing>().FirstOrDefault();
+                            }
+                            if (drawing == null) {
+                                var fallback = ac.ChildElements.OfType<AlternateContentFallback>().FirstOrDefault();
+                                if (fallback != null) {
+                                    drawing = fallback.Descendants<Drawing>().FirstOrDefault();
+                                }
+                            }
+                        }
+                    }
                     if (drawing != null) {
                         bool hasPicture = drawing.Descendants<DocumentFormat.OpenXml.Drawing.Pictures.Picture>().Any();
                         bool hasTextBox = drawing.Descendants<Wps.TextBoxInfo2>().Any();
@@ -1010,7 +1045,7 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
-        /// Gets a value indicating whether the paragraph contains a VML shape.
+        /// Gets a value indicating whether the paragraph contains a shape.
         /// </summary>
         public bool IsShape {
             get {


### PR DESCRIPTION
## Summary
- avoid treating shapes containing text as both Shape and TextBox
- only classify AlternateContent runs as text boxes when they contain textbox elements
- add regression tests and example for shape/text box detection
- look inside AlternateContent fallback for shapes and text boxes
- handle AlternateContent choice/fallback combinations when classifying text boxes and shapes

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689450c708d4832e89c45e23e164747d