### PR TITLE
Add per-edge PDF margin options

### DIFF
--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdf.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdf.cs
@@ -57,7 +57,9 @@ namespace OfficeIMO.Examples.Word {
                     PageSize = PageSizes.A4,
                     Orientation = PdfPageOrientation.Landscape,
                     Margin = 2,
-                    MarginUnit = Unit.Centimetre
+                    MarginUnit = Unit.Centimetre,
+                    MarginBottom = 1,
+                    MarginBottomUnit = Unit.Centimetre
                 });
             }
         }

--- a/OfficeIMO.Examples/Converters/Pdf/Pdf01_SaveAsPdf.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf01_SaveAsPdf.cs
@@ -48,7 +48,11 @@ namespace OfficeIMO.Examples.Word.Converters {
             doc.SaveAsPdf(outputPath, new PdfSaveOptions {
                 Orientation = PdfPageOrientation.Portrait,
                 Margin = 2,
-                MarginUnit = QuestPDF.Infrastructure.Unit.Centimetre
+                MarginUnit = QuestPDF.Infrastructure.Unit.Centimetre,
+                MarginTop = 3,
+                MarginTopUnit = QuestPDF.Infrastructure.Unit.Centimetre,
+                MarginLeft = 1,
+                MarginLeftUnit = QuestPDF.Infrastructure.Unit.Centimetre
             });
             
             Console.WriteLine($"✓ Created: {outputPath}");

--- a/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
+++ b/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
@@ -32,6 +32,46 @@ namespace OfficeIMO.Word.Pdf {
         public Unit MarginUnit { get; set; } = Unit.Centimetre;
 
         /// <summary>
+        /// Optional left page margin for the generated PDF.
+        /// </summary>
+        public float? MarginLeft { get; set; }
+
+        /// <summary>
+        /// Measurement unit for the left margin value.
+        /// </summary>
+        public Unit MarginLeftUnit { get; set; } = Unit.Centimetre;
+
+        /// <summary>
+        /// Optional right page margin for the generated PDF.
+        /// </summary>
+        public float? MarginRight { get; set; }
+
+        /// <summary>
+        /// Measurement unit for the right margin value.
+        /// </summary>
+        public Unit MarginRightUnit { get; set; } = Unit.Centimetre;
+
+        /// <summary>
+        /// Optional top page margin for the generated PDF.
+        /// </summary>
+        public float? MarginTop { get; set; }
+
+        /// <summary>
+        /// Measurement unit for the top margin value.
+        /// </summary>
+        public Unit MarginTopUnit { get; set; } = Unit.Centimetre;
+
+        /// <summary>
+        /// Optional bottom page margin for the generated PDF.
+        /// </summary>
+        public float? MarginBottom { get; set; }
+
+        /// <summary>
+        /// Measurement unit for the bottom margin value.
+        /// </summary>
+        public Unit MarginBottomUnit { get; set; } = Unit.Centimetre;
+
+        /// <summary>
         /// Optional default page size applied when creating new documents.
         /// </summary>
         public WordPageSize? DefaultPageSize { get; set; }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -119,7 +119,21 @@ namespace OfficeIMO.Word.Pdf {
                             page.DefaultTextStyle(t => t.FontFamily(options.FontFamily));
                         }
 
-                        if (options?.Margin != null) {
+                        if (options?.MarginLeft != null || options?.MarginRight != null || options?.MarginTop != null || options?.MarginBottom != null) {
+                            float left = options.MarginLeft ?? options.Margin ?? (section.Margins.Left.Value / 20f);
+                            Unit leftUnit = options.MarginLeft != null ? options.MarginLeftUnit : options.Margin != null ? options.MarginUnit : Unit.Point;
+                            float right = options.MarginRight ?? options.Margin ?? (section.Margins.Right.Value / 20f);
+                            Unit rightUnit = options.MarginRight != null ? options.MarginRightUnit : options.Margin != null ? options.MarginUnit : Unit.Point;
+                            float top = options.MarginTop ?? options.Margin ?? (section.Margins.Top.Value / 20f);
+                            Unit topUnit = options.MarginTop != null ? options.MarginTopUnit : options.Margin != null ? options.MarginUnit : Unit.Point;
+                            float bottom = options.MarginBottom ?? options.Margin ?? (section.Margins.Bottom.Value / 20f);
+                            Unit bottomUnit = options.MarginBottom != null ? options.MarginBottomUnit : options.Margin != null ? options.MarginUnit : Unit.Point;
+
+                            page.MarginLeft(left, leftUnit);
+                            page.MarginRight(right, rightUnit);
+                            page.MarginTop(top, topUnit);
+                            page.MarginBottom(bottom, bottomUnit);
+                        } else if (options?.Margin != null) {
                             page.Margin(options.Margin.Value, options.MarginUnit);
                         } else {
                             float leftMargin = section.Margins.Left.Value / 20f;


### PR DESCRIPTION
## Summary
- add individual margin options to `PdfSaveOptions`
- support per-edge margins in PDF converter
- document per-edge margins in examples and tests

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689616f8a39c832eb268b87bbed4eaca