### PR TITLE
Reset sheet ID list before enumerating sheets

### DIFF
--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -22,12 +22,19 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public List<ExcelSheet> Sheets {
             get {
+                // Always rebuild the ID list to avoid duplicate entries when
+                // accessing the Sheets property multiple times
+                id.Clear();
+                id.Add(0);
+
                 List<ExcelSheet> listExcel = new List<ExcelSheet>();
                 if (_spreadSheetDocument.WorkbookPart.Workbook.Sheets != null) {
                     var elements = _spreadSheetDocument.WorkbookPart.Workbook.Sheets.OfType<Sheet>().ToList();
                     foreach (Sheet s in elements) {
                         ExcelSheet excelSheet = new ExcelSheet(this, _spreadSheetDocument, s);
-                        id.Add(s.SheetId);
+                        if (!id.Contains(s.SheetId)) {
+                            id.Add(s.SheetId);
+                        }
                         listExcel.Add(excelSheet);
                     }
                 }

--- a/OfficeIMO.Excel/OfficeIMO.Excel.csproj
+++ b/OfficeIMO.Excel/OfficeIMO.Excel.csproj
@@ -52,4 +52,8 @@
             <PackagePath>\</PackagePath>
         </None>
     </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="OfficeIMO.Tests" />
+    </ItemGroup>
 </Project>

--- a/OfficeIMO.Tests/Excel.Sheets.cs
+++ b/OfficeIMO.Tests/Excel.Sheets.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using System.Linq;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    /// <summary>
+    /// Tests related to worksheet collection behavior.
+    /// </summary>
+    public partial class Excel {
+        [Fact]
+        public void Test_SheetsGetter_DoesNotIncreaseIdCount() {
+            string filePath = Path.Combine(_directoryDocuments, "BasicExcel.xlsx");
+            using var document = ExcelDocument.Load(filePath);
+
+            // First access to Sheets initializes the ID list
+            var sheets1 = document.Sheets;
+            int idCountAfterFirst = document.id.Count;
+
+            // Subsequent accesses should not change the ID list count
+            var sheets2 = document.Sheets;
+            int idCountAfterSecond = document.id.Count;
+            var sheets3 = document.Sheets;
+            int idCountAfterThird = document.id.Count;
+
+            Assert.Equal(idCountAfterFirst, idCountAfterSecond);
+            Assert.Equal(idCountAfterSecond, idCountAfterThird);
+
+            // Ensure the ID list contains a unique entry for each sheet plus the initial 0
+            Assert.Equal(sheets1.Count + 1, idCountAfterFirst);
+            Assert.Equal(document.id.Count, document.id.Distinct().Count());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Clear and rebuild worksheet ID cache each time `Sheets` is accessed to avoid duplicates
- Guard against duplicate SheetId additions
- Expose internals for tests and add regression test for sheet ID list stability

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Test_SheetsGetter_DoesNotIncreaseIdCount --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68966ad73214832e842167bb745dc967