### PR TITLE
feat: add numbering definition helpers

### DIFF
--- a/OfficeIMO.Examples/Word/Lists/Lists.NumberingDefinition.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.NumberingDefinition.cs
@@ -1,0 +1,19 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Lists {
+        internal static void Example_NumberingDefinition(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "NumberingDefinition.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var numbering = document.CreateNumberingDefinition();
+                numbering.AddLevel(new WordListLevel(WordListLevelKind.Decimal));
+                var retrieved = document.GetNumberingDefinition(numbering.AbstractNumberId);
+                Console.WriteLine("Numbering levels: " + retrieved.Levels.Count);
+                document.Save(openWord);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Word.ListNumbering.cs
+++ b/OfficeIMO.Tests/Word.ListNumbering.cs
@@ -1,0 +1,28 @@
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_CreateAndRetrieveNumberingDefinition() {
+            string filePath = Path.Combine(_directoryWithFiles, "NumberingDefinition.docx");
+            int abstractId;
+
+            using (var document = WordDocument.Create(filePath)) {
+                var numbering = document.CreateNumberingDefinition();
+                numbering.AddLevel(new WordListLevel(WordListLevelKind.Decimal));
+                abstractId = numbering.AbstractNumberId;
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                var numbering = document.GetNumberingDefinition(abstractId);
+                Assert.NotNull(numbering);
+                Assert.Single(numbering.Levels);
+                Assert.Equal(abstractId, numbering.AbstractNumberId);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -316,6 +316,23 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Creates a numbering definition that can be customized and reused.
+        /// </summary>
+        /// <returns>The created <see cref="WordListNumbering"/>.</returns>
+        public WordListNumbering CreateNumberingDefinition() {
+            return WordListNumbering.CreateNumberingDefinition(this);
+        }
+
+        /// <summary>
+        /// Retrieves a numbering definition by its identifier.
+        /// </summary>
+        /// <param name="abstractNumberId">Identifier of the numbering definition.</param>
+        /// <returns>The <see cref="WordListNumbering"/> if found; otherwise, <c>null</c>.</returns>
+        public WordListNumbering GetNumberingDefinition(int abstractNumberId) {
+            return WordListNumbering.GetNumberingDefinition(this, abstractNumberId);
+        }
+
+        /// <summary>
         /// Adds a table to the end of the document body.
         /// </summary>
         /// <param name="rows">Number of rows to create.</param>


### PR DESCRIPTION
## Summary
- support creating and retrieving numbering definitions
- expose numbering definition helpers on WordDocument
- add example and tests for numbering definitions

## Testing
- `dotnet build --no-restore`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Test_CreateAndRetrieveNumberingDefinition`


------
https://chatgpt.com/codex/tasks/task_e_689f41ce4cd8832e9a7dd3f179350374