### PR TITLE
Ensure exclusive file access when saving images

### DIFF
--- a/OfficeIMO.Examples/Word/Images/Images.SaveToFileExclusive.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.SaveToFileExclusive.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Images {
+        internal static void Example_ImageSaveToFileExclusive(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Demonstrating exclusive access when saving images");
+            string filePath = Path.Combine(folderPath, "ImageSaveExclusive.docx");
+            string imagePaths = Path.Combine(Directory.GetCurrentDirectory(), "Images");
+
+            using var document = WordDocument.Create(filePath);
+            var paragraph = document.AddParagraph();
+            paragraph.AddImage(Path.Combine(imagePaths, "Kulek.jpg"), 50, 50);
+
+            string fileToSave = Path.Combine(folderPath, "LockedImage.jpg");
+            using (var lockStream = new FileStream(fileToSave, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite)) {
+                try {
+                    paragraph.Image.SaveToFile(fileToSave);
+                } catch (IOException) {
+                    Console.WriteLine("[!] Unable to save image while file is locked");
+                }
+            }
+
+            paragraph.Image.SaveToFile(fileToSave);
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.ImageExclusiveAccess.cs
+++ b/OfficeIMO.Tests/Word.ImageExclusiveAccess.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_ImageSaveToFileRequiresExclusiveAccess() {
+            var docPath = Path.Combine(_directoryWithFiles, "ImageExclusive.docx");
+            using var document = WordDocument.Create(docPath);
+            document.AddParagraph().AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 50, 50);
+
+            var fileToSave = Path.Combine(_directoryWithFiles, "LockedImage.jpg");
+            using (var lockStream = new FileStream(fileToSave, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite)) {
+                Assert.Throws<IOException>(() => document.Images[0].SaveToFile(fileToSave));
+            }
+
+            document.Images[0].SaveToFile(fileToSave);
+            Assert.True(new FileInfo(fileToSave).Length > 0);
+        }
+    }
+}

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -1997,7 +1997,7 @@ namespace OfficeIMO.Word {
             }
 
             try {
-                using (FileStream outputFileStream = new FileStream(fileToSave, FileMode.Create)) {
+                using (FileStream outputFileStream = new FileStream(fileToSave, FileMode.Create, FileAccess.Write, FileShare.None)) {
                     var stream = _imagePart.GetStream();
                     stream.CopyTo(outputFileStream);
                     stream.Close();


### PR DESCRIPTION
## Summary
- ensure images are saved with write-only exclusive FileStream
- add tests asserting that saving fails when destination file is locked
- document exclusive image saving behavior in examples

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6897286c4178832e87a5f0b8621b5378