### PR TITLE
Add figure to caption conversion support

### DIFF
--- a/OfficeIMO.Tests/Html.Figures.cs
+++ b/OfficeIMO.Tests/Html.Figures.cs
@@ -13,11 +13,27 @@ namespace OfficeIMO.Tests {
             string base64 = Convert.ToBase64String(imageBytes);
             string html = $"<figure><img src=\"data:image/png;base64,{base64}\" alt=\"Logo\"/><figcaption>Logo caption</figcaption></figure>";
 
-            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
 
             Assert.Single(doc.Images);
             Assert.Equal("Logo caption", doc.Paragraphs[1].Text);
             Assert.Equal("Caption", doc.Paragraphs[1].StyleId);
+
+            string roundTrip = doc.ToHtml();
+            Assert.Contains("<figure>", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<figcaption>Logo caption</figcaption>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void WordToHtml_FigureWithCaption_RendersFigure() {
+            string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
+            using var doc = WordDocument.Create();
+            doc.AddParagraph().AddImage(assetPath);
+            doc.AddParagraph("Logo caption").SetStyleId("Caption");
+
+            string html = doc.ToHtml();
+            Assert.Contains("<figure>", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<figcaption>Logo caption</figcaption>", html, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -815,20 +815,23 @@ namespace OfficeIMO.Word.Html.Converters {
                             break;
                         }
                     case "figure": {
-                            var img = element.QuerySelector("img") as IHtmlImageElement;
-                            if (img != null) {
-                                ProcessImage(img, doc, options, currentParagraph, headerFooter);
-                            }
-                            var caption = element.QuerySelector("figcaption");
-                            if (caption != null) {
-                                ApplyCssToElement(caption);
-                                var paragraph = cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
-                                paragraph.SetStyleId("Caption");
-                                ApplyParagraphStyleFromCss(paragraph, caption);
-                                ApplyClassStyle(caption, paragraph, options);
-                                AddBookmarkIfPresent(caption, paragraph);
-                                foreach (var child in caption.ChildNodes) {
-                                    ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell, headerFooter, headingList);
+                            WordParagraph? figPara = currentParagraph;
+                            foreach (var child in element.ChildNodes) {
+                                if (child is IElement childEl && string.Equals(childEl.TagName, "figcaption", StringComparison.OrdinalIgnoreCase)) {
+                                    ApplyCssToElement(childEl);
+                                    var paragraph = cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                                    paragraph.SetStyleId("Caption");
+                                    ApplyParagraphStyleFromCss(paragraph, childEl);
+                                    ApplyClassStyle(childEl, paragraph, options);
+                                    AddBookmarkIfPresent(childEl, paragraph);
+                                    foreach (var captionChild in childEl.ChildNodes) {
+                                        ProcessNode(captionChild, doc, section, options, paragraph, listStack, formatting, cell, headerFooter, headingList);
+                                    }
+                                } else {
+                                    ProcessNode(child, doc, section, options, figPara, listStack, formatting, cell, headerFooter, headingList);
+                                    if (figPara == null && doc.Paragraphs.Count > 0) {
+                                        figPara = doc.Paragraphs.Last();
+                                    }
                                 }
                             }
                             break;

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -688,7 +688,19 @@ namespace OfficeIMO.Word.Html.Converters {
                             AppendRuns(li, paragraph);
                         } else {
                             CloseLists();
-                            if (IsCodeParagraph(paragraph)) {
+                            if (paragraph.IsImage && idx + 1 < elements.Count && elements[idx + 1] is WordParagraph captionPara && string.Equals(captionPara.StyleId, "Caption", StringComparison.OrdinalIgnoreCase)) {
+                                var figure = htmlDoc.CreateElement("figure");
+                                AppendRuns(figure, paragraph);
+                                var figCap = htmlDoc.CreateElement("figcaption");
+                                if (options.IncludeParagraphClasses && !string.IsNullOrEmpty(captionPara.StyleId)) {
+                                    figCap.SetAttribute("class", captionPara.StyleId);
+                                    paragraphStyles.Add(captionPara.StyleId);
+                                }
+                                AppendRuns(figCap, captionPara);
+                                figure.AppendChild(figCap);
+                                body.AppendChild(figure);
+                                idx++;
+                            } else if (IsCodeParagraph(paragraph)) {
                                 List<string> lines = new();
                                 lines.Add(paragraph.Text);
                                 while (idx + 1 < elements.Count && elements[idx + 1] is WordParagraph nextPara && DocumentTraversal.GetListInfo(nextPara) == null && IsCodeParagraph(nextPara)) {


### PR DESCRIPTION
## Summary
- map HTML `<figure>` elements to Word containers with `<figcaption>` to caption paragraphs
- emit `<figure>` and `<figcaption>` when converting Word images with caption style back to HTML
- test round-trip of figures between HTML and Word

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a0232c7bcc832ebe1c2a9fb1c3064d