### PR TITLE
feat(html): add list numbering continuation

### DIFF
--- a/OfficeIMO.Tests/Html.ListNumbering.cs
+++ b/OfficeIMO.Tests/Html.ListNumbering.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_ListNumbering_ContiguousLists() {
+            string html = "<ol><li>One</li></ol><ol><li>Two</li></ol>";
+            var options = new HtmlToWordOptions { ContinueNumbering = true };
+            var doc = html.LoadFromHtml(options);
+            Assert.True(doc.Paragraphs.Count(p => p.IsListItem) >= 2);
+            Assert.Single(doc.Paragraphs.Where(p => p.IsListItem).Select(p => p._listNumberId).Distinct());
+        }
+
+        [Fact]
+        public void HtmlToWord_ListNumbering_SeparatedLists() {
+            string html = "<ol><li>One</li></ol><p>Break</p><ol><li>Two</li></ol>";
+            var options = new HtmlToWordOptions { ContinueNumbering = true };
+            var doc = html.LoadFromHtml(options);
+            Assert.True(doc.Paragraphs.Count(p => p.IsListItem) >= 2);
+            Assert.Single(doc.Paragraphs.Where(p => p.IsListItem).Select(p => p._listNumberId).Distinct());
+            Assert.Contains(doc.Paragraphs, p => !p.IsListItem);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
@@ -1,66 +1,79 @@
-using AngleSharp.Dom;
-using AngleSharp.Html.Dom;
-using DocumentFormat.OpenXml.Wordprocessing;
-using OfficeIMO.Word;
-using System.Collections.Generic;
-
-namespace OfficeIMO.Word.Html.Converters {
-    internal partial class HtmlToWordConverter {
-        private void ProcessList(IElement element, WordDocument doc, WordSection section, HtmlToWordOptions options,
-            Stack<WordList> listStack, WordTableCell? cell, TextFormatting formatting, WordHeaderFooter? headerFooter) {
-            WordList list;
-            bool ordered = element.TagName.Equals("ol", System.StringComparison.OrdinalIgnoreCase);
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace OfficeIMO.Word.Html.Converters {
+    internal partial class HtmlToWordConverter {
+        private int? _orderedListNumberId;
+
+        private void ProcessList(IElement element, WordDocument doc, WordSection section, HtmlToWordOptions options,
+            Stack<WordList> listStack, WordTableCell? cell, TextFormatting formatting, WordHeaderFooter? headerFooter) {
+            WordList list;
+            bool ordered = element.TagName.Equals("ol", System.StringComparison.OrdinalIgnoreCase);
             if (ordered) {
-                list = cell != null ? cell.AddList(WordListStyle.Headings111) : headerFooter != null ? headerFooter.AddList(WordListStyle.Headings111) : doc.AddListNumbered();
-                var level = list.Numbering.Levels[0];
-                var start = element.GetAttribute("start");
-                if (!string.IsNullOrEmpty(start) && int.TryParse(start, out int startVal)) {
-                    level.SetStartNumberingValue(startVal);
-                }
-                var type = element.GetAttribute("type");
-                if (!string.IsNullOrEmpty(type)) {
-                    var format = type switch {
-                        "a" => NumberFormatValues.LowerLetter,
-                        "A" => NumberFormatValues.UpperLetter,
-                        "i" => NumberFormatValues.LowerRoman,
-                        "I" => NumberFormatValues.UpperRoman,
-                        _ => NumberFormatValues.Decimal,
-                    };
-                    level._level.NumberingFormat = new NumberingFormat { Val = format };
-                }
-            } else {
-                list = cell != null ? cell.AddList(WordListStyle.Bulleted) : headerFooter != null ? headerFooter.AddList(WordListStyle.Bulleted) : doc.AddListBulleted();
-                var type = element.GetAttribute("type")?.ToLowerInvariant();
-                if (!string.IsNullOrEmpty(type)) {
-                    var level = list.Numbering.Levels[0];
-                    switch (type) {
-                        case "circle":
-                            level._level.LevelText.Val = "o";
-                            break;
-                        case "square":
-                            level._level.LevelText.Val = "■";
-                            break;
-                        // disc is the default, nothing to change
+                if (options.ContinueNumbering && _orderedListNumberId.HasValue && listStack.Count == 0 && cell == null && headerFooter == null) {
+                    list = new WordList(doc);
+                    var field = typeof(WordList).GetField("_numberId", BindingFlags.NonPublic | BindingFlags.Instance);
+                    field?.SetValue(list, _orderedListNumberId.Value);
+                } else {
+                    list = cell != null ? cell.AddList(WordListStyle.Headings111) : headerFooter != null ? headerFooter.AddList(WordListStyle.Headings111) : doc.AddListNumbered();
+                    if (options.ContinueNumbering && listStack.Count == 0 && cell == null && headerFooter == null) {
+                        var field = typeof(WordList).GetField("_numberId", BindingFlags.NonPublic | BindingFlags.Instance);
+                        _orderedListNumberId = (int?)field?.GetValue(list);
                     }
                 }
-            }
-            listStack.Push(list);
-            foreach (var li in element.Children.OfType<IHtmlListItemElement>()) {
-                ProcessListItem(li, doc, section, options, listStack, formatting, cell, headerFooter);
-            }
-            listStack.Pop();
-        }
-
-        private void ProcessListItem(IHtmlListItemElement element, WordDocument doc, WordSection section, HtmlToWordOptions options,
-            Stack<WordList> listStack, TextFormatting formatting, WordTableCell? cell, WordHeaderFooter? headerFooter) {
-            var list = listStack.Peek();
-            int level = listStack.Count - 1;
-            var paragraph = list.AddItem("", level);
-            ApplyClassStyle(element, paragraph, options);
-            AddBookmarkIfPresent(element, paragraph);
-            foreach (var child in element.ChildNodes) {
-                ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell, headerFooter);
-            }
-        }
-    }
+                var level = list.Numbering.Levels[0];
+                var start = element.GetAttribute("start");
+                if (!string.IsNullOrEmpty(start) && int.TryParse(start, out int startVal)) {
+                    level.SetStartNumberingValue(startVal);
+                }
+                var type = element.GetAttribute("type");
+                if (!string.IsNullOrEmpty(type)) {
+                    var format = type switch {
+                        "a" => NumberFormatValues.LowerLetter,
+                        "A" => NumberFormatValues.UpperLetter,
+                        "i" => NumberFormatValues.LowerRoman,
+                        "I" => NumberFormatValues.UpperRoman,
+                        _ => NumberFormatValues.Decimal,
+                    };
+                    level._level.NumberingFormat = new NumberingFormat { Val = format };
+                }
+            } else {
+                list = cell != null ? cell.AddList(WordListStyle.Bulleted) : headerFooter != null ? headerFooter.AddList(WordListStyle.Bulleted) : doc.AddListBulleted();
+                var type = element.GetAttribute("type")?.ToLowerInvariant();
+                if (!string.IsNullOrEmpty(type)) {
+                    var level = list.Numbering.Levels[0];
+                    switch (type) {
+                        case "circle":
+                            level._level.LevelText.Val = "o";
+                            break;
+                        case "square":
+                            level._level.LevelText.Val = "■";
+                            break;
+                        // disc is the default, nothing to change
+                    }
+                }
+            }
+            listStack.Push(list);
+            foreach (var li in element.Children.OfType<IHtmlListItemElement>()) {
+                ProcessListItem(li, doc, section, options, listStack, formatting, cell, headerFooter);
+            }
+            listStack.Pop();
+        }
+
+        private void ProcessListItem(IHtmlListItemElement element, WordDocument doc, WordSection section, HtmlToWordOptions options,
+            Stack<WordList> listStack, TextFormatting formatting, WordTableCell? cell, WordHeaderFooter? headerFooter) {
+            var list = listStack.Peek();
+            int level = listStack.Count - 1;
+            var paragraph = list.AddItem("", level);
+            ApplyClassStyle(element, paragraph, options);
+            AddBookmarkIfPresent(element, paragraph);
+            foreach (var child in element.ChildNodes) {
+                ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell, headerFooter);
+            }
+        }
+    }
 }

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -44,6 +44,11 @@ namespace OfficeIMO.Word.Html {
         public bool IncludeListStyles { get; set; }
 
         /// <summary>
+        /// When true, numbered lists will continue numbering across separate lists.
+        /// </summary>
+        public bool ContinueNumbering { get; set; }
+
+        /// <summary>
         /// Base directory used to resolve relative resource paths like images.
         /// </summary>
         public string? BasePath { get; set; }


### PR DESCRIPTION
## Summary
- allow HTML conversion to continue numbering across separate lists
- reuse existing numbering IDs when continuation is enabled
- verify contiguous and separated list scenarios

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_689c8d33661c832e9c0394cb6355e36b