### PR TITLE
Add shape retrieval and removal helpers to PowerPoint slides

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/ShapesPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/ShapesPowerPoint.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.Examples.PowerPoint {
+    /// <summary>
+    /// Demonstrates retrieving and removing shapes.
+    /// </summary>
+    public static class ShapesPowerPoint {
+        public static void Example_PowerPointShapes(string folderPath, bool openPowerPoint) {
+            Console.WriteLine("[*] PowerPoint - Shape operations");
+            string filePath = Path.Combine(folderPath, "Shape Operations.pptx");
+            string imagePath = Path.Combine(Directory.GetCurrentDirectory(), "Images", "BackgroundImage.png");
+
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+            PowerPointSlide slide = presentation.AddSlide();
+            PPTextBox textBox = slide.AddTextBox("Hello");
+            PPPicture picture = slide.AddPicture(imagePath);
+
+            PPShape? shape = slide.GetShape("TextBox 1");
+            Console.WriteLine("Found shape: " + shape?.Name);
+            slide.RemoveShape(picture);
+            presentation.Save();
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PPShape.cs
+++ b/OfficeIMO.PowerPoint/PPShape.cs
@@ -14,6 +14,24 @@ namespace OfficeIMO.PowerPoint {
         }
 
         /// <summary>
+        /// Name assigned to the shape.
+        /// </summary>
+        public string? Name {
+            get {
+                switch (Element) {
+                    case Shape s:
+                        return s.NonVisualShapeProperties?.NonVisualDrawingProperties.Name?.Value;
+                    case Picture p:
+                        return p.NonVisualPictureProperties?.NonVisualDrawingProperties.Name?.Value;
+                    case GraphicFrame g:
+                        return g.NonVisualGraphicFrameProperties?.NonVisualDrawingProperties.Name?.Value;
+                    default:
+                        return null;
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the fill color of the shape in hex format (e.g. "FF0000").
         /// </summary>
         public string? FillColor {

--- a/OfficeIMO.PowerPoint/PowerPointSlide.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.cs
@@ -48,6 +48,39 @@ namespace OfficeIMO.PowerPoint {
         public IEnumerable<PPChart> Charts => _shapes.OfType<PPChart>();
 
         /// <summary>
+        /// Retrieves a shape by its name.
+        /// </summary>
+        public PPShape? GetShape(string name) => _shapes.FirstOrDefault(s => s.Name == name);
+
+        /// <summary>
+        /// Retrieves a textbox by its name.
+        /// </summary>
+        public PPTextBox? GetTextBox(string name) => TextBoxes.FirstOrDefault(tb => tb.Name == name);
+
+        /// <summary>
+        /// Retrieves a picture by its name.
+        /// </summary>
+        public PPPicture? GetPicture(string name) => Pictures.FirstOrDefault(p => p.Name == name);
+
+        /// <summary>
+        /// Retrieves a table by its name.
+        /// </summary>
+        public PPTable? GetTable(string name) => Tables.FirstOrDefault(t => t.Name == name);
+
+        /// <summary>
+        /// Retrieves a chart by its name.
+        /// </summary>
+        public PPChart? GetChart(string name) => Charts.FirstOrDefault(c => c.Name == name);
+
+        /// <summary>
+        /// Removes the specified shape from the slide.
+        /// </summary>
+        public void RemoveShape(PPShape shape) {
+            shape.Element.Remove();
+            _shapes.Remove(shape);
+        }
+
+        /// <summary>
         /// Notes associated with the slide.
         /// </summary>
         public PPNotes Notes => _notes ??= new PPNotes(_slidePart);
@@ -133,13 +166,23 @@ namespace OfficeIMO.PowerPoint {
             }
         }
 
+        private string GenerateUniqueName(string baseName) {
+            int index = 1;
+            string name;
+            do {
+                name = baseName + " " + index++;
+            } while (_shapes.Any(s => s.Name == name));
+            return name;
+        }
+
         /// <summary>
         /// Adds a textbox with the specified text.
         /// </summary>
         public PPTextBox AddTextBox(string text) {
+            string name = GenerateUniqueName("TextBox");
             Shape shape = new(
                 new NonVisualShapeProperties(
-                    new NonVisualDrawingProperties { Id = (UInt32Value)(uint)(_shapes.Count + 1), Name = "TextBox" + (_shapes.Count + 1) },
+                    new NonVisualDrawingProperties { Id = (UInt32Value)(uint)(_shapes.Count + 1), Name = name },
                     new NonVisualShapeDrawingProperties(new A.ShapeLocks { NoGrouping = true }),
                     new ApplicationNonVisualDrawingProperties(new PlaceholderShape())
                 ),
@@ -166,9 +209,10 @@ namespace OfficeIMO.PowerPoint {
             imagePart.FeedData(stream);
             string relationshipId = _slidePart.GetIdOfPart(imagePart);
 
+            string name = GenerateUniqueName("Picture");
             Picture picture = new(
                 new NonVisualPictureProperties(
-                    new NonVisualDrawingProperties { Id = (UInt32Value)(uint)(_shapes.Count + 1), Name = Path.GetFileName(imagePath) },
+                    new NonVisualDrawingProperties { Id = (UInt32Value)(uint)(_shapes.Count + 1), Name = name },
                     new NonVisualPictureDrawingProperties(new A.PictureLocks { NoChangeAspect = true }),
                     new ApplicationNonVisualDrawingProperties()
                 ),
@@ -213,9 +257,10 @@ namespace OfficeIMO.PowerPoint {
                 table.Append(row);
             }
 
+            string name = GenerateUniqueName("Table");
             GraphicFrame frame = new(
                 new NonVisualGraphicFrameProperties(
-                    new NonVisualDrawingProperties { Id = (UInt32Value)(uint)(_shapes.Count + 1), Name = "Table" + (_shapes.Count + 1) },
+                    new NonVisualDrawingProperties { Id = (UInt32Value)(uint)(_shapes.Count + 1), Name = name },
                     new NonVisualGraphicFrameDrawingProperties(),
                     new ApplicationNonVisualDrawingProperties()
                 ),
@@ -237,9 +282,10 @@ namespace OfficeIMO.PowerPoint {
             GenerateDefaultChart(chartPart);
 
             string relId = _slidePart.GetIdOfPart(chartPart);
+            string name = GenerateUniqueName("Chart");
             GraphicFrame frame = new(
                 new NonVisualGraphicFrameProperties(
-                    new NonVisualDrawingProperties { Id = (UInt32Value)(uint)(_shapes.Count + 1), Name = "Chart" + (_shapes.Count + 1) },
+                    new NonVisualDrawingProperties { Id = (UInt32Value)(uint)(_shapes.Count + 1), Name = name },
                     new NonVisualGraphicFrameDrawingProperties(),
                     new ApplicationNonVisualDrawingProperties()
                 ),

--- a/OfficeIMO.Tests/PowerPoint.ShapesManagement.cs
+++ b/OfficeIMO.Tests/PowerPoint.ShapesManagement.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointShapesManagement {
+        [Fact]
+        public void CanGetAndRemoveShapes() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string imagePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", "BackgroundImage.png");
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                PowerPointSlide slide = presentation.AddSlide();
+                PPTextBox box1 = slide.AddTextBox("First");
+                PPPicture pic1 = slide.AddPicture(imagePath);
+                PPTextBox box2 = slide.AddTextBox("Second");
+                PPPicture pic2 = slide.AddPicture(imagePath);
+
+                Assert.Equal("TextBox 1", box1.Name);
+                Assert.Equal("TextBox 2", box2.Name);
+                Assert.Equal("Picture 1", pic1.Name);
+                Assert.Equal("Picture 2", pic2.Name);
+
+                Assert.Same(box1, slide.GetTextBox("TextBox 1"));
+                Assert.Same(pic2, slide.GetPicture("Picture 2"));
+                Assert.Same(box1, slide.GetShape("TextBox 1"));
+
+                slide.RemoveShape(pic1);
+                Assert.Null(slide.GetPicture("Picture 1"));
+                Assert.Equal(3, slide.Shapes.Count);
+
+                presentation.Save();
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow retrieving shapes by name with `GetShape`, `GetTextBox`, `GetPicture`, `GetTable`, and `GetChart`
- ensure shape names are unique when adding new shapes and expose `PPShape.Name`
- support removing shapes from slides and keep examples/tests updated

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a397a2d824832ea3842a3f68698c8c