### PR TITLE
Add async Markdown conversions

### DIFF
--- a/OfficeIMO.Tests/Markdown.Async.cs
+++ b/OfficeIMO.Tests/Markdown.Async.cs
@@ -45,6 +45,15 @@ namespace OfficeIMO.Tests {
 
             Assert.True(stream.CanRead);
         }
+
+        [Fact]
+        public async Task Test_ToMarkdownAsync_MatchesSync() {
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Async conversion");
+            string sync = doc.ToMarkdown();
+            string asyncResult = await doc.ToMarkdownAsync();
+            Assert.Equal(sync, asyncResult);
+        }
     }
 }
 

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
@@ -7,6 +7,8 @@ using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
 using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace OfficeIMO.Word.Markdown.Converters {
     /// <summary>
@@ -25,6 +27,10 @@ namespace OfficeIMO.Word.Markdown.Converters {
     /// </summary>
     internal partial class MarkdownToWordConverter {
         public WordDocument Convert(string markdown, MarkdownToWordOptions options) {
+            return ConvertAsync(markdown, options).GetAwaiter().GetResult();
+        }
+
+        public Task<WordDocument> ConvertAsync(string markdown, MarkdownToWordOptions options, CancellationToken cancellationToken = default) {
             if (markdown == null) {
                 throw new ArgumentNullException(nameof(markdown));
             }
@@ -41,10 +47,11 @@ namespace OfficeIMO.Word.Markdown.Converters {
             MarkdownDocument markdownDocument = Markdig.Markdown.Parse(markdown, pipeline);
 
             foreach (var block in markdownDocument) {
+                cancellationToken.ThrowIfCancellationRequested();
                 ProcessBlock(block, document, options);
             }
 
-            return document;
+            return Task.FromResult(document);
         }
 
         private static void ProcessBlock(Block block, WordDocument document, MarkdownToWordOptions options, WordList? currentList = null, int listLevel = 0, int quoteDepth = 0) {


### PR DESCRIPTION
## Summary
- add asynchronous ConvertAsync methods for Markdown converters
- update extension methods to favor async conversions
- test async ToMarkdown alongside sync version

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a3456bda10832e8cdab398b8c13db2