### PR TITLE
Convert CodeLang paragraphs to fenced blocks

### DIFF
--- a/OfficeIMO.Examples/Converters/Markdown/Markdown.CodeBlocks.cs
+++ b/OfficeIMO.Examples/Converters/Markdown/Markdown.CodeBlocks.cs
@@ -35,5 +35,22 @@ namespace OfficeIMO.Examples.Markdown {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
             }
         }
+
+        public static void Example_WordToMarkdownCodeBlocks_CustomFont(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "WordToMarkdownCodeBlockCustomFont.docx");
+            using var doc = WordDocument.Create();
+            const string codeFont = "Courier New";
+            doc.AddParagraph("System.out.println(\"Hello\");").SetFontFamily(codeFont).SetStyleId("CodeLang_java");
+
+            var options = new WordToMarkdownOptions { FontFamily = codeFont };
+            string markdown = doc.ToMarkdown(options);
+            Console.WriteLine(markdown);
+
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Markdown.CodeBlocks.cs
+++ b/OfficeIMO.Tests/Markdown.CodeBlocks.cs
@@ -14,6 +14,18 @@ namespace OfficeIMO.Tests {
 
             Assert.Equal("```csharp\nConsole.WriteLine(\"Hello\");\n```", markdown);
         }
+
+        [Fact]
+        public void WordToMarkdown_CodeParagraph_OutputFence_OptionFont() {
+            using var doc = WordDocument.Create();
+            const string codeFont = "Courier New";
+            doc.AddParagraph("System.out.println(\"Hello\");").SetFontFamily(codeFont).SetStyleId("CodeLang_java");
+
+            var options = new WordToMarkdownOptions { FontFamily = codeFont };
+            string markdown = doc.ToMarkdown(options);
+
+            Assert.Equal("```java\nSystem.out.println(\"Hello\");\n```", markdown);
+        }
     }
 }
 

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.cs
@@ -59,12 +59,13 @@ namespace OfficeIMO.Word.Markdown.Converters {
         }
 
         private string ConvertParagraph(WordParagraph paragraph, WordToMarkdownOptions options) {
+            const string codeLangPrefix = "CodeLang_";
             string? styleId = paragraph.StyleId;
-            string? mono = options.FontFamily ?? FontResolver.Resolve("monospace");
-            if (!string.IsNullOrEmpty(styleId) && styleId.StartsWith("CodeLang_", StringComparison.Ordinal) && !string.IsNullOrEmpty(mono)) {
+            string? codeFont = options.FontFamily ?? FontResolver.Resolve("monospace");
+            if (!string.IsNullOrEmpty(styleId) && styleId.StartsWith(codeLangPrefix, StringComparison.Ordinal) && !string.IsNullOrEmpty(codeFont)) {
                 var runs = paragraph.GetRuns().ToList();
-                if (runs.Count > 0 && runs.All(r => string.Equals(r.FontFamily, mono, StringComparison.OrdinalIgnoreCase))) {
-                    string language = styleId.Substring("CodeLang_".Length);
+                if (runs.Count > 0 && runs.All(r => string.Equals(r.FontFamily, codeFont, StringComparison.OrdinalIgnoreCase))) {
+                    string language = styleId.Substring(codeLangPrefix.Length);
                     string code = string.Concat(runs.Select(r => r.Text));
                     return $"```{language}\n{code}\n```";
                 }


### PR DESCRIPTION
## Summary
- support "CodeLang_" styled paragraphs by emitting fenced code blocks with language hints when all runs use the code font
- test conversion of code paragraphs to fenced blocks with language hints using default and custom code fonts
- add example demonstrating markdown conversion of CodeLang paragraphs with a specified code font

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~WordToMarkdown_CodeParagraph"`


------
https://chatgpt.com/codex/tasks/task_e_6897be21cd8c832ea9908facef67b174