### PR TITLE
Support Markdown footnotes on import

### DIFF
--- a/OfficeIMO.Examples/Converters/Markdown/Markdown.LoadFootNotes.cs
+++ b/OfficeIMO.Examples/Converters/Markdown/Markdown.LoadFootNotes.cs
@@ -1,0 +1,16 @@
+using System.IO;
+using OfficeIMO.Word.Markdown;
+
+namespace OfficeIMO.Examples.Markdown {
+    internal static partial class Markdown {
+        public static void Example_MarkdownLoadFootNotes(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "MarkdownLoadFootNotes.docx");
+            string md = "Paragraph with footnote[^1].\n\n[^1]: Footnote text";
+            using var document = md.LoadFromMarkdown();
+            document.Save(filePath);
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Markdown.Footnotes.cs
+++ b/OfficeIMO.Tests/Markdown.Footnotes.cs
@@ -1,0 +1,14 @@
+using OfficeIMO.Word.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Markdown {
+        [Fact]
+        public void MarkdownToWord_Footnotes() {
+            string md = "Text with footnote[^1].\n\n[^1]: Footnote text";
+            using var doc = md.LoadFromMarkdown();
+            Assert.Single(doc.FootNotes);
+            Assert.Equal("Footnote text", doc.FootNotes[0].Paragraphs[1].Text);
+        }
+    }
+}

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Inlines.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Inlines.cs
@@ -1,3 +1,4 @@
+using Markdig.Extensions.Footnotes;
 using Markdig.Renderers.Html;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
@@ -36,6 +37,10 @@ namespace OfficeIMO.Word.Markdown.Converters {
                             hyperlink.SetFontFamily(options.FontFamily);
                         }
                     }
+                } else if (current is FootnoteLink footnoteLink) {
+                    Flush();
+                    string text = BuildFootnoteText(footnoteLink.Footnote);
+                    paragraph.AddFootNote(text);
                 } else if (current is EmphasisInline emphasis && emphasis.DelimiterChar == '~') {
                     Flush();
                     string text = BuildMarkdown(emphasis.FirstChild);
@@ -142,6 +147,21 @@ namespace OfficeIMO.Word.Markdown.Converters {
                 }
             }
 
+            return sb.ToString();
+        }
+
+        private static string BuildFootnoteText(Footnote footnote) {
+            var sb = new StringBuilder();
+            bool first = true;
+            foreach (var block in footnote) {
+                if (block is ParagraphBlock pb) {
+                    if (!first) {
+                        sb.AppendLine();
+                    }
+                    sb.Append(BuildMarkdown(pb.Inline));
+                    first = false;
+                }
+            }
             return sb.ToString();
         }
 

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
@@ -1,4 +1,5 @@
 using Markdig;
+using Markdig.Extensions.Footnotes;
 using Markdig.Extensions.Tables;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
@@ -32,7 +33,10 @@ namespace OfficeIMO.Word.Markdown.Converters {
             var document = WordDocument.Create();
             options.ApplyDefaults(document);
 
-            var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+            var pipeline = new MarkdownPipelineBuilder()
+                .UseAdvancedExtensions()
+                .UseFootnotes()
+                .Build();
             var parsed = Markdig.Markdown.Parse(markdown, pipeline);
 
             foreach (var block in parsed) {
@@ -92,6 +96,9 @@ namespace OfficeIMO.Word.Markdown.Converters {
                     break;
                 case ThematicBreakBlock:
                     document.AddHorizontalLine();
+                    break;
+                case FootnoteGroup:
+                    // Footnote definitions are processed when their links are encountered
                     break;
             }
         }


### PR DESCRIPTION
## Summary
- enable Footnotes extension in Markdig pipeline
- convert FootnoteLink nodes into Word footnotes
- add example and unit test for Markdown footnotes

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6895a2b4bfc0832e9ae0f9f2fa1f68ab