### PR TITLE
feat: allow adding html to headers and footers

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.HeaderFooter.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.HeaderFooter.cs
@@ -1,0 +1,22 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlHeaderFooter(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlHeaderFooter.docx");
+
+            using WordDocument document = WordDocument.Create();
+            document.AddHtmlToHeader("<p>Header content</p>");
+            document.AddHtmlToFooter("<p>Footer content</p>");
+            document.Save(filePath);
+            Console.WriteLine($"Created: {filePath}");
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.HeaderFooter.cs
+++ b/OfficeIMO.Tests/Html.HeaderFooter.cs
@@ -1,0 +1,31 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void AddHtmlToHeader_PlacesContentInHeader() {
+            using WordDocument document = WordDocument.Create();
+            document.AddHtmlToHeader("<p>Header content</p>");
+            using var ms = new System.IO.MemoryStream();
+            document.Save(ms);
+            ms.Position = 0;
+            using var docx = DocumentFormat.OpenXml.Packaging.WordprocessingDocument.Open(ms, false);
+            var headerPart = docx.MainDocumentPart!.HeaderParts.First();
+            Assert.Contains("Header content", headerPart.RootElement!.InnerText);
+        }
+
+        [Fact]
+        public void AddHtmlToFooter_PlacesContentInFooter() {
+            using WordDocument document = WordDocument.Create();
+            document.AddHtmlToFooter("<p>Footer content</p>");
+            using var ms = new System.IO.MemoryStream();
+            document.Save(ms);
+            ms.Position = 0;
+            using var docx = DocumentFormat.OpenXml.Packaging.WordprocessingDocument.Open(ms, false);
+            var footerPart = docx.MainDocumentPart!.FooterParts.First();
+            Assert.Contains("Footer content", footerPart.RootElement!.InnerText);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
@@ -7,11 +7,11 @@ using System.Collections.Generic;
 namespace OfficeIMO.Word.Html.Converters {
     internal partial class HtmlToWordConverter {
         private void ProcessList(IElement element, WordDocument doc, WordSection section, HtmlToWordOptions options,
-            Stack<WordList> listStack, WordTableCell? cell, TextFormatting formatting) {
+            Stack<WordList> listStack, WordTableCell? cell, TextFormatting formatting, WordHeaderFooter? headerFooter) {
             WordList list;
             bool ordered = element.TagName.Equals("ol", System.StringComparison.OrdinalIgnoreCase);
             if (ordered) {
-                list = cell != null ? cell.AddList(WordListStyle.Headings111) : doc.AddListNumbered();
+                list = cell != null ? cell.AddList(WordListStyle.Headings111) : headerFooter != null ? headerFooter.AddList(WordListStyle.Headings111) : doc.AddListNumbered();
                 var level = list.Numbering.Levels[0];
                 var start = element.GetAttribute("start");
                 if (!string.IsNullOrEmpty(start) && int.TryParse(start, out int startVal)) {
@@ -29,7 +29,7 @@ namespace OfficeIMO.Word.Html.Converters {
                     level._level.NumberingFormat = new NumberingFormat { Val = format };
                 }
             } else {
-                list = cell != null ? cell.AddList(WordListStyle.Bulleted) : doc.AddListBulleted();
+                list = cell != null ? cell.AddList(WordListStyle.Bulleted) : headerFooter != null ? headerFooter.AddList(WordListStyle.Bulleted) : doc.AddListBulleted();
                 var type = element.GetAttribute("type")?.ToLowerInvariant();
                 if (!string.IsNullOrEmpty(type)) {
                     var level = list.Numbering.Levels[0];
@@ -46,20 +46,20 @@ namespace OfficeIMO.Word.Html.Converters {
             }
             listStack.Push(list);
             foreach (var li in element.Children.OfType<IHtmlListItemElement>()) {
-                ProcessListItem(li, doc, section, options, listStack, formatting, cell);
+                ProcessListItem(li, doc, section, options, listStack, formatting, cell, headerFooter);
             }
             listStack.Pop();
         }
 
         private void ProcessListItem(IHtmlListItemElement element, WordDocument doc, WordSection section, HtmlToWordOptions options,
-            Stack<WordList> listStack, TextFormatting formatting, WordTableCell? cell) {
+            Stack<WordList> listStack, TextFormatting formatting, WordTableCell? cell, WordHeaderFooter? headerFooter) {
             var list = listStack.Peek();
             int level = listStack.Count - 1;
             var paragraph = list.AddItem("", level);
             ApplyClassStyle(element, paragraph, options);
             AddBookmarkIfPresent(element, paragraph);
             foreach (var child in element.ChildNodes) {
-                ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell);
+                ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell, headerFooter);
             }
         }
     }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 namespace OfficeIMO.Word.Html.Converters {
     internal partial class HtmlToWordConverter {
         private void ProcessTable(IHtmlTableElement tableElem, WordDocument doc, WordSection section, HtmlToWordOptions options,
-            Stack<WordList> listStack, WordTableCell? cell, WordParagraph? currentParagraph) {
+            Stack<WordList> listStack, WordTableCell? cell, WordParagraph? currentParagraph, WordHeaderFooter? headerFooter) {
             int headRows = tableElem.Head?.Rows.Length ?? 0;
             int bodyRows = 0;
             foreach (var body in tableElem.Bodies) {
@@ -39,7 +39,7 @@ namespace OfficeIMO.Word.Html.Converters {
             } else if (currentParagraph != null) {
                 wordTable = currentParagraph.AddTableAfter(rows, cols);
             } else {
-                var placeholder = section.AddParagraph("");
+                var placeholder = headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
                 wordTable = placeholder.AddTableAfter(rows, cols);
             }
             ApplyTableStyles(wordTable, tableElem);
@@ -66,7 +66,7 @@ namespace OfficeIMO.Word.Html.Converters {
 
                         WordParagraph? innerParagraph = null;
                         foreach (var child in htmlCell.ChildNodes) {
-                            ProcessNode(child, doc, section, options, innerParagraph, listStack, new TextFormatting(), wordCell);
+                            ProcessNode(child, doc, section, options, innerParagraph, listStack, new TextFormatting(), wordCell, headerFooter);
                             if (wordCell.Paragraphs.Count > 0) {
                                 innerParagraph = wordCell.Paragraphs[wordCell.Paragraphs.Count - 1];
                             } else {

--- a/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
+++ b/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html.Converters;
 using System.IO;
@@ -65,6 +66,62 @@ namespace OfficeIMO.Word.Html {
             using var reader = new StreamReader(htmlStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
             string html = reader.ReadToEnd();
             return LoadFromHtml(html, options);
+        }
+
+        /// <summary>
+        /// Appends HTML content to the document's header.
+        /// </summary>
+        /// <param name="doc">Document to modify.</param>
+        /// <param name="html">HTML fragment to insert.</param>
+        /// <param name="type">Header type to target.</param>
+        /// <param name="options">Optional conversion options.</param>
+        public static void AddHtmlToHeader(this WordDocument doc, string html, HeaderFooterValues? type = null, HtmlToWordOptions? options = null) {
+            if (doc == null) throw new System.ArgumentNullException(nameof(doc));
+            if (html == null) throw new System.ArgumentNullException(nameof(html));
+
+            doc.AddHeadersAndFooters();
+            options ??= new HtmlToWordOptions();
+            type ??= HeaderFooterValues.Default;
+
+            WordHeader header;
+            if (type == HeaderFooterValues.First) {
+                header = doc.Header.First;
+            } else if (type == HeaderFooterValues.Even) {
+                header = doc.Header.Even;
+            } else {
+                header = doc.Header.Default;
+            }
+
+            var converter = new HtmlToWordConverter();
+            converter.AddHtmlToHeaderAsync(doc, header, html, options).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Appends HTML content to the document's footer.
+        /// </summary>
+        /// <param name="doc">Document to modify.</param>
+        /// <param name="html">HTML fragment to insert.</param>
+        /// <param name="type">Footer type to target.</param>
+        /// <param name="options">Optional conversion options.</param>
+        public static void AddHtmlToFooter(this WordDocument doc, string html, HeaderFooterValues? type = null, HtmlToWordOptions? options = null) {
+            if (doc == null) throw new System.ArgumentNullException(nameof(doc));
+            if (html == null) throw new System.ArgumentNullException(nameof(html));
+
+            doc.AddHeadersAndFooters();
+            options ??= new HtmlToWordOptions();
+            type ??= HeaderFooterValues.Default;
+
+            WordFooter footer;
+            if (type == HeaderFooterValues.First) {
+                footer = doc.Footer.First;
+            } else if (type == HeaderFooterValues.Even) {
+                footer = doc.Footer.Even;
+            } else {
+                footer = doc.Footer.Default;
+            }
+
+            var converter = new HtmlToWordConverter();
+            converter.AddHtmlToFooterAsync(doc, footer, html, options).GetAwaiter().GetResult();
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow inserting HTML into document headers and footers
- extend converter to process header/footer content
- document helpers with tests and example

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FullyQualifiedName~AddHtmlToHeader_PlacesContentInHeader -l "console;verbosity=minimal"`

------
https://chatgpt.com/codex/tasks/task_e_689c73c572c8832e8a2da5f6a3f57bee