### PR TITLE
feat: preserve preformatted code in HTML↔Word

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.CodeBlocks.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.CodeBlocks.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlCodeBlocks(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlCodeBlocks.docx");
+            string html = "<pre><code>Console.WriteLine(\"Hello\");\nConsole.WriteLine(\"World\");</code></pre>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.CodeBlocks.cs
+++ b/OfficeIMO.Tests/Html.CodeBlocks.cs
@@ -1,0 +1,41 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System.Text.RegularExpressions;
+using System.Linq;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_CodeBlock_RoundTrip() {
+            string html = "<pre><code>var x = 1;\nvar y = 2;</code></pre>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            var codeParas = doc.Paragraphs.Where(p => p.StyleId == "HTMLPreformatted" && !string.IsNullOrEmpty(p.Text)).ToList();
+            Assert.Equal(2, codeParas.Count);
+            Assert.Equal("var x = 1;", codeParas[0].Text);
+            Assert.Equal("var y = 2;", codeParas[1].Text);
+            foreach (var p in codeParas) {
+                Assert.Equal(FontResolver.Resolve("monospace"), p.FontFamily);
+            }
+
+            string roundTrip = doc.ToHtml();
+            Assert.Contains("<pre><code>", roundTrip);
+            Assert.Contains("var x = 1;", roundTrip);
+            Assert.Contains("var y = 2;", roundTrip);
+            Assert.Equal(1, Regex.Matches(roundTrip, "<pre>").Count);
+        }
+
+        [Fact]
+        public void WordToHtml_MonospaceParagraph_OutputCodeBlock() {
+            using var document = WordDocument.Create();
+            var mono = FontResolver.Resolve("monospace")!;
+            document.AddParagraph("Console.WriteLine(\"Hello\");").SetFontFamily(mono).SetStyleId("HTMLPreformatted");
+
+            string html = document.ToHtml();
+
+            Assert.Contains("<pre><code>Console.WriteLine(\"Hello\");</code></pre>", html);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -97,6 +97,27 @@ namespace OfficeIMO.Word.Html.Converters {
                             }
                             break;
                         }
+                    case "pre":
+                    case "code": {
+                            var textContent = element.TextContent;
+                            var lines = textContent.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n');
+                            int start = 0;
+                            int end = lines.Length;
+                            while (start < end && string.IsNullOrEmpty(lines[start])) start++;
+                            while (end > start && string.IsNullOrEmpty(lines[end - 1])) end--;
+                            var mono = FontResolver.Resolve("monospace");
+                            for (int i = start; i < end; i++) {
+                                var line = lines[i];
+                                var paragraph = cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
+                                paragraph.SetStyleId("HTMLPreformatted");
+                                if (!string.IsNullOrEmpty(mono)) {
+                                    paragraph.SetFontFamily(mono);
+                                }
+                                var fmt = new TextFormatting(false, false, false, null, mono);
+                                AddTextRun(paragraph, line, fmt, options);
+                            }
+                            break;
+                        }
                     case "div": {
                             var fmt = formatting;
                             var divStyle = element.GetAttribute("style");


### PR DESCRIPTION
## Summary
- support `<pre><code>` blocks when converting HTML to Word, using Preformatted style and monospace fonts
- emit `<pre><code>` for paragraphs styled as code or using monospace fonts when converting Word back to HTML
- add example and tests to ensure code blocks survive round trips

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689466d64d04832e938033a1535ca136