### PR TITLE
Add synchronous HTML converter wrappers

### DIFF
--- a/OfficeIMO.Examples/Converters/Html/Html07_Async.cs
+++ b/OfficeIMO.Examples/Converters/Html/Html07_Async.cs
@@ -11,19 +11,24 @@ namespace OfficeIMO.Examples.Word.Converters {
 
             using var doc = WordDocument.Create();
             doc.AddParagraph("Async HTML");
-            await doc.AddHtmlToHeaderAsync("<p>Header async</p>");
-            await doc.AddHtmlToFooterAsync("<p>Footer async</p>");
 
-            string outputPath = Path.Combine(folderPath, "HtmlAsync.html");
-            await doc.SaveAsHtmlAsync(outputPath);
+            string syncPath = Path.Combine(folderPath, "HtmlSync.html");
+            doc.SaveAsHtml(syncPath);
 
-            string html = await doc.ToHtmlAsync();
-            using var roundTrip = await html.LoadFromHtmlAsync();
+            string asyncPath = Path.Combine(folderPath, "HtmlAsync.html");
+            await doc.SaveAsHtmlAsync(asyncPath);
 
-            Console.WriteLine($"✓ Created: {outputPath}");
+            string htmlSync = doc.ToHtml();
+            using var roundTripSync = htmlSync.LoadFromHtml();
+
+            string htmlAsync = await doc.ToHtmlAsync();
+            using var roundTripAsync = await htmlAsync.LoadFromHtmlAsync();
+
+            Console.WriteLine($"✓ Created: {syncPath}");
+            Console.WriteLine($"✓ Created: {asyncPath}");
 
             if (openWord) {
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(outputPath) { UseShellExecute = true });
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(syncPath) { UseShellExecute = true });
             }
         }
     }

--- a/OfficeIMO.Tests/Html.Convert.cs
+++ b/OfficeIMO.Tests/Html.Convert.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using OfficeIMO.Word.Html.Converters;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void WordToHtmlConverter_Convert_EqualsAsync() {
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Test");
+            var converter = new WordToHtmlConverter();
+            string sync = converter.Convert(doc, new WordToHtmlOptions());
+            string asyncResult = converter.ConvertAsync(doc, new WordToHtmlOptions()).GetAwaiter().GetResult();
+            Assert.Equal(sync, asyncResult);
+        }
+
+        [Fact]
+        public void HtmlToWordConverter_Convert_EqualsAsync() {
+            string html = "<p>Test</p>";
+            var converter = new HtmlToWordConverter();
+            using var syncDoc = converter.Convert(html, new HtmlToWordOptions());
+            using var asyncDoc = converter.ConvertAsync(html, new HtmlToWordOptions()).GetAwaiter().GetResult();
+            Assert.Equal(syncDoc.Paragraphs.Count, asyncDoc.Paragraphs.Count);
+            Assert.Equal(syncDoc.Paragraphs[0].Text, asyncDoc.Paragraphs[0].Text);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -127,7 +127,7 @@ namespace OfficeIMO.Word.Html.Converters {
                 var commaIndex = src.IndexOf(',');
                 if (commaIndex < 0) return;
                 var base64 = src.Substring(commaIndex + 1);
-                var bytes = Convert.FromBase64String(base64);
+                var bytes = System.Convert.FromBase64String(base64);
                 svgContent = Encoding.UTF8.GetString(bytes);
             } else if (Uri.TryCreate(src, UriKind.Absolute, out var uri) && uri.IsFile) {
                 svgContent = File.ReadAllText(uri.LocalPath);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -41,6 +41,10 @@ namespace OfficeIMO.Word.Html.Converters {
         private static readonly ConcurrentDictionary<string, ICssStyleRule[]> _stylesheetCache = new(StringComparer.OrdinalIgnoreCase);
         private IBrowsingContext? _context;
         private static readonly Regex _classRegex = new(@"\.([a-zA-Z0-9_-]+)", RegexOptions.Compiled);
+        public WordDocument Convert(string html, HtmlToWordOptions options) {
+            return ConvertAsync(html, options, CancellationToken.None).GetAwaiter().GetResult();
+        }
+
         public async Task<WordDocument> ConvertAsync(string html, HtmlToWordOptions options, CancellationToken cancellationToken = default) {
             if (html == null) throw new ArgumentNullException(nameof(html));
             options ??= new HtmlToWordOptions();

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -18,6 +18,10 @@ namespace OfficeIMO.Word.Html.Converters {
     /// Converts <see cref="WordDocument"/> instances into HTML markup.
     /// </summary>
     internal class WordToHtmlConverter {
+        public string Convert(WordDocument document, WordToHtmlOptions options) {
+            return ConvertAsync(document, options, CancellationToken.None).GetAwaiter().GetResult();
+        }
+
         /// <summary>
         /// Converts the specified document to HTML asynchronously using provided options.
         /// </summary>
@@ -193,7 +197,7 @@ namespace OfficeIMO.Word.Html.Converters {
                         } else {
                             var bytes = imgObj.GetBytes();
                             var mime = MimeFromFileName(imgObj.FileName);
-                            src = $"data:{mime};base64,{Convert.ToBase64String(bytes)}";
+                            src = $"data:{mime};base64,{System.Convert.ToBase64String(bytes)}";
                         }
                         img!.Source = src;
                         if (imgObj.Width.HasValue) img.DisplayWidth = (int)Math.Round(imgObj.Width.Value);

--- a/OfficeIMO.Word.Html/OfficeIMO.Word.Html.csproj
+++ b/OfficeIMO.Word.Html/OfficeIMO.Word.Html.csproj
@@ -69,4 +69,8 @@
         <Using Include="DocumentFormat.OpenXml" />
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="OfficeIMO.Tests" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add synchronous Convert wrappers for HTML converters
- show both sync and async HTML conversion in example
- test Convert and ConvertAsync parity for HTML converters

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Debug`


------
https://chatgpt.com/codex/tasks/task_e_68a36de4f508832eb877b4e0fb99ffbe