### PR TITLE
Use compiled regex for whitespace collapsing

### DIFF
--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -258,6 +258,7 @@ namespace OfficeIMO.Word.Html.Converters {
         }
 
         private static readonly Regex _urlRegex = new(@"((?:https?|ftp)://[^\s]+)", RegexOptions.IgnoreCase);
+        private static readonly Regex _collapseWhitespaceRegex = new(@"\s+", RegexOptions.Compiled);
 
         private static void AddTextRun(WordParagraph paragraph, string text, TextFormatting formatting, HtmlToWordOptions options) {
             text = ApplyWhiteSpace(text, formatting.WhiteSpace);
@@ -296,7 +297,7 @@ namespace OfficeIMO.Word.Html.Converters {
         }
 
         private static string CollapseWhiteSpace(string text, bool noWrap) {
-            var collapsed = Regex.Replace(text, "\\s+", " ");
+            var collapsed = _collapseWhitespaceRegex.Replace(text, " ");
             if (noWrap) {
                 collapsed = collapsed.Replace(" ", " ");
             }


### PR DESCRIPTION
## Summary
- precompile whitespace-collapsing regex for HtmlToWord converter
- use static compiled regex instead of inline Regex.Replace

## Testing
- `dotnet build`
- `dotnet test OfficeIMO.Tests --filter "FullyQualifiedName~Html.*List"`

------
https://chatgpt.com/codex/tasks/task_e_68a3451bc808832e8500a17c1d4c29a0