### PR TITLE
Add fluent document API with builders

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.Example.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.Example.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class FluentDocument {
+        public static void Example_FluentDocument(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with fluent API");
+            string filePath = Path.Combine(folderPath, "FluentDocument.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Info.SetTitle("Fluent Document")
+                    .Sections.AddSection()
+                    .Paragraphs.AddParagraph("Hello from fluent API");
+                document.Save(false);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Fluent.cs
+++ b/OfficeIMO.Tests/Word.Fluent.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_FluentDocumentBasic() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentTest.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Info.SetTitle("Fluent")
+                    .Sections.AddSection()
+                    .Paragraphs.AddParagraph("Test");
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal("Fluent", document.BuiltinDocumentProperties.Title);
+                Assert.Equal(2, document.Sections.Count);
+                Assert.Single(document.Paragraphs);
+                Assert.Equal("Test", document.Paragraphs[0].Text);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/FootersBuilder.cs
+++ b/OfficeIMO.Word/Fluent/FootersBuilder.cs
@@ -1,0 +1,18 @@
+namespace OfficeIMO.Word.Fluent {
+    /// <summary>
+    /// Builder for footers.
+    /// </summary>
+    public class FootersBuilder {
+        private readonly WordFluentDocument _fluent;
+
+        internal FootersBuilder(WordFluentDocument fluent) {
+            _fluent = fluent;
+        }
+
+        public WordFluentDocument AddFooter(string text) {
+            var footer = _fluent.Document.Footer;
+            footer?.Default?.AddParagraph(text);
+            return _fluent;
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/HeadersBuilder.cs
+++ b/OfficeIMO.Word/Fluent/HeadersBuilder.cs
@@ -1,0 +1,18 @@
+namespace OfficeIMO.Word.Fluent {
+    /// <summary>
+    /// Builder for headers.
+    /// </summary>
+    public class HeadersBuilder {
+        private readonly WordFluentDocument _fluent;
+
+        internal HeadersBuilder(WordFluentDocument fluent) {
+            _fluent = fluent;
+        }
+
+        public WordFluentDocument AddHeader(string text) {
+            var header = _fluent.Document.Header;
+            header?.Default?.AddParagraph(text);
+            return _fluent;
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/ImageBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ImageBuilder.cs
@@ -1,0 +1,17 @@
+namespace OfficeIMO.Word.Fluent {
+    /// <summary>
+    /// Builder for images.
+    /// </summary>
+    public class ImageBuilder {
+        private readonly WordFluentDocument _fluent;
+
+        internal ImageBuilder(WordFluentDocument fluent) {
+            _fluent = fluent;
+        }
+
+        public WordFluentDocument AddImage(string url) {
+            _fluent.Document.AddImageFromUrl(url);
+            return _fluent;
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/InfoBuilder.cs
+++ b/OfficeIMO.Word/Fluent/InfoBuilder.cs
@@ -1,0 +1,17 @@
+namespace OfficeIMO.Word.Fluent {
+    /// <summary>
+    /// Builder for document information such as properties.
+    /// </summary>
+    public class InfoBuilder {
+        private readonly WordFluentDocument _fluent;
+
+        internal InfoBuilder(WordFluentDocument fluent) {
+            _fluent = fluent;
+        }
+
+        public WordFluentDocument SetTitle(string title) {
+            _fluent.Document.BuiltinDocumentProperties.Title = title;
+            return _fluent;
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/ListBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ListBuilder.cs
@@ -1,0 +1,20 @@
+namespace OfficeIMO.Word.Fluent {
+    /// <summary>
+    /// Builder for lists.
+    /// </summary>
+    public class ListBuilder {
+        private readonly WordFluentDocument _fluent;
+
+        internal ListBuilder(WordFluentDocument fluent) {
+            _fluent = fluent;
+        }
+
+        public WordFluentDocument AddBulletedList(params string[] items) {
+            var list = _fluent.Document.AddListBulleted();
+            foreach (var item in items) {
+                list.AddItem(item);
+            }
+            return _fluent;
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/PageBuilder.cs
+++ b/OfficeIMO.Word/Fluent/PageBuilder.cs
@@ -1,0 +1,19 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word.Fluent {
+    /// <summary>
+    /// Builder for page settings.
+    /// </summary>
+    public class PageBuilder {
+        private readonly WordFluentDocument _fluent;
+
+        internal PageBuilder(WordFluentDocument fluent) {
+            _fluent = fluent;
+        }
+
+        public WordFluentDocument SetOrientation(PageOrientationValues orientation) {
+            _fluent.Document.PageOrientation = orientation;
+            return _fluent;
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
@@ -1,0 +1,17 @@
+namespace OfficeIMO.Word.Fluent {
+    /// <summary>
+    /// Builder for paragraphs.
+    /// </summary>
+    public class ParagraphBuilder {
+        private readonly WordFluentDocument _fluent;
+
+        internal ParagraphBuilder(WordFluentDocument fluent) {
+            _fluent = fluent;
+        }
+
+        public WordFluentDocument AddParagraph(string text) {
+            _fluent.Document.AddParagraph(text);
+            return _fluent;
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/RunBuilder.cs
+++ b/OfficeIMO.Word/Fluent/RunBuilder.cs
@@ -1,0 +1,20 @@
+namespace OfficeIMO.Word.Fluent {
+    /// <summary>
+    /// Builder for text runs.
+    /// </summary>
+    public class RunBuilder {
+        private readonly WordFluentDocument _fluent;
+
+        internal RunBuilder(WordFluentDocument fluent) {
+            _fluent = fluent;
+        }
+
+        public WordFluentDocument AddRun(string text, bool bold = false) {
+            var paragraph = _fluent.Document.AddParagraph(text);
+            if (bold) {
+                paragraph.SetBold();
+            }
+            return _fluent;
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/SectionBuilder.cs
+++ b/OfficeIMO.Word/Fluent/SectionBuilder.cs
@@ -1,0 +1,19 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word.Fluent {
+    /// <summary>
+    /// Builder for sections.
+    /// </summary>
+    public class SectionBuilder {
+        private readonly WordFluentDocument _fluent;
+
+        internal SectionBuilder(WordFluentDocument fluent) {
+            _fluent = fluent;
+        }
+
+        public WordFluentDocument AddSection(SectionMarkValues? mark = null) {
+            _fluent.Document.AddSection(mark);
+            return _fluent;
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/TableBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TableBuilder.cs
@@ -1,0 +1,17 @@
+namespace OfficeIMO.Word.Fluent {
+    /// <summary>
+    /// Builder for tables.
+    /// </summary>
+    public class TableBuilder {
+        private readonly WordFluentDocument _fluent;
+
+        internal TableBuilder(WordFluentDocument fluent) {
+            _fluent = fluent;
+        }
+
+        public WordFluentDocument AddTable(int rows, int columns) {
+            _fluent.Document.AddTable(rows, columns);
+            return _fluent;
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/WordFluentDocument.cs
+++ b/OfficeIMO.Word/Fluent/WordFluentDocument.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace OfficeIMO.Word.Fluent {
+    /// <summary>
+    /// Provides a fluent API wrapper around <see cref="WordDocument"/>.
+    /// </summary>
+    public class WordFluentDocument {
+        internal WordDocument Document { get; }
+
+        public WordFluentDocument(WordDocument document) {
+            Document = document ?? throw new ArgumentNullException(nameof(document));
+        }
+
+        public InfoBuilder Info => new InfoBuilder(this);
+        public SectionBuilder Sections => new SectionBuilder(this);
+        public PageBuilder Pages => new PageBuilder(this);
+        public ParagraphBuilder Paragraphs => new ParagraphBuilder(this);
+        public RunBuilder Runs => new RunBuilder(this);
+        public ListBuilder Lists => new ListBuilder(this);
+        public TableBuilder Tables => new TableBuilder(this);
+        public ImageBuilder Images => new ImageBuilder(this);
+        public HeadersBuilder Headers => new HeadersBuilder(this);
+        public FootersBuilder Footers => new FootersBuilder(this);
+    }
+}

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -10,6 +10,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word.Fluent;
 
 namespace OfficeIMO.Word {
     /// <summary>
@@ -1768,6 +1769,14 @@ namespace OfficeIMO.Word {
                 listErrors.Add(error);
             }
             return listErrors;
+        }
+
+        /// <summary>
+        /// Creates a fluent wrapper for this document.
+        /// </summary>
+        /// <returns>A new <see cref="WordFluentDocument"/> instance.</returns>
+        public WordFluentDocument AsFluent() {
+            return new WordFluentDocument(this);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add `AsFluent` method on `WordDocument`
- introduce `WordFluentDocument` with builder classes for sections, paragraphs, etc.
- add example and tests demonstrating fluent usage

## Testing
- `dotnet build`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FluentDocumentBasic`


------
https://chatgpt.com/codex/tasks/task_e_68a379c8f3f0832e869d71494a55e32f