### PR TITLE
Handle HTML hyperlink attributes

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.Hyperlinks.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.Hyperlinks.cs
@@ -7,7 +7,7 @@ namespace OfficeIMO.Examples.Html {
     internal static partial class Html {
         public static void Example_HtmlHyperlinks(string folderPath, bool openWord) {
             string filePath = Path.Combine(folderPath, "HtmlHyperlinks.docx");
-            string html = "<p>Visit <a href=\"https://evotec.xyz\">Evotec</a> or go to https://github.com</p>";
+            string html = "<p id=\"top\">Top</p><p>Visit <a href=\"https://evotec.xyz\" title=\"Evotec site\" target=\"_blank\">Evotec</a> or <a href=\"#top\" title=\"Back to top\">back to top</a></p>";
 
             var doc = html.LoadFromHtml(new HtmlToWordOptions());
             doc.Save(filePath);

--- a/OfficeIMO.Tests/Html.Hyperlinks.cs
+++ b/OfficeIMO.Tests/Html.Hyperlinks.cs
@@ -1,0 +1,36 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void Html_Hyperlinks_Title_And_Target_External() {
+            string html = "<p><a href=\"https://example.com\" title=\"Example\" target=\"_self\">Example</a></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            var hyperlink = doc.ParagraphsHyperLinks[0].Hyperlink;
+
+            Assert.NotNull(hyperlink);
+            Assert.Equal("Example", hyperlink.Tooltip);
+            Assert.Equal(TargetFrame._self, hyperlink.TargetFrame);
+        }
+
+        [Fact]
+        public void Html_Hyperlinks_InternalAnchor() {
+            string html = "<p id=\"top\">Top</p><p><a href=\"#top\" title=\"Back\" target=\"_blank\">Back</a></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Contains(doc.Bookmarks, b => b.Name == "top");
+
+            var hyperlink = doc.ParagraphsHyperLinks[0].Hyperlink;
+
+            Assert.NotNull(hyperlink);
+            Assert.Equal("Back", hyperlink.Tooltip);
+            Assert.Equal(TargetFrame._blank, hyperlink.TargetFrame);
+            Assert.Equal("top", hyperlink.Anchor);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
@@ -57,6 +57,7 @@ namespace OfficeIMO.Word.Html.Converters {
             int level = listStack.Count - 1;
             var paragraph = list.AddItem("", level);
             ApplyClassStyle(element, paragraph, options);
+            AddBookmarkIfPresent(element, paragraph);
             foreach (var child in element.ChildNodes) {
                 ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);
             }


### PR DESCRIPTION
## Summary
- read title and target attributes when converting HTML hyperlinks
- create bookmarks for HTML ids and anchor links
- demonstrate and test hyperlink tooltips, target frames, and internal anchors

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6894a630210c832eba7fe9d280453385