### PR TITLE
Handle anchor name attributes and ensure top bookmark

### DIFF
--- a/OfficeIMO.Tests/Html.Hyperlinks.cs
+++ b/OfficeIMO.Tests/Html.Hyperlinks.cs
@@ -1,12 +1,49 @@
-using OfficeIMO.Word;
-using OfficeIMO.Word.Html;
-using Xunit;
-
-namespace OfficeIMO.Tests {
-    public partial class Html {
-        [Fact]
-        public void Html_Hyperlinks_Title_And_Target_External() {
-            string html = "<p><a href=\"https://example.com\" title=\"Example\" target=\"_self\">Example</a></p>";
+        [Fact]
+        public void Html_Hyperlinks_IdAnchor() {
+            string html = "<p id=\"section1\">Start</p><p><a href=\"#section1\" title=\"Back\" target=\"_blank\">Back</a></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Contains(doc.Bookmarks, b => b.Name == "section1");
+
+            var hyperlink = doc.ParagraphsHyperLinks[0].Hyperlink;
+
+            Assert.NotNull(hyperlink);
+            Assert.Equal("Back", hyperlink.Tooltip);
+            Assert.Equal(TargetFrame._blank, hyperlink.TargetFrame);
+            Assert.Equal("section1", hyperlink.Anchor);
+        }
+
+        [Fact]
+        public void Html_Hyperlinks_NameAnchor() {
+            string html = "<p><a name=\"intro\"></a>Intro</p><p><a href=\"#intro\">Back</a></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Contains(doc.Bookmarks, b => b.Name == "intro");
+
+            var hyperlink = doc.ParagraphsHyperLinks[0].Hyperlink;
+
+            Assert.NotNull(hyperlink);
+            Assert.Equal("intro", hyperlink.Anchor);
+        }
+
+        [Fact]
+        public void Html_Hyperlinks_LinkToTopUsesTopBookmark() {
+            string html = "<p>Content</p><p><a href=\"#top\">Top</a></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Contains(doc.Bookmarks, b => b.Name == "_top");
+
+            var hyperlink = doc.ParagraphsHyperLinks[0].Hyperlink;
+
+            Assert.NotNull(hyperlink);
+            Assert.Equal("_top", hyperlink.Anchor);
+        }
+    }
+}
+
 
             var doc = html.LoadFromHtml(new HtmlToWordOptions());
 


### PR DESCRIPTION
## Summary
- Support `name` attributes on HTML anchors when converting to Word bookmarks
- Normalize `#top` hyperlinks to built-in `_top` bookmark
- Ensure converted documents include a `_top` bookmark at the start

## Testing
- `dotnet test` *(fails: Assert.Equal() Failure: Values differ; Assert.Single() Failure: collection contained 2 items)*

------
https://chatgpt.com/codex/tasks/task_e_689ceb4bc330832eb6aa935ff6c94015