### PR TITLE
Add header and footer cleanup tests

### DIFF
--- a/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample04.cs
+++ b/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample04.cs
@@ -1,0 +1,32 @@
+using System;
+using OfficeIMO.Word;
+
+/// <summary>
+/// Demonstrates cleanup of headers and footers.
+/// </summary>
+internal static partial class CleanupDocuments {
+    /// <summary>
+    /// Creates a document with redundant runs and empty paragraphs in headers and footers and cleans it up.
+    /// </summary>
+    /// <param name="folderPath">Directory to create the file in.</param>
+    /// <param name="openWord">Opens Word when <c>true</c>.</param>
+    public static void CleanupDocuments_Sample04(string folderPath, bool openWord) {
+        string filePath = System.IO.Path.Combine(folderPath, "CleanupHeadersFooters.docx");
+        using (WordDocument document = WordDocument.Create(filePath)) {
+            document.AddHeadersAndFooters();
+
+            var headerParagraph = document.Header.Default.AddParagraph("Header ");
+            headerParagraph.AddText("clutter ");
+            headerParagraph.AddText("text");
+            document.Header.Default.AddParagraph();
+
+            var footerParagraph = document.Footer.Default.AddParagraph("Footer ");
+            footerParagraph.AddText("clutter ");
+            footerParagraph.AddText("text");
+            document.Footer.Default.AddParagraph();
+
+            document.CleanupDocument();
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.CleanupHeadersFooters.cs
+++ b/OfficeIMO.Tests/Word.CleanupHeadersFooters.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using System.Linq;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void CleanupDocument_RemovesClutterFromHeadersAndFooters() {
+            string filePath = Path.Combine(_directoryWithFiles, "CleanupHeadersAndFooters.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddHeadersAndFooters();
+
+                var headerParagraph = document.Header.Default.AddParagraph("Header ");
+                headerParagraph.AddText("clutter ");
+                headerParagraph.AddText("text");
+                document.Header.Default.AddParagraph();
+
+                var footerParagraph = document.Footer.Default.AddParagraph("Footer ");
+                footerParagraph.AddText("clutter ");
+                footerParagraph.AddText("text");
+                document.Footer.Default.AddParagraph();
+
+                Assert.True(document.Header.Default.Paragraphs.Count > 1);
+                Assert.True(headerParagraph.GetRuns().Count() > 1);
+                Assert.True(document.Footer.Default.Paragraphs.Count > 1);
+                Assert.True(footerParagraph.GetRuns().Count() > 1);
+
+                document.CleanupDocument();
+
+                Assert.True(document.Header.Default.Paragraphs.Count == 1);
+                Assert.True(document.Header.Default.Paragraphs[0].GetRuns().Count() == 1);
+                Assert.True(document.Header.Default.Paragraphs[0].Text == "Header clutter text");
+
+                Assert.True(document.Footer.Default.Paragraphs.Count == 1);
+                Assert.True(document.Footer.Default.Paragraphs[0].GetRuns().Count() == 1);
+                Assert.True(document.Footer.Default.Paragraphs[0].Text == "Footer clutter text");
+
+                document.Save(false);
+            }
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CleanupHeadersAndFooters.docx"))) {
+                Assert.True(document.Header.Default.Paragraphs.Count == 1);
+                Assert.True(document.Header.Default.Paragraphs[0].GetRuns().Count() == 1);
+                Assert.True(document.Header.Default.Paragraphs[0].Text == "Header clutter text");
+
+                Assert.True(document.Footer.Default.Paragraphs.Count == 1);
+                Assert.True(document.Footer.Default.Paragraphs[0].GetRuns().Count() == 1);
+                Assert.True(document.Footer.Default.Paragraphs[0].Text == "Footer clutter text");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- test CleanupDocument merges runs and trims empty paragraphs in headers and footers
- add example illustrating header/footer cleanup

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a34523260c832eaf6dadb8e9a4465a