### PR TITLE
Guard header and footer access when document has no sections

### DIFF
--- a/OfficeIMO.Tests/Word.HeadersAndFooter.cs
+++ b/OfficeIMO.Tests/Word.HeadersAndFooter.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using Xunit;
@@ -254,6 +255,15 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Sections.Count == 1, "Number of sections during creation is wrong.");
                 Assert.True(document.Sections[0].Paragraphs.Count == 1, "Number of paragraphs on 1st section is wrong. Current: " + document.Sections[0].Paragraphs.Count);
             }
+        }
+
+        [Fact]
+        public void Test_LoadEmptyDocumentWithoutSections_Throws() {
+            string filePath = Path.Combine(_directoryDocuments, "EmptyDocument.docx");
+            using var document = WordDocument.Load(filePath);
+            document.RemoveSection(0);
+            var ex = Assert.Throws<InvalidOperationException>(() => _ = document.Header);
+            Assert.Equal("The document does not contain any sections.", ex.Message);
         }
         [Fact]
         public void Test_CreatingWordDocumentHeadersAndFootersAndDeletingHeadersAndFooters() {

--- a/OfficeIMO.Word/WordDocument.HeadersAndFooters.cs
+++ b/OfficeIMO.Word/WordDocument.HeadersAndFooters.cs
@@ -26,6 +26,9 @@ namespace OfficeIMO.Word {
         /// </summary>
         public WordHeaders Header {
             get {
+                if (this.Sections.Count == 0) {
+                    throw new InvalidOperationException("The document does not contain any sections.");
+                }
                 if (this.Sections.Count > 1) {
                     Debug.WriteLine("This document contains more than 1 section. Consider using Sections[wantedSection].Headers.");
                 }
@@ -37,6 +40,9 @@ namespace OfficeIMO.Word {
         /// </summary>
         public WordFooters Footer {
             get {
+                if (this.Sections.Count == 0) {
+                    throw new InvalidOperationException("The document does not contain any sections.");
+                }
                 if (this.Sections.Count > 1) {
                     Debug.WriteLine("This document contains more than 1 section. Consider using Sections[wantedSection].Headers.");
                 }
@@ -49,12 +55,18 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool DifferentFirstPage {
             get {
+                if (this.Sections.Count == 0) {
+                    throw new InvalidOperationException("The document does not contain any sections.");
+                }
                 if (this.Sections.Count > 1) {
                     Debug.WriteLine("This document contains more than 1 section. Consider using Sections[wantedSection].Headers.");
                 }
                 return this.Sections[0].DifferentFirstPage;
             }
             set {
+                if (this.Sections.Count == 0) {
+                    throw new InvalidOperationException("The document does not contain any sections.");
+                }
                 this.Sections[0].DifferentFirstPage = value;
             }
 
@@ -101,12 +113,18 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool DifferentOddAndEvenPages {
             get {
+                if (this.Sections.Count == 0) {
+                    throw new InvalidOperationException("The document does not contain any sections.");
+                }
                 if (this.Sections.Count > 1) {
                     Debug.WriteLine("This document contains more than 1 section. Consider using Sections[wantedSection].Headers.");
                 }
                 return this.Sections[0].DifferentOddAndEvenPages;
             }
             set {
+                if (this.Sections.Count == 0) {
+                    throw new InvalidOperationException("The document does not contain any sections.");
+                }
                 this.Sections[0].DifferentOddAndEvenPages = value;
             }
             //get {


### PR DESCRIPTION
## Summary
- ensure Header, Footer, DifferentFirstPage and DifferentOddAndEvenPages validate that the document contains sections before accessing the first section
- add unit test covering empty-document scenario

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689728928540832e8fd1b4a588b286f5