### PR TITLE
Handle HTML table sections and column groups

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.TableSections.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.TableSections.cs
@@ -1,0 +1,19 @@
+using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
+using System.IO;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlTableSections(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlTableSections.docx");
+            string html = "<table><colgroup><col style=\"width:20%\"><col style=\"width:80%\"></colgroup><thead><tr style=\"background-color:#ff0000\"><th>Header1</th><th>Header2</th></tr></thead><tbody><tr><td>Body1</td><td>Body2</td></tr></tbody><tfoot><tr><td>Foot1</td><td>Foot2</td></tr></tfoot></table>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.TableSections.cs
+++ b/OfficeIMO.Tests/Html.TableSections.cs
@@ -1,0 +1,21 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System.Collections.Generic;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_TableSections_ColGroupAndHeader() {
+            string html = "<table><colgroup><col style=\"width:20%\"><col style=\"width:80%\"></colgroup><thead><tr style=\"background-color:#ff0000\"><th>H1</th><th>H2</th></tr></thead><tbody><tr><td>B1</td><td>B2</td></tr></tbody><tfoot><tr><td>F1</td><td>F2</td></tr></tfoot></table>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var table = doc.Tables[0];
+            Assert.True(table.RepeatHeaderRowAtTheTopOfEachPage);
+            Assert.Equal("ff0000", table.Rows[0].Cells[0].ShadingFillColorHex);
+            Assert.Equal(new List<int> { 1000, 4000 }, table.ColumnWidth);
+            Assert.Equal(TableWidthUnitValues.Pct, table.ColumnWidthType);
+            Assert.Equal("F1", table.Rows[^1].Cells[0].Paragraphs[0]._paragraph.InnerText);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -392,7 +392,7 @@ namespace OfficeIMO.Word.Html.Converters {
                 if (string.IsNullOrWhiteSpace(text)) {
                     return;
                 }
-                currentParagraph ??= cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
+                currentParagraph ??= cell != null ? cell.AddParagraph(paragraph: null, removeExistingParagraphs: true) : section.AddParagraph("");
                 AddTextRun(currentParagraph, text, formatting, options);
             }
         }


### PR DESCRIPTION
## Summary
- process HTML table sections separately, preserving header rows and footers
- apply `<colgroup>` widths to Word tables
- fix table cell text handling and add tests and examples

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6895a27ec5dc832e8c81771b1ec4ca97