### PR TITLE
Fix nullable warnings in WordBorders

### DIFF
--- a/OfficeIMO.Word/WordBorders.cs
+++ b/OfficeIMO.Word/WordBorders.cs
@@ -42,54 +42,39 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the width of the left border.
         /// </summary>
-        public UInt32Value LeftSize {
+        public UInt32Value? LeftSize {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return pageBorder.LeftBorder.Size;
-                }
-
-                return null;
+                return _section._sectionProperties.GetFirstChild<PageBorders>()?.LeftBorder?.Size;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.LeftBorder == null) {
-                    pageBorder.LeftBorder = new LeftBorder();
-                }
-
-                pageBorder.LeftBorder.Size = value;
+                var leftBorder = pageBorder.LeftBorder ?? (pageBorder.LeftBorder = new LeftBorder());
+                leftBorder.Size = value;
             }
         }
 
         /// <summary>
         /// Gets or sets the left border color using a hexadecimal value.
         /// </summary>
-        public string LeftColorHex {
+        public string? LeftColorHex {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return (pageBorder.LeftBorder.Color).Value.Replace("#", "").ToLowerInvariant();
-                }
-
-                return null;
+                var color = _section._sectionProperties.GetFirstChild<PageBorders>()?.LeftBorder?.Color?.Value;
+                return color != null ? color.Replace("#", "").ToLowerInvariant() : null;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.LeftBorder == null) {
-                    pageBorder.LeftBorder = new LeftBorder();
-                }
-
-                pageBorder.LeftBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                var leftBorder = pageBorder.LeftBorder ?? (pageBorder.LeftBorder = new LeftBorder());
+                leftBorder.Color = value?.Replace("#", "").ToLowerInvariant();
             }
         }
 
@@ -97,8 +82,13 @@ namespace OfficeIMO.Word {
         /// Gets or sets the left border color using a <see cref="SixLabors.ImageSharp.Color"/> value.
         /// </summary>
         public SixLabors.ImageSharp.Color LeftColor {
-            get { return Helpers.ParseColor(LeftColorHex); }
-            set { this.LeftColorHex = value.ToHexColor(); }
+            get {
+                var hex = LeftColorHex;
+                return Helpers.ParseColor(hex ?? throw new InvalidOperationException("LeftColorHex is null"));
+            }
+            set {
+                LeftColorHex = value.ToHexColor();
+            }
         }
 
         /// <summary>
@@ -106,52 +96,40 @@ namespace OfficeIMO.Word {
         /// </summary>
         public BorderValues? LeftStyle {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return pageBorder.LeftBorder.Val;
-                }
-
-                return null;
+                return _section._sectionProperties.GetFirstChild<PageBorders>()?.LeftBorder?.Val?.Value;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.LeftBorder == null) {
-                    pageBorder.LeftBorder = new LeftBorder();
+                var leftBorder = pageBorder.LeftBorder ?? (pageBorder.LeftBorder = new LeftBorder());
+                if (value.HasValue) {
+                    leftBorder.Val = value.Value;
+                } else {
+                    leftBorder.Val = null;
                 }
-
-                pageBorder.LeftBorder.Val = value;
             }
         }
 
         /// <summary>
         /// Gets or sets the space between the left border and page text.
         /// </summary>
-        public UInt32Value LeftSpace {
+        public UInt32Value? LeftSpace {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return pageBorder.LeftBorder.Space;
-                }
-
-                return null;
+                return _section._sectionProperties.GetFirstChild<PageBorders>()?.LeftBorder?.Space;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.LeftBorder == null) {
-                    pageBorder.LeftBorder = new LeftBorder();
-                }
-
-                pageBorder.LeftBorder.Space = value;
+                var leftBorder = pageBorder.LeftBorder ?? (pageBorder.LeftBorder = new LeftBorder());
+                leftBorder.Space = value;
             }
         }
 
@@ -160,25 +138,18 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool? LeftShadow {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null && pageBorder.LeftBorder.Shadow != null) {
-                    return pageBorder.LeftBorder.Shadow;
-                }
-
-                return null;
+                var shadow = _section._sectionProperties.GetFirstChild<PageBorders>()?.LeftBorder?.Shadow;
+                return shadow != null ? shadow.Value : (bool?)null;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.LeftBorder == null) {
-                    pageBorder.LeftBorder = new LeftBorder();
-                }
-
-                pageBorder.LeftBorder.Shadow = value;
+                var leftBorder = pageBorder.LeftBorder ?? (pageBorder.LeftBorder = new LeftBorder());
+                leftBorder.Shadow = value;
             }
         }
 
@@ -187,79 +158,57 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool? LeftFrame {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null && pageBorder.LeftBorder.Frame != null) {
-                    return pageBorder.LeftBorder.Frame;
-                }
-
-                return null;
+                var frame = _section._sectionProperties.GetFirstChild<PageBorders>()?.LeftBorder?.Frame;
+                return frame != null ? frame.Value : (bool?)null;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.LeftBorder == null) {
-                    pageBorder.LeftBorder = new LeftBorder();
-                }
-
-                pageBorder.LeftBorder.Frame = value;
+                var leftBorder = pageBorder.LeftBorder ?? (pageBorder.LeftBorder = new LeftBorder());
+                leftBorder.Frame = value;
             }
         }
 
         /// <summary>
         /// Gets or sets the width of the right border.
         /// </summary>
-        public UInt32Value RightSize {
+        public UInt32Value? RightSize {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return pageBorder.RightBorder.Size;
-                }
-
-                return null;
+                return _section._sectionProperties.GetFirstChild<PageBorders>()?.RightBorder?.Size;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.RightBorder == null) {
-                    pageBorder.RightBorder = new RightBorder();
-                }
-
-                pageBorder.RightBorder.Size = value;
+                var rightBorder = pageBorder.RightBorder ?? (pageBorder.RightBorder = new RightBorder());
+                rightBorder.Size = value;
             }
         }
 
         /// <summary>
         /// Gets or sets the right border color using a hexadecimal value.
         /// </summary>
-        public string RightColorHex {
+        public string? RightColorHex {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return (pageBorder.RightBorder.Color).Value.Replace("#", "").ToLowerInvariant();
-                }
-
-                return null;
+                var color = _section._sectionProperties.GetFirstChild<PageBorders>()?.RightBorder?.Color?.Value;
+                return color != null ? color.Replace("#", "").ToLowerInvariant() : null;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.RightBorder == null) {
-                    pageBorder.RightBorder = new RightBorder();
-                }
-
-                pageBorder.RightBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                var rightBorder = pageBorder.RightBorder ?? (pageBorder.RightBorder = new RightBorder());
+                rightBorder.Color = value?.Replace("#", "").ToLowerInvariant();
             }
         }
 
@@ -267,8 +216,13 @@ namespace OfficeIMO.Word {
         /// Gets or sets the right border color using a <see cref="SixLabors.ImageSharp.Color"/> value.
         /// </summary>
         public SixLabors.ImageSharp.Color RightColor {
-            get { return Helpers.ParseColor(RightColorHex); }
-            set { this.RightColorHex = value.ToHexColor(); }
+            get {
+                var hex = RightColorHex;
+                return Helpers.ParseColor(hex ?? throw new InvalidOperationException("RightColorHex is null"));
+            }
+            set {
+                RightColorHex = value.ToHexColor();
+            }
         }
 
         /// <summary>
@@ -276,52 +230,40 @@ namespace OfficeIMO.Word {
         /// </summary>
         public BorderValues? RightStyle {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return pageBorder.RightBorder.Val;
-                }
-
-                return null;
+                return _section._sectionProperties.GetFirstChild<PageBorders>()?.RightBorder?.Val?.Value;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.RightBorder == null) {
-                    pageBorder.RightBorder = new RightBorder();
+                var rightBorder = pageBorder.RightBorder ?? (pageBorder.RightBorder = new RightBorder());
+                if (value.HasValue) {
+                    rightBorder.Val = value.Value;
+                } else {
+                    rightBorder.Val = null;
                 }
-
-                pageBorder.RightBorder.Val = value;
             }
         }
 
         /// <summary>
         /// Gets or sets the space between the right border and page text.
         /// </summary>
-        public UInt32Value RightSpace {
+        public UInt32Value? RightSpace {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return pageBorder.RightBorder.Space;
-                }
-
-                return null;
+                return _section._sectionProperties.GetFirstChild<PageBorders>()?.RightBorder?.Space;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.RightBorder == null) {
-                    pageBorder.RightBorder = new RightBorder();
-                }
-
-                pageBorder.RightBorder.Space = value;
+                var rightBorder = pageBorder.RightBorder ?? (pageBorder.RightBorder = new RightBorder());
+                rightBorder.Space = value;
             }
         }
 
@@ -330,25 +272,18 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool? RightShadow {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null && pageBorder.RightBorder.Shadow != null) {
-                    return pageBorder.RightBorder.Shadow;
-                }
-
-                return null;
+                var shadow = _section._sectionProperties.GetFirstChild<PageBorders>()?.RightBorder?.Shadow;
+                return shadow != null ? shadow.Value : (bool?)null;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.RightBorder == null) {
-                    pageBorder.RightBorder = new RightBorder();
-                }
-
-                pageBorder.RightBorder.Shadow = value;
+                var rightBorder = pageBorder.RightBorder ?? (pageBorder.RightBorder = new RightBorder());
+                rightBorder.Shadow = value;
             }
         }
 
@@ -357,79 +292,57 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool? RightFrame {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null && pageBorder.RightBorder.Frame != null) {
-                    return pageBorder.RightBorder.Frame;
-                }
-
-                return null;
+                var frame = _section._sectionProperties.GetFirstChild<PageBorders>()?.RightBorder?.Frame;
+                return frame != null ? frame.Value : (bool?)null;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.RightBorder == null) {
-                    pageBorder.RightBorder = new RightBorder();
-                }
-
-                pageBorder.RightBorder.Frame = value;
+                var rightBorder = pageBorder.RightBorder ?? (pageBorder.RightBorder = new RightBorder());
+                rightBorder.Frame = value;
             }
         }
 
         /// <summary>
         /// Gets or sets the width of the top border.
         /// </summary>
-        public UInt32Value TopSize {
+        public UInt32Value? TopSize {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return pageBorder.TopBorder.Size;
-                }
-
-                return null;
+                return _section._sectionProperties.GetFirstChild<PageBorders>()?.TopBorder?.Size;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.TopBorder == null) {
-                    pageBorder.TopBorder = new TopBorder();
-                }
-
-                pageBorder.TopBorder.Size = value;
+                var topBorder = pageBorder.TopBorder ?? (pageBorder.TopBorder = new TopBorder());
+                topBorder.Size = value;
             }
         }
 
         /// <summary>
         /// Gets or sets the top border color using a hexadecimal value.
         /// </summary>
-        public string TopColorHex {
+        public string? TopColorHex {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return (pageBorder.TopBorder.Color).Value.Replace("#", "").ToLowerInvariant();
-                }
-
-                return null;
+                var color = _section._sectionProperties.GetFirstChild<PageBorders>()?.TopBorder?.Color?.Value;
+                return color != null ? color.Replace("#", "").ToLowerInvariant() : null;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.TopBorder == null) {
-                    pageBorder.TopBorder = new TopBorder();
-                }
-
-                pageBorder.TopBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                var topBorder = pageBorder.TopBorder ?? (pageBorder.TopBorder = new TopBorder());
+                topBorder.Color = value?.Replace("#", "").ToLowerInvariant();
             }
         }
 
@@ -437,8 +350,13 @@ namespace OfficeIMO.Word {
         /// Gets or sets the top border color using a <see cref="SixLabors.ImageSharp.Color"/> value.
         /// </summary>
         public SixLabors.ImageSharp.Color TopColor {
-            get { return Helpers.ParseColor(TopColorHex); }
-            set { this.TopColorHex = value.ToHexColor(); }
+            get {
+                var hex = TopColorHex;
+                return Helpers.ParseColor(hex ?? throw new InvalidOperationException("TopColorHex is null"));
+            }
+            set {
+                TopColorHex = value.ToHexColor();
+            }
         }
 
         /// <summary>
@@ -446,52 +364,40 @@ namespace OfficeIMO.Word {
         /// </summary>
         public BorderValues? TopStyle {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return pageBorder.TopBorder.Val;
-                }
-
-                return null;
+                return _section._sectionProperties.GetFirstChild<PageBorders>()?.TopBorder?.Val?.Value;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.TopBorder == null) {
-                    pageBorder.TopBorder = new TopBorder();
+                var topBorder = pageBorder.TopBorder ?? (pageBorder.TopBorder = new TopBorder());
+                if (value.HasValue) {
+                    topBorder.Val = value.Value;
+                } else {
+                    topBorder.Val = null;
                 }
-
-                pageBorder.TopBorder.Val = value;
             }
         }
 
         /// <summary>
         /// Gets or sets the space between the top border and page text.
         /// </summary>
-        public UInt32Value TopSpace {
+        public UInt32Value? TopSpace {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return pageBorder.TopBorder.Space;
-                }
-
-                return null;
+                return _section._sectionProperties.GetFirstChild<PageBorders>()?.TopBorder?.Space;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.TopBorder == null) {
-                    pageBorder.TopBorder = new TopBorder();
-                }
-
-                pageBorder.TopBorder.Space = value;
+                var topBorder = pageBorder.TopBorder ?? (pageBorder.TopBorder = new TopBorder());
+                topBorder.Space = value;
             }
         }
 
@@ -541,54 +447,39 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the width of the bottom border.
         /// </summary>
-        public UInt32Value BottomSize {
+        public UInt32Value? BottomSize {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return pageBorder.BottomBorder.Size;
-                }
-
-                return null;
+                return _section._sectionProperties.GetFirstChild<PageBorders>()?.BottomBorder?.Size;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.BottomBorder == null) {
-                    pageBorder.BottomBorder = new BottomBorder();
-                }
-
-                pageBorder.BottomBorder.Size = value;
+                var bottomBorder = pageBorder.BottomBorder ?? (pageBorder.BottomBorder = new BottomBorder());
+                bottomBorder.Size = value;
             }
         }
 
         /// <summary>
         /// Gets or sets the bottom border color using a hexadecimal value.
         /// </summary>
-        public string BottomColorHex {
+        public string? BottomColorHex {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return (pageBorder.BottomBorder.Color).Value.Replace("#", "").ToLowerInvariant();
-                }
-
-                return null;
+                var color = _section._sectionProperties.GetFirstChild<PageBorders>()?.BottomBorder?.Color?.Value;
+                return color != null ? color.Replace("#", "").ToLowerInvariant() : null;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.BottomBorder == null) {
-                    pageBorder.BottomBorder = new BottomBorder();
-                }
-
-                pageBorder.BottomBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                var bottomBorder = pageBorder.BottomBorder ?? (pageBorder.BottomBorder = new BottomBorder());
+                bottomBorder.Color = value?.Replace("#", "").ToLowerInvariant();
             }
         }
 
@@ -596,8 +487,13 @@ namespace OfficeIMO.Word {
         /// Gets or sets the bottom border color using a <see cref="SixLabors.ImageSharp.Color"/> value.
         /// </summary>
         public SixLabors.ImageSharp.Color BottomColor {
-            get { return Helpers.ParseColor(BottomColorHex); }
-            set { this.BottomColorHex = value.ToHexColor(); }
+            get {
+                var hex = BottomColorHex;
+                return Helpers.ParseColor(hex ?? throw new InvalidOperationException("BottomColorHex is null"));
+            }
+            set {
+                BottomColorHex = value.ToHexColor();
+            }
         }
 
         /// <summary>
@@ -605,52 +501,40 @@ namespace OfficeIMO.Word {
         /// </summary>
         public BorderValues? BottomStyle {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return pageBorder.BottomBorder.Val;
-                }
-
-                return null;
+                return _section._sectionProperties.GetFirstChild<PageBorders>()?.BottomBorder?.Val?.Value;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.BottomBorder == null) {
-                    pageBorder.BottomBorder = new BottomBorder();
+                var bottomBorder = pageBorder.BottomBorder ?? (pageBorder.BottomBorder = new BottomBorder());
+                if (value.HasValue) {
+                    bottomBorder.Val = value.Value;
+                } else {
+                    bottomBorder.Val = null;
                 }
-
-                pageBorder.BottomBorder.Val = value;
             }
         }
 
         /// <summary>
         /// Gets or sets the space between the bottom border and page text.
         /// </summary>
-        public UInt32Value BottomSpace {
+        public UInt32Value? BottomSpace {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    return pageBorder.BottomBorder.Space;
-                }
-
-                return null;
+                return _section._sectionProperties.GetFirstChild<PageBorders>()?.BottomBorder?.Space;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.BottomBorder == null) {
-                    pageBorder.BottomBorder = new BottomBorder();
-                }
-
-                pageBorder.BottomBorder.Space = value;
+                var bottomBorder = pageBorder.BottomBorder ?? (pageBorder.BottomBorder = new BottomBorder());
+                bottomBorder.Space = value;
             }
         }
 
@@ -659,25 +543,18 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool? BottomShadow {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null && pageBorder.BottomBorder.Shadow != null) {
-                    return pageBorder.BottomBorder.Shadow;
-                }
-
-                return null;
+                var shadow = _section._sectionProperties.GetFirstChild<PageBorders>()?.BottomBorder?.Shadow;
+                return shadow != null ? shadow.Value : (bool?)null;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.BottomBorder == null) {
-                    pageBorder.BottomBorder = new BottomBorder();
-                }
-
-                pageBorder.BottomBorder.Shadow = value;
+                var bottomBorder = pageBorder.BottomBorder ?? (pageBorder.BottomBorder = new BottomBorder());
+                bottomBorder.Shadow = value;
             }
         }
 
@@ -686,25 +563,18 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool? BottomFrame {
             get {
-                var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null && pageBorder.BottomBorder.Frame != null) {
-                    return pageBorder.BottomBorder.Frame;
-                }
-
-                return null;
+                var frame = _section._sectionProperties.GetFirstChild<PageBorders>()?.BottomBorder?.Frame;
+                return frame != null ? frame.Value : (bool?)null;
             }
             set {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
-                    _section._sectionProperties.Append(Custom);
-                    pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
+                    pageBorder = Custom;
+                    _section._sectionProperties.Append(pageBorder);
                 }
 
-                if (pageBorder.BottomBorder == null) {
-                    pageBorder.BottomBorder = new BottomBorder();
-                }
-
-                pageBorder.BottomBorder.Frame = value;
+                var bottomBorder = pageBorder.BottomBorder ?? (pageBorder.BottomBorder = new BottomBorder());
+                bottomBorder.Frame = value;
             }
         }
 
@@ -713,9 +583,7 @@ namespace OfficeIMO.Word {
             var pageBorderSettings = GetDefault(wordBorder);
             if (pageBorderSettings == null) {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
-                if (pageBorder != null) {
-                    pageBorder.Remove();
-                }
+                pageBorder?.Remove();
             } else {
                 var pageBorder = _section._sectionProperties.GetFirstChild<PageBorders>();
                 if (pageBorder == null) {
@@ -740,6 +608,9 @@ namespace OfficeIMO.Word {
                         }
 
                         var pageBordersBuiltin = GetDefault(wordBorder);
+                        if (pageBordersBuiltin == null) {
+                            continue;
+                        }
 
                         if ((pageBordersBuiltin.LeftBorder == null && pageBorder.LeftBorder == null) &&
                             (pageBordersBuiltin.RightBorder == null && pageBorder.RightBorder == null) &&
@@ -780,7 +651,7 @@ namespace OfficeIMO.Word {
             set => SetBorder(value);
         }
 
-        private static PageBorders GetDefault(WordBorder border) {
+        private static PageBorders? GetDefault(WordBorder border) {
             switch (border) {
                 case WordBorder.Box: return Box;
                 case WordBorder.Shadow: return Shadow;


### PR DESCRIPTION
## Summary
- add null-safe border accessors for page sections
- return nullable PageBorders from GetDefault to simplify null handling

## Testing
- `dotnet build OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a38d1fe2cc832eab699872bb93120e