### PR TITLE
feat: add fluent PowerPoint builder

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/FluentPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/FluentPowerPoint.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using OfficeIMO.PowerPoint;
+using OfficeIMO.PowerPoint.Fluent;
+
+namespace OfficeIMO.Examples.PowerPoint {
+    /// <summary>
+    /// Demonstrates fluent API for building presentations.
+    /// </summary>
+    public static class FluentPowerPoint {
+        public static void Example_FluentPowerPoint(string folderPath, bool openPowerPoint) {
+            Console.WriteLine("[*] PowerPoint - Creating presentation with fluent API");
+            string filePath = Path.Combine(folderPath, "FluentPowerPoint.pptx");
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                presentation.AsFluent()
+                    .Slide()
+                        .Title("Fluent Presentation")
+                        .Text("Hello from fluent API")
+                        .Bullets("First", "Second")
+                        .Notes("Example notes");
+                presentation.Save();
+            }
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
+++ b/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
@@ -1,0 +1,22 @@
+namespace OfficeIMO.PowerPoint.Fluent {
+    /// <summary>
+    /// Provides a fluent API wrapper around <see cref="PowerPointPresentation"/>.
+    /// </summary>
+    public class PowerPointFluentPresentation {
+        internal PowerPointPresentation Presentation { get; }
+
+        public PowerPointFluentPresentation(PowerPointPresentation presentation) {
+            Presentation = presentation ?? throw new System.ArgumentNullException(nameof(presentation));
+        }
+
+        /// <summary>
+        /// Adds a new slide to the presentation.
+        /// </summary>
+        /// <param name="masterIndex">Index of the slide master.</param>
+        /// <param name="layoutIndex">Index of the slide layout.</param>
+        public SlideBuilder Slide(int masterIndex = 0, int layoutIndex = 0) {
+            PowerPointSlide slide = Presentation.AddSlide(masterIndex, layoutIndex);
+            return new SlideBuilder(slide);
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/Fluent/SlideBuilder.cs
+++ b/OfficeIMO.PowerPoint/Fluent/SlideBuilder.cs
@@ -1,0 +1,63 @@
+namespace OfficeIMO.PowerPoint.Fluent {
+    /// <summary>
+    /// Builder for slide content.
+    /// </summary>
+    public class SlideBuilder {
+        private readonly PowerPointSlide _slide;
+
+        internal SlideBuilder(PowerPointSlide slide) {
+            _slide = slide;
+        }
+
+        /// <summary>
+        /// Adds a title textbox to the slide.
+        /// </summary>
+        public SlideBuilder Title(string text) {
+            _slide.AddTextBox(text);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a textbox with the specified text.
+        /// </summary>
+        public SlideBuilder Text(string text) {
+            _slide.AddTextBox(text);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a bulleted list to the slide.
+        /// </summary>
+        public SlideBuilder Bullets(params string[] bullets) {
+            PPTextBox box = _slide.AddTextBox(string.Empty);
+            foreach (string bullet in bullets) {
+                box.AddBullet(bullet);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Adds an image from the given file path.
+        /// </summary>
+        public SlideBuilder Image(string imagePath) {
+            _slide.AddPicture(imagePath);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a table to the slide.
+        /// </summary>
+        public SlideBuilder Table(int rows, int columns) {
+            _slide.AddTable(rows, columns);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets notes text for the slide.
+        /// </summary>
+        public SlideBuilder Notes(string text) {
+            _slide.Notes.Text = text;
+            return this;
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
+using OfficeIMO.PowerPoint.Fluent;
 using A = DocumentFormat.OpenXml.Drawing;
 
 namespace OfficeIMO.PowerPoint {
@@ -107,6 +108,13 @@ namespace OfficeIMO.PowerPoint {
             _document.Save();
         }
 
+        /// <summary>
+        /// Creates a fluent wrapper for this presentation.
+        /// </summary>
+        public PowerPointFluentPresentation AsFluent() {
+            return new PowerPointFluentPresentation(this);
+        }
+
         private void InitializeDefaultParts() {
             SlideMasterPart slideMasterPart = _presentationPart.AddNewPart<SlideMasterPart>();
             slideMasterPart.SlideMaster = new SlideMaster(new CommonSlideData(new ShapeTree()));
@@ -167,4 +175,3 @@ namespace OfficeIMO.PowerPoint {
         }
     }
 }
-

--- a/OfficeIMO.Tests/PowerPoint.Fluent.cs
+++ b/OfficeIMO.Tests/PowerPoint.Fluent.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Linq;
+using OfficeIMO.PowerPoint;
+using OfficeIMO.PowerPoint.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointFluentPresentation {
+        [Fact]
+        public void CanBuildPresentationFluently() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string imagePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", "BackgroundImage.png");
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                presentation.AsFluent()
+                    .Slide()
+                        .Title("Fluent Title")
+                        .Text("Hello")
+                        .Bullets("One", "Two")
+                        .Image(imagePath)
+                        .Table(2, 2)
+                        .Notes("Notes text");
+                presentation.Save();
+            }
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                Assert.Single(presentation.Slides);
+                PowerPointSlide slide = presentation.Slides[0];
+                Assert.Equal("Notes text", slide.Notes.Text);
+                Assert.Equal(5, slide.Shapes.Count);
+                var textBoxes = slide.Shapes.OfType<PPTextBox>().ToList();
+                Assert.Equal(3, textBoxes.Count);
+                Assert.Equal("Fluent Title", textBoxes[0].Text);
+                Assert.Equal("Hello", textBoxes[1].Text);
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add PowerPointFluentPresentation with AsFluent entry point
- implement chainable SlideBuilder for titles, text, bullets, images, tables and notes
- cover fluent API with tests and example
- fix formatting and using order for fluent API files

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Debug -f net8.0 --no-build`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Debug -f net9.0 --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68a38ee63bbc832eab940ea8bd4b27e5