### PR TITLE
Fix nullable warnings in Markdown converters

### DIFF
--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Inlines.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Inlines.cs
@@ -20,7 +20,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
             }
 
             void Handle(Inline? node, bool bold = false, bool italic = false, bool strike = false, bool underline = false, Inline? stop = null) {
-                for (var current = node; current != null && current != stop; current = current.NextSibling) {
+                for (var current = node; current != null && current != stop; current = current?.NextSibling) {
                     switch (current) {
                         case LiteralInline literal:
                             var run = paragraph.AddText(literal.Content.ToString());
@@ -85,7 +85,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
                                 AddImage(document, paragraph, link);
                             } else {
                                 string label = GetPlainText(link.FirstChild);
-                                var hyperlink = paragraph.AddHyperLink(label, new Uri(link.Url, UriKind.RelativeOrAbsolute));
+                                var hyperlink = paragraph.AddHyperLink(label, new Uri(link.Url ?? string.Empty, UriKind.RelativeOrAbsolute));
                                 if (!string.IsNullOrEmpty(options.FontFamily)) {
                                     hyperlink.SetFontFamily(options.FontFamily);
                                 }
@@ -103,7 +103,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
                             break;
                         default:
                             if (current is LeafInline leaf) {
-                                var other = paragraph.AddText(leaf.ToString());
+                                var other = paragraph.AddText(leaf.ToString() ?? string.Empty);
                                 if (bold) other.SetBold();
                                 if (italic) other.SetItalic();
                                 if (strike) other.SetStrike();
@@ -142,13 +142,14 @@ namespace OfficeIMO.Word.Markdown.Converters {
 
             // Size hints may also appear after the title
             if (!string.IsNullOrEmpty(title)) {
-                var matchTitle = Regex.Match(title, @"\s*=([0-9]+)(?:x([0-9]+))?\s*$");
+                var titleText = title;
+                var matchTitle = Regex.Match(titleText, @"\s*=([0-9]+)(?:x([0-9]+))?\s*$");
                 if (matchTitle.Success) {
                     width ??= double.Parse(matchTitle.Groups[1].Value);
                     if (matchTitle.Groups[2].Success) {
                         height ??= double.Parse(matchTitle.Groups[2].Value);
                     }
-                    title = title.Substring(0, matchTitle.Index).Trim();
+                    title = titleText.Substring(0, matchTitle.Index).Trim();
                 }
             }
 

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Tables.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
             var wordTable = document.AddTable(rows, cols);
             int r = 0;
             foreach (TableRow row in table) {
-                var rowAlignments = GetRowAlignments(row);
+                var rowAlignments = GetRowAlignments(row);            object? data = row.GetData("alignment") ?? row.GetData("alignments");
                 int c = 0;
                 foreach (TableCell cell in row) {
                     var wordCell = wordTable.Rows[r].Cells[c];

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
@@ -100,7 +100,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
                     var monoFont = FontResolver.Resolve("monospace") ?? "Consolas";
                     run.SetFontFamily(monoFont);
                     if (codeBlock is FencedCodeBlock fenced && !string.IsNullOrWhiteSpace(fenced.Info)) {
-                        var info = fenced.Info.Split(new[] { ' ', '{' }, StringSplitOptions.RemoveEmptyEntries);
+                        var info = (fenced.Info ?? string.Empty).Split(new[] { ' ', '{' }, StringSplitOptions.RemoveEmptyEntries);
                         if (info.Length > 0) {
                             var lang = new string(info[0].Where(char.IsLetterOrDigit).ToArray());
                             if (!string.IsNullOrEmpty(lang)) {

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Paragraphs.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Paragraphs.cs
@@ -50,7 +50,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
 
         private string RenderRuns(WordParagraph paragraph, WordToMarkdownOptions options) {
             var sb = new StringBuilder();
-            string codeFont = options.FontFamily ?? FontResolver.Resolve("monospace");
+            string? codeFont = options.FontFamily ?? FontResolver.Resolve("monospace");
             foreach (var run in paragraph.GetRuns()) {
                 if (run.IsFootNote && run.FootNote != null && run.FootNote.ReferenceId.HasValue) {
                     long id = run.FootNote.ReferenceId.Value;
@@ -63,7 +63,7 @@ namespace OfficeIMO.Word.Markdown.Converters {
                     continue;
                 }
 
-                string text = run.Text;
+                string? text = run.Text;
                 if (string.IsNullOrEmpty(text)) {
                     continue;
                 }

--- a/OfficeIMO.Word.Markdown/Options/MarkdownToWordOptions.cs
+++ b/OfficeIMO.Word.Markdown/Options/MarkdownToWordOptions.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Word.Markdown {
         /// <summary>
         /// Optional font family applied to created runs during conversion.
         /// </summary>
-        public string FontFamily { get; set; }
+        public string? FontFamily { get; set; }
         
         /// <summary>
         /// Optional default page size applied when creating new documents.

--- a/OfficeIMO.Word.Markdown/Options/WordToMarkdownOptions.cs
+++ b/OfficeIMO.Word.Markdown/Options/WordToMarkdownOptions.cs
@@ -9,7 +9,7 @@ namespace OfficeIMO.Word.Markdown {
         /// Font family whose runs should be rendered as inline code. When <c>null</c>,
         /// <see cref="FontResolver.Resolve(string)"/> is used with "monospace" to determine the code font.
         /// </summary>
-        public string FontFamily { get; set; }
+        public string? FontFamily { get; set; }
 
         /// <summary>
         /// Enables wrapping underlined text with &lt;u&gt; tags.
@@ -31,6 +31,6 @@ namespace OfficeIMO.Word.Markdown {
         /// When <see cref="ImageExportMode"/> is set to <see cref="ImageExportMode.File"/>,
         /// images are written to this directory. If not specified, the current working directory is used.
         /// </summary>
-        public string ImageDirectory { get; set; }
+        public string? ImageDirectory { get; set; }
     }
 }

--- a/OfficeIMO.Word.Markdown/WordMarkdownConverterExtensions.cs
+++ b/OfficeIMO.Word.Markdown/WordMarkdownConverterExtensions.cs
@@ -40,7 +40,7 @@ namespace OfficeIMO.Word.Markdown {
         public static async Task SaveAsMarkdownAsync(this WordDocument document, string path, WordToMarkdownOptions? options = null, CancellationToken cancellationToken = default) {
             options ??= new WordToMarkdownOptions();
             if (options.ImageExportMode == ImageExportMode.File && string.IsNullOrEmpty(options.ImageDirectory)) {
-                options.ImageDirectory = Path.GetDirectoryName(path);
+                options.ImageDirectory = Path.GetDirectoryName(path) ?? Directory.GetCurrentDirectory();
             }
             var markdown = await document.ToMarkdownAsync(options, cancellationToken).ConfigureAwait(false);
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
@@ -79,6 +79,13 @@ namespace OfficeIMO.Word.Markdown {
             return document.ToMarkdownAsync(options).GetAwaiter().GetResult();
         }
 
+        /// <summary>
+        /// Converts the document to a Markdown string asynchronously.
+        /// </summary>
+        /// <param name="document">Document to convert.</param>
+        /// <param name="options">Optional conversion options.</param>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        /// <returns>Markdown representation of the document.</returns>
         public static async Task<string> ToMarkdownAsync(this WordDocument document, WordToMarkdownOptions? options = null, CancellationToken cancellationToken = default) {
             var converter = new WordToMarkdownConverter();
             return await converter.ConvertAsync(document, options ?? new WordToMarkdownOptions(), cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add null-safe defaults and XML docs for Markdown conversion extensions
- make Markdown conversion options nullable
- guard against null references in Markdown converters

## Testing
- `dotnet build OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a38810383c832e89c2f023a8abae60