### PR TITLE
Add PowerPoint slide enumeration, formatting, transitions, and chart support

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/AdvancedPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/AdvancedPowerPoint.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.Examples.PowerPoint {
+    /// <summary>
+    /// Demonstrates advanced slide features such as backgrounds, transitions and charts.
+    /// </summary>
+    public static class AdvancedPowerPoint {
+        public static void Example_AdvancedPowerPoint(string folderPath, bool openPowerPoint) {
+            Console.WriteLine("[*] PowerPoint - Advanced features");
+            string filePath = Path.Combine(folderPath, "Advanced PowerPoint.pptx");
+
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+            PowerPointSlide slide = presentation.AddSlide();
+            PPTextBox text = slide.AddTextBox("Sample text");
+            slide.AddChart();
+            slide.BackgroundColor = "FFFF00";
+            text.FillColor = "FF0000";
+            slide.Transition = SlideTransition.Wipe;
+            slide.Notes.Text = "Demo notes";
+            presentation.Save();
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PPChart.cs
+++ b/OfficeIMO.PowerPoint/PPChart.cs
@@ -1,0 +1,11 @@
+using DocumentFormat.OpenXml.Presentation;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    /// Represents a chart on a slide.
+    /// </summary>
+    public class PPChart : PPShape {
+        internal PPChart(GraphicFrame frame) : base(frame) {
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PPShape.cs
+++ b/OfficeIMO.PowerPoint/PPShape.cs
@@ -1,4 +1,6 @@
 using DocumentFormat.OpenXml;
+using A = DocumentFormat.OpenXml.Drawing;
+using DocumentFormat.OpenXml.Presentation;
 
 namespace OfficeIMO.PowerPoint {
     /// <summary>
@@ -9,6 +11,28 @@ namespace OfficeIMO.PowerPoint {
 
         internal PPShape(OpenXmlElement element) {
             Element = element;
+        }
+
+        /// <summary>
+        /// Gets or sets the fill color of the shape in hex format (e.g. "FF0000").
+        /// </summary>
+        public string? FillColor {
+            get {
+                if (Element is Shape shape) {
+                    A.SolidFill? solid = shape.ShapeProperties?.GetFirstChild<A.SolidFill>();
+                    return solid?.RgbColorModelHex?.Val;
+                }
+                return null;
+            }
+            set {
+                if (Element is Shape shape) {
+                    shape.ShapeProperties ??= new ShapeProperties();
+                    shape.ShapeProperties.RemoveAllChildren<A.SolidFill>();
+                    if (value != null) {
+                        shape.ShapeProperties.Append(new A.SolidFill(new A.RgbColorModelHex { Val = value }));
+                    }
+                }
+            }
         }
     }
 }

--- a/OfficeIMO.PowerPoint/PowerPointSlide.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.cs
@@ -5,6 +5,8 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using A = DocumentFormat.OpenXml.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+using S = DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.PowerPoint {
     /// <summary>
@@ -26,9 +28,93 @@ namespace OfficeIMO.PowerPoint {
         public IReadOnlyList<PPShape> Shapes => _shapes;
 
         /// <summary>
+        /// Enumerates all textbox shapes on the slide.
+        /// </summary>
+        public IEnumerable<PPTextBox> TextBoxes => _shapes.OfType<PPTextBox>();
+
+        /// <summary>
+        /// Enumerates all picture shapes on the slide.
+        /// </summary>
+        public IEnumerable<PPPicture> Pictures => _shapes.OfType<PPPicture>();
+
+        /// <summary>
+        /// Enumerates all table shapes on the slide.
+        /// </summary>
+        public IEnumerable<PPTable> Tables => _shapes.OfType<PPTable>();
+
+        /// <summary>
+        /// Enumerates all charts on the slide.
+        /// </summary>
+        public IEnumerable<PPChart> Charts => _shapes.OfType<PPChart>();
+
+        /// <summary>
         /// Notes associated with the slide.
         /// </summary>
         public PPNotes Notes => _notes ??= new PPNotes(_slidePart);
+
+        /// <summary>
+        /// Gets or sets the slide background color in hex format (e.g. "FF0000").
+        /// </summary>
+        public string? BackgroundColor {
+            get {
+                Background? bg = _slidePart.Slide.CommonSlideData!.Background;
+                A.SolidFill? solid = bg?.BackgroundProperties?.GetFirstChild<A.SolidFill>();
+                return solid?.RgbColorModelHex?.Val;
+            }
+            set {
+                if (value == null) {
+                    _slidePart.Slide.CommonSlideData!.Background = null;
+                    return;
+                }
+
+                Background bg = _slidePart.Slide.CommonSlideData!.Background ?? new Background();
+                BackgroundProperties props = bg.BackgroundProperties ?? new BackgroundProperties();
+                props.RemoveAllChildren<A.SolidFill>();
+                props.Append(new A.SolidFill(new A.RgbColorModelHex { Val = value }));
+                bg.BackgroundProperties = props;
+                _slidePart.Slide.CommonSlideData!.Background = bg;
+            }
+        }
+
+        /// <summary>
+        /// Transition applied when moving to this slide.
+        /// </summary>
+        public SlideTransition Transition {
+            get {
+                Transition? t = _slidePart.Slide.Transition;
+                if (t == null) {
+                    return SlideTransition.None;
+                }
+
+                if (t.GetFirstChild<FadeTransition>() != null) {
+                    return SlideTransition.Fade;
+                }
+
+                if (t.GetFirstChild<WipeTransition>() != null) {
+                    return SlideTransition.Wipe;
+                }
+
+                return SlideTransition.None;
+            }
+            set {
+                if (value == SlideTransition.None) {
+                    _slidePart.Slide.Transition = null;
+                    return;
+                }
+
+                Transition transition = new Transition();
+                switch (value) {
+                    case SlideTransition.Fade:
+                        transition.Append(new FadeTransition());
+                        break;
+                    case SlideTransition.Wipe:
+                        transition.Append(new WipeTransition());
+                        break;
+                }
+
+                _slidePart.Slide.Transition = transition;
+            }
+        }
 
         /// <summary>
         /// Gets the index of the layout used by this slide.
@@ -143,6 +229,86 @@ namespace OfficeIMO.PowerPoint {
             return tbl;
         }
 
+        /// <summary>
+        /// Adds a basic clustered column chart with default data.
+        /// </summary>
+        public PPChart AddChart() {
+            ChartPart chartPart = _slidePart.AddNewPart<ChartPart>();
+            GenerateDefaultChart(chartPart);
+
+            string relId = _slidePart.GetIdOfPart(chartPart);
+            GraphicFrame frame = new(
+                new NonVisualGraphicFrameProperties(
+                    new NonVisualDrawingProperties { Id = (UInt32Value)(uint)(_shapes.Count + 1), Name = "Chart" + (_shapes.Count + 1) },
+                    new NonVisualGraphicFrameDrawingProperties(),
+                    new ApplicationNonVisualDrawingProperties()
+                ),
+                new Transform(new A.Offset { X = 0L, Y = 0L }, new A.Extents { Cx = 5486400L, Cy = 3200400L }),
+                new A.Graphic(new A.GraphicData(new C.ChartReference { Id = relId }) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/chart" })
+            );
+
+            _slidePart.Slide.CommonSlideData!.ShapeTree.AppendChild(frame);
+            PPChart chart = new(frame);
+            _shapes.Add(chart);
+            return chart;
+        }
+
+        private static void GenerateDefaultChart(ChartPart chartPart) {
+            C.ChartSpace chartSpace = new(new C.EditingLanguage { Val = "en-US" }, new C.RoundedCorners { Val = false });
+            C.Chart chart = new();
+            C.PlotArea plotArea = new();
+            C.BarChart barChart = new(new C.BarDirection { Val = C.BarDirectionValues.Column }, new C.BarGrouping { Val = C.BarGroupingValues.Clustered });
+
+            C.BarChartSeries series = new(new C.Index { Val = 0U }, new C.Order { Val = 0U }, new C.SeriesText(new C.NumericValue { Text = "Series 1" }));
+
+            C.CategoryAxisData catData = new(new C.StringLiteral(new C.PointCount { Val = 2U }, new C.StringPoint { Index = 0U, NumericValue = new C.NumericValue("A") }, new C.StringPoint { Index = 1U, NumericValue = new C.NumericValue("B") }));
+            C.Values values = new(new C.NumberLiteral(new C.PointCount { Val = 2U }, new C.NumericPoint { Index = 0U, NumericValue = new C.NumericValue("4") }, new C.NumericPoint { Index = 1U, NumericValue = new C.NumericValue("5") }));
+
+            series.Append(catData, values);
+            barChart.Append(series, new C.AxisId { Val = 48650112U }, new C.AxisId { Val = 48672768U });
+
+            C.CategoryAxis catAxis = new(new C.AxisId { Val = 48650112U }, new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }), new C.AxisPosition { Val = C.AxisPositionValues.Bottom }, new C.TickLabelPosition { Val = C.TickLabelPositionValues.NextTo }, new C.CrossingAxis { Val = 48672768U }, new C.Crosses { Val = C.CrossesValues.AutoZero }, new C.AutoLabeled { Val = true }, new C.LabelAlignment { Val = C.LabelAlignmentValues.Center }, new C.LabelOffset { Val = (UInt16Value)100U });
+
+            C.ValueAxis valAxis = new(new C.AxisId { Val = 48672768U }, new C.Scaling(new C.Orientation { Val = C.OrientationValues.MinMax }), new C.AxisPosition { Val = C.AxisPositionValues.Left }, new C.MajorGridlines(), new C.NumberingFormat { FormatCode = "General", SourceLinked = true }, new C.TickLabelPosition { Val = C.TickLabelPositionValues.NextTo }, new C.CrossingAxis { Val = 48650112U }, new C.Crosses { Val = C.CrossesValues.AutoZero }, new C.CrossBetween { Val = C.CrossBetweenValues.Between });
+
+            plotArea.Append(barChart, catAxis, valAxis);
+            chart.Append(plotArea, new C.PlotVisibleOnly { Val = true });
+            chartSpace.Append(chart, new C.DisplayBlanksAs { Val = C.DisplayBlanksAsValues.Gap }, new C.ShowDataLabelsOverMaximum { Val = false });
+
+            EmbeddedPackagePart excelPart = chartPart.AddNewPart<EmbeddedPackagePart>("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+            using (MemoryStream ms = new()) {
+                using (SpreadsheetDocument doc = SpreadsheetDocument.Create(ms, SpreadsheetDocumentType.Workbook)) {
+                    WorkbookPart wbPart = doc.AddWorkbookPart();
+                    wbPart.Workbook = new S.Workbook();
+                    WorksheetPart wsPart = wbPart.AddNewPart<WorksheetPart>();
+                    S.SheetData sheetData = new(
+                        new S.Row(
+                            new S.Cell { CellValue = new S.CellValue("Category"), DataType = S.CellValues.String },
+                            new S.Cell { CellValue = new S.CellValue("Value"), DataType = S.CellValues.String }
+                        ),
+                        new S.Row(
+                            new S.Cell { CellValue = new S.CellValue("A"), DataType = S.CellValues.String },
+                            new S.Cell { CellValue = new S.CellValue("4"), DataType = S.CellValues.Number }
+                        ),
+                        new S.Row(
+                            new S.Cell { CellValue = new S.CellValue("B"), DataType = S.CellValues.String },
+                            new S.Cell { CellValue = new S.CellValue("5"), DataType = S.CellValues.Number }
+                        )
+                    );
+                    wsPart.Worksheet = new S.Worksheet(sheetData);
+                    wbPart.Workbook.Append(new S.Sheets(new S.Sheet { Id = wbPart.GetIdOfPart(wsPart), SheetId = 1U, Name = "Sheet1" }));
+                    wbPart.Workbook.Save();
+                }
+                ms.Position = 0;
+                excelPart.FeedData(ms);
+            }
+
+            chartSpace.Append(new C.ExternalData { Id = chartPart.GetIdOfPart(excelPart) });
+
+            chartPart.ChartSpace = chartSpace;
+            chartPart.ChartSpace.Save();
+        }
+
         internal void Save() {
             _slidePart.Slide.Save();
             _notes?.Save();
@@ -160,6 +326,9 @@ namespace OfficeIMO.PowerPoint {
                         break;
                     case GraphicFrame g when g.Graphic?.GraphicData?.GetFirstChild<A.Table>() != null:
                         _shapes.Add(new PPTable(g));
+                        break;
+                    case GraphicFrame g when g.Graphic?.GraphicData?.GetFirstChild<C.ChartReference>() != null:
+                        _shapes.Add(new PPChart(g));
                         break;
                 }
             }

--- a/OfficeIMO.PowerPoint/SlideTransition.cs
+++ b/OfficeIMO.PowerPoint/SlideTransition.cs
@@ -1,0 +1,10 @@
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    /// Represents simple slide transitions.
+    /// </summary>
+    public enum SlideTransition {
+        None,
+        Fade,
+        Wipe
+    }
+}

--- a/OfficeIMO.Tests/PowerPoint.AdvancedFeatures.cs
+++ b/OfficeIMO.Tests/PowerPoint.AdvancedFeatures.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using System.Linq;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointAdvancedFeatures {
+        [Fact]
+        public void CanHandleBackgroundFormattingTransitionsAndCharts() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string imagePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", "BackgroundImage.png");
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                PowerPointSlide slide = presentation.AddSlide();
+                PPTextBox text = slide.AddTextBox("Test");
+                slide.AddPicture(imagePath);
+                slide.AddTable(2, 2);
+                slide.AddChart();
+                slide.Notes.Text = "Notes";
+
+                slide.BackgroundColor = "FF0000";
+                text.FillColor = "00FF00";
+                slide.Transition = SlideTransition.Fade;
+
+                presentation.Save();
+            }
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                PowerPointSlide slide = presentation.Slides.Single();
+                Assert.Equal("FF0000", slide.BackgroundColor);
+                Assert.Equal(SlideTransition.Fade, slide.Transition);
+                Assert.Single(slide.TextBoxes);
+                Assert.Single(slide.Pictures);
+                Assert.Single(slide.Tables);
+                Assert.Single(slide.Charts);
+                Assert.Equal("00FF00", slide.TextBoxes.First().FillColor);
+                Assert.Equal("Notes", slide.Notes.Text);
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enable enumeration of text boxes, pictures, tables, and charts on slides
- add per-slide background color, per-shape fill color, and simple slide transitions
- support basic chart embedding using an Excel part and provide examples and tests

## Testing
- `dotnet build`
- `dotnet test --filter PowerPointAdvancedFeatures`


------
https://chatgpt.com/codex/tasks/task_e_68a38ef0e4b0832ea9f3717cb8b6277c