### PR TITLE
Handle blockquote citations in HTML to Word conversion

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.BlockquoteCitations.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.BlockquoteCitations.cs
@@ -1,0 +1,22 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlBlockquoteCitations(string folderPath, bool openWord) {
+            string html = "<blockquote cite=\"https://example.com\">Quoted text</blockquote>";
+            using WordDocument document = html.LoadFromHtml(new HtmlToWordOptions());
+            Console.WriteLine("Footnotes count: " + document.FootNotes.Count);
+            if (document.FootNotes.Count > 0) {
+                Console.WriteLine("Citation: " + document.FootNotes[0].Paragraphs[1].Text);
+            }
+            string filePath = Path.Combine(folderPath, "HtmlBlockquoteCitation.docx");
+            document.Save(filePath);
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.BlockquoteCitations.cs
+++ b/OfficeIMO.Tests/Html.BlockquoteCitations.cs
@@ -1,0 +1,18 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class HtmlBlockquoteCitations {
+        [Fact]
+        public void BlockquoteWithCitationCreatesFootnote() {
+            string html = "<blockquote cite=\"https://example.com\"><p>First</p><p>Second</p></blockquote>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Equal("First", doc.Paragraphs[0].Text);
+            Assert.Contains(doc.Paragraphs, p => p.Text == "Second");
+            Assert.Single(doc.FootNotes);
+            Assert.Equal("https://example.com", doc.FootNotes[0].Paragraphs[1].Text);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- attach citation attribute from `<blockquote>` as a footnote on the first generated paragraph
- add example demonstrating blockquote citation support
- test blockquote conversion with citation footnotes

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_689c60154624832e9610b1a51fe3c475