### PR TITLE
Add table caption positioning for HTML converter

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.TableCaptions.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.TableCaptions.cs
@@ -1,0 +1,24 @@
+using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlTableCaptions(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlTableCaptions.docx");
+            string html = "<table><caption>Sample caption</caption><tr><td>Cell</td></tr></table>";
+
+            var options = new HtmlToWordOptions { TableCaptionPosition = TableCaptionPosition.Below };
+            var doc = html.LoadFromHtml(options);
+
+            doc.Save(filePath);
+            string roundTrip = doc.ToHtml(new WordToHtmlOptions());
+            Console.WriteLine(roundTrip);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.TableCaptions.cs
+++ b/OfficeIMO.Tests/Html.TableCaptions.cs
@@ -1,0 +1,25 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using DocumentFormat.OpenXml.Packaging;
+using System;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_TableCaptionAbove() {
+            string html = "<table><caption>Above</caption><tr><td>A</td></tr></table>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions { TableCaptionPosition = TableCaptionPosition.Above });
+            var bodyXml = doc._wordprocessingDocument.MainDocumentPart.Document.Body.OuterXml;
+            Assert.True(bodyXml.IndexOf("Above", StringComparison.Ordinal) < bodyXml.IndexOf("<w:tbl", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void HtmlToWord_TableCaptionBelow() {
+            string html = "<table><caption>Below</caption><tr><td>A</td></tr></table>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions { TableCaptionPosition = TableCaptionPosition.Below });
+            var bodyXml = doc._wordprocessingDocument.MainDocumentPart.Document.Body.OuterXml;
+            Assert.True(bodyXml.IndexOf("Below", StringComparison.Ordinal) > bodyXml.IndexOf("<w:tbl", StringComparison.Ordinal));
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -57,5 +57,25 @@ namespace OfficeIMO.Word.Html {
         /// Raw CSS stylesheet contents that should be applied during conversion.
         /// </summary>
         public List<string> StylesheetContents { get; } = new List<string>();
+
+        /// <summary>
+        /// Specifies where table captions should be inserted relative to the table.
+        /// </summary>
+        public TableCaptionPosition TableCaptionPosition { get; set; } = TableCaptionPosition.Above;
+    }
+
+    /// <summary>
+    /// Determines the position of a table caption relative to the table.
+    /// </summary>
+    public enum TableCaptionPosition {
+        /// <summary>
+        /// Caption is placed before the table.
+        /// </summary>
+        Above,
+
+        /// <summary>
+        /// Caption is placed after the table.
+        /// </summary>
+        Below
     }
 }


### PR DESCRIPTION
## Summary
- allow configuring table caption placement via `TableCaptionPosition`
- parse `<caption>` elements and insert above or below the table accordingly
- add example and tests for table caption rendering

## Testing
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689c8fd05098832ebe70fdd36b235e61