### PR TITLE
Resolve Visio pages via relationships

### DIFF
--- a/OfficeIMO.Tests/Visio.LoadRelId.cs
+++ b/OfficeIMO.Tests/Visio.LoadRelId.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.IO.Packaging;
+using System.Xml.Linq;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioLoadRelId {
+        [Fact]
+        public void LoadIgnoresDeprecatedRelIdAttribute() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            page.Shapes.Add(new VisioShape("1", 1, 2, 3, 4, "Rectangle"));
+            document.Save(filePath);
+
+            using (Package package = Package.Open(filePath, FileMode.Open, FileAccess.ReadWrite)) {
+                PackagePart pagesPart = package.GetPart(new Uri("/visio/pages/pages.xml", UriKind.Relative));
+                XDocument pagesDoc;
+                using (Stream readStream = pagesPart.GetStream()) {
+                    pagesDoc = XDocument.Load(readStream);
+                }
+
+                XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
+                XElement? pageElement = pagesDoc.Root?.Element(ns + "Page");
+                pageElement?.SetAttributeValue("RelId", "rId999");
+
+                using Stream partStream = pagesPart.GetStream(FileMode.Create, FileAccess.Write);
+                pagesDoc.Save(partStream);
+            }
+
+            VisioDocument loaded = VisioDocument.Load(filePath);
+            Assert.Single(loaded.Pages);
+            VisioPage loadedPage = loaded.Pages[0];
+            Assert.Single(loadedPage.Shapes);
+            VisioShape shape = loadedPage.Shapes[0];
+            Assert.Equal("Rectangle", shape.Text);
+        }
+    }
+}
+

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -61,7 +61,7 @@ namespace OfficeIMO.Visio {
                 string name = pageRef.Attribute("NameU")?.Value ?? pageRef.Attribute("Name")?.Value ?? "Page";
                 VisioPage page = document.AddPage(name);
 
-                string? relId = pageRef.Element(ns + "Rel")?.Attribute(rNs + "id")?.Value ?? pageRef.Attribute("RelId")?.Value;
+                string? relId = pageRef.Element(ns + "Rel")?.Attribute(rNs + "id")?.Value;
                 if (string.IsNullOrEmpty(relId)) {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- Resolve the Visio document via its specific relationship type when loading
- Read page part relationships from `<Rel>` elements and drop deprecated `RelId` attribute fallback
- Test loading when an obsolete `RelId` attribute is present

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FullyQualifiedName~Visio`


------
https://chatgpt.com/codex/tasks/task_e_68a3935b1018832e81eeecf640a10d1f