### PR TITLE
Add tests for additional HTML head tags

### DIFF
--- a/OfficeIMO.Tests/Html.AdditionalHeadTags.cs
+++ b/OfficeIMO.Tests/Html.AdditionalHeadTags.cs
@@ -1,0 +1,34 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class HtmlAdditionalHeadTags {
+        [Fact]
+        public void Test_WordToHtml_WithAdditionalMetaTags() {
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Content");
+
+            var options = new WordToHtmlOptions();
+            options.AdditionalMetaTags.Add(("viewport", "width=device-width, initial-scale=1"));
+
+            string html = doc.ToHtml(options);
+
+            Assert.Contains("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_WithAdditionalLinkTags() {
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Content");
+
+            var options = new WordToHtmlOptions();
+            options.AdditionalLinkTags.Add(("stylesheet", "styles.css"));
+
+            string html = doc.ToHtml(options);
+
+            Assert.Contains("<link rel=\"stylesheet\" href=\"styles.css\"", html, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests covering AdditionalMetaTags and AdditionalLinkTags when converting Word to HTML

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a3453eb530832e80fdfca921811452