### PR TITLE
Add image Fit and Center fill modes

### DIFF
--- a/OfficeIMO.Examples/Word/Images/Images.NewFeatures.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.NewFeatures.cs
@@ -34,8 +34,16 @@ namespace OfficeIMO.Examples.Word {
             paragraph1.Image.TintAmount = 50;
             paragraph1.Image.TintHue = 300;
 
-            var paragraph2 = document.AddParagraph("Linked image from web");
-            paragraph2.AddImage(new Uri("http://example.com/logo.png"), 100, 100);
+            var paragraph2 = document.AddParagraph("Fit image");
+            paragraph2.AddImage(System.IO.Path.Combine(imagePaths, "Kulek.jpg"), 100, 50);
+            paragraph2.Image.FillMode = ImageFillMode.Fit;
+
+            var paragraph3 = document.AddParagraph("Centered image");
+            paragraph3.AddImage(System.IO.Path.Combine(imagePaths, "Kulek.jpg"), 100, 50);
+            paragraph3.Image.FillMode = ImageFillMode.Center;
+
+            var paragraph4 = document.AddParagraph("Linked image from web");
+            paragraph4.AddImage(new Uri("http://example.com/logo.png"), 100, 100);
 
             document.Save(openWord);
         }

--- a/OfficeIMO.Tests/Word.Images.cs
+++ b/OfficeIMO.Tests/Word.Images.cs
@@ -501,6 +501,51 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ImageFillMode_Fit() {
+            var filePath = Path.Combine(_directoryWithFiles, "DocumentImageFillModeFit.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph();
+                paragraph.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 100, 50);
+                paragraph.Image.FillMode = ImageFillMode.Fit;
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(ImageFillMode.Fit, document.Images[0].FillMode);
+            }
+
+            using (var pkg = WordprocessingDocument.Open(filePath, false)) {
+                var blipFill = pkg.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Pictures.BlipFill>().First();
+                var stretch = blipFill.GetFirstChild<DocumentFormat.OpenXml.Drawing.Stretch>();
+                Assert.NotNull(stretch);
+                Assert.Null(stretch.GetFirstChild<DocumentFormat.OpenXml.Drawing.FillRectangle>());
+                Assert.Null(blipFill.GetFirstChild<DocumentFormat.OpenXml.Drawing.Tile>());
+            }
+        }
+
+        [Fact]
+        public void Test_ImageFillMode_Center() {
+            var filePath = Path.Combine(_directoryWithFiles, "DocumentImageFillModeCenter.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph();
+                paragraph.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 100, 50);
+                paragraph.Image.FillMode = ImageFillMode.Center;
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(ImageFillMode.Center, document.Images[0].FillMode);
+            }
+
+            using (var pkg = WordprocessingDocument.Open(filePath, false)) {
+                var blipFill = pkg.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Pictures.BlipFill>().First();
+                var tile = blipFill.GetFirstChild<DocumentFormat.OpenXml.Drawing.Tile>();
+                Assert.NotNull(tile);
+                Assert.Equal(RectangleAlignmentValues.Center, tile.Alignment?.Value);
+            }
+        }
+
+        [Fact]
         public void Test_AddExternalImage() {
             var filePath = Path.Combine(_directoryWithFiles, "DocumentExternalImage.docx");
             using (var document = WordDocument.Create(filePath)) {

--- a/OfficeIMO.Word/ImageFillMode.cs
+++ b/OfficeIMO.Word/ImageFillMode.cs
@@ -6,6 +6,10 @@ namespace OfficeIMO.Word {
         /// <summary>Stretch the image to fill the area.</summary>
         Stretch,
         /// <summary>Tile the image to fill the area.</summary>
-        Tile
+        Tile,
+        /// <summary>Scale the image uniformly to fit within the area.</summary>
+        Fit,
+        /// <summary>Place the image at the center without scaling.</summary>
+        Center
     }
 }

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -885,10 +885,24 @@ namespace OfficeIMO.Word {
             get {
                 var picture = GetPicture();
                 var blipFill = picture?.BlipFill;
-                if (blipFill != null && blipFill.GetFirstChild<Tile>() != null) {
-                    _fillMode = ImageFillMode.Tile;
-                } else {
-                    _fillMode = ImageFillMode.Stretch;
+                if (blipFill != null) {
+                    var tile = blipFill.GetFirstChild<Tile>();
+                    if (tile != null) {
+                        if (tile.Alignment?.Value == RectangleAlignmentValues.Center) {
+                            _fillMode = ImageFillMode.Center;
+                        } else {
+                            _fillMode = ImageFillMode.Tile;
+                        }
+                    } else {
+                        var stretch = blipFill.GetFirstChild<Stretch>();
+                        if (stretch != null) {
+                            _fillMode = stretch.GetFirstChild<FillRectangle>() == null
+                                ? ImageFillMode.Fit
+                                : ImageFillMode.Stretch;
+                        } else {
+                            _fillMode = ImageFillMode.Stretch;
+                        }
+                    }
                 }
                 return _fillMode;
             }
@@ -901,16 +915,42 @@ namespace OfficeIMO.Word {
                 var tile = blipFill.GetFirstChild<Tile>();
                 var stretch = blipFill.GetFirstChild<Stretch>();
 
-                if (value == ImageFillMode.Stretch) {
-                    tile?.Remove();
-                    if (stretch == null) {
-                        blipFill.AppendChild(new Stretch(new FillRectangle()));
-                    }
-                } else {
-                    stretch?.Remove();
-                    if (tile == null) {
-                        blipFill.AppendChild(new Tile());
-                    }
+                switch (value) {
+                    case ImageFillMode.Stretch:
+                        tile?.Remove();
+                        if (stretch == null) {
+                            stretch = new Stretch();
+                            blipFill.AppendChild(stretch);
+                        }
+                        if (stretch.GetFirstChild<FillRectangle>() == null) {
+                            stretch.AppendChild(new FillRectangle());
+                        }
+                        break;
+                    case ImageFillMode.Tile:
+                        stretch?.Remove();
+                        if (tile == null) {
+                            tile = new Tile();
+                            blipFill.AppendChild(tile);
+                        }
+                        tile.Alignment = null;
+                        break;
+                    case ImageFillMode.Fit:
+                        tile?.Remove();
+                        if (stretch == null) {
+                            stretch = new Stretch();
+                            blipFill.AppendChild(stretch);
+                        }
+                        var fillRect = stretch.GetFirstChild<FillRectangle>();
+                        fillRect?.Remove();
+                        break;
+                    case ImageFillMode.Center:
+                        stretch?.Remove();
+                        if (tile == null) {
+                            tile = new Tile();
+                            blipFill.AppendChild(tile);
+                        }
+                        tile.Alignment = RectangleAlignmentValues.Center;
+                        break;
                 }
             }
         }
@@ -1764,12 +1804,19 @@ namespace OfficeIMO.Word {
                 blipFlip.Append(srcRect);
             }
 
-            if (_fillMode == ImageFillMode.Stretch) {
-                blipFlip.Append(new Stretch(new FillRectangle()));
-            } else {
-                if (blipFlip.GetFirstChild<Tile>() == null) {
+            switch (_fillMode) {
+                case ImageFillMode.Stretch:
+                    blipFlip.Append(new Stretch(new FillRectangle()));
+                    break;
+                case ImageFillMode.Tile:
                     blipFlip.AppendChild(new Tile());
-                }
+                    break;
+                case ImageFillMode.Fit:
+                    blipFlip.Append(new Stretch());
+                    break;
+                case ImageFillMode.Center:
+                    blipFlip.AppendChild(new Tile { Alignment = RectangleAlignmentValues.Center });
+                    break;
             }
 
             var picture = new DocumentFormat.OpenXml.Drawing.Pictures.Picture();


### PR DESCRIPTION
## Summary
- extend image fill mode enum with Fit and Center options
- support new fill modes in Word image rendering
- test and document new fill mode behavior

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a3454646a4832eaf14aefa67353425