### PR TITLE
Add table-based rendering option for HTML pre tags

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.PreAsTable.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.PreAsTable.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlPreAsTable(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlPreAsTable.docx");
+            string html = "<pre><code>Console.WriteLine(\"Hello\");\nConsole.WriteLine(\"World\");</code></pre>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions { RenderPreAsTable = true });
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.PreAsTable.cs
+++ b/OfficeIMO.Tests/Html.PreAsTable.cs
@@ -1,0 +1,36 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System.Linq;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void PreDefaultRendersParagraphs() {
+            string html = "<pre><code>var x = 1;\nvar y = 2;</code></pre>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Empty(doc.Tables);
+            var codeParas = doc.Paragraphs.Where(p => p.StyleId == "HTMLPreformatted" && !string.IsNullOrEmpty(p.Text)).ToList();
+            Assert.Equal(2, codeParas.Count);
+        }
+
+        [Fact]
+        public void PreAsTableRendersTable() {
+            string html = "<pre><code>var x = 1;\nvar y = 2;</code></pre>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions { RenderPreAsTable = true });
+
+            Assert.Single(doc.Tables);
+            var table = doc.Tables[0];
+            Assert.Equal(1, table.RowsCount);
+            Assert.Equal(1, table.Rows[0].CellsCount);
+            var cell = table.Rows[0].Cells[0];
+            var paras = cell.Paragraphs.Where(p => p.StyleId == "HTMLPreformatted" && !string.IsNullOrEmpty(p.Text)).ToList();
+            Assert.Equal(2, paras.Count);
+            Assert.Equal("var x = 1;", paras[0].Text);
+            Assert.Equal("var y = 2;", paras[1].Text);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -346,19 +346,48 @@ namespace OfficeIMO.Word.Html.Converters {
                             while (end > start && string.IsNullOrEmpty(lines[end - 1])) end--;
                             var mono = FontResolver.Resolve("monospace");
                             bool bookmarkAdded = false;
-                            for (int i = start; i < end; i++) {
-                                var line = lines[i];
-                                var paragraph = cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
-                                paragraph.SetStyleId("HTMLPreformatted");
-                                if (!string.IsNullOrEmpty(mono)) {
-                                    paragraph.SetFontFamily(mono);
+                            if (options.RenderPreAsTable) {
+                                WordTable preTable;
+                                if (cell != null) {
+                                    preTable = cell.AddTable(1, 1);
+                                } else if (currentParagraph != null) {
+                                    preTable = currentParagraph.AddTableAfter(1, 1);
+                                } else if (headerFooter != null) {
+                                    preTable = headerFooter.AddTable(1, 1);
+                                } else {
+                                    var placeholder = section.AddParagraph("");
+                                    preTable = placeholder.AddTableAfter(1, 1);
                                 }
-                                if (!bookmarkAdded) {
-                                    AddBookmarkIfPresent(element, paragraph);
-                                    bookmarkAdded = true;
+                                var preCell = preTable.Rows[0].Cells[0];
+                                for (int i = start; i < end; i++) {
+                                    var line = lines[i];
+                                    var paragraph = i == start ? preCell.AddParagraph("", true) : preCell.AddParagraph("");
+                                    paragraph.SetStyleId("HTMLPreformatted");
+                                    if (!string.IsNullOrEmpty(mono)) {
+                                        paragraph.SetFontFamily(mono);
+                                    }
+                                    if (!bookmarkAdded) {
+                                        AddBookmarkIfPresent(element, paragraph);
+                                        bookmarkAdded = true;
+                                    }
+                                    var fmt = new TextFormatting(false, false, false, null, mono);
+                                    AddTextRun(paragraph, line, fmt, options);
                                 }
-                                var fmt = new TextFormatting(false, false, false, null, mono);
-                                AddTextRun(paragraph, line, fmt, options);
+                            } else {
+                                for (int i = start; i < end; i++) {
+                                    var line = lines[i];
+                                    var paragraph = cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                                    paragraph.SetStyleId("HTMLPreformatted");
+                                    if (!string.IsNullOrEmpty(mono)) {
+                                        paragraph.SetFontFamily(mono);
+                                    }
+                                    if (!bookmarkAdded) {
+                                        AddBookmarkIfPresent(element, paragraph);
+                                        bookmarkAdded = true;
+                                    }
+                                    var fmt = new TextFormatting(false, false, false, null, mono);
+                                    AddTextRun(paragraph, line, fmt, options);
+                                }
                             }
                             break;
                         }

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -64,6 +64,11 @@ namespace OfficeIMO.Word.Html {
         public List<string> StylesheetContents { get; } = new List<string>();
 
         /// <summary>
+        /// When true, <pre> elements are rendered inside a single-cell table.
+        /// </summary>
+        public bool RenderPreAsTable { get; set; }
+
+        /// <summary>
         /// Specifies where table captions should be inserted relative to the table.
         /// </summary>
         public TableCaptionPosition TableCaptionPosition { get; set; } = TableCaptionPosition.Above;


### PR DESCRIPTION
## Summary
- add `RenderPreAsTable` option to HTML conversion settings
- render `<pre>` blocks as a single-cell table when enabled
- test default paragraph output and table output for `<pre>` blocks
- add example demonstrating the new option

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689c9bed5378832e941ce2469a3a95e9