### PR TITLE
Handle cite, dfn, and time HTML tags

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.Citations.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.Citations.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlCitations(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlCitations.docx");
+            string html = "<p>This is a <cite>citation</cite> example.</p>";
+
+            using var document = html.LoadFromHtml();
+            document.Save(filePath);
+
+            string roundTrip = document.ToHtml();
+            Console.WriteLine(roundTrip);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Examples/Converters/Html/Html.Definitions.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.Definitions.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlDefinitions(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlDefinitions.docx");
+            string html = "<p>A <dfn>term</dfn> appears.</p>";
+
+            using var document = html.LoadFromHtml();
+            document.Save(filePath);
+
+            string roundTrip = document.ToHtml();
+            Console.WriteLine(roundTrip);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Examples/Converters/Html/Html.Time.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.Time.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlTime(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlTime.docx");
+            string html = "<p>On <time datetime=\"2023-01-01\">2023-01-01</time> we met.</p>";
+
+            using var document = html.LoadFromHtml();
+            document.Save(filePath);
+
+            string roundTrip = document.ToHtml();
+            Console.WriteLine(roundTrip);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Html.Citations.cs
+++ b/OfficeIMO.Tests/Html.Citations.cs
@@ -1,0 +1,24 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class HtmlCitations {
+        [Fact]
+        public void CiteIsItalicAndRoundsTrip() {
+            const string html = "<p>This is a <cite>citation</cite>.</p>";
+            using var doc = html.LoadFromHtml();
+            var runs = doc.Paragraphs[0].GetRuns().ToList();
+            Assert.Equal("HtmlCite", runs[1].CharacterStyleId);
+            Assert.True(runs[1].Italic);
+            Assert.Equal("citation", runs[1].Text);
+
+            string roundTrip = doc.ToHtml();
+            Assert.Contains("<cite", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("</cite>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Html.Definitions.cs
+++ b/OfficeIMO.Tests/Html.Definitions.cs
@@ -1,0 +1,24 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class HtmlDefinitions {
+        [Fact]
+        public void DfnIsItalicAndRoundsTrip() {
+            const string html = "<p>A <dfn>term</dfn> appears.</p>";
+            using var doc = html.LoadFromHtml();
+            var runs = doc.Paragraphs[0].GetRuns().ToList();
+            Assert.Equal("HtmlDfn", runs[1].CharacterStyleId);
+            Assert.True(runs[1].Italic);
+            Assert.Equal("term", runs[1].Text);
+
+            string roundTrip = doc.ToHtml();
+            Assert.Contains("<dfn", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("</dfn>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Html.Quotes.cs
+++ b/OfficeIMO.Tests/Html.Quotes.cs
@@ -1,0 +1,23 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class HtmlQuotes {
+        [Fact]
+        public void QuotesRoundTrip() {
+            const string html = "<p>Before <q>quoted</q> after</p>";
+            using var doc = html.LoadFromHtml();
+            var runs = doc.Paragraphs[0].GetRuns().ToList();
+            Assert.Equal("HtmlQuote", runs[1].CharacterStyleId);
+            Assert.Equal("HtmlQuote", runs[3].CharacterStyleId);
+            Assert.Equal("quoted", runs[2].Text);
+
+            string roundTrip = doc.ToHtml();
+            Assert.Contains("<q>quoted</q>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Html.Time.cs
+++ b/OfficeIMO.Tests/Html.Time.cs
@@ -1,0 +1,24 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class HtmlTimeTag {
+        [Fact]
+        public void TimeRoundsTripWithDateTime() {
+            const string html = "<p>On <time datetime=\"2023-01-01\">2023-01-01</time> we met.</p>";
+            using var doc = html.LoadFromHtml();
+            var runs = doc.Paragraphs[0].GetRuns().ToList();
+            Assert.Equal("HtmlTime", runs[1].CharacterStyleId);
+            Assert.Equal("2023-01-01", runs[1].Text);
+
+            string roundTrip = doc.ToHtml();
+            Assert.Contains("<time", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("datetime=\"2023-01-01", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("2023-01-01</time>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}
+

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -497,9 +497,53 @@ namespace OfficeIMO.Word.Html.Converters {
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);
                             }
-                            var close = currentParagraph.AddFormattedText(options.QuoteSuffix, fmt.Bold, fmt.Italic, fmt.Underline ? UnderlineValues.Single : null);
-                            ApplyFormatting(close, fmt, options);
-                            close.SetCharacterStyleId("HtmlQuote");
+                        var close = currentParagraph.AddFormattedText(options.QuoteSuffix, fmt.Bold, fmt.Italic, fmt.Underline ? UnderlineValues.Single : null);
+                        ApplyFormatting(close, fmt, options);
+                        close.SetCharacterStyleId("HtmlQuote");
+                        break;
+                    }
+                    case "cite": {
+                            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                            var fmt = formatting;
+                            fmt.Italic = true;
+                            ApplySpanStyles(element, ref fmt);
+                            int startRuns = currentParagraph.GetRuns().Count();
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);
+                            }
+                            var runs = currentParagraph.GetRuns().ToList();
+                            for (int i = startRuns; i < runs.Count; i++) {
+                                runs[i].SetCharacterStyleId("HtmlCite");
+                            }
+                            break;
+                        }
+                    case "dfn": {
+                            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                            var fmt = formatting;
+                            fmt.Italic = true;
+                            ApplySpanStyles(element, ref fmt);
+                            int startRuns = currentParagraph.GetRuns().Count();
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);
+                            }
+                            var runs = currentParagraph.GetRuns().ToList();
+                            for (int i = startRuns; i < runs.Count; i++) {
+                                runs[i].SetCharacterStyleId("HtmlDfn");
+                            }
+                            break;
+                        }
+                    case "time": {
+                            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                            var fmt = formatting;
+                            ApplySpanStyles(element, ref fmt);
+                            int startRuns = currentParagraph.GetRuns().Count();
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);
+                            }
+                            var runs = currentParagraph.GetRuns().ToList();
+                            for (int i = startRuns; i < runs.Count; i++) {
+                                runs[i].SetCharacterStyleId("HtmlTime");
+                            }
                             break;
                         }
                     case "sup": {

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -254,6 +254,29 @@ namespace OfficeIMO.Word.Html.Converters {
                         node = a;
                     }
 
+                    bool handledHtmlStyle = false;
+                    if (string.Equals(run.CharacterStyleId, "HtmlCite", StringComparison.OrdinalIgnoreCase)) {
+                        var cite = htmlDoc.CreateElement("cite");
+                        cite.AppendChild(node);
+                        node = cite;
+                        handledHtmlStyle = true;
+                    } else if (string.Equals(run.CharacterStyleId, "HtmlDfn", StringComparison.OrdinalIgnoreCase)) {
+                        var dfn = htmlDoc.CreateElement("dfn");
+                        dfn.AppendChild(node);
+                        node = dfn;
+                        handledHtmlStyle = true;
+                    } else if (string.Equals(run.CharacterStyleId, "HtmlTime", StringComparison.OrdinalIgnoreCase)) {
+                        var time = htmlDoc.CreateElement("time");
+                        string dt = run.Text;
+                        if (DateTime.TryParse(run.Text, out var parsed)) {
+                            dt = parsed.ToString("o");
+                        }
+                        time.SetAttribute("datetime", dt);
+                        time.AppendChild(node);
+                        node = time;
+                        handledHtmlStyle = true;
+                    }
+
                     if (options.IncludeFontStyles && !string.IsNullOrEmpty(options.FontFamily)) {
                         var span = htmlDoc.CreateElement("span");
                         span.SetAttribute("style", $"font-family:{options.FontFamily}");
@@ -261,7 +284,7 @@ namespace OfficeIMO.Word.Html.Converters {
                         node = span;
                     }
 
-                    if (options.IncludeRunClasses && !string.IsNullOrEmpty(run.CharacterStyleId)) {
+                    if (options.IncludeRunClasses && !string.IsNullOrEmpty(run.CharacterStyleId) && !handledHtmlStyle) {
                         var spanClass = htmlDoc.CreateElement("span");
                         spanClass.SetAttribute("class", run.CharacterStyleId);
                         spanClass.AppendChild(node);


### PR DESCRIPTION
## Summary
- map `<cite>`, `<dfn>`, and `<time>` tags to dedicated character styles during HTML→Word conversion
- emit `<cite>`, `<dfn>`, `<time>` tags from Word documents when exporting back to HTML
- add examples and regression tests for `<q>`, `<cite>`, `<dfn>`, and `<time>` round-tripping

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FullyQualifiedName~HtmlCitations`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FullyQualifiedName~HtmlDefinitions`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FullyQualifiedName~HtmlTimeTag`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FullyQualifiedName~HtmlQuotes`


------
https://chatgpt.com/codex/tasks/task_e_689d7d2029f0832e880cbcb234c24f09