### PR TITLE
feat(html): support adding HTML to document body

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.Body.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.Body.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlBody(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlBody.docx");
+
+            using WordDocument document = WordDocument.Create();
+            document.AddParagraph("Before HTML");
+            document.AddHtmlToBody("<p>Inserted <b>HTML</b> content</p>");
+            document.AddParagraph("After HTML");
+            document.Save(filePath);
+            Console.WriteLine($"Created: {filePath}");
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Html.AddHtmlToBody.cs
+++ b/OfficeIMO.Tests/Html.AddHtmlToBody.cs
@@ -1,0 +1,42 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void AddHtmlToBody_InsertsAtBeginning() {
+            using WordDocument document = WordDocument.Create();
+            document.AddHtmlToBody("<p>First</p>");
+            document.AddParagraph("Second");
+
+            Assert.Equal("First", document.Paragraphs[0].Text);
+            Assert.Equal("Second", document.Paragraphs[1].Text);
+        }
+
+        [Fact]
+        public void AddHtmlToBody_InsertsInMiddle() {
+            using WordDocument document = WordDocument.Create();
+            document.AddParagraph("Start");
+            document.AddHtmlToBody("<p>Middle</p>");
+            document.AddParagraph("End");
+
+            Assert.Equal("Start", document.Paragraphs[0].Text);
+            Assert.Equal("Middle", document.Paragraphs[1].Text);
+            Assert.Equal("End", document.Paragraphs[2].Text);
+        }
+
+        [Fact]
+        public void AddHtmlToBody_InsertsAtEnd() {
+            using WordDocument document = WordDocument.Create();
+            document.AddParagraph("Start");
+            document.AddParagraph("Middle");
+            document.AddHtmlToBody("<p>End</p>");
+
+            Assert.Equal("Start", document.Paragraphs[0].Text);
+            Assert.Equal("Middle", document.Paragraphs[1].Text);
+            Assert.Equal("End", document.Paragraphs[2].Text);
+        }
+    }
+}
+

--- a/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
+++ b/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
@@ -2,6 +2,7 @@ using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html.Converters;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -103,6 +104,36 @@ namespace OfficeIMO.Word.Html {
             string html = await reader.ReadToEndAsync().ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             return await LoadFromHtmlAsync(html, options, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Appends HTML content to the document's body.
+        /// </summary>
+        /// <param name="doc">Document to modify.</param>
+        /// <param name="html">HTML fragment to insert.</param>
+        /// <param name="options">Optional conversion options.</param>
+        public static void AddHtmlToBody(this WordDocument doc, string html, HtmlToWordOptions? options = null) {
+            doc.AddHtmlToBodyAsync(html, options).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Asynchronously appends HTML content to the document's body.
+        /// </summary>
+        /// <param name="doc">Document to modify.</param>
+        /// <param name="html">HTML fragment to insert.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        public static async Task AddHtmlToBodyAsync(this WordDocument doc, string html, HtmlToWordOptions? options = null, CancellationToken cancellationToken = default) {
+            if (doc == null) throw new System.ArgumentNullException(nameof(doc));
+            if (html == null) throw new System.ArgumentNullException(nameof(html));
+            cancellationToken.ThrowIfCancellationRequested();
+
+            options ??= new HtmlToWordOptions();
+
+            var section = doc.Sections.Last();
+            var converter = new HtmlToWordConverter();
+            await converter.AddHtmlToBodyAsync(doc, section, html, options).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add AddHtmlToBody[Async] extension to append HTML into a document's body
- allow HtmlToWordConverter to inject HTML nodes into existing sections
- document body insertion and cover with unit tests

## Testing
- `dotnet build`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build --filter AddHtmlToBody`


------
https://chatgpt.com/codex/tasks/task_e_689d7d0cef48832e8c90fc9b44ec0672