### PR TITLE
Allow custom head tags in Word to HTML conversion

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html05_SaveAsHtmlWithAdditionalHeadTags.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html05_SaveAsHtmlWithAdditionalHeadTags.cs
@@ -1,0 +1,31 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word.Converters {
+    internal static class Html05_SaveAsHtmlWithAdditionalHeadTags {
+        public static void Example(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating Word document with extra head elements and saving as HTML");
+
+            using var doc = WordDocument.Create();
+
+            doc.BuiltinDocumentProperties.Title = "Sample HTML";
+
+            doc.AddParagraph("Example Document").Style = WordParagraphStyles.Heading1;
+
+            var options = new WordToHtmlOptions();
+            options.AdditionalMetaTags.Add(("viewport", "width=device-width, initial-scale=1"));
+            options.AdditionalLinkTags.Add(("stylesheet", "styles.css"));
+
+            string outputPath = Path.Combine(folderPath, "SaveAsHtmlWithAdditionalHeadTags.html");
+            doc.SaveAsHtml(outputPath, options);
+
+            Console.WriteLine($"✓ Created: {outputPath}");
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(outputPath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Html.WordToHtml.cs
+++ b/OfficeIMO.Tests/Html.WordToHtml.cs
@@ -238,6 +238,25 @@ namespace OfficeIMO.Tests {
 
             Assert.Contains("<hr", html, StringComparison.OrdinalIgnoreCase);
         }
+
+        [Fact]
+        public void Test_WordToHtml_AdditionalHeadElements() {
+            using var doc = WordDocument.Create();
+            doc.BuiltinDocumentProperties.Creator = "Tester";
+            doc.AddParagraph("Content");
+
+            var options = new WordToHtmlOptions();
+            options.AdditionalMetaTags.Add(("viewport", "width=device-width"));
+            options.AdditionalLinkTags.Add(("stylesheet", "styles.css"));
+
+            string html = doc.ToHtml(options);
+
+            Assert.Contains("<meta name=\"viewport\" content=\"width=device-width\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<link rel=\"stylesheet\" href=\"styles.css\"", html, StringComparison.OrdinalIgnoreCase);
+            int authorIndex = html.IndexOf("name=\"author\"", StringComparison.OrdinalIgnoreCase);
+            int viewportIndex = html.IndexOf("name=\"viewport\"", StringComparison.OrdinalIgnoreCase);
+            Assert.True(viewportIndex > authorIndex);
+        }
     }
 }
 

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -47,6 +47,26 @@ namespace OfficeIMO.Word.Html.Converters {
                 AddMeta("subject", props.Subject);
             }
 
+            foreach (var (name, content) in options.AdditionalMetaTags) {
+                if (!string.IsNullOrEmpty(name)) {
+                    var meta = htmlDoc.CreateElement("meta");
+                    meta.SetAttribute("name", name);
+                    if (!string.IsNullOrEmpty(content)) {
+                        meta.SetAttribute("content", content);
+                    }
+                    head.AppendChild(meta);
+                }
+            }
+
+            foreach (var (rel, href) in options.AdditionalLinkTags) {
+                if (!string.IsNullOrEmpty(rel) && !string.IsNullOrEmpty(href)) {
+                    var link = htmlDoc.CreateElement("link");
+                    link.SetAttribute("rel", rel);
+                    link.SetAttribute("href", href);
+                    head.AppendChild(link);
+                }
+            }
+
             if (!string.IsNullOrEmpty(options.FontFamily)) {
                 body.SetAttribute("style", $"font-family:{options.FontFamily}");
             }

--- a/OfficeIMO.Word.Html/Options/WordToHtmlOptions.cs
+++ b/OfficeIMO.Word.Html/Options/WordToHtmlOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Word.Html {
@@ -31,5 +32,17 @@ namespace OfficeIMO.Word.Html {
         /// uses the image file paths instead.
         /// </summary>
         public bool EmbedImagesAsBase64 { get; set; } = true;
+
+        /// <summary>
+        /// Additional meta tags to include in the HTML head. Each tuple represents
+        /// the <c>name</c> and <c>content</c> attributes of a meta element.
+        /// </summary>
+        public List<(string Name, string Content)> AdditionalMetaTags { get; } = new();
+
+        /// <summary>
+        /// Additional link tags to include in the HTML head. Each tuple represents
+        /// the <c>rel</c> and <c>href</c> attributes of a link element.
+        /// </summary>
+        public List<(string Rel, string Href)> AdditionalLinkTags { get; } = new();
     }
 }


### PR DESCRIPTION
## Summary
- support custom `<meta>` and `<link>` tags via `WordToHtmlOptions`
- render additional head elements in the HTML converter
- demonstrate usage in HTML example and unit tests

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6894ee2ed3f8832e9d6ef74ec7bfb040