### PR TITLE
feat: handle nested HTML tables

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.NestedTables.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.NestedTables.cs
@@ -1,0 +1,26 @@
+using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlNestedTables(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlNestedTables.docx");
+            string html = "<table><tr><td>Outer</td><td><table><tr><td>Inner</td></tr></table></td></tr></table>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            doc.Save(filePath);
+
+            var outer = doc.Sections[0].Tables[0];
+            var inner = outer.Rows[0].Cells[1].NestedTables[0];
+            Console.WriteLine("Outer cell text: " + outer.Rows[0].Cells[0].Paragraphs[0].Text);
+            Console.WriteLine("Inner cell text: " + inner.Rows[0].Cells[0].Paragraphs[0].Text);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -28,6 +28,7 @@ namespace OfficeIMO.Examples {
             OfficeIMO.Examples.Html.Html.Example_HtmlLists(folderPath, false);
             OfficeIMO.Examples.Html.Html.Example_HtmlRoundTrip(folderPath, false);
             OfficeIMO.Examples.Html.Html.Example_HtmlTables(folderPath, false);
+            OfficeIMO.Examples.Html.Html.Example_HtmlNestedTables(folderPath, false);
             // Markdown/Markdown
             OfficeIMO.Examples.Markdown.Markdown.Example_MarkdownInterface(folderPath, false);
             OfficeIMO.Examples.Markdown.Markdown.Example_MarkdownLists(folderPath, false);

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -73,15 +73,25 @@ public partial class Html {
         Assert.Contains("D", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact(Skip = "TODO: Implement nested table support")]
+    [Fact]
     public void Test_Html_NestedTable_RoundTrip() {
         string html = "<table><tr><td>Outer</td><td><table><tr><td>Inner</td></tr></table></td></tr></table>";
-        
-        var doc = html.LoadFromHtml(new HtmlToWordOptions());
-        string roundTrip = doc.ToHtml(new WordToHtmlOptions());
 
-        int tableCount = roundTrip.Split(new string[] { "<table>" }, StringSplitOptions.None).Length - 1;
+        var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+        Assert.Single(doc.Sections[0].Tables);
+        var outer = doc.Sections[0].Tables[0];
+        Assert.Equal(2, outer.Rows[0].Cells.Count);
+        var innerCell = outer.Rows[0].Cells[1];
+        Assert.True(innerCell.HasNestedTables);
+        var inner = innerCell.NestedTables[0];
+        Assert.Equal(1, inner.Rows.Count);
+        Assert.Equal(1, inner.Rows[0].Cells.Count);
+
+        string roundTrip = doc.ToHtml(new WordToHtmlOptions());
+        int tableCount = System.Text.RegularExpressions.Regex.Matches(roundTrip, "<table", System.Text.RegularExpressions.RegexOptions.IgnoreCase).Count;
         Assert.True(tableCount >= 2);
+        Assert.Contains("Outer", roundTrip, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Inner", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -63,8 +63,15 @@ namespace OfficeIMO.Word.Html.Converters {
                         if (wordCell.Paragraphs.Count == 1 && string.IsNullOrEmpty(wordCell.Paragraphs[0].Text)) {
                             wordCell.Paragraphs[0].Remove();
                         }
+
+                        WordParagraph? innerParagraph = null;
                         foreach (var child in htmlCell.ChildNodes) {
-                            ProcessNode(child, doc, section, options, null, listStack, new TextFormatting(), wordCell);
+                            ProcessNode(child, doc, section, options, innerParagraph, listStack, new TextFormatting(), wordCell);
+                            if (wordCell.Paragraphs.Count > 0) {
+                                innerParagraph = wordCell.Paragraphs[wordCell.Paragraphs.Count - 1];
+                            } else {
+                                innerParagraph = null;
+                            }
                         }
 
                         int rowSpan = 1;

--- a/OfficeIMO.Word/WordParagraphBorders.cs
+++ b/OfficeIMO.Word/WordParagraphBorders.cs
@@ -755,9 +755,12 @@ namespace OfficeIMO.Word {
         /// </summary>
         public BorderValues? BottomStyle {
             get {
-                var pageBorder = _wordParagraph._paragraphProperties.GetFirstChild<ParagraphBorders>();
-                if (pageBorder != null) {
-                    return pageBorder.BottomBorder.Val;
+                var props = _wordParagraph._paragraphProperties;
+                if (props != null) {
+                    var pageBorder = props.GetFirstChild<ParagraphBorders>();
+                    if (pageBorder != null && pageBorder.BottomBorder != null) {
+                        return pageBorder.BottomBorder.Val;
+                    }
                 }
 
                 return null;


### PR DESCRIPTION
## Summary
- support recursive table rendering in HTML-to-Word converter
- export nested Word tables back to HTML
- cover nested table scenarios with tests and examples

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68973914afe4832e82720ac4c7d2b3ba