### PR TITLE
feat: support table borders from HTML

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.TableBorders.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.TableBorders.cs
@@ -1,0 +1,19 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlTableBorders(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlTableBorders.docx");
+            string html = "<table border=\"2\"><tr><td>A1</td><td style=\"border:1px solid #ff0000\">B1</td></tr></table>";
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Html.TableBordersAttribute.cs
+++ b/OfficeIMO.Tests/Html.TableBordersAttribute.cs
@@ -1,0 +1,30 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_TableBorderAttribute_AndCellContent() {
+            string html = "<table border=\"2\"><tr><td>A1</td><td style=\"border:1px solid #ff0000\">B1</td></tr></table>";
+            using WordDocument doc = html.LoadFromHtml();
+            var table = doc.Tables[0];
+
+            var (style, size, colorHex) = table.StyleDetails.GetBorderProperties(WordTableBorderSide.Top);
+            Assert.Equal(BorderValues.Single, style);
+            Assert.Equal((UInt32Value)12U, size);
+            Assert.Equal("000000", colorHex);
+
+            Assert.Contains("A1", string.Join(string.Empty, table.Rows[0].Cells[0].Paragraphs.ConvertAll(p => p.Text)));
+            Assert.Contains("B1", string.Join(string.Empty, table.Rows[0].Cells[1].Paragraphs.ConvertAll(p => p.Text)));
+
+            var cell = table.Rows[0].Cells[1];
+            Assert.Equal(BorderValues.Single, cell.Borders.TopStyle);
+            Assert.Equal("ff0000", cell.Borders.TopColorHex);
+            Assert.Equal((UInt32Value)6U, cell.Borders.TopSize);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- parse `<table>` and `<td>` border attributes when converting HTML to Word
- add example demonstrating table conversion with borders
- test table cell content and border mapping

## Testing
- `dotnet test --filter HtmlToWord_TableBorderAttribute_AndCellContent -v m`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6896f09d1660832e97260de9fc1e0125