### PR TITLE
Add async HTML conversion extensions

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html07_Async.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html07_Async.cs
@@ -1,0 +1,30 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Examples.Word.Converters {
+    internal static class Html07_Async {
+        public static async Task Example(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Demonstrating async HTML conversion");
+
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Async HTML");
+            await doc.AddHtmlToHeaderAsync("<p>Header async</p>");
+            await doc.AddHtmlToFooterAsync("<p>Footer async</p>");
+
+            string outputPath = Path.Combine(folderPath, "HtmlAsync.html");
+            await doc.SaveAsHtmlAsync(outputPath);
+
+            string html = await doc.ToHtmlAsync();
+            using var roundTrip = await html.LoadFromHtmlAsync();
+
+            Console.WriteLine($"✓ Created: {outputPath}");
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(outputPath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.Async.cs
+++ b/OfficeIMO.Tests/Html.Async.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public async Task ToHtmlAsync_EqualsSync() {
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Async test");
+            string sync = doc.ToHtml();
+            string asyncResult = await doc.ToHtmlAsync();
+            Assert.Equal(sync, asyncResult);
+        }
+
+        [Fact]
+        public async Task LoadFromHtmlAsync_EqualsSync() {
+            string html = "<p>Hello</p>";
+            using var syncDoc = html.LoadFromHtml();
+            using var asyncDoc = await html.LoadFromHtmlAsync();
+            Assert.Equal(syncDoc.Paragraphs.Count, asyncDoc.Paragraphs.Count);
+            Assert.Equal(syncDoc.Paragraphs.First().Text, asyncDoc.Paragraphs.First().Text);
+        }
+
+        [Fact]
+        public async Task SaveAsHtmlAsync_EqualsSync() {
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Save test");
+            string dir = Path.Combine(AppContext.BaseDirectory, "HtmlAsync");
+            Directory.CreateDirectory(dir);
+            string syncPath = Path.Combine(dir, "sync.html");
+            string asyncPath = Path.Combine(dir, "async.html");
+            if (File.Exists(syncPath)) File.Delete(syncPath);
+            if (File.Exists(asyncPath)) File.Delete(asyncPath);
+
+            doc.SaveAsHtml(syncPath);
+            await doc.SaveAsHtmlAsync(asyncPath);
+
+            string syncHtml = File.ReadAllText(syncPath);
+            string asyncHtml = File.ReadAllText(asyncPath);
+            Assert.Equal(syncHtml, asyncHtml);
+        }
+
+        [Fact]
+        public async Task AddHtmlHeaderFooterAsync_EqualsSync() {
+            using var docSync = WordDocument.Create();
+            using var docAsync = WordDocument.Create();
+            string fragment = "<p>Header</p>";
+            docSync.AddHtmlToHeader(fragment);
+            await docAsync.AddHtmlToHeaderAsync(fragment);
+            Assert.Equal(docSync.Header.Default.Paragraphs[0].Text, docAsync.Header.Default.Paragraphs[0].Text);
+
+            string footerFrag = "<p>Footer</p>";
+            docSync.AddHtmlToFooter(footerFrag);
+            await docAsync.AddHtmlToFooterAsync(footerFrag);
+            Assert.Equal(docSync.Footer.Default.Paragraphs[0].Text, docAsync.Footer.Default.Paragraphs[0].Text);
+        }
+
+        [Fact]
+        public async Task AsyncMethods_CanBeCancelled() {
+            using var doc = WordDocument.Create();
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(() => doc.ToHtmlAsync(cancellationToken: cts.Token));
+            await Assert.ThrowsAsync<OperationCanceledException>(() => "<p>a</p>".LoadFromHtmlAsync(cancellationToken: cts.Token));
+            await Assert.ThrowsAsync<OperationCanceledException>(() => doc.SaveAsHtmlAsync("foo.html", cancellationToken: cts.Token));
+            await Assert.ThrowsAsync<OperationCanceledException>(() => doc.AddHtmlToHeaderAsync("<p>h</p>", cancellationToken: cts.Token));
+            await Assert.ThrowsAsync<OperationCanceledException>(() => doc.AddHtmlToFooterAsync("<p>f</p>", cancellationToken: cts.Token));
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
+++ b/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
@@ -3,6 +3,8 @@ using OfficeIMO.Word;
 using OfficeIMO.Word.Html.Converters;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace OfficeIMO.Word.Html {
     /// <summary>
@@ -16,8 +18,7 @@ namespace OfficeIMO.Word.Html {
         /// <param name="path">Destination file path.</param>
         /// <param name="options">Optional conversion options.</param>
         public static void SaveAsHtml(this WordDocument document, string path, WordToHtmlOptions? options = null) {
-            var html = document.ToHtml(options);
-            File.WriteAllText(path, html, Encoding.UTF8);
+            document.SaveAsHtmlAsync(path, options).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -27,9 +28,7 @@ namespace OfficeIMO.Word.Html {
         /// <param name="stream">Target stream.</param>
         /// <param name="options">Optional conversion options.</param>
         public static void SaveAsHtml(this WordDocument document, Stream stream, WordToHtmlOptions? options = null) {
-            var html = document.ToHtml(options);
-            var bytes = Encoding.UTF8.GetBytes(html);
-            stream.Write(bytes, 0, bytes.Length);
+            document.SaveAsHtmlAsync(stream, options).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -39,9 +38,21 @@ namespace OfficeIMO.Word.Html {
         /// <param name="options">Optional conversion options.</param>
         /// <returns>HTML representation of the document.</returns>
         public static string ToHtml(this WordDocument document, WordToHtmlOptions? options = null) {
+            return document.ToHtmlAsync(options).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Asynchronously converts the document to an HTML string.
+        /// </summary>
+        /// <param name="document">Document to convert.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        /// <returns>HTML representation of the document.</returns>
+        public static async Task<string> ToHtmlAsync(this WordDocument document, WordToHtmlOptions? options = null, CancellationToken cancellationToken = default) {
+            if (document == null) throw new System.ArgumentNullException(nameof(document));
+            cancellationToken.ThrowIfCancellationRequested();
             var converter = new WordToHtmlConverter();
-            // Use GetAwaiter().GetResult() to call async method synchronously
-            return converter.ConvertAsync(document, options).GetAwaiter().GetResult();
+            return await converter.ConvertAsync(document, options ?? new WordToHtmlOptions()).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -51,9 +62,21 @@ namespace OfficeIMO.Word.Html {
         /// <param name="options">Optional conversion options.</param>
         /// <returns>A new <see cref="WordDocument"/> instance.</returns>
         public static WordDocument LoadFromHtml(this string html, HtmlToWordOptions? options = null) {
+            return LoadFromHtmlAsync(html, options).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Asynchronously creates a new document from an HTML string.
+        /// </summary>
+        /// <param name="html">HTML content to convert.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        /// <returns>A new <see cref="WordDocument"/> instance.</returns>
+        public static async Task<WordDocument> LoadFromHtmlAsync(this string html, HtmlToWordOptions? options = null, CancellationToken cancellationToken = default) {
+            if (html == null) throw new System.ArgumentNullException(nameof(html));
+            cancellationToken.ThrowIfCancellationRequested();
             var converter = new HtmlToWordConverter();
-            // Use GetAwaiter().GetResult() to call async method synchronously
-            return converter.ConvertAsync(html, options).GetAwaiter().GetResult();
+            return await converter.ConvertAsync(html, options ?? new HtmlToWordOptions()).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -63,9 +86,23 @@ namespace OfficeIMO.Word.Html {
         /// <param name="options">Optional conversion options.</param>
         /// <returns>A new <see cref="WordDocument"/> instance.</returns>
         public static WordDocument LoadFromHtml(this Stream htmlStream, HtmlToWordOptions? options = null) {
+            return LoadFromHtmlAsync(htmlStream, options).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Asynchronously creates a new document from an HTML stream.
+        /// </summary>
+        /// <param name="htmlStream">Stream containing HTML content.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        /// <returns>A new <see cref="WordDocument"/> instance.</returns>
+        public static async Task<WordDocument> LoadFromHtmlAsync(this Stream htmlStream, HtmlToWordOptions? options = null, CancellationToken cancellationToken = default) {
+            if (htmlStream == null) throw new System.ArgumentNullException(nameof(htmlStream));
+            cancellationToken.ThrowIfCancellationRequested();
             using var reader = new StreamReader(htmlStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
-            string html = reader.ReadToEnd();
-            return LoadFromHtml(html, options);
+            string html = await reader.ReadToEndAsync().ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            return await LoadFromHtmlAsync(html, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -76,8 +113,21 @@ namespace OfficeIMO.Word.Html {
         /// <param name="type">Header type to target.</param>
         /// <param name="options">Optional conversion options.</param>
         public static void AddHtmlToHeader(this WordDocument doc, string html, HeaderFooterValues? type = null, HtmlToWordOptions? options = null) {
+            doc.AddHtmlToHeaderAsync(html, type, options).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Asynchronously appends HTML content to the document's header.
+        /// </summary>
+        /// <param name="doc">Document to modify.</param>
+        /// <param name="html">HTML fragment to insert.</param>
+        /// <param name="type">Header type to target.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        public static async Task AddHtmlToHeaderAsync(this WordDocument doc, string html, HeaderFooterValues? type = null, HtmlToWordOptions? options = null, CancellationToken cancellationToken = default) {
             if (doc == null) throw new System.ArgumentNullException(nameof(doc));
             if (html == null) throw new System.ArgumentNullException(nameof(html));
+            cancellationToken.ThrowIfCancellationRequested();
 
             doc.AddHeadersAndFooters();
             options ??= new HtmlToWordOptions();
@@ -93,7 +143,8 @@ namespace OfficeIMO.Word.Html {
             }
 
             var converter = new HtmlToWordConverter();
-            converter.AddHtmlToHeaderAsync(doc, header, html, options).GetAwaiter().GetResult();
+            await converter.AddHtmlToHeaderAsync(doc, header, html, options).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
         }
 
         /// <summary>
@@ -104,8 +155,21 @@ namespace OfficeIMO.Word.Html {
         /// <param name="type">Footer type to target.</param>
         /// <param name="options">Optional conversion options.</param>
         public static void AddHtmlToFooter(this WordDocument doc, string html, HeaderFooterValues? type = null, HtmlToWordOptions? options = null) {
+            doc.AddHtmlToFooterAsync(html, type, options).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Asynchronously appends HTML content to the document's footer.
+        /// </summary>
+        /// <param name="doc">Document to modify.</param>
+        /// <param name="html">HTML fragment to insert.</param>
+        /// <param name="type">Footer type to target.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        public static async Task AddHtmlToFooterAsync(this WordDocument doc, string html, HeaderFooterValues? type = null, HtmlToWordOptions? options = null, CancellationToken cancellationToken = default) {
             if (doc == null) throw new System.ArgumentNullException(nameof(doc));
             if (html == null) throw new System.ArgumentNullException(nameof(html));
+            cancellationToken.ThrowIfCancellationRequested();
 
             doc.AddHeadersAndFooters();
             options ??= new HtmlToWordOptions();
@@ -121,7 +185,48 @@ namespace OfficeIMO.Word.Html {
             }
 
             var converter = new HtmlToWordConverter();
-            converter.AddHtmlToFooterAsync(doc, footer, html, options).GetAwaiter().GetResult();
+            await converter.AddHtmlToFooterAsync(doc, footer, html, options).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        /// <summary>
+        /// Asynchronously saves the document as an HTML file at the specified path.
+        /// </summary>
+        /// <param name="document">Document to convert.</param>
+        /// <param name="path">Destination file path.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        public static async Task SaveAsHtmlAsync(this WordDocument document, string path, WordToHtmlOptions? options = null, CancellationToken cancellationToken = default) {
+            if (document == null) throw new System.ArgumentNullException(nameof(document));
+            if (path == null) throw new System.ArgumentNullException(nameof(path));
+            cancellationToken.ThrowIfCancellationRequested();
+            var html = await document.ToHtmlAsync(options, cancellationToken).ConfigureAwait(false);
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+            await File.WriteAllTextAsync(path, html, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
+#else
+            using var writer = new StreamWriter(path, false, Encoding.UTF8);
+            await writer.WriteAsync(html).ConfigureAwait(false);
+#endif
+        }
+
+        /// <summary>
+        /// Asynchronously saves the document as HTML to the provided stream.
+        /// </summary>
+        /// <param name="document">Document to convert.</param>
+        /// <param name="stream">Target stream.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        public static async Task SaveAsHtmlAsync(this WordDocument document, Stream stream, WordToHtmlOptions? options = null, CancellationToken cancellationToken = default) {
+            if (document == null) throw new System.ArgumentNullException(nameof(document));
+            if (stream == null) throw new System.ArgumentNullException(nameof(stream));
+            cancellationToken.ThrowIfCancellationRequested();
+            var html = await document.ToHtmlAsync(options, cancellationToken).ConfigureAwait(false);
+            var bytes = Encoding.UTF8.GetBytes(html);
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+            await stream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+#else
+            await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+#endif
         }
     }
 }


### PR DESCRIPTION
## Summary
- add async HTML conversion extension methods for Word documents
- demonstrate asynchronous HTML conversions in examples
- validate async HTML methods including cancellation

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689ceb3a2408832ea5c74ec8371d9be0