### PR TITLE
Render Word shapes in PDF output

### DIFF
--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.Shapes.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.Shapes.cs
@@ -1,0 +1,23 @@
+using OfficeIMO.Word.Pdf;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Pdf {
+        public static void Example_SaveShapes(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with shapes and exporting to PDF");
+            string docPath = Path.Combine(folderPath, "ExportShapesToPdf.docx");
+            string pdfPath = Path.Combine(folderPath, "ExportShapesToPdf.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                var paragraph = document.AddParagraph();
+                paragraph.AddShape(ShapeType.Rectangle, 80, 40, Color.Aqua, Color.Black, 1);
+                WordShape.AddLine(paragraph, 0, 50, 80, 50, Color.Red, 2);
+                document.Save();
+                document.SaveAsPdf(pdfPath);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Shapes.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Shapes.cs
@@ -1,0 +1,47 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using SixLabors.ImageSharp;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_Shapes() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfShapesSample.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfShapesSample.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            var paragraph = document.AddParagraph();
+            paragraph.AddShape(ShapeType.Rectangle, 80, 40, Color.Aqua, Color.Black, 1);
+            WordShape.AddLine(paragraph, 0, 50, 80, 50, Color.Red, 2);
+            document.Save();
+            document.SaveAsPdf(pdfPath);
+        }
+
+        Assert.True(File.Exists(pdfPath));
+
+        byte[] bytes = File.ReadAllBytes(pdfPath);
+        byte[] startPattern = Encoding.ASCII.GetBytes("stream\n");
+        byte[] endPattern = Encoding.ASCII.GetBytes("\nendstream");
+        int start = IndexOf(bytes, startPattern, 0);
+        Assert.True(start >= 0, "stream marker not found");
+        start += startPattern.Length;
+        int end = IndexOf(bytes, endPattern, start);
+        Assert.True(end >= 0, "endstream marker not found");
+        int length = end - start;
+        if (length > 6) {
+            int deflateLength = length - 6;
+            byte[] deflateData = new byte[deflateLength];
+            System.Array.Copy(bytes, start + 2, deflateData, 0, deflateLength);
+            using MemoryStream ms = new MemoryStream(deflateData);
+            using DeflateStream ds = new DeflateStream(ms, CompressionMode.Decompress);
+            using StreamReader reader = new StreamReader(ds, Encoding.GetEncoding("ISO-8859-1"));
+            string content = reader.ReadToEnd();
+            Assert.False(string.IsNullOrEmpty(content));
+        }
+    }
+}

--- a/OfficeIMO.Word.Pdf/OfficeIMO.Word.Pdf.csproj
+++ b/OfficeIMO.Word.Pdf/OfficeIMO.Word.Pdf.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="QuestPDF" Version="2025.7.0" />
+    <PackageReference Include="SkiaSharp" Version="2.88.6" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="System" />

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
@@ -1,9 +1,12 @@
 using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Vml;
 using OfficeIMO.Word;
 using QuestPDF.Fluent;
 using QuestPDF.Infrastructure;
+using SkiaSharp;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using W = DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word.Pdf {
@@ -152,9 +155,70 @@ namespace OfficeIMO.Word.Pdf {
             if (shape == null) {
                 return container;
             }
+            float width = (float)shape.Width;
+            float height = (float)shape.Height;
 
-            container.Text("[Shape]");
+            string? fill = shape.FillColorHex;
+            string? stroke = shape.StrokeColorHex;
+            float strokeWidth = (float)(shape.StrokeWeight ?? 1);
+            bool drawStroke = shape.Stroked ?? false;
+
+            var type = shape.GetType();
+            var runField = type.GetField("_run", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var run = runField?.GetValue(shape) as DocumentFormat.OpenXml.Wordprocessing.Run;
+            string text = run?.InnerText ?? string.Empty;
+
+            var lineField = type.GetField("_line", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var line = lineField?.GetValue(shape) as Line;
+
+            if (line != null) {
+                container.Canvas((canvasObj, size) => {
+                    var canvasType = canvasObj.GetType();
+                    var positionType = canvasType.Assembly.GetType("QuestPDF.Infrastructure.Position");
+                    var ctor = positionType!.GetConstructor(new[] { typeof(float), typeof(float) });
+
+                    (float x1, float y1) = ParsePoint(line.From?.Value ?? "0pt,0pt");
+                    (float x2, float y2) = ParsePoint(line.To?.Value ?? "0pt,0pt");
+                    object start = ctor!.Invoke(new object[] { x1, y1 });
+                    object end = ctor.Invoke(new object[] { x2, y2 });
+
+                    var paint = new SKPaint {
+                        Style = SKPaintStyle.Stroke,
+                        Color = SKColor.Parse("#" + (stroke ?? "000000")),
+                        StrokeWidth = strokeWidth
+                    };
+
+                    canvasType.GetMethod("DrawLine")!.Invoke(canvasObj, new object[] { start, end, paint });
+                });
+
+                return container;
+            }
+
+            container = container.Width(width).Height(height);
+
+            if (!string.IsNullOrEmpty(fill)) {
+                container = container.Background("#" + fill);
+            }
+
+            if (drawStroke) {
+                container = container.BorderColor("#" + (stroke ?? "000000")).Border(strokeWidth);
+            }
+
+            if (!string.IsNullOrWhiteSpace(text)) {
+                container = container.AlignCenter().AlignMiddle();
+                container.Text(text);
+            }
+
             return container;
+
+            static (float, float) ParsePoint(string value) {
+                var parts = value.Split(',');
+                return (Parse(parts[0]), Parse(parts[1]));
+            }
+
+            static float Parse(string value) {
+                return (float)double.Parse(value.Replace("pt", string.Empty), CultureInfo.InvariantCulture);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- draw Word line shapes on QuestPDF canvas using SkiaSharp paints
- support fills, strokes and centered text for rectangular shapes
- add PDF shape example and regression test

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_6894ef8d2058832e8f631da195a5d79b