### PR TITLE
Add sup/sub baseline support in HTML conversions

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.SupSub.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.SupSub.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlSupSub(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlSupSub.docx");
+            string html = "<p>H<sub>2</sub>O is water and E=mc<sup>2</sup>.</p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Html.SupSub.cs
+++ b/OfficeIMO.Tests/Html.SupSub.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_SupSub_RoundTrip() {
+            string html = "<p>H<sub>2</sub>O</p><p>Note<sup>1</sup></p>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var docRuns = doc.Paragraphs;
+
+            var subRun = docRuns.First(r => r.Text == "2");
+            Assert.Equal(VerticalPositionValues.Subscript, subRun.VerticalTextAlignment);
+
+            var supRun = docRuns.First(r => r.Text == "1");
+            Assert.Equal(VerticalPositionValues.Superscript, supRun.VerticalTextAlignment);
+
+            string roundTrip = doc.ToHtml();
+            Assert.Contains("<sub>2</sub>", roundTrip);
+            Assert.Contains("<sup>1</sup>", roundTrip);
+        }
+    }
+}
+

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -15,14 +15,18 @@ namespace OfficeIMO.Word.Html.Converters {
             public bool Bold;
             public bool Italic;
             public bool Underline;
+            public bool Superscript;
+            public bool Subscript;
             public string? ColorHex;
             public string? FontFamily;
             public int? FontSize;
 
-            public TextFormatting(bool bold = false, bool italic = false, bool underline = false, string? colorHex = null, string? fontFamily = null, int? fontSize = null) {
+            public TextFormatting(bool bold = false, bool italic = false, bool underline = false, string? colorHex = null, string? fontFamily = null, int? fontSize = null, bool superscript = false, bool subscript = false) {
                 Bold = bold;
                 Italic = italic;
                 Underline = underline;
+                Superscript = superscript;
+                Subscript = subscript;
                 ColorHex = colorHex;
                 FontFamily = fontFamily;
                 FontSize = fontSize;
@@ -153,6 +157,8 @@ namespace OfficeIMO.Word.Html.Converters {
             if (formatting.Bold) run.SetBold();
             if (formatting.Italic) run.SetItalic();
             if (formatting.Underline) run.SetUnderline(UnderlineValues.Single);
+            if (formatting.Superscript) run.SetSuperScript();
+            if (formatting.Subscript) run.SetSubScript();
             if (!string.IsNullOrEmpty(formatting.ColorHex)) run.SetColorHex(formatting.ColorHex);
             if (formatting.FontSize.HasValue) run.SetFontSize(formatting.FontSize.Value);
             if (!string.IsNullOrEmpty(formatting.FontFamily)) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -150,7 +150,8 @@ namespace OfficeIMO.Word.Html.Converters {
                         }
                     case "strong":
                     case "b": {
-                            var fmt = new TextFormatting(true, formatting.Italic, formatting.Underline);
+                            var fmt = formatting;
+                            fmt.Bold = true;
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
                             }
@@ -158,14 +159,32 @@ namespace OfficeIMO.Word.Html.Converters {
                         }
                     case "em":
                     case "i": {
-                            var fmt = new TextFormatting(formatting.Bold, true, formatting.Underline);
+                            var fmt = formatting;
+                            fmt.Italic = true;
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
                             }
                             break;
                         }
                     case "u": {
-                            var fmt = new TextFormatting(formatting.Bold, formatting.Italic, true);
+                            var fmt = formatting;
+                            fmt.Underline = true;
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
+                            }
+                            break;
+                        }
+                    case "sup": {
+                            var fmt = formatting;
+                            fmt.Superscript = true;
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
+                            }
+                            break;
+                        }
+                    case "sub": {
+                            var fmt = formatting;
+                            fmt.Subscript = true;
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
                             }

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -119,6 +119,18 @@ namespace OfficeIMO.Word.Html.Converters {
                         node = u;
                     }
 
+                    if (run.Superscript) {
+                        var sup = htmlDoc.CreateElement("sup");
+                        sup.AppendChild(node);
+                        node = sup;
+                    }
+
+                    if (run.Subscript) {
+                        var sub = htmlDoc.CreateElement("sub");
+                        sub.AppendChild(node);
+                        node = sub;
+                    }
+
                     if (!string.IsNullOrEmpty(run.Hyperlink)) {
                         var a = htmlDoc.CreateElement("a");
                         a.SetAttribute("href", run.Hyperlink);

--- a/OfficeIMO.Word/Converters/FormattingHelper.cs
+++ b/OfficeIMO.Word/Converters/FormattingHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
     /// <summary>
@@ -16,16 +17,20 @@ namespace OfficeIMO.Word {
             public bool Italic { get; }
             public bool Underline { get; }
             public bool Strike { get; }
+            public bool Superscript { get; }
+            public bool Subscript { get; }
             public bool Code { get; }
             public string? Hyperlink { get; }
 
-            public FormattedRun(string? text, WordImage? image, bool bold, bool italic, bool underline, bool strike, bool code, string? hyperlink) {
+            public FormattedRun(string? text, WordImage? image, bool bold, bool italic, bool underline, bool strike, bool superscript, bool subscript, bool code, string? hyperlink) {
                 Text = text;
                 Image = image;
                 Bold = bold;
                 Italic = italic;
                 Underline = underline;
                 Strike = strike;
+                Superscript = superscript;
+                Subscript = subscript;
                 Code = code;
                 Hyperlink = hyperlink;
             }
@@ -41,7 +46,7 @@ namespace OfficeIMO.Word {
 
             foreach (WordParagraph run in paragraph.GetRuns()) {
                 if (run.IsImage && run.Image != null) {
-                    yield return new FormattedRun(null, run.Image, false, false, false, false, false, null);
+                    yield return new FormattedRun(null, run.Image, false, false, false, false, false, false, false, null);
                     continue;
                 }
 
@@ -52,9 +57,11 @@ namespace OfficeIMO.Word {
 
                 string? hyperlink = run.IsHyperLink && run.Hyperlink != null ? run.Hyperlink.Uri?.ToString() : null;
                 bool strike = run.Strike;
+                bool superscript = run.VerticalTextAlignment == VerticalPositionValues.Superscript;
+                bool subscript = run.VerticalTextAlignment == VerticalPositionValues.Subscript;
                 string? monospace = FontResolver.Resolve("monospace");
                 bool code = !string.IsNullOrEmpty(monospace) && string.Equals(run.FontFamily, monospace, StringComparison.OrdinalIgnoreCase);
-                yield return new FormattedRun(text, null, run.Bold, run.Italic, run.Underline != null, strike, code, hyperlink);
+                yield return new FormattedRun(text, null, run.Bold, run.Italic, run.Underline != null, strike, superscript, subscript, code, hyperlink);
             }
         }
     }


### PR DESCRIPTION
## Summary
- handle `<sup>` and `<sub>` elements when importing HTML by adjusting run baselines
- emit `<sup>` and `<sub>` tags when exporting Word runs with baseline shifts
- add example and round-trip tests for chemical formulas and citations

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release`
- `dotnet build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68946ef7334c832e8a026c5a8fb25ff9