### PR TITLE
Resolve relative image paths using base URL or options

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.ImagesRelative.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.ImagesRelative.cs
@@ -1,0 +1,19 @@
+using System;
+using System.IO;
+using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlImagesRelative(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlImageRelative.docx");
+            string html = "<p><img src=\"OfficeIMO.png\" alt=\"Logo\"/></p>";
+            var options = new HtmlToWordOptions { BasePath = "Assets" };
+            var doc = html.LoadFromHtml(options);
+            doc.Save(filePath);
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -1,0 +1,46 @@
+using OfficeIMO.Word.Html;
+using System;
+using System.IO;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_RelativeImage_UsesBaseUrl() {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            var source = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
+            var dest = Path.Combine(dir, "logo.png");
+            File.Copy(source, dest);
+            try {
+                var baseHref = new Uri(dir + Path.DirectorySeparatorChar).AbsoluteUri;
+                string html = $"<base href=\"{baseHref}\"><img src=\"logo.png\" alt=\"Logo\" />";
+                var doc = html.LoadFromHtml(new HtmlToWordOptions());
+                Assert.Single(doc.Images);
+                Assert.Equal("Logo", doc.Images[0].Description);
+            } finally {
+                File.Delete(dest);
+                Directory.Delete(dir);
+            }
+        }
+
+        [Fact]
+        public void HtmlToWord_RelativeImage_UsesOptionsBasePath() {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            var source = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
+            var dest = Path.Combine(dir, "logo.png");
+            File.Copy(source, dest);
+            try {
+                string html = "<img src=\"logo.png\" alt=\"Logo\" />";
+                var options = new HtmlToWordOptions { BasePath = dir };
+                var doc = html.LoadFromHtml(options);
+                Assert.Single(doc.Images);
+                Assert.Equal("Logo", doc.Images[0].Description);
+            } finally {
+                File.Delete(dest);
+                Directory.Delete(dir);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -5,9 +5,17 @@ using System.IO;
 
 namespace OfficeIMO.Word.Html.Converters {
     internal partial class HtmlToWordConverter {
-        private void ProcessImage(IHtmlImageElement img, WordDocument doc) {
-            var src = img.Source;
+        private void ProcessImage(IHtmlImageElement img, WordDocument doc, HtmlToWordOptions options) {
+            var src = img.GetAttribute("src");
             if (string.IsNullOrEmpty(src)) return;
+
+            if (!src.StartsWith("data:image", StringComparison.OrdinalIgnoreCase) && !Uri.TryCreate(src, UriKind.Absolute, out _)) {
+                if (!string.IsNullOrEmpty(options.BasePath)) {
+                    src = Path.Combine(options.BasePath, src);
+                } else if (img.BaseUrl != null && Uri.TryCreate(img.BaseUrl.Href, UriKind.Absolute, out var baseUri) && !string.Equals(img.BaseUrl.Href, "http://localhost/", StringComparison.OrdinalIgnoreCase)) {
+                    src = new Uri(baseUri, src).ToString();
+                }
+            }
 
             double? width = img.DisplayWidth > 0 ? img.DisplayWidth : null;
             double? height = img.DisplayHeight > 0 ? img.DisplayHeight : null;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -394,7 +394,7 @@ namespace OfficeIMO.Word.Html.Converters {
                     case "figure": {
                             var img = element.QuerySelector("img") as IHtmlImageElement;
                             if (img != null) {
-                                ProcessImage(img, doc);
+                                ProcessImage(img, doc, options);
                             }
                             var caption = element.QuerySelector("figcaption");
                             if (caption != null) {
@@ -411,7 +411,7 @@ namespace OfficeIMO.Word.Html.Converters {
                             break;
                         }
                     case "img": {
-                            ProcessImage((IHtmlImageElement)element, doc);
+                            ProcessImage((IHtmlImageElement)element, doc, options);
                             break;
                         }
                     case "style": {

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -34,6 +34,11 @@ namespace OfficeIMO.Word.Html {
         public bool IncludeListStyles { get; set; }
 
         /// <summary>
+        /// Base directory used to resolve relative resource paths like images.
+        /// </summary>
+        public string? BasePath { get; set; }
+
+        /// <summary>
         /// File paths pointing to external stylesheets that should be applied during conversion.
         /// </summary>
         public List<string> StylesheetPaths { get; } = new List<string>();


### PR DESCRIPTION
## Summary
- resolve relative img src using document base URL or conversion options base path
- add BasePath option and tests for relative image handling
- include example showing image resolution via BasePath

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68965eaf26f4832eb931ee5307dc101e