### PR TITLE
Fix AddBreak tracking and test paragraph counts

### DIFF
--- a/OfficeIMO.Tests/Word.AddBreak.cs
+++ b/OfficeIMO.Tests/Word.AddBreak.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void DocumentAddBreakIncreasesParagraphCount() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentAddBreakIncreasesParagraphCount.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Paragraph 1");
+                int paragraphCount = document.Paragraphs.Count;
+                document.AddBreak();
+                Assert.Equal(paragraphCount + 1, document.Paragraphs.Count);
+                Assert.Equal(paragraphCount + 1, document.Sections[0].Paragraphs.Count);
+                Assert.Equal(1, document.Breaks.Count);
+                document.Save(false);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -76,7 +76,8 @@ namespace OfficeIMO.Word {
             newWordParagraph._paragraph = new Paragraph(newWordParagraph._run);
 
             this._document.Body.Append(newWordParagraph._paragraph);
-            this.Paragraphs.Add(newWordParagraph);
+            var currentSection = this.Sections.LastOrDefault();
+            currentSection?.Paragraphs.Add(newWordParagraph);
             return newWordParagraph;
         }
 


### PR DESCRIPTION
## Summary
- avoid storing break paragraphs in WordDocument.Paragraphs list and instead append to current section
- add unit test verifying paragraphs count grows after calling AddBreak

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68965e976ca4832e829895bebcd8cc78