### PR TITLE
Parse letter-spacing and text-transform in HTML converter

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.TextTransformAndLetterSpacing.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.TextTransformAndLetterSpacing.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlTextTransformAndLetterSpacing(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlTextTransformAndLetterSpacing.docx");
+            string html = "<p style=\"text-transform:uppercase;letter-spacing:2pt\">Example Text</p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.LetterSpacing.cs
+++ b/OfficeIMO.Tests/Html.LetterSpacing.cs
@@ -1,0 +1,15 @@
+using System.Linq;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_LetterSpacing() {
+            string html = "<p style=\"letter-spacing:2pt\">spaced</p>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var run = doc.Paragraphs.First();
+            Assert.Equal(40, run.Spacing);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.TextTransform.cs
+++ b/OfficeIMO.Tests/Html.TextTransform.cs
@@ -1,0 +1,18 @@
+using System.Linq;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Theory]
+        [InlineData("uppercase", "HeLLo wORld", "HELLO WORLD")]
+        [InlineData("lowercase", "HeLLo wORld", "hello world")]
+        [InlineData("capitalize", "hello world", "Hello World")]
+        public void HtmlToWord_TextTransform(string transform, string input, string expected) {
+            string html = $"<p style=\"text-transform:{transform}\">{input}</p>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var run = doc.Paragraphs.First();
+            Assert.Equal(expected, run.Text);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `TextTransform` enum and letter-spacing support in HTML to Word converter
- transform run text for `text-transform` and apply character spacing from `letter-spacing`
- document usage with example and cover scenarios with new tests

## Testing
- `dotnet build`
- `dotnet test --no-build --filter HtmlToWord_LetterSpacing`
- `dotnet test --no-build --filter HtmlToWord_TextTransform`


------
https://chatgpt.com/codex/tasks/task_e_689edc075a50832eb53fe6e99d844ead