### PR TITLE
Add AutoFilter support for Excel sheets

### DIFF
--- a/OfficeIMO.Examples/Excel/AutoFilter.cs
+++ b/OfficeIMO.Examples/Excel/AutoFilter.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using OfficeIMO.Excel;
+
+namespace OfficeIMO.Examples.Excel {
+    /// <summary>
+    /// Demonstrates adding an autofilter to a worksheet.
+    /// </summary>
+    public static class AutoFilter {
+        public static void Example(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - AutoFilter example");
+            string filePath = System.IO.Path.Combine(folderPath, "AutoFilter.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.SetCellValue(1, 1, "Name");
+                sheet.SetCellValue(1, 2, "Value");
+                sheet.SetCellValue(2, 1, "A");
+                sheet.SetCellValue(2, 2, 10d);
+                sheet.SetCellValue(3, 1, "B");
+                sheet.SetCellValue(3, 2, 20d);
+
+                Dictionary<uint, IEnumerable<string>> criteria = new Dictionary<uint, IEnumerable<string>> {
+                    { 0, new[] { "A" } }
+                };
+
+                sheet.AddAutoFilter("A1:B3", criteria);
+                document.Save(openExcel);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.cs
+++ b/OfficeIMO.Excel/ExcelSheet.cs
@@ -280,6 +280,37 @@ namespace OfficeIMO.Excel {
             worksheet.Save();
         }
 
+        public void AddAutoFilter(string range, Dictionary<uint, IEnumerable<string>> filterCriteria = null) {
+            if (string.IsNullOrEmpty(range)) {
+                throw new ArgumentNullException(nameof(range));
+            }
+
+            Worksheet worksheet = _worksheetPart.Worksheet;
+
+            AutoFilter existing = worksheet.Elements<AutoFilter>().FirstOrDefault();
+            if (existing != null) {
+                worksheet.RemoveChild(existing);
+            }
+
+            AutoFilter autoFilter = new AutoFilter { Reference = range };
+
+            if (filterCriteria != null) {
+                foreach (KeyValuePair<uint, IEnumerable<string>> criteria in filterCriteria) {
+                    FilterColumn filterColumn = new FilterColumn { ColumnId = criteria.Key };
+                    Filters filters = new Filters();
+                    foreach (string value in criteria.Value) {
+                        filters.Append(new Filter { Val = value });
+                    }
+
+                    filterColumn.Append(filters);
+                    autoFilter.Append(filterColumn);
+                }
+            }
+
+            worksheet.Append(autoFilter);
+            worksheet.Save();
+        }
+
         public void SetCellValue(int row, int column, string value, bool autoFitColumns = false, bool autoFitRows = false) {
             Cell cell = GetCell(row, column);
             int sharedStringIndex = _excelDocument.GetSharedStringIndex(value);

--- a/OfficeIMO.Tests/Excel.AutoFilter.cs
+++ b/OfficeIMO.Tests/Excel.AutoFilter.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    /// <summary>
+    /// Tests for adding and persisting auto filters in Excel sheets.
+    /// </summary>
+    public partial class Excel {
+        [Fact]
+        public void Test_AddAutoFilterPersists() {
+            string filePath = Path.Combine(_directoryWithFiles, "AutoFilter.xlsx");
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.SetCellValue(1, 1, "Name");
+                sheet.SetCellValue(1, 2, "Value");
+                sheet.SetCellValue(2, 1, "A");
+                sheet.SetCellValue(2, 2, 10d);
+                sheet.SetCellValue(3, 1, "B");
+                sheet.SetCellValue(3, 2, 20d);
+                Dictionary<uint, IEnumerable<string>> criteria = new Dictionary<uint, IEnumerable<string>> {
+                    { 0, new[] { "A" } }
+                };
+                sheet.AddAutoFilter("A1:B3", criteria);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                AutoFilter autoFilter = wsPart.Worksheet.Elements<AutoFilter>().FirstOrDefault();
+                Assert.NotNull(autoFilter);
+                Assert.Equal("A1:B3", autoFilter.Reference.Value);
+                FilterColumn filterColumn = autoFilter.Elements<FilterColumn>().FirstOrDefault();
+                Assert.NotNull(filterColumn);
+                Filters filters = filterColumn.GetFirstChild<Filters>();
+                Assert.NotNull(filters);
+                Filter filter = filters.Elements<Filter>().First();
+                Assert.Equal("A", filter.Val.Value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `AddAutoFilter` method to insert AutoFilter with optional criteria
- cover AutoFilter usage with unit test and sample

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a36a08a4c8832eaa0f54328c31c585