### PR TITLE
Handle HTML text-decoration tags and styles

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.TextDecorations.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.TextDecorations.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlTextDecorations(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlTextDecorations.docx");
+            string html = "<p><s>strike</s> <del>delete</del> <ins>insert</ins> <mark>mark</mark></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.SpanStyles.cs
+++ b/OfficeIMO.Tests/Html.SpanStyles.cs
@@ -1,6 +1,7 @@
 using OfficeIMO.Word.Html;
 using OfficeIMO.Word;
 using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -15,6 +16,23 @@ namespace OfficeIMO.Tests {
             Assert.Equal("ff0000", run.ColorHex);
             Assert.Equal("Arial", run.FontFamily);
             Assert.Equal(24, run.FontSize);
+        }
+
+        [Fact]
+        public void HtmlToWord_SpanStyles_Decorations() {
+            string html = "<p><span style=\"text-decoration:line-through\">strike</span><span style=\"text-decoration:underline\">under</span><span style=\"background-color:#ffff00\">mark</span></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var runs = doc.Paragraphs;
+
+            var strikeRun = runs.First(r => r.Text == "strike");
+            Assert.True(strikeRun.Strike);
+
+            var underRun = runs.First(r => r.Text == "under");
+            Assert.Equal(UnderlineValues.Single, underRun.Underline);
+
+            var markRun = runs.First(r => r.Text == "mark");
+            Assert.Equal(HighlightColorValues.Yellow, markRun.Highlight);
         }
     }
 }

--- a/OfficeIMO.Tests/Html.TextDecorations.cs
+++ b/OfficeIMO.Tests/Html.TextDecorations.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_TextDecorationTags() {
+            string html = "<p><s>strike</s><del>delete</del><ins>insert</ins><mark>mark</mark></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var runs = doc.Paragraphs;
+
+            var strikeRun = runs.First(r => r.Text == "strike");
+            Assert.True(strikeRun.Strike);
+
+            var delRun = runs.First(r => r.Text == "delete");
+            Assert.True(delRun.Strike);
+
+            var insRun = runs.First(r => r.Text == "insert");
+            Assert.Equal(UnderlineValues.Single, insRun.Underline);
+
+            var markRun = runs.First(r => r.Text == "mark");
+            Assert.Equal(HighlightColorValues.Yellow, markRun.Highlight);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -195,6 +195,31 @@ namespace OfficeIMO.Word.Html.Converters {
                             }
                             break;
                         }
+                    case "s":
+                    case "del": {
+                            var fmt = formatting;
+                            fmt.Strike = true;
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
+                            }
+                            break;
+                        }
+                    case "ins": {
+                            var fmt = formatting;
+                            fmt.Underline = true;
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
+                            }
+                            break;
+                        }
+                    case "mark": {
+                            var fmt = formatting;
+                            fmt.Highlight = HighlightColorValues.Yellow;
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
+                            }
+                            break;
+                        }
                     case "sup": {
                             var fmt = formatting;
                             fmt.Superscript = true;


### PR DESCRIPTION
## Summary
- map `<s>`/`<del>` to strikethrough, `<ins>` to underline, and `<mark>` to highlighted runs
- parse `text-decoration` and `background-color` span styles for underline/strike/highlight
- add example and tests for new HTML text decorations

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6894dccf85ec832e8296dfef8b4df41e