### PR TITLE
Add optional PDF metadata overrides

### DIFF
--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.MetadataOverrides.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.MetadataOverrides.cs
@@ -1,0 +1,29 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Pdf {
+        public static void Example_SaveAsPdfWithMetadataOverrides(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with overridden metadata and exporting to PDF");
+            string docPath = Path.Combine(folderPath, "PdfWithMetadataOverrides.docx");
+            string pdfPath = Path.Combine(folderPath, "PdfWithMetadataOverrides.pdf");
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.BuiltinDocumentProperties.Title = "Original Title";
+                document.BuiltinDocumentProperties.Creator = "Original Author";
+                document.BuiltinDocumentProperties.Subject = "Original Subject";
+                document.BuiltinDocumentProperties.Keywords = "orig1, orig2";
+                document.AddParagraph("Test");
+                document.Save();
+                var options = new PdfSaveOptions {
+                    Title = "Pdf Title",
+                    Author = "Pdf Author",
+                    Subject = "Pdf Subject",
+                    Keywords = "keyword1, keyword2"
+                };
+                document.SaveAsPdf(pdfPath, options);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.MetadataOverrides.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.MetadataOverrides.cs
@@ -1,0 +1,38 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using System.IO;
+using UglyToad.PdfPig;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_WordDocument_SaveAsPdf_MetadataOverrides() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfMetadataOverride.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfMetadataOverride.pdf");
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.BuiltinDocumentProperties.Title = "Original Title";
+                document.BuiltinDocumentProperties.Creator = "Original Author";
+                document.BuiltinDocumentProperties.Subject = "Original Subject";
+                document.BuiltinDocumentProperties.Keywords = "orig1, orig2";
+                document.AddParagraph("Test");
+                document.Save();
+                var options = new PdfSaveOptions {
+                    Title = "Override Title",
+                    Author = "Override Author",
+                    Subject = "Override Subject",
+                    Keywords = "override1, override2"
+                };
+                document.SaveAsPdf(pdfPath, options);
+            }
+            Assert.True(File.Exists(pdfPath));
+            using (PdfDocument pdf = PdfDocument.Open(pdfPath)) {
+                var info = pdf.Information;
+                Assert.Equal("Override Title", info.Title);
+                Assert.Equal("Override Author", info.Author);
+                Assert.Equal("Override Subject", info.Subject);
+                Assert.Equal("override1, override2", info.Keywords);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
+++ b/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
@@ -82,6 +82,26 @@ namespace OfficeIMO.Word.Pdf {
         public DocumentFormat.OpenXml.Wordprocessing.PageOrientationValues? DefaultOrientation { get; set; }
 
         /// <summary>
+        /// Optional PDF title that overrides the Word document title.
+        /// </summary>
+        public string? Title { get; set; }
+
+        /// <summary>
+        /// Optional PDF author that overrides the Word document author.
+        /// </summary>
+        public string? Author { get; set; }
+
+        /// <summary>
+        /// Optional PDF subject that overrides the Word document subject.
+        /// </summary>
+        public string? Subject { get; set; }
+
+        /// <summary>
+        /// Optional PDF keywords that override the Word document keywords.
+        /// </summary>
+        public string? Keywords { get; set; }
+
+        /// <summary>
         /// Optional QuestPDF license type used when generating the PDF.
         /// </summary>
         public LicenseType? QuestPdfLicenseType { get; set; }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -209,10 +209,10 @@ namespace OfficeIMO.Word.Pdf {
                 }
             })
             .WithMetadata(new DocumentMetadata {
-                Title = properties.Title,
-                Author = properties.Creator,
-                Subject = properties.Subject,
-                Keywords = properties.Keywords
+                Title = options?.Title ?? properties.Title,
+                Author = options?.Author ?? properties.Creator,
+                Subject = options?.Subject ?? properties.Subject,
+                Keywords = options?.Keywords ?? properties.Keywords
             });
 
             return pdf;


### PR DESCRIPTION
## Summary
- add Title, Author, Subject and Keywords overrides to PDF save options
- use override values when building PDF metadata
- document usage with example and cover overrides with unit tests

## Testing
- `dotnet test -c Release`
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68961e76e9a8832e904cce02e72540dd