### PR TITLE
Resolve font-family handling in HTML conversion

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.Fonts.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.Fonts.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlFonts(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlFonts.docx");
+            string html = "<p style=\"font-family: 'Courier New', monospace\">Sample text</p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+
+            string roundTrip = doc.ToHtml(new WordToHtmlOptions { IncludeFontStyles = true });
+            Console.WriteLine(roundTrip);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/FontResolver.cs
+++ b/OfficeIMO.Tests/FontResolver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 using OfficeIMO.Word;
 using Xunit;
@@ -29,6 +30,14 @@ public class FontResolverTests {
         } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
             Assert.Equal("Helvetica", resolved);
         }
+    }
+
+    [Theory]
+    [InlineData("cursive")]
+    [InlineData("fantasy")]
+    public void Resolve_ExtendedGenericFonts(string generic) {
+        string resolved = FontResolver.Resolve(generic)!;
+        Assert.False(string.Equals(resolved, generic, StringComparison.OrdinalIgnoreCase));
     }
 }
 

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -125,12 +125,16 @@ public partial class Html {
     [Fact]
     public void Test_Html_FontResolver() {
         string html = "<p>Hello</p>";
-        
+
         var doc = html.LoadFromHtml(new HtmlToWordOptions { FontFamily = "monospace" });
         string roundTrip = doc.ToHtml(new WordToHtmlOptions { IncludeFontStyles = true });
-        
-        Assert.Contains($"font-family:{FontResolver.Resolve("monospace")}", roundTrip, StringComparison.OrdinalIgnoreCase);
+
+        string expected = FontResolver.Resolve("monospace")!;
+        Assert.Contains("font-family", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(expected, roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("monospace", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
+
 
     [Fact]
     public void Test_Html_Urls_CreateHyperlinks() {

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -122,7 +122,7 @@ public partial class Html {
         Assert.Contains("data:image/png;base64", roundTrip, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact(Skip = "TODO: Implement font family mapping and CSS font-family support")]
+    [Fact]
     public void Test_Html_FontResolver() {
         string html = "<p>Hello</p>";
         

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -75,14 +75,29 @@ namespace OfficeIMO.Word.Html.Converters {
         private static bool IsGenericFont(string family) =>
             string.Equals(family, "serif", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(family, "sans-serif", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(family, "monospace", StringComparison.OrdinalIgnoreCase);
+            string.Equals(family, "monospace", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(family, "cursive", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(family, "fantasy", StringComparison.OrdinalIgnoreCase);
 
         private static string? ResolveFontFamily(string? family) {
             if (string.IsNullOrWhiteSpace(family)) {
                 return null;
             }
-            var trimmed = family.Trim('"', '\'', ' ');
-            return IsGenericFont(trimmed) ? FontResolver.Resolve(trimmed) : trimmed;
+            foreach (var part in family.Split(',')) {
+                var trimmed = part.Trim('"', '\'', ' ');
+                if (string.IsNullOrEmpty(trimmed)) {
+                    continue;
+                }
+                if (IsGenericFont(trimmed)) {
+                    var resolved = FontResolver.Resolve(trimmed);
+                    if (!string.IsNullOrEmpty(resolved)) {
+                        return resolved;
+                    }
+                } else {
+                    return trimmed;
+                }
+            }
+            return null;
         }
 
         private static void ApplyParagraphStyleFromCss(WordParagraph paragraph, IElement element) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -48,6 +48,10 @@ namespace OfficeIMO.Word.Html.Converters {
             var document = await context.OpenAsync(req => req.Content(html), cancellationToken).ConfigureAwait(false);
 
             var wordDoc = WordDocument.Create();
+            if (!string.IsNullOrEmpty(options.FontFamily)) {
+                var resolved = ResolveFontFamily(options.FontFamily) ?? options.FontFamily;
+                wordDoc.Settings.FontFamily = resolved;
+            }
 
             _footnoteMap.Clear();
             _cssRules.Clear();

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -282,11 +282,14 @@ namespace OfficeIMO.Word.Html.Converters {
                         handledHtmlStyle = true;
                     }
 
-                    if (options.IncludeFontStyles && !string.IsNullOrEmpty(options.FontFamily)) {
-                        var span = htmlDoc.CreateElement("span");
-                        span.SetAttribute("style", $"font-family:{options.FontFamily}");
-                        span.AppendChild(node);
-                        node = span;
+                    if (options.IncludeFontStyles) {
+                        var font = run.FontFamily ?? options.FontFamily;
+                        if (!string.IsNullOrEmpty(font)) {
+                            var span = htmlDoc.CreateElement("span");
+                            span.SetAttribute("style", $"font-family:{font}");
+                            span.AppendChild(node);
+                            node = span;
+                        }
                     }
 
                     if (options.IncludeRunClasses && !string.IsNullOrEmpty(run.CharacterStyleId) && !handledHtmlStyle) {

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -286,7 +286,8 @@ namespace OfficeIMO.Word.Html.Converters {
                         var font = run.FontFamily ?? options.FontFamily;
                         if (!string.IsNullOrEmpty(font)) {
                             var span = htmlDoc.CreateElement("span");
-                            span.SetAttribute("style", $"font-family:{font}");
+                            var value = font.Contains(' ') ? $"\"{font}\"" : font;
+                            span.SetAttribute("style", $"font-family:{value}");
                             span.AppendChild(node);
                             node = span;
                         }
@@ -738,7 +739,8 @@ namespace OfficeIMO.Word.Html.Converters {
                             }
                             var font = rPr.RunFonts?.Ascii;
                             if (!string.IsNullOrEmpty(font)) {
-                                props["font-family"] = font;
+                                string value = font;
+                                props["font-family"] = value.Contains(' ') ? $"\"{value}\"" : value;
                             }
                         }
                     }

--- a/OfficeIMO.Word/Converters/FormattingHelper.cs
+++ b/OfficeIMO.Word/Converters/FormattingHelper.cs
@@ -83,7 +83,10 @@ namespace OfficeIMO.Word {
                 bool superscript = run.VerticalTextAlignment == VerticalPositionValues.Superscript;
                 bool subscript = run.VerticalTextAlignment == VerticalPositionValues.Subscript;
                 string? monospace = FontResolver.Resolve("monospace");
-                bool code = !string.IsNullOrEmpty(monospace) && string.Equals(run.FontFamily, monospace, StringComparison.OrdinalIgnoreCase);
+                string? defaultFont = paragraph._document?.Settings.FontFamily;
+                bool code = !string.IsNullOrEmpty(monospace) &&
+                            string.Equals(run.FontFamily, monospace, StringComparison.OrdinalIgnoreCase) &&
+                            !string.Equals(run.FontFamily, defaultFont, StringComparison.OrdinalIgnoreCase);
                 yield return new FormattedRun(text, null, run.Bold, run.Italic, run.Underline != null, strike, superscript, subscript, code, hyperlink);
             }
         }

--- a/OfficeIMO.Word/Helpers/FontResolver.cs
+++ b/OfficeIMO.Word/Helpers/FontResolver.cs
@@ -12,19 +12,25 @@ public static class FontResolver {
     private static readonly Dictionary<string, string> _windowsFonts = new(StringComparer.OrdinalIgnoreCase) {
         { "serif", "Times New Roman" },
         { "sans-serif", "Calibri" },
-        { "monospace", "Consolas" }
+        { "monospace", "Consolas" },
+        { "cursive", "Comic Sans MS" },
+        { "fantasy", "Impact" }
     };
 
     private static readonly Dictionary<string, string> _linuxFonts = new(StringComparer.OrdinalIgnoreCase) {
         { "serif", "DejaVu Serif" },
         { "sans-serif", "DejaVu Sans" },
-        { "monospace", "DejaVu Sans Mono" }
+        { "monospace", "DejaVu Sans Mono" },
+        { "cursive", "DejaVu Sans" },
+        { "fantasy", "DejaVu Sans" }
     };
 
     private static readonly Dictionary<string, string> _macFonts = new(StringComparer.OrdinalIgnoreCase) {
         { "serif", "Times" },
         { "sans-serif", "Helvetica" },
-        { "monospace", "Menlo" }
+        { "monospace", "Menlo" },
+        { "cursive", "Apple Chancery" },
+        { "fantasy", "Papyrus" }
     };
 
     private static readonly string[] _windowsFallbackFonts = {


### PR DESCRIPTION
## Summary
- resolve generic CSS font families via `FontResolver`
- emit `font-family` styles when converting Word runs to HTML
- enable font resolver round-trip test

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_689d9c923e9c832e8a5d59831c726d3d