### PR TITLE
Fix missing SixLabors.Fonts build error

### DIFF
--- a/OfficeIMO.Excel/OfficeIMO.Excel.csproj
+++ b/OfficeIMO.Excel/OfficeIMO.Excel.csproj
@@ -35,7 +35,7 @@
     <ItemGroup>
         <PackageReference Include="DocumentFormat.OpenXml" Version="[3.3.0,4.0.0)" />
         <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-        <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
+        <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- update SixLabors.Fonts to v1.0.1 for Excel project

## Testing
- `dotnet build -c Release`
- `dotnet build OfficeIMO.Excel/OfficeIMO.Excel.csproj -c Release -p:TargetFrameworks=netstandard2.0`


------
https://chatgpt.com/codex/tasks/task_e_68a37f079354832eb4f583540810d7a0