### PR TITLE
Validate SaveAsPdf paths

### DIFF
--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Async.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Async.cs
@@ -1,12 +1,12 @@
-using OfficeIMO.Word.Pdf;
 using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
 using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace OfficeIMO.Tests;
 
-    public partial class Word {
+public partial class Word {
     [Fact]
     public async Task Test_WordDocument_SaveAsPdfAsync() {
         var docPath = Path.Combine(_directoryWithFiles, "PdfAsync.docx");
@@ -40,5 +40,18 @@ namespace OfficeIMO.Tests;
             }
         }
     }
-    }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task Test_WordDocument_SaveAsPdfAsync_EmptyOrWhitespacePath_Throws(string path) {
+        var docPath = Path.Combine(_directoryWithFiles, "PdfAsyncEmptyPath.docx");
+
+        using (var document = WordDocument.Create(docPath)) {
+            document.AddParagraph("Hello World");
+            document.Save();
+            var ex = await Assert.ThrowsAsync<ArgumentException>(() => document.SaveAsPdfAsync(path));
+            Assert.Contains("empty or whitespace", ex.Message);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
@@ -154,6 +154,20 @@ public partial class Word {
         }
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Test_WordDocument_SaveAsPdf_EmptyOrWhitespacePath_Throws(string path) {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfEmptyPath.docx");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            document.AddParagraph("Hello World");
+            document.Save();
+            var ex = Assert.Throws<ArgumentException>(() => document.SaveAsPdf(path));
+            Assert.Contains("empty or whitespace", ex.Message);
+        }
+    }
+
     [Fact]
     public void Test_WordDocument_SaveAsPdf_NullDocument_Throws() {
         Assert.Throws<ArgumentNullException>(() => WordPdfConverterExtensions.SaveAsPdf(null!, "file.pdf"));

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -32,6 +32,10 @@ namespace OfficeIMO.Word.Pdf {
                 throw new ArgumentNullException(nameof(path));
             }
 
+            if (string.IsNullOrWhiteSpace(path)) {
+                throw new ArgumentException("Path cannot be empty or whitespace.", nameof(path));
+            }
+
             string? directory = Path.GetDirectoryName(path);
             if (!string.IsNullOrEmpty(directory)) {
                 Directory.CreateDirectory(directory);
@@ -92,6 +96,10 @@ namespace OfficeIMO.Word.Pdf {
 
             if (path == null) {
                 throw new ArgumentNullException(nameof(path));
+            }
+
+            if (string.IsNullOrWhiteSpace(path)) {
+                throw new ArgumentException("Path cannot be empty or whitespace.", nameof(path));
             }
 
             string? directory = Path.GetDirectoryName(path);


### PR DESCRIPTION
## Summary
- ensure SaveAsPdf throws ArgumentException when path is empty or whitespace
- add tests for empty/whitespace paths on both sync and async SaveAsPdf

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689738bedd48832e8c1032d89e02f437