### PR TITLE
Handle missing Quote style when converting blockquotes

### DIFF
--- a/OfficeIMO.Examples/Word/BlockquoteWithQuoteStyleExample.cs
+++ b/OfficeIMO.Examples/Word/BlockquoteWithQuoteStyleExample.cs
@@ -1,0 +1,21 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using DocumentFormat.OpenXml.Wordprocessing;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static class BlockquoteWithQuoteStyleExample {
+        public static void Example_BlockquoteWithQuoteStyle(string folderPath, bool openWord) {
+            var style = WordParagraphStyle.CreateFontStyle("Quote", "Arial");
+            WordParagraphStyle.RegisterCustomStyle("Quote", style);
+
+            string html = "<blockquote>Quoted text</blockquote>";
+            using WordDocument document = html.LoadFromHtml(new HtmlToWordOptions());
+            string docPath = Path.Combine(folderPath, "BlockquoteWithQuoteStyle.docx");
+            document.Save(docPath);
+            Console.WriteLine($"✓ Created: {docPath}");
+        }
+    }
+}
+

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -193,7 +193,9 @@ namespace OfficeIMO.Word.Html.Converters {
                         }
                     case "blockquote": {
                             var paragraph = cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
-                            paragraph.SetStyleId("Quote");
+                            if (doc.StyleExists("Quote")) {
+                                paragraph.SetStyleId("Quote");
+                            }
                             paragraph.IndentationBefore = 720;
                             ApplyParagraphStyleFromCss(paragraph, element);
                             ApplyClassStyle(element, paragraph, options);

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -81,6 +81,19 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Determines whether a paragraph style with the specified identifier exists in the document.
+        /// </summary>
+        /// <param name="styleId">The style identifier to look for.</param>
+        /// <returns><c>true</c> if the style exists; otherwise, <c>false</c>.</returns>
+        public bool StyleExists(string styleId) {
+            if (string.IsNullOrWhiteSpace(styleId)) {
+                return false;
+            }
+            var styles = _wordprocessingDocument?.MainDocumentPart?.StyleDefinitionsPart?.Styles;
+            return styles != null && styles.OfType<DocumentFormat.OpenXml.Wordprocessing.Style>().Any(s => string.Equals(s.StyleId, styleId, StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
         /// Adds a hyperlink pointing to an external URI.
         /// </summary>
         /// <param name="text">Display text for the hyperlink.</param>


### PR DESCRIPTION
## Summary
- avoid applying Quote style to blockquotes when the style is absent
- add StyleExists helper on WordDocument
- test blockquotes with and without Quote style
- add example demonstrating custom Quote style

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68965ebdcd1c832e8498e4edf5bf76d7