### PR TITLE
Allow positioning and sizing of PowerPoint shapes

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/ShapesPosition.cs
+++ b/OfficeIMO.Examples/PowerPoint/ShapesPosition.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.Examples.PowerPoint {
+    /// <summary>
+    /// Demonstrates positioning and sizing of shapes.
+    /// </summary>
+    public static class ShapesPosition {
+        public static void Example_ShapesPosition(string folderPath, bool openPowerPoint) {
+            Console.WriteLine("[*] PowerPoint - Shapes position and size");
+            string filePath = Path.Combine(folderPath, "Shapes Position.pptx");
+            string imagePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", "BackgroundImage.png");
+
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+            PowerPointSlide slide = presentation.AddSlide();
+            slide.AddTextBox("Text box", left: 1000000L, top: 1000000L, width: 3000000L, height: 1000000L);
+            slide.AddPicture(imagePath, left: 3000000L, top: 1000000L, width: 2000000L, height: 2000000L);
+            slide.AddTable(2, 2, left: 1000000L, top: 2500000L, width: 4000000L, height: 1000000L);
+            presentation.Save();
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PPShape.cs
+++ b/OfficeIMO.PowerPoint/PPShape.cs
@@ -34,6 +34,140 @@ namespace OfficeIMO.PowerPoint {
                 }
             }
         }
+
+        private A.Transform2D EnsureTransform2D(ShapeProperties props) {
+            props.Transform2D ??= new A.Transform2D(new A.Offset { X = 0L, Y = 0L }, new A.Extents { Cx = 0L, Cy = 0L });
+            props.Transform2D.Offset ??= new A.Offset { X = 0L, Y = 0L };
+            props.Transform2D.Extents ??= new A.Extents { Cx = 0L, Cy = 0L };
+            return props.Transform2D;
+        }
+
+        private Transform EnsureTransform(GraphicFrame frame) {
+            frame.Transform ??= new Transform(new A.Offset { X = 0L, Y = 0L }, new A.Extents { Cx = 0L, Cy = 0L });
+            frame.Transform.Offset ??= new A.Offset { X = 0L, Y = 0L };
+            frame.Transform.Extents ??= new A.Extents { Cx = 0L, Cy = 0L };
+            return frame.Transform;
+        }
+
+        /// <summary>
+        /// Left position of the shape in English Metric Units (EMU).
+        /// </summary>
+        public long Left {
+            get {
+                return Element switch {
+                    Shape s => s.ShapeProperties?.Transform2D?.Offset?.X ?? 0L,
+                    Picture p => p.ShapeProperties?.Transform2D?.Offset?.X ?? 0L,
+                    GraphicFrame g => g.Transform?.Offset?.X ?? 0L,
+                    _ => 0L,
+                };
+            }
+            set {
+                switch (Element) {
+                    case Shape s:
+                        A.Transform2D ts = EnsureTransform2D(s.ShapeProperties ??= new ShapeProperties());
+                        ts.Offset!.X = value;
+                        break;
+                    case Picture p:
+                        A.Transform2D tp = EnsureTransform2D(p.ShapeProperties ??= new ShapeProperties());
+                        tp.Offset!.X = value;
+                        break;
+                    case GraphicFrame g:
+                        Transform tg = EnsureTransform(g);
+                        tg.Offset!.X = value;
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Top position of the shape in English Metric Units (EMU).
+        /// </summary>
+        public long Top {
+            get {
+                return Element switch {
+                    Shape s => s.ShapeProperties?.Transform2D?.Offset?.Y ?? 0L,
+                    Picture p => p.ShapeProperties?.Transform2D?.Offset?.Y ?? 0L,
+                    GraphicFrame g => g.Transform?.Offset?.Y ?? 0L,
+                    _ => 0L,
+                };
+            }
+            set {
+                switch (Element) {
+                    case Shape s:
+                        A.Transform2D ts = EnsureTransform2D(s.ShapeProperties ??= new ShapeProperties());
+                        ts.Offset!.Y = value;
+                        break;
+                    case Picture p:
+                        A.Transform2D tp = EnsureTransform2D(p.ShapeProperties ??= new ShapeProperties());
+                        tp.Offset!.Y = value;
+                        break;
+                    case GraphicFrame g:
+                        Transform tg = EnsureTransform(g);
+                        tg.Offset!.Y = value;
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Width of the shape in English Metric Units (EMU).
+        /// </summary>
+        public long Width {
+            get {
+                return Element switch {
+                    Shape s => s.ShapeProperties?.Transform2D?.Extents?.Cx ?? 0L,
+                    Picture p => p.ShapeProperties?.Transform2D?.Extents?.Cx ?? 0L,
+                    GraphicFrame g => g.Transform?.Extents?.Cx ?? 0L,
+                    _ => 0L,
+                };
+            }
+            set {
+                switch (Element) {
+                    case Shape s:
+                        A.Transform2D ts = EnsureTransform2D(s.ShapeProperties ??= new ShapeProperties());
+                        ts.Extents!.Cx = value;
+                        break;
+                    case Picture p:
+                        A.Transform2D tp = EnsureTransform2D(p.ShapeProperties ??= new ShapeProperties());
+                        tp.Extents!.Cx = value;
+                        break;
+                    case GraphicFrame g:
+                        Transform tg = EnsureTransform(g);
+                        tg.Extents!.Cx = value;
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Height of the shape in English Metric Units (EMU).
+        /// </summary>
+        public long Height {
+            get {
+                return Element switch {
+                    Shape s => s.ShapeProperties?.Transform2D?.Extents?.Cy ?? 0L,
+                    Picture p => p.ShapeProperties?.Transform2D?.Extents?.Cy ?? 0L,
+                    GraphicFrame g => g.Transform?.Extents?.Cy ?? 0L,
+                    _ => 0L,
+                };
+            }
+            set {
+                switch (Element) {
+                    case Shape s:
+                        A.Transform2D ts = EnsureTransform2D(s.ShapeProperties ??= new ShapeProperties());
+                        ts.Extents!.Cy = value;
+                        break;
+                    case Picture p:
+                        A.Transform2D tp = EnsureTransform2D(p.ShapeProperties ??= new ShapeProperties());
+                        tp.Extents!.Cy = value;
+                        break;
+                    case GraphicFrame g:
+                        Transform tg = EnsureTransform(g);
+                        tg.Extents!.Cy = value;
+                        break;
+                }
+            }
+        }
     }
 }
 

--- a/OfficeIMO.PowerPoint/PowerPointSlide.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.cs
@@ -136,14 +136,20 @@ namespace OfficeIMO.PowerPoint {
         /// <summary>
         /// Adds a textbox with the specified text.
         /// </summary>
-        public PPTextBox AddTextBox(string text) {
+        public PPTextBox AddTextBox(string text, long? left = null, long? top = null, long? width = null, long? height = null) {
             Shape shape = new(
                 new NonVisualShapeProperties(
                     new NonVisualDrawingProperties { Id = (UInt32Value)(uint)(_shapes.Count + 1), Name = "TextBox" + (_shapes.Count + 1) },
                     new NonVisualShapeDrawingProperties(new A.ShapeLocks { NoGrouping = true }),
                     new ApplicationNonVisualDrawingProperties(new PlaceholderShape())
                 ),
-                new ShapeProperties(),
+                new ShapeProperties(
+                    new A.Transform2D(
+                        new A.Offset { X = left ?? 0L, Y = top ?? 0L },
+                        new A.Extents { Cx = width ?? 914400L, Cy = height ?? 914400L }
+                    ),
+                    new A.PresetGeometry(new A.AdjustValueList()) { Preset = A.ShapeTypeValues.Rectangle }
+                ),
                 new TextBody(
                     new A.BodyProperties(),
                     new A.ListStyle(),
@@ -160,7 +166,7 @@ namespace OfficeIMO.PowerPoint {
         /// <summary>
         /// Adds an image from the given file path.
         /// </summary>
-        public PPPicture AddPicture(string imagePath) {
+        public PPPicture AddPicture(string imagePath, long? left = null, long? top = null, long? width = null, long? height = null) {
             ImagePart imagePart = _slidePart.AddImagePart(ImagePartType.Png);
             using FileStream stream = new(imagePath, FileMode.Open, FileAccess.Read);
             imagePart.FeedData(stream);
@@ -176,8 +182,13 @@ namespace OfficeIMO.PowerPoint {
                     new A.Blip { Embed = relationshipId },
                     new A.Stretch(new A.FillRectangle())
                 ),
-                new ShapeProperties(new A.Transform2D(new A.Offset { X = 0, Y = 0 }, new A.Extents { Cx = 914400L, Cy = 914400L }),
-                    new A.PresetGeometry(new A.AdjustValueList()) { Preset = A.ShapeTypeValues.Rectangle })
+                new ShapeProperties(
+                    new A.Transform2D(
+                        new A.Offset { X = left ?? 0L, Y = top ?? 0L },
+                        new A.Extents { Cx = width ?? 914400L, Cy = height ?? 914400L }
+                    ),
+                    new A.PresetGeometry(new A.AdjustValueList()) { Preset = A.ShapeTypeValues.Rectangle }
+                )
             );
 
             _slidePart.Slide.CommonSlideData!.ShapeTree.AppendChild(picture);
@@ -189,7 +200,7 @@ namespace OfficeIMO.PowerPoint {
         /// <summary>
         /// Adds a table with the specified rows and columns.
         /// </summary>
-        public PPTable AddTable(int rows, int columns) {
+        public PPTable AddTable(int rows, int columns, long? left = null, long? top = null, long? width = null, long? height = null) {
             A.Table table = new();
             A.TableProperties props = new();
             props.Append(new A.TableStyleId { Text = "{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}" });
@@ -219,7 +230,10 @@ namespace OfficeIMO.PowerPoint {
                     new NonVisualGraphicFrameDrawingProperties(),
                     new ApplicationNonVisualDrawingProperties()
                 ),
-                new Transform(new A.Offset { X = 0L, Y = 0L }, new A.Extents { Cx = 5000000L, Cy = 3000000L }),
+                new Transform(
+                    new A.Offset { X = left ?? 0L, Y = top ?? 0L },
+                    new A.Extents { Cx = width ?? 5000000L, Cy = height ?? 3000000L }
+                ),
                 new A.Graphic(new A.GraphicData(table) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/table" })
             );
 

--- a/OfficeIMO.Tests/PowerPoint.ShapeGeometry.cs
+++ b/OfficeIMO.Tests/PowerPoint.ShapeGeometry.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.Linq;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointShapeGeometry {
+        [Fact]
+        public void CanSetShapePositionAndSize() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string imagePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", "BackgroundImage.png");
+            long left = 1000000L;
+            long top = 2000000L;
+            long width = 3000000L;
+            long height = 4000000L;
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                PowerPointSlide slide = presentation.AddSlide();
+                slide.AddTextBox("Test", left, top, width, height);
+                slide.AddPicture(imagePath, left, top, width, height);
+                slide.AddTable(2, 2, left, top, width, height);
+                presentation.Save();
+            }
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                PowerPointSlide slide = presentation.Slides[0];
+                PPTextBox box = slide.TextBoxes.First();
+                Assert.Equal(left, box.Left);
+                Assert.Equal(top, box.Top);
+                Assert.Equal(width, box.Width);
+                Assert.Equal(height, box.Height);
+
+                PPPicture pic = slide.Pictures.First();
+                Assert.Equal(left, pic.Left);
+                Assert.Equal(top, pic.Top);
+                Assert.Equal(width, pic.Width);
+                Assert.Equal(height, pic.Height);
+
+                PPTable tbl = slide.Tables.First();
+                Assert.Equal(left, tbl.Left);
+                Assert.Equal(top, tbl.Top);
+                Assert.Equal(width, tbl.Width);
+                Assert.Equal(height, tbl.Height);
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add optional left/top/width/height parameters to PowerPointSlide.AddTextBox, AddPicture, and AddTable
- expose Left, Top, Width, and Height properties on PPShape
- add example and tests demonstrating shape geometry

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FullyQualifiedName~PowerPointShapeGeometry`


------
https://chatgpt.com/codex/tasks/task_e_68a397982b4c832eaa34195c8dd3abea