### PR TITLE
Propagate Word metadata to PDF

### DIFF
--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.Metadata.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.Metadata.cs
@@ -1,0 +1,22 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using System;
+using System.IO;
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Pdf {
+        public static void Example_SaveAsPdfWithMetadata(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with metadata and exporting to PDF");
+            string docPath = Path.Combine(folderPath, "PdfWithMetadata.docx");
+            string pdfPath = Path.Combine(folderPath, "PdfWithMetadata.pdf");
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.BuiltinDocumentProperties.Title = "Pdf Title";
+                document.BuiltinDocumentProperties.Creator = "Pdf Author";
+                document.BuiltinDocumentProperties.Subject = "Pdf Subject";
+                document.BuiltinDocumentProperties.Keywords = "keyword1, keyword2";
+                document.AddParagraph("Test");
+                document.Save();
+                document.SaveAsPdf(pdfPath);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -238,6 +238,7 @@ namespace OfficeIMO.Examples {
             OfficeIMO.Examples.Word.Pdf.Example_SaveAsPdfInMemory(folderPath, false);
             OfficeIMO.Examples.Word.Pdf.Example_SaveAsPdfRelative(folderPath, false);
             OfficeIMO.Examples.Word.Pdf.Example_SaveAsPdfWithHyperlinks(folderPath, false);
+            OfficeIMO.Examples.Word.Pdf.Example_SaveAsPdfWithMetadata(folderPath, false);
             OfficeIMO.Examples.Word.Pdf.Example_SaveLists(folderPath, false);
             OfficeIMO.Examples.Word.Pdf.Example_TableStyles(folderPath, false);
             // Word/PictureControls

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Metadata.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Metadata.cs
@@ -1,0 +1,31 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using System.IO;
+using UglyToad.PdfPig;
+using Xunit;
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_WordDocument_SaveAsPdf_Metadata() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfMetadata.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfMetadata.pdf");
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.BuiltinDocumentProperties.Title = "Pdf Title";
+                document.BuiltinDocumentProperties.Creator = "Pdf Author";
+                document.BuiltinDocumentProperties.Subject = "Pdf Subject";
+                document.BuiltinDocumentProperties.Keywords = "keyword1, keyword2";
+                document.AddParagraph("Test");
+                document.Save();
+                document.SaveAsPdf(pdfPath);
+            }
+            Assert.True(File.Exists(pdfPath));
+            using (PdfDocument pdf = PdfDocument.Open(pdfPath)) {
+                var info = pdf.Information;
+                Assert.Equal("Pdf Title", info.Title);
+                Assert.Equal("Pdf Author", info.Author);
+                Assert.Equal("Pdf Subject", info.Subject);
+                Assert.Equal("keyword1, keyword2", info.Keywords);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -61,6 +61,7 @@ namespace OfficeIMO.Word.Pdf {
         private static Document CreatePdfDocument(WordDocument document, PdfSaveOptions? options) {
             QuestPDF.Settings.License = LicenseType.Community;
 
+            BuiltinDocumentProperties properties = document.BuiltinDocumentProperties;
             Dictionary<WordParagraph, (int Level, string Marker)> listMarkers = DocumentTraversal.BuildListMarkers(document);
 
             Document pdf = Document.Create(container => {
@@ -144,6 +145,12 @@ namespace OfficeIMO.Word.Pdf {
                         RenderFooter(page, section, footnotes, footnoteMap);
                     });
                 }
+            })
+            .WithMetadata(new DocumentMetadata {
+                Title = properties.Title,
+                Author = properties.Creator,
+                Subject = properties.Subject,
+                Keywords = properties.Keywords
             });
 
             return pdf;


### PR DESCRIPTION
## Summary
- pass Word document properties to QuestPDF metadata
- add PDF metadata example
- test that generated PDFs retain metadata

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6895a29a1208832eaadeaa79bd9d51b8