### PR TITLE
Improve test nullability handling and async usage

### DIFF
--- a/OfficeIMO.Tests/Html.CodeBlocks.cs
+++ b/OfficeIMO.Tests/Html.CodeBlocks.cs
@@ -24,7 +24,7 @@ namespace OfficeIMO.Tests {
             Assert.Contains("<pre><code>", roundTrip);
             Assert.Contains("var x = 1;", roundTrip);
             Assert.Contains("var y = 2;", roundTrip);
-            Assert.Equal(1, Regex.Matches(roundTrip, "<pre>").Count);
+            Assert.Single(Regex.Matches(roundTrip, "<pre>"));
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Html.Convert.cs
+++ b/OfficeIMO.Tests/Html.Convert.cs
@@ -7,21 +7,21 @@ using Xunit;
 namespace OfficeIMO.Tests {
     public partial class Html {
         [Fact]
-        public void WordToHtmlConverter_Convert_EqualsAsync() {
+        public async Task WordToHtmlConverter_Convert_EqualsAsync() {
             using var doc = WordDocument.Create();
             doc.AddParagraph("Test");
             var converter = new WordToHtmlConverter();
             string sync = converter.Convert(doc, new WordToHtmlOptions());
-            string asyncResult = converter.ConvertAsync(doc, new WordToHtmlOptions()).GetAwaiter().GetResult();
+            string asyncResult = await converter.ConvertAsync(doc, new WordToHtmlOptions());
             Assert.Equal(sync, asyncResult);
         }
 
         [Fact]
-        public void HtmlToWordConverter_Convert_EqualsAsync() {
+        public async Task HtmlToWordConverter_Convert_EqualsAsync() {
             string html = "<p>Test</p>";
             var converter = new HtmlToWordConverter();
             using var syncDoc = converter.Convert(html, new HtmlToWordOptions());
-            using var asyncDoc = converter.ConvertAsync(html, new HtmlToWordOptions()).GetAwaiter().GetResult();
+            using var asyncDoc = await converter.ConvertAsync(html, new HtmlToWordOptions());
             Assert.Equal(syncDoc.Paragraphs.Count, asyncDoc.Paragraphs.Count);
             Assert.Equal(syncDoc.Paragraphs[0].Text, asyncDoc.Paragraphs[0].Text);
         }

--- a/OfficeIMO.Tests/Markdown.Images.cs
+++ b/OfficeIMO.Tests/Markdown.Images.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace OfficeIMO.Tests {
     public partial class Markdown {
         [Fact]
-        public void MarkdownToWord_ParsesImageHints() {
+        public async Task MarkdownToWord_ParsesImageHints() {
             string imagePath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png"));
             int port = GetAvailablePort();
 
@@ -40,7 +40,7 @@ namespace OfficeIMO.Tests {
             Assert.Equal(50, doc.Images[1].Width);
             Assert.Equal(20, doc.Images[1].Height);
 
-            serverTask.Wait();
+            await serverTask;
             listener.Stop();
         }
 

--- a/OfficeIMO.Tests/Word.Helpers.cs
+++ b/OfficeIMO.Tests/Word.Helpers.cs
@@ -26,7 +26,7 @@ public partial class Word {
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void Open_WithInvalidFilePath_ThrowsArgumentException(string path) {
-        Assert.Throws<ArgumentException>(() => Helpers.Open(path, true));
-    }
+        public void Open_WithInvalidFilePath_ThrowsArgumentException(string? path) {
+            Assert.Throws<ArgumentException>(() => Helpers.Open(path!, true));
+        }
 }

--- a/OfficeIMO.Tests/Word.Settings.cs
+++ b/OfficeIMO.Tests/Word.Settings.cs
@@ -214,7 +214,7 @@ namespace OfficeIMO.Tests {
         [InlineData("1", true)]
         [InlineData("0", false)]
         [InlineData(null, false)]
-        public void Test_FinalDocument_CustomPropertyValues(string value, bool expected) {
+        public void Test_FinalDocument_CustomPropertyValues(string? value, bool expected) {
             string filePath = Path.Combine(_directoryWithFiles, $"Test_FinalDocument_Value_{expected}.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddParagraph("Test FinalDocument values");

--- a/OfficeIMO.Tests/Word.StructuredDocumentTagBody.cs
+++ b/OfficeIMO.Tests/Word.StructuredDocumentTagBody.cs
@@ -20,7 +20,9 @@ namespace OfficeIMO.Tests {
                         new Paragraph(new Run(new Text("Body text") { Space = SpaceProcessingModeValues.Preserve }))
                     )
                 );
-                document._wordprocessingDocument.MainDocumentPart.Document.Body.Append(block);
+                var body = document._wordprocessingDocument?.MainDocumentPart?.Document?.Body;
+                Assert.NotNull(body);
+                body.Append(block);
                 document.Save(false);
                 Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
             }

--- a/OfficeIMO.Tests/Word.TOC.cs
+++ b/OfficeIMO.Tests/Word.TOC.cs
@@ -151,7 +151,7 @@ namespace OfficeIMO.Tests {
                 document.AddPageBreak();
 
                 // lets find a list which has items which suggest it's a TOC attached list
-                WordList wordListToc = null;
+                WordList? wordListToc = null;
                 foreach (var list in document.Lists) {
                     if (list.IsToc) {
                         wordListToc = list;

--- a/OfficeIMO.Tests/Word.Tables.Margins.cs
+++ b/OfficeIMO.Tests/Word.Tables.Margins.cs
@@ -28,16 +28,16 @@ namespace OfficeIMO.Tests {
                 table1.StyleDetails.MarginDefaultRightCentimeters = 0.2;
 
                 // Verify the centimeter values
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightCentimeters.Value - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightCentimeters.GetValueOrDefault() - 0.2) < 0.01);
 
                 // Verify the twips values (0.2 cm should be approximately 113.4 twips)
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopWidth.Value - 113) <= 1);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomWidth.Value - 113) <= 1);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftWidth.Value - 113) <= 1);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightWidth.Value - 113) <= 1);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopWidth.GetValueOrDefault() - 113) <= 1);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomWidth.GetValueOrDefault() - 113) <= 1);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftWidth.GetValueOrDefault() - 113) <= 1);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightWidth.GetValueOrDefault() - 113) <= 1);
 
                 document.AddParagraph();
 
@@ -52,8 +52,8 @@ namespace OfficeIMO.Tests {
                 table2.StyleDetails.MarginDefaultRightWidth = 170;
 
                 // Verify centimeter values
-                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultTopCentimeters.Value - 0.3) < 0.01);
-                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultBottomCentimeters.Value - 0.3) < 0.01);
+                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.3) < 0.01);
+                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.3) < 0.01);
 
                 // Verify twips values
                 Assert.True(table2.StyleDetails.MarginDefaultLeftWidth == 170);
@@ -69,10 +69,10 @@ namespace OfficeIMO.Tests {
                 table3.StyleDetails.CellSpacingCentimeters = 0.15;
 
                 // Verify centimeter value
-                Assert.True(Math.Abs(table3.StyleDetails.CellSpacingCentimeters.Value - 0.15) < 0.01);
+                Assert.True(Math.Abs(table3.StyleDetails.CellSpacingCentimeters.GetValueOrDefault() - 0.15) < 0.01);
 
                 // Verify twips value (0.15 cm should be approximately 85 twips)
-                Assert.True(Math.Abs(table3.StyleDetails.CellSpacing.Value - 85) <= 1);
+                Assert.True(Math.Abs(table3.StyleDetails.CellSpacing.GetValueOrDefault() - 85) <= 1);
 
                 document.AddParagraph();
 
@@ -86,9 +86,9 @@ namespace OfficeIMO.Tests {
                 table4.StyleDetails.CellSpacingCentimeters = 0.1;
 
                 // Verify values are set
-                Assert.True(Math.Abs(table4.StyleDetails.MarginDefaultTopCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table4.StyleDetails.MarginDefaultBottomCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table4.StyleDetails.CellSpacingCentimeters.Value - 0.1) < 0.01);
+                  Assert.True(Math.Abs(table4.StyleDetails.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                  Assert.True(Math.Abs(table4.StyleDetails.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                  Assert.True(Math.Abs(table4.StyleDetails.CellSpacingCentimeters.GetValueOrDefault() - 0.1) < 0.01);
 
                 // Clear values
                 table4.StyleDetails.MarginDefaultTopCentimeters = null;
@@ -107,21 +107,21 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithTableMargins.docx"))) {
                 // Verify table 1 values
                 var table1 = document.Tables[0];
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightCentimeters.Value - 0.2) < 0.01);
+                  Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                  Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                  Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                  Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightCentimeters.GetValueOrDefault() - 0.2) < 0.01);
 
                 // Verify table 2 values
                 var table2 = document.Tables[1];
-                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultTopCentimeters.Value - 0.3) < 0.01);
-                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultBottomCentimeters.Value - 0.3) < 0.01);
+                  Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.3) < 0.01);
+                  Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.3) < 0.01);
                 Assert.True(table2.StyleDetails.MarginDefaultLeftWidth == 170);
                 Assert.True(table2.StyleDetails.MarginDefaultRightWidth == 170);
 
                 // Verify table 3 values
                 var table3 = document.Tables[2];
-                Assert.True(Math.Abs(table3.StyleDetails.CellSpacingCentimeters.Value - 0.15) < 0.01);
+                  Assert.True(Math.Abs(table3.StyleDetails.CellSpacingCentimeters.GetValueOrDefault() - 0.15) < 0.01);
 
                 // Verify table 4 values are cleared
                 var table4 = document.Tables[3];

--- a/OfficeIMO.Tests/Word.TablesLoading.cs
+++ b/OfficeIMO.Tests/Word.TablesLoading.cs
@@ -15,15 +15,15 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryDocuments, "DocumentWithTables.docx");
             using (WordDocument document = WordDocument.Load(filePath)) {
                 // We check for style definition part.
-                StyleDefinitionsPart styleDefinitionsPart = document._document.MainDocumentPart.GetPartsOfType<StyleDefinitionsPart>().FirstOrDefault();
+                StyleDefinitionsPart? styleDefinitionsPart = document._document?.MainDocumentPart?.GetPartsOfType<StyleDefinitionsPart>().FirstOrDefault();
                 // It should exists
                 Assert.True(styleDefinitionsPart != null);
 
                 // we now check if all table styles are available for use
                 List<Style> listTableStyles = new List<Style>();
-                var styles = styleDefinitionsPart.Styles.OfType<Style>().ToList();
+                var styles = styleDefinitionsPart!.Styles?.OfType<Style>()?.ToList() ?? new List<Style>();
                 foreach (var style in styles) {
-                    if (style.Type == StyleValues.Table) {
+                    if (style.Type != null && style.Type == StyleValues.Table) {
                         listTableStyles.Add(style);
                     }
                 }

--- a/OfficeIMO.Tests/Word.TablesNested.cs
+++ b/OfficeIMO.Tests/Word.TablesNested.cs
@@ -88,17 +88,19 @@ namespace OfficeIMO.Tests {
 
                 foreach (var table in document.TablesIncludingNestedTables) {
                     if (table.IsNestedTable) {
+                        Assert.NotNull(table.ParentTable);
                         Assert.True(table.ParentTable.RowsCount > 0);
                     } else {
-                        Assert.True(table.ParentTable == null);
+                        Assert.Null(table.ParentTable);
                     }
                 }
 
                 foreach (var table in document.Sections[0].TablesIncludingNestedTables) {
                     if (table.IsNestedTable) {
+                        Assert.NotNull(table.ParentTable);
                         Assert.True(table.ParentTable.RowsCount > 0);
                     } else {
-                        Assert.True(table.ParentTable == null);
+                        Assert.Null(table.ParentTable);
                     }
                 }
                 Assert.True(document.Sections[0].TablesIncludingNestedTables.Count == 7);

--- a/OfficeIMO.Tests/Word.TextBox.cs
+++ b/OfficeIMO.Tests/Word.TextBox.cs
@@ -182,7 +182,8 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.LeftSpace == 24);
 
                 Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightStyle == BorderValues.Single);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightSize == 4);
+                Assert.NotNull(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightSize);
+                Assert.Equal(4U, document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightSize!.Value);
                 Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightColor == null);
                 Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightShadow == true);
                 Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightSpace == 24);
@@ -246,7 +247,8 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftSpace == 24);
                 Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftFrame == null);
                 Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightStyle == BorderValues.Single);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightSize == 4);
+                Assert.NotNull(document.TextBoxes[1].Paragraphs[0].Borders.RightSize);
+                Assert.Equal(4U, document.TextBoxes[1].Paragraphs[0].Borders.RightSize!.Value);
                 Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightColor == null);
                 Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightShadow == null);
                 Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightSpace == 24);

--- a/OfficeIMO.Tests/Word.Validation.cs
+++ b/OfficeIMO.Tests/Word.Validation.cs
@@ -88,7 +88,9 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(filePath)) {
                 var numbering = document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart!.Numbering;
                 Assert.NotNull(numbering.LookupNamespace("w15"));
-                Assert.Contains("w15", numbering.MCAttributes!.Ignorable!.Value.Split(' '));
+                var ignorable = numbering.MCAttributes?.Ignorable?.Value;
+                Assert.NotNull(ignorable);
+                Assert.Contains("w15", ignorable.Split(' '));
                 Assert.DoesNotContain(
                     document.DocumentValidationErrors.Select(e => e.Description),
                     d => d.Contains("restartNumberingAfterBreak"));


### PR DESCRIPTION
## Summary
- add explicit null checks in Word table and structured document tag tests
- update converter and markdown tests to use async/await patterns
- guard against nullable value use in table margin tests

## Testing
- `dotnet build OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a38e9fddc4832ebea7df18575e12da