### PR TITLE
Use image descriptions for Markdown alt text

### DIFF
--- a/OfficeIMO.Examples/Converters/Markdown/Markdown.Images.cs
+++ b/OfficeIMO.Examples/Converters/Markdown/Markdown.Images.cs
@@ -8,9 +8,9 @@ namespace OfficeIMO.Examples.Markdown {
         public static void Example_MarkdownImages(string folderPath, bool openWord) {
             string assets = Path.Combine(AppContext.BaseDirectory, "..", "Assets");
             string localImage = Path.Combine(assets, "OfficeIMO.png");
-            string markdown = $"![Local image]({localImage} \"Local description\" =100x100)\n" +
-                               "![Remote image](https://via.placeholder.com/120 \"Remote description\" =120x80)\n" +
-                               $"![Native size]({localImage} \"No size hints\")";
+            string markdown = $"![Local description]({localImage} =100x100)\n" +
+                               "![Remote description](https://via.placeholder.com/120 =120x80)\n" +
+                               $"![Native size]({localImage})";
 
             var doc = markdown.LoadFromMarkdown(new MarkdownToWordOptions());
             string filePath = Path.Combine(folderPath, "MarkdownImages.docx");

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Inlines.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Inlines.cs
@@ -90,6 +90,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
 
         private static void AddImage(WordDocument document, WordParagraph paragraph, LinkInline link) {
             string url = link.Url?.Trim() ?? string.Empty;
+            string altText = GetPlainText(link.FirstChild);
             string? title = link.Title?.Trim();
             double? width = null;
             double? height = null;
@@ -176,15 +177,15 @@ namespace OfficeIMO.Word.Markdown.Converters {
             if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase)) {
                 if (imageData != null) {
                     using var ms = new MemoryStream(imageData);
-                    paragraph.AddImage(ms, remoteFileName ?? "image", width, height, description: title ?? string.Empty);
+                    paragraph.AddImage(ms, remoteFileName ?? "image", width, height, description: altText);
                 } else {
                     var img = document.AddImageFromUrl(url, width, height);
-                    if (!string.IsNullOrEmpty(title)) {
-                        img.Description = title;
+                    if (!string.IsNullOrEmpty(altText)) {
+                        img.Description = altText;
                     }
                 }
             } else {
-                paragraph.AddImage(url, width, height, description: title ?? string.Empty);
+                paragraph.AddImage(url, width, height, description: altText);
             }
         }
 

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Paragraphs.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Paragraphs.cs
@@ -117,9 +117,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
                 return string.Empty;
             }
 
-            string alt = !string.IsNullOrEmpty(image.Description)
-                ? image.Description
-                : (string.IsNullOrEmpty(image.FilePath) ? "" : Path.GetFileName(image.FilePath));
+            string alt = image.Description ?? string.Empty;
 
             if (options.ImageExportMode == ImageExportMode.File) {
                 string directory = options.ImageDirectory ?? Directory.GetCurrentDirectory();


### PR DESCRIPTION
## Summary
- use `WordImage.Description` when rendering Markdown images
- populate `WordImage.Description` from Markdown image alt text
- test image description round-trips and update example

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "MarkdownToWord_ParsesImageHints|MarkdownToWord_UsesNaturalSizeWhenNoHints|WordToMarkdown_WritesImageDescription"`


------
https://chatgpt.com/codex/tasks/task_e_689f420019a0832eadbf89d8fa4f40e3