### PR TITLE
Stream image data for WordImage and add performance test

### DIFF
--- a/OfficeIMO.Tests/Word.Images.cs
+++ b/OfficeIMO.Tests/Word.Images.cs
@@ -614,6 +614,32 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Test_ImageStreamPerformance() {
+            var filePath = Path.Combine(_directoryWithFiles, "ImageStreamPerformance.docx");
+            using var document = WordDocument.Create(filePath);
+
+            var imagePath = Path.Combine(_directoryWithImages, "Kulek.jpg");
+            document.AddParagraph().AddImage(imagePath, 100, 100);
+
+            var image = document.Images[0];
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            var before = GC.GetTotalMemory(true);
+            using (var stream = image.GetStream()) {
+                Assert.False(stream is MemoryStream);
+                var buffer = new byte[1];
+                stream.Read(buffer, 0, 1);
+            }
+            var after = GC.GetTotalMemory(true);
+
+            var fileLength = new FileInfo(imagePath).Length;
+            Assert.True(Math.Abs(after - before) < fileLength / 2);
+        }
+
     }
 
 }

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -2035,20 +2035,15 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
-        /// Retrieves the image data as a new memory stream.
+        /// Retrieves the image data as a stream without loading the entire image into memory.
         /// </summary>
-        /// <returns>A <see cref="Stream"/> containing the image bytes.</returns>
+        /// <returns>A <see cref="Stream"/> for reading the image bytes.</returns>
         public Stream GetStream() {
             if (_imagePart == null) {
                 throw new InvalidOperationException("Image is linked externally and cannot be extracted.");
             }
 
-            MemoryStream ms = new MemoryStream();
-            using (var stream = _imagePart.GetStream()) {
-                stream.CopyTo(ms);
-            }
-            ms.Position = 0;
-            return ms;
+            return _imagePart.GetStream();
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -2025,9 +2025,8 @@ namespace OfficeIMO.Word {
 
             try {
                 using (FileStream outputFileStream = new FileStream(fileToSave, FileMode.Create, FileAccess.Write, FileShare.None)) {
-                    var stream = _imagePart.GetStream();
+                    using var stream = _imagePart.GetStream(FileMode.Open, FileAccess.Read);
                     stream.CopyTo(outputFileStream);
-                    stream.Close();
                 }
             } catch (UnauthorizedAccessException ex) {
                 throw new IOException($"Failed to save to '{fileToSave}'. Access denied or path is read-only.", ex);
@@ -2043,7 +2042,7 @@ namespace OfficeIMO.Word {
                 throw new InvalidOperationException("Image is linked externally and cannot be extracted.");
             }
 
-            return _imagePart.GetStream();
+            return _imagePart.GetStream(FileMode.Open, FileAccess.Read);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- stream image data from `ImagePart` instead of buffering in memory
- add performance test verifying streamed image access

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689f255c34e8832e90aa0e187c36cd5e