### PR TITLE
Support CSS float left/right for images and paragraphs

### DIFF
--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
 using System;
 using System.IO;
 using System.Linq;
@@ -84,6 +85,32 @@ namespace OfficeIMO.Tests {
             Assert.Collection(doc.Images, _ => { }, _ => { });
             Assert.Equal(doc.Images[0].RelationshipId, doc.Images[1].RelationshipId);
             Assert.Single(doc._wordprocessingDocument.MainDocumentPart.ImageParts);
+        }
+
+        [Fact]
+        public void ImageFloatLeftWrapsLeft() {
+            var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
+            var base64 = Convert.ToBase64String(File.ReadAllBytes(path));
+            string html = $"<img src=\"data:image/png;base64,{base64}\" style=\"float:left\"/>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var img = Assert.Single(doc.Images);
+            Assert.Equal(WrapTextImage.Square, img.WrapText);
+            var hPos = img.horizontalPosition;
+            Assert.NotNull(hPos.HorizontalAlignment);
+            Assert.Equal("left", hPos.HorizontalAlignment.Text);
+        }
+
+        [Fact]
+        public void ImageFloatRightWrapsRight() {
+            var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
+            var base64 = Convert.ToBase64String(File.ReadAllBytes(path));
+            string html = $"<img src=\"data:image/png;base64,{base64}\" style=\"float:right\"/>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var img = Assert.Single(doc.Images);
+            Assert.Equal(WrapTextImage.Square, img.WrapText);
+            var hPos = img.horizontalPosition;
+            Assert.NotNull(hPos.HorizontalAlignment);
+            Assert.Equal("right", hPos.HorizontalAlignment.Text);
         }
     }
 }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -147,6 +147,15 @@ namespace OfficeIMO.Word.Html.Converters {
                 };
             }
 
+            var floatVal = declaration.GetPropertyValue("float")?.Trim();
+            if (!string.IsNullOrEmpty(floatVal)) {
+                alignment = floatVal.ToLowerInvariant() switch {
+                    "left" => JustificationValues.Left,
+                    "right" => JustificationValues.Right,
+                    _ => alignment
+                };
+            }
+
             if (TryConvertToTwip(declaration.GetProperty("padding-left")?.RawValue, out int pl)) paddingLeft = pl;
             if (TryConvertToTwip(declaration.GetProperty("padding-right")?.RawValue, out int pr)) paddingRight = pr;
             if (TryConvertToTwip(declaration.GetProperty("padding-top")?.RawValue, out int pt)) paddingTop = pt;


### PR DESCRIPTION
## Summary
- honor CSS `float` to set paragraph alignment
- float images using wrap and horizontal alignment
- add tests for left/right floated images

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689ecbd2d6ec832ea6f11b62e243b783