### PR TITLE
Ensure Helpers.Open validates file path

### DIFF
--- a/OfficeIMO.Tests/Word.Helpers.cs
+++ b/OfficeIMO.Tests/Word.Helpers.cs
@@ -22,4 +22,11 @@ public partial class Word {
         var imageСharacteristics = Helpers.GetImageCharacteristics(imageStream, filename);
         Assert.Equal(expectedType, imageСharacteristics.Type);
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Open_WithInvalidFilePath_ThrowsArgumentException(string path) {
+        Assert.Throws<ArgumentException>(() => Helpers.Open(path, true));
+    }
 }

--- a/OfficeIMO.Word/Helpers.cs
+++ b/OfficeIMO.Word/Helpers.cs
@@ -69,6 +69,10 @@ namespace OfficeIMO.Word {
         /// <param name="open"></param>
         public static void Open(string filePath, bool open) {
             if (open) {
+                if (string.IsNullOrEmpty(filePath)) {
+                    throw new ArgumentException("File path cannot be null or empty.", nameof(filePath));
+                }
+
                 ProcessStartInfo startInfo = new ProcessStartInfo(filePath) {
                     UseShellExecute = true
                 };


### PR DESCRIPTION
## Summary
- throw `ArgumentException` when `Helpers.Open` receives a null or empty file path
- add unit tests covering invalid file path scenarios

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Open_WithInvalidFilePath_ThrowsArgumentException -v normal`

------
https://chatgpt.com/codex/tasks/task_e_689728a1063c832eb2ad3c117f2ef0e0