### PR TITLE
Respect !important CSS declarations in HTML conversion

### DIFF
--- a/OfficeIMO.Tests/Html.Important.cs
+++ b/OfficeIMO.Tests/Html.Important.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_StylesheetImportant_OverridesInline() {
+            string html = "<style>p { color:#0000ff !important; }</style><p style=\"color:#ff0000\">Test</p>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var run = doc.Paragraphs[0].GetRuns().First();
+            Assert.Equal("0000ff", run.ColorHex);
+        }
+
+        [Fact]
+        public void HtmlToWord_ImportantBeatsSpecificity() {
+            string html = "<style>p { color:#0000ff !important; } div p { color:#ff0000; }</style><div><p>Test</p></div>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var run = doc.Paragraphs[0].GetRuns().First();
+            Assert.Equal("0000ff", run.ColorHex);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- prioritize `!important` CSS declarations when applying styles during HTML-to-Word conversion
- add tests ensuring `!important` rules override higher-specificity inline and stylesheet rules

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6895c8f09728832eae110a75384939cf