### PR TITLE
feat(word): add image cloning API

### DIFF
--- a/OfficeIMO.Examples/Word/Images/Images.Clone.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.Clone.cs
@@ -1,0 +1,21 @@
+using System;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Images {
+        internal static void Example_CloneImage(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Cloning image in a document");
+            var filePath = System.IO.Path.Combine(folderPath, "DocumentWithClonedImage.docx");
+            var imagePath = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "Images", "Kulek.jpg");
+
+            using var document = WordDocument.Create(filePath);
+            var paragraph1 = document.AddParagraph();
+            paragraph1.AddImage(imagePath, 100, 100);
+
+            var paragraph2 = document.AddParagraph();
+            paragraph1.Image.Clone(paragraph2);
+
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -88,6 +88,16 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void DuplicateImageFileSrcSharesPart() {
+            var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
+            string html = $"<p><img src=\"{path}\"/><img src=\"{path}\"/></p>"; 
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            Assert.Equal(2, doc.Images.Count);
+            Assert.Equal(doc.Images[0].RelationshipId, doc.Images[1].RelationshipId);
+            Assert.Single(doc._wordprocessingDocument.MainDocumentPart.ImageParts);
+        }
+
+        [Fact]
         public void ImageFloatLeftWrapsLeft() {
             var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
             var base64 = Convert.ToBase64String(File.ReadAllBytes(path));

--- a/OfficeIMO.Tests/Word.ImageClone.cs
+++ b/OfficeIMO.Tests/Word.ImageClone.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void WordImage_Clone_ReusesImagePart() {
+            var filePath = Path.Combine(_directoryWithFiles, "ImageClone.docx");
+            using var document = WordDocument.Create(filePath);
+
+            var paragraph1 = document.AddParagraph();
+            paragraph1.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 50, 50);
+
+            var paragraph2 = document.AddParagraph();
+            var clone = paragraph1.Image.Clone(paragraph2);
+
+            Assert.Equal(paragraph1.Image.RelationshipId, clone.RelationshipId);
+            Assert.Equal(2, document.Images.Count);
+            Assert.Single(document._wordprocessingDocument.MainDocumentPart.ImageParts);
+
+            document.Save(false);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -1,13 +1,11 @@
 using AngleSharp.Html.Dom;
 using AngleSharp.Dom;
-using DocumentFormat.OpenXml.Wordprocessing;
 using Wp = DocumentFormat.OpenXml.Drawing.Wordprocessing;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html.Helpers;
 using System;
 using System.IO;
 using System.Net.Http;
-using System.Reflection;
 using System.Text;
 
 namespace OfficeIMO.Word.Html.Converters {
@@ -49,13 +47,7 @@ namespace OfficeIMO.Word.Html.Converters {
 
             if (horizontalAlignment == null && _imageCache.TryGetValue(src, out var cached)) {
                 paragraph ??= headerFooter != null ? headerFooter.AddParagraph() : doc.AddParagraph();
-                var drawingField = typeof(WordImage).GetField("_Image", BindingFlags.Instance | BindingFlags.NonPublic);
-                var drawing = (DocumentFormat.OpenXml.Wordprocessing.Drawing)drawingField!.GetValue(cached);
-                var clone = (DocumentFormat.OpenXml.Wordprocessing.Drawing)drawing.CloneNode(true);
-                var run = new Run(clone);
-                var paragraphField = typeof(WordParagraph).GetField("_paragraph", BindingFlags.Instance | BindingFlags.NonPublic);
-                var p = (Paragraph)paragraphField!.GetValue(paragraph);
-                p.Append(run);
+                cached.Clone(paragraph);
                 return;
             }
 

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -1987,6 +1987,22 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Creates a copy of this image and appends it to the specified paragraph.
+        /// The cloned image shares the same underlying image part.
+        /// </summary>
+        /// <param name="paragraph">The paragraph to append the cloned image to.</param>
+        /// <returns>The newly created <see cref="WordImage"/> instance.</returns>
+        public WordImage Clone(WordParagraph paragraph) {
+            if (paragraph == null) throw new ArgumentNullException(nameof(paragraph));
+
+            var drawingClone = (Drawing)_Image.CloneNode(true);
+            var run = new DocumentFormat.OpenXml.Wordprocessing.Run(drawingClone);
+            paragraph._paragraph.Append(run);
+
+            return new WordImage(paragraph._document, drawingClone);
+        }
+
+        /// <summary>
         /// Extract image from Word Document and save it to file
         /// </summary>
         /// <param name="fileToSave"></param>


### PR DESCRIPTION
## Summary
- add `WordImage.Clone` to duplicate images without reflection
- refactor HTML image processing to use cloning
- add tests and example for image reuse

## Testing
- `dotnet build`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_689ef4644864832ea898864e75c7da7f