### PR TITLE
Handle named font sizes, percentages and small-caps in HTML converter

### DIFF
--- a/OfficeIMO.Tests/Html.SpanStyles.cs
+++ b/OfficeIMO.Tests/Html.SpanStyles.cs
@@ -59,5 +59,35 @@ namespace OfficeIMO.Tests {
             var subRun = runs.First(r => r.Text == "sub");
             Assert.Equal(VerticalPositionValues.Subscript, subRun.VerticalTextAlignment);
         }
+
+        [Fact]
+        public void HtmlToWord_SpanStyles_FontSizeNamed() {
+            string html = "<p><span style=\"font-size:small\">text</span></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var run = doc.Paragraphs[0].GetRuns().First();
+
+            Assert.Equal(13, run.FontSize);
+        }
+
+        [Fact]
+        public void HtmlToWord_SpanStyles_FontSizePercentage() {
+            string html = "<p><span style=\"font-size:200%\">text</span></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var run = doc.Paragraphs[0].GetRuns().First();
+
+            Assert.Equal(32, run.FontSize);
+        }
+
+        [Fact]
+        public void HtmlToWord_SpanStyles_SmallCaps() {
+            string html = "<p><span style=\"font-variant:small-caps\">caps</span></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var run = doc.Paragraphs[0].GetRuns().First();
+
+            Assert.Equal(CapsStyle.SmallCaps, run.CapsStyle);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- support CSS named font sizes and percentages in HtmlToWordConverter
- parse `font-variant: small-caps` and apply to runs
- add tests for named/percentage sizes and small-caps styling

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689ed1c80204832e9e76ac17e34d692e