### PR TITLE
Add Visio .vsdx reading capability with tests and example

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -16,6 +16,7 @@ namespace OfficeIMO.Examples {
 
             // Visio/BasicVisioDocument
             OfficeIMO.Examples.Visio.BasicVisioDocument.Example_BasicVisio(folderPath, false);
+            OfficeIMO.Examples.Visio.ReadVisioDocument.Example_ReadVisio(folderPath, false);
 
             // Excel/BasicExcelFunctionality
             OfficeIMO.Examples.Excel.BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);

--- a/OfficeIMO.Examples/Visio/ReadVisioDocument.cs
+++ b/OfficeIMO.Examples/Visio/ReadVisioDocument.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    /// <summary>
+    /// Demonstrates loading an existing <see cref="VisioDocument"/>.
+    /// </summary>
+    public static class ReadVisioDocument {
+        public static void Example_ReadVisio(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Reading basic document");
+            string filePath = Path.Combine(folderPath, "Basic Visio.vsdx");
+
+            VisioDocument document = VisioDocument.Load(filePath);
+            foreach (VisioPage page in document.Pages) {
+                Console.WriteLine($"Page: {page.Name}");
+                foreach (VisioShape shape in page.Shapes) {
+                    Console.WriteLine($"  Shape {shape.Id} {shape.NameU} {shape.Text}");
+                }
+            }
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.Load.cs
+++ b/OfficeIMO.Tests/Visio.Load.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioLoad {
+        [Fact]
+        public void CanRoundTripVisioDocument() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            VisioShape shape = new("1", 1, 2, 3, 4, "Rectangle") { NameU = "Rectangle" };
+            page.Shapes.Add(shape);
+            document.Save(filePath);
+
+            VisioDocument loaded = VisioDocument.Load(filePath);
+            Assert.Single(loaded.Pages);
+            VisioPage loadedPage = loaded.Pages[0];
+            Assert.Single(loadedPage.Shapes);
+            VisioShape loadedShape = loadedPage.Shapes[0];
+            Assert.Equal("1", loadedShape.Id);
+            Assert.Equal("Rectangle", loadedShape.NameU);
+            Assert.Equal("Rectangle", loadedShape.Text);
+            Assert.Equal(1d, loadedShape.PinX);
+            Assert.Equal(2d, loadedShape.PinY);
+            Assert.Equal(3d, loadedShape.Width);
+            Assert.Equal(4d, loadedShape.Height);
+
+            string secondPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+            loaded.Save(secondPath);
+            VisioDocument roundTrip = VisioDocument.Load(secondPath);
+            VisioShape roundTripShape = roundTrip.Pages[0].Shapes[0];
+            Assert.Equal(loadedShape.Text, roundTripShape.Text);
+            Assert.Equal(loadedShape.Width, roundTripShape.Width);
+        }
+    }
+}

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -6,6 +6,7 @@ using System.IO.Packaging;
 using System.Linq;
 using System.Text;
 using System.Xml;
+using System.Xml.Linq;
 
 namespace OfficeIMO.Visio {
     /// <summary>
@@ -27,6 +28,64 @@ namespace OfficeIMO.Visio {
             VisioPage page = new(name);
             _pages.Add(page);
             return page;
+        }
+
+        /// <summary>
+        /// Loads an existing <c>.vsdx</c> file into a <see cref="VisioDocument"/>.
+        /// </summary>
+        /// <param name="filePath">Path to the <c>.vsdx</c> file.</param>
+        public static VisioDocument Load(string filePath) {
+            VisioDocument document = new();
+
+            using Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read);
+
+            PackageRelationship documentRel = package.GetRelationshipsByType("http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument").Single();
+            Uri documentUri = PackUriHelper.ResolvePartUri(new Uri("/", UriKind.Relative), documentRel.TargetUri);
+            PackagePart documentPart = package.GetPart(documentUri);
+
+            PackageRelationship pagesRel = documentPart.GetRelationshipsByType("http://schemas.microsoft.com/visio/2010/relationships/pages").Single();
+            Uri pagesUri = PackUriHelper.ResolvePartUri(documentPart.Uri, pagesRel.TargetUri);
+            PackagePart pagesPart = package.GetPart(pagesUri);
+
+            XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
+            XDocument pagesDoc = XDocument.Load(pagesPart.GetStream());
+
+            foreach (XElement pageRef in pagesDoc.Root?.Elements(ns + "Page") ?? Enumerable.Empty<XElement>()) {
+                string name = pageRef.Attribute("NameU")?.Value ?? pageRef.Attribute("Name")?.Value ?? "Page";
+                VisioPage page = document.AddPage(name);
+
+                string? relId = pageRef.Attribute("RelId")?.Value;
+                if (string.IsNullOrEmpty(relId)) {
+                    continue;
+                }
+
+                PackageRelationship pageRel = pagesPart.GetRelationship(relId);
+                Uri pageUri = PackUriHelper.ResolvePartUri(pagesPart.Uri, pageRel.TargetUri);
+                PackagePart pagePart = package.GetPart(pageUri);
+                XDocument pageDoc = XDocument.Load(pagePart.GetStream());
+
+                foreach (XElement shapeElement in pageDoc.Root?.Element(ns + "Shapes")?.Elements(ns + "Shape") ?? Enumerable.Empty<XElement>()) {
+                    string id = shapeElement.Attribute("ID")?.Value ?? string.Empty;
+                    VisioShape shape = new(id) {
+                        NameU = shapeElement.Attribute("NameU")?.Value,
+                        Text = shapeElement.Element(ns + "Text")?.Value
+                    };
+
+                    XElement? xform = shapeElement.Element(ns + "XForm");
+                    shape.PinX = ParseDouble(xform?.Element(ns + "PinX")?.Value);
+                    shape.PinY = ParseDouble(xform?.Element(ns + "PinY")?.Value);
+                    shape.Width = ParseDouble(xform?.Element(ns + "Width")?.Value);
+                    shape.Height = ParseDouble(xform?.Element(ns + "Height")?.Value);
+
+                    page.Shapes.Add(shape);
+                }
+            }
+
+            return document;
+        }
+
+        private static double ParseDouble(string? value) {
+            return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double result) ? result : 0;
         }
 
         /// <summary>
@@ -83,6 +142,9 @@ namespace OfficeIMO.Visio {
                 writer.WriteStartElement("Shapes", ns);
                 writer.WriteStartElement("Shape", ns);
                 writer.WriteAttributeString("ID", shape.Id);
+                if (!string.IsNullOrEmpty(shape.NameU)) {
+                    writer.WriteAttributeString("NameU", shape.NameU);
+                }
                 writer.WriteStartElement("XForm", ns);
                 writer.WriteElementString("PinX", ns, shape.PinX.ToString(CultureInfo.InvariantCulture));
                 writer.WriteElementString("PinY", ns, shape.PinY.ToString(CultureInfo.InvariantCulture));

--- a/OfficeIMO.Visio/VisioShape.cs
+++ b/OfficeIMO.Visio/VisioShape.cs
@@ -20,6 +20,8 @@ namespace OfficeIMO.Visio {
         /// </summary>
         public string Id { get; }
 
+        public string? NameU { get; set; }
+
         public double PinX { get; set; }
 
         public double PinY { get; set; }


### PR DESCRIPTION
## Summary
- add loader for existing Visio packages that resolves pages and shapes
- expose shape NameU and preserve it when saving
- include example and unit test covering round-trip read/write

## Testing
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Visio`


------
https://chatgpt.com/codex/tasks/task_e_68a37f67a910832ebe17298d745d96de