### PR TITLE
Honor native image dimensions when converting Markdown

### DIFF
--- a/OfficeIMO.Examples/Converters/Markdown/Markdown.Images.cs
+++ b/OfficeIMO.Examples/Converters/Markdown/Markdown.Images.cs
@@ -9,7 +9,8 @@ namespace OfficeIMO.Examples.Markdown {
             string assets = Path.Combine(AppContext.BaseDirectory, "..", "Assets");
             string localImage = Path.Combine(assets, "OfficeIMO.png");
             string markdown = $"![Local image]({localImage} \"Local description\" =100x100)\n" +
-                               "![Remote image](https://via.placeholder.com/120 \"Remote description\" =120x80)";
+                               "![Remote image](https://via.placeholder.com/120 \"Remote description\" =120x80)\n" +
+                               $"![Native size]({localImage} \"No size hints\")";
 
             var doc = markdown.LoadFromMarkdown(new MarkdownToWordOptions());
             string filePath = Path.Combine(folderPath, "MarkdownImages.docx");

--- a/OfficeIMO.Tests/Markdown.Images.cs
+++ b/OfficeIMO.Tests/Markdown.Images.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
+using SixLabors.ImageSharp;
 using OfficeIMO.Word.Markdown;
 using Xunit;
 
@@ -40,6 +41,19 @@ namespace OfficeIMO.Tests {
 
             serverTask.Wait();
             listener.Stop();
+        }
+
+        [Fact]
+        public void MarkdownToWord_UsesNaturalSizeWhenNoHints() {
+            string imagePath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png"));
+            string md = $"![Local]({imagePath})";
+            var doc = md.LoadFromMarkdown(new MarkdownToWordOptions());
+
+            using var image = Image.Load(imagePath, out _);
+
+            Assert.Single(doc.Images);
+            Assert.Equal(image.Width, doc.Images[0].Width);
+            Assert.Equal(image.Height, doc.Images[0].Height);
         }
 
         private static int GetAvailablePort() {

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Inlines.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Inlines.cs
@@ -5,8 +5,11 @@ using Markdig.Syntax.Inlines;
 using OfficeIMO.Word;
 using System;
 using System.IO;
+using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Linq;
+using SixLabors.ImageSharp;
 
 namespace OfficeIMO.Word.Markdown.Converters {
     internal partial class MarkdownToWordConverter {
@@ -61,6 +64,8 @@ namespace OfficeIMO.Word.Markdown.Converters {
             string? title = link.Title?.Trim();
             double? width = null;
             double? height = null;
+            byte[]? imageData = null;
+            string? remoteFileName = null;
 
             // Check for size hints in URL (e.g. "path =100x200")
             var matchUrl = Regex.Match(url, @"\s*=([0-9]+)(?:x([0-9]+))?\s*$");
@@ -101,6 +106,35 @@ namespace OfficeIMO.Word.Markdown.Converters {
                 }
             }
 
+            if (width == null && height == null) {
+                try {
+                    if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase)) {
+                        using HttpClient client = new();
+                        imageData = client.GetByteArrayAsync(url).GetAwaiter().GetResult();
+                        using var image = Image.Load(imageData, out var format);
+                        width = image.Width;
+                        height = image.Height;
+                        string extension = format.FileExtensions.FirstOrDefault() ?? "png";
+                        try {
+                            remoteFileName = Path.GetFileName(new Uri(url).LocalPath);
+                        } catch {
+                            remoteFileName = null;
+                        }
+                        if (string.IsNullOrEmpty(remoteFileName)) {
+                            remoteFileName = "image." + extension;
+                        } else if (string.IsNullOrEmpty(Path.GetExtension(remoteFileName))) {
+                            remoteFileName += "." + extension;
+                        }
+                    } else if (File.Exists(url)) {
+                        using var image = Image.Load(url, out _);
+                        width = image.Width;
+                        height = image.Height;
+                    }
+                } catch {
+                    // ignore errors when determining natural image size
+                }
+            }
+
             if (width == null && height != null) {
                 width = height;
             } else if (height == null && width != null) {
@@ -111,9 +145,14 @@ namespace OfficeIMO.Word.Markdown.Converters {
             height ??= 50;
 
             if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase)) {
-                var img = document.AddImageFromUrl(url, width, height);
-                if (!string.IsNullOrEmpty(title)) {
-                    img.Description = title;
+                if (imageData != null) {
+                    using var ms = new MemoryStream(imageData);
+                    paragraph.AddImage(ms, remoteFileName ?? "image", width, height, description: title ?? string.Empty);
+                } else {
+                    var img = document.AddImageFromUrl(url, width, height);
+                    if (!string.IsNullOrEmpty(title)) {
+                        img.Description = title;
+                    }
                 }
             } else {
                 paragraph.AddImage(url, width, height, description: title ?? string.Empty);

--- a/OfficeIMO.Word.Markdown/OfficeIMO.Word.Markdown.csproj
+++ b/OfficeIMO.Word.Markdown/OfficeIMO.Word.Markdown.csproj
@@ -35,6 +35,10 @@
     <ProjectReference Include="..\OfficeIMO.Word\OfficeIMO.Word.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Update="Converters/MarkdownToWordConverter.Tables.cs" />
     <Compile Update="Converters/MarkdownToWordConverter.Lists.cs" />


### PR DESCRIPTION
## Summary
- load image data to infer native width and height when no size hints are supplied
- reuse downloaded data for remote images and pass dimensions to AddImage
- document natural-size behavior with test and example

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter MarkdownToWord_UsesNaturalSizeWhenNoHints -v n`


------
https://chatgpt.com/codex/tasks/task_e_689782da56ec832eb9606239c76b8f70