### PR TITLE
Map NumberFormatValues to HTML list types

### DIFF
--- a/OfficeIMO.Tests/Html.WordToHtml.cs
+++ b/OfficeIMO.Tests/Html.WordToHtml.cs
@@ -105,7 +105,7 @@ namespace OfficeIMO.Tests {
 
             string html = doc.ToHtml(new WordToHtmlOptions { IncludeListStyles = true });
 
-            Assert.Contains("<ol type=\"I\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<ol start=\"1\" type=\"I\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("list-style-type:upper-roman", html, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -120,6 +120,36 @@ namespace OfficeIMO.Tests {
             string html = doc.ToHtml();
 
             Assert.Contains("<ul type=\"circle\"", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_LowerLetter() {
+            using var doc = WordDocument.Create();
+            var list = doc.AddList(WordListStyle.ArticleSections);
+            list.Numbering.Levels[0]._level.NumberingFormat.Val = NumberFormatValues.LowerLetter;
+            list.AddItem("alpha");
+            list.AddItem("beta");
+
+            string html = doc.ToHtml(new WordToHtmlOptions { IncludeListStyles = true });
+
+            Assert.Contains("<ol start=\"1\" type=\"a\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("list-style-type:lower-alpha", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_DecimalLeadingZero() {
+            using var doc = WordDocument.Create();
+            var list = doc.AddList(WordListStyle.ArticleSections);
+            list.Numbering.Levels[0]._level.NumberingFormat.Val = NumberFormatValues.DecimalZero;
+            list.Numbering.Levels[0].SetStartNumberingValue(3);
+            list.AddItem("three");
+            list.AddItem("four");
+
+            string html = doc.ToHtml(new WordToHtmlOptions { IncludeListStyles = true });
+
+            Assert.Contains("<ol", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("start=\"3\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("list-style-type:decimal-leading-zero", html, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -221,56 +221,41 @@ namespace OfficeIMO.Word.Html.Converters {
                 return table.Rows.Any(r => r.Cells.Any(CellHasBorder));
             }
 
+            var formatMap = new Dictionary<NumberFormatValues, (string? Type, string Css)>{
+                { NumberFormatValues.Decimal, ("1", "decimal") },
+                { NumberFormatValues.DecimalZero, (null, "decimal-leading-zero") },
+                { NumberFormatValues.LowerLetter, ("a", "lower-alpha") },
+                { NumberFormatValues.UpperLetter, ("A", "upper-alpha") },
+                { NumberFormatValues.LowerRoman, ("i", "lower-roman") },
+                { NumberFormatValues.UpperRoman, ("I", "upper-roman") },
+            };
+
             string? GetListStyle(DocumentTraversal.ListInfo info) {
                 var format = info.NumberFormat;
-                if (format == NumberFormatValues.Decimal) {
-                    return "decimal";
-                }
-                if (format == NumberFormatValues.LowerLetter) {
-                    return "lower-alpha";
-                }
-                if (format == NumberFormatValues.UpperLetter) {
-                    return "upper-alpha";
-                }
-                if (format == NumberFormatValues.LowerRoman) {
-                    return "lower-roman";
-                }
-                if (format == NumberFormatValues.UpperRoman) {
-                    return "upper-roman";
-                }
                 if (format == NumberFormatValues.Bullet) {
                     return info.LevelText switch {
                         "o" or "◦" => "circle",
                         "■" or "§" => "square",
                         _ => "disc",
                     };
+                }
+                if (format != null && formatMap.TryGetValue(format.Value, out var map)) {
+                    return map.Css;
                 }
                 return null;
             }
 
             string? GetListType(DocumentTraversal.ListInfo info) {
                 var format = info.NumberFormat;
-                if (format == NumberFormatValues.Decimal) {
-                    return "1";
-                }
-                if (format == NumberFormatValues.LowerLetter) {
-                    return "a";
-                }
-                if (format == NumberFormatValues.UpperLetter) {
-                    return "A";
-                }
-                if (format == NumberFormatValues.LowerRoman) {
-                    return "i";
-                }
-                if (format == NumberFormatValues.UpperRoman) {
-                    return "I";
-                }
                 if (format == NumberFormatValues.Bullet) {
                     return info.LevelText switch {
                         "o" or "◦" => "circle",
                         "■" or "§" => "square",
                         _ => "disc",
                     };
+                }
+                if (format != null && formatMap.TryGetValue(format.Value, out var map)) {
+                    return map.Type;
                 }
                 return null;
             }
@@ -291,7 +276,7 @@ namespace OfficeIMO.Word.Html.Converters {
                                 bool ordered = listInfo.Value.Ordered;
                                 var listTag = ordered ? "ol" : "ul";
                                 var listEl = htmlDoc.CreateElement(listTag);
-                                if (ordered && listInfo.Value.Start > 1) {
+                                if (ordered) {
                                     listEl.SetAttribute("start", listInfo.Value.Start.ToString());
                                 }
                                 var typeAttr = GetListType(listInfo.Value);


### PR DESCRIPTION
## Summary
- map NumberFormatValues to HTML list `type` attributes or CSS counters
- always emit `start` attribute to reflect list numbering
- cover additional numbering formats in WordToHtml tests

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter WordToHtml -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68946eb32980832ebb6ae7434af3712f