### PR TITLE
Handle unreachable images in HTML conversion

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.ImagesUnreachable.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.ImagesUnreachable.cs
@@ -1,0 +1,19 @@
+using System;
+using System.IO;
+using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlImagesUnreachable(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlImageUnreachable.docx");
+            string html = "<p><img src=\"http://localhost:1/missing.png\" alt=\"Missing\" /></p>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+            Console.WriteLine($"Images: {doc.Images.Count}, Paragraphs: {doc.Paragraphs.Count}");
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -43,5 +43,22 @@ namespace OfficeIMO.Tests {
                 Directory.Delete(dir);
             }
         }
+
+        [Fact]
+        public void HtmlToWord_UnreachableImage_InsertsPlaceholder() {
+            string html = "<img src=\"http://localhost:1/missing.png\" alt=\"Missing\" />";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            Assert.Empty(doc.Images);
+            Assert.Single(doc.Paragraphs);
+            Assert.Equal("Missing", doc.Paragraphs[0].Text);
+        }
+
+        [Fact]
+        public void HtmlToWord_UnreachableImage_NoAlt_SkipsImage() {
+            string html = "<img src=\"http://localhost:1/missing.png\" />";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            Assert.Empty(doc.Images);
+            Assert.Empty(doc.Paragraphs);
+        }
     }
 }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -38,8 +38,15 @@ namespace OfficeIMO.Word.Html.Converters {
             } else if (File.Exists(src)) {
                 doc.AddParagraph().AddImage(src, width, height, description: alt);
             } else {
-                var image = doc.AddImageFromUrl(src, width, height);
-                image.Description = alt;
+                try {
+                    var image = doc.AddImageFromUrl(src, width, height);
+                    image.Description = alt;
+                } catch (Exception ex) {
+                    Console.WriteLine($"Failed to load image from '{src}': {ex.Message}");
+                    if (!string.IsNullOrEmpty(alt)) {
+                        doc.AddParagraph(alt);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- protect URL image loading with try/catch and log failures
- add placeholder or skip when image URL is unreachable
- cover unreachable image scenarios with tests and example

## Testing
- `dotnet build`
- `dotnet test --filter HtmlToWord_UnreachableImage`


------
https://chatgpt.com/codex/tasks/task_e_6897390c1034832ea92ce85a5d545197