### PR TITLE
Add footnote support and page numbers to PDF export

### DIFF
--- a/OfficeIMO.Tests/OfficeIMO.Tests.csproj
+++ b/OfficeIMO.Tests/OfficeIMO.Tests.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="AutoFixture" Version="4.18.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="SemanticComparison" Version="4.1.0" />
+        <PackageReference Include="PdfPig" Version="0.1.11" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="coverlet.collector" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Footnotes.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Footnotes.cs
@@ -1,0 +1,32 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using UglyToad.PdfPig;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void SaveAsPdf_Renders_Footnotes_And_PageNumbers() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfFootnotes.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfFootnotes.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                WordParagraph p = document.AddParagraph("Footnote here");
+                p.AddFootNote("Footnote text");
+                document.Save();
+                document.SaveAsPdf(pdfPath);
+            }
+
+            Assert.True(File.Exists(pdfPath));
+            using (var pdf = PdfDocument.Open(pdfPath)) {
+                string allText = string.Concat(pdf.GetPages().Select(p => p.Text));
+                Assert.Contains("Footnote here1", allText);
+                Assert.Equal(1, pdf.NumberOfPages);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Tables.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Tables.cs
@@ -8,7 +8,7 @@ using W = DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word.Pdf {
     public static partial class WordPdfConverterExtensions {
-        private static IContainer RenderTable(IContainer container, WordTable table, Func<WordParagraph, (int Level, string Marker)?> getMarker, PdfSaveOptions? options) {
+        private static IContainer RenderTable(IContainer container, WordTable table, Func<WordParagraph, (int Level, string Marker)?> getMarker, PdfSaveOptions? options, Dictionary<WordParagraph, int> footnoteMap) {
             container.Table(tableContainer => {
                 TableLayout layout = TableLayoutCache.GetLayout(table);
                 tableContainer.ColumnsDefinition(columns => {
@@ -28,11 +28,13 @@ namespace OfficeIMO.Word.Pdf {
 
                             cellContainer.Column(cellColumn => {
                                 foreach (WordParagraph paragraph in cell.Paragraphs) {
-                                    cellColumn.Item().Element(e => RenderParagraph(e, paragraph, getMarker(paragraph), options));
+                                    cellColumn.Item().Element(e => {
+                                        return RenderParagraph(e, paragraph, getMarker(paragraph), options, footnoteMap);
+                                    });
                                 }
 
                                 foreach (WordTable nested in cell.NestedTables) {
-                                    cellColumn.Item().Element(e => RenderTable(e, nested, getMarker, options));
+                                    cellColumn.Item().Element(e => RenderTable(e, nested, getMarker, options, footnoteMap));
                                 }
                             });
 


### PR DESCRIPTION
## Summary
- collect Word footnotes before rendering and display them at the bottom of PDF pages
- add footer layer with dynamic page numbers
- test PDF export for footnote numbering and page count
- switch PDF parser dependency to official PdfPig 0.1.11 package

## Testing
- `dotnet build`
- `dotnet test --filter SaveAsPdf_Renders_Footnotes_And_PageNumbers`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68950c184558832e933ce88cd942f4e2