### PR TITLE
Support HTML footnote round-trips

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.Footnotes.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.Footnotes.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlFootnotes(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlFootnotes.docx");
+
+            using var doc = WordDocument.Create(filePath);
+            doc.AddParagraph("Text with footnote").AddFootNote("Example footnote");
+            doc.Save();
+
+            string html = doc.ToHtml(new WordToHtmlOptions { ExportFootnotes = true });
+            Console.WriteLine(html);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Html.Footnotes.cs
+++ b/OfficeIMO.Tests/Html.Footnotes.cs
@@ -1,0 +1,39 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class HtmlFootnotes {
+        [Fact]
+        public void FootnotesRoundTrip() {
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Hello").AddFootNote("footnote text");
+
+            string html = doc.ToHtml(new WordToHtmlOptions { ExportFootnotes = true });
+
+            Assert.Contains("<sup", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("footnote text", html, StringComparison.OrdinalIgnoreCase);
+
+            using var roundTrip = html.LoadFromHtml();
+
+            Assert.True(roundTrip.FootNotes.Count >= 1);
+            Assert.Equal("footnote text", roundTrip.FootNotes[0].Paragraphs[1].Text);
+
+            string html2 = roundTrip.ToHtml(new WordToHtmlOptions { ExportFootnotes = true });
+            Assert.Contains("footnote text", html2, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void FootnotesCanBeOmitted() {
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Hello").AddFootNote("hidden");
+
+            string html = doc.ToHtml(new WordToHtmlOptions { ExportFootnotes = false });
+
+            Assert.DoesNotContain("<sup", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("hidden", html, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}
+

--- a/OfficeIMO.Word.Html/Options/WordToHtmlOptions.cs
+++ b/OfficeIMO.Word.Html/Options/WordToHtmlOptions.cs
@@ -20,5 +20,10 @@ namespace OfficeIMO.Word.Html {
         /// When set, includes list style information in generated HTML.
         /// </summary>
         public bool IncludeListStyles { get; set; }
+
+        /// <summary>
+        /// When true, footnotes are exported to HTML. Set to false to omit footnotes.
+        /// </summary>
+        public bool ExportFootnotes { get; set; } = true;
     }
 }


### PR DESCRIPTION
## Summary
- enable optional footnote export in Word-to-HTML conversion
- emit and consume footnote anchors and section for round-tripping
- add example and tests for footnote HTML conversion

## Testing
- `dotnet test OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_6894780a8e6c832ea39a2fb1c076384a