### PR TITLE
Handle figure captions in HTML converter

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.Figure.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.Figure.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlFigureWithCaption(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlFigureWithCaption.docx");
+            byte[] imageBytes = File.ReadAllBytes(Path.Combine("Assets", "OfficeIMO.png"));
+            string base64 = Convert.ToBase64String(imageBytes);
+            string html = $"<figure><img src=\"data:image/png;base64,{base64}\" alt=\"Logo\"/><figcaption>OfficeIMO Logo</figcaption></figure>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -23,6 +23,7 @@ namespace OfficeIMO.Examples {
             // Html/Html
             OfficeIMO.Examples.Html.Html.Example_HtmlHeadings(folderPath, false);
             OfficeIMO.Examples.Html.Html.Example_HtmlImages(folderPath, false);
+            OfficeIMO.Examples.Html.Html.Example_HtmlFigureWithCaption(folderPath, false);
             OfficeIMO.Examples.Html.Html.Example_HtmlInterface(folderPath, false);
             OfficeIMO.Examples.Html.Html.Example_HtmlLists(folderPath, false);
             OfficeIMO.Examples.Html.Html.Example_HtmlRoundTrip(folderPath, false);

--- a/OfficeIMO.Tests/Html.Figures.cs
+++ b/OfficeIMO.Tests/Html.Figures.cs
@@ -1,0 +1,23 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System;
+using System.IO;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void Html_FigureWithCaption_Converts() {
+            string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
+            byte[] imageBytes = File.ReadAllBytes(assetPath);
+            string base64 = Convert.ToBase64String(imageBytes);
+            string html = $"<figure><img src=\"data:image/png;base64,{base64}\" alt=\"Logo\"/><figcaption>Logo caption</figcaption></figure>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Single(doc.Images);
+            Assert.Equal("Logo caption", doc.Paragraphs[1].Text);
+            Assert.Equal("Caption", doc.Paragraphs[1].StyleId);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -343,6 +343,25 @@ namespace OfficeIMO.Word.Html.Converters {
                             ProcessTable((IHtmlTableElement)element, doc, section, options, listStack, cell, currentParagraph);
                             break;
                         }
+                    case "figure": {
+                            var img = element.QuerySelector("img") as IHtmlImageElement;
+                            if (img != null) {
+                                ProcessImage(img, doc);
+                            }
+                            var caption = element.QuerySelector("figcaption");
+                            if (caption != null) {
+                                ApplyCssToElement(caption);
+                                var paragraph = cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
+                                paragraph.SetStyleId("Caption");
+                                ApplyParagraphStyleFromCss(paragraph, caption);
+                                ApplyClassStyle(caption, paragraph, options);
+                                AddBookmarkIfPresent(caption, paragraph);
+                                foreach (var child in caption.ChildNodes) {
+                                    ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);
+                                }
+                            }
+                            break;
+                        }
                     case "img": {
                             ProcessImage((IHtmlImageElement)element, doc);
                             break;


### PR DESCRIPTION
## Summary
- support `<figure>` with image and caption in HTML to Word conversion
- add example demonstrating figure caption conversion
- cover figure caption conversion with unit test

## Testing
- `dotnet build`
- `dotnet test --filter Html_FigureWithCaption_Converts`


------
https://chatgpt.com/codex/tasks/task_e_68950c2b2f8c832eb3da0c379b2e5df6