### PR TITLE
Dispose CSS file streams during HTML conversion

### DIFF
--- a/OfficeIMO.Tests/Html.Stylesheets.cs
+++ b/OfficeIMO.Tests/Html.Stylesheets.cs
@@ -96,6 +96,33 @@ namespace OfficeIMO.Tests {
                 Directory.Delete(dir);
             }
         }
+
+        [Fact]
+        public void HtmlToWord_OptionsStylesheet_ReleasesFileLock() {
+            var cssPath = Path.GetTempFileName();
+            File.WriteAllText(cssPath, "p { color:#00ff00; }");
+            var options = new HtmlToWordOptions();
+            options.StylesheetPaths.Add(cssPath);
+            using (var doc = "<p>Test</p>".LoadFromHtml(options)) {
+                var run = doc.Paragraphs[0].GetRuns().First();
+                Assert.Equal("00ff00", run.ColorHex);
+            }
+            File.Delete(cssPath);
+            Assert.False(File.Exists(cssPath));
+        }
+
+        [Fact]
+        public void HtmlToWord_LinkStylesheet_ReleasesFileLock() {
+            var cssPath = Path.GetTempFileName();
+            File.WriteAllText(cssPath, "p { color:#ff00ff; }");
+            string html = $"<link rel=\"stylesheet\" href=\"{cssPath}\" /><p>Test</p>";
+            using (var doc = html.LoadFromHtml(new HtmlToWordOptions())) {
+                var run = doc.Paragraphs[0].GetRuns().First();
+                Assert.Equal("ff00ff", run.ColorHex);
+            }
+            File.Delete(cssPath);
+            Assert.False(File.Exists(cssPath));
+        }
     }
 }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -53,17 +53,17 @@ namespace OfficeIMO.Word.Html.Converters {
                     if (absolute.Scheme == Uri.UriSchemeHttp || absolute.Scheme == Uri.UriSchemeHttps) {
                         await LoadAndParseCssAsync(context, new Url(absolute.ToString()));
                     } else if (absolute.Scheme == Uri.UriSchemeFile && File.Exists(absolute.LocalPath)) {
-                        ParseCss(File.ReadAllText(absolute.LocalPath));
+                        ParseCssFromFile(absolute.LocalPath);
                     }
                 } else if (document.BaseUrl != null) {
                     var url = new Url(new Url(document.BaseUrl), path);
                     if (url.Scheme == "http" || url.Scheme == "https") {
                         await LoadAndParseCssAsync(context, url);
                     } else if (url.Scheme == "file" && File.Exists(url.Path)) {
-                        ParseCss(File.ReadAllText(url.Path));
+                        ParseCssFromFile(url.Path);
                     }
                 } else if (File.Exists(path)) {
-                    ParseCss(File.ReadAllText(path));
+                    ParseCssFromFile(path);
                 }
             }
             foreach (var content in options.StylesheetContents) {
@@ -95,7 +95,7 @@ namespace OfficeIMO.Word.Html.Converters {
                     }
 
                     if (File.Exists(hrefAttr)) {
-                        ParseCss(File.ReadAllText(hrefAttr));
+                        ParseCssFromFile(hrefAttr);
                         continue;
                     }
 
@@ -104,7 +104,7 @@ namespace OfficeIMO.Word.Html.Converters {
                         if (combined.Scheme == Uri.UriSchemeHttp || combined.Scheme == Uri.UriSchemeHttps) {
                             await LoadAndParseCssAsync(context, new Url(combined.ToString()));
                         } else if (combined.Scheme == Uri.UriSchemeFile && File.Exists(combined.LocalPath)) {
-                            ParseCss(File.ReadAllText(combined.LocalPath));
+                            ParseCssFromFile(combined.LocalPath);
                         }
                     }
                 }
@@ -135,6 +135,11 @@ namespace OfficeIMO.Word.Html.Converters {
             }
 
             return wordDoc;
+        }
+
+        private void ParseCssFromFile(string path) {
+            using var reader = File.OpenText(path);
+            ParseCss(reader.ReadToEnd());
         }
 
         private async Task LoadAndParseCssAsync(IBrowsingContext context, Url url) {
@@ -441,7 +446,7 @@ namespace OfficeIMO.Word.Html.Converters {
                             }
 
                             if (!string.IsNullOrEmpty(hrefAttr) && File.Exists(hrefAttr)) {
-                                ParseCss(File.ReadAllText(hrefAttr));
+                                ParseCssFromFile(hrefAttr);
                                 break;
                             }
 
@@ -455,7 +460,7 @@ namespace OfficeIMO.Word.Html.Converters {
                                     LoadAndParseCssAsync(_context, url).GetAwaiter().GetResult();
                                 }
                             } else if (url.Scheme == "file" && File.Exists(url.Path)) {
-                                ParseCss(File.ReadAllText(url.Path));
+                                ParseCssFromFile(url.Path);
                             }
                             break;
                         }


### PR DESCRIPTION
## Summary
- ensure CSS files are read with using blocks to prevent file locks
- test that stylesheet files can be deleted after conversion

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6896f85999c8832ebbcf0a9585735d1a