### PR TITLE
Support inline quote elements in HTML conversion

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.Quotes.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.Quotes.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlQuotes(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlQuotes.docx");
+            string html = "<p>Before <q>quoted</q> after</p>";
+
+            using var document = html.LoadFromHtml();
+            document.Save(filePath);
+
+            string roundTrip = document.ToHtml();
+            Console.WriteLine(roundTrip);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -217,6 +217,33 @@ public partial class Html {
     }
 
     [Fact]
+    public void Test_Html_Q_RoundTrip() {
+        string html = "<p>Before <q>quoted</q> after</p>";
+
+        var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+        var text = string.Concat(doc.Paragraphs[0].GetRuns().Select(r => r.Text));
+        Assert.Equal($"Before \u201Cquoted\u201D after", text);
+
+        string roundTrip = doc.ToHtml();
+        Assert.Contains("<q>quoted</q>", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Test_Html_Q_CustomCharacters() {
+        var options = new HtmlToWordOptions { QuotePrefix = "«", QuoteSuffix = "»" };
+        string html = "<p>Before <q>quoted</q> after</p>";
+
+        var doc = html.LoadFromHtml(options);
+
+        var text = string.Concat(doc.Paragraphs[0].GetRuns().Select(r => r.Text));
+        Assert.Equal("Before «quoted» after", text);
+
+        string roundTrip = doc.ToHtml();
+        Assert.Contains("<q>quoted</q>", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Test_Html_Lists_Structure() {
         string html = "<ul><li>Item 1<ul><li>Sub 1</li></ul></li><li>Item 2</li></ul>";
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -343,6 +343,21 @@ namespace OfficeIMO.Word.Html.Converters {
                             }
                             break;
                         }
+                    case "q": {
+                            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : section.AddParagraph("");
+                            var fmt = formatting;
+                            ApplySpanStyles(element, ref fmt);
+                            var open = currentParagraph.AddFormattedText(options.QuotePrefix, fmt.Bold, fmt.Italic, fmt.Underline ? UnderlineValues.Single : null);
+                            ApplyFormatting(open, fmt, options);
+                            open.SetCharacterStyleId("HtmlQuote");
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell);
+                            }
+                            var close = currentParagraph.AddFormattedText(options.QuoteSuffix, fmt.Bold, fmt.Italic, fmt.Underline ? UnderlineValues.Single : null);
+                            ApplyFormatting(close, fmt, options);
+                            close.SetCharacterStyleId("HtmlQuote");
+                            break;
+                        }
                     case "sup": {
                             var fmt = formatting;
                             fmt.Superscript = true;

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -116,6 +116,8 @@ namespace OfficeIMO.Word.Html.Converters {
             void AppendRuns(IElement parent, WordParagraph para, bool processFootnotes = true) {
                 var runs = para.GetRuns().ToList();
                 List<INode> nodes = new();
+                bool inQuote = false;
+                IElement? quote = null;
                 for (int i = 0; i < runs.Count; i++) {
                     var run = runs[i];
                     if (processFootnotes && options.ExportFootnotes && run.FootNote != null) {
@@ -169,6 +171,17 @@ namespace OfficeIMO.Word.Html.Converters {
                     }
 
                     if (string.IsNullOrEmpty(run.Text)) {
+                        continue;
+                    }
+
+                    if (string.Equals(run.CharacterStyleId, "HtmlQuote", StringComparison.OrdinalIgnoreCase)) {
+                        if (!inQuote) {
+                            quote = htmlDoc.CreateElement("q");
+                            nodes.Add(quote);
+                        } else {
+                            quote = null;
+                        }
+                        inQuote = !inQuote;
                         continue;
                     }
 
@@ -226,7 +239,11 @@ namespace OfficeIMO.Word.Html.Converters {
                         runStyles.Add(run.CharacterStyleId);
                     }
 
-                    nodes.Add(node);
+                    if (inQuote && quote != null) {
+                        quote.AppendChild(node);
+                    } else {
+                        nodes.Add(node);
+                    }
                 }
                 foreach (var node in nodes) {
                     parent.AppendChild(node);

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -12,6 +12,16 @@ namespace OfficeIMO.Word.Html {
         /// Optional font family applied to created runs during conversion.
         /// </summary>
         public string FontFamily { get; set; }
+
+        /// <summary>
+        /// Character inserted before inline quoted text. Defaults to left double quotation mark.
+        /// </summary>
+        public string QuotePrefix { get; set; } = "\u201C";
+
+        /// <summary>
+        /// Character inserted after inline quoted text. Defaults to right double quotation mark.
+        /// </summary>
+        public string QuoteSuffix { get; set; } = "\u201D";
         
         /// <summary>
         /// Optional default page size applied when creating new documents.


### PR DESCRIPTION
## Summary
- allow customizing quote characters with `QuotePrefix` and `QuoteSuffix`
- convert `<q>` tags to Word runs with quote markers
- emit `<q>` tags for runs styled as quotes and add samples/tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689c73b4702c832e96c054de0323e3dd