### PR TITLE
Add cancellation token support to HTML converters

### DIFF
--- a/OfficeIMO.Tests/Html.Cancellation.cs
+++ b/OfficeIMO.Tests/Html.Cancellation.cs
@@ -1,0 +1,48 @@
+using System.Threading;
+using System.Threading.Tasks;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public async Task LoadFromHtmlAsync_Cancelled_Throws() {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(() => "<p>a</p>".LoadFromHtmlAsync(cancellationToken: cts.Token));
+        }
+
+        [Fact]
+        public async Task ToHtmlAsync_Cancelled_Throws() {
+            using var doc = WordDocument.Create();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(() => doc.ToHtmlAsync(cancellationToken: cts.Token));
+        }
+
+        [Fact]
+        public async Task AddHtmlToHeaderAsync_Cancelled_Throws() {
+            using var doc = WordDocument.Create();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(() => doc.AddHtmlToHeaderAsync("<p>h</p>", cancellationToken: cts.Token));
+        }
+
+        [Fact]
+        public async Task AddHtmlToFooterAsync_Cancelled_Throws() {
+            using var doc = WordDocument.Create();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(() => doc.AddHtmlToFooterAsync("<p>f</p>", cancellationToken: cts.Token));
+        }
+
+        [Fact]
+        public async Task AddHtmlToBodyAsync_Cancelled_Throws() {
+            using var doc = WordDocument.Create();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(() => doc.AddHtmlToBodyAsync("<p>b</p>", cancellationToken: cts.Token));
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
+++ b/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
@@ -53,7 +53,7 @@ namespace OfficeIMO.Word.Html {
             if (document == null) throw new System.ArgumentNullException(nameof(document));
             cancellationToken.ThrowIfCancellationRequested();
             var converter = new WordToHtmlConverter();
-            return await converter.ConvertAsync(document, options ?? new WordToHtmlOptions()).ConfigureAwait(false);
+            return await converter.ConvertAsync(document, options ?? new WordToHtmlOptions(), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace OfficeIMO.Word.Html {
             if (html == null) throw new System.ArgumentNullException(nameof(html));
             cancellationToken.ThrowIfCancellationRequested();
             var converter = new HtmlToWordConverter();
-            return await converter.ConvertAsync(html, options ?? new HtmlToWordOptions()).ConfigureAwait(false);
+            return await converter.ConvertAsync(html, options ?? new HtmlToWordOptions(), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -101,8 +101,12 @@ namespace OfficeIMO.Word.Html {
             if (htmlStream == null) throw new System.ArgumentNullException(nameof(htmlStream));
             cancellationToken.ThrowIfCancellationRequested();
             using var reader = new StreamReader(htmlStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
+#if NET8_0_OR_GREATER
+            string html = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+#else
             string html = await reader.ReadToEndAsync().ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
+#endif
             return await LoadFromHtmlAsync(html, options, cancellationToken).ConfigureAwait(false);
         }
 
@@ -132,7 +136,7 @@ namespace OfficeIMO.Word.Html {
 
             var section = doc.Sections.Last();
             var converter = new HtmlToWordConverter();
-            await converter.AddHtmlToBodyAsync(doc, section, html, options).ConfigureAwait(false);
+            await converter.AddHtmlToBodyAsync(doc, section, html, options, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
         }
 
@@ -174,7 +178,7 @@ namespace OfficeIMO.Word.Html {
             }
 
             var converter = new HtmlToWordConverter();
-            await converter.AddHtmlToHeaderAsync(doc, header, html, options).ConfigureAwait(false);
+            await converter.AddHtmlToHeaderAsync(doc, header, html, options, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
         }
 
@@ -216,7 +220,7 @@ namespace OfficeIMO.Word.Html {
             }
 
             var converter = new HtmlToWordConverter();
-            await converter.AddHtmlToFooterAsync(doc, footer, html, options).ConfigureAwait(false);
+            await converter.AddHtmlToFooterAsync(doc, footer, html, options, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
         }
 


### PR DESCRIPTION
## Summary
- allow HTML-to-Word and Word-to-HTML converters to accept `CancellationToken`
- plumb cancellation tokens through extension methods and async helpers
- add regression tests verifying conversion cancellation

## Testing
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689d8a8748c4832e9a64489752dad191