### PR TITLE
Handle font weight/style and vertical-align in HTML converter

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.SpanStyles.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.SpanStyles.cs
@@ -7,7 +7,7 @@ namespace OfficeIMO.Examples.Html {
     internal static partial class Html {
         public static void Example_HtmlSpanStyles(string folderPath, bool openWord) {
             string filePath = Path.Combine(folderPath, "HtmlSpanStyles.docx");
-            string html = "<p>Span with <span style=\"color:#ff0000;font-family:Arial;font-size:24px\">styled text</span></p>";
+            string html = "<p>Span with <span style=\"color:#ff0000;font-family:Arial;font-size:24px;font-weight:bold;font-style:italic\">styled text</span> <span style=\"vertical-align:super\">super</span><span style=\"vertical-align:sub\">sub</span></p>";
 
             var doc = html.LoadFromHtml(new HtmlToWordOptions());
             doc.Save(filePath);

--- a/OfficeIMO.Tests/Html.SpanStyles.cs
+++ b/OfficeIMO.Tests/Html.SpanStyles.cs
@@ -34,5 +34,30 @@ namespace OfficeIMO.Tests {
             var markRun = runs.First(r => r.Text == "mark");
             Assert.Equal(HighlightColorValues.Yellow, markRun.Highlight);
         }
+
+        [Fact]
+        public void HtmlToWord_SpanStyles_FontStyles() {
+            string html = "<p><span style=\"font-weight:bold;font-style:italic\">styled</span></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var run = doc.Paragraphs[0].GetRuns().First();
+
+            Assert.True(run.Bold);
+            Assert.True(run.Italic);
+        }
+
+        [Fact]
+        public void HtmlToWord_SpanStyles_VerticalAlign() {
+            string html = "<p><span style=\"vertical-align:super\">sup</span><span style=\"vertical-align:sub\">sub</span></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var runs = doc.Paragraphs;
+
+            var supRun = runs.First(r => r.Text == "sup");
+            Assert.Equal(VerticalPositionValues.Superscript, supRun.VerticalTextAlignment);
+
+            var subRun = runs.First(r => r.Text == "sub");
+            Assert.Equal(VerticalPositionValues.Subscript, subRun.VerticalTextAlignment);
+        }
     }
 }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -202,6 +202,36 @@ namespace OfficeIMO.Word.Html.Converters {
                             formatting.FontSize = size;
                         }
                         break;
+                    case "font-weight":
+                        if (int.TryParse(value, out int weight)) {
+                            formatting.Bold = weight >= 600;
+                        } else if (string.Equals(value, "bold", StringComparison.OrdinalIgnoreCase)) {
+                            formatting.Bold = true;
+                        } else if (string.Equals(value, "normal", StringComparison.OrdinalIgnoreCase)) {
+                            formatting.Bold = false;
+                        }
+                        break;
+                    case "font-style":
+                        var fs = value.ToLowerInvariant();
+                        if (fs == "italic" || fs == "oblique") {
+                            formatting.Italic = true;
+                        } else if (fs == "normal") {
+                            formatting.Italic = false;
+                        }
+                        break;
+                    case "vertical-align":
+                        var va = value.ToLowerInvariant();
+                        if (va == "super" || va == "sup") {
+                            formatting.Superscript = true;
+                            formatting.Subscript = false;
+                        } else if (va == "sub") {
+                            formatting.Subscript = true;
+                            formatting.Superscript = false;
+                        } else if (va == "baseline") {
+                            formatting.Superscript = false;
+                            formatting.Subscript = false;
+                        }
+                        break;
                     case "text-decoration":
                         foreach (var deco in value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)) {
                             switch (deco.Trim().ToLowerInvariant()) {


### PR DESCRIPTION
## Summary
- parse `font-weight`, `font-style`, and `vertical-align` span styles
- support bold/italic and superscript/subscript via CSS
- add unit tests and example for new span styles

## Testing
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6895b5c19114832ea3865b8b2228f1ed