### PR TITLE
Refactor inline markdown processing

### DIFF
--- a/OfficeIMO.Examples/Converters/Markdown/Markdown.NestedFormatting.cs
+++ b/OfficeIMO.Examples/Converters/Markdown/Markdown.NestedFormatting.cs
@@ -1,0 +1,17 @@
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Markdown;
+
+namespace OfficeIMO.Examples.Markdown {
+    internal static partial class Markdown {
+        public static void Example_MarkdownNestedFormatting(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "MarkdownNestedFormatting.docx");
+            string markdown = "Text ~~**bold strike**~~ and ***bold italic***.";
+            var doc = markdown.LoadFromMarkdown(new MarkdownToWordOptions());
+            doc.Save(filePath);
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Markdown.NestedFormatting.cs
+++ b/OfficeIMO.Tests/Markdown.NestedFormatting.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Markdown {
+        [Fact]
+        public void Markdown_NestedEmphasis_BoldItalic() {
+            string md = "This ***bolditalic*** text.";
+            var doc = md.LoadFromMarkdown(new MarkdownToWordOptions());
+            var run = doc.Paragraphs[0].GetRuns().First(r => r.Bold && r.Italic);
+            Assert.Equal("bolditalic", run.Text);
+        }
+
+        [Fact]
+        public void Markdown_MixedFormatting_StrikeBoldItalic() {
+            string md = "Text ~~**bold strike**~~ and ***bold italic***.";
+            var doc = md.LoadFromMarkdown(new MarkdownToWordOptions());
+            var runs = doc.Paragraphs[0].GetRuns().ToList();
+            Assert.Contains(runs, r => r.Bold && r.Strike && r.Text == "bold strike");
+            Assert.Contains(runs, r => r.Bold && r.Italic && r.Text == "bold italic");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create runs directly for markdown inline nodes instead of buffering and parsing text
- handle footnote text via plain inline traversal
- add examples and tests for nested and mixed formatting

## Testing
- `dotnet test OfficeImo.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_689782e23034832e9ad9c97a2de23fd2