### PR TITLE
Add PDF rendering tests for paragraphs and tables

### DIFF
--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.ParagraphsAndTables.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.ParagraphsAndTables.cs
@@ -1,0 +1,57 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using System.IO;
+using System.Linq;
+using UglyToad.PdfPig;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void SaveAsPdf_Renders_Paragraphs() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfParagraphs.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfParagraphs.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddParagraph("First paragraph");
+                document.AddParagraph("Second paragraph");
+                document.Save();
+                document.SaveAsPdf(pdfPath);
+            }
+
+            Assert.True(File.Exists(pdfPath));
+            using (PdfDocument pdf = PdfDocument.Open(pdfPath)) {
+                string allText = string.Concat(pdf.GetPages().Select(p => p.Text));
+                int first = allText.IndexOf("First paragraph", StringComparison.Ordinal);
+                int second = allText.IndexOf("Second paragraph", StringComparison.Ordinal);
+                Assert.True(first >= 0 && second > first);
+            }
+        }
+
+        [Fact]
+        public void SaveAsPdf_Renders_Tables() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfTableContent.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfTableContent.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                WordTable table = document.AddTable(2, 2);
+                table.Rows[0].Cells[0].Paragraphs[0].Text = "A1";
+                table.Rows[0].Cells[1].Paragraphs[0].Text = "B1";
+                table.Rows[1].Cells[0].Paragraphs[0].Text = "A2";
+                table.Rows[1].Cells[1].Paragraphs[0].Text = "B2";
+                document.Save();
+                document.SaveAsPdf(pdfPath);
+            }
+
+            Assert.True(File.Exists(pdfPath));
+            using (PdfDocument pdf = PdfDocument.Open(pdfPath)) {
+                string allText = string.Concat(pdf.GetPages().Select(p => p.Text));
+                int a1 = allText.IndexOf("A1", StringComparison.Ordinal);
+                int b1 = allText.IndexOf("B1", StringComparison.Ordinal);
+                int a2 = allText.IndexOf("A2", StringComparison.Ordinal);
+                int b2 = allText.IndexOf("B2", StringComparison.Ordinal);
+                Assert.True(a1 >= 0 && b1 > a1 && a2 > b1 && b2 > a2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests ensuring SaveAsPdf renders paragraphs in order
- add tests validating table cell content in PDF output

## Testing
- `dotnet build -c Release`
- `dotnet test --filter "SaveAsPdf_Renders_Paragraphs|SaveAsPdf_Renders_Tables" -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6896f860b5c8832ea3a41f6f278ae250