### PR TITLE
Apply Word styles based on CSS class rules

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.StylesheetClassStyles.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.StylesheetClassStyles.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlStylesheetClassStyles(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlStylesheetClassStyles.docx");
+            string html = "<style>.title { font-weight:bold; font-size:32px; }</style><p class=\"title\">Title</p><p>Content</p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Html.CssStylesheetClassStyles.cs
+++ b/OfficeIMO.Tests/Html.CssStylesheetClassStyles.cs
@@ -1,0 +1,22 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_CssStylesheet_Paragraph() {
+            string html = "<style>.title { font-weight:bold; font-size:32px; }</style><p class=\"title\">Text</p>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            Assert.Equal(WordParagraphStyles.Heading1, doc.Paragraphs[0].Style);
+        }
+
+        [Fact]
+        public void HtmlToWord_CssStylesheet_ListItem() {
+            string html = "<style>.special { font-weight:bold; font-size:24px; }</style><ul><li class=\"special\">Item</li></ul>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            Assert.Equal(WordParagraphStyles.Heading2, doc.Paragraphs[0].Style);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- parse `<style>` rules and map class selectors to `WordParagraphStyles`
- consult parsed stylesheet mappings when applying class-based styles
- add tests and example demonstrating automatic style application

## Testing
- `dotnet test -c Release`
- `dotnet build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689de35ce154832ebd08b8d4692fd6b3