### PR TITLE
Allow concurrent asynchronous Excel loading

### DIFF
--- a/OfficeIMO.Examples/Excel/ExcelConcurrentAccess.Async.cs
+++ b/OfficeIMO.Examples/Excel/ExcelConcurrentAccess.Async.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using OfficeIMO.Excel;
+
+namespace OfficeIMO.Examples.Excel {
+    /// <summary>
+    /// Demonstrates concurrent asynchronous loading of Excel documents.
+    /// </summary>
+    public class ExcelConcurrentAccessAsync {
+        /// <summary>
+        /// Opens the same workbook concurrently in read/write mode.
+        /// </summary>
+        /// <param name="folderPath">Path to the folder used for the workbook.</param>
+        public static async Task Example_ExcelAsyncConcurrent(string folderPath) {
+            Console.WriteLine("[*] Async concurrent load example for ExcelDocument");
+            string filePath = Path.Combine(folderPath, "AsyncExcelConcurrent.xlsx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Sheet1");
+                await document.SaveAsync();
+            }
+
+            var loadTask1 = ExcelDocument.LoadAsync(filePath, false);
+            var loadTask2 = ExcelDocument.LoadAsync(filePath, false);
+
+            var documents = await Task.WhenAll(loadTask1, loadTask2);
+
+            using (documents[0])
+            using (documents[1]) {
+                Console.WriteLine($"Document1 sheets: {documents[0].Sheets.Count}");
+                Console.WriteLine($"Document2 sheets: {documents[1].Sheets.Count}");
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}
+

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -120,7 +120,7 @@ namespace OfficeIMO.Excel {
                     throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
                 }
             }
-            using var fileStream = new FileStream(filePath, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite, FileShare.Read, 4096, FileOptions.Asynchronous);
+            using var fileStream = new FileStream(filePath, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite, readOnly ? FileShare.Read : FileShare.ReadWrite, 4096, FileOptions.Asynchronous);
             var memoryStream = new MemoryStream();
             await fileStream.CopyToAsync(memoryStream);
             memoryStream.Seek(0, SeekOrigin.Begin);

--- a/OfficeIMO.Tests/Excel.Async.cs
+++ b/OfficeIMO.Tests/Excel.Async.cs
@@ -26,5 +26,29 @@ namespace OfficeIMO.Tests {
 
             File.Delete(filePath);
         }
+
+        [Fact]
+        public async Task Test_ExcelLoadAsync_ConcurrentReadWrite() {
+            var filePath = Path.Combine(_directoryWithFiles, "AsyncExcelConcurrent.xlsx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Sheet1");
+                await document.SaveAsync();
+            }
+
+            var loadTask1 = ExcelDocument.LoadAsync(filePath, false);
+            var loadTask2 = ExcelDocument.LoadAsync(filePath, false);
+
+            var documents = await Task.WhenAll(loadTask1, loadTask2);
+
+            using (documents[0])
+            using (documents[1]) {
+                Assert.True(documents[0].Sheets.Count > 0);
+                Assert.True(documents[1].Sheets.Count > 0);
+            }
+
+            File.Delete(filePath);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow `ExcelDocument.LoadAsync` to share files for read/write access when not opened read-only
- exercise concurrent read/write loading with a unit test
- add example demonstrating concurrent asynchronous Excel document access

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Test_ExcelLoadAsync_ConcurrentReadWrite`
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68966ade7dd0832ea9dce55af8ef7978