### PR TITLE
Ensure PDF stream writeability and reset

### DIFF
--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdfStream.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdfStream.cs
@@ -1,0 +1,26 @@
+using OfficeIMO.Word.Pdf;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Pdf {
+        public static void Example_SaveAsPdfStreamRewind(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document and exporting to PDF stream");
+            string docPath = Path.Combine(folderPath, "ExportToPdfStreamRewind.docx");
+            string pdfPath = Path.Combine(folderPath, "ExportToPdfStreamRewind.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddParagraph("Hello World");
+                document.Save();
+
+                using (MemoryStream stream = new MemoryStream()) {
+                    document.SaveAsPdf(stream);
+                    using (FileStream fileStream = File.Create(pdfPath)) {
+                        stream.CopyTo(fileStream);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Streams.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Streams.cs
@@ -1,0 +1,62 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_ToStream_NotWritable_Throws() {
+        var docPath = Path.Combine(_directoryWithFiles, "PdfStreamReadOnly.docx");
+
+        using var document = WordDocument.Create(docPath);
+        document.AddParagraph("Hello World");
+        document.Save();
+
+        using var stream = new MemoryStream(new byte[1], 0, 1, writable: false);
+        Assert.Throws<ArgumentException>(() => document.SaveAsPdf(stream));
+    }
+
+    [Fact]
+    public async Task Test_WordDocument_SaveAsPdfAsync_ToStream_NotWritable_Throws() {
+        var docPath = Path.Combine(_directoryWithFiles, "PdfStreamReadOnlyAsync.docx");
+
+        using var document = WordDocument.Create(docPath);
+        document.AddParagraph("Hello World");
+        document.Save();
+
+        using var stream = new MemoryStream(new byte[1], 0, 1, writable: false);
+        await Assert.ThrowsAsync<ArgumentException>(() => document.SaveAsPdfAsync(stream, cancellationToken: CancellationToken.None));
+    }
+
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_ToStream_Rewinds() {
+        var docPath = Path.Combine(_directoryWithFiles, "PdfStreamRewind.docx");
+
+        using var document = WordDocument.Create(docPath);
+        document.AddParagraph("Hello World");
+        document.Save();
+
+        using var stream = new MemoryStream();
+        document.SaveAsPdf(stream);
+        Assert.Equal(0, stream.Position);
+        Assert.True(stream.Length > 0);
+    }
+
+    [Fact]
+    public async Task Test_WordDocument_SaveAsPdfAsync_ToStream_Rewinds() {
+        var docPath = Path.Combine(_directoryWithFiles, "PdfStreamRewindAsync.docx");
+
+        using var document = WordDocument.Create(docPath);
+        document.AddParagraph("Hello World");
+        document.Save();
+
+        using var stream = new MemoryStream();
+        await document.SaveAsPdfAsync(stream, cancellationToken: CancellationToken.None);
+        Assert.Equal(0, stream.Position);
+        Assert.True(stream.Length > 0);
+    }
+}

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -61,8 +61,16 @@ namespace OfficeIMO.Word.Pdf {
                 throw new ArgumentNullException(nameof(stream));
             }
 
+            if (!stream.CanWrite) {
+                throw new ArgumentException("Stream must be writable.", nameof(stream));
+            }
+
             Document pdf = CreatePdfDocument(document, options);
             pdf.GeneratePdf(stream);
+
+            if (stream.CanSeek) {
+                stream.Position = 0;
+            }
         }
 
         /// <summary>
@@ -133,8 +141,17 @@ namespace OfficeIMO.Word.Pdf {
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            if (!stream.CanWrite) {
+                throw new ArgumentException("Stream must be writable.", nameof(stream));
+            }
+
             Document pdf = CreatePdfDocument(document, options);
-            return Task.Run(() => pdf.GeneratePdf(stream), cancellationToken);
+            return Task.Run(() => {
+                pdf.GeneratePdf(stream);
+                if (stream.CanSeek) {
+                    stream.Position = 0;
+                }
+            }, cancellationToken);
         }
 
         private static Document CreatePdfDocument(WordDocument document, PdfSaveOptions? options) {


### PR DESCRIPTION
## Summary
- validate PDF output streams are writable and rewind after generation
- add tests for unreadable streams and auto rewind
- document stream rewind with example

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689cbc21370c832ea949ee7cd7625dab