### PR TITLE
Add section cloning support

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -269,6 +269,7 @@ namespace OfficeIMO.Examples {
             OfficeIMO.Examples.Word.Sections.Example_SectionsWithHeaders(folderPath, false);
             OfficeIMO.Examples.Word.Sections.Example_SectionsWithHeadersDefault(folderPath, false);
             OfficeIMO.Examples.Word.Sections.Example_SectionsWithParagraphs(folderPath, false);
+            OfficeIMO.Examples.Word.Sections.Example_CloneSection(folderPath, false);
             // Word/Shapes
             OfficeIMO.Examples.Word.Shapes.Example_AddBasicShape(folderPath, false);
             OfficeIMO.Examples.Word.Shapes.Example_AddEllipseAndPolygon(folderPath, false);

--- a/OfficeIMO.Examples/Word/Sections/Sections.Example8.cs
+++ b/OfficeIMO.Examples/Word/Sections/Sections.Example8.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal partial class Sections {
+        internal static void Example_CloneSection(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Cloning sections");
+            string filePath = Path.Combine(folderPath, "Document with Cloned Section.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Section0 - Paragraph0");
+                var section1 = document.AddSection();
+                section1.AddParagraph("Section1 - Paragraph0");
+                document.AddParagraph("Section2 - Paragraph0");
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var clone = document.Sections[0].CloneSection();
+                Console.WriteLine("+ Sections: " + document.Sections.Count);
+                Console.WriteLine("Section 0 P0: " + document.Sections[0].Paragraphs[0].Text);
+                Console.WriteLine("Section 1 P0: " + document.Sections[1].Paragraphs[0].Text);
+                Console.WriteLine("Section 2 P0: " + document.Sections[2].Paragraphs[0].Text);
+                Console.WriteLine("Section 3 P0: " + document.Sections[3].Paragraphs[0].Text);
+                document.Save(openWord);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Word.Sections.cs
+++ b/OfficeIMO.Tests/Word.Sections.cs
@@ -548,6 +548,36 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CloningSection() {
+            string filePath = Path.Combine(_directoryWithFiles, "CloneSection.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Section0");
+                var section1 = document.AddSection();
+                section1.AddParagraph("Section1");
+                var section2 = document.AddSection();
+                section2.AddParagraph("Section2");
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal(3, document.Sections.Count);
+                var clone = document.Sections[1].CloneSection();
+                document.Save(false);
+                Assert.Equal(4, document.Sections.Count);
+                Assert.Equal("Section1", document.Sections[1].Paragraphs[0].Text);
+                Assert.Equal("Section1", document.Sections[2].Paragraphs[0].Text);
+                Assert.Equal("Section2", document.Sections[3].Paragraphs[0].Text);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal(4, document.Sections.Count);
+                Assert.Equal("Section1", document.Sections[1].Paragraphs[0].Text);
+                Assert.Equal("Section1", document.Sections[2].Paragraphs[0].Text);
+                Assert.Equal("Section2", document.Sections[3].Paragraphs[0].Text);
+            }
+        }
+
+        [Fact]
         public void Test_HeaderFooterReturnNullWhenNoSections() {
             string filePath = Path.Combine(_directoryWithFiles, "NoSectionsHeaderFooter.docx");
 

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -583,6 +583,19 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Clones the section at the specified index and inserts the clone after it.
+        /// </summary>
+        /// <param name="index">Zero based index of the section to clone.</param>
+        /// <returns>The cloned <see cref="WordSection"/>.</returns>
+        public WordSection CloneSection(int index) {
+            if (index < 0 || index >= this.Sections.Count) {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            return this.Sections[index].CloneSection();
+        }
+
+        /// <summary>
         /// Inserts a bookmark in a new paragraph.
         /// </summary>
         /// <param name="bookmarkName">Name of the bookmark.</param>


### PR DESCRIPTION
## Summary
- add `CloneSection` API on `WordSection` and `WordDocument`
- add section cloning example
- test section cloning functionality

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689f41bbe558832e8982c21fd107eec0