### PR TITLE
Add XML documentation to public APIs

### DIFF
--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -12,7 +12,16 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace OfficeIMO.Word.Html.Converters {
+    /// <summary>
+    /// Converts <see cref="WordDocument"/> instances into HTML markup.
+    /// </summary>
     internal class WordToHtmlConverter {
+        /// <summary>
+        /// Converts the specified document to HTML asynchronously using provided options.
+        /// </summary>
+        /// <param name="document">Document to convert.</param>
+        /// <param name="options">Conversion options controlling HTML output.</param>
+        /// <returns>HTML representation of the document.</returns>
         public async Task<string> ConvertAsync(WordDocument document, WordToHtmlOptions options) {
             if (document == null) throw new ArgumentNullException(nameof(document));
             options ??= new WordToHtmlOptions();

--- a/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
+++ b/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
@@ -4,30 +4,63 @@ using System.IO;
 using System.Text;
 
 namespace OfficeIMO.Word.Html {
+    /// <summary>
+    /// Extension methods enabling HTML conversions for <see cref="WordDocument"/> instances.
+    /// </summary>
     public static class WordHtmlConverterExtensions {
+        /// <summary>
+        /// Saves the document as an HTML file at the specified path.
+        /// </summary>
+        /// <param name="document">Document to convert.</param>
+        /// <param name="path">Destination file path.</param>
+        /// <param name="options">Optional conversion options.</param>
         public static void SaveAsHtml(this WordDocument document, string path, WordToHtmlOptions? options = null) {
             var html = document.ToHtml(options);
             File.WriteAllText(path, html, Encoding.UTF8);
         }
 
+        /// <summary>
+        /// Saves the document as HTML to the provided stream.
+        /// </summary>
+        /// <param name="document">Document to convert.</param>
+        /// <param name="stream">Target stream.</param>
+        /// <param name="options">Optional conversion options.</param>
         public static void SaveAsHtml(this WordDocument document, Stream stream, WordToHtmlOptions? options = null) {
             var html = document.ToHtml(options);
             var bytes = Encoding.UTF8.GetBytes(html);
             stream.Write(bytes, 0, bytes.Length);
         }
 
+        /// <summary>
+        /// Converts the document to an HTML string.
+        /// </summary>
+        /// <param name="document">Document to convert.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <returns>HTML representation of the document.</returns>
         public static string ToHtml(this WordDocument document, WordToHtmlOptions? options = null) {
             var converter = new WordToHtmlConverter();
             // Use GetAwaiter().GetResult() to call async method synchronously
             return converter.ConvertAsync(document, options).GetAwaiter().GetResult();
         }
 
+        /// <summary>
+        /// Creates a new document from an HTML string.
+        /// </summary>
+        /// <param name="html">HTML content to convert.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <returns>A new <see cref="WordDocument"/> instance.</returns>
         public static WordDocument LoadFromHtml(this string html, HtmlToWordOptions? options = null) {
             var converter = new HtmlToWordConverter();
             // Use GetAwaiter().GetResult() to call async method synchronously
             return converter.ConvertAsync(html, options).GetAwaiter().GetResult();
         }
 
+        /// <summary>
+        /// Creates a new document from an HTML stream.
+        /// </summary>
+        /// <param name="htmlStream">Stream containing HTML content.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <returns>A new <see cref="WordDocument"/> instance.</returns>
         public static WordDocument LoadFromHtml(this Stream htmlStream, HtmlToWordOptions? options = null) {
             using var reader = new StreamReader(htmlStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
             string html = reader.ReadToEnd();

--- a/OfficeIMO.Word.Markdown/WordMarkdownConverterExtensions.cs
+++ b/OfficeIMO.Word.Markdown/WordMarkdownConverterExtensions.cs
@@ -4,7 +4,16 @@ using System.IO;
 using System.Text;
 
 namespace OfficeIMO.Word.Markdown {
+    /// <summary>
+    /// Extension methods enabling Markdown conversions for <see cref="WordDocument"/> instances.
+    /// </summary>
     public static class WordMarkdownConverterExtensions {
+        /// <summary>
+        /// Saves the document as a Markdown file at the specified path.
+        /// </summary>
+        /// <param name="document">Document to convert.</param>
+        /// <param name="path">Destination file path.</param>
+        /// <param name="options">Optional conversion options.</param>
         public static void SaveAsMarkdown(this WordDocument document, string path, WordToMarkdownOptions? options = null) {
             options ??= new WordToMarkdownOptions();
             if (options.ImageExportMode == ImageExportMode.File && string.IsNullOrEmpty(options.ImageDirectory)) {
@@ -14,6 +23,12 @@ namespace OfficeIMO.Word.Markdown {
             File.WriteAllText(path, markdown, Encoding.UTF8);
         }
 
+        /// <summary>
+        /// Saves the document as Markdown to the provided stream.
+        /// </summary>
+        /// <param name="document">Document to convert.</param>
+        /// <param name="stream">Target stream.</param>
+        /// <param name="options">Optional conversion options.</param>
         public static void SaveAsMarkdown(this WordDocument document, Stream stream, WordToMarkdownOptions? options = null) {
             options ??= new WordToMarkdownOptions();
             var markdown = document.ToMarkdown(options);
@@ -21,16 +36,34 @@ namespace OfficeIMO.Word.Markdown {
             stream.Write(bytes, 0, bytes.Length);
         }
 
+        /// <summary>
+        /// Converts the document to a Markdown string.
+        /// </summary>
+        /// <param name="document">Document to convert.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <returns>Markdown representation of the document.</returns>
         public static string ToMarkdown(this WordDocument document, WordToMarkdownOptions? options = null) {
             var converter = new WordToMarkdownConverter();
             return converter.Convert(document, options);
         }
 
+        /// <summary>
+        /// Creates a new document from a Markdown string.
+        /// </summary>
+        /// <param name="markdown">Markdown content to convert.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <returns>A new <see cref="WordDocument"/> instance.</returns>
         public static WordDocument LoadFromMarkdown(this string markdown, MarkdownToWordOptions? options = null) {
             var converter = new MarkdownToWordConverter();
             return converter.Convert(markdown, options);
         }
 
+        /// <summary>
+        /// Creates a new document from a Markdown stream.
+        /// </summary>
+        /// <param name="markdownStream">Stream containing Markdown content.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <returns>A new <see cref="WordDocument"/> instance.</returns>
         public static WordDocument LoadFromMarkdown(this Stream markdownStream, MarkdownToWordOptions? options = null) {
             using var reader = new StreamReader(markdownStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
             string markdown = reader.ReadToEnd();

--- a/OfficeIMO.Word.Pdf/PdfPageOrientation.cs
+++ b/OfficeIMO.Word.Pdf/PdfPageOrientation.cs
@@ -3,7 +3,9 @@ namespace OfficeIMO.Word.Pdf {
     /// Specifies page orientation for PDF export.
     /// </summary>
     public enum PdfPageOrientation {
+        /// <summary>Portrait page orientation.</summary>
         Portrait,
+        /// <summary>Landscape page orientation.</summary>
         Landscape
     }
 }

--- a/OfficeIMO.Word/Converters/ConversionException.cs
+++ b/OfficeIMO.Word/Converters/ConversionException.cs
@@ -2,17 +2,37 @@ using System;
 using System.Runtime.Serialization;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Represents errors that occur during document conversion processes.
+    /// </summary>
     [Serializable]
     public class ConversionException : Exception {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConversionException"/> class.
+        /// </summary>
         public ConversionException() {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConversionException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
         public ConversionException(string message) : base(message) {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConversionException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public ConversionException(string message, Exception innerException) : base(message, innerException) {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConversionException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data.</param>
+        /// <param name="context">The contextual information about the source or destination.</param>
         protected ConversionException(SerializationInfo info, StreamingContext context) : base(info, context) {
         }
     }

--- a/OfficeIMO.Word/Converters/DocumentTraversal.cs
+++ b/OfficeIMO.Word/Converters/DocumentTraversal.cs
@@ -15,6 +15,14 @@ namespace OfficeIMO.Word {
         /// Describes list information for a paragraph.
         /// </summary>
         public readonly struct ListInfo {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ListInfo"/> struct.
+            /// </summary>
+            /// <param name="level">Zero-based numbering level.</param>
+            /// <param name="ordered"><c>true</c> if the list uses numbering; otherwise, <c>false</c>.</param>
+            /// <param name="start">Starting index for the list.</param>
+            /// <param name="format">Numbering format for the list.</param>
+            /// <param name="text">Raw text pattern defining the marker.</param>
             public ListInfo(int level, bool ordered, int start, NumberFormatValues? format, string? text) {
                 Level = level;
                 Ordered = ordered;
@@ -23,10 +31,15 @@ namespace OfficeIMO.Word {
                 LevelText = text;
             }
 
+            /// <summary>Zero-based nesting level.</summary>
             public int Level { get; }
+            /// <summary>Indicates whether numbering is used.</summary>
             public bool Ordered { get; }
+            /// <summary>Starting index for the list.</summary>
             public int Start { get; }
+            /// <summary>Numbering format applied to the list.</summary>
             public NumberFormatValues? NumberFormat { get; }
+            /// <summary>Pattern used to build the list marker.</summary>
             public string? LevelText { get; }
         }
 

--- a/OfficeIMO.Word/Converters/FormattingHelper.cs
+++ b/OfficeIMO.Word/Converters/FormattingHelper.cs
@@ -11,17 +11,40 @@ namespace OfficeIMO.Word {
         /// Represents a run of text or image with associated formatting flags.
         /// </summary>
         public readonly struct FormattedRun {
+            /// <summary>Text content of the run, if any.</summary>
             public string? Text { get; }
+            /// <summary>Embedded image for the run, when present.</summary>
             public WordImage? Image { get; }
+            /// <summary>Indicates whether bold formatting is applied.</summary>
             public bool Bold { get; }
+            /// <summary>Indicates whether italic formatting is applied.</summary>
             public bool Italic { get; }
+            /// <summary>Indicates whether underline formatting is applied.</summary>
             public bool Underline { get; }
+            /// <summary>Indicates whether strike-through formatting is applied.</summary>
             public bool Strike { get; }
+            /// <summary>Indicates whether superscript formatting is applied.</summary>
             public bool Superscript { get; }
+            /// <summary>Indicates whether subscript formatting is applied.</summary>
             public bool Subscript { get; }
+            /// <summary>Indicates whether the run should be rendered with monospace formatting.</summary>
             public bool Code { get; }
+            /// <summary>Hyperlink target associated with the run.</summary>
             public string? Hyperlink { get; }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="FormattedRun"/> struct.
+            /// </summary>
+            /// <param name="text">Text content of the run.</param>
+            /// <param name="image">Embedded image for the run.</param>
+            /// <param name="bold">Indicates whether bold formatting is applied.</param>
+            /// <param name="italic">Indicates whether italic formatting is applied.</param>
+            /// <param name="underline">Indicates whether underline formatting is applied.</param>
+            /// <param name="strike">Indicates whether strike-through formatting is applied.</param>
+            /// <param name="superscript">Indicates whether superscript formatting is applied.</param>
+            /// <param name="subscript">Indicates whether subscript formatting is applied.</param>
+            /// <param name="code">Indicates whether monospace formatting is applied.</param>
+            /// <param name="hyperlink">Hyperlink target associated with the run.</param>
             public FormattedRun(string? text, WordImage? image, bool bold, bool italic, bool underline, bool strike, bool superscript, bool subscript, bool code, string? hyperlink) {
                 Text = text;
                 Image = image;

--- a/OfficeIMO.Word/Converters/HeadingStyleMapper.cs
+++ b/OfficeIMO.Word/Converters/HeadingStyleMapper.cs
@@ -1,5 +1,13 @@
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides helper methods for mapping between heading levels and paragraph styles.
+    /// </summary>
     public static class HeadingStyleMapper {
+        /// <summary>
+        /// Returns the corresponding paragraph style for the specified heading level.
+        /// </summary>
+        /// <param name="level">Heading level starting at 1.</param>
+        /// <returns>The matching <see cref="WordParagraphStyles"/> value.</returns>
         public static WordParagraphStyles GetHeadingStyleForLevel(int level) {
             return level switch {
                 1 => WordParagraphStyles.Heading1,
@@ -15,6 +23,11 @@ namespace OfficeIMO.Word {
             };
         }
 
+        /// <summary>
+        /// Resolves the heading level for the provided paragraph style.
+        /// </summary>
+        /// <param name="style">Paragraph style to evaluate.</param>
+        /// <returns>The heading level or 0 when the style is not a heading.</returns>
         public static int GetLevelForHeadingStyle(WordParagraphStyles style) {
             return style switch {
                 WordParagraphStyles.Heading1 => 1,

--- a/OfficeIMO.Word/Helpers/ImageEmbedder.cs
+++ b/OfficeIMO.Word/Helpers/ImageEmbedder.cs
@@ -9,7 +9,16 @@ using DW = DocumentFormat.OpenXml.Drawing.Wordprocessing;
 using PIC = DocumentFormat.OpenXml.Drawing.Pictures;
 
 namespace OfficeIMO.Word {
+    /// <summary>
+    /// Provides methods for embedding images into Wordprocessing documents.
+    /// </summary>
     public static class ImageEmbedder {
+        /// <summary>
+        /// Creates a run element containing an image loaded from the specified source.
+        /// </summary>
+        /// <param name="mainPart">Main document part where the image will be stored.</param>
+        /// <param name="src">Path, URI or data URI representing the image.</param>
+        /// <returns>A <see cref="Run"/> containing the embedded image.</returns>
         public static Run CreateImageRun(MainDocumentPart mainPart, string src) {
             byte[] bytes = ResolveImageSource(src);
             using Image image = Image.Load(bytes, out var format);
@@ -47,6 +56,11 @@ namespace OfficeIMO.Word {
             return new Run(drawing);
         }
 
+        /// <summary>
+        /// Retrieves raw bytes from a <see cref="WordImage"/> instance.
+        /// </summary>
+        /// <param name="image">Image to extract bytes from.</param>
+        /// <returns>Binary data representing the image.</returns>
         public static byte[] GetImageBytes(WordImage image) {
             return image.GetBytes();
         }

--- a/OfficeIMO.Word/WordListTraversal.cs
+++ b/OfficeIMO.Word/WordListTraversal.cs
@@ -9,6 +9,13 @@ namespace OfficeIMO.Word {
     /// Represents events emitted while traversing document lists.
     /// </summary>
     public readonly struct WordListEvent {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WordListEvent"/> struct.
+        /// </summary>
+        /// <param name="eventType">Type of event being reported.</param>
+        /// <param name="paragraph">Paragraph associated with the event when applicable.</param>
+        /// <param name="ordered"><c>true</c> when the current list is ordered.</param>
+        /// <param name="level">Zero-based nesting level of the list.</param>
         public WordListEvent(WordListEventType eventType, Paragraph? paragraph, bool ordered, int level) {
             EventType = eventType;
             Paragraph = paragraph;
@@ -41,10 +48,15 @@ namespace OfficeIMO.Word {
     /// Types of list traversal events.
     /// </summary>
     public enum WordListEventType {
+        /// <summary>Signals the start of a new list.</summary>
         StartList,
+        /// <summary>Signals the end of the current list.</summary>
         EndList,
+        /// <summary>Signals the start of a new list item.</summary>
         StartItem,
+        /// <summary>Signals the end of the current list item.</summary>
         EndItem,
+        /// <summary>Represents a standalone paragraph outside of lists.</summary>
         Paragraph
     }
 


### PR DESCRIPTION
## Summary
- document ConversionException and constructors
- document list traversal helpers and formatting structures
- add XML docs to HTML and Markdown conversion extensions and PDF orientation

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_6896f16a7958832e95bbd9f73544cc44