### PR TITLE
Implement standard dispose pattern for WordDocument

### DIFF
--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Dispose.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Dispose.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class BasicDocument {
+        /// <summary>
+        /// Creates a document and disposes it multiple times.
+        /// </summary>
+        public static void Example_DisposeMultipleTimes(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document and disposing it multiple times");
+            string filePath = System.IO.Path.Combine(folderPath, "DisposeMultipleTimes.docx");
+            WordDocument document = WordDocument.Create(filePath);
+            document.AddParagraph("This is my test");
+            document.Save();
+            document.Dispose();
+            document.Dispose();
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Dispose.cs
+++ b/OfficeIMO.Tests/Word.Dispose.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    /// <summary>
+    /// Contains tests for disposing Word documents.
+    /// </summary>
+    public partial class Word {
+        [Fact]
+        public void Test_DisposeMultipleTimes() {
+            var filePath = Path.Combine(_directoryWithFiles, "DisposeTestingMultipleTimes.docx");
+            File.Delete(filePath);
+
+            var document = WordDocument.Create(filePath);
+            document.AddParagraph("This is my test");
+            document.Save();
+            document.Dispose();
+            document.Dispose();
+
+            Assert.False(filePath.IsFileLocked());
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -19,6 +19,7 @@ namespace OfficeIMO.Word {
         internal List<int> _listNumbersUsed = new List<int>();
         internal int? _tableOfContentIndex;
         internal TableOfContentStyle? _tableOfContentStyle;
+        private bool _disposed;
 
         internal int BookmarkId {
             get {
@@ -1676,22 +1677,44 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
-        /// Closes the underlying <see cref="WordprocessingDocument"/> and
-        /// saves the document when <see cref="DocumentFormat.OpenXml.Packaging.OpenXmlPackage.AutoSave"/> is enabled.
+        /// Releases resources associated with this <see cref="WordDocument"/> instance.
         /// </summary>
         public void Dispose() {
-            if (this._wordprocessingDocument.AutoSave) {
-                Save();
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases resources associated with this <see cref="WordDocument"/> instance.
+        /// </summary>
+        /// <param name="disposing">Indicates whether the method is called from <see cref="Dispose()"/>.</param>
+        protected virtual void Dispose(bool disposing) {
+            if (this._disposed) {
+                return;
             }
 
-            if (this._wordprocessingDocument != null) {
-                try {
-                    this._wordprocessingDocument.Dispose();
-                } catch {
-                    // ignored
+            if (disposing) {
+                if (this._wordprocessingDocument.AutoSave) {
+                    Save();
+                }
+
+                if (this._wordprocessingDocument != null) {
+                    try {
+                        this._wordprocessingDocument.Dispose();
+                    } catch {
+                        // ignored
+                    }
                 }
             }
 
+            this._disposed = true;
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="WordDocument"/> class.
+        /// </summary>
+        ~WordDocument() {
+            Dispose(false);
         }
 
         private static void InitialiseStyleDefinitions(WordprocessingDocument wordDocument, bool readOnly, bool overrideStyles) {


### PR DESCRIPTION
## Summary
- add standard Dispose(bool) pattern and finalizer in WordDocument
- add example and unit test for safe multiple disposals

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6897be4c8bdc832eb1cee75cd5132e97