### PR TITLE
Validate inputs when saving Word as PDF

### DIFF
--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
@@ -107,6 +107,41 @@ namespace OfficeIMO.Tests;
     }
 
     [Fact]
+    public void Test_WordDocument_SaveAsPdf_CreatesDirectory() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfCreateDir.docx");
+        string pdfDir = Path.Combine(_directoryWithFiles, "MissingDir");
+        string pdfPath = Path.Combine(pdfDir, "PdfCreateDir.pdf");
+
+        if (Directory.Exists(pdfDir)) {
+            Directory.Delete(pdfDir, true);
+        }
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            document.AddParagraph("Hello World");
+            document.Save();
+            document.SaveAsPdf(pdfPath);
+        }
+
+        Assert.True(File.Exists(pdfPath));
+    }
+
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_NullPath_Throws() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfNullPath.docx");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            document.AddParagraph("Hello World");
+            document.Save();
+            Assert.Throws<ArgumentNullException>(() => document.SaveAsPdf((string)null!));
+        }
+    }
+
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_NullDocument_Throws() {
+        Assert.Throws<ArgumentNullException>(() => WordPdfConverterExtensions.SaveAsPdf(null!, "file.pdf"));
+    }
+
+    [Fact]
     public void Test_WordDocument_SaveAsPdf_CustomParagraphFont() {
         string font = FontResolver.Resolve("monospace")!;
         string expected = Regex.Replace(font, @"\s+", "");

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -22,6 +22,19 @@ namespace OfficeIMO.Word.Pdf {
         /// <param name="path">The output PDF file path.</param>
         /// <param name="options">Optional PDF configuration.</param>
         public static void SaveAsPdf(this WordDocument document, string path, PdfSaveOptions? options = null) {
+            if (document == null) {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            if (path == null) {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            string? directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory)) {
+                Directory.CreateDirectory(directory);
+            }
+
             Document pdf = CreatePdfDocument(document, options);
             pdf.GeneratePdf(path);
         }
@@ -33,6 +46,14 @@ namespace OfficeIMO.Word.Pdf {
         /// <param name="stream">The output stream to receive the PDF data.</param>
         /// <param name="options">Optional PDF configuration.</param>
         public static void SaveAsPdf(this WordDocument document, Stream stream, PdfSaveOptions? options = null) {
+            if (document == null) {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            if (stream == null) {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
             Document pdf = CreatePdfDocument(document, options);
             pdf.GeneratePdf(stream);
         }


### PR DESCRIPTION
## Summary
- guard against null document and path when saving as PDF
- ensure PDF destination directory exists
- test SaveAsPdf for invalid arguments and missing directories

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6894e1d969dc832eb9ec44561d9c0ff9