### PR TITLE
Support table cell merges in HTML conversion

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.Tables.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.Tables.cs
@@ -7,7 +7,7 @@ namespace OfficeIMO.Examples.Html {
     internal static partial class Html {
         public static void Example_HtmlTables(string folderPath, bool openWord) {
             string filePath = Path.Combine(folderPath, "HtmlTables.docx");
-            string html = "<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td><table><tr><td>Nested</td></tr></table></td></tr></table>";
+            string html = "<table><tr><td rowspan=\"2\">A</td><td>B</td></tr><tr><td>C</td></tr><tr><td colspan=\"2\">D</td></tr></table>";
 
             // Convert HTML to Word document
             var doc = html.LoadFromHtml(new HtmlToWordOptions());

--- a/OfficeIMO.Tests/HtmlTableMergeTests.cs
+++ b/OfficeIMO.Tests/HtmlTableMergeTests.cs
@@ -1,0 +1,38 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class HtmlTableMergeTests {
+        [Fact]
+        public void HtmlToWordConverter_HandlesRowspanAndColspan() {
+            string html = "<table><tr><td rowspan=\"2\">A1</td><td>B1</td></tr><tr><td>B2</td></tr><tr><td colspan=\"2\">A3</td></tr></table>";
+            using WordDocument doc = html.LoadFromHtml();
+            var table = doc.Tables[0];
+
+            Assert.Equal(MergedCellValues.Restart, table.Rows[0].Cells[0].VerticalMerge);
+            Assert.Equal(MergedCellValues.Continue, table.Rows[1].Cells[0].VerticalMerge);
+            Assert.Equal(MergedCellValues.Restart, table.Rows[2].Cells[0].HorizontalMerge);
+            Assert.Equal(MergedCellValues.Continue, table.Rows[2].Cells[1].HorizontalMerge);
+        }
+
+        [Fact]
+        public void WordToHtmlConverter_EmitsSpanAttributes() {
+            using WordDocument doc = WordDocument.Create();
+            WordTable table = doc.AddTable(3, 2);
+            table.Rows[0].Cells[0].Paragraphs[0].Text = "A1";
+            table.Rows[0].Cells[1].Paragraphs[0].Text = "B1";
+            table.Rows[1].Cells[1].Paragraphs[0].Text = "B2";
+            table.Rows[2].Cells[0].Paragraphs[0].Text = "A3";
+
+            table.MergeCells(0, 0, 2, 1);
+            table.MergeCells(2, 0, 1, 2);
+
+            string html = doc.ToHtml();
+            Assert.Contains("rowspan=\"2\"", html);
+            Assert.Contains("colspan=\"2\"", html);
+        }
+    }
+}
+

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -9,8 +9,16 @@ namespace OfficeIMO.Word.Html.Converters {
             Stack<WordList> listStack, WordTableCell? cell, WordParagraph? currentParagraph) {
             int rows = tableElem.Rows.Length;
             int cols = 0;
-            foreach (var r in tableElem.Rows) {
-                cols = Math.Max(cols, r.Cells.Length);
+            foreach (var row in tableElem.Rows) {
+                int count = 0;
+                foreach (var cellElem in row.Cells) {
+                    int span = 1;
+                    if (cellElem is IHtmlTableCellElement cellElement) {
+                        span = Math.Max(1, cellElement.ColumnSpan);
+                    }
+                    count += span;
+                }
+                cols = Math.Max(cols, count);
             }
             WordTable wordTable;
             if (cell != null) {
@@ -21,17 +29,44 @@ namespace OfficeIMO.Word.Html.Converters {
                 var placeholder = section.AddParagraph("");
                 wordTable = placeholder.AddTableAfter(rows, cols);
             }
+            var occupied = new bool[rows, cols];
             for (int r = 0; r < rows; r++) {
                 var htmlRow = tableElem.Rows[r];
+                int cIndex = 0;
                 for (int c = 0; c < htmlRow.Cells.Length; c++) {
+                    while (cIndex < cols && occupied[r, cIndex]) {
+                        cIndex++;
+                    }
+
                     var htmlCell = htmlRow.Cells[c];
-                    var wordCell = wordTable.Rows[r].Cells[c];
+                    var wordCell = wordTable.Rows[r].Cells[cIndex];
                     if (wordCell.Paragraphs.Count == 1 && string.IsNullOrEmpty(wordCell.Paragraphs[0].Text)) {
                         wordCell.Paragraphs[0].Remove();
                     }
                     foreach (var child in htmlCell.ChildNodes) {
                         ProcessNode(child, doc, section, options, null, listStack, new TextFormatting(), wordCell);
                     }
+
+                    int rowSpan = 1;
+                    int colSpan = 1;
+                    if (htmlCell is IHtmlTableCellElement htmlTableCell) {
+                        rowSpan = Math.Max(1, htmlTableCell.RowSpan);
+                        colSpan = Math.Max(1, htmlTableCell.ColumnSpan);
+                    }
+
+                    if (rowSpan > 1 || colSpan > 1) {
+                        wordTable.MergeCells(r, cIndex, rowSpan, colSpan);
+                        for (int rr = r; rr < r + rowSpan; rr++) {
+                            for (int cc = cIndex; cc < cIndex + colSpan; cc++) {
+                                if (rr == r && cc == cIndex) {
+                                    continue;
+                                }
+                                occupied[rr, cc] = true;
+                            }
+                        }
+                    }
+
+                    cIndex++;
                 }
             }
         }

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -317,10 +317,38 @@ namespace OfficeIMO.Word.Html.Converters {
                             tableEl.SetAttribute("style", string.Join(";", tableStyles));
                         }
 
-                        foreach (var row in table.Rows) {
+                        for (int r = 0; r < table.Rows.Count; r++) {
+                            var row = table.Rows[r];
                             var tr = htmlDoc.CreateElement("tr");
-                            foreach (var cell in row.Cells) {
+                            for (int c = 0; c < row.Cells.Count; c++) {
+                                var cell = row.Cells[c];
+                                if (cell.HorizontalMerge == MergedCellValues.Continue || cell.VerticalMerge == MergedCellValues.Continue) {
+                                    continue;
+                                }
                                 var td = htmlDoc.CreateElement("td");
+                                int colSpan = 1;
+                                int rowSpan = 1;
+                                if (cell.HorizontalMerge == MergedCellValues.Restart) {
+                                    int cc = c + 1;
+                                    while (cc < row.Cells.Count && row.Cells[cc].HorizontalMerge == MergedCellValues.Continue) {
+                                        colSpan++;
+                                        cc++;
+                                    }
+                                    if (colSpan > 1) {
+                                        td.SetAttribute("colspan", colSpan.ToString());
+                                    }
+                                }
+                                if (cell.VerticalMerge == MergedCellValues.Restart) {
+                                    int rr = r + 1;
+                                    while (rr < table.Rows.Count && table.Rows[rr].Cells[c].VerticalMerge == MergedCellValues.Continue) {
+                                        rowSpan++;
+                                        rr++;
+                                    }
+                                    if (rowSpan > 1) {
+                                        td.SetAttribute("rowspan", rowSpan.ToString());
+                                    }
+                                }
+
                                 var cellStyles = new List<string>();
                                 var width = GetWidthCss(cell.WidthType, cell.Width);
                                 if (!string.IsNullOrEmpty(width)) {

--- a/OfficeIMO.Word/WordTable.Methods.cs
+++ b/OfficeIMO.Word/WordTable.Methods.cs
@@ -159,6 +159,30 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Merges a rectangular range of cells.
+        /// </summary>
+        /// <param name="rowIndex">Zero-based starting row index.</param>
+        /// <param name="columnIndex">Zero-based starting column index.</param>
+        /// <param name="rowSpan">Number of rows spanned by the merged region.</param>
+        /// <param name="colSpan">Number of columns spanned by the merged region.</param>
+        /// <param name="copyParagraphs">
+        /// If set to <c>true</c>, paragraphs from merged cells are copied into the first cell.
+        /// </param>
+        public void MergeCells(int rowIndex, int columnIndex, int rowSpan, int colSpan, bool copyParagraphs = false) {
+            if (rowSpan < 1 || colSpan < 1) {
+                return;
+            }
+
+            for (int r = rowIndex; r < rowIndex + rowSpan; r++) {
+                Rows[r].Cells[columnIndex].MergeHorizontally(colSpan - 1, copyParagraphs);
+            }
+
+            for (int c = columnIndex; c < columnIndex + colSpan; c++) {
+                Rows[rowIndex].MergeVertically(c, rowSpan - 1, copyParagraphs);
+            }
+        }
+
+        /// <summary>
         /// Sets the table layout with proper AutoFit options
         /// </summary>
         /// <param name="layoutType">Type of layout to apply</param>


### PR DESCRIPTION
## Summary
- handle rowspan and colspan when importing HTML tables, merging cells using WordTable.MergeCells
- export merged Word table cells as rowspan/colspan attributes in generated HTML
- add unit tests to cover round-trip scenarios for merged cells

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689461d68be4832eb84b9657540dee59