### PR TITLE
Enable implemented Html converter tests

### DIFF
--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -26,7 +26,7 @@ public partial class Html {
         Assert.Contains($"font-family:{FontResolver.Resolve("Calibri")}", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact(Skip = "TODO: Implement heading conversion (h1-h6 -> WordParagraphStyles.Heading1-6)")]
+    [Fact]
     public void Test_Html_Headings_RoundTrip() {
         string html = "<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><h4>Heading 4</h4><h5>Heading 5</h5><h6>Heading 6</h6>";
         
@@ -41,7 +41,7 @@ public partial class Html {
         }
     }
 
-    [Fact(Skip = "TODO: Implement list conversion (ul/ol -> WordList)")]
+    [Fact]
     public void Test_Html_Lists_RoundTrip() {
         string html = "<ul><li>Item 1<ul><li>Sub 1</li><li>Sub 2</li></ul></li><li>Item 2</li></ul><ol><li>First</li><li>Second</li></ol>";
         
@@ -54,7 +54,7 @@ public partial class Html {
         Assert.Contains("Second", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact(Skip = "TODO: Implement table conversion (HTML table -> WordTable)")]
+    [Fact]
     public void Test_Html_Table_RoundTrip() {
         string html = "<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr></table>";
         
@@ -78,7 +78,7 @@ public partial class Html {
         Assert.Contains("Inner", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact(Skip = "TODO: Implement image conversion (base64 -> WordImage)")]
+    [Fact]
     public void Test_Html_Image_Base64_RoundTrip() {
         string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
         byte[] imageBytes = File.ReadAllBytes(assetPath);
@@ -92,7 +92,7 @@ public partial class Html {
         Assert.Contains("data:image/png;base64", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact(Skip = "TODO: Implement image conversion (file URL -> WordImage)")]
+    [Fact]
     public void Test_Html_Image_File_RoundTrip() {
         string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
         string uri = new Uri(assetPath).AbsoluteUri;

--- a/OfficeIMO.Tests/Html.Important.cs
+++ b/OfficeIMO.Tests/Html.Important.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using OfficeIMO.Word.Html;
 using Xunit;
@@ -10,6 +11,8 @@ namespace OfficeIMO.Tests {
             var doc = html.LoadFromHtml(new HtmlToWordOptions());
             var run = doc.Paragraphs[0].GetRuns().First();
             Assert.Equal("0000ff", run.ColorHex);
+            string roundTrip = doc.ToHtml();
+            Assert.Contains("<p>Test</p>", roundTrip, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -18,6 +21,8 @@ namespace OfficeIMO.Tests {
             var doc = html.LoadFromHtml(new HtmlToWordOptions());
             var run = doc.Paragraphs[0].GetRuns().First();
             Assert.Equal("0000ff", run.ColorHex);
+            string roundTrip = doc.ToHtml();
+            Assert.Contains("<p>Test</p>", roundTrip, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/OfficeIMO.Tests/Html.Stylesheets.cs
+++ b/OfficeIMO.Tests/Html.Stylesheets.cs
@@ -1,3 +1,4 @@
+using System;
 using OfficeIMO.Word.Html;
 using Xunit;
 using System.Net;
@@ -73,6 +74,8 @@ namespace OfficeIMO.Tests {
             listener.Stop();
             var run = doc.Paragraphs[0].GetRuns().First();
             Assert.Equal("123456", run.ColorHex);
+            string roundTrip = doc.ToHtml();
+            Assert.Contains("<p>Test</p>", roundTrip, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- enable HTML converter tests for headings, lists, tables, and images
- add round-trip assertions for `!important` styles and remote stylesheets

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689658058550832ea7eda1e3f81e999d