### PR TITLE
Support abbr/acronym footnotes

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.Abbreviations.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.Abbreviations.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlAbbreviations(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlAbbreviations.docx");
+            string html = "<abbr title=\"World Health Organization\">WHO</abbr>";
+
+            using var document = html.LoadFromHtml();
+            document.Save(filePath);
+
+            string roundTrip = document.ToHtml(new WordToHtmlOptions { ExportFootnotes = true });
+            Console.WriteLine(roundTrip);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.Abbreviations.cs
+++ b/OfficeIMO.Tests/Html.Abbreviations.cs
@@ -1,0 +1,24 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class HtmlAbbreviations {
+        [Fact]
+        public void AbbrBecomesFootnoteAndRoundsTrip() {
+            const string html = "<abbr title=\"desc\">text</abbr>";
+            using var doc = html.LoadFromHtml();
+            Assert.True(doc.Paragraphs.Count >= 1);
+            Assert.Equal("text", doc.Paragraphs[0].Text);
+            Assert.Single(doc.FootNotes);
+            Assert.Equal("desc", doc.FootNotes[0].Paragraphs[1].Text);
+
+            string roundTrip = doc.ToHtml(new WordToHtmlOptions { ExportFootnotes = true });
+            Assert.Contains("<abbr", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("title=\"desc\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(">text</abbr>", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("<sup", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -348,6 +348,21 @@ namespace OfficeIMO.Word.Html.Converters {
                             }
                             break;
                         }
+                    case "abbr":
+                    case "acronym": {
+                            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
+                            var title = element.GetAttribute("title");
+                            var fmt = formatting;
+                            ApplySpanStyles(element, ref fmt);
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
+                            }
+                            if (!string.IsNullOrEmpty(title)) {
+                                var fnRun = currentParagraph.AddFootNote(title);
+                                fnRun.SetCharacterStyleId("HtmlAbbr");
+                            }
+                            break;
+                        }
                     case "a": {
                             var href = element.GetAttribute("href");
                             var title = element.GetAttribute("title");

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -114,22 +114,33 @@ namespace OfficeIMO.Word.Html.Converters {
             }
 
             void AppendRuns(IElement parent, WordParagraph para, bool processFootnotes = true) {
-                foreach (var run in para.GetRuns()) {
+                var runs = para.GetRuns().ToList();
+                List<INode> nodes = new();
+                for (int i = 0; i < runs.Count; i++) {
+                    var run = runs[i];
                     if (processFootnotes && options.ExportFootnotes && run.FootNote != null) {
                         var note = run.FootNote;
-                        long id = note.ReferenceId ?? 0;
-                        if (!footnoteMap.TryGetValue(id, out int number)) {
-                            number = footnotes.Count + 1;
-                            footnoteMap[id] = number;
-                            footnotes.Add((number, note));
+                        if (string.Equals(run.CharacterStyleId, "HtmlAbbr", StringComparison.OrdinalIgnoreCase) && nodes.Count > 0) {
+                            string text = string.Join(string.Empty, note.Paragraphs?.Skip(1).Select(r => r.Text) ?? Enumerable.Empty<string>());
+                            var abbr = htmlDoc.CreateElement("abbr");
+                            abbr.SetAttribute("title", text);
+                            abbr.AppendChild(nodes[^1]);
+                            nodes[^1] = abbr;
+                        } else {
+                            long id = note.ReferenceId ?? 0;
+                            if (!footnoteMap.TryGetValue(id, out int number)) {
+                                number = footnotes.Count + 1;
+                                footnoteMap[id] = number;
+                                footnotes.Add((number, note));
+                            }
+                            var sup = htmlDoc.CreateElement("sup");
+                            var a = htmlDoc.CreateElement("a");
+                            a.SetAttribute("href", $"#fn{number}");
+                            a.SetAttribute("id", $"fnref{number}");
+                            a.TextContent = number.ToString();
+                            sup.AppendChild(a);
+                            nodes.Add(sup);
                         }
-                        var sup = htmlDoc.CreateElement("sup");
-                        var a = htmlDoc.CreateElement("a");
-                        a.SetAttribute("href", $"#fn{number}");
-                        a.SetAttribute("id", $"fnref{number}");
-                        a.TextContent = number.ToString();
-                        sup.AppendChild(a);
-                        parent.AppendChild(sup);
                         continue;
                     }
 
@@ -152,7 +163,7 @@ namespace OfficeIMO.Word.Html.Converters {
                         if (!string.IsNullOrEmpty(imgObj.Description)) {
                             img.AlternativeText = imgObj.Description;
                         }
-                        parent.AppendChild(img);
+                        nodes.Add(img);
                         continue;
                     }
 
@@ -214,6 +225,9 @@ namespace OfficeIMO.Word.Html.Converters {
                         runStyles.Add(run.CharacterStyleId);
                     }
 
+                    nodes.Add(node);
+                }
+                foreach (var node in nodes) {
                     parent.AppendChild(node);
                 }
             }


### PR DESCRIPTION
## Summary
- parse `<abbr>` and `<acronym>` tags into paragraphs and footnotes
- preserve abbreviation footnotes when converting back to HTML via `<abbr title="...">`
- add example and tests for abbreviation footnotes

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689c501b1bbc832e8c8b3a42be6fc2b1