### PR TITLE
Handle recursive table layouts and cache measurements

### DIFF
--- a/OfficeIMO.Tests/Pdf/TableLayoutCacheTests.cs
+++ b/OfficeIMO.Tests/Pdf/TableLayoutCacheTests.cs
@@ -18,6 +18,44 @@ namespace OfficeIMO.Tests.Pdf {
             Assert.Equal(2, first.ColumnWidths.Length);
             Assert.Equal(72f, first.ColumnWidths[0]);
         }
+
+        [Fact]
+        public void NestedTableWidthsPropagateToParent() {
+            using WordDocument document = WordDocument.Create();
+            WordTable outer = document.AddTable(1, 2);
+            outer.Rows[0].Cells[0].Width = 1440;
+            outer.Rows[0].Cells[1].Width = 720;
+
+            WordTable inner = outer.Rows[0].Cells[1].AddTable(1, 1);
+            inner.Rows[0].Cells[0].Width = 2880;
+
+            TableLayout outerLayout = TableLayoutCache.GetLayout(outer);
+            Assert.Equal(144f, outerLayout.ColumnWidths[1]);
+
+            TableLayout innerLayout = TableLayoutCache.GetLayout(inner);
+            TableLayout innerLayoutSecond = TableLayoutCache.GetLayout(inner);
+            Assert.Same(innerLayout, innerLayoutSecond);
+            Assert.Equal(144f, innerLayout.ColumnWidths[0]);
+        }
+
+        [Fact]
+        public void RecursiveNestedTablesAreMeasured() {
+            using WordDocument document = WordDocument.Create();
+            WordTable outer = document.AddTable(1, 1);
+            outer.Rows[0].Cells[0].Width = 720;
+            WordTable middle = outer.Rows[0].Cells[0].AddTable(1, 1);
+            middle.Rows[0].Cells[0].Width = 720;
+            WordTable inner = middle.Rows[0].Cells[0].AddTable(1, 1);
+            inner.Rows[0].Cells[0].Width = 2880;
+
+            TableLayout outerLayout = TableLayoutCache.GetLayout(outer);
+            Assert.Equal(144f, outerLayout.ColumnWidths[0]);
+
+            TableLayout middleLayout = TableLayoutCache.GetLayout(middle);
+            Assert.Equal(144f, middleLayout.ColumnWidths[0]);
+            TableLayout innerLayout = TableLayoutCache.GetLayout(inner);
+            Assert.Equal(144f, innerLayout.ColumnWidths[0]);
+        }
     }
 }
 

--- a/OfficeIMO.Word.Pdf/TableLayoutCache.cs
+++ b/OfficeIMO.Word.Pdf/TableLayoutCache.cs
@@ -20,11 +20,23 @@ namespace OfficeIMO.Word.Pdf {
             foreach (IReadOnlyList<WordTableCell> row in rows) {
                 for (int i = 0; i < row.Count; i++) {
                     WordTableCell cell = row[i];
+                    float width = 0f;
                     if (cell.Width.HasValue && cell.WidthType == TableWidthUnitValues.Dxa) {
-                        float width = cell.Width.Value / 20f;
-                        if (width > widths[i]) {
-                            widths[i] = width;
+                        width = cell.Width.Value / 20f;
+                    }
+
+                    if (cell.HasNestedTables) {
+                        foreach (WordTable nested in cell.NestedTables) {
+                            TableLayout nestedLayout = GetLayout(nested);
+                            float nestedWidth = nestedLayout.ColumnWidths.Sum();
+                            if (nestedWidth > width) {
+                                width = nestedWidth;
+                            }
                         }
+                    }
+
+                    if (width > widths[i]) {
+                        widths[i] = width;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- account for nested tables when calculating column widths
- cache nested table measurements for reuse
- add regression tests for nested and recursive layouts

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter TableLayoutCacheTests`


------
https://chatgpt.com/codex/tasks/task_e_689f85cf8ae4832eb757b4946c3e5b62