### PR TITLE
Respect section orientation without explicit page size

### DIFF
--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -144,8 +144,8 @@ namespace OfficeIMO.Word.Pdf {
                         PdfPageOrientation orientation;
                         if (options?.Orientation != null) {
                             orientation = options.Orientation.Value;
-                        } else if (section.PageSettings.PageSize.HasValue) {
-                            orientation = section.PageSettings.Orientation == W.PageOrientationValues.Landscape ? PdfPageOrientation.Landscape : PdfPageOrientation.Portrait;
+                        } else if (section.PageSettings.Orientation == W.PageOrientationValues.Landscape) {
+                            orientation = PdfPageOrientation.Landscape;
                         } else if (options?.DefaultOrientation != null) {
                             orientation = options.DefaultOrientation == W.PageOrientationValues.Landscape ? PdfPageOrientation.Landscape : PdfPageOrientation.Portrait;
                         } else {


### PR DESCRIPTION
## Summary
- ensure PDF orientation uses section orientation even when page size is undefined
- add tests verifying landscape and portrait output without page size

## Testing
- `dotnet test OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_6895d1ba3760832eaf4d2772167943d0