### PR TITLE
Add CancellationToken support to HTML converters

### DIFF
--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace OfficeIMO.Word.Html.Converters {
     /// <summary>
@@ -23,12 +24,14 @@ namespace OfficeIMO.Word.Html.Converters {
         /// <param name="document">Document to convert.</param>
         /// <param name="options">Conversion options controlling HTML output.</param>
         /// <returns>HTML representation of the document.</returns>
-        public async Task<string> ConvertAsync(WordDocument document, WordToHtmlOptions options) {
+        public async Task<string> ConvertAsync(WordDocument document, WordToHtmlOptions options, CancellationToken cancellationToken = default) {
             if (document == null) throw new ArgumentNullException(nameof(document));
             options ??= new WordToHtmlOptions();
 
+            cancellationToken.ThrowIfCancellationRequested();
             var context = BrowsingContext.New(Configuration.Default);
-            var htmlDoc = await context.OpenNewAsync();
+            var htmlDoc = await context.OpenNewAsync().ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
 
             var head = htmlDoc.Head;
             var body = htmlDoc.Body;

--- a/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
+++ b/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
@@ -52,7 +52,7 @@ namespace OfficeIMO.Word.Html {
             if (document == null) throw new System.ArgumentNullException(nameof(document));
             cancellationToken.ThrowIfCancellationRequested();
             var converter = new WordToHtmlConverter();
-            return await converter.ConvertAsync(document, options ?? new WordToHtmlOptions()).ConfigureAwait(false);
+            return await converter.ConvertAsync(document, options ?? new WordToHtmlOptions(), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace OfficeIMO.Word.Html {
             if (html == null) throw new System.ArgumentNullException(nameof(html));
             cancellationToken.ThrowIfCancellationRequested();
             var converter = new HtmlToWordConverter();
-            return await converter.ConvertAsync(html, options ?? new HtmlToWordOptions()).ConfigureAwait(false);
+            return await converter.ConvertAsync(html, options ?? new HtmlToWordOptions(), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -100,8 +100,13 @@ namespace OfficeIMO.Word.Html {
             if (htmlStream == null) throw new System.ArgumentNullException(nameof(htmlStream));
             cancellationToken.ThrowIfCancellationRequested();
             using var reader = new StreamReader(htmlStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
-            string html = await reader.ReadToEndAsync().ConfigureAwait(false);
+            string html;
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+            html = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+#else
+            html = await reader.ReadToEndAsync().ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
+#endif
             return await LoadFromHtmlAsync(html, options, cancellationToken).ConfigureAwait(false);
         }
 
@@ -143,7 +148,7 @@ namespace OfficeIMO.Word.Html {
             }
 
             var converter = new HtmlToWordConverter();
-            await converter.AddHtmlToHeaderAsync(doc, header, html, options).ConfigureAwait(false);
+            await converter.AddHtmlToHeaderAsync(doc, header, html, options, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
         }
 
@@ -185,7 +190,7 @@ namespace OfficeIMO.Word.Html {
             }
 
             var converter = new HtmlToWordConverter();
-            await converter.AddHtmlToFooterAsync(doc, footer, html, options).ConfigureAwait(false);
+            await converter.AddHtmlToFooterAsync(doc, footer, html, options, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
         }
 


### PR DESCRIPTION
## Summary
- allow passing a CancellationToken through HtmlToWordConverter and WordToHtmlConverter
- propagate token through CSS loading, image downloads and AngleSharp operations
- expose token-aware overloads and add cancellation safety tests

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689cf07115f8832e9b3b46e5c3f433de