### PR TITLE
Build Visio packages with typed relationships

### DIFF
--- a/OfficeIMO.Tests/Visio.PackageCreation.cs
+++ b/OfficeIMO.Tests/Visio.PackageCreation.cs
@@ -20,6 +20,7 @@ namespace OfficeIMO.Tests {
 
             XDocument pageDoc;
             Uri pageUri;
+            XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
 
             using (Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read)) {
                 Assert.True(package.PartExists(new Uri("/visio/document.xml", UriKind.Relative)));
@@ -39,6 +40,9 @@ namespace OfficeIMO.Tests {
                 pageUri = PackUriHelper.ResolvePartUri(pagesPart.Uri, pageRel.TargetUri);
                 Assert.Equal("/visio/pages/page1.xml", pageUri.OriginalString);
 
+                XDocument pagesDoc = XDocument.Load(pagesPart.GetStream());
+                Assert.Equal(pageRel.Id, pagesDoc.Root?.Element(ns + "Page")?.Attribute("RelId")?.Value);
+
                 PackagePart pagePart = package.GetPart(pageUri);
                 pageDoc = XDocument.Load(pagePart.GetStream());
             }
@@ -56,7 +60,6 @@ namespace OfficeIMO.Tests {
             Assert.NotNull(contentTypes.Root?.Elements(ct + "Override").FirstOrDefault(e => e.Attribute("PartName")?.Value == "/visio/pages/pages.xml"));
             Assert.NotNull(contentTypes.Root?.Elements(ct + "Override").FirstOrDefault(e => e.Attribute("PartName")?.Value == "/visio/pages/page1.xml"));
 
-            XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
             XElement shape = pageDoc.Root?.Element(ns + "Shapes")?.Element(ns + "Shape");
             Assert.Equal("1", shape?.Attribute("ID")?.Value);
             Assert.Equal("Rectangle", shape?.Element(ns + "Text")?.Value);

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -45,7 +45,7 @@ namespace OfficeIMO.Visio {
 
             Uri page1Uri = new("/visio/pages/page1.xml", UriKind.Relative);
             PackagePart page1Part = package.CreatePart(page1Uri, "application/vnd.ms-visio.page+xml");
-            pagesPart.CreateRelationship(new Uri("page1.xml", UriKind.Relative), TargetMode.Internal, "http://schemas.microsoft.com/visio/2010/relationships/page");
+            PackageRelationship pageRel = pagesPart.CreateRelationship(new Uri("page1.xml", UriKind.Relative), TargetMode.Internal, "http://schemas.microsoft.com/visio/2010/relationships/page");
 
             XmlWriterSettings settings = new() {
                 Encoding = new UTF8Encoding(false),
@@ -68,7 +68,7 @@ namespace OfficeIMO.Visio {
                 writer.WriteStartElement("Page", ns);
                 writer.WriteAttributeString("ID", "0");
                 writer.WriteAttributeString("Name", pageName);
-                writer.WriteAttributeString("RelId", "rId1");
+                writer.WriteAttributeString("RelId", pageRel.Id);
                 writer.WriteEndElement();
                 writer.WriteEndElement();
                 writer.WriteEndDocument();


### PR DESCRIPTION
## Summary
- create Visio pages with relationships resolved by type and emitted content types
- test package creation and verify page relationship wiring

## Testing
- `dotnet build OfficeImo.sln --no-restore | tail -n 20`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter VisioPackageCreation --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68a37809df84832ea1f54c5be56cd8b7