### PR TITLE
Respect section page settings in PDF export

### DIFF
--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.SectionPageSettings.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.SectionPageSettings.cs
@@ -1,0 +1,30 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Pdf {
+        public static void Example_SaveSectionsPageSettings(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Exporting sections with different page settings to PDF");
+            string docPath = Path.Combine(folderPath, "PdfSectionsPageSettings.docx");
+            string pdfPath = Path.Combine(folderPath, "PdfSectionsPageSettings.pdf");
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.Sections[0].PageSettings.PageSize = WordPageSize.A4;
+                document.Sections[0].PageSettings.Orientation = PageOrientationValues.Landscape;
+                document.AddParagraph("Section 1");
+                WordSection section2 = document.AddSection();
+                section2.PageSettings.PageSize = WordPageSize.A5;
+                section2.PageSettings.Orientation = PageOrientationValues.Portrait;
+                section2.AddParagraph("Section 2");
+                document.Save();
+                document.SaveAsPdf(pdfPath);
+            }
+            Console.WriteLine($"Created: {pdfPath}");
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(pdfPath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -48,28 +48,45 @@ namespace OfficeIMO.Word.Pdf {
                         if (!string.IsNullOrEmpty(options?.FontFamily)) {
                             page.DefaultTextStyle(t => t.FontFamily(options.FontFamily));
                         }
-                        float margin = options?.Margin ?? 1;
-                        Unit unit = options?.MarginUnit ?? Unit.Centimetre;
-                        page.Margin(margin, unit);
 
-                        PageSize size = PageSizes.A4;
-                        PdfPageOrientation? orientation = null;
-                        if (options != null) {
-                            if (options.PageSize != null) {
-                                size = options.PageSize;
-                            } else if (options.DefaultPageSize.HasValue) {
-                                size = MapToPageSize(options.DefaultPageSize.Value);
-                            }
+                        if (options?.Margin != null) {
+                            page.Margin(options.Margin.Value, options.MarginUnit);
+                        } else {
+                            float leftMargin = section.Margins.Left.Value / 20f;
+                            float rightMargin = section.Margins.Right.Value / 20f;
+                            float topMargin = section.Margins.Top.Value / 20f;
+                            float bottomMargin = section.Margins.Bottom.Value / 20f;
+                            page.MarginLeft(leftMargin, Unit.Point);
+                            page.MarginRight(rightMargin, Unit.Point);
+                            page.MarginTop(topMargin, Unit.Point);
+                            page.MarginBottom(bottomMargin, Unit.Point);
+                        }
 
-                            orientation = options.Orientation;
-                            if (orientation == null && options.DefaultOrientation.HasValue) {
-                                orientation = options.DefaultOrientation == W.PageOrientationValues.Landscape ? PdfPageOrientation.Landscape : PdfPageOrientation.Portrait;
-                            }
+                        PageSize size;
+                        if (options?.PageSize != null) {
+                            size = options.PageSize;
+                        } else if (section.PageSettings.PageSize.HasValue) {
+                            size = MapToPageSize(section.PageSettings.PageSize.Value);
+                        } else if (options?.DefaultPageSize.HasValue == true) {
+                            size = MapToPageSize(options.DefaultPageSize.Value);
+                        } else {
+                            size = PageSizes.A4;
+                        }
+
+                        PdfPageOrientation orientation;
+                        if (options?.Orientation != null) {
+                            orientation = options.Orientation.Value;
+                        } else if (section.PageSettings.PageSize.HasValue) {
+                            orientation = section.PageSettings.Orientation == W.PageOrientationValues.Landscape ? PdfPageOrientation.Landscape : PdfPageOrientation.Portrait;
+                        } else if (options?.DefaultOrientation != null) {
+                            orientation = options.DefaultOrientation == W.PageOrientationValues.Landscape ? PdfPageOrientation.Landscape : PdfPageOrientation.Portrait;
+                        } else {
+                            orientation = PdfPageOrientation.Portrait;
                         }
 
                         if (orientation == PdfPageOrientation.Landscape) {
                             size = size.Landscape();
-                        } else if (orientation == PdfPageOrientation.Portrait) {
+                        } else {
                             size = size.Portrait();
                         }
 


### PR DESCRIPTION
## Summary
- honor each section's page size, margins, and orientation when converting to PDF
- add regression test ensuring per-section settings are reflected in the PDF output
- document usage with example showing sections with different page settings

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68946e9c5d58832e96f0be257b2ccfe1