### PR TITLE
Handle null paths in ExcelDocument.Load

### DIFF
--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -82,10 +82,12 @@ namespace OfficeIMO.Excel {
         /// <param name="autoSave">Enable auto-save on dispose.</param>
         /// <returns>Loaded <see cref="ExcelDocument"/> instance.</returns>
         public static ExcelDocument Load(string filePath, bool readOnly = false, bool autoSave = false) {
-            if (filePath != null) {
-                if (!File.Exists(filePath)) {
-                    throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
-                }
+            if (filePath == null) {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+
+            if (!File.Exists(filePath)) {
+                throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
             }
             ExcelDocument document = new ExcelDocument();
             document.FilePath = filePath;
@@ -93,8 +95,6 @@ namespace OfficeIMO.Excel {
             var openSettings = new OpenSettings {
                 AutoSave = autoSave
             };
-
-            FileMode fileMode = readOnly ? FileMode.Open : FileMode.OpenOrCreate;
 
             SpreadsheetDocument spreadSheetDocument = SpreadsheetDocument.Open(filePath, !readOnly, openSettings);
 

--- a/OfficeIMO.Tests/Excel.LoadExceptions.cs
+++ b/OfficeIMO.Tests/Excel.LoadExceptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using OfficeIMO.Excel;
@@ -13,10 +14,22 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_LoadNullPath_ThrowsArgumentNullException() {
+            var ex = Assert.Throws<ArgumentNullException>(() => ExcelDocument.Load(null));
+            Assert.Equal("Value cannot be null. (Parameter 'filePath')", ex.Message);
+        }
+
+        [Fact]
         public async Task Test_LoadAsyncMissingFile_ThrowsWithPath() {
             string filePath = Path.Combine(_directoryWithFiles, "missingAsync.xlsx");
             var ex = await Assert.ThrowsAsync<FileNotFoundException>(() => ExcelDocument.LoadAsync(filePath));
             Assert.Equal($"File '{filePath}' doesn't exist.", ex.Message);
+        }
+
+        [Fact]
+        public async Task Test_LoadAsyncNullPath_ThrowsArgumentNullException() {
+            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => ExcelDocument.LoadAsync(null));
+            Assert.Equal("Value cannot be null. (Parameter 'path')", ex.Message);
         }
     }
 }


### PR DESCRIPTION
## Summary
- validate `filePath` in `ExcelDocument.Load` and remove unused variable
- test loading with null paths for sync and async APIs

## Testing
- `dotnet build`
- `dotnet test --logger "trx" --results-directory /tmp/test-results`


------
https://chatgpt.com/codex/tasks/task_e_68966acd314c832ea88a0a2a11f754ad