### PR TITLE
Fix nullable warnings in Word components

### DIFF
--- a/OfficeIMO.Word/Parts/WordDocument.Parts.StyleDefinitions.cs
+++ b/OfficeIMO.Word/Parts/WordDocument.Parts.StyleDefinitions.cs
@@ -45,7 +45,7 @@ namespace OfficeIMO.Word {
         /// <param name="styleDefinitionsPart">The style definitions part to update.</param>
         /// <param name="overrideExisting">When <c>true</c>, existing styles are replaced with the library versions.</param>
         private static void AddStyleDefinitions(StyleDefinitionsPart styleDefinitionsPart, bool overrideExisting) {
-            var styles = styleDefinitionsPart.Styles;
+            var styles = styleDefinitionsPart.Styles ??= new Styles();
             AddTableStyles(styles, overrideExisting);
 
             foreach (var style in WordParagraphStyle.CustomStyles) {

--- a/OfficeIMO.Word/WordBorders.cs
+++ b/OfficeIMO.Word/WordBorders.cs
@@ -501,24 +501,18 @@ namespace OfficeIMO.Word {
         public bool? TopShadow {
             get {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null && pageBorder.TopBorder.Shadow != null) {
-                    return pageBorder.TopBorder.Shadow;
-                }
-
-                return null;
+                var shadow = pageBorder?.TopBorder?.Shadow;
+                return shadow != null ? shadow.Value : (bool?)null;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.TopBorder == null) {
-                    pageBorder.TopBorder = new TopBorder();
-                }
-
-                pageBorder.TopBorder.Shadow = value;
+                var topBorder = pageBorder.TopBorder ?? (pageBorder.TopBorder = new TopBorder());
+                topBorder.Shadow = value;
             }
         }
 
@@ -528,24 +522,18 @@ namespace OfficeIMO.Word {
         public bool? TopFrame {
             get {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null && pageBorder.TopBorder.Frame != null) {
-                    return pageBorder.TopBorder.Frame;
-                }
-
-                return null;
+                var frame = pageBorder?.TopBorder?.Frame;
+                return frame != null ? frame.Value : (bool?)null;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.TopBorder == null) {
-                    pageBorder.TopBorder = new TopBorder();
-                }
-
-                pageBorder.TopBorder.Frame = value;
+                var topBorder = pageBorder.TopBorder ?? (pageBorder.TopBorder = new TopBorder());
+                topBorder.Frame = value;
             }
         }
 

--- a/OfficeIMO.Word/WordParagraphBorders.cs
+++ b/OfficeIMO.Word/WordParagraphBorders.cs
@@ -235,69 +235,53 @@ namespace OfficeIMO.Word {
             set {
                 var pageBorder = _wordParagraph._paragraphProperties.GetFirstChild<ParagraphBorders>();
                 if (pageBorder == null) {
-                    _wordParagraph._paragraphProperties.Append(Custom);
-                    pageBorder = _wordParagraph._paragraphProperties.GetFirstChild<ParagraphBorders>();
+                    pageBorder = Custom;
+                    _wordParagraph._paragraphProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.LeftBorder == null) {
-                    pageBorder.LeftBorder = new LeftBorder();
-                }
-
-                pageBorder.LeftBorder.Frame = value;
+                var leftBorder = pageBorder.LeftBorder ?? (pageBorder.LeftBorder = new LeftBorder());
+                leftBorder.Frame = value;
             }
         }
 
         /// <summary>
         /// Gets or sets the right border width in points.
         /// </summary>
-        public UInt32Value RightSize {
+        public UInt32Value? RightSize {
             get {
                 var pageBorder = _wordParagraph._paragraphProperties.GetFirstChild<ParagraphBorders>();
-                if (pageBorder != null) {
-                    return pageBorder.RightBorder.Size;
-                }
-
-                return null;
+                return pageBorder?.RightBorder?.Size;
             }
             set {
                 var pageBorder = _wordParagraph._paragraphProperties.GetFirstChild<ParagraphBorders>();
                 if (pageBorder == null) {
-                    _wordParagraph._paragraphProperties.Append(Custom);
-                    pageBorder = _wordParagraph._paragraphProperties.GetFirstChild<ParagraphBorders>();
+                    pageBorder = Custom;
+                    _wordParagraph._paragraphProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.RightBorder == null) {
-                    pageBorder.RightBorder = new RightBorder();
-                }
-
-                pageBorder.RightBorder.Size = value;
+                var rightBorder = pageBorder.RightBorder ?? (pageBorder.RightBorder = new RightBorder());
+                rightBorder.Size = value;
             }
         }
 
         /// <summary>
         /// Gets or sets the right border color as a hex value.
         /// </summary>
-        public string RightColorHex {
+        public string? RightColorHex {
             get {
                 var pageBorder = _wordParagraph._paragraphProperties.GetFirstChild<ParagraphBorders>();
-                if (pageBorder != null && pageBorder.RightBorder != null && pageBorder.RightBorder.Color != null) {
-                    return (pageBorder.RightBorder.Color).Value.Replace("#", "").ToLowerInvariant();
-                }
-
-                return null;
+                var color = pageBorder?.RightBorder?.Color;
+                return color != null ? color.Value.Replace("#", "").ToLowerInvariant() : null;
             }
             set {
                 var pageBorder = _wordParagraph._paragraphProperties.GetFirstChild<ParagraphBorders>();
                 if (pageBorder == null) {
-                    _wordParagraph._paragraphProperties.Append(Custom);
-                    pageBorder = _wordParagraph._paragraphProperties.GetFirstChild<ParagraphBorders>();
+                    pageBorder = Custom;
+                    _wordParagraph._paragraphProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.RightBorder == null) {
-                    pageBorder.RightBorder = new RightBorder();
-                }
-
-                pageBorder.RightBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                var rightBorder = pageBorder.RightBorder ?? (pageBorder.RightBorder = new RightBorder());
+                rightBorder.Color = value.Replace("#", "").ToLowerInvariant();
             }
         }
 

--- a/OfficeIMO.Word/WordSmartArt.cs
+++ b/OfficeIMO.Word/WordSmartArt.cs
@@ -18,7 +18,7 @@ namespace OfficeIMO.Word {
             return (UInt32Value)(uint)id;
         }
 
-        internal Drawing _drawing;
+        internal Drawing _drawing = null!;
         private readonly WordDocument _document;
         private readonly WordParagraph _paragraph;
 

--- a/OfficeIMO.Word/WordWatermark.cs
+++ b/OfficeIMO.Word/WordWatermark.cs
@@ -38,8 +38,8 @@ namespace OfficeIMO.Word {
     public class WordWatermark : WordElement {
         private WordDocument _document;
         private SdtBlock _sdtBlock;
-        private WordHeader _wordHeader;
-        private WordSection _section;
+        private WordHeader? _wordHeader;
+        private WordSection? _section;
         //private WordParagraph _wordParagraph;
 
         /// <summary>
@@ -516,7 +516,7 @@ namespace OfficeIMO.Word {
         /// <param name="scale">Scale factor for width and height.</param>
         public WordWatermark(WordDocument wordDocument, WordSection wordSection, WordWatermarkStyle style, string textOrFilePath, double? horizontalOffset = null, double? verticalOffset = null, double scale = 1.0) {
             this._document = wordDocument;
-            this._section = wordSection;
+            this._section = wordSection ?? throw new ArgumentNullException(nameof(wordSection));
 
             if (style == WordWatermarkStyle.Text) {
                 this._sdtBlock = GetStyle(style);
@@ -542,7 +542,8 @@ namespace OfficeIMO.Word {
                     lastParagraph._paragraph.Parent.Append(_sdtBlock);
                 }
 
-                var paragraph = this._sdtBlock.SdtContentBlock.GetFirstChild<Paragraph>();
+                var sdtContentBlock = this._sdtBlock.SdtContentBlock ?? throw new InvalidOperationException("Missing content block in watermark");
+                var paragraph = sdtContentBlock.GetFirstChild<Paragraph>() ?? sdtContentBlock.AppendChild(new Paragraph());
                 var wordParagraph = new WordParagraph(wordDocument, paragraph);
                 var imageLocation = WordImage.AddImageToLocation(wordDocument, wordParagraph, imageStream, fileName);
                 SetWatermarkImageData(imageLocation);
@@ -575,7 +576,7 @@ namespace OfficeIMO.Word {
         /// <param name="scale">Scale factor for width and height.</param>
         public WordWatermark(WordDocument wordDocument, WordSection wordSection, WordHeader wordHeader, WordWatermarkStyle style, string textOrFilePath, double? horizontalOffset = null, double? verticalOffset = null, double scale = 1.0) {
             this._document = wordDocument;
-            this._section = wordSection;
+            this._section = wordSection ?? throw new ArgumentNullException(nameof(wordSection));
 
             if (wordHeader == null) {
                 // user didn't create headers first, so we do it for the user
@@ -598,7 +599,8 @@ namespace OfficeIMO.Word {
 
                 wordHeader._header.Append(_sdtBlock);
 
-                var paragraph = this._sdtBlock.SdtContentBlock.GetFirstChild<Paragraph>();
+                var sdtContentBlock = this._sdtBlock.SdtContentBlock ?? throw new InvalidOperationException("Missing content block in watermark");
+                var paragraph = sdtContentBlock.GetFirstChild<Paragraph>() ?? sdtContentBlock.AppendChild(new Paragraph());
                 var wordParagraph = new WordParagraph(wordDocument, paragraph);
                 var imageLocation = WordImage.AddImageToLocation(wordDocument, wordParagraph, imageStream, fileName);
                 SetWatermarkImageData(imageLocation);


### PR DESCRIPTION
## Summary
- handle nullable section/header in watermark creation
- initialize SmartArt drawing field
- guard border access in WordBorders and WordParagraphBorders
- ensure style definitions part always has Styles collection

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a387e87f50832eb9c98154ffaf1457