### PR TITLE
Support CSS white-space handling in HTML converter

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html.WhiteSpace.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html.WhiteSpace.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+
+namespace OfficeIMO.Examples.Html {
+    internal static partial class Html {
+        public static void Example_HtmlWhiteSpace(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "HtmlWhiteSpace.docx");
+            string html = "<p style=\"white-space:normal\">Hello   world\nFoo</p>" +
+                          "<p style=\"white-space:pre\">Hello   world\nFoo</p>" +
+                          "<p style=\"white-space:pre-wrap\">Hello   world\nFoo</p>" +
+                          "<p style=\"white-space:nowrap\">Hello   world\nFoo</p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            doc.Save(filePath);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.WhiteSpace.cs
+++ b/OfficeIMO.Tests/Html.WhiteSpace.cs
@@ -1,0 +1,42 @@
+using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
+using System.Linq;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlToWord_WhiteSpace_Normal() {
+            string html = "<p style=\"white-space:normal\">Hello   world\nFoo</p>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var text = string.Concat(doc.Paragraphs[0].GetRuns().Where(r => !r.IsBreak).Select(r => r.Text));
+            Assert.Equal("Hello world Foo", text);
+        }
+
+        [Fact]
+        public void HtmlToWord_WhiteSpace_Pre() {
+            string html = "<p style=\"white-space:pre\">Hello   world\nFoo</p>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var runs = doc.Paragraphs[0].GetRuns().Where(r => !r.IsBreak).ToArray();
+            Assert.Equal("Hello\u00A0\u00A0\u00A0world", runs[0].Text);
+            Assert.Equal("Foo", runs[1].Text);
+        }
+
+        [Fact]
+        public void HtmlToWord_WhiteSpace_PreWrap() {
+            string html = "<p style=\"white-space:pre-wrap\">Hello   world\nFoo</p>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var runs = doc.Paragraphs[0].GetRuns().Where(r => !r.IsBreak).ToArray();
+            Assert.Equal("Hello   world", runs[0].Text);
+            Assert.Equal("Foo", runs[1].Text);
+        }
+
+        [Fact]
+        public void HtmlToWord_WhiteSpace_NoWrap() {
+            string html = "<p style=\"white-space:nowrap\">Hello   world\nFoo</p>";
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var text = string.Concat(doc.Paragraphs[0].GetRuns().Where(r => !r.IsBreak).Select(r => r.Text));
+            Assert.Equal("Hello\u00A0world\u00A0Foo", text);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -45,11 +45,15 @@ namespace OfficeIMO.Word.Html.Converters {
                     : headerFooter != null ? headerFooter.AddParagraph("")
                     : section.AddParagraph("");
                 captionParagraph.SetStyleId("Caption");
-                ApplyParagraphStyleFromCss(captionParagraph, caption);
+                var props = ApplyParagraphStyleFromCss(captionParagraph, caption);
                 ApplyClassStyle(caption, captionParagraph, options);
                 AddBookmarkIfPresent(caption, captionParagraph);
+                var fmt = new TextFormatting();
+                if (props.WhiteSpace.HasValue) {
+                    fmt.WhiteSpace = props.WhiteSpace.Value;
+                }
                 foreach (var child in caption.ChildNodes) {
-                    ProcessNode(child, doc, section, options, captionParagraph, listStack, new TextFormatting(), cell, headerFooter);
+                    ProcessNode(child, doc, section, options, captionParagraph, listStack, fmt, cell, headerFooter);
                 }
             }
 
@@ -146,11 +150,15 @@ namespace OfficeIMO.Word.Html.Converters {
                     captionParagraphBelow = lastCellParagraph.AddParagraphAfterSelf(section);
                 }
                 captionParagraphBelow.SetStyleId("Caption");
-                ApplyParagraphStyleFromCss(captionParagraphBelow, caption);
+                var propsBelow = ApplyParagraphStyleFromCss(captionParagraphBelow, caption);
                 ApplyClassStyle(caption, captionParagraphBelow, options);
                 AddBookmarkIfPresent(caption, captionParagraphBelow);
+                var fmtBelow = new TextFormatting();
+                if (propsBelow.WhiteSpace.HasValue) {
+                    fmtBelow.WhiteSpace = propsBelow.WhiteSpace.Value;
+                }
                 foreach (var child in caption.ChildNodes) {
-                    ProcessNode(child, doc, section, options, captionParagraphBelow, listStack, new TextFormatting(), cell, headerFooter);
+                    ProcessNode(child, doc, section, options, captionParagraphBelow, listStack, fmtBelow, cell, headerFooter);
                 }
             }
         }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -411,11 +411,15 @@ namespace OfficeIMO.Word.Html.Converters {
                                 paragraph = cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
                             }
                             paragraph.Style = HeadingStyleMapper.GetHeadingStyleForLevel(level);
-                            ApplyParagraphStyleFromCss(paragraph, element);
+                            var props = ApplyParagraphStyleFromCss(paragraph, element);
                             ApplyClassStyle(element, paragraph, options);
                             AddBookmarkIfPresent(element, paragraph);
+                            var fmt = formatting;
+                            if (props.WhiteSpace.HasValue) {
+                                fmt.WhiteSpace = props.WhiteSpace.Value;
+                            }
                             foreach (var child in element.ChildNodes) {
-                                ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell, headerFooter, headingList);
+                                ProcessNode(child, doc, section, options, paragraph, listStack, fmt, cell, headerFooter, headingList);
                             }
                             break;
                         }
@@ -423,7 +427,10 @@ namespace OfficeIMO.Word.Html.Converters {
                             var paragraph = cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
-                            ApplyParagraphStyleFromCss(paragraph, element);
+                            var props = ApplyParagraphStyleFromCss(paragraph, element);
+                            if (props.WhiteSpace.HasValue) {
+                                fmt.WhiteSpace = props.WhiteSpace.Value;
+                            }
                             ApplyClassStyle(element, paragraph, options);
                             AddBookmarkIfPresent(element, paragraph);
                             foreach (var child in element.ChildNodes) {

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
@@ -8,6 +8,13 @@ using Color = SixLabors.ImageSharp.Color;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace OfficeIMO.Word.Html.Helpers {
+    internal enum WhiteSpaceMode {
+        Normal,
+        Pre,
+        PreWrap,
+        NoWrap,
+    }
+
     internal static class CssStyleMapper {
         internal class CssProperties {
             public int? MarginLeft;
@@ -19,6 +26,7 @@ namespace OfficeIMO.Word.Html.Helpers {
             public string? BackgroundColor;
             public int? LineHeight;
             public LineSpacingRuleValues? LineHeightRule;
+            public WhiteSpaceMode? WhiteSpace;
         }
 
         public static WordParagraphStyles? MapParagraphStyle(string? style) {
@@ -89,6 +97,17 @@ namespace OfficeIMO.Word.Html.Helpers {
             if (properties.TryGetValue("line-height", out string? lh) && TryParseLineHeight(lh, out int line, out LineSpacingRuleValues rule)) {
                 result.LineHeight = line;
                 result.LineHeightRule = rule;
+            }
+
+            if (properties.TryGetValue("white-space", out string? ws)) {
+                ws = ws.Trim().ToLowerInvariant();
+                result.WhiteSpace = ws switch {
+                    "normal" => WhiteSpaceMode.Normal,
+                    "pre" => WhiteSpaceMode.Pre,
+                    "pre-wrap" => WhiteSpaceMode.PreWrap,
+                    "nowrap" => WhiteSpaceMode.NoWrap,
+                    _ => null,
+                };
             }
 
             return result;


### PR DESCRIPTION
## Summary
- parse CSS `white-space` values and track on formatting
- respect `white-space` when adding text runs to preserve or collapse spaces
- propagate parsed `white-space` into paragraph processing
- add example and unit tests for whitespace modes

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689f240ac80c832eb1c37af497f18ba9