### PR TITLE
feat(html): support letter-spacing and text-transform

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.TextTransformLetterSpacing.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.TextTransformLetterSpacing.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlTextTransformLetterSpacing(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlTextTransformLetterSpacing.docx");
+            string html = "<p style=\"letter-spacing:2pt;text-transform:uppercase\">Hello World</p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.LetterSpacing.cs
+++ b/OfficeIMO.Tests/Html.LetterSpacing.cs
@@ -1,0 +1,17 @@
+using System.Linq;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_LetterSpacing() {
+            string html = "<p style=\"letter-spacing:2pt\">space</p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var run = doc.Paragraphs[0].GetRuns().First();
+
+            Assert.Equal(40, run.Spacing);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.TextTransform.cs
+++ b/OfficeIMO.Tests/Html.TextTransform.cs
@@ -1,0 +1,20 @@
+using System.Linq;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Theory]
+        [InlineData("uppercase", "Hello World", "HELLO WORLD")]
+        [InlineData("lowercase", "Hello World", "hello world")]
+        [InlineData("capitalize", "hello world", "Hello World")]
+        public void HtmlToWord_TextTransform(string transform, string input, string expected) {
+            string html = $"<p><span style=\"text-transform:{transform}\">{input}</span></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var run = doc.Paragraphs[0].GetRuns().First();
+
+            Assert.Equal(expected, run.Text);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- handle `letter-spacing` and `text-transform` CSS during HTML import
- apply text casing conversions before inserting runs
- add examples and unit tests for spacing and text casing

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "HtmlToWord_LetterSpacing"`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "HtmlToWord_TextTransform"`


------
https://chatgpt.com/codex/tasks/task_e_689ed1c36204832e83fe4b2733a3aa12