### PR TITLE
Ensure culture-invariant string comparisons

### DIFF
--- a/OfficeIMO.Tests/Word.CultureInvariant.cs
+++ b/OfficeIMO.Tests/Word.CultureInvariant.cs
@@ -1,0 +1,48 @@
+using System.Globalization;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void NormalizeColor_IsCultureInvariant() {
+            var current = CultureInfo.CurrentCulture;
+            var currentUi = CultureInfo.CurrentUICulture;
+            try {
+                CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+                CultureInfo.CurrentUICulture = new CultureInfo("tr-TR");
+
+                var normalized = Helpers.NormalizeColor("AAEEDD");
+                Assert.Equal("aaeedd", normalized);
+            } finally {
+                CultureInfo.CurrentCulture = current;
+                CultureInfo.CurrentUICulture = currentUi;
+            }
+        }
+
+        [Fact]
+        public void WatermarkParsing_IsCultureInvariant() {
+            var current = CultureInfo.CurrentCulture;
+            var currentUi = CultureInfo.CurrentUICulture;
+            try {
+                CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+                CultureInfo.CurrentUICulture = new CultureInfo("tr-TR");
+
+                using var document = WordDocument.Create();
+                document.AddParagraph("Section 0");
+                document.AddHeadersAndFooters();
+
+                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Watermark");
+
+                Assert.Equal(90, watermark.Rotation);
+
+                watermark.Rotation = 135;
+                Assert.Equal(135, watermark.Rotation);
+            } finally {
+                CultureInfo.CurrentCulture = current;
+                CultureInfo.CurrentUICulture = currentUi;
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Word/Helpers.PackageFixer.cs
+++ b/OfficeIMO.Word/Helpers.PackageFixer.cs
@@ -66,10 +66,10 @@ namespace OfficeIMO.Word {
                 foreach (var relationship in relationships) {
                     var targetAttribute = relationship.Attribute("Target");
                     if (targetAttribute != null) {
-                        if (removeWordPrefix && targetAttribute.Value.StartsWith("/word/")) {
+                        if (removeWordPrefix && targetAttribute.Value.StartsWith("/word/", StringComparison.Ordinal)) {
                             targetAttribute.Value = targetAttribute.Value.Substring(6); // Remove "/word/"
                             modified = true;
-                        } else if (!removeWordPrefix && targetAttribute.Value.StartsWith("/")) {
+                        } else if (!removeWordPrefix && targetAttribute.Value.StartsWith("/", StringComparison.Ordinal)) {
                             targetAttribute.Value = targetAttribute.Value.TrimStart('/');
                             modified = true;
                         }

--- a/OfficeIMO.Word/Helpers.cs
+++ b/OfficeIMO.Word/Helpers.cs
@@ -35,7 +35,7 @@ namespace OfficeIMO.Word {
             if (string.IsNullOrEmpty(hex)) {
                 throw new ArgumentException("Value cannot be null or empty.", nameof(hex));
             }
-            if (!hex.StartsWith("#")) {
+            if (!hex.StartsWith("#", StringComparison.Ordinal)) {
                 hex = "#" + hex;
             }
             return SixLabors.ImageSharp.Color.Parse(hex);
@@ -54,7 +54,7 @@ namespace OfficeIMO.Word {
                 var parsed = SixLabors.ImageSharp.Color.Parse(color);
                 return parsed.ToHexColor();
             } catch {
-                if (!color.StartsWith("#")) {
+                if (!color.StartsWith("#", StringComparison.Ordinal)) {
                     var parsedHex = SixLabors.ImageSharp.Color.Parse("#" + color);
                     return parsedHex.ToHexColor();
                 }

--- a/OfficeIMO.Word/Helpers/InlineRunHelper.cs
+++ b/OfficeIMO.Word/Helpers/InlineRunHelper.cs
@@ -19,8 +19,8 @@ public static class InlineRunHelper {
     public static void AddInlineRuns(WordParagraph paragraph, string text, string? fontFamily = null) {
         foreach (Match match in _inlineRegex.Matches(text)) {
             string token = match.Value;
-            bool bold = token.StartsWith("**") && token.EndsWith("**");
-            bool italic = !bold && token.StartsWith("*") && token.EndsWith("*");
+            bool bold = token.StartsWith("**", StringComparison.Ordinal) && token.EndsWith("**");
+            bool italic = !bold && token.StartsWith("*", StringComparison.Ordinal) && token.EndsWith("*");
             string value = bold ? token.Substring(2, token.Length - 4) :
                            italic ? token.Substring(1, token.Length - 2) : token;
 

--- a/OfficeIMO.Word/WordLine.cs
+++ b/OfficeIMO.Word/WordLine.cs
@@ -54,7 +54,7 @@ namespace OfficeIMO.Word {
         public Color Color {
             get {
                 var color = _line.StrokeColor?.Value ?? "";
-                if (!color.StartsWith("#")) color = "#" + color;
+                if (!color.StartsWith("#", StringComparison.Ordinal)) color = "#" + color;
                 return Color.Parse(color);
             }
             set => _line.StrokeColor = value.ToHexColor();

--- a/OfficeIMO.Word/WordParagraph.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PrivateMethods.cs
@@ -149,11 +149,11 @@ namespace OfficeIMO.Word {
             for (int i = 0; i < textSplit.Length; i++) {
                 // check if there's new line at the beginning of the text
                 // if there is add empty string to the list
-                if (i == 0 && text.StartsWith(Environment.NewLine)) {
+                if (i == 0 && text.StartsWith(Environment.NewLine, StringComparison.Ordinal)) {
                     list.Add("");
-                } else if (i == 0 && text.StartsWith("\r\n")) {
+                } else if (i == 0 && text.StartsWith("\r\n", StringComparison.Ordinal)) {
                     list.Add("");
-                } else if (i == 0 && text.StartsWith("\n")) {
+                } else if (i == 0 && text.StartsWith("\n", StringComparison.Ordinal)) {
                     list.Add("");
                 }
                 // add splitted text to the list

--- a/OfficeIMO.Word/WordShape.cs
+++ b/OfficeIMO.Word/WordShape.cs
@@ -275,7 +275,7 @@ namespace OfficeIMO.Word {
             get {
                 var hex = FillColorHex;
                 if (string.IsNullOrEmpty(hex)) return SixLabors.ImageSharp.Color.Transparent;
-                if (!hex.StartsWith("#")) hex = "#" + hex;
+                if (!hex.StartsWith("#", StringComparison.Ordinal)) hex = "#" + hex;
                 return SixLabors.ImageSharp.Color.Parse(hex);
             }
             set => FillColorHex = value.ToHexColor();
@@ -398,7 +398,7 @@ namespace OfficeIMO.Word {
             get {
                 var hex = StrokeColorHex;
                 if (string.IsNullOrEmpty(hex)) return SixLabors.ImageSharp.Color.Transparent;
-                if (!hex.StartsWith("#")) hex = "#" + hex;
+                if (!hex.StartsWith("#", StringComparison.Ordinal)) hex = "#" + hex;
                 return SixLabors.ImageSharp.Color.Parse(hex);
             }
             set => StrokeColorHex = value.ToHexColor();

--- a/OfficeIMO.Word/WordWatermark.cs
+++ b/OfficeIMO.Word/WordWatermark.cs
@@ -99,7 +99,7 @@ namespace OfficeIMO.Word {
                     //
                     var style = shape.Style.Value;
                     if (style != null) {
-                        var rotation = style.Split(';').FirstOrDefault(c => c.StartsWith("rotation:"));
+                        var rotation = style.Split(';').FirstOrDefault(c => c.StartsWith("rotation:", StringComparison.Ordinal));
                         if (rotation != null) {
                             var rotationValue = rotation.Split(':').LastOrDefault();
                             if (rotationValue != null) {
@@ -115,7 +115,7 @@ namespace OfficeIMO.Word {
                 if (shape != null) {
                     var style = shape.Style.Value;
                     if (style != null) {
-                        var rotation = style.Split(';').FirstOrDefault(c => c.StartsWith("rotation:"));
+                        var rotation = style.Split(';').FirstOrDefault(c => c.StartsWith("rotation:", StringComparison.Ordinal));
                         if (rotation != null) {
                             var rotationValue = rotation.Split(':').LastOrDefault();
                             if (rotationValue != null) {
@@ -136,7 +136,7 @@ namespace OfficeIMO.Word {
                 if (shape != null) {
                     var style = shape.Style.Value;
                     if (style != null) {
-                        var width = style.Split(';').FirstOrDefault(c => c.StartsWith("width:"));
+                        var width = style.Split(';').FirstOrDefault(c => c.StartsWith("width:", StringComparison.Ordinal));
                         if (width != null) {
                             var widthValue = width.Split(':').LastOrDefault();
                             if (widthValue != null) {
@@ -153,7 +153,7 @@ namespace OfficeIMO.Word {
                 if (shape != null) {
                     var style = shape.Style.Value;
                     if (style != null) {
-                        var width = style.Split(';').FirstOrDefault(c => c.StartsWith("width:"));
+                        var width = style.Split(';').FirstOrDefault(c => c.StartsWith("width:", StringComparison.Ordinal));
                         if (width != null) {
                             var widthValue = width.Split(':').LastOrDefault();
                             if (widthValue != null) {
@@ -174,7 +174,7 @@ namespace OfficeIMO.Word {
                 if (shape != null) {
                     var style = shape.Style.Value;
                     if (style != null) {
-                        var height = style.Split(';').FirstOrDefault(c => c.StartsWith("height:"));
+                        var height = style.Split(';').FirstOrDefault(c => c.StartsWith("height:", StringComparison.Ordinal));
                         if (height != null) {
                             var heightValue = height.Split(':').LastOrDefault();
                             if (heightValue != null) {
@@ -191,7 +191,7 @@ namespace OfficeIMO.Word {
                 if (shape != null) {
                     var style = shape.Style.Value;
                     if (style != null) {
-                        var height = style.Split(';').FirstOrDefault(c => c.StartsWith("height:"));
+                        var height = style.Split(';').FirstOrDefault(c => c.StartsWith("height:", StringComparison.Ordinal));
                         if (height != null) {
                             var heightValue = height.Split(':').LastOrDefault();
                             if (heightValue != null) {
@@ -212,7 +212,7 @@ namespace OfficeIMO.Word {
                 if (shape != null) {
                     var style = shape.Style.Value;
                     if (style != null) {
-                        var left = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-left:"));
+                        var left = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-left:", StringComparison.Ordinal));
                         if (left != null) {
                             var value = left.Split(':').LastOrDefault();
                             if (value != null) {
@@ -229,7 +229,7 @@ namespace OfficeIMO.Word {
                 if (shape != null) {
                     var style = shape.Style.Value;
                     if (style != null) {
-                        var left = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-left:"));
+                        var left = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-left:", StringComparison.Ordinal));
                         if (left != null) {
                             shape.Style.Value = style.Replace(left, "margin-left:" + value + "pt");
                         }
@@ -247,7 +247,7 @@ namespace OfficeIMO.Word {
                 if (shape != null) {
                     var style = shape.Style.Value;
                     if (style != null) {
-                        var top = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-top:"));
+                        var top = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-top:", StringComparison.Ordinal));
                         if (top != null) {
                             var value = top.Split(':').LastOrDefault();
                             if (value != null) {
@@ -264,7 +264,7 @@ namespace OfficeIMO.Word {
                 if (shape != null) {
                     var style = shape.Style.Value;
                     if (style != null) {
-                        var top = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-top:"));
+                        var top = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-top:", StringComparison.Ordinal));
                         if (top != null) {
                             shape.Style.Value = style.Replace(top, "margin-top:" + value + "pt");
                         }
@@ -283,7 +283,7 @@ namespace OfficeIMO.Word {
                     var textPath = shape.GetFirstChild<V.TextPath>();
                     if (textPath != null && textPath.Style != null) {
                         var style = textPath.Style.Value;
-                        var family = style.Split(';').FirstOrDefault(c => c.StartsWith("font-family:"));
+                        var family = style.Split(';').FirstOrDefault(c => c.StartsWith("font-family:", StringComparison.Ordinal));
                         if (family != null) {
                             var value = family.Split(':').LastOrDefault();
                             if (value != null) {
@@ -320,7 +320,7 @@ namespace OfficeIMO.Word {
                     var textPath = shape.GetFirstChild<V.TextPath>();
                     if (textPath != null && textPath.Style != null) {
                         var style = textPath.Style.Value;
-                        var size = style.Split(';').FirstOrDefault(c => c.StartsWith("font-size:"));
+                        var size = style.Split(';').FirstOrDefault(c => c.StartsWith("font-size:", StringComparison.Ordinal));
                         if (size != null) {
                             var value = size.Split(':').LastOrDefault();
                             if (value != null) {


### PR DESCRIPTION
## Summary
- enforce `StringComparison.Ordinal` for `StartsWith` across Word components
- add tests confirming culture-invariant behavior for color normalization and watermark parsing

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_6896f837f0a8832eaa1e204b4d1c36e4