### PR TITLE
Add async Markdown save/load APIs

### DIFF
--- a/OfficeIMO.Examples/Converters/Markdown/Markdown04_Async.cs
+++ b/OfficeIMO.Examples/Converters/Markdown/Markdown04_Async.cs
@@ -1,0 +1,29 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Markdown;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Examples.Word.Converters {
+    internal static class Markdown04_Async {
+        public static async Task Example(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating Word document and saving/loading Markdown asynchronously");
+
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Async paragraph");
+
+            string markdownPath = Path.Combine(folderPath, "AsyncMarkdown.md");
+            await doc.SaveAsMarkdownAsync(markdownPath);
+
+            using var loaded = await markdownPath.LoadFromMarkdownAsync();
+            Console.WriteLine($"Loaded paragraphs: {loaded.Paragraphs.Count}");
+
+            Console.WriteLine($"✓ Created: {markdownPath}");
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(markdownPath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Markdown.Async.cs
+++ b/OfficeIMO.Tests/Markdown.Async.cs
@@ -1,0 +1,50 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Markdown {
+        [Fact]
+        public async Task Test_SaveAsMarkdownAsync_FileAndLoadAsync() {
+            string tempDir = Path.Combine(AppContext.BaseDirectory, "TempMarkdown");
+            Directory.CreateDirectory(tempDir);
+            string mdPath = Path.Combine(tempDir, "AsyncFile.md");
+            if (File.Exists(mdPath)) File.Delete(mdPath);
+
+            using (var doc = WordDocument.Create()) {
+                doc.AddParagraph("Async file");
+                await doc.SaveAsMarkdownAsync(mdPath);
+            }
+
+            Assert.True(File.Exists(mdPath));
+
+            using (var doc = await mdPath.LoadFromMarkdownAsync()) {
+                Assert.True(doc.Paragraphs.Count >= 1);
+                Assert.Contains("Async file", string.Join("\n", doc.Paragraphs.Select(p => p.Text)));
+            }
+
+            File.Delete(mdPath);
+        }
+
+        [Fact]
+        public async Task Test_SaveAsMarkdownAsync_StreamAndLoadAsync() {
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Async stream");
+
+            using var stream = new MemoryStream();
+            await doc.SaveAsMarkdownAsync(stream);
+            Assert.True(stream.CanRead);
+            stream.Position = 0;
+
+            using var loaded = await stream.LoadFromMarkdownAsync();
+            Assert.True(loaded.Paragraphs.Count >= 1);
+            Assert.Contains("Async stream", string.Join("\n", loaded.Paragraphs.Select(p => p.Text)));
+
+            Assert.True(stream.CanRead);
+        }
+    }
+}
+

--- a/OfficeIMO.Word.Markdown/WordMarkdownConverterExtensions.cs
+++ b/OfficeIMO.Word.Markdown/WordMarkdownConverterExtensions.cs
@@ -2,6 +2,8 @@ using OfficeIMO.Word;
 using OfficeIMO.Word.Markdown.Converters;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace OfficeIMO.Word.Markdown {
     /// <summary>
@@ -37,6 +39,45 @@ namespace OfficeIMO.Word.Markdown {
         }
 
         /// <summary>
+        /// Asynchronously saves the document as a Markdown file at the specified path.
+        /// </summary>
+        /// <param name="document">Document to convert.</param>
+        /// <param name="path">Destination file path.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        public static async Task SaveAsMarkdownAsync(this WordDocument document, string path, WordToMarkdownOptions? options = null, CancellationToken cancellationToken = default) {
+            options ??= new WordToMarkdownOptions();
+            if (options.ImageExportMode == ImageExportMode.File && string.IsNullOrEmpty(options.ImageDirectory)) {
+                options.ImageDirectory = Path.GetDirectoryName(path);
+            }
+            var markdown = document.ToMarkdown(options);
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+            await File.WriteAllTextAsync(path, markdown, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
+#else
+            using var writer = new StreamWriter(path, false, Encoding.UTF8);
+            await writer.WriteAsync(markdown).ConfigureAwait(false);
+#endif
+        }
+
+        /// <summary>
+        /// Asynchronously saves the document as Markdown to the provided stream.
+        /// </summary>
+        /// <param name="document">Document to convert.</param>
+        /// <param name="stream">Target stream.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        public static async Task SaveAsMarkdownAsync(this WordDocument document, Stream stream, WordToMarkdownOptions? options = null, CancellationToken cancellationToken = default) {
+            options ??= new WordToMarkdownOptions();
+            var markdown = document.ToMarkdown(options);
+            var bytes = Encoding.UTF8.GetBytes(markdown);
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+            await stream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+#else
+            await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+#endif
+        }
+
+        /// <summary>
         /// Converts the document to a Markdown string.
         /// </summary>
         /// <param name="document">Document to convert.</param>
@@ -67,6 +108,36 @@ namespace OfficeIMO.Word.Markdown {
         public static WordDocument LoadFromMarkdown(this Stream markdownStream, MarkdownToWordOptions? options = null) {
             using var reader = new StreamReader(markdownStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
             string markdown = reader.ReadToEnd();
+            return LoadFromMarkdown(markdown, options);
+        }
+
+        /// <summary>
+        /// Asynchronously creates a new document from a Markdown string read from the specified path.
+        /// </summary>
+        /// <param name="path">Path to the Markdown file.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        /// <returns>A new <see cref="WordDocument"/> instance.</returns>
+        public static async Task<WordDocument> LoadFromMarkdownAsync(this string path, MarkdownToWordOptions? options = null, CancellationToken cancellationToken = default) {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+            var markdown = await File.ReadAllTextAsync(path, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
+#else
+            using var reader = new StreamReader(path, Encoding.UTF8);
+            var markdown = await reader.ReadToEndAsync().ConfigureAwait(false);
+#endif
+            return LoadFromMarkdown(markdown, options);
+        }
+
+        /// <summary>
+        /// Asynchronously creates a new document from a Markdown stream.
+        /// </summary>
+        /// <param name="markdownStream">Stream containing Markdown content.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        /// <returns>A new <see cref="WordDocument"/> instance.</returns>
+        public static async Task<WordDocument> LoadFromMarkdownAsync(this Stream markdownStream, MarkdownToWordOptions? options = null, CancellationToken cancellationToken = default) {
+            using var reader = new StreamReader(markdownStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
+            string markdown = await reader.ReadToEndAsync().ConfigureAwait(false);
             return LoadFromMarkdown(markdown, options);
         }
     }


### PR DESCRIPTION
## Summary
- add async SaveAsMarkdownAsync and LoadFromMarkdownAsync overloads for file paths and streams
- test async Markdown conversions and ensure streams stay open
- document async Markdown conversion usage example

## Testing
- `dotnet build -c Release`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --filter "FullyQualifiedName~SaveAsMarkdownAsync" --logger "console;verbosity=detailed"`


------
https://chatgpt.com/codex/tasks/task_e_689cbc02e0c8832eb511e099ed3a6a8d