### PR TITLE
Add HTML image export options and sizing

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html04_SaveAsHtmlWithImagePaths.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html04_SaveAsHtmlWithImagePaths.cs
@@ -1,0 +1,26 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word.Converters {
+    internal static class Html04_SaveAsHtmlWithImagePaths {
+        public static void Example(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating Word document with image paths and saving as HTML");
+
+            using var doc = WordDocument.Create();
+
+            string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "Assets", "OfficeIMO.png");
+            doc.AddParagraph("Image Example").Style = WordParagraphStyles.Heading1;
+            doc.AddParagraph().AddImage(assetPath, 100, 100);
+
+            string outputPath = Path.Combine(folderPath, "SaveAsHtmlWithImagePaths.html");
+            doc.SaveAsHtml(outputPath, new WordToHtmlOptions { EmbedImagesAsBase64 = false });
+
+            Console.WriteLine($"✓ Created: {outputPath}");
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(outputPath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.WordToHtml.cs
+++ b/OfficeIMO.Tests/Html.WordToHtml.cs
@@ -72,7 +72,7 @@ namespace OfficeIMO.Tests {
 
             string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
             var paragraph = doc.AddParagraph();
-            paragraph.AddImage(assetPath, description: "Company logo");
+            paragraph.AddImage(assetPath, 40, 40, description: "Company logo");
 
             Assert.Equal("Company logo", paragraph.Image.Description);
 
@@ -81,6 +81,22 @@ namespace OfficeIMO.Tests {
             Assert.Contains("data:image/png", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("content=\"Tester\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("alt=\"Company logo\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("width=\"40\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("height=\"40\"", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_ImageFilePathOption() {
+            using var doc = WordDocument.Create();
+
+            string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
+            var paragraph = doc.AddParagraph();
+            paragraph.AddImage(assetPath, 20, 20);
+
+            string html = doc.ToHtml(new WordToHtmlOptions { EmbedImagesAsBase64 = false });
+
+            Assert.DoesNotContain("data:image", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(Path.GetFileName(assetPath), html, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -105,13 +105,19 @@ namespace OfficeIMO.Word.Html.Converters {
                         var imgObj = run.Image;
                         if (imgObj.IsExternal && imgObj.ExternalUri != null) {
                             src = imgObj.ExternalUri.ToString();
+                        } else if (!options.EmbedImagesAsBase64) {
+                            src = string.IsNullOrEmpty(imgObj.FilePath) ? imgObj.FileName : imgObj.FilePath;
                         } else {
                             var bytes = imgObj.GetBytes();
                             var mime = MimeFromFileName(imgObj.FileName);
                             src = $"data:{mime};base64,{Convert.ToBase64String(bytes)}";
                         }
                         img!.Source = src;
-                        img.AlternativeText = imgObj.Description ?? string.Empty;
+                        if (imgObj.Width.HasValue) img.DisplayWidth = (int)Math.Round(imgObj.Width.Value);
+                        if (imgObj.Height.HasValue) img.DisplayHeight = (int)Math.Round(imgObj.Height.Value);
+                        if (!string.IsNullOrEmpty(imgObj.Description)) {
+                            img.AlternativeText = imgObj.Description;
+                        }
                         parent.AppendChild(img);
                         continue;
                     }

--- a/OfficeIMO.Word.Html/Options/WordToHtmlOptions.cs
+++ b/OfficeIMO.Word.Html/Options/WordToHtmlOptions.cs
@@ -25,5 +25,11 @@ namespace OfficeIMO.Word.Html {
         /// When true, footnotes are exported to HTML. Set to false to omit footnotes.
         /// </summary>
         public bool ExportFootnotes { get; set; } = true;
+
+        /// <summary>
+        /// When true (default), embeds images as base64 data URIs. When false,
+        /// uses the image file paths instead.
+        /// </summary>
+        public bool EmbedImagesAsBase64 { get; set; } = true;
     }
 }


### PR DESCRIPTION
## Summary
- add WordToHtmlOptions.EmbedImagesAsBase64 to choose image export mode
- set image width/height and optional alt text during HTML conversion
- add example and tests for exporting image paths

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6894a907bfb0832ebbd801569bf03232