### PR TITLE
Render images and links in PDFs

### DIFF
--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.Hyperlinks.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.Hyperlinks.cs
@@ -11,8 +11,8 @@ namespace OfficeIMO.Examples.Word {
             string pdfPath = Path.Combine(folderPath, "HyperlinksToPdf.pdf");
 
             using (WordDocument document = WordDocument.Create(docPath)) {
-                document.AddParagraph("Visit ").AddHyperLink("OfficeIMO", new Uri("https://evotec.xyz"), addStyle: true);
-                document.AddParagraph("Contact ").AddHyperLink("Email", new Uri("mailto:kontakt@evotec.pl"), addStyle: true);
+                document.AddHyperLink("OfficeIMO", new Uri("https://evotec.xyz"), addStyle: true);
+                document.AddHyperLink("Email", new Uri("mailto:kontakt@evotec.pl"), addStyle: true);
                 document.Save();
                 document.SaveAsPdf(pdfPath);
             }

--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdf.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdf.cs
@@ -50,7 +50,8 @@ namespace OfficeIMO.Examples.Word {
                 WordTable nested = table.Rows[0].Cells[0].AddTable(1, 1);
                 nested.Rows[0].Cells[0].Paragraphs[0].Text = "N1";
 
-                document.AddParagraph().AddImage(imagePath, 50, 50);
+                document.AddImage(imagePath, 50, 50);
+                document.AddHyperLink("OfficeIMO", new Uri("https://evotec.xyz"), addStyle: true);
 
                 document.Save();
                 document.SaveAsPdf(pdfPath, new PdfSaveOptions {

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.ImagesAndHyperlinks.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.ImagesAndHyperlinks.cs
@@ -1,0 +1,29 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_ImagesAndHyperlinks() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfImagesLinks.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfImagesLinks.pdf");
+        string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            document.AddParagraph().AddImage(imagePath, 50, 50);
+            document.AddHyperLink("OfficeIMO", new Uri("https://evotec.xyz"), addStyle: true);
+            document.Save();
+            document.SaveAsPdf(pdfPath);
+        }
+
+        Assert.True(File.Exists(pdfPath));
+        string pdfContent = Encoding.ASCII.GetString(File.ReadAllBytes(pdfPath));
+        Assert.Contains("/Subtype /Image", pdfContent);
+        Assert.Contains("/URI (https://evotec.xyz", pdfContent);
+    }
+}

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
@@ -12,6 +12,25 @@ using W = DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word.Pdf {
     public static partial class WordPdfConverterExtensions {
+        static void RenderElement(ColumnDescriptor column, WordElement element, Func<WordParagraph, (int Level, string Marker)?> getMarker, PdfSaveOptions? options, Dictionary<WordParagraph, int> footnoteMap) {
+            switch (element) {
+                case WordParagraph paragraph:
+                    column.Item().Element(e => RenderParagraph(e, paragraph, getMarker(paragraph), options, footnoteMap));
+                    break;
+                case WordTable table:
+                    column.Item().Element(e => RenderTable(e, table, getMarker, options, footnoteMap));
+                    break;
+                case WordImage image:
+                    column.Item().Element(e => RenderImage(e, image));
+                    break;
+                case WordHyperLink link:
+                    column.Item().Element(e => RenderHyperLink(e, link));
+                    break;
+                case WordShape shape:
+                    column.Item().Element(e => RenderShape(e, shape));
+                    break;
+            }
+        }
         static IContainer RenderParagraph(IContainer container, WordParagraph paragraph, (int Level, string Marker)? marker, PdfSaveOptions? options, Dictionary<WordParagraph, int> footnoteMap) {
             if (paragraph == null) {
                 return container;


### PR DESCRIPTION
## Summary
- add central renderer that handles WordImage and WordHyperLink elements
- render images and hyperlinks within sections, headers and footers
- document usage with image and hyperlink examples
- test PDF output for embedded images and links

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68965f110eac832e93ef0543286b29c9