### PR TITLE
Respect configurable code font in Markdown conversion

### DIFF
--- a/OfficeIMO.Tests/Markdown.FontFamily.cs
+++ b/OfficeIMO.Tests/Markdown.FontFamily.cs
@@ -1,0 +1,28 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Markdown {
+        [Fact]
+        public void WordToMarkdown_UsesSpecifiedFontForCode() {
+            using var doc = WordDocument.Create();
+            string codeFont = FontResolver.Resolve("sans-serif")!;
+            string normalFont = FontResolver.Resolve("serif")!;
+
+            var paragraph = doc.AddParagraph();
+            paragraph.AddText("code").SetFontFamily(codeFont);
+            paragraph.AddText(" normal").SetFontFamily(normalFont);
+
+            var options = new WordToMarkdownOptions {
+                FontFamily = codeFont
+            };
+
+            string markdown = doc.ToMarkdown(options);
+
+            Assert.Contains("`code`", markdown);
+            Assert.Contains("normal", markdown);
+            Assert.DoesNotContain("`normal`", markdown);
+        }
+    }
+}

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.cs
@@ -1,9 +1,9 @@
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using System;
 using System.IO;
 using System.Linq;
 using System.Text;
-using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word.Markdown.Converters {
     /// <summary>
@@ -82,6 +82,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
 
         private string RenderRuns(WordParagraph paragraph, WordToMarkdownOptions options) {
             var sb = new StringBuilder();
+            string codeFont = options.FontFamily ?? FontResolver.Resolve("monospace");
             foreach (var run in paragraph.GetRuns()) {
                 if (run.IsFootNote && run.FootNote != null && run.FootNote.ReferenceId.HasValue) {
                     long id = run.FootNote.ReferenceId.Value;
@@ -119,8 +120,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
                     text = $"=={text}==";
                 }
 
-                string monospace = FontResolver.Resolve("monospace");
-                bool code = !string.IsNullOrEmpty(monospace) && string.Equals(run.FontFamily, monospace, StringComparison.OrdinalIgnoreCase);
+                bool code = !string.IsNullOrEmpty(codeFont) && string.Equals(run.FontFamily, codeFont, StringComparison.OrdinalIgnoreCase);
                 if (code) {
                     text = $"`{text}`";
                 }

--- a/OfficeIMO.Word.Markdown/Options/WordToMarkdownOptions.cs
+++ b/OfficeIMO.Word.Markdown/Options/WordToMarkdownOptions.cs
@@ -2,11 +2,12 @@ using OfficeIMO.Word;
 
 namespace OfficeIMO.Word.Markdown {
     /// <summary>
-    /// Options for Word to Markdown conversion.
+    /// Provides settings that control how a Word document is converted to Markdown.
     /// </summary>
     public class WordToMarkdownOptions {
         /// <summary>
-        /// Optional font family applied to created runs during conversion.
+        /// Font family whose runs should be rendered as inline code. When <c>null</c>,
+        /// <see cref="FontResolver.Resolve(string)"/> is used with "monospace" to determine the code font.
         /// </summary>
         public string FontFamily { get; set; }
 


### PR DESCRIPTION
## Summary
- allow configuring which font is treated as inline code in Word-to-Markdown conversion
- clarify `WordToMarkdownOptions` documentation
- test that only runs using the configured font are wrapped in backticks

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_689741c72280832e941f127eba4aebab