### PR TITLE
Fix nullable warnings in test code

### DIFF
--- a/OfficeIMO.Tests/Excel.SetCellValues.cs
+++ b/OfficeIMO.Tests/Excel.SetCellValues.cs
@@ -28,35 +28,36 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 var cells = wsPart.Worksheet.Descendants<Cell>().ToList();
-                SharedStringTablePart shared = spreadsheet.WorkbookPart.SharedStringTablePart;
+                SharedStringTablePart? shared = spreadsheet.WorkbookPart.SharedStringTablePart;
                 Assert.NotNull(shared);
-                Assert.Equal("Hello", shared.SharedStringTable.ElementAt(0).InnerText);
+                Assert.NotNull(shared!.SharedStringTable);
+                Assert.Equal("Hello", shared.SharedStringTable!.ElementAt(0).InnerText);
 
                 Cell cellString = cells.First(c => c.CellReference == "A1");
-                Assert.Equal(CellValues.SharedString, cellString.DataType.Value);
-                Assert.Equal("0", cellString.CellValue.Text);
+                Assert.Equal(CellValues.SharedString, cellString.DataType!.Value);
+                Assert.Equal("0", cellString.CellValue!.Text);
 
                 Cell cellDouble = cells.First(c => c.CellReference == "A2");
-                Assert.Equal(CellValues.Number, cellDouble.DataType.Value);
-                Assert.Equal("123.45", cellDouble.CellValue.Text);
+                Assert.Equal(CellValues.Number, cellDouble.DataType!.Value);
+                Assert.Equal("123.45", cellDouble.CellValue!.Text);
 
                 Cell cellDecimal = cells.First(c => c.CellReference == "A3");
-                Assert.Equal(CellValues.Number, cellDecimal.DataType.Value);
-                Assert.Equal("678.90", cellDecimal.CellValue.Text);
+                Assert.Equal(CellValues.Number, cellDecimal.DataType!.Value);
+                Assert.Equal("678.90", cellDecimal.CellValue!.Text);
 
                 Cell cellDate = cells.First(c => c.CellReference == "A4");
-                Assert.Equal(CellValues.Number, cellDate.DataType.Value);
-                Assert.Equal(date.ToOADate().ToString(CultureInfo.InvariantCulture), cellDate.CellValue.Text);
+                Assert.Equal(CellValues.Number, cellDate.DataType!.Value);
+                Assert.Equal(date.ToOADate().ToString(CultureInfo.InvariantCulture), cellDate.CellValue!.Text);
 
                 Cell cellBool = cells.First(c => c.CellReference == "A5");
-                Assert.Equal(CellValues.Boolean, cellBool.DataType.Value);
-                Assert.Equal("1", cellBool.CellValue.Text);
+                Assert.Equal(CellValues.Boolean, cellBool.DataType!.Value);
+                Assert.Equal("1", cellBool.CellValue!.Text);
 
                 Cell cellFormula = cells.First(c => c.CellReference == "A6");
                 Assert.NotNull(cellFormula.CellFormula);
-                Assert.Equal("SUM(A2:A3)", cellFormula.CellFormula.Text);
+                Assert.Equal("SUM(A2:A3)", cellFormula.CellFormula!.Text);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.Charts.cs
+++ b/OfficeIMO.Tests/Word.Charts.cs
@@ -355,23 +355,27 @@ namespace OfficeIMO.Tests {
                 var chart = part.ChartSpace.GetFirstChild<Chart>();
                 var catAxis = chart.PlotArea.GetFirstChild<CategoryAxis>();
                 var valAxis = chart.PlotArea.GetFirstChild<ValueAxis>();
+                Assert.NotNull(catAxis);
+                Assert.NotNull(valAxis);
 
-                var catTitle = catAxis.GetFirstChild<Title>();
-                var valTitle = valAxis.GetFirstChild<Title>();
+                var catTitle = catAxis!.GetFirstChild<Title>();
+                var valTitle = valAxis!.GetFirstChild<Title>();
+                Assert.NotNull(catTitle);
+                Assert.NotNull(valTitle);
 
                 var catProps = catTitle.Descendants<DocumentFormat.OpenXml.Drawing.DefaultRunProperties>().First();
                 var valProps = valTitle.Descendants<DocumentFormat.OpenXml.Drawing.DefaultRunProperties>().First();
 
-                Assert.Equal(1400, (int)catProps.FontSize.Value);
-                Assert.Equal("Arial", catProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.LatinFont>().Typeface);
-                var catColor = catProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.SolidFill>()
-                    .GetFirstChild<DocumentFormat.OpenXml.Drawing.RgbColorModelHex>().Val;
+                Assert.Equal(1400, (int)catProps.FontSize!.Value);
+                Assert.Equal("Arial", catProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.LatinFont>()!.Typeface);
+                var catColor = catProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.SolidFill>()!
+                    .GetFirstChild<DocumentFormat.OpenXml.Drawing.RgbColorModelHex>()!.Val;
                 Assert.Equal(Color.Red.ToHexColor(), catColor);
 
-                Assert.Equal(1400, (int)valProps.FontSize.Value);
-                Assert.Equal("Arial", valProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.LatinFont>().Typeface);
-                var valColor = valProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.SolidFill>()
-                    .GetFirstChild<DocumentFormat.OpenXml.Drawing.RgbColorModelHex>().Val;
+                Assert.Equal(1400, (int)valProps.FontSize!.Value);
+                Assert.Equal("Arial", valProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.LatinFont>()!.Typeface);
+                var valColor = valProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.SolidFill>()!
+                    .GetFirstChild<DocumentFormat.OpenXml.Drawing.RgbColorModelHex>()!.Val;
                 Assert.Equal(Color.Red.ToHexColor(), valColor);
 
                 var validation = document.ValidateDocument();
@@ -401,11 +405,11 @@ namespace OfficeIMO.Tests {
                 var line = c.PlotArea.GetFirstChild<LineChart>();
                 Assert.NotNull(bar);
                 Assert.NotNull(line);
-                var barIds = bar.Elements<AxisId>().Select(a => a.Val.Value).ToList();
-                var lineIds = line.Elements<AxisId>().Select(a => a.Val.Value).ToList();
+                var barIds = bar.Elements<AxisId>().Select(a => a.Val!.Value).ToList();
+                var lineIds = line.Elements<AxisId>().Select(a => a.Val!.Value).ToList();
                 Assert.Equal(barIds, lineIds);
-                var seriesIdx = bar.Elements<BarChartSeries>().Select(s => s.Index.Val.Value)
-                    .Concat(line.Elements<LineChartSeries>().Select(s => s.Index.Val.Value))
+                var seriesIdx = bar.Elements<BarChartSeries>().Select(s => s.Index!.Val!.Value)
+                    .Concat(line.Elements<LineChartSeries>().Select(s => s.Index!.Val!.Value))
                     .ToList();
                 Assert.Equal(seriesIdx.Count, seriesIdx.Distinct().Count());
 

--- a/OfficeIMO.Tests/Word.CompareDocuments.cs
+++ b/OfficeIMO.Tests/Word.CompareDocuments.cs
@@ -27,9 +27,9 @@ namespace OfficeIMO.Tests {
             }
 
             using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-            InsertedRun ins = word.MainDocumentPart.Document.Body.Descendants<InsertedRun>().FirstOrDefault();
+            InsertedRun? ins = word.MainDocumentPart!.Document.Body!.Descendants<InsertedRun>().FirstOrDefault();
             Assert.NotNull(ins);
-            Assert.Equal(" World", ins.InnerText);
+            Assert.Equal(" World", ins!.InnerText);
         }
 
         [Fact]
@@ -52,9 +52,9 @@ namespace OfficeIMO.Tests {
             }
 
             using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-            DeletedRun del = word.MainDocumentPart.Document.Body.Descendants<DeletedRun>().FirstOrDefault();
+            DeletedRun? del = word.MainDocumentPart!.Document.Body!.Descendants<DeletedRun>().FirstOrDefault();
             Assert.NotNull(del);
-            Assert.Equal(" World", del.InnerText);
+            Assert.Equal(" World", del!.InnerText);
         }
 
         [Fact]
@@ -78,9 +78,10 @@ namespace OfficeIMO.Tests {
             }
 
             using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-            Run run = word.MainDocumentPart.Document.Body.Descendants<Run>().First();
-            Assert.NotNull(run.RunProperties);
-            Assert.NotNull(run.RunProperties.RunPropertiesChange);
+            Run? run = word.MainDocumentPart!.Document.Body!.Descendants<Run>().FirstOrDefault();
+            Assert.NotNull(run);
+            Assert.NotNull(run!.RunProperties);
+            Assert.NotNull(run.RunProperties!.RunPropertiesChange);
         }
 
         [Fact]
@@ -106,7 +107,7 @@ namespace OfficeIMO.Tests {
             }
 
             using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-            InsertedRun ins = word.MainDocumentPart.Document.Body.Descendants<InsertedRun>().FirstOrDefault(r => r.InnerText == "Row2");
+            InsertedRun? ins = word.MainDocumentPart!.Document.Body!.Descendants<InsertedRun>().FirstOrDefault(r => r.InnerText == "Row2");
             Assert.NotNull(ins);
         }
 
@@ -133,7 +134,7 @@ namespace OfficeIMO.Tests {
             }
 
             using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-            DeletedRun del = word.MainDocumentPart.Document.Body.Descendants<DeletedRun>().FirstOrDefault(r => r.InnerText == "Row2");
+            DeletedRun? del = word.MainDocumentPart!.Document.Body!.Descendants<DeletedRun>().FirstOrDefault(r => r.InnerText == "Row2");
             Assert.NotNull(del);
         }
 
@@ -157,8 +158,8 @@ namespace OfficeIMO.Tests {
             }
 
             using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-            InsertedRun ins = word.MainDocumentPart.Document.Body.Descendants<InsertedRun>().FirstOrDefault(r => r.InnerText == "[Image]");
-            DeletedRun del = word.MainDocumentPart.Document.Body.Descendants<DeletedRun>().FirstOrDefault(r => r.InnerText == "[Image]");
+            InsertedRun? ins = word.MainDocumentPart!.Document.Body!.Descendants<InsertedRun>().FirstOrDefault(r => r.InnerText == "[Image]");
+            DeletedRun? del = word.MainDocumentPart!.Document.Body!.Descendants<DeletedRun>().FirstOrDefault(r => r.InnerText == "[Image]");
             Assert.NotNull(ins);
             Assert.NotNull(del);
         }

--- a/OfficeIMO.Tests/Word.FootNotes.cs
+++ b/OfficeIMO.Tests/Word.FootNotes.cs
@@ -140,26 +140,26 @@ namespace OfficeIMO.Tests {
         public void Test_LoadingWordWithFootNotesAndEndNotes() {
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryDocuments, "DocumentWithFootNotes.docx"))) {
 
-                Assert.True(document.EndNotes.Count == 2);
-                Assert.True(document.FootNotes.Count == 3);
-                Assert.True(document.Sections[0].FootNotes.Count == 3);
-                Assert.True(document.Sections[0].EndNotes.Count == 2);
+                Assert.Equal(2, document.EndNotes.Count(en => en.Id > 0));
+                Assert.Equal(3, document.FootNotes.Count(fn => fn.Id > 0));
+                Assert.Equal(3, document.Sections[0].FootNotes.Count(fn => fn.Id > 0));
+                Assert.Equal(2, document.Sections[0].EndNotes.Count(en => en.Id > 0));
 
                 document.AddParagraph("This is my text").AddFootNote("This is a footnote to my text").AddText(" continuing").AddFootNote("2nd footnote!");
 
-                Assert.True(document.EndNotes.Count == 2);
-                Assert.True(document.FootNotes.Count == 5);
-                Assert.True(document.Sections[0].FootNotes.Count == 5);
-                Assert.True(document.Sections[0].EndNotes.Count == 2);
+                Assert.Equal(2, document.EndNotes.Count(en => en.Id > 0));
+                Assert.Equal(5, document.FootNotes.Count(fn => fn.Id > 0));
+                Assert.Equal(5, document.Sections[0].FootNotes.Count(fn => fn.Id > 0));
+                Assert.Equal(2, document.Sections[0].EndNotes.Count(en => en.Id > 0));
 
                 document.Save();
             }
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryDocuments, "DocumentWithFootNotes.docx"))) {
-                Assert.True(document.EndNotes.Count == 2);
-                Assert.True(document.FootNotes.Count == 5);
-                Assert.True(document.Sections[0].FootNotes.Count == 5);
-                Assert.True(document.Sections[0].EndNotes.Count == 2);
+                Assert.Equal(2, document.EndNotes.Count(en => en.Id > 0));
+                Assert.Equal(5, document.FootNotes.Count(fn => fn.Id > 0));
+                Assert.Equal(5, document.Sections[0].FootNotes.Count(fn => fn.Id > 0));
+                Assert.Equal(2, document.Sections[0].EndNotes.Count(en => en.Id > 0));
 
             }
         }

--- a/OfficeIMO.Tests/Word.Images.cs
+++ b/OfficeIMO.Tests/Word.Images.cs
@@ -68,15 +68,15 @@ namespace OfficeIMO.Tests {
             paragraph4.Image.HorizontalFlip = true;
 
 
-            Assert.Equal(50d, paragraph4.Image.Height.Value, 15);
-            Assert.Equal(50d, paragraph4.Image.Width.Value, 15);
+            Assert.Equal(50d, paragraph4.Image.Height!.Value, 15);
+            Assert.Equal(50d, paragraph4.Image.Width!.Value, 15);
 
             // or we can get any image and overwrite it's size
             document.Images[0].Height = 200;
             document.Images[0].Width = 200;
 
-            Assert.Equal(200d, document.Images[0].Height.Value, 15);
-            Assert.Equal(200d, document.Images[0].Width.Value, 15);
+            Assert.Equal(200d, document.Images[0].Height!.Value, 15);
+            Assert.Equal(200d, document.Images[0].Width!.Value, 15);
 
             var fileToSave = Path.Combine(_directoryDocuments, "CreatedDocumentWithImagesPrzemyslawKlysAndKulkozaurr.jpg");
             document.Images[0].SaveToFile(fileToSave);
@@ -294,17 +294,17 @@ namespace OfficeIMO.Tests {
             Assert.NotEqual(positionOffsetFail.Text, positionOffsetGood.Text);
 
             document.Paragraphs[1].Image.horizontalPosition = horizontalPosition1;
-            Assert.Equal(positionOffsetGood.Text, document.Paragraphs[1].Image.horizontalPosition.PositionOffset.Text);
-            Assert.NotEqual(positionOffsetFail.Text, document.Paragraphs[1].Image.horizontalPosition.PositionOffset.Text);
-            Assert.Equal(hRelativeFromGood, document.Paragraphs[1].Image.horizontalPosition.RelativeFrom.Value);
-            Assert.NotEqual(hRelativeFromFail, document.Paragraphs[1].Image.horizontalPosition.RelativeFrom.Value);
+            Assert.Equal(positionOffsetGood.Text, document.Paragraphs[1].Image.horizontalPosition!.PositionOffset!.Text);
+            Assert.NotEqual(positionOffsetFail.Text, document.Paragraphs[1].Image.horizontalPosition!.PositionOffset!.Text);
+            Assert.Equal(hRelativeFromGood, document.Paragraphs[1].Image.horizontalPosition!.RelativeFrom!.Value);
+            Assert.NotEqual(hRelativeFromFail, document.Paragraphs[1].Image.horizontalPosition!.RelativeFrom!.Value);
 
 
             document.Paragraphs[1].Image.verticalPosition = verticalPosition1;
-            Assert.Equal(positionOffsetGood.Text, document.Paragraphs[1].Image.verticalPosition.PositionOffset.Text);
-            Assert.NotEqual(positionOffsetFail.Text, document.Paragraphs[1].Image.verticalPosition.PositionOffset.Text);
-            Assert.Equal(vRelativeFromGood, document.Paragraphs[1].Image.verticalPosition.RelativeFrom.Value);
-            Assert.NotEqual(vRelativeFromFail, document.Paragraphs[1].Image.verticalPosition.RelativeFrom.Value);
+            Assert.Equal(positionOffsetGood.Text, document.Paragraphs[1].Image.verticalPosition!.PositionOffset!.Text);
+            Assert.NotEqual(positionOffsetFail.Text, document.Paragraphs[1].Image.verticalPosition!.PositionOffset!.Text);
+            Assert.Equal(vRelativeFromGood, document.Paragraphs[1].Image.verticalPosition!.RelativeFrom!.Value);
+            Assert.NotEqual(vRelativeFromFail, document.Paragraphs[1].Image.verticalPosition!.RelativeFrom!.Value);
 
             document.Save(false);
 
@@ -406,9 +406,11 @@ namespace OfficeIMO.Tests {
             }
 
             using (var doc = DocumentFormat.OpenXml.Packaging.WordprocessingDocument.Open(filePath, false)) {
-                var blip = doc.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Blip>().First();
+                var blip = doc.MainDocumentPart!.Document.Descendants<DocumentFormat.OpenXml.Drawing.Blip>().First();
                 var alpha = blip.GetFirstChild<DocumentFormat.OpenXml.Drawing.AlphaModulationFixed>();
-                Assert.Equal(75000, alpha.Amount.Value);
+                Assert.NotNull(alpha);
+                Assert.NotNull(alpha!.Amount);
+                Assert.Equal(75000, alpha.Amount!.Value);
             }
         }
 
@@ -428,9 +430,11 @@ namespace OfficeIMO.Tests {
             }
 
             using (var doc = DocumentFormat.OpenXml.Packaging.WordprocessingDocument.Open(filePath, false)) {
-                var blip = doc.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Blip>().First();
+                var blip = doc.MainDocumentPart!.Document.Descendants<DocumentFormat.OpenXml.Drawing.Blip>().First();
                 var alpha = blip.GetFirstChild<DocumentFormat.OpenXml.Drawing.AlphaModulationFixed>();
-                Assert.Equal(50000, alpha.Amount.Value);
+                Assert.NotNull(alpha);
+                Assert.NotNull(alpha!.Amount);
+                Assert.Equal(50000, alpha.Amount!.Value);
             }
         }
 
@@ -449,7 +453,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (var doc = DocumentFormat.OpenXml.Packaging.WordprocessingDocument.Open(filePath, false)) {
-                var blip = doc.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Blip>().First();
+                var blip = doc.MainDocumentPart!.Document.Descendants<DocumentFormat.OpenXml.Drawing.Blip>().First();
                 var alpha = blip.GetFirstChild<DocumentFormat.OpenXml.Drawing.AlphaModulationFixed>();
                 Assert.Null(alpha);
             }
@@ -495,7 +499,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (var pkg = WordprocessingDocument.Open(filePath, false)) {
-                var blipFill = pkg.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Pictures.BlipFill>().First();
+                var blipFill = pkg.MainDocumentPart!.Document.Descendants<DocumentFormat.OpenXml.Drawing.Pictures.BlipFill>().First();
                 Assert.NotNull(blipFill.GetFirstChild<DocumentFormat.OpenXml.Drawing.Tile>());
                 var blip = blipFill.Blip;
                 var ext = blip.GetFirstChild<BlipExtensionList>()?.OfType<BlipExtension>().FirstOrDefault(e => e.Uri == "{28A0092B-C50C-407E-A947-70E740481C1C}");
@@ -518,7 +522,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (var pkg = WordprocessingDocument.Open(filePath, false)) {
-                var blipFill = pkg.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Pictures.BlipFill>().First();
+                var blipFill = pkg.MainDocumentPart!.Document.Descendants<DocumentFormat.OpenXml.Drawing.Pictures.BlipFill>().First();
                 var stretch = blipFill.GetFirstChild<DocumentFormat.OpenXml.Drawing.Stretch>();
                 Assert.NotNull(stretch);
                 Assert.Null(stretch.GetFirstChild<DocumentFormat.OpenXml.Drawing.FillRectangle>());
@@ -541,7 +545,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (var pkg = WordprocessingDocument.Open(filePath, false)) {
-                var blipFill = pkg.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Pictures.BlipFill>().First();
+                var blipFill = pkg.MainDocumentPart!.Document.Descendants<DocumentFormat.OpenXml.Drawing.Pictures.BlipFill>().First();
                 var tile = blipFill.GetFirstChild<DocumentFormat.OpenXml.Drawing.Tile>();
                 Assert.NotNull(tile);
                 Assert.Equal(RectangleAlignmentValues.Center, tile.Alignment?.Value);
@@ -565,7 +569,8 @@ namespace OfficeIMO.Tests {
 
             using (var pkg = WordprocessingDocument.Open(filePath, false)) {
                 // ensure document opens correctly after removing the external image
-                Assert.NotNull(pkg.MainDocumentPart.Document);
+                Assert.NotNull(pkg.MainDocumentPart);
+                Assert.NotNull(pkg.MainDocumentPart!.Document);
             }
         }
 
@@ -584,14 +589,16 @@ namespace OfficeIMO.Tests {
             }
 
             using (var pkg = WordprocessingDocument.Open(filePath, false)) {
-                var pic = pkg.MainDocumentPart.Document.Descendants<DocumentFormat.OpenXml.Drawing.Pictures.Picture>().First();
+                var pic = pkg.MainDocumentPart!.Document.Descendants<DocumentFormat.OpenXml.Drawing.Pictures.Picture>().First();
                 var nv = pic.NonVisualPictureProperties;
                 Assert.Equal("MyTitle", nv.NonVisualDrawingProperties.Title);
                 Assert.True(nv.NonVisualDrawingProperties.Hidden);
                 Assert.True(nv.NonVisualPictureDrawingProperties.PreferRelativeResize);
                 Assert.True(nv.NonVisualPictureDrawingProperties.PictureLocks.NoChangeAspect);
                 var ar = pic.BlipFill.Blip.GetFirstChild<DocumentFormat.OpenXml.Drawing.AlphaReplace>();
-                Assert.Equal(80000, ar.Alpha.Value);
+                Assert.NotNull(ar);
+                Assert.NotNull(ar!.Alpha);
+                Assert.Equal(80000, ar.Alpha!.Value);
             }
         }
 
@@ -679,7 +686,8 @@ namespace OfficeIMO.Tests {
             Assert.False(stream is MemoryStream);
             Assert.Equal(new FileInfo(imagePath).Length, stream.Length);
             var buffer = new byte[1];
-            stream.Read(buffer, 0, 1);
+            int bytesRead = stream.Read(buffer, 0, 1);
+            Assert.Equal(1, bytesRead);
         }
 
     }

--- a/OfficeIMO.Tests/Word.ParagraphCustomStyles.cs
+++ b/OfficeIMO.Tests/Word.ParagraphCustomStyles.cs
@@ -27,7 +27,7 @@ namespace OfficeIMO.Tests {
                 Assert.NotNull(styles.Elements<Style>().FirstOrDefault(s => s.StyleId == "MyStyle"));
             }
 
-            var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static);
+            var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static)!;
             var dict = (IDictionary<string, Style>)field.GetValue(null)!;
             dict.Clear();
         }
@@ -72,7 +72,7 @@ namespace OfficeIMO.Tests {
             }
 
             // cleanup
-            var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static);
+            var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static)!;
             var dict = (IDictionary<string, Style>)field.GetValue(null)!;
             dict.Clear();
         }
@@ -100,7 +100,7 @@ namespace OfficeIMO.Tests {
             }
 
             // cleanup
-            var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static);
+            var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static)!;
             var dict = (IDictionary<string, Style>)field.GetValue(null)!;
             dict.Clear();
         }

--- a/OfficeIMO.Tests/Word.Tables.Margins.cs
+++ b/OfficeIMO.Tests/Word.Tables.Margins.cs
@@ -28,16 +28,16 @@ namespace OfficeIMO.Tests {
                 table1.StyleDetails.MarginDefaultRightCentimeters = 0.2;
 
                 // Verify the centimeter values
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightCentimeters.Value - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopCentimeters!.Value - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomCentimeters!.Value - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftCentimeters!.Value - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightCentimeters!.Value - 0.2) < 0.01);
 
                 // Verify the twips values (0.2 cm should be approximately 113.4 twips)
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopWidth.Value - 113) <= 1);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomWidth.Value - 113) <= 1);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftWidth.Value - 113) <= 1);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightWidth.Value - 113) <= 1);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopWidth!.Value - 113) <= 1);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomWidth!.Value - 113) <= 1);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftWidth!.Value - 113) <= 1);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightWidth!.Value - 113) <= 1);
 
                 document.AddParagraph();
 
@@ -52,8 +52,8 @@ namespace OfficeIMO.Tests {
                 table2.StyleDetails.MarginDefaultRightWidth = 170;
 
                 // Verify centimeter values
-                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultTopCentimeters.Value - 0.3) < 0.01);
-                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultBottomCentimeters.Value - 0.3) < 0.01);
+                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultTopCentimeters!.Value - 0.3) < 0.01);
+                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultBottomCentimeters!.Value - 0.3) < 0.01);
 
                 // Verify twips values
                 Assert.True(table2.StyleDetails.MarginDefaultLeftWidth == 170);
@@ -69,10 +69,10 @@ namespace OfficeIMO.Tests {
                 table3.StyleDetails.CellSpacingCentimeters = 0.15;
 
                 // Verify centimeter value
-                Assert.True(Math.Abs(table3.StyleDetails.CellSpacingCentimeters.Value - 0.15) < 0.01);
+                Assert.True(Math.Abs(table3.StyleDetails.CellSpacingCentimeters!.Value - 0.15) < 0.01);
 
                 // Verify twips value (0.15 cm should be approximately 85 twips)
-                Assert.True(Math.Abs(table3.StyleDetails.CellSpacing.Value - 85) <= 1);
+                Assert.True(Math.Abs(table3.StyleDetails.CellSpacing!.Value - 85) <= 1);
 
                 document.AddParagraph();
 
@@ -86,9 +86,9 @@ namespace OfficeIMO.Tests {
                 table4.StyleDetails.CellSpacingCentimeters = 0.1;
 
                 // Verify values are set
-                Assert.True(Math.Abs(table4.StyleDetails.MarginDefaultTopCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table4.StyleDetails.MarginDefaultBottomCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table4.StyleDetails.CellSpacingCentimeters.Value - 0.1) < 0.01);
+                Assert.True(Math.Abs(table4.StyleDetails.MarginDefaultTopCentimeters!.Value - 0.2) < 0.01);
+                Assert.True(Math.Abs(table4.StyleDetails.MarginDefaultBottomCentimeters!.Value - 0.2) < 0.01);
+                Assert.True(Math.Abs(table4.StyleDetails.CellSpacingCentimeters!.Value - 0.1) < 0.01);
 
                 // Clear values
                 table4.StyleDetails.MarginDefaultTopCentimeters = null;
@@ -107,21 +107,21 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithTableMargins.docx"))) {
                 // Verify table 1 values
                 var table1 = document.Tables[0];
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftCentimeters.Value - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightCentimeters.Value - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopCentimeters!.Value - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomCentimeters!.Value - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftCentimeters!.Value - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightCentimeters!.Value - 0.2) < 0.01);
 
                 // Verify table 2 values
                 var table2 = document.Tables[1];
-                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultTopCentimeters.Value - 0.3) < 0.01);
-                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultBottomCentimeters.Value - 0.3) < 0.01);
+                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultTopCentimeters!.Value - 0.3) < 0.01);
+                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultBottomCentimeters!.Value - 0.3) < 0.01);
                 Assert.True(table2.StyleDetails.MarginDefaultLeftWidth == 170);
                 Assert.True(table2.StyleDetails.MarginDefaultRightWidth == 170);
 
                 // Verify table 3 values
                 var table3 = document.Tables[2];
-                Assert.True(Math.Abs(table3.StyleDetails.CellSpacingCentimeters.Value - 0.15) < 0.01);
+                Assert.True(Math.Abs(table3.StyleDetails.CellSpacingCentimeters!.Value - 0.15) < 0.01);
 
                 // Verify table 4 values are cleared
                 var table4 = document.Tables[3];


### PR DESCRIPTION
## Summary
- address nullable warnings across Word image and chart tests
- add null checks in Excel and Word comparison tests
- adjust footnote test to account for separator notes

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a38e9020e4832e9adec892b57a9adb