### PR TITLE
fix: resolve analyzer warnings

### DIFF
--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -17,7 +17,7 @@ namespace OfficeIMO.Word {
         /// <param name="wordParagraph">The paragraph after which the item should be inserted. If <c>null</c> the item is appended at the default position.</param>
         /// <param name="level">The zero-based list level for the new item.</param>
         /// <returns>The newly created <see cref="WordParagraph"/> representing the list item.</returns>
-        public WordParagraph AddItem(WordParagraph wordParagraph, int level = 0) {
+        public WordParagraph AddItem(WordParagraph? wordParagraph, int level = 0) {
             return AddItem(null, level, wordParagraph);
         }
 
@@ -28,7 +28,7 @@ namespace OfficeIMO.Word {
         /// <param name="level">The zero-based list level for the item.</param>
         /// <param name="wordParagraph">The paragraph after which the item is inserted. When <c>null</c> the item is appended in the default position.</param>
         /// <returns>The <see cref="WordParagraph"/> representing the created list item.</returns>
-        public WordParagraph AddItem(string text, int level = 0, WordParagraph wordParagraph = null) {
+        public WordParagraph AddItem(string? text, int level = 0, WordParagraph? wordParagraph = null) {
             var paragraph = new Paragraph();
             var run = new Run();
             run.Append(new RunProperties());
@@ -50,20 +50,19 @@ namespace OfficeIMO.Word {
             paragraph.Append(paragraphProperties);
             paragraph.Append(run);
 
-            if (wordParagraph != null) {
+            if (wordParagraph is not null) {
                 wordParagraph._paragraph.InsertAfterSelf(paragraph);
-            } else if (this.ListItems.Count == 0 && _wordParagraph != null) {
+            } else if (this.ListItems.Count == 0 && _wordParagraph is not null) {
                 _wordParagraph._paragraph.InsertAfterSelf(paragraph);
             } else if (_isToc || IsToc) {
                 _wordprocessingDocument.MainDocumentPart!.Document.Body!.AppendChild(paragraph);
             } else if (_headerFooter != null) {
-                if (_headerFooter._header != null) {
+                if (_headerFooter._header is not null) {
                     _headerFooter._header.Append(paragraph);
-                } else if (_headerFooter._footer != null) {
+                } else if (_headerFooter._footer is not null) {
                     _headerFooter._footer.Append(paragraph);
                 }
-            } else if (_wordParagraph != null && _wordParagraph._paragraph.Parent is TableCell) {
-                var parent = _wordParagraph._paragraph.Parent;
+            } else if (_wordParagraph is not null && _wordParagraph._paragraph.Parent is TableCell parent) {
                 if (this.ListItems.Count > 0) {
                     var lastItem = this.ListItems.Last();
                     lastItem._paragraph.InsertAfterSelf(paragraph);
@@ -102,24 +101,26 @@ namespace OfficeIMO.Word {
             }
             _listItems.Clear();
 
-            var numberingPart = _document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart;
+            var numberingPart = _document._wordprocessingDocument?.MainDocumentPart?.NumberingDefinitionsPart;
             var numbering = numberingPart?.Numbering;
             if (numbering != null) {
                 bool stillReferenced = _document.EnumerateAllParagraphs()
                     .Any(p => p.IsListItem && p._listNumberId == _numberId);
 
                 if (!stillReferenced) {
-                    var abstractNum = numbering.Elements<AbstractNum>().FirstOrDefault(a => a.AbstractNumberId.Value == _abstractId);
-                    abstractNum?.Remove();
+                      var abstractNum = numbering.Elements<AbstractNum>().FirstOrDefault(a => a.AbstractNumberId?.Value == _abstractId);
+                      abstractNum?.Remove();
 
-                    var numberingInstance = numbering.Elements<NumberingInstance>().FirstOrDefault(n => n.NumberID.Value == _numberId);
-                    numberingInstance?.Remove();
+                      var numberingInstance = numbering.Elements<NumberingInstance>().FirstOrDefault(n => n.NumberID?.Value == _numberId);
+                      numberingInstance?.Remove();
 
-                    if (!numbering.Elements<AbstractNum>().Any() &&
-                        !numbering.Elements<NumberingInstance>().Any() &&
-                        !numbering.Elements<NumberingPictureBullet>().Any()) {
-                        _document._wordprocessingDocument.MainDocumentPart.DeletePart(numberingPart);
-                    }
+                      if (!numbering.Elements<AbstractNum>().Any() &&
+                          !numbering.Elements<NumberingInstance>().Any() &&
+                          !numbering.Elements<NumberingPictureBullet>().Any()) {
+                          if (numberingPart != null) {
+                              _document._wordprocessingDocument!.MainDocumentPart!.DeletePart(numberingPart);
+                          }
+                      }
                 }
             }
         }
@@ -174,7 +175,7 @@ namespace OfficeIMO.Word {
         /// <param name="colorHex">Optional hexadecimal color for the symbol.</param>
         /// <param name="fontSize">Optional font size for the symbol in points.</param>
         /// <returns>The created <see cref="WordList"/>.</returns>
-        public static WordList AddCustomBulletList(WordDocument document, char symbol, string fontName, string colorHex, int? fontSize = null) {
+        public static WordList AddCustomBulletList(WordDocument document, char symbol, string fontName, string? colorHex, int? fontSize = null) {
             if (document == null) throw new ArgumentNullException(nameof(document));
 
             var list = document.AddList(WordListStyle.Custom);
@@ -218,8 +219,8 @@ namespace OfficeIMO.Word {
         /// <param name="colorHex">Optional color specified as hex string. Ignored when <paramref name="color"/> is provided.</param>
         /// <param name="fontSize">Optional font size in points.</param>
         /// <returns>The created <see cref="WordList"/>.</returns>
-        public static WordList AddCustomBulletList(WordDocument document, WordBulletSymbol symbol, string fontName, SixLabors.ImageSharp.Color? color = null, string colorHex = null, int? fontSize = null) {
-            string finalColor = color?.ToHexColor() ?? colorHex;
+        public static WordList AddCustomBulletList(WordDocument document, WordBulletSymbol symbol, string fontName, SixLabors.ImageSharp.Color? color = null, string? colorHex = null, int? fontSize = null) {
+            string? finalColor = color?.ToHexColor() ?? colorHex;
             return AddCustomBulletList(document, (char)symbol, fontName, finalColor, fontSize);
         }
 
@@ -233,9 +234,9 @@ namespace OfficeIMO.Word {
         /// <param name="colorHex">Optional color specified as hex string. Ignored when <paramref name="color"/> is provided.</param>
         /// <param name="fontSize">Optional font size in points.</param>
         /// <returns>The created <see cref="WordList"/>.</returns>
-        public static WordList AddCustomBulletList(WordDocument document, WordListLevelKind kind, string fontName, SixLabors.ImageSharp.Color? color = null, string colorHex = null, int? fontSize = null) {
+        public static WordList AddCustomBulletList(WordDocument document, WordListLevelKind kind, string fontName, SixLabors.ImageSharp.Color? color = null, string? colorHex = null, int? fontSize = null) {
             char symbol = GetBulletSymbol(kind);
-            string finalColor = color?.ToHexColor() ?? colorHex;
+            string? finalColor = color?.ToHexColor() ?? colorHex;
             return AddCustomBulletList(document, symbol, fontName, finalColor, fontSize);
         }
 
@@ -264,9 +265,9 @@ namespace OfficeIMO.Word {
             if (document == null) throw new ArgumentNullException(nameof(document));
             if (imageStream == null) throw new ArgumentNullException(nameof(imageStream));
 
-            var numberingPart = document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart;
+            var numberingPart = document._wordprocessingDocument?.MainDocumentPart?.NumberingDefinitionsPart;
             if (numberingPart == null) {
-                numberingPart = document._wordprocessingDocument.MainDocumentPart.AddNewPart<NumberingDefinitionsPart>();
+                numberingPart = document._wordprocessingDocument!.MainDocumentPart!.AddNewPart<NumberingDefinitionsPart>();
                 numberingPart.Numbering = new Numbering();
             }
             var numbering = numberingPart.Numbering;
@@ -279,7 +280,7 @@ namespace OfficeIMO.Word {
             var relId = numberingPart.GetIdOfPart(imagePart);
 
             int picId = numbering.Elements<NumberingPictureBullet>()
-                .Select(p => (int)p.NumberingPictureBulletId.Value)
+                .Select(p => (int)(p.NumberingPictureBulletId?.Value ?? 0))
                 .DefaultIfEmpty(0)
                 .Max() + 1;
 
@@ -318,7 +319,7 @@ namespace OfficeIMO.Word {
         /// <param name="colorHex">Bullet color specified as hex string.</param>
         /// <param name="fontSize">Optional font size in points.</param>
         /// <returns>The current <see cref="WordList"/>.</returns>
-        public WordList AddListLevel(int levelIndex, char symbol, string fontName, string colorHex, int? fontSize = null) {
+        public WordList AddListLevel(int levelIndex, char symbol, string fontName, string? colorHex, int? fontSize = null) {
             if (levelIndex < 1) throw new ArgumentOutOfRangeException(nameof(levelIndex));
 
             var currentCount = this.Numbering.Levels.Count;
@@ -331,14 +332,14 @@ namespace OfficeIMO.Word {
             }
 
             if (currentCount == 0 && levelIndex > 1) {
-                var placeholder = CreateBulletLevel(symbol, fontName, colorHex, fontSize);
+                var placeholder = CreateBulletLevel(symbol, fontName, colorHex ?? string.Empty, fontSize);
                 while (this.Numbering.Levels.Count < levelIndex - 1) {
                     var clone = (Level)placeholder.CloneNode(true);
                     this.Numbering.AddLevel(clone);
                 }
             }
 
-            var newLevel = CreateBulletLevel(symbol, fontName, colorHex, fontSize);
+            var newLevel = CreateBulletLevel(symbol, fontName, colorHex ?? string.Empty, fontSize);
             this.Numbering.AddLevel(newLevel);
             return this;
         }
@@ -353,8 +354,8 @@ namespace OfficeIMO.Word {
         /// <param name="colorHex">Optional color specified as hex string. Ignored when <paramref name="color"/> is provided.</param>
         /// <param name="fontSize">Optional font size in points.</param>
         /// <returns>The current <see cref="WordList"/>.</returns>
-        public WordList AddListLevel(int levelIndex, WordBulletSymbol symbol, string fontName, SixLabors.ImageSharp.Color? color = null, string colorHex = null, int? fontSize = null) {
-            string finalColor = color?.ToHexColor() ?? colorHex;
+        public WordList AddListLevel(int levelIndex, WordBulletSymbol symbol, string fontName, SixLabors.ImageSharp.Color? color = null, string? colorHex = null, int? fontSize = null) {
+            string? finalColor = color?.ToHexColor() ?? colorHex;
             return AddListLevel(levelIndex, (char)symbol, fontName, finalColor, fontSize);
         }
 
@@ -368,9 +369,9 @@ namespace OfficeIMO.Word {
         /// <param name="colorHex">Optional color specified as hex string. Ignored when <paramref name="color"/> is provided.</param>
         /// <param name="fontSize">Optional font size in points.</param>
         /// <returns>The current <see cref="WordList"/>.</returns>
-        public WordList AddListLevel(int levelIndex, WordListLevelKind kind, string fontName, SixLabors.ImageSharp.Color? color = null, string colorHex = null, int? fontSize = null) {
+        public WordList AddListLevel(int levelIndex, WordListLevelKind kind, string fontName, SixLabors.ImageSharp.Color? color = null, string? colorHex = null, int? fontSize = null) {
             char symbol = GetBulletSymbol(kind);
-            string finalColor = color?.ToHexColor() ?? colorHex;
+            string? finalColor = color?.ToHexColor() ?? colorHex;
             return AddListLevel(levelIndex, symbol, fontName, finalColor, fontSize);
         }
 

--- a/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.ParagraphProperties.cs
@@ -18,7 +18,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the identifier of the paragraph style, if any.
         /// </summary>
-        public string StyleId {
+        public string? StyleId {
             get {
                 if (_paragraphProperties != null && _paragraphProperties.ParagraphStyleId != null) {
                     return _paragraphProperties.ParagraphStyleId.Val;
@@ -35,14 +35,14 @@ namespace OfficeIMO.Word {
             get {
                 if (_paragraphProperties != null)
                     if (_paragraphProperties.Justification != null)
-                        return _paragraphProperties.Justification.Val;
+                        return _paragraphProperties.Justification.Val?.Value;
                 return null;
             }
             set {
                 if (_paragraphProperties == null) {
-                    _paragraph.ParagraphProperties = new ParagraphProperties();
+                _paragraph.ParagraphProperties = new ParagraphProperties();
                 }
-                _paragraphProperties.Justification = new Justification {
+                _paragraph.ParagraphProperties!.Justification = new Justification {
                     Val = value
                 };
             }
@@ -56,16 +56,16 @@ namespace OfficeIMO.Word {
             get {
                 if (_paragraphProperties != null)
                     if (_paragraphProperties.TextAlignment != null)
-                        return _paragraphProperties.TextAlignment.Val;
+                        return _paragraphProperties.TextAlignment.Val?.Value;
                 return null;
             }
             set {
-                DocumentFormat.OpenXml.Wordprocessing.TextAlignment textAlignment = new TextAlignment();
+                var textAlignment = new TextAlignment();
                 textAlignment.Val = value;
                 if (_paragraphProperties == null) {
                     _paragraph.ParagraphProperties = new ParagraphProperties();
                 }
-                _paragraphProperties.TextAlignment = textAlignment;
+                _paragraph.ParagraphProperties!.TextAlignment = textAlignment;
             }
         }
         /// <summary>
@@ -73,14 +73,14 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? IndentationBefore {
             get {
-                if (_paragraphProperties != null && _paragraphProperties.Indentation != null) {                    if (_paragraphProperties.Indentation.Left != "") {
-                        return int.Parse(_paragraphProperties.Indentation.Left);
-                    } else {
-                        return null;
+                if (_paragraphProperties != null && _paragraphProperties.Indentation != null) {
+                    if (!string.IsNullOrEmpty(_paragraphProperties.Indentation.Left)) {
+                        if (int.TryParse(_paragraphProperties.Indentation.Left, out var left)) {
+                            return left;
+                        }
                     }
-                } else {
-                    return null;
                 }
+                return null;
             }
             set {
                 Indentation indentation;
@@ -90,7 +90,7 @@ namespace OfficeIMO.Word {
                     indentation = _paragraphProperties.Indentation;
                 }
 
-                indentation.Left = value.ToString();
+                indentation.Left = value?.ToString();
                 _paragraphProperties.Indentation = indentation;
             }
         }
@@ -116,14 +116,14 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? IndentationAfter {
             get {
-                if (_paragraphProperties != null && _paragraphProperties.Indentation != null) {                    if (_paragraphProperties.Indentation.Right != "") {
-                        return int.Parse(_paragraphProperties.Indentation.Right);
-                    } else {
-                        return null;
+                if (_paragraphProperties != null && _paragraphProperties.Indentation != null) {
+                    if (!string.IsNullOrEmpty(_paragraphProperties.Indentation.Right)) {
+                        if (int.TryParse(_paragraphProperties.Indentation.Right, out var right)) {
+                            return right;
+                        }
                     }
-                } else {
-                    return null;
                 }
+                return null;
             }
             set {
                 Indentation indentation;
@@ -133,7 +133,7 @@ namespace OfficeIMO.Word {
                     indentation = _paragraphProperties.Indentation;
                 }
 
-                indentation.Right = value.ToString();
+                indentation.Right = value?.ToString();
                 _paragraphProperties.Indentation = indentation;
             }
         }
@@ -178,14 +178,13 @@ namespace OfficeIMO.Word {
         public int? IndentationFirstLine {
             get {
                 if (_paragraphProperties != null && _paragraphProperties.Indentation != null) {
-                    if (_paragraphProperties.Indentation.FirstLine != "") {
-                        return int.Parse(_paragraphProperties.Indentation.FirstLine);
-                    } else {
-                        return null;
+                    if (!string.IsNullOrEmpty(_paragraphProperties.Indentation.FirstLine)) {
+                        if (int.TryParse(_paragraphProperties.Indentation.FirstLine, out var firstLine)) {
+                            return firstLine;
+                        }
                     }
-                } else {
-                    return null;
                 }
+                return null;
             }
             set {
                 Indentation indentation;
@@ -195,7 +194,7 @@ namespace OfficeIMO.Word {
                     indentation = _paragraphProperties.Indentation;
                 }
 
-                indentation.FirstLine = value.ToString();
+                indentation.FirstLine = value?.ToString();
                 _paragraphProperties.Indentation = indentation;
             }
         }
@@ -221,14 +220,14 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? IndentationHanging {
             get {
-                if (_paragraphProperties != null && _paragraphProperties.Indentation != null) {                    if (_paragraphProperties.Indentation.Hanging != "") {
-                        return int.Parse(_paragraphProperties.Indentation.Hanging);
-                    } else {
-                        return null;
+                if (_paragraphProperties != null && _paragraphProperties.Indentation != null) {
+                    if (!string.IsNullOrEmpty(_paragraphProperties.Indentation.Hanging)) {
+                        if (int.TryParse(_paragraphProperties.Indentation.Hanging, out var hanging)) {
+                            return hanging;
+                        }
                     }
-                } else {
-                    return null;
                 }
+                return null;
             }
             set {
                 Indentation indentation;
@@ -238,7 +237,7 @@ namespace OfficeIMO.Word {
                     indentation = _paragraphProperties.Indentation;
                 }
 
-                indentation.Hanging = value.ToString();
+                indentation.Hanging = value?.ToString();
                 _paragraphProperties.Indentation = indentation;
             }
         }
@@ -265,19 +264,16 @@ namespace OfficeIMO.Word {
         public TextDirectionValues? TextDirection {
             get {
                 if (_paragraphProperties != null && _paragraphProperties.TextDirection != null) {
-                    if (_paragraphProperties.TextDirection != null) {
-                        return _paragraphProperties.TextDirection.Val;
-                    } else {
-                        return null;
-                    }
-                } else {
-                    return null;
+                    return _paragraphProperties.TextDirection.Val?.Value;
                 }
+                return null;
             }
             set {
-                TextDirection textDirection = new TextDirection();
-                textDirection.Val = value;
-                _paragraphProperties.TextDirection = textDirection;
+                var textDirection = new TextDirection { Val = value };
+                if (_paragraphProperties == null) {
+                    _paragraph.ParagraphProperties = new ParagraphProperties();
+                }
+                _paragraph.ParagraphProperties!.TextDirection = textDirection;
             }
         }
 
@@ -293,14 +289,12 @@ namespace OfficeIMO.Word {
                     _paragraph.ParagraphProperties = new ParagraphProperties();
                 }
 
+                var paragraphProps = _paragraph.ParagraphProperties!;
+
                 if (value) {
-                    if (_paragraphProperties.BiDi == null) {
-                        _paragraphProperties.BiDi = new BiDi();
-                    }
+                    paragraphProps.BiDi ??= new BiDi();
                 } else {
-                    if (_paragraphProperties.BiDi != null) {
-                        _paragraphProperties.BiDi.Remove();
-                    }
+                    paragraphProps.BiDi?.Remove();
                 }
             }
         }
@@ -312,12 +306,9 @@ namespace OfficeIMO.Word {
                 if (_paragraphProperties != null && _paragraphProperties.SpacingBetweenLines != null) {
                     if (_paragraphProperties.SpacingBetweenLines.LineRule != null) {
                         return _paragraphProperties.SpacingBetweenLines.LineRule;
-                    } else {
-                        return null;
                     }
-                } else {
-                    return null;
                 }
+                return null;
             }
             set {
                 SpacingBetweenLines spacing;
@@ -336,14 +327,13 @@ namespace OfficeIMO.Word {
         public int? LineSpacing {
             get {
                 if (_paragraphProperties != null && _paragraphProperties.SpacingBetweenLines != null) {
-                    if (_paragraphProperties.SpacingBetweenLines.Line != "") {
-                        return int.Parse(_paragraphProperties.SpacingBetweenLines.Line);
-                    } else {
-                        return null;
+                    if (!string.IsNullOrEmpty(_paragraphProperties.SpacingBetweenLines.Line)) {
+                        if (int.TryParse(_paragraphProperties.SpacingBetweenLines.Line, out var line)) {
+                            return line;
+                        }
                     }
-                } else {
-                    return null;
                 }
+                return null;
             }
             set {
                 SpacingBetweenLines spacing;
@@ -353,7 +343,7 @@ namespace OfficeIMO.Word {
                     spacing = _paragraphProperties.SpacingBetweenLines;
                 }
 
-                spacing.Line = value.ToString();
+                spacing.Line = value?.ToString();
                 _paragraphProperties.SpacingBetweenLines = spacing;
             }
         }
@@ -379,14 +369,13 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? LineSpacingBefore {
             get {
-                if (_paragraphProperties != null && _paragraphProperties.SpacingBetweenLines != null) {                    if (_paragraphProperties.SpacingBetweenLines.Before != "") {
-                        return int.Parse(_paragraphProperties.SpacingBetweenLines.Before);
-                    } else {
-                        return null;
+                if (_paragraphProperties != null && _paragraphProperties.SpacingBetweenLines != null) {                    if (!string.IsNullOrEmpty(_paragraphProperties.SpacingBetweenLines.Before)) {
+                        if (int.TryParse(_paragraphProperties.SpacingBetweenLines.Before, out var before)) {
+                            return before;
+                        }
                     }
-                } else {
-                    return null;
                 }
+                return null;
             }
             set {
                 SpacingBetweenLines spacing;
@@ -396,7 +385,7 @@ namespace OfficeIMO.Word {
                     spacing = _paragraphProperties.SpacingBetweenLines;
                 }
 
-                spacing.Before = value.ToString();
+                spacing.Before = value?.ToString();
                 _paragraphProperties.SpacingBetweenLines = spacing;
             }
         }
@@ -423,14 +412,13 @@ namespace OfficeIMO.Word {
         public int? LineSpacingAfter {
             get {
                 if (_paragraphProperties != null && _paragraphProperties.SpacingBetweenLines != null) {
-                    if (_paragraphProperties.SpacingBetweenLines.After != "") {
-                        return int.Parse(_paragraphProperties.SpacingBetweenLines.After);
-                    } else {
-                        return null;
+                    if (!string.IsNullOrEmpty(_paragraphProperties.SpacingBetweenLines.After)) {
+                        if (int.TryParse(_paragraphProperties.SpacingBetweenLines.After, out var after)) {
+                            return after;
+                        }
                     }
-                } else {
-                    return null;
                 }
+                return null;
             }
             set {
                 SpacingBetweenLines spacing;
@@ -440,7 +428,7 @@ namespace OfficeIMO.Word {
                     spacing = _paragraphProperties.SpacingBetweenLines;
                 }
 
-                spacing.After = value.ToString();
+                spacing.After = value?.ToString();
                 _paragraphProperties.SpacingBetweenLines = spacing;
             }
         }
@@ -468,7 +456,7 @@ namespace OfficeIMO.Word {
         public VerticalPositionValues? VerticalTextAlignment {
             get {
                 if (_runProperties != null && _runProperties.VerticalTextAlignment != null) {
-                    return _runProperties.VerticalTextAlignment.Val;
+                    return _runProperties.VerticalTextAlignment.Val?.Value;
                 }
                 return null;
             }

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -80,10 +80,9 @@ namespace OfficeIMO.Word {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Underline != null) {
-                    return runProperties.Underline.Val;
-                } else {
-                    return null;
+                    return runProperties.Underline.Val?.Value;
                 }
+                return null;
             }
             set {
                 RunProperties runProperties;
@@ -142,10 +141,9 @@ namespace OfficeIMO.Word {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Spacing != null) {
-                    return runProperties.Spacing.Val;
-                } else {
-                    return null;
+                    return runProperties.Spacing.Val?.Value;
                 }
+                return null;
             }
             set {
                 RunProperties runProperties;
@@ -230,11 +228,12 @@ namespace OfficeIMO.Word {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.FontSize != null) {
-                    var fontSizeInHalfPoint = int.Parse(runProperties.FontSize.Val);
-                    return fontSizeInHalfPoint / 2;
-                } else {
-                    return null;
+                    var val = runProperties.FontSize.Val;
+                    if (!string.IsNullOrEmpty(val) && int.TryParse(val, out var fontSizeInHalfPoint)) {
+                        return fontSizeInHalfPoint / 2;
+                    }
                 }
+                return null;
             }
             set {
                 RunProperties runProperties;
@@ -264,7 +263,6 @@ namespace OfficeIMO.Word {
                     return null;
                 }
                 return Helpers.ParseColor(ColorHex);
-
             }
             set {
                 if (value != null) {
@@ -280,10 +278,9 @@ namespace OfficeIMO.Word {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Color != null) {
-                    return runProperties.Color.Val;
-                } else {
-                    return "";
+                    return runProperties.Color.Val?.Value ?? "";
                 }
+                return "";
             }
             set {
                 RunProperties runProperties;
@@ -311,10 +308,9 @@ namespace OfficeIMO.Word {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Color != null && runProperties.Color.ThemeColor != null) {
-                    return runProperties.Color.ThemeColor.Value;
-                } else {
-                    return null;
+                    return runProperties.Color.ThemeColor?.Value;
                 }
+                return null;
             }
             set {
                 RunProperties runProperties;
@@ -345,10 +341,9 @@ namespace OfficeIMO.Word {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Highlight != null) {
-                    return runProperties.Highlight.Val;
-                } else {
-                    return null;
+                    return runProperties.Highlight.Val?.Value;
                 }
+                return null;
             }
             set {
                 RunProperties runProperties;
@@ -410,14 +405,13 @@ namespace OfficeIMO.Word {
         /// please use FontFamilyHighAnsi, FontFamilyEastAsia or FontFamilyComplexScript
         /// in proper order (to overwrite given FontFamily)
         /// </summary>
-        public string FontFamily {
+        public string? FontFamily {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.RunFonts != null) {
                     return runProperties.RunFonts.Ascii;
-                } else {
-                    return null;
                 }
+                return null;
             }
             set {
                 RunProperties runProperties;
@@ -449,14 +443,13 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the HighAnsi font family.
         /// </summary>
-        public string FontFamilyHighAnsi {
+        public string? FontFamilyHighAnsi {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.RunFonts != null) {
                     return runProperties.RunFonts.HighAnsi;
-                } else {
-                    return null;
                 }
+                return null;
             }
             set {
                 RunProperties runProperties;
@@ -482,14 +475,13 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the East Asia font family.
         /// </summary>
-        public string FontFamilyEastAsia {
+        public string? FontFamilyEastAsia {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.RunFonts != null) {
                     return runProperties.RunFonts.EastAsia;
-                } else {
-                    return null;
                 }
+                return null;
             }
             set {
                 RunProperties runProperties;
@@ -515,14 +507,13 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the complex script font family.
         /// </summary>
-        public string FontFamilyComplexScript {
+        public string? FontFamilyComplexScript {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.RunFonts != null) {
                     return runProperties.RunFonts.ComplexScript;
-                } else {
-                    return null;
                 }
+                return null;
             }
             set {
                 RunProperties runProperties;
@@ -552,7 +543,10 @@ namespace OfficeIMO.Word {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.RunStyle != null) {
-                    return WordCharacterStyle.GetStyle(runProperties.RunStyle.Val);
+                    var styleId = runProperties.RunStyle.Val;
+                    if (!string.IsNullOrEmpty(styleId)) {
+                        return WordCharacterStyle.GetStyle(styleId!);
+                    }
                 }
                 return null;
             }
@@ -578,7 +572,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the style identifier applied to the run.
         /// </summary>
-        public string CharacterStyleId {
+        public string? CharacterStyleId {
             get {
                 var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
                 return runProperties?.RunStyle?.Val;

--- a/OfficeIMO.Word/WordStructuredDocumentTag.cs
+++ b/OfficeIMO.Word/WordStructuredDocumentTag.cs
@@ -10,21 +10,21 @@ namespace OfficeIMO.Word {
     /// </summary>
     public class WordStructuredDocumentTag : WordElement {
         private WordDocument _document;
-        private Paragraph _paragraph;
-        private SdtRun _stdRun;
-        private SdtBlock _sdtBlock;
+        private Paragraph? _paragraph;
+        private SdtRun? _stdRun;
+        private SdtBlock? _sdtBlock;
 
         /// <summary>
         /// Gets the alias associated with this content control.
         /// </summary>
-        public string Alias {
+        public string? Alias {
             get {
                 if (_stdRun != null) {
-                    var sdtAlias = _stdRun.SdtProperties.OfType<SdtAlias>().FirstOrDefault();
-                    if (sdtAlias != null) {
-                        return sdtAlias.Val;
-                    }
-                } else if (_sdtBlock != null) {
+                    var sdtAlias = _stdRun.SdtProperties?.OfType<SdtAlias>().FirstOrDefault();
+                    return sdtAlias?.Val;
+                }
+
+                if (_sdtBlock != null) {
                     var sdtAlias = _sdtBlock.SdtProperties?.OfType<SdtAlias>().FirstOrDefault();
                     return sdtAlias?.Val;
                 }
@@ -36,34 +36,35 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the tag value for this content control.
         /// </summary>
-        public string Tag {
+        public string? Tag {
             get {
                 if (_stdRun != null) {
-                    var tag = _stdRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                    var tag = _stdRun.SdtProperties?.OfType<Tag>().FirstOrDefault();
                     return tag?.Val;
                 }
+
                 if (_sdtBlock != null) {
                     var tag = _sdtBlock.SdtProperties?.OfType<Tag>().FirstOrDefault();
                     return tag?.Val;
                 }
+
                 return null;
             }
             set {
                 if (_stdRun != null) {
-                    var tag = _stdRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                    var properties = _stdRun.SdtProperties ??= new SdtProperties();
+                    var tag = properties.OfType<Tag>().FirstOrDefault();
                     if (tag == null) {
                         tag = new Tag();
-                        _stdRun.SdtProperties.Append(tag);
+                        properties.Append(tag);
                     }
                     tag.Val = value;
                 } else if (_sdtBlock != null) {
-                    if (_sdtBlock.SdtProperties == null) {
-                        _sdtBlock.SdtProperties = new SdtProperties();
-                    }
-                    var tag = _sdtBlock.SdtProperties.OfType<Tag>().FirstOrDefault();
+                    var properties = _sdtBlock.SdtProperties ??= new SdtProperties();
+                    var tag = properties.OfType<Tag>().FirstOrDefault();
                     if (tag == null) {
                         tag = new Tag();
-                        _sdtBlock.SdtProperties.Append(tag);
+                        properties.Append(tag);
                     }
                     tag.Val = value;
                 }
@@ -73,29 +74,29 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the inner text of the content control.
         /// </summary>
-        public string Text {
+        public string? Text {
             get {
                 if (_stdRun != null) {
-                    var run = _stdRun.SdtContentRun.ChildElements.OfType<Run>().FirstOrDefault();
-                    if (run != null) {
-                        var text = run.OfType<Text>().FirstOrDefault();
-                        if (text != null) {
-                            return text.Text;
-                        }
-                    }
-                } else if (_sdtBlock != null) {
+                    var run = _stdRun.SdtContentRun?.ChildElements.OfType<Run>().FirstOrDefault();
+                    var text = run?.OfType<Text>().FirstOrDefault();
+                    return text?.Text;
+                }
+
+                if (_sdtBlock != null) {
                     var paragraph = _sdtBlock.SdtContentBlock?.ChildElements.OfType<Paragraph>().FirstOrDefault();
                     var run = paragraph?.ChildElements.OfType<Run>().FirstOrDefault();
                     var text = run?.OfType<Text>().FirstOrDefault();
                     return text?.Text;
                 }
+
                 return null;
             }
             set {
                 if (_stdRun != null) {
-                    var run = _stdRun.SdtContentRun.ChildElements.OfType<Run>().FirstOrDefault();
+                    var run = _stdRun.SdtContentRun?.ChildElements.OfType<Run>().FirstOrDefault();
                     if (run == null) {
                         run = new Run();
+                        _stdRun.SdtContentRun ??= new SdtContentRun();
                         _stdRun.SdtContentRun.Append(run);
                     }
 
@@ -105,27 +106,28 @@ namespace OfficeIMO.Word {
                         run.Append(text);
                     }
 
-                    text.Text = value;
+                    text.Text = value ?? string.Empty;
                 } else if (_sdtBlock != null) {
-                    if (_sdtBlock.SdtContentBlock == null) {
-                        _sdtBlock.SdtContentBlock = new SdtContentBlock();
-                    }
+                    _sdtBlock.SdtContentBlock ??= new SdtContentBlock();
                     var paragraph = _sdtBlock.SdtContentBlock.ChildElements.OfType<Paragraph>().FirstOrDefault();
                     if (paragraph == null) {
                         paragraph = new Paragraph();
                         _sdtBlock.SdtContentBlock.Append(paragraph);
                     }
+
                     var run = paragraph.ChildElements.OfType<Run>().FirstOrDefault();
                     if (run == null) {
                         run = new Run();
                         paragraph.Append(run);
                     }
+
                     var text = run.OfType<Text>().FirstOrDefault();
                     if (text == null) {
                         text = new Text { Space = SpaceProcessingModeValues.Preserve };
                         run.Append(text);
                     }
-                    text.Text = value;
+
+                    text.Text = value ?? string.Empty;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- handle nullable styles and alignment values in tables
- harden paragraph formatting and list APIs against nulls
- clean up structured document tag accessors

## Testing
- `dotnet build OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a38e977190832ebc676ad6fb9db6f5