### PR TITLE
Remove duplicate list style initialization

### DIFF
--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1092,7 +1092,6 @@ namespace OfficeIMO.Word {
             WordDocumentStatistics statistics = new WordDocumentStatistics(word);
 
             WordListStyles.InitializeAbstractNumberId(word._wordprocessingDocument);
-            WordListStyles.InitializeAbstractNumberId(word._wordprocessingDocument);
 
             return word;
         }


### PR DESCRIPTION
## Summary
- Remove duplicate WordListStyles.InitializeAbstractNumberId call in WordDocument initialization

## Testing
- `dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj -f net472 -c Release` *(fails: reference assemblies for .NETFramework v4.7.2 not found)*
- `dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj -f net8.0 -c Release`
- `dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj -p:TargetFrameworks=net9.0 -f net9.0 -c Release`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -p:TargetFrameworks=net472 -f net472 -c Release --filter FullyQualifiedName~Word` *(fails: mono host not found)*
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -f net8.0 -c Release --filter Test_SimpleWordDocumentCreation`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -p:TargetFrameworks=net9.0 -f net9.0 -c Release --filter Test_SimpleWordDocumentCreation`


------
https://chatgpt.com/codex/tasks/task_e_68a1c77efdf8832eb2affe92c6172c48