### PR TITLE
Add custom font registration for PDF export

### DIFF
--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.CustomFonts.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.CustomFonts.cs
@@ -1,0 +1,32 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Pdf {
+        public static void Example_PdfCustomFonts(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating PDF with custom fonts");
+            string docPath = Path.Combine(folderPath, "PdfCustomFonts.docx");
+            string pdfPath = Path.Combine(folderPath, "PdfCustomFonts.pdf");
+            string fontPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Fonts), "arial.ttf")
+                : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                    ? "/System/Library/Fonts/Supplemental/Arial.ttf"
+                    : "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddParagraph("File font paragraph").FontFamily = "FileFont";
+                document.AddParagraph("Stream font paragraph").FontFamily = "StreamFont";
+                document.Save();
+                using var fontStream = File.OpenRead(fontPath);
+                document.SaveAsPdf(pdfPath, new PdfSaveOptions {
+                    FontFilePaths = new Dictionary<string, string> { { "FileFont", fontPath } },
+                    FontStreams = new Dictionary<string, Stream> { { "StreamFont", fontStream } }
+                });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/OfficeIMO.Examples.csproj
+++ b/OfficeIMO.Examples/OfficeIMO.Examples.csproj
@@ -8,18 +8,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\OfficeIMO.Excel\OfficeIMO.Excel.csproj" />
-        <ProjectReference Include="..\OfficeIMO.Word\OfficeIMO.Word.csproj" />
-        <ProjectReference Include="..\OfficeIMO.Word.Pdf\OfficeIMO.Word.Pdf.csproj" />
-        <ProjectReference Include="..\OfficeIMO.Word.Html\OfficeIMO.Word.Html.csproj" />
-        <ProjectReference Include="..\OfficeIMO.Word.Markdown\OfficeIMO.Word.Markdown.csproj" />
+        <ProjectReference Include="..\\OfficeIMO.Excel\\OfficeIMO.Excel.csproj" />
+        <ProjectReference Include="..\\OfficeIMO.Word\\OfficeIMO.Word.csproj" />
+        <ProjectReference Include="..\\OfficeIMO.Word.Pdf\\OfficeIMO.Word.Pdf.csproj" />
+        <ProjectReference Include="..\\OfficeIMO.Word.Html\\OfficeIMO.Word.Html.csproj" />
+        <ProjectReference Include="..\\OfficeIMO.Word.Markdown\\OfficeIMO.Word.Markdown.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Update="Images\**">
+        <None Update="Images\\**">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
-        <None Update="Templates\**">
+        <None Update="Templates\\**">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
     </ItemGroup>

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -245,6 +245,7 @@ namespace OfficeIMO.Examples {
             OfficeIMO.Examples.Word.Pdf.Example_SaveAsPdfWithLicense(folderPath, false);
             OfficeIMO.Examples.Word.Pdf.Example_SaveLists(folderPath, false);
             OfficeIMO.Examples.Word.Pdf.Example_TableStyles(folderPath, false);
+            OfficeIMO.Examples.Word.Pdf.Example_PdfCustomFonts(folderPath, false);
             // Word/PictureControls
             OfficeIMO.Examples.Word.PictureControls.Example_BasicPictureControl(folderPath, false);
             // Word/RepeatingSections

--- a/OfficeIMO.Tests/OfficeIMO.Tests.csproj
+++ b/OfficeIMO.Tests/OfficeIMO.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
@@ -29,11 +29,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\OfficeIMO.Word\OfficeIMO.Word.csproj" />
-        <ProjectReference Include="..\OfficeIMO.Excel\OfficeIMO.Excel.csproj" />
-        <ProjectReference Include="..\OfficeIMO.Word.Pdf\OfficeIMO.Word.Pdf.csproj" />
-        <ProjectReference Include="..\OfficeIMO.Word.Html\OfficeIMO.Word.Html.csproj" />
-        <ProjectReference Include="..\OfficeIMO.Word.Markdown\OfficeIMO.Word.Markdown.csproj" />
+        <ProjectReference Include="..\\OfficeIMO.Word\\OfficeIMO.Word.csproj" />
+        <ProjectReference Include="..\\OfficeIMO.Excel\\OfficeIMO.Excel.csproj" />
+        <ProjectReference Include="..\\OfficeIMO.Word.Pdf\\OfficeIMO.Word.Pdf.csproj" />
+        <ProjectReference Include="..\\OfficeIMO.Word.Html\\OfficeIMO.Word.Html.csproj" />
+        <ProjectReference Include="..\\OfficeIMO.Word.Markdown\\OfficeIMO.Word.Markdown.csproj" />
     </ItemGroup>
 
     <ItemGroup>
@@ -46,13 +46,13 @@
     </ItemGroup>
 
   <ItemGroup>
-      <None Update="Documents\**">
+      <None Update="Documents\\**">
           <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
-      <None Update="Images\**">
+      <None Update="Images\\**">
           <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
-      <EmbeddedResource Include="Images\Kulek.jpg" />
+      <EmbeddedResource Include="Images\\Kulek.jpg" />
   </ItemGroup>
 
 </Project>

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.CustomFonts.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.CustomFonts.cs
@@ -17,6 +17,10 @@ namespace OfficeIMO.Tests {
                 : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
                     ? "/System/Library/Fonts/Supplemental/Arial.ttf"
                     : "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
+            string expectedFont = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+                                   RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                ? "Arial"
+                : "DejaVuSans";
             string docPath = Path.Combine(_directoryWithFiles, "PdfFontFile.docx");
 
             using (WordDocument document = WordDocument.Create(docPath)) {
@@ -28,7 +32,7 @@ namespace OfficeIMO.Tests {
                 byte[] pdf = document.SaveAsPdf(options);
                 using (PdfDocument pdfDoc = PdfDocument.Open(new MemoryStream(pdf))) {
                     var fonts = pdfDoc.GetPage(1).Letters.Select(l => l.FontName).Distinct();
-                    Assert.Contains(fonts, f => f.Contains("DejaVuSans"));
+                    Assert.Contains(fonts, f => f.Contains(expectedFont));
                 }
             }
         }
@@ -40,6 +44,10 @@ namespace OfficeIMO.Tests {
                 : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
                     ? "/System/Library/Fonts/Supplemental/Arial.ttf"
                     : "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
+            string expectedFont = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+                                   RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                ? "Arial"
+                : "DejaVuSans";
             string docPath = Path.Combine(_directoryWithFiles, "PdfFontStream.docx");
 
             using (WordDocument document = WordDocument.Create(docPath)) {
@@ -52,7 +60,7 @@ namespace OfficeIMO.Tests {
                 byte[] pdf = document.SaveAsPdf(options);
                 using (PdfDocument pdfDoc = PdfDocument.Open(new MemoryStream(pdf))) {
                     var fonts = pdfDoc.GetPage(1).Letters.Select(l => l.FontName).Distinct();
-                    Assert.Contains(fonts, f => f.Contains("DejaVuSans"));
+                    Assert.Contains(fonts, f => f.Contains(expectedFont));
                 }
             }
         }

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.CustomFonts.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.CustomFonts.cs
@@ -1,0 +1,60 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using UglyToad.PdfPig;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_WordDocument_SaveAsPdf_CustomFontFile() {
+            string fontPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Fonts), "arial.ttf")
+                : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                    ? "/System/Library/Fonts/Supplemental/Arial.ttf"
+                    : "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
+            string docPath = Path.Combine(_directoryWithFiles, "PdfFontFile.docx");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddParagraph("Hello from file font").FontFamily = "FileFont";
+                document.Save();
+                var options = new PdfSaveOptions {
+                    FontFilePaths = new Dictionary<string, string> { { "FileFont", fontPath } }
+                };
+                byte[] pdf = document.SaveAsPdf(options);
+                using (PdfDocument pdfDoc = PdfDocument.Open(new MemoryStream(pdf))) {
+                    var fonts = pdfDoc.GetPage(1).Letters.Select(l => l.FontName).Distinct();
+                    Assert.Contains(fonts, f => f.Contains("DejaVuSans"));
+                }
+            }
+        }
+
+        [Fact]
+        public void Test_WordDocument_SaveAsPdf_CustomFontStream() {
+            string fontPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Fonts), "arial.ttf")
+                : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                    ? "/System/Library/Fonts/Supplemental/Arial.ttf"
+                    : "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
+            string docPath = Path.Combine(_directoryWithFiles, "PdfFontStream.docx");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddParagraph("Hello from stream font").FontFamily = "StreamFont";
+                document.Save();
+                using var fs = File.OpenRead(fontPath);
+                var options = new PdfSaveOptions {
+                    FontStreams = new Dictionary<string, Stream> { { "StreamFont", fs } }
+                };
+                byte[] pdf = document.SaveAsPdf(options);
+                using (PdfDocument pdfDoc = PdfDocument.Open(new MemoryStream(pdf))) {
+                    var fonts = pdfDoc.GetPage(1).Letters.Select(l => l.FontName).Distinct();
+                    Assert.Contains(fonts, f => f.Contains("DejaVuSans"));
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
+++ b/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
@@ -1,6 +1,8 @@
 using QuestPDF.Helpers;
 using QuestPDF.Infrastructure;
 using OfficeIMO.Word;
+using System.Collections.Generic;
+using System.IO;
 
 namespace OfficeIMO.Word.Pdf {
     /// <summary>
@@ -11,6 +13,15 @@ namespace OfficeIMO.Word.Pdf {
         /// Optional font family applied to created runs during conversion.
         /// </summary>
         public string FontFamily { get; set; }
+        /// <summary>
+        /// Optional mapping of font family names to font file paths.
+        /// </summary>
+        public Dictionary<string, string>? FontFilePaths { get; set; }
+
+        /// <summary>
+        /// Optional mapping of font family names to font data streams.
+        /// </summary>
+        public Dictionary<string, Stream>? FontStreams { get; set; }
         /// <summary>
         /// Optional page size for the generated PDF.
         /// </summary>

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -453,6 +453,9 @@ namespace OfficeIMO.Word.Pdf {
                         kvp.Value.Position = 0;
                     }
                     FontManager.RegisterFontWithCustomName(kvp.Key, kvp.Value);
+                    if (kvp.Value.CanSeek) {
+                        kvp.Value.Position = 0;
+                    }
                 }
             }
         }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -449,12 +449,16 @@ namespace OfficeIMO.Word.Pdf {
                     if (!_embeddedFonts.Add(kvp.Key)) {
                         continue;
                     }
-                    if (kvp.Value.CanSeek) {
-                        kvp.Value.Position = 0;
+                    Stream stream = kvp.Value;
+                    if (stream.CanSeek) {
+                        stream.Position = 0;
                     }
-                    FontManager.RegisterFontWithCustomName(kvp.Key, kvp.Value);
-                    if (kvp.Value.CanSeek) {
-                        kvp.Value.Position = 0;
+                    using MemoryStream ms = new();
+                    stream.CopyTo(ms);
+                    ms.Position = 0;
+                    FontManager.RegisterFontWithCustomName(kvp.Key, ms);
+                    if (stream.CanSeek) {
+                        stream.Position = 0;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- allow specifying font file paths and streams when saving PDFs
- register provided fonts with QuestPDF during PDF generation
- add example and tests demonstrating custom font usage

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a1c7df6264832e8b9f2990d3df8a41