### PR TITLE
feat: add style missing event

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.StyleMissing.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.StyleMissing.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlStyleMissing(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlStyleMissing.docx");
+            string html = "<p class=\"warning\">Warning</p>";
+            EventHandler<StyleMissingEventArgs> handler = (s, e) => {
+                if (e.ClassName == "warning") {
+                    WordParagraphStyle.RegisterFontStyle("WarningStyle", "Courier New");
+                    e.StyleId = "WarningStyle";
+                }
+            };
+            WordHtmlConverterExtensions.StyleMissing += handler;
+            var doc = html.LoadFromHtml();
+            WordHtmlConverterExtensions.StyleMissing -= handler;
+            doc.Save(filePath);
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.StyleMissing.cs
+++ b/OfficeIMO.Tests/Html.StyleMissing.cs
@@ -1,0 +1,44 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_StyleMissing_EventProvidesReplacement() {
+            string html = "<p class=\"unknown\">Text</p>";
+            bool invoked = false;
+            EventHandler<StyleMissingEventArgs> handler = (s, e) => {
+                invoked = true;
+                e.Style = WordParagraphStyles.Heading1;
+            };
+            WordHtmlConverterExtensions.StyleMissing += handler;
+            try {
+                var doc = html.LoadFromHtml();
+                Assert.True(invoked);
+                Assert.Equal(WordParagraphStyles.Heading1, doc.Paragraphs[0].Style);
+            } finally {
+                WordHtmlConverterExtensions.StyleMissing -= handler;
+            }
+        }
+
+        [Fact]
+        public void HtmlToWord_StyleMissing_CreateStyleOnDemand() {
+            string html = "<p class=\"custom\">Text</p>";
+            string styleId = "DynamicStyle";
+            EventHandler<StyleMissingEventArgs> handler = (s, e) => {
+                if (e.ClassName == "custom") {
+                    WordParagraphStyle.RegisterFontStyle(styleId, "Courier New");
+                    e.StyleId = styleId;
+                }
+            };
+            WordHtmlConverterExtensions.StyleMissing += handler;
+            try {
+                var doc = html.LoadFromHtml();
+                Assert.Equal(styleId, doc.Paragraphs[0].StyleId);
+            } finally {
+                WordHtmlConverterExtensions.StyleMissing -= handler;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -7,6 +7,7 @@ using AngleSharp.Html.Dom;
 using AngleSharp.Io;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
 using OfficeIMO.Word.Html.Helpers;
 using System;
 using System.Collections.Concurrent;
@@ -861,6 +862,16 @@ namespace OfficeIMO.Word.Html.Converters {
             foreach (var cls in classAttr.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)) {
                 if (options.ClassStyles.TryGetValue(cls, out var style) || _cssClassStyles.TryGetValue(cls, out style)) {
                     paragraph.Style = style;
+                    break;
+                }
+
+                var args = WordHtmlConverterExtensions.OnStyleMissing(paragraph, cls);
+                if (args.Style.HasValue) {
+                    paragraph.Style = args.Style.Value;
+                    break;
+                }
+                if (!string.IsNullOrEmpty(args.StyleId)) {
+                    paragraph.SetStyleId(args.StyleId);
                     break;
                 }
             }

--- a/OfficeIMO.Word.Html/StyleMissingEventArgs.cs
+++ b/OfficeIMO.Word.Html/StyleMissingEventArgs.cs
@@ -1,0 +1,15 @@
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Word.Html {
+    public class StyleMissingEventArgs : EventArgs {
+        public StyleMissingEventArgs(WordParagraph paragraph, string className) {
+            Paragraph = paragraph ?? throw new ArgumentNullException(nameof(paragraph));
+            ClassName = className ?? throw new ArgumentNullException(nameof(className));
+        }
+
+        public WordParagraph Paragraph { get; }
+        public string ClassName { get; }
+        public WordParagraphStyles? Style { get; set; }
+        public string? StyleId { get; set; }
+    }
+}

--- a/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
+++ b/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
@@ -12,6 +12,14 @@ namespace OfficeIMO.Word.Html {
     /// Extension methods enabling HTML conversions for <see cref="WordDocument"/> instances.
     /// </summary>
     public static class WordHtmlConverterExtensions {
+        public static event EventHandler<StyleMissingEventArgs>? StyleMissing;
+
+        internal static StyleMissingEventArgs OnStyleMissing(WordParagraph paragraph, string className) {
+            var args = new StyleMissingEventArgs(paragraph, className);
+            StyleMissing?.Invoke(null, args);
+            return args;
+        }
+
         /// <summary>
         /// Saves the document as an HTML file at the specified path.
         /// </summary>


### PR DESCRIPTION
## Summary
- add `StyleMissing` event to customize paragraph styles when HTML class has no mapping
- support handlers that provide replacement styles or style IDs
- cover event usage with tests and example

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689ecbdc87b4832e938c08b091d0a2f6