### PR TITLE
Guard footer property when no sections

### DIFF
--- a/OfficeIMO.Tests/Word.Sections.cs
+++ b/OfficeIMO.Tests/Word.Sections.cs
@@ -547,5 +547,18 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Test_HeaderFooterReturnNullWhenNoSections() {
+            string filePath = Path.Combine(_directoryWithFiles, "NoSectionsHeaderFooter.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.RemoveSection(0);
+
+                Assert.Empty(document.Sections);
+                Assert.Null(document.Header);
+                Assert.Null(document.Footer);
+            }
+        }
+
     }
 }

--- a/OfficeIMO.Word/WordDocument.HeadersAndFooters.cs
+++ b/OfficeIMO.Word/WordDocument.HeadersAndFooters.cs
@@ -26,9 +26,14 @@ namespace OfficeIMO.Word {
         /// </summary>
         public WordHeaders Header {
             get {
+                if (this.Sections.Count == 0) {
+                    return null;
+                }
+
                 if (this.Sections.Count > 1) {
                     Debug.WriteLine("This document contains more than 1 section. Consider using Sections[wantedSection].Headers.");
                 }
+
                 return this.Sections[0].Header;
             }
         }
@@ -37,9 +42,14 @@ namespace OfficeIMO.Word {
         /// </summary>
         public WordFooters Footer {
             get {
+                if (this.Sections.Count == 0) {
+                    return null;
+                }
+
                 if (this.Sections.Count > 1) {
                     Debug.WriteLine("This document contains more than 1 section. Consider using Sections[wantedSection].Headers.");
                 }
+
                 return this.Sections[0].Footer;
             }
         }


### PR DESCRIPTION
## Summary
- guard `Header` and `Footer` properties when a document has no sections
- test header and footer access after removing the only section

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Test_HeaderFooterReturnNullWhenNoSections --no-build`


------
https://chatgpt.com/codex/tasks/task_e_689728984074832e87175642f4b7096e