### PR TITLE
Handle HTML font tag for color and size

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.FontTag.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.FontTag.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlFontTag(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlFontTag.docx");
+            string html = "<p><font color=\"#00ff00\" size=\"5\">Green text</font></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.FontTag.cs
+++ b/OfficeIMO.Tests/Html.FontTag.cs
@@ -1,0 +1,19 @@
+using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
+using System.Linq;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_FontTagAttributes() {
+            string html = "<p><font color=\"#00FF00\" size=\"5\">Green</font></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var run = doc.Paragraphs[0].GetRuns().First();
+
+            Assert.Equal("00ff00", run.ColorHex);
+            Assert.Equal(18, run.FontSize);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -256,6 +256,40 @@ namespace OfficeIMO.Word.Html.Converters {
             }
         }
 
+        private static bool TryParseHtmlFontSize(string? value, out int size) {
+            size = 0;
+            if (TryParseFontSize(value, out size)) {
+                return true;
+            }
+            if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int numeric)) {
+                size = numeric switch {
+                    1 => 8,
+                    2 => 10,
+                    3 => 12,
+                    4 => 14,
+                    5 => 18,
+                    6 => 24,
+                    7 => 36,
+                    _ => 0
+                };
+                return size > 0;
+            }
+            return false;
+        }
+
+        private static void ApplyFontStyles(IElement element, ref TextFormatting formatting) {
+            ApplySpanStyles(element, ref formatting);
+
+            var colorAttr = NormalizeColor(element.GetAttribute("color"));
+            if (colorAttr != null) {
+                formatting.ColorHex = colorAttr;
+            }
+
+            if (TryParseHtmlFontSize(element.GetAttribute("size"), out int size)) {
+                formatting.FontSize = size;
+            }
+        }
+
         private static string MergeStyles(string parentStyle, string? childStyle) {
             var parser = new CssParser();
             var parent = parser.ParseDeclaration(parentStyle);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -518,6 +518,14 @@ namespace OfficeIMO.Word.Html.Converters {
                             }
                             break;
                         }
+                    case "font": {
+                            var fmt = formatting;
+                            ApplyFontStyles(element, ref fmt);
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);
+                            }
+                            break;
+                        }
                     case "span": {
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);


### PR DESCRIPTION
## Summary
- map `<font>` color and size attributes to text formatting
- convert `<font>` tag contents in HTML to Word
- add example and tests for `<font>` tag handling

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689ceb3fb3c8832e9f499fdc4eee7e2b