### PR TITLE
Fix nullability warnings in watermark and textbox

### DIFF
--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -11,9 +11,9 @@ namespace OfficeIMO.Word {
     public class WordTextBox : WordElement {
         private readonly WordDocument _document;
         private readonly WordParagraph _wordParagraph;
-        private readonly WordHeaderFooter _headerFooter;
+        private readonly WordHeaderFooter? _headerFooter;
         private Run _run => _wordParagraph._run;
-        private V.TextBox _vmlTextBox;
+        private V.TextBox? _vmlTextBox;
 
         /// <summary>
         /// Add a new text box to the document
@@ -84,13 +84,13 @@ namespace OfficeIMO.Word {
         public List<WordParagraph> Paragraphs {
             get {
                 if (_textBoxInfo2 != null) {
-                    return _textBoxInfo2.Descendants<Run>().Select(run => new WordParagraph(_document, _paragraph, run)).ToList();
+                    return _textBoxInfo2.Descendants<Run>().Select(run => new WordParagraph(_document, _paragraph!, run)).ToList();
                 }
                 if (_vmlTextBox != null) {
                     var content = _vmlTextBox.Descendants<DocumentFormat.OpenXml.Wordprocessing.TextBoxContent>().FirstOrDefault();
                     if (content != null) {
                         return content.Descendants<Run>()
-                            .Select(run => new WordParagraph(_document, run.Ancestors<Paragraph>().FirstOrDefault(), run))
+                            .Select(run => new WordParagraph(_document, run.Ancestors<Paragraph>().FirstOrDefault()!, run))
                             .ToList();
                     }
                 }
@@ -128,8 +128,8 @@ namespace OfficeIMO.Word {
         /// Gets or sets the wrap text of the text box
         /// </summary>
         public WrapTextImage? WrapText {
-            get => WordWrapTextImage.GetWrapTextImage(_anchor, _inline);
-            set => WordWrapTextImage.SetWrapTextImage(_drawing, _anchor, _inline, value);
+            get => WordWrapTextImage.GetWrapTextImage(_anchor!, _inline!);
+            set => WordWrapTextImage.SetWrapTextImage(_drawing!, _anchor!, _inline!, value);
         }
 
         /// <summary>
@@ -149,16 +149,18 @@ namespace OfficeIMO.Word {
             set {
                 var anchor = _anchor;
                 if (anchor != null) {
-                    var horizontalPosition = anchor.HorizontalPosition;
+                    HorizontalPosition? horizontalPosition = anchor.HorizontalPosition;
                     if (horizontalPosition == null) {
                         horizontalPosition = AddHorizontalPosition(anchor, true);
                     }
-                    if (horizontalPosition.HorizontalAlignment == null) {
-                        horizontalPosition.HorizontalAlignment = new HorizontalAlignment() {
-                            Text = HorizontalAlignmentHelper.ToString(value)
-                        };
-                    } else {
-                        horizontalPosition.HorizontalAlignment.Text = HorizontalAlignmentHelper.ToString(value);
+                    if (horizontalPosition != null) {
+                        if (horizontalPosition.HorizontalAlignment == null) {
+                            horizontalPosition.HorizontalAlignment = new HorizontalAlignment() {
+                                Text = HorizontalAlignmentHelper.ToString(value)
+                            };
+                        } else {
+                            horizontalPosition.HorizontalAlignment.Text = HorizontalAlignmentHelper.ToString(value);
+                        }
                     }
                 }
             }
@@ -526,32 +528,31 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private Drawing _drawing {
+        private Drawing? _drawing {
             get {
-                var alternateContent = _run.ChildElements.OfType<AlternateContent>().FirstOrDefault();
+                AlternateContent? alternateContent = _run.ChildElements.OfType<AlternateContent>().FirstOrDefault();
                 if (alternateContent != null) {
-                    var alternateContentChoice = alternateContent.ChildElements.OfType<AlternateContentChoice>().FirstOrDefault();
+                    AlternateContentChoice? alternateContentChoice = alternateContent.ChildElements.OfType<AlternateContentChoice>().FirstOrDefault();
                     if (alternateContentChoice != null) {
-                        var drawing = alternateContentChoice.ChildElements.OfType<DocumentFormat.OpenXml.Wordprocessing.Drawing>().FirstOrDefault();
+                        Drawing? drawing = alternateContentChoice.ChildElements.OfType<Drawing>().FirstOrDefault();
                         if (drawing != null) {
                             return drawing;
                         }
                     }
                 }
-
                 return null;
             }
         }
 
-        private Inline _inline {
+        private Inline? _inline {
             get {
-                var alternateContent = _run.ChildElements.OfType<AlternateContent>().FirstOrDefault();
+                AlternateContent? alternateContent = _run.ChildElements.OfType<AlternateContent>().FirstOrDefault();
                 if (alternateContent != null) {
-                    var alternateContentChoice = alternateContent.ChildElements.OfType<AlternateContentChoice>().FirstOrDefault();
+                    AlternateContentChoice? alternateContentChoice = alternateContent.ChildElements.OfType<AlternateContentChoice>().FirstOrDefault();
                     if (alternateContentChoice != null) {
-                        var drawing = alternateContentChoice.ChildElements.OfType<DocumentFormat.OpenXml.Wordprocessing.Drawing>().FirstOrDefault();
+                        Drawing? drawing = alternateContentChoice.ChildElements.OfType<Drawing>().FirstOrDefault();
                         if (drawing != null) {
-                            var inline = drawing.Inline;
+                            Inline? inline = drawing.Inline;
                             if (inline != null) {
                                 return inline;
                             }
@@ -562,15 +563,15 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private Anchor _anchor {
+        private Anchor? _anchor {
             get {
-                var alternateContent = _run.ChildElements.OfType<AlternateContent>().FirstOrDefault();
+                AlternateContent? alternateContent = _run.ChildElements.OfType<AlternateContent>().FirstOrDefault();
                 if (alternateContent != null) {
-                    var alternateContentChoice = alternateContent.ChildElements.OfType<AlternateContentChoice>().FirstOrDefault();
+                    AlternateContentChoice? alternateContentChoice = alternateContent.ChildElements.OfType<AlternateContentChoice>().FirstOrDefault();
                     if (alternateContentChoice != null) {
-                        var drawing = alternateContentChoice.ChildElements.OfType<DocumentFormat.OpenXml.Wordprocessing.Drawing>().FirstOrDefault();
+                        Drawing? drawing = alternateContentChoice.ChildElements.OfType<Drawing>().FirstOrDefault();
                         if (drawing != null) {
-                            var anchor = drawing.Anchor;
+                            Anchor? anchor = drawing.Anchor;
                             if (anchor != null) {
                                 return anchor;
                             }
@@ -651,21 +652,24 @@ namespace OfficeIMO.Word {
             return inline1;
         }
 
-        private DocumentFormat.OpenXml.Drawing.GraphicData _graphicData {
+        private DocumentFormat.OpenXml.Drawing.GraphicData? _graphicData {
             get {
-                var graphic = _anchor.ChildElements.OfType<DocumentFormat.OpenXml.Drawing.Graphic>().FirstOrDefault();
-                if (graphic != null) {
-                    return graphic.GraphicData;
+                Anchor? anchor = _anchor;
+                if (anchor != null) {
+                    DocumentFormat.OpenXml.Drawing.Graphic? graphic = anchor.ChildElements.OfType<DocumentFormat.OpenXml.Drawing.Graphic>().FirstOrDefault();
+                    if (graphic != null) {
+                        return graphic.GraphicData;
+                    }
                 }
                 return null;
             }
         }
 
-        private DocumentFormat.OpenXml.Office2010.Word.DrawingShape.WordprocessingShape _wordprocessingShape {
+        private DocumentFormat.OpenXml.Office2010.Word.DrawingShape.WordprocessingShape? _wordprocessingShape {
             get {
                 var graphicData = _graphicData;
                 if (graphicData != null) {
-                    var wsp = graphicData.GetFirstChild<DocumentFormat.OpenXml.Office2010.Word.DrawingShape.WordprocessingShape>();
+                    DocumentFormat.OpenXml.Office2010.Word.DrawingShape.WordprocessingShape? wsp = graphicData.GetFirstChild<DocumentFormat.OpenXml.Office2010.Word.DrawingShape.WordprocessingShape>();
                     if (wsp != null) {
                         return wsp;
                     }
@@ -674,11 +678,11 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private TextBoxInfo2 _textBoxInfo2 {
+        private TextBoxInfo2? _textBoxInfo2 {
             get {
                 var wordprocessingShape = _wordprocessingShape;
                 if (wordprocessingShape != null) {
-                    var textBoxInfo = wordprocessingShape.GetFirstChild<DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2>();
+                    DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2? textBoxInfo = wordprocessingShape.GetFirstChild<DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2>();
                     if (textBoxInfo != null) {
                         return textBoxInfo;
                     }
@@ -687,31 +691,30 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private Paragraph _paragraph {
+        private Paragraph? _paragraph {
             get {
                 var wordprocessingShape = _wordprocessingShape;
                 if (wordprocessingShape != null) {
-                    var textBoxInfo = wordprocessingShape.GetFirstChild<DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2>();
+                    DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2? textBoxInfo = wordprocessingShape.GetFirstChild<DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2>();
                     if (textBoxInfo != null) {
-                        var textBoxContent = textBoxInfo.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.TextBoxContent>();
+                        DocumentFormat.OpenXml.Wordprocessing.TextBoxContent? textBoxContent = textBoxInfo.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.TextBoxContent>();
                         if (textBoxContent != null) {
-                            var sdtBlock = textBoxContent.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.Paragraph>();
+                            Paragraph? sdtBlock = textBoxContent.GetFirstChild<Paragraph>();
                             if (sdtBlock != null) {
                                 return sdtBlock;
                             }
                         }
                     }
-
                 }
                 return null;
             }
         }
 
-        private SdtContentBlock _sdtContentBlock {
+        private SdtContentBlock? _sdtContentBlock {
             get {
                 var sdtBlock = _paragraph;
                 if (sdtBlock != null) {
-                    var sdtContentBlock = sdtBlock.GetFirstChild<SdtContentBlock>();
+                    SdtContentBlock? sdtContentBlock = sdtBlock.GetFirstChild<SdtContentBlock>();
                     if (sdtContentBlock != null) {
                         return sdtContentBlock;
                     }
@@ -720,7 +723,7 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private VerticalPosition AddVerticalPosition(Anchor anchor, bool expectedPositionOffset = false) {
+        private VerticalPosition? AddVerticalPosition(Anchor? anchor, bool expectedPositionOffset = false) {
             if (anchor != null) {
                 var verticalPosition = anchor.VerticalPosition;
                 if (verticalPosition == null) {
@@ -752,7 +755,7 @@ namespace OfficeIMO.Word {
         /// <param name="anchor"></param>
         /// <param name="expectedPositionOffset"></param>
         /// <returns></returns>
-        private HorizontalPosition AddHorizontalPosition(Anchor anchor, bool expectedPositionOffset = false) {
+        private HorizontalPosition? AddHorizontalPosition(Anchor? anchor, bool expectedPositionOffset = false) {
             if (anchor != null) {
                 var horizontalPosition = anchor.HorizontalPosition;
                 if (horizontalPosition == null && expectedPositionOffset) {

--- a/OfficeIMO.Word/WordWatermark.cs
+++ b/OfficeIMO.Word/WordWatermark.cs
@@ -47,7 +47,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string Text {
             get {
-                var paragraph = _sdtBlock.SdtContentBlock.ChildElements.OfType<Paragraph>().FirstOrDefault();
+                var paragraph = _sdtBlock.SdtContentBlock?.ChildElements.OfType<Paragraph>().FirstOrDefault();
                 if (paragraph != null) {
                     var run = paragraph.Descendants().OfType<Run>().FirstOrDefault();
                     if (run != null) {
@@ -55,10 +55,9 @@ namespace OfficeIMO.Word {
                         if (picture != null) {
                             var shape = picture.Descendants().OfType<Shape>().FirstOrDefault();
                             if (shape != null) {
-                                TextPath textPath = shape.GetFirstChild<V.TextPath>();
+                                TextPath? textPath = shape.GetFirstChild<V.TextPath>();
                                 if (textPath != null) {
-                                    return textPath.String;
-
+                                    return textPath.String ?? string.Empty;
                                 }
                             }
                         }
@@ -68,7 +67,7 @@ namespace OfficeIMO.Word {
                 return "";
             }
             set {
-                var paragraph = _sdtBlock.SdtContentBlock.ChildElements.OfType<Paragraph>().FirstOrDefault();
+                var paragraph = _sdtBlock.SdtContentBlock?.ChildElements.OfType<Paragraph>().FirstOrDefault();
                 if (paragraph != null) {
                     var run = paragraph.Descendants().OfType<Run>().FirstOrDefault();
                     if (run != null) {
@@ -76,7 +75,7 @@ namespace OfficeIMO.Word {
                         if (picture != null) {
                             var shape = picture.Descendants().OfType<Shape>().FirstOrDefault();
                             if (shape != null) {
-                                TextPath textPath = shape.GetFirstChild<V.TextPath>();
+                                TextPath? textPath = shape.GetFirstChild<V.TextPath>();
                                 if (textPath != null) {
                                     textPath.String = value;
                                 }
@@ -97,7 +96,7 @@ namespace OfficeIMO.Word {
 
                     // Style = "position:absolute;margin-left:0;margin-top:0;width:527.85pt;height:131.95pt;rotation:315;z-index:-251657216;mso-position-horizontal:center;mso-position-horizontal-relative:margin;mso-position-vertical:center;mso-position-vertical-relative:margin", OptionalString = "_x0000_s1025", AllowInCell = false, FillColor = "silver", Stroked = false, Type = "#_x0000_t136" };
                     //
-                    var style = shape.Style.Value;
+                    var style = shape.Style?.Value;
                     if (style != null) {
                         var rotation = style.Split(';').FirstOrDefault(c => c.StartsWith("rotation:", StringComparison.Ordinal));
                         if (rotation != null) {
@@ -112,15 +111,13 @@ namespace OfficeIMO.Word {
             }
             set {
                 var shape = _shape;
-                if (shape != null) {
-                    var style = shape.Style.Value;
-                    if (style != null) {
-                        var rotation = style.Split(';').FirstOrDefault(c => c.StartsWith("rotation:", StringComparison.Ordinal));
-                        if (rotation != null) {
-                            var rotationValue = rotation.Split(':').LastOrDefault();
-                            if (rotationValue != null) {
-                                shape.Style.Value = style.Replace(rotation, "rotation:" + value);
-                            }
+                var style = shape?.Style?.Value;
+                if (shape?.Style != null && style != null) {
+                    var rotation = style.Split(';').FirstOrDefault(c => c.StartsWith("rotation:", StringComparison.Ordinal));
+                    if (rotation != null) {
+                        var rotationValue = rotation.Split(':').LastOrDefault();
+                        if (rotationValue != null) {
+                            shape.Style.Value = style.Replace(rotation, "rotation:" + value);
                         }
                     }
                 }
@@ -134,7 +131,7 @@ namespace OfficeIMO.Word {
             get {
                 var shape = _shape;
                 if (shape != null) {
-                    var style = shape.Style.Value;
+                    var style = shape.Style?.Value;
                     if (style != null) {
                         var width = style.Split(';').FirstOrDefault(c => c.StartsWith("width:", StringComparison.Ordinal));
                         if (width != null) {
@@ -150,15 +147,13 @@ namespace OfficeIMO.Word {
             }
             set {
                 var shape = _shape;
-                if (shape != null) {
-                    var style = shape.Style.Value;
-                    if (style != null) {
-                        var width = style.Split(';').FirstOrDefault(c => c.StartsWith("width:", StringComparison.Ordinal));
-                        if (width != null) {
-                            var widthValue = width.Split(':').LastOrDefault();
-                            if (widthValue != null) {
-                                shape.Style.Value = style.Replace(width, "width:" + value + "pt");
-                            }
+                var style = shape?.Style?.Value;
+                if (shape?.Style != null && style != null) {
+                    var width = style.Split(';').FirstOrDefault(c => c.StartsWith("width:", StringComparison.Ordinal));
+                    if (width != null) {
+                        var widthValue = width.Split(':').LastOrDefault();
+                        if (widthValue != null) {
+                            shape.Style.Value = style.Replace(width, "width:" + value + "pt");
                         }
                     }
                 }
@@ -172,7 +167,7 @@ namespace OfficeIMO.Word {
             get {
                 var shape = _shape;
                 if (shape != null) {
-                    var style = shape.Style.Value;
+                    var style = shape.Style?.Value;
                     if (style != null) {
                         var height = style.Split(';').FirstOrDefault(c => c.StartsWith("height:", StringComparison.Ordinal));
                         if (height != null) {
@@ -188,15 +183,13 @@ namespace OfficeIMO.Word {
             }
             set {
                 var shape = _shape;
-                if (shape != null) {
-                    var style = shape.Style.Value;
-                    if (style != null) {
-                        var height = style.Split(';').FirstOrDefault(c => c.StartsWith("height:", StringComparison.Ordinal));
-                        if (height != null) {
-                            var heightValue = height.Split(':').LastOrDefault();
-                            if (heightValue != null) {
-                                shape.Style.Value = style.Replace(height, "height:" + value + "pt");
-                            }
+                var style = shape?.Style?.Value;
+                if (shape?.Style != null && style != null) {
+                    var height = style.Split(';').FirstOrDefault(c => c.StartsWith("height:", StringComparison.Ordinal));
+                    if (height != null) {
+                        var heightValue = height.Split(':').LastOrDefault();
+                        if (heightValue != null) {
+                            shape.Style.Value = style.Replace(height, "height:" + value + "pt");
                         }
                     }
                 }
@@ -210,7 +203,7 @@ namespace OfficeIMO.Word {
             get {
                 var shape = _shape;
                 if (shape != null) {
-                    var style = shape.Style.Value;
+                    var style = shape.Style?.Value;
                     if (style != null) {
                         var left = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-left:", StringComparison.Ordinal));
                         if (left != null) {
@@ -226,13 +219,11 @@ namespace OfficeIMO.Word {
             }
             set {
                 var shape = _shape;
-                if (shape != null) {
-                    var style = shape.Style.Value;
-                    if (style != null) {
-                        var left = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-left:", StringComparison.Ordinal));
-                        if (left != null) {
-                            shape.Style.Value = style.Replace(left, "margin-left:" + value + "pt");
-                        }
+                var style = shape?.Style?.Value;
+                if (shape?.Style != null && style != null) {
+                    var left = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-left:", StringComparison.Ordinal));
+                    if (left != null) {
+                        shape.Style.Value = style.Replace(left, "margin-left:" + value + "pt");
                     }
                 }
             }
@@ -245,7 +236,7 @@ namespace OfficeIMO.Word {
             get {
                 var shape = _shape;
                 if (shape != null) {
-                    var style = shape.Style.Value;
+                    var style = shape.Style?.Value;
                     if (style != null) {
                         var top = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-top:", StringComparison.Ordinal));
                         if (top != null) {
@@ -261,13 +252,11 @@ namespace OfficeIMO.Word {
             }
             set {
                 var shape = _shape;
-                if (shape != null) {
-                    var style = shape.Style.Value;
-                    if (style != null) {
-                        var top = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-top:", StringComparison.Ordinal));
-                        if (top != null) {
-                            shape.Style.Value = style.Replace(top, "margin-top:" + value + "pt");
-                        }
+                var style = shape?.Style?.Value;
+                if (shape?.Style != null && style != null) {
+                    var top = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-top:", StringComparison.Ordinal));
+                    if (top != null) {
+                        shape.Style.Value = style.Replace(top, "margin-top:" + value + "pt");
                     }
                 }
             }
@@ -281,8 +270,7 @@ namespace OfficeIMO.Word {
                 var shape = _shape;
                 if (shape != null) {
                     var textPath = shape.GetFirstChild<V.TextPath>();
-                    if (textPath != null && textPath.Style != null) {
-                        var style = textPath.Style.Value;
+                    if (textPath?.Style?.Value is { } style) {
                         var family = style.Split(';').FirstOrDefault(c => c.StartsWith("font-family:", StringComparison.Ordinal));
                         if (family != null) {
                             var value = family.Split(':').LastOrDefault();
@@ -304,6 +292,7 @@ namespace OfficeIMO.Word {
                             .Select(p => p.Split(':'))
                             .ToDictionary(p => p[0], p => p.Length > 1 ? p[1] : string.Empty);
                         dict["font-family"] = "\"" + value + "\"";
+                        textPath.Style ??= new StringValue();
                         textPath.Style.Value = string.Join(";", dict.Select(kvp => $"{kvp.Key}:{kvp.Value}"));
                     }
                 }
@@ -318,8 +307,7 @@ namespace OfficeIMO.Word {
                 var shape = _shape;
                 if (shape != null) {
                     var textPath = shape.GetFirstChild<V.TextPath>();
-                    if (textPath != null && textPath.Style != null) {
-                        var style = textPath.Style.Value;
+                    if (textPath?.Style?.Value is { } style) {
                         var size = style.Split(';').FirstOrDefault(c => c.StartsWith("font-size:", StringComparison.Ordinal));
                         if (size != null) {
                             var value = size.Split(':').LastOrDefault();
@@ -342,6 +330,7 @@ namespace OfficeIMO.Word {
                             .Select(p => p.Split(':'))
                             .ToDictionary(p => p[0], p => p.Length > 1 ? p[1] : string.Empty);
                         dict["font-size"] = value + "pt";
+                        textPath.Style ??= new StringValue();
                         textPath.Style.Value = string.Join(";", dict.Select(kvp => $"{kvp.Key}:{kvp.Value}"));
                     }
                 }
@@ -379,14 +368,14 @@ namespace OfficeIMO.Word {
         public bool Stroked {
             get {
                 var shape = _shape;
-                if (shape != null) {
+                if (shape?.Stroked?.Value != null) {
                     return shape.Stroked.Value;
                 }
                 return false;
             }
             set {
                 var shape = _shape;
-                if (shape != null) {
+                if (shape?.Stroked != null) {
                     shape.Stroked.Value = value;
                 }
             }
@@ -398,14 +387,14 @@ namespace OfficeIMO.Word {
         public bool? AllowInCell {
             get {
                 var shape = _shape;
-                if (shape != null) {
+                if (shape?.AllowInCell?.Value != null) {
                     return shape.AllowInCell.Value;
                 }
                 return null;
             }
             set {
                 var shape = _shape;
-                if (shape != null) {
+                if (shape?.AllowInCell != null && value.HasValue) {
                     shape.AllowInCell.Value = value.Value;
                 }
             }
@@ -438,23 +427,23 @@ namespace OfficeIMO.Word {
         public string ColorHex {
             get {
                 var shape = _shape;
-                if (shape != null && shape.FillColor != null) {
+                if (shape?.FillColor?.Value != null) {
                     return shape.FillColor.Value;
                 }
                 return "";
             }
             set {
                 var shape = _shape;
-                if (shape != null) {
+                if (shape?.FillColor != null) {
                     shape.FillColor.Value = value;
                 }
             }
         }
 
-        private Shape _shape {
+        private Shape? _shape {
             get {
 
-                var shape = _picture.Descendants().OfType<Shape>().FirstOrDefault();
+                var shape = _picture?.Descendants().OfType<Shape>().FirstOrDefault();
                 if (shape != null) {
                     return shape;
                 }
@@ -462,18 +451,16 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private Picture _picture {
+        private Picture? _picture {
             get {
-                if (_sdtBlock != null) {
-                    if (_sdtBlock.SdtContentBlock != null) {
-                        var paragraph = _sdtBlock.SdtContentBlock.ChildElements.OfType<Paragraph>().FirstOrDefault();
-                        if (paragraph != null) {
-                            var run = paragraph.Descendants().OfType<Run>().FirstOrDefault();
-                            if (run != null) {
-                                var picture = run.Descendants().OfType<Picture>().FirstOrDefault();
-                                if (picture != null) {
-                                    return picture;
-                                }
+                if (_sdtBlock?.SdtContentBlock != null) {
+                    Paragraph? paragraph = _sdtBlock.SdtContentBlock.ChildElements.OfType<Paragraph>().FirstOrDefault();
+                    if (paragraph != null) {
+                        Run? run = paragraph.Descendants().OfType<Run>().FirstOrDefault();
+                        if (run != null) {
+                            Picture? picture = run.Descendants().OfType<Picture>().FirstOrDefault();
+                            if (picture != null) {
+                                return picture;
                             }
                         }
                     }
@@ -482,11 +469,11 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private SdtContentBlock _sdtContentBlock {
+        private SdtContentBlock? _sdtContentBlock {
             get {
                 var sdtBlock = _sdtBlock;
                 if (sdtBlock != null) {
-                    var sdtContentBlock = sdtBlock.GetFirstChild<SdtContentBlock>();
+                    SdtContentBlock? sdtContentBlock = sdtBlock.GetFirstChild<SdtContentBlock>();
                     if (sdtContentBlock != null) {
                         return sdtContentBlock;
                     }


### PR DESCRIPTION
## Summary
- add null checks for watermark elements
- ensure textbox structures handle nullable content

## Testing
- `dotnet build OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a38e93db70832e886c0d6934bd962d