### PR TITLE
Use Path.Combine for directory URIs

### DIFF
--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -13,7 +13,8 @@ namespace OfficeIMO.Tests {
             var dest = Path.Combine(dir, "logo.png");
             File.Copy(source, dest);
             try {
-                var baseHref = new Uri(dir + Path.DirectorySeparatorChar).AbsoluteUri;
+                var baseHref = new Uri(new Uri(Path.Combine(dir, "dummy"), UriKind.Absolute), ".").AbsoluteUri;
+                Assert.EndsWith("/", baseHref);
                 string html = $"<base href=\"{baseHref}\"><img src=\"logo.png\" alt=\"Logo\" />";
                 var doc = html.LoadFromHtml(new HtmlToWordOptions());
                 Assert.Single(doc.Images);

--- a/OfficeIMO.Tests/Html.Stylesheets.cs
+++ b/OfficeIMO.Tests/Html.Stylesheets.cs
@@ -85,7 +85,8 @@ namespace OfficeIMO.Tests {
             var cssPath = Path.Combine(dir, "style.css");
             File.WriteAllText(cssPath, "p { color:#654321; }");
             try {
-                var baseHref = new Uri(dir + Path.DirectorySeparatorChar).AbsoluteUri;
+                var baseHref = new Uri(new Uri(Path.Combine(dir, "dummy"), UriKind.Absolute), ".").AbsoluteUri;
+                Assert.EndsWith("/", baseHref);
                 string html = $"<base href=\"{baseHref}\"><link rel=\"stylesheet\" href=\"style.css\" /><p>Test</p>";
                 var doc = html.LoadFromHtml(new HtmlToWordOptions());
                 var run = doc.Paragraphs[0].GetRuns().First();

--- a/OfficeIMO.Tests/Path.CrossPlatform.cs
+++ b/OfficeIMO.Tests/Path.CrossPlatform.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PathCrossPlatform {
+        [Fact]
+        public void PathCombine_AppendsSeparator_ForDirectoryUri() {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            try {
+                var baseHref = new Uri(new Uri(Path.Combine(dir, "dummy"), UriKind.Absolute), ".").AbsoluteUri;
+                Assert.EndsWith("/", baseHref);
+            } finally {
+                Directory.Delete(dir);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace string concatenation when building URIs with `Path.Combine`
- add cross-platform path test and assertions

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68966ab5dd54832ebeb5d0247a6f97f6