### PR TITLE
feat: export table cell CSS styling

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.TableCellCss.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.TableCellCss.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlTableCellCss(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlTableCellCss.docx");
+            using var doc = WordDocument.Create();
+            var table = doc.AddTable(1, 1);
+            var cell = table.Rows[0].Cells[0];
+            cell.Paragraphs[0].Text = "Styled";
+            cell.Paragraphs[0].ParagraphAlignment = JustificationValues.Right;
+            cell.ShadingFillColorHex = "ff0000";
+            cell.Borders.LeftStyle = BorderValues.Single;
+            cell.Borders.RightStyle = BorderValues.Single;
+            cell.Borders.TopStyle = BorderValues.Single;
+            cell.Borders.BottomStyle = BorderValues.Single;
+            cell.Borders.LeftColorHex = "00ff00";
+            cell.Borders.RightColorHex = "00ff00";
+            cell.Borders.TopColorHex = "00ff00";
+            cell.Borders.BottomColorHex = "00ff00";
+            cell.Borders.LeftSize = 8;
+            cell.Borders.RightSize = 8;
+            cell.Borders.TopSize = 8;
+            cell.Borders.BottomSize = 8;
+            doc.Save(filePath);
+
+            string html = doc.ToHtml();
+            Console.WriteLine(html);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.WordToHtml.cs
+++ b/OfficeIMO.Tests/Html.WordToHtml.cs
@@ -175,6 +175,33 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_WordToHtml_TableCellCss() {
+            using var doc = WordDocument.Create();
+            var table = doc.AddTable(1, 1);
+            var cell = table.Rows[0].Cells[0];
+            cell.Paragraphs[0].ParagraphAlignment = JustificationValues.Right;
+            cell.ShadingFillColorHex = "ff0000";
+            cell.Borders.LeftStyle = BorderValues.Single;
+            cell.Borders.RightStyle = BorderValues.Single;
+            cell.Borders.TopStyle = BorderValues.Single;
+            cell.Borders.BottomStyle = BorderValues.Single;
+            cell.Borders.LeftColorHex = "00ff00";
+            cell.Borders.RightColorHex = "00ff00";
+            cell.Borders.TopColorHex = "00ff00";
+            cell.Borders.BottomColorHex = "00ff00";
+            cell.Borders.LeftSize = 8;
+            cell.Borders.RightSize = 8;
+            cell.Borders.TopSize = 8;
+            cell.Borders.BottomSize = 8;
+
+            string html = doc.ToHtml();
+
+            Assert.Contains("background-color:#ff0000", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("text-align:right", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("border:1px solid #00ff00", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void Test_WordToHtml_Blockquote() {
             using var doc = WordDocument.Create();
             var p = doc.AddParagraph("Quoted text");

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -1,6 +1,7 @@
 using AngleSharp;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using System;
@@ -245,6 +246,63 @@ namespace OfficeIMO.Word.Html.Converters {
                 return null;
             }
 
+            string? BuildBorderCss(BorderValues? style, string colorHex, UInt32Value size) {
+                if (style == null) {
+                    return null;
+                }
+
+                string cssStyle = "solid";
+                if (style == BorderValues.Dashed) {
+                    cssStyle = "dashed";
+                } else if (style == BorderValues.Dotted) {
+                    cssStyle = "dotted";
+                } else if (style == BorderValues.Double) {
+                    cssStyle = "double";
+                }
+
+                string color = !string.IsNullOrEmpty(colorHex) ? $"#{colorHex}" : "black";
+                double widthPt = size != null ? size.Value / 8.0 : 1.0;
+                double widthPx = widthPt * 96 / 72;
+                string width = $"{Math.Round(widthPx)}px";
+                return $"{width} {cssStyle} {color}";
+            }
+
+            List<string> GetBorderCss(WordTableCell cell) {
+                List<string> styles = new();
+                var b = cell.Borders;
+                if (b == null) {
+                    return styles;
+                }
+
+                var left = BuildBorderCss(b.LeftStyle, b.LeftColorHex, b.LeftSize);
+                var right = BuildBorderCss(b.RightStyle, b.RightColorHex, b.RightSize);
+                var top = BuildBorderCss(b.TopStyle, b.TopColorHex, b.TopSize);
+                var bottom = BuildBorderCss(b.BottomStyle, b.BottomColorHex, b.BottomSize);
+
+                if (left == null && right == null && top == null && bottom == null) {
+                    return styles;
+                }
+
+                if (left == top && top == right && right == bottom && left != null) {
+                    styles.Add($"border:{left}");
+                } else {
+                    if (left != null) {
+                        styles.Add($"border-left:{left}");
+                    }
+                    if (right != null) {
+                        styles.Add($"border-right:{right}");
+                    }
+                    if (top != null) {
+                        styles.Add($"border-top:{top}");
+                    }
+                    if (bottom != null) {
+                        styles.Add($"border-bottom:{bottom}");
+                    }
+                }
+
+                return styles;
+            }
+
             bool CellHasBorder(WordTableCell cell) {
                 var b = cell.Borders;
                 return b != null && (b.LeftStyle != null || b.RightStyle != null || b.TopStyle != null || b.BottomStyle != null);
@@ -410,9 +468,11 @@ namespace OfficeIMO.Word.Html.Converters {
                                 if (!string.IsNullOrEmpty(align)) {
                                     cellStyles.Add($"text-align:{align}");
                                 }
-                                if (CellHasBorder(cell)) {
-                                    cellStyles.Add("border:1px solid black");
+                                var bg = cell.ShadingFillColorHex;
+                                if (!string.IsNullOrEmpty(bg)) {
+                                    cellStyles.Add($"background-color:#{bg}");
                                 }
+                                cellStyles.AddRange(GetBorderCss(cell));
                                 if (cellStyles.Count > 0) {
                                     td.SetAttribute("style", string.Join(";", cellStyles));
                                 }


### PR DESCRIPTION
## Summary
- compute CSS for table cell borders, shading and alignment
- verify HTML export includes border, background and text align styles
- add example demonstrating table cell CSS styling

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_6894a90e8d74832e9e7007c363a79a2d