### PR TITLE
Add CancellationToken support to WordDocument async methods

### DIFF
--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Async.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Async.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using OfficeIMO.Word;
 
@@ -10,12 +11,12 @@ namespace OfficeIMO.Examples.Word {
             string filePath = Path.Combine(folderPath, "AsyncWord.docx");
             if (File.Exists(filePath)) File.Delete(filePath);
 
-            using (var document = await WordDocument.CreateAsync(filePath)) {
+            using (var document = await WordDocument.CreateAsync(filePath, cancellationToken: CancellationToken.None)) {
                 document.AddParagraph("Async paragraph");
                 await document.SaveAsync();
             }
 
-            using (var document = await WordDocument.LoadAsync(filePath)) {
+            using (var document = await WordDocument.LoadAsync(filePath, cancellationToken: CancellationToken.None)) {
                 Console.WriteLine($"Paragraph count: {document.Paragraphs.Count}");
             }
 

--- a/OfficeIMO.Tests/Word.Async.cs
+++ b/OfficeIMO.Tests/Word.Async.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using OfficeIMO.Word;
 using Xunit;
@@ -17,7 +19,7 @@ namespace OfficeIMO.Tests {
 
             Assert.True(File.Exists(filePath));
 
-            using (var document = await WordDocument.LoadAsync(filePath)) {
+            using (var document = await WordDocument.LoadAsync(filePath, cancellationToken: CancellationToken.None)) {
                 Assert.Single(document.Paragraphs);
             }
 
@@ -29,16 +31,43 @@ namespace OfficeIMO.Tests {
             var filePath = Path.Combine(_directoryWithFiles, "AsyncCreate.docx");
             if (File.Exists(filePath)) File.Delete(filePath);
 
-            using (var document = await WordDocument.CreateAsync(filePath)) {
+            using (var document = await WordDocument.CreateAsync(filePath, cancellationToken: CancellationToken.None)) {
                 document.AddParagraph("Created");
                 await document.SaveAsync();
             }
 
             Assert.True(File.Exists(filePath));
 
-            using (var document = await WordDocument.LoadAsync(filePath)) {
+            using (var document = await WordDocument.LoadAsync(filePath, cancellationToken: CancellationToken.None)) {
                 Assert.Single(document.Paragraphs);
             }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public async Task Test_WordCreateAsync_CanBeCancelled() {
+            var filePath = Path.Combine(_directoryWithFiles, "AsyncCreateCancelled.docx");
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => WordDocument.CreateAsync(filePath, cancellationToken: cts.Token));
+        }
+
+        [Fact]
+        public async Task Test_WordLoadAsync_CanBeCancelled() {
+            var filePath = Path.Combine(_directoryWithFiles, "AsyncLoadCancelled.docx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+
+            using (var document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Cancelled");
+                document.Save();
+            }
+
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => WordDocument.LoadAsync(filePath, cancellationToken: cts.Token));
 
             File.Delete(filePath);
         }

--- a/OfficeIMO.Tests/Word.LoadExceptions.cs
+++ b/OfficeIMO.Tests/Word.LoadExceptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using OfficeIMO.Word;
 using Xunit;
@@ -16,7 +17,7 @@ namespace OfficeIMO.Tests {
         [Fact]
         public async Task Test_LoadAsyncMissingFile_ThrowsWithPath() {
             string filePath = Path.Combine(_directoryWithFiles, "missingAsync.docx");
-            var ex = await Assert.ThrowsAsync<FileNotFoundException>(() => WordDocument.LoadAsync(filePath));
+            var ex = await Assert.ThrowsAsync<FileNotFoundException>(() => WordDocument.LoadAsync(filePath, cancellationToken: CancellationToken.None));
             Assert.Equal($"File '{filePath}' doesn't exist.", ex.Message);
         }
 

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1272,7 +1272,7 @@ namespace OfficeIMO.Word {
 
             using var fileStream = new FileStream(filePath, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite, FileShare.Read, 4096, FileOptions.Asynchronous);
             var memoryStream = new MemoryStream();
-            await fileStream.CopyToAsync(memoryStream, cancellationToken);
+            await fileStream.CopyToAsync(memoryStream, 81920, cancellationToken);
             memoryStream.Seek(0, SeekOrigin.Begin);
 
             var openSettings = new OpenSettings {

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1102,11 +1102,12 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="filePath">Destination file path.</param>
         /// <param name="autoSave">Enable auto-save on dispose.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Created <see cref="WordDocument"/>.</returns>
-        public static async Task<WordDocument> CreateAsync(string filePath = "", bool autoSave = false) {
+        public static async Task<WordDocument> CreateAsync(string filePath = "", bool autoSave = false, CancellationToken cancellationToken = default) {
             if (!string.IsNullOrEmpty(filePath)) {
                 using var fs = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.Asynchronous);
-                await fs.FlushAsync();
+                await fs.FlushAsync(cancellationToken);
             }
 
             var documentType = GetDocumentType(filePath);
@@ -1259,9 +1260,10 @@ namespace OfficeIMO.Word {
         /// <param name="readOnly">Open the document in read-only mode.</param>
         /// <param name="autoSave">Enable auto-save on dispose.</param>
         /// <param name="overrideStyles">When <c>true</c>, existing styles are replaced with library versions. Ignored when <paramref name="readOnly"/> is <c>true</c>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Loaded <see cref="WordDocument"/> instance.</returns>
         /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
-        public static async Task<WordDocument> LoadAsync(string filePath, bool readOnly = false, bool autoSave = false, bool overrideStyles = false) {
+        public static async Task<WordDocument> LoadAsync(string filePath, bool readOnly = false, bool autoSave = false, bool overrideStyles = false, CancellationToken cancellationToken = default) {
             if (filePath != null) {
                 if (!File.Exists(filePath)) {
                     throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
@@ -1270,7 +1272,7 @@ namespace OfficeIMO.Word {
 
             using var fileStream = new FileStream(filePath, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite, FileShare.Read, 4096, FileOptions.Asynchronous);
             var memoryStream = new MemoryStream();
-            await fileStream.CopyToAsync(memoryStream);
+            await fileStream.CopyToAsync(memoryStream, cancellationToken);
             memoryStream.Seek(0, SeekOrigin.Begin);
 
             var openSettings = new OpenSettings {


### PR DESCRIPTION
## Summary
- allow passing `CancellationToken` to `WordDocument.CreateAsync` and `WordDocument.LoadAsync`
- propagate token to async file operations
- update examples and tests to use and verify cancellation

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --framework net8.0 --no-build --filter "FullyQualifiedName=OfficeIMO.Tests.Word.Test_WordCreateAsync_CanBeCancelled" --logger "console;verbosity=normal"`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --framework net8.0 --no-build --filter "FullyQualifiedName=OfficeIMO.Tests.Word.Test_WordLoadAsync_CanBeCancelled" --logger "console;verbosity=normal"`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --framework net9.0 --no-build --filter "FullyQualifiedName=OfficeIMO.Tests.Word.Test_WordCreateAsync_CanBeCancelled" --logger "console;verbosity=normal"`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --framework net9.0 --no-build --filter "FullyQualifiedName=OfficeIMO.Tests.Word.Test_WordLoadAsync_CanBeCancelled" --logger "console;verbosity=normal"`


------
https://chatgpt.com/codex/tasks/task_e_68a1c785bcb0832e8769f3ebe505bd9c