### PR TITLE
Handle additional HTML structural tags

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.StructuralTags.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.StructuralTags.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlStructuralTags(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlStructuralTags.docx");
+            string html = "<address style=\"text-align:right\"><p>Location</p></address>" +
+                          "<article style=\"text-align:center\"><p>Article text</p></article>" +
+                          "<aside style=\"text-align:justify\"><p>Aside note</p></aside>" +
+                          "<nav style=\"margin-left:20pt;padding-left:10pt\"><p>Menu</p></nav>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Html.StructuralTags.cs
+++ b/OfficeIMO.Tests/Html.StructuralTags.cs
@@ -1,0 +1,52 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_Address_ParsesLikeDiv() {
+            string html = "<address style=\"text-align:right\"><p>Location</p></address>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var paragraph = doc.Paragraphs[0];
+
+            Assert.Equal("Location", paragraph.Text);
+            Assert.Equal(JustificationValues.Right, paragraph.ParagraphAlignment);
+        }
+
+        [Fact]
+        public void HtmlToWord_Article_ParsesLikeDiv() {
+            string html = "<article style=\"text-align:center\"><p>Article text</p></article>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var paragraph = doc.Paragraphs[0];
+
+            Assert.Equal("Article text", paragraph.Text);
+            Assert.Equal(JustificationValues.Center, paragraph.ParagraphAlignment);
+        }
+
+        [Fact]
+        public void HtmlToWord_Aside_ParsesLikeDiv() {
+            string html = "<aside style=\"text-align:justify\"><p>Aside note</p></aside>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var paragraph = doc.Paragraphs[0];
+
+            Assert.Equal("Aside note", paragraph.Text);
+            Assert.Equal(JustificationValues.Both, paragraph.ParagraphAlignment);
+        }
+
+        [Fact]
+        public void HtmlToWord_Nav_ParsesLikeDiv() {
+            string html = "<nav style=\"margin-left:20pt;padding-left:10pt\"><p>Menu</p></nav>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var paragraph = doc.Paragraphs[0];
+
+            Assert.Equal("Menu", paragraph.Text);
+            Assert.Equal(30d, paragraph.IndentationBeforePoints);
+        }
+    }
+}
+

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -522,7 +522,11 @@ namespace OfficeIMO.Word.Html.Converters {
                             }
                             break;
                         }
-                    case "div": {
+                    case "div":
+                    case "address":
+                    case "article":
+                    case "aside":
+                    case "nav": {
                             var fmt = formatting;
                             var divStyle = element.GetAttribute("style");
                             if (!string.IsNullOrWhiteSpace(divStyle)) {


### PR DESCRIPTION
## Summary
- parse `address`, `article`, `aside`, and `nav` tags like `div` during HTML-to-Word conversion
- add unit coverage for new structural tags
- provide an example demonstrating the new HTML tags

## Testing
- `dotnet test`
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_689ecbbc949c832e9a70c327c87b4267