### PR TITLE
Add regex search support for Word documents

### DIFF
--- a/OfficeIMO.Tests/Word.FindAndReplace.cs
+++ b/OfficeIMO.Tests/Word.FindAndReplace.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using OfficeIMO.Word;
 using Xunit;
 
@@ -89,6 +90,32 @@ namespace OfficeIMO.Tests {
 
 
                 document.Save(false);
+            }
+        }
+
+        [Fact]
+        public void Test_DocumentRegexFind() {
+            string filePath = Path.Combine(_directoryWithFiles, "RegexWordDocument.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Item 123");
+                document.AddParagraph("Item 456");
+                document.AddParagraph("Different 789");
+
+                var regex = new Regex(@"Item \d{3}");
+                var result = document.Find(regex);
+
+                Assert.Equal(2, result.Found);
+                Assert.Equal(2, result.Paragraphs.Count);
+
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var regex = new Regex(@"Item \d{3}");
+                var result = document.Find(regex);
+
+                Assert.Equal(2, result.Found);
+                Assert.Equal(2, result.Paragraphs.Count);
             }
         }
     }

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1804,3 +1804,77 @@ namespace OfficeIMO.Word {
         }
     }
 }
+
+namespace OfficeIMO.Word {
+    /// <summary>
+    /// Extension methods for <see cref="WordDocument"/> providing regular expression search.
+    /// </summary>
+    public static class WordDocumentRegexExtensions {
+        /// <summary>
+        /// Searches the document for text matching the specified regular expression.
+        /// </summary>
+        /// <param name="document">Document to search.</param>
+        /// <param name="regex">Regular expression used for searching.</param>
+        /// <returns>A <see cref="WordFind"/> instance containing all matches.</returns>
+        public static WordFind Find(this WordDocument document, Regex regex) {
+            if (document == null) {
+                throw new ArgumentNullException(nameof(document));
+            }
+            if (regex == null) {
+                throw new ArgumentNullException(nameof(regex));
+            }
+
+            var result = new WordFind();
+
+            result.FindRegex(document.Paragraphs, regex, result.Paragraphs);
+
+            foreach (var table in document.Tables) {
+                result.FindRegex(table.Paragraphs, regex, result.Tables);
+            }
+
+            if (document.Header.Default != null) {
+                result.FindRegex(document.Header.Default.Paragraphs, regex, result.HeaderDefault);
+                foreach (var table in document.Header.Default.Tables) {
+                    result.FindRegex(table.Paragraphs, regex, result.HeaderDefault);
+                }
+            }
+
+            if (document.Header.Even != null) {
+                result.FindRegex(document.Header.Even.Paragraphs, regex, result.HeaderEven);
+                foreach (var table in document.Header.Even.Tables) {
+                    result.FindRegex(table.Paragraphs, regex, result.HeaderEven);
+                }
+            }
+
+            if (document.Header.First != null) {
+                result.FindRegex(document.Header.First.Paragraphs, regex, result.HeaderFirst);
+                foreach (var table in document.Header.First.Tables) {
+                    result.FindRegex(table.Paragraphs, regex, result.HeaderFirst);
+                }
+            }
+
+            if (document.Footer.Default != null) {
+                result.FindRegex(document.Footer.Default.Paragraphs, regex, result.FooterDefault);
+                foreach (var table in document.Footer.Default.Tables) {
+                    result.FindRegex(table.Paragraphs, regex, result.FooterDefault);
+                }
+            }
+
+            if (document.Footer.Even != null) {
+                result.FindRegex(document.Footer.Even.Paragraphs, regex, result.FooterEven);
+                foreach (var table in document.Footer.Even.Tables) {
+                    result.FindRegex(table.Paragraphs, regex, result.FooterEven);
+                }
+            }
+
+            if (document.Footer.First != null) {
+                result.FindRegex(document.Footer.First.Paragraphs, regex, result.FooterFirst);
+                foreach (var table in document.Footer.First.Tables) {
+                    result.FindRegex(table.Paragraphs, regex, result.FooterFirst);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/OfficeIMO.Word/WordFind.cs
+++ b/OfficeIMO.Word/WordFind.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace OfficeIMO.Word {
     /// <summary>
@@ -29,46 +30,26 @@ namespace OfficeIMO.Word {
         /// <summary>Footer paragraphs containing matches when using the first page footer.</summary>
         public List<WordParagraph> FooterFirst = new List<WordParagraph>();
 
+        /// <summary>
+        /// Searches the provided paragraphs for matches of the supplied regular expression and
+        /// stores the paragraphs containing matches in the specified list.
+        /// </summary>
+        /// <param name="paragraphs">Paragraphs to search.</param>
+        /// <param name="regex">Regular expression pattern.</param>
+        /// <param name="destination">Collection to store paragraphs with matches.</param>
+        internal void FindRegex(IEnumerable<WordParagraph> paragraphs, Regex regex, List<WordParagraph> destination) {
+            if (paragraphs == null || regex == null) {
+                return;
+            }
 
-        //public List<WordParagraph> Paragraphs {
-        //    get;
-        //    set;
-        //}
-
-        //public List<WordParagraph> Tables {
-        //    get;
-        //    set;
-        //}
-
-        //public List<WordParagraph> HeaderDefault {
-        //    get;
-        //    set;
-        //}
-
-        //public List<WordParagraph> HeaderEven {
-        //    get;
-        //    set;
-        //}
-
-        //public List<WordParagraph> HeaderFirst {
-        //    get;
-        //    set;
-        //}
-
-        //public List<WordParagraph> FooterDefault {
-        //    get;
-        //    set;
-        //}
-
-        //public List<WordParagraph> FooterEven {
-        //    get;
-        //    set;
-        //}
-
-        //public List<WordParagraph> FooterFirst {
-        //    get;
-        //    set;
-        //}
+            foreach (var paragraph in paragraphs) {
+                var matches = regex.Matches(paragraph.Text);
+                if (matches.Count > 0) {
+                    Found += matches.Count;
+                    destination.Add(paragraph);
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- enable regex-based paragraph search
- expose `WordDocument.Find(Regex)` extension
- add tests for regex find

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build --filter Test_DocumentRegexFind`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_689f41b32d6c832e89442502435177a7