### PR TITLE
Add configurable QuestPDF license

### DIFF
--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.License.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.License.cs
@@ -1,0 +1,31 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using QuestPDF.Infrastructure;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Pdf {
+        public static void Example_SaveAsPdfWithLicense(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document and exporting to PDF with explicit QuestPDF license");
+            string docPath = Path.Combine(folderPath, "PdfWithLicense.docx");
+            string pdfPath = Path.Combine(folderPath, "PdfWithLicense.pdf");
+
+            QuestPDF.Settings.License = null;
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddParagraph("Hello World");
+                document.Save();
+
+                document.SaveAsPdf(pdfPath, new PdfSaveOptions {
+                    QuestPdfLicenseType = LicenseType.Community
+                });
+            }
+
+            if (openWord) {
+                // openWord functionality not implemented
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -239,6 +239,7 @@ namespace OfficeIMO.Examples {
             OfficeIMO.Examples.Word.Pdf.Example_SaveAsPdfRelative(folderPath, false);
             OfficeIMO.Examples.Word.Pdf.Example_SaveAsPdfWithHyperlinks(folderPath, false);
             OfficeIMO.Examples.Word.Pdf.Example_SaveAsPdfWithMetadata(folderPath, false);
+            OfficeIMO.Examples.Word.Pdf.Example_SaveAsPdfWithLicense(folderPath, false);
             OfficeIMO.Examples.Word.Pdf.Example_SaveLists(folderPath, false);
             OfficeIMO.Examples.Word.Pdf.Example_TableStyles(folderPath, false);
             // Word/PictureControls

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.License.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.License.cs
@@ -1,0 +1,32 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using QuestPDF.Infrastructure;
+using System.IO;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void SaveAsPdf_DoesNotOverwriteExistingLicense() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfPreSetLicense.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfPreSetLicense.pdf");
+
+            QuestPDF.Settings.License = LicenseType.Enterprise;
+            try {
+                using (WordDocument document = WordDocument.Create(docPath)) {
+                    document.AddParagraph("Hello World");
+                    document.Save();
+                    document.SaveAsPdf(pdfPath, new PdfSaveOptions {
+                        QuestPdfLicenseType = LicenseType.Community
+                    });
+                }
+
+                Assert.True(File.Exists(pdfPath));
+                Assert.Equal(LicenseType.Enterprise, QuestPDF.Settings.License);
+            } finally {
+                QuestPDF.Settings.License = null;
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
+++ b/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
@@ -30,7 +30,7 @@ namespace OfficeIMO.Word.Pdf {
         /// Measurement unit for the margin value.
         /// </summary>
         public Unit MarginUnit { get; set; } = Unit.Centimetre;
-        
+
         /// <summary>
         /// Optional default page size applied when creating new documents.
         /// </summary>
@@ -40,5 +40,10 @@ namespace OfficeIMO.Word.Pdf {
         /// Optional default page orientation applied when creating new documents.
         /// </summary>
         public DocumentFormat.OpenXml.Wordprocessing.PageOrientationValues? DefaultOrientation { get; set; }
+
+        /// <summary>
+        /// Optional QuestPDF license type used when generating the PDF.
+        /// </summary>
+        public LicenseType? QuestPdfLicenseType { get; set; }
     }
 }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -105,7 +105,9 @@ namespace OfficeIMO.Word.Pdf {
         }
 
         private static Document CreatePdfDocument(WordDocument document, PdfSaveOptions? options) {
-            QuestPDF.Settings.License = LicenseType.Community;
+            if (QuestPDF.Settings.License == null) {
+                QuestPDF.Settings.License = options?.QuestPdfLicenseType ?? LicenseType.Community;
+            }
 
             BuiltinDocumentProperties properties = document.BuiltinDocumentProperties;
             Dictionary<WordParagraph, (int Level, string Marker)> listMarkers = DocumentTraversal.BuildListMarkers(document);


### PR DESCRIPTION
## Summary
- add `QuestPdfLicenseType` option to `PdfSaveOptions`
- only set QuestPDF license when unset and honor explicit save option
- cover with unit test and example

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_6895d1ae14d0832e95b9822056f92517