### PR TITLE
Add slide layout selection and theme support to PowerPoint

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/ThemeAndLayoutPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/ThemeAndLayoutPowerPoint.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.Examples.PowerPoint {
+    /// <summary>
+    /// Demonstrates theme manipulation and layout selection.
+    /// </summary>
+    public static class ThemeAndLayoutPowerPoint {
+        public static void Example_PowerPointThemeAndLayout(string folderPath, bool openPowerPoint) {
+            Console.WriteLine("[*] PowerPoint - Theme and Layout presentation");
+            string filePath = Path.Combine(folderPath, "ThemeAndLayout.pptx");
+
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+            presentation.ThemeName = "Custom Theme";
+            PowerPointSlide first = presentation.AddSlide();
+            first.AddTextBox("Default layout");
+            PowerPointSlide second = presentation.AddSlide(layoutIndex: 1);
+            second.AddTextBox("Second layout");
+            presentation.Save();
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointSlide.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.cs
@@ -31,6 +31,23 @@ namespace OfficeIMO.PowerPoint {
         public PPNotes Notes => _notes ??= new PPNotes(_slidePart);
 
         /// <summary>
+        /// Gets the index of the layout used by this slide.
+        /// </summary>
+        public int LayoutIndex {
+            get {
+                SlideLayoutPart layoutPart = _slidePart.SlideLayoutPart!;
+                SlideMasterPart master = layoutPart.GetParentParts().OfType<SlideMasterPart>().First();
+                SlideLayoutPart[] layouts = master.SlideLayoutParts.ToArray();
+                for (int i = 0; i < layouts.Length; i++) {
+                    if (layouts[i] == layoutPart) {
+                        return i;
+                    }
+                }
+                return -1;
+            }
+        }
+
+        /// <summary>
         /// Adds a textbox with the specified text.
         /// </summary>
         public PPTextBox AddTextBox(string text) {

--- a/OfficeIMO.Tests/PowerPoint.ThemeAndLayout.cs
+++ b/OfficeIMO.Tests/PowerPoint.ThemeAndLayout.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointThemeAndLayout {
+        [Fact]
+        public void CanSetThemeAndSelectLayout() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                Assert.Equal("Office Theme", presentation.ThemeName);
+                presentation.ThemeName = "My Theme";
+                presentation.AddSlide();
+                presentation.AddSlide(layoutIndex: 1);
+                presentation.Save();
+            }
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                Assert.Equal("My Theme", presentation.ThemeName);
+                Assert.Equal(2, presentation.Slides.Count);
+                Assert.Equal(0, presentation.Slides[0].LayoutIndex);
+                Assert.Equal(1, presentation.Slides[1].LayoutIndex);
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enable slide creation with specific master/layout indexes
- expose presentation theme name and support multiple layouts
- add examples and tests for layout selection and theme round-tripping

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a37f8629d4832ea18bc46693349313