### PR TITLE
Remove stray semicolon in WordDocument BookmarkId getter

### DIFF
--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -23,7 +23,6 @@ namespace OfficeIMO.Word {
         internal int BookmarkId {
             get {
                 List<int> bookmarksList = new List<int>() { 0 };
-                ;
                 foreach (var paragraph in this.ParagraphsBookmarks) {
                     bookmarksList.Add(paragraph.Bookmark.Id);
                 }


### PR DESCRIPTION
## Summary
- remove stray semicolon in BookmarkId getter of WordDocument to avoid empty statement

## Testing
- `dotnet build`
- `rg CS0642 build_after.log`


------
https://chatgpt.com/codex/tasks/task_e_68965eea3700832ea7a5f8a472a18c79