### PR TITLE
Add asynchronous PDF saving helpers

### DIFF
--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdfAsync.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdfAsync.cs
@@ -1,0 +1,28 @@
+using OfficeIMO.Word.Pdf;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Pdf {
+        public static async Task Example_SaveAsPdfAsync(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document and exporting to PDF asynchronously");
+            string docPath = Path.Combine(folderPath, "ExportToPdfAsync.docx");
+            string pdfPath = Path.Combine(folderPath, "ExportToPdfAsync.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddParagraph("Hello Async PDF");
+                document.Save();
+                await document.SaveAsPdfAsync(pdfPath);
+            }
+
+            Console.WriteLine($"✓ Created: {pdfPath}");
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(pdfPath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Async.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Async.cs
@@ -1,0 +1,49 @@
+using OfficeIMO.Word.Pdf;
+using OfficeIMO.Word;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+    public partial class Word {
+    [Fact]
+    public async Task Test_WordDocument_SaveAsPdfAsync() {
+        var docPath = Path.Combine(_directoryWithFiles, "PdfAsync.docx");
+        var pdfPath = Path.Combine(_directoryWithFiles, "PdfAsync.pdf");
+
+        using (var document = WordDocument.Create(docPath)) {
+            document.AddParagraph("Hello World");
+            document.Save();
+
+            var stopwatch = Stopwatch.StartNew();
+            var saveTask = document.SaveAsPdfAsync(pdfPath);
+            stopwatch.Stop();
+            Assert.True(stopwatch.ElapsedMilliseconds < 100);
+            await saveTask;
+        }
+
+        Assert.True(File.Exists(pdfPath));
+    }
+
+    [Fact]
+    public async Task Test_WordDocument_SaveAsPdfAsync_ToStream() {
+        var docPath = Path.Combine(_directoryWithFiles, "PdfAsyncStream.docx");
+
+        using (var document = WordDocument.Create(docPath)) {
+            document.AddParagraph("Hello World");
+            document.Save();
+
+            using (var stream = new MemoryStream()) {
+                var stopwatch = Stopwatch.StartNew();
+                var saveTask = document.SaveAsPdfAsync(stream);
+                stopwatch.Stop();
+                Assert.True(stopwatch.ElapsedMilliseconds < 100);
+                await saveTask;
+                Assert.True(stream.Length > 0);
+            }
+        }
+    }
+    }
+

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using W = DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word.Pdf {
@@ -56,6 +57,51 @@ namespace OfficeIMO.Word.Pdf {
 
             Document pdf = CreatePdfDocument(document, options);
             pdf.GeneratePdf(stream);
+        }
+
+        /// <summary>
+        /// Saves the specified <see cref="WordDocument"/> as a PDF at the given <paramref name="path"/> asynchronously.
+        /// </summary>
+        /// <param name="document">The document to convert.</param>
+        /// <param name="path">The output PDF file path.</param>
+        /// <param name="options">Optional PDF configuration.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public static Task SaveAsPdfAsync(this WordDocument document, string path, PdfSaveOptions? options = null) {
+            if (document == null) {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            if (path == null) {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            string? directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory)) {
+                Directory.CreateDirectory(directory);
+            }
+
+            Document pdf = CreatePdfDocument(document, options);
+            return Task.Run(() => pdf.GeneratePdf(path));
+        }
+
+        /// <summary>
+        /// Saves the specified <see cref="WordDocument"/> as a PDF to the provided <paramref name="stream"/> asynchronously.
+        /// </summary>
+        /// <param name="document">The document to convert.</param>
+        /// <param name="stream">The output stream to receive the PDF data.</param>
+        /// <param name="options">Optional PDF configuration.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public static Task SaveAsPdfAsync(this WordDocument document, Stream stream, PdfSaveOptions? options = null) {
+            if (document == null) {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            if (stream == null) {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            Document pdf = CreatePdfDocument(document, options);
+            return Task.Run(() => pdf.GeneratePdf(stream));
         }
 
         private static Document CreatePdfDocument(WordDocument document, PdfSaveOptions? options) {


### PR DESCRIPTION
## Summary
- add `SaveAsPdfAsync` overloads for file paths and streams
- include example showcasing async PDF export
- test async PDF saving to ensure quick, non-blocking calls

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6895ca207c48832e8480c5b869f39893