### PR TITLE
Expose HTML content of embedded Word documents

### DIFF
--- a/OfficeIMO.Tests/Markdown.MarkdownConverter.cs
+++ b/OfficeIMO.Tests/Markdown.MarkdownConverter.cs
@@ -74,6 +74,9 @@ namespace OfficeIMO.Tests {
         public void Test_WordToMarkdown_PreservesEmbeddedHtml() {
             using var doc = WordDocument.Create();
             doc.AddEmbeddedFragment("<div>HTML Block</div>", WordAlternativeFormatImportPartType.Html);
+            string? html = doc.EmbeddedDocuments[0].GetHtml();
+            Assert.NotNull(html);
+            Assert.Contains("<div>HTML Block</div>", html, StringComparison.OrdinalIgnoreCase);
             string md = doc.ToMarkdown(new WordToMarkdownOptions());
             Assert.Contains("<div>HTML Block</div>", md, StringComparison.OrdinalIgnoreCase);
         }

--- a/OfficeIMO.Tests/Word.EmbeddedDocumentsEncoding.cs
+++ b/OfficeIMO.Tests/Word.EmbeddedDocumentsEncoding.cs
@@ -1,7 +1,4 @@
 using System.IO;
-using System.Linq;
-using System.Text;
-using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Word;
 using Xunit;
 
@@ -21,9 +18,8 @@ public partial class Word {
 
         using (var document = WordDocument.Load(filePath)) {
             Assert.Single(document.EmbeddedDocuments);
-            AlternativeFormatImportPart part = document._document.MainDocumentPart.AlternativeFormatImportParts.First();
-            using var reader = new StreamReader(part.GetStream(), Encoding.UTF8);
-            string content = reader.ReadToEnd();
+            string? content = document.EmbeddedDocuments[0].GetHtml();
+            Assert.NotNull(content);
             Assert.Contains(phrase, content);
         }
     }

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.cs
@@ -1,10 +1,8 @@
 using OfficeIMO.Word;
 using System;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
-using DocumentFormat.OpenXml.Packaging;
+using System.IO;
 
 namespace OfficeIMO.Word.Markdown.Converters {
     /// <summary>
@@ -47,14 +45,9 @@ namespace OfficeIMO.Word.Markdown.Converters {
                 }
 
                 foreach (var embedded in section.EmbeddedDocuments) {
-                    if (string.Equals(embedded.ContentType, "text/html", StringComparison.OrdinalIgnoreCase)) {
-                        var field = typeof(WordEmbeddedDocument).GetField("_altContent", BindingFlags.NonPublic | BindingFlags.Instance);
-                        if (field?.GetValue(embedded) is AlternativeFormatImportPart part) {
-                            using var stream = part.GetStream();
-                            using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
-                            string html = reader.ReadToEnd();
-                            _output.AppendLine(html);
-                        }
+                    var html = embedded.GetHtml();
+                    if (!string.IsNullOrEmpty(html)) {
+                        _output.AppendLine(html);
                     }
                 }
             }

--- a/OfficeIMO.Word/WordEmbeddedDocument.cs
+++ b/OfficeIMO.Word/WordEmbeddedDocument.cs
@@ -21,6 +21,21 @@ namespace OfficeIMO.Word {
 
 
         /// <summary>
+        /// Retrieves the HTML markup of the embedded document when available.
+        /// </summary>
+        /// <returns>HTML content or <c>null</c> if the embedded document is not HTML.</returns>
+        public string? GetHtml() {
+            if (!string.Equals(ContentType, "text/html", StringComparison.OrdinalIgnoreCase)) {
+                return null;
+            }
+
+            using var stream = _altContent.GetStream();
+            using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            return reader.ReadToEnd();
+        }
+
+
+        /// <summary>
         /// Saves the embedded document to the specified file.
         /// </summary>
         /// <param name="fileName">Target file path.</param>


### PR DESCRIPTION
## Summary
- add `GetHtml` method to `WordEmbeddedDocument`
- update Markdown converter to consume the new API instead of reflection
- adjust HTML embedding tests to use the public accessor

## Testing
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a1c7ca8254832e90692c0a0ec3bc79