### PR TITLE
Parse table element styles

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.TableStyles.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.TableStyles.cs
@@ -1,0 +1,18 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlTableStyles(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlTableStyles.docx");
+            string html = "<table style=\"border:2px solid #ff0000; background-color:#00ff00\"><tr><td style=\"border:1px dashed #0000ff\">Cell</td></tr></table>";
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.TableStyles.cs
+++ b/OfficeIMO.Tests/Html.TableStyles.cs
@@ -1,0 +1,24 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_TableStyles_BorderAndShading() {
+            string html = "<table style=\"border:2px solid #ff0000\"><tr style=\"background-color:#00ff00\"><td style=\"border:1px dashed #0000ff\">Cell</td></tr></table>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var table = doc.Tables[0];
+            var (style, size, colorHex) = table.StyleDetails.GetBorderProperties(WordTableBorderSide.Top);
+            Assert.Equal(BorderValues.Single, style);
+            Assert.Equal((UInt32Value)12U, size);
+            Assert.Equal("ff0000", colorHex);
+            var cell = table.Rows[0].Cells[0];
+            Assert.Equal("00ff00", cell.ShadingFillColorHex);
+            Assert.Equal(BorderValues.Dashed, cell.Borders.TopStyle);
+            Assert.Equal("0000ff", cell.Borders.TopColorHex);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- parse table CSS styles like border, padding, background color and width when converting HTML to Word
- demonstrate table styling in HTML conversion example
- test table border and shading parsing

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68950c242734832eafb1504eeb4a87fe