### PR TITLE
Support cancellation in async Excel saves

### DIFF
--- a/OfficeIMO.Examples/Excel/BasicExcelFunctionality.Async.cs
+++ b/OfficeIMO.Examples/Excel/BasicExcelFunctionality.Async.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using OfficeIMO.Excel;
 
@@ -27,6 +28,34 @@ namespace OfficeIMO.Examples.Excel {
             }
 
             File.Delete(filePath);
+        }
+
+        /// <summary>
+        /// Demonstrates cancelling an asynchronous save operation.
+        /// </summary>
+        /// <param name="folderPath">Path to the folder used for the workbook.</param>
+        public static async Task Example_ExcelAsync_Cancel(string folderPath) {
+            Console.WriteLine("[*] Async cancel example for ExcelDocument");
+            string sourcePath = Path.Combine(folderPath, "AsyncSource.xlsx");
+            string targetPath = Path.Combine(folderPath, "AsyncCancelled.xlsx");
+            if (File.Exists(sourcePath)) File.Delete(sourcePath);
+            if (File.Exists(targetPath)) File.Delete(targetPath);
+
+            using (var document = ExcelDocument.Create(sourcePath)) {
+                document.AddWorkSheet("Sheet1");
+                using var cts = new CancellationTokenSource();
+                var saveTask = document.SaveAsync(targetPath, false, cts.Token);
+                cts.Cancel();
+                try {
+                    await saveTask;
+                } catch (OperationCanceledException) {
+                    Console.WriteLine("Save operation was cancelled.");
+                }
+            }
+
+            Console.WriteLine($"File exists after cancel: {File.Exists(targetPath)}");
+            if (File.Exists(sourcePath)) File.Delete(sourcePath);
+            if (File.Exists(targetPath)) File.Delete(targetPath);
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.Async.cs
+++ b/OfficeIMO.Tests/Excel.Async.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using OfficeIMO.Excel;
 using Xunit;
@@ -25,6 +26,24 @@ namespace OfficeIMO.Tests {
             }
 
             File.Delete(filePath);
+        }
+
+        [Fact]
+        public async Task Test_ExcelSaveAsyncCancelledDoesNotWriteFile() {
+            var sourcePath = Path.Combine(_directoryWithFiles, "AsyncSource.xlsx");
+            var targetPath = Path.Combine(_directoryWithFiles, "AsyncCancelled.xlsx");
+            if (File.Exists(sourcePath)) File.Delete(sourcePath);
+            if (File.Exists(targetPath)) File.Delete(targetPath);
+
+            using (var document = ExcelDocument.Create(sourcePath)) {
+                document.AddWorkSheet("Sheet1");
+                using var cts = new CancellationTokenSource();
+                cts.Cancel();
+                await Assert.ThrowsAsync<OperationCanceledException>(() => document.SaveAsync(targetPath, false, cts.Token));
+            }
+
+            Assert.False(File.Exists(targetPath));
+            if (File.Exists(sourcePath)) File.Delete(sourcePath);
         }
     }
 }


### PR DESCRIPTION
## Summary
- honor cancellation tokens in `ExcelDocument.SaveAsync`
- add example and tests for cancelling save operations

## Testing
- `dotnet build`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FullyQualifiedName~Test_ExcelSaveAsyncCancelledDoesNotWriteFile`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FullyQualifiedName~Test_ExcelSaveLoadAsync`


------
https://chatgpt.com/codex/tasks/task_e_68966ae39e28832ea579205955b0266d