### PR TITLE
Handle code block languages

### DIFF
--- a/OfficeIMO.Examples/Converters/Markdown/Markdown.CodeBlocks.cs
+++ b/OfficeIMO.Examples/Converters/Markdown/Markdown.CodeBlocks.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using OfficeIMO.Word.Markdown;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Markdown {
+    internal static partial class Markdown {
+        public static void Example_MarkdownCodeBlocks(string folderPath, bool openWord) {
+            string markdown = "```csharp\nConsole.WriteLine(\"Hello\");\n```";
+
+            var doc = markdown.LoadFromMarkdown(new MarkdownToWordOptions());
+            var codeParagraph = doc.Paragraphs[0];
+            Console.WriteLine($"Detected language style: {codeParagraph.StyleId}");
+
+            string filePath = Path.Combine(folderPath, "MarkdownCodeBlock.docx");
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Markdown.BasicBlocks.cs
+++ b/OfficeIMO.Tests/Markdown.BasicBlocks.cs
@@ -36,17 +36,20 @@ code
             var doc = md.LoadFromMarkdown(new MarkdownToWordOptions { FontFamily = "Calibri" });
 
             Assert.Equal(WordParagraphStyles.Heading1, doc.Paragraphs[0].Style);
-              var quoteParagraph = doc.Paragraphs.First(p => p.Text.Contains("Quote line"));
-              Assert.True(quoteParagraph.IndentationBefore > 0);
+            var quoteParagraph = doc.Paragraphs.First(p => p.Text.Contains("Quote line"));
+            Assert.True(quoteParagraph.IndentationBefore > 0);
+
+            var codeParagraph = doc.Paragraphs.First(p => p.Text.Contains("code"));
+            Assert.Equal("CodeLang_c", codeParagraph.StyleId);
 
             using MemoryStream ms = new();
             doc.Save(ms);
             ms.Position = 0;
-              using WordprocessingDocument docx = WordprocessingDocument.Open(ms, false);
-              var body = docx.MainDocumentPart!.Document.Body!;
+            using WordprocessingDocument docx = WordprocessingDocument.Open(ms, false);
+            var body = docx.MainDocumentPart!.Document.Body!;
 
-              var codeRun = body.Descendants<Run>().First(r => r.InnerText.Contains("code"));
-              Assert.Equal("Consolas", codeRun.RunProperties!.RunFonts!.Ascii);
+            var codeRun = body.Descendants<Run>().First(r => r.InnerText.Contains("code"));
+            Assert.Equal(FontResolver.Resolve("monospace"), codeRun.RunProperties!.RunFonts!.Ascii);
         }
     }
 }

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
@@ -4,6 +4,7 @@ using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using OfficeIMO.Word;
 using System;
+using System.Linq;
 
 namespace OfficeIMO.Word.Markdown.Converters {
     /// <summary>
@@ -74,7 +75,17 @@ namespace OfficeIMO.Word.Markdown.Converters {
                     var codeParagraph = document.AddParagraph(string.Empty);
                     var codeText = GetCodeBlockText(codeBlock);
                     var run = codeParagraph.AddFormattedText(codeText);
-                    run.SetFontFamily("Consolas");
+                    var monoFont = FontResolver.Resolve("monospace") ?? "Consolas";
+                    run.SetFontFamily(monoFont);
+                    if (codeBlock is FencedCodeBlock fenced && !string.IsNullOrWhiteSpace(fenced.Info)) {
+                        var info = fenced.Info.Split(new[] { ' ', '{' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (info.Length > 0) {
+                            var lang = new string(info[0].Where(char.IsLetterOrDigit).ToArray());
+                            if (!string.IsNullOrEmpty(lang)) {
+                                codeParagraph.SetStyleId($"CodeLang_{lang}");
+                            }
+                        }
+                    }
                     break;
                 case Table table:
                     ProcessTable(table, document, options);


### PR DESCRIPTION
## Summary
- detect language in fenced code blocks and tag paragraphs with CodeLang_* style ids
- use FontResolver to apply platform-appropriate monospace fonts to code blocks
- add example and tests for code block language metadata

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6894e6cb3424832ea1b794add5df47bd