### PR TITLE
Add hyperlink argument validation

### DIFF
--- a/OfficeIMO.Tests/Word.Hyperlinks.InvalidInputs.cs
+++ b/OfficeIMO.Tests/Word.Hyperlinks.InvalidInputs.cs
@@ -1,0 +1,28 @@
+using System;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+
+        [Fact]
+        public void Test_AddHyperLink_InvalidTextThrows() {
+            using var document = WordDocument.Create();
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink(null, new Uri("https://example.com")));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink(string.Empty, new Uri("https://example.com")));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink(" ", new Uri("https://example.com")));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink(null, "Bookmark"));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink(string.Empty, "Bookmark"));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink(" ", "Bookmark"));
+        }
+
+        [Fact]
+        public void Test_AddHyperLink_InvalidUriOrAnchorThrows() {
+            using var document = WordDocument.Create();
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", (Uri)null));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", (string)null));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", string.Empty));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", " "));
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -104,6 +104,14 @@ namespace OfficeIMO.Word {
         /// <param name="history">Whether to track link history.</param>
         /// <returns>The created <see cref="WordParagraph"/>.</returns>
         public WordParagraph AddHyperLink(string text, Uri uri, bool addStyle = false, string tooltip = "", bool history = true) {
+            if (string.IsNullOrWhiteSpace(text)) {
+                throw new ArgumentException("Text cannot be null or empty.", nameof(text));
+            }
+
+            if (uri == null) {
+                throw new ArgumentException("Uri cannot be null.", nameof(uri));
+            }
+
             return this.AddParagraph().AddHyperLink(text, uri, addStyle, tooltip, history);
         }
 
@@ -117,6 +125,14 @@ namespace OfficeIMO.Word {
         /// <param name="history">Whether to track link history.</param>
         /// <returns>The created <see cref="WordParagraph"/>.</returns>
         public WordParagraph AddHyperLink(string text, string anchor, bool addStyle = false, string tooltip = "", bool history = true) {
+            if (string.IsNullOrWhiteSpace(text)) {
+                throw new ArgumentException("Text cannot be null or empty.", nameof(text));
+            }
+
+            if (string.IsNullOrWhiteSpace(anchor)) {
+                throw new ArgumentException("Anchor cannot be null or empty.", nameof(anchor));
+            }
+
             return this.AddParagraph().AddHyperLink(text, anchor, addStyle, tooltip, history);
         }
 


### PR DESCRIPTION
## Summary
- validate hyperlink text and destination inputs
- test invalid hyperlink inputs

## Testing
- `dotnet test OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_6896f83e76ec832ea98dda9f63f57231