### PR TITLE
Limit CI jobs to 20 minutes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    timeout-minutes: 20
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -28,6 +28,7 @@ jobs:
   test-windows:
     name: 'Windows'
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -75,6 +76,7 @@ jobs:
   test-ubuntu:
     name: 'Ubuntu'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -115,6 +117,7 @@ jobs:
   test-macos:
     name: 'macOS'
     runs-on: macos-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -33,6 +33,7 @@ pr: none
 
 pool:
   vmImage: 'ubuntu-latest'
+timeoutInMinutes: 20
 
 variables:
   solution: '**/*.sln'

--- a/azure-pipelines-macos.yml
+++ b/azure-pipelines-macos.yml
@@ -33,6 +33,7 @@ pr: none
 
 pool:
   vmImage: 'macos-latest'
+timeoutInMinutes: 20
 
 variables:
   solution: '**/*.sln'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,7 @@ pr: none
 
 pool:
   vmImage: 'windows-latest'
+timeoutInMinutes: 20
 
 variables:
   solution: '**/*.sln'


### PR DESCRIPTION
## Summary
- cap GitHub Actions test and CodeQL jobs at 20 minutes
- set 20-minute timeout for Azure Pipelines jobs across Windows, Linux, and macOS

## Testing
- `timeout 1200 dotnet build OfficeImo.sln --configuration Release`
- `timeout 1200 dotnet test OfficeImo.sln --configuration Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_689834040d00832e88180fd9db73a98e