### PR TITLE
Add initial Visio support with basic API and tests

### DIFF
--- a/OfficeIMO.Examples/OfficeIMO.Examples.csproj
+++ b/OfficeIMO.Examples/OfficeIMO.Examples.csproj
@@ -13,6 +13,7 @@
         <ProjectReference Include="..\\OfficeIMO.Word.Pdf\\OfficeIMO.Word.Pdf.csproj" />
         <ProjectReference Include="..\\OfficeIMO.Word.Html\\OfficeIMO.Word.Html.csproj" />
         <ProjectReference Include="..\\OfficeIMO.Word.Markdown\\OfficeIMO.Word.Markdown.csproj" />
+        <ProjectReference Include="..\\OfficeIMO.Visio\\OfficeIMO.Visio.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -14,6 +14,9 @@ namespace OfficeIMO.Examples {
             string folderPath = Path.Combine(Directory.GetCurrentDirectory(), "Documents");
             Setup(folderPath);
 
+            // Visio/BasicVisioDocument
+            OfficeIMO.Examples.Visio.BasicVisioDocument.Example_BasicVisio(folderPath, false);
+
             // Excel/BasicExcelFunctionality
             OfficeIMO.Examples.Excel.BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);
             OfficeIMO.Examples.Excel.BasicExcelFunctionality.BasicExcel_Example2(folderPath, false);

--- a/OfficeIMO.Examples/Visio/BasicVisioDocument.cs
+++ b/OfficeIMO.Examples/Visio/BasicVisioDocument.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    /// <summary>
+    /// Demonstrates basic <see cref="VisioDocument"/> usage.
+    /// </summary>
+    public static class BasicVisioDocument {
+        public static void Example_BasicVisio(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Creating basic document");
+            string filePath = Path.Combine(folderPath, "Basic Visio.vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page1");
+            VisioShape shape1 = new("Shape1");
+            VisioShape shape2 = new("Shape2");
+            page.Shapes.Add(shape1);
+            page.Shapes.Add(shape2);
+            page.Connectors.Add(new VisioConnector(shape1, shape2));
+
+            // Saving not yet implemented; placeholder for future development.
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/OfficeIMO.Tests.csproj
+++ b/OfficeIMO.Tests/OfficeIMO.Tests.csproj
@@ -34,6 +34,7 @@
         <ProjectReference Include="..\\OfficeIMO.Word.Pdf\\OfficeIMO.Word.Pdf.csproj" />
         <ProjectReference Include="..\\OfficeIMO.Word.Html\\OfficeIMO.Word.Html.csproj" />
         <ProjectReference Include="..\\OfficeIMO.Word.Markdown\\OfficeIMO.Word.Markdown.csproj" />
+        <ProjectReference Include="..\\OfficeIMO.Visio\\OfficeIMO.Visio.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OfficeIMO.Tests/Visio.BasicDocument.cs
+++ b/OfficeIMO.Tests/Visio.BasicDocument.cs
@@ -1,0 +1,22 @@
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioBasicDocument {
+        [Fact]
+        public void CanCreateBasicVisioDocument() {
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page1");
+            VisioShape shape1 = new("S1");
+            VisioShape shape2 = new("S2");
+            page.Shapes.Add(shape1);
+            page.Shapes.Add(shape2);
+            page.Connectors.Add(new VisioConnector(shape1, shape2));
+
+            Assert.Single(document.Pages);
+            Assert.Equal(2, page.Shapes.Count);
+            Assert.Single(page.Connectors);
+        }
+    }
+}
+

--- a/OfficeIMO.Visio/Fluent/VisioDocumentFluent.cs
+++ b/OfficeIMO.Visio/Fluent/VisioDocumentFluent.cs
@@ -1,0 +1,15 @@
+namespace OfficeIMO.Visio.Fluent {
+    /// <summary>
+    /// Provides fluent helpers for <see cref="VisioDocument"/>.
+    /// </summary>
+    public static class VisioDocumentFluent {
+        /// <summary>
+        /// Adds a page and returns the document for chaining.
+        /// </summary>
+        public static VisioDocument AddPage(this VisioDocument document, string name, out VisioPage page) {
+            page = document.AddPage(name);
+            return document;
+        }
+    }
+}
+

--- a/OfficeIMO.Visio/OfficeIMO.Visio.csproj
+++ b/OfficeIMO.Visio/OfficeIMO.Visio.csproj
@@ -1,0 +1,82 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>An Open Source cross-platform .NET library providing an easy way to create
+            Microsoft Visio documents.</Description>
+        <AssemblyName>OfficeIMO.Visio</AssemblyName>
+        <AssemblyTitle>OfficeIMO.Visio</AssemblyTitle>
+
+        <VersionPrefix>1.0.6</VersionPrefix>
+        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
+            netstandard2.0;net472;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
+            net8.0</TargetFrameworks>
+        <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+        <Company>Evotec</Company>
+        <Authors>Przemyslaw Klys</Authors>
+
+        <PackageId>OfficeIMO.Visio</PackageId>
+        <PackageTags>
+            vsdx;visio;office;openxml;net472;net48;net50;netstandard;netstandard2.0,netstandard2.1;net70</PackageTags>
+        <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <DelaySign>False</DelaySign>
+        <IsPublishable>True</IsPublishable>
+        <Copyright>(c) 2011 - 2024 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
+        <PackageIcon>OfficeIMO.png</PackageIcon>
+        <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
+        <DebugType>portable</DebugType>
+        <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <RepositoryType>git</RepositoryType>
+        <SignAssembly>False</SignAssembly>
+        <GenerateDocumentationFile>True</GenerateDocumentationFile>
+        <LangVersion>Latest</LangVersion>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+
+
+    <ItemGroup>
+        <None Include="..\Assets\OfficeIMO.png">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+        <None Include="..\README.md">
+            <Pack>True</Pack>
+            <PackagePath>README.md</PackagePath>
+        </None>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="DocumentFormat.OpenXml" Version="[3.3.0,4.0.0)" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
+        <PackageReference Include="System.Drawing.Common" Version="8.0.4" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+        <Reference Include="System.Net.Http" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="System" />
+        <Using Include="System.Text" />
+        <Using Include="System.Collections.Generic" />
+        <Using Include="System.Collections" />
+        <Using Include="System.Linq" />
+        <Using Include="System.IO" />
+        <Using Include="DocumentFormat.OpenXml" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="OfficeIMO.Tests" />
+    </ItemGroup>
+
+</Project>

--- a/OfficeIMO.Visio/VisioConnector.cs
+++ b/OfficeIMO.Visio/VisioConnector.cs
@@ -1,0 +1,22 @@
+namespace OfficeIMO.Visio {
+    /// <summary>
+    /// Connects two shapes together.
+    /// </summary>
+    public class VisioConnector {
+        public VisioConnector(VisioShape from, VisioShape to) {
+            From = from;
+            To = to;
+        }
+
+        /// <summary>
+        /// Shape from which the connector starts.
+        /// </summary>
+        public VisioShape From { get; }
+
+        /// <summary>
+        /// Shape at which the connector ends.
+        /// </summary>
+        public VisioShape To { get; }
+    }
+}
+

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace OfficeIMO.Visio {
+    /// <summary>
+    /// Represents a Visio document containing pages.
+    /// </summary>
+    public class VisioDocument {
+        private readonly List<VisioPage> _pages = new();
+
+        /// <summary>
+        /// Collection of pages in the document.
+        /// </summary>
+        public IReadOnlyList<VisioPage> Pages => _pages;
+
+        /// <summary>
+        /// Adds a new page to the document.
+        /// </summary>
+        /// <param name="name">Name of the page.</param>
+        public VisioPage AddPage(string name) {
+            VisioPage page = new(name);
+            _pages.Add(page);
+            return page;
+        }
+    }
+}
+

--- a/OfficeIMO.Visio/VisioPage.cs
+++ b/OfficeIMO.Visio/VisioPage.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+
+namespace OfficeIMO.Visio {
+    /// <summary>
+    /// Represents a single page within a Visio document.
+    /// </summary>
+    public class VisioPage {
+        private readonly List<VisioShape> _shapes = new();
+        private readonly List<VisioConnector> _connectors = new();
+
+        public VisioPage(string name) {
+            Name = name;
+        }
+
+        /// <summary>
+        /// Gets the page name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Shapes placed on the page.
+        /// </summary>
+        public IList<VisioShape> Shapes => _shapes;
+
+        /// <summary>
+        /// Connectors placed on the page.
+        /// </summary>
+        public IList<VisioConnector> Connectors => _connectors;
+    }
+}
+

--- a/OfficeIMO.Visio/VisioShape.cs
+++ b/OfficeIMO.Visio/VisioShape.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.Visio {
+    /// <summary>
+    /// Represents a shape on a Visio page.
+    /// </summary>
+    public class VisioShape {
+        public VisioShape(string id) {
+            Id = id;
+        }
+
+        /// <summary>
+        /// Identifier of the shape.
+        /// </summary>
+        public string Id { get; }
+    }
+}
+

--- a/OfficeImo.sln
+++ b/OfficeImo.sln
@@ -136,6 +136,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Word.Html", "Offi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Word.Markdown", "OfficeIMO.Word.Markdown\OfficeIMO.Word.Markdown.csproj", "{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Visio", "OfficeIMO.Visio\OfficeIMO.Visio.csproj", "{42E46CA9-CB23-446A-8D48-07E04E88A65C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -242,6 +244,18 @@ Global
 		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Release|x64.Build.0 = Release|Any CPU
 		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Release|x86.ActiveCfg = Release|Any CPU
 		{9C2CC069-324D-4B80-88D2-1E3F49FB2C19}.Release|x86.Build.0 = Release|Any CPU
+		{42E46CA9-CB23-446A-8D48-07E04E88A65C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42E46CA9-CB23-446A-8D48-07E04E88A65C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42E46CA9-CB23-446A-8D48-07E04E88A65C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{42E46CA9-CB23-446A-8D48-07E04E88A65C}.Debug|x64.Build.0 = Debug|Any CPU
+		{42E46CA9-CB23-446A-8D48-07E04E88A65C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{42E46CA9-CB23-446A-8D48-07E04E88A65C}.Debug|x86.Build.0 = Debug|Any CPU
+		{42E46CA9-CB23-446A-8D48-07E04E88A65C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42E46CA9-CB23-446A-8D48-07E04E88A65C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42E46CA9-CB23-446A-8D48-07E04E88A65C}.Release|x64.ActiveCfg = Release|Any CPU
+		{42E46CA9-CB23-446A-8D48-07E04E88A65C}.Release|x64.Build.0 = Release|Any CPU
+		{42E46CA9-CB23-446A-8D48-07E04E88A65C}.Release|x86.ActiveCfg = Release|Any CPU
+		{42E46CA9-CB23-446A-8D48-07E04E88A65C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add OfficeIMO.Visio project targeting netstandard2.0, net472, net8.0, net9.0
- stub VisioDocument, page, shape and connector classes with fluent helper
- wire up example and test projects
- remove unsupported Visio icon

## Testing
- `dotnet build OfficeImo.sln -c Release`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --no-build --logger "console;verbosity=normal" --filter VisioBasicDocument`


------
https://chatgpt.com/codex/tasks/task_e_68a367de7ad0832eb868958addc28b11