### PR TITLE
Refactor fluent builder API for WordFluentDocument

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.Example.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.Example.cs
@@ -10,9 +10,9 @@ namespace OfficeIMO.Examples.Word {
             string filePath = Path.Combine(folderPath, "FluentDocument.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AsFluent()
-                    .Info.SetTitle("Fluent Document")
-                    .Sections.AddSection()
-                    .Paragraphs.AddParagraph("Hello from fluent API");
+                    .Info(i => i.SetTitle("Fluent Document"))
+                    .Section(s => s.AddSection())
+                    .Paragraph(p => p.AddParagraph("Hello from fluent API"));
                 document.Save(false);
             }
             Helpers.Open(filePath, openWord);

--- a/OfficeIMO.Examples/Word/Fluent/Fluent.ReadHelpers.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.ReadHelpers.cs
@@ -11,9 +11,9 @@ namespace OfficeIMO.Examples.Word {
             string filePath = Path.Combine(folderPath, "FluentReadHelpers.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AsFluent()
-                    .Paragraphs.AddParagraph("First")
-                    .Paragraphs.AddParagraph("Second")
-                    .Paragraphs.AddParagraph("Third");
+                    .Paragraph(p => p.AddParagraph("First"))
+                    .Paragraph(p => p.AddParagraph("Second"))
+                    .Paragraph(p => p.AddParagraph("Third"));
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(filePath)) {

--- a/OfficeIMO.Tests/Word.Fluent.ReadHelpers.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ReadHelpers.cs
@@ -11,9 +11,9 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "FluentReadHelpers.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AsFluent()
-                    .Paragraphs.AddParagraph("First")
-                    .Paragraphs.AddParagraph("Second match")
-                    .Paragraphs.AddParagraph("Third");
+                    .Paragraph(p => p.AddParagraph("First"))
+                    .Paragraph(p => p.AddParagraph("Second match"))
+                    .Paragraph(p => p.AddParagraph("Third"));
                 document.Save(false);
             }
 

--- a/OfficeIMO.Tests/Word.Fluent.cs
+++ b/OfficeIMO.Tests/Word.Fluent.cs
@@ -10,9 +10,10 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "FluentTest.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AsFluent()
-                    .Info.SetTitle("Fluent")
-                    .Sections.AddSection()
-                    .Paragraphs.AddParagraph("Test");
+                    .Info(i => i.SetTitle("Fluent"))
+                    .Section(s => s.AddSection())
+                    .Paragraph(p => p.AddParagraph("Test"))
+                    .Table(t => t.AddTable(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell"));
                 document.Save(false);
             }
 
@@ -21,6 +22,8 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(2, document.Sections.Count);
                 Assert.Single(document.Paragraphs);
                 Assert.Equal("Test", document.Paragraphs[0].Text);
+                Assert.Single(document.Tables);
+                Assert.Equal("Cell", document.Tables[0].Rows[0].Cells[0].Paragraphs[1].Text);
             }
         }
     }

--- a/OfficeIMO.Word/Fluent/FootersBuilder.cs
+++ b/OfficeIMO.Word/Fluent/FootersBuilder.cs
@@ -1,18 +1,28 @@
+using OfficeIMO.Word;
+
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
     /// Builder for footers.
     /// </summary>
     public class FootersBuilder {
         private readonly WordFluentDocument _fluent;
+        private readonly WordParagraph? _paragraph;
 
         internal FootersBuilder(WordFluentDocument fluent) {
             _fluent = fluent;
         }
 
-        public WordFluentDocument AddFooter(string text) {
+        internal FootersBuilder(WordFluentDocument fluent, WordParagraph? paragraph) {
+            _fluent = fluent;
+            _paragraph = paragraph;
+        }
+
+        public WordParagraph? Paragraph => _paragraph;
+
+        public FootersBuilder AddFooter(string text) {
             var footer = _fluent.Document.Footer;
-            footer?.Default?.AddParagraph(text);
-            return _fluent;
+            var paragraph = footer?.Default?.AddParagraph(text);
+            return new FootersBuilder(_fluent, paragraph);
         }
     }
 }

--- a/OfficeIMO.Word/Fluent/HeadersBuilder.cs
+++ b/OfficeIMO.Word/Fluent/HeadersBuilder.cs
@@ -1,18 +1,28 @@
+using OfficeIMO.Word;
+
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
     /// Builder for headers.
     /// </summary>
     public class HeadersBuilder {
         private readonly WordFluentDocument _fluent;
+        private readonly WordParagraph? _paragraph;
 
         internal HeadersBuilder(WordFluentDocument fluent) {
             _fluent = fluent;
         }
 
-        public WordFluentDocument AddHeader(string text) {
+        internal HeadersBuilder(WordFluentDocument fluent, WordParagraph? paragraph) {
+            _fluent = fluent;
+            _paragraph = paragraph;
+        }
+
+        public WordParagraph? Paragraph => _paragraph;
+
+        public HeadersBuilder AddHeader(string text) {
             var header = _fluent.Document.Header;
-            header?.Default?.AddParagraph(text);
-            return _fluent;
+            var paragraph = header?.Default?.AddParagraph(text);
+            return new HeadersBuilder(_fluent, paragraph);
         }
     }
 }

--- a/OfficeIMO.Word/Fluent/ImageBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ImageBuilder.cs
@@ -1,17 +1,27 @@
+using OfficeIMO.Word;
+
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
     /// Builder for images.
     /// </summary>
     public class ImageBuilder {
         private readonly WordFluentDocument _fluent;
+        private readonly WordImage? _image;
 
         internal ImageBuilder(WordFluentDocument fluent) {
             _fluent = fluent;
         }
 
-        public WordFluentDocument AddImage(string url) {
-            _fluent.Document.AddImageFromUrl(url);
-            return _fluent;
+        internal ImageBuilder(WordFluentDocument fluent, WordImage image) {
+            _fluent = fluent;
+            _image = image;
+        }
+
+        public WordImage? Image => _image;
+
+        public ImageBuilder AddImage(string url) {
+            var image = _fluent.Document.AddImageFromUrl(url);
+            return new ImageBuilder(_fluent, image);
         }
     }
 }

--- a/OfficeIMO.Word/Fluent/InfoBuilder.cs
+++ b/OfficeIMO.Word/Fluent/InfoBuilder.cs
@@ -9,9 +9,9 @@ namespace OfficeIMO.Word.Fluent {
             _fluent = fluent;
         }
 
-        public WordFluentDocument SetTitle(string title) {
+        public InfoBuilder SetTitle(string title) {
             _fluent.Document.BuiltinDocumentProperties.Title = title;
-            return _fluent;
+            return this;
         }
     }
 }

--- a/OfficeIMO.Word/Fluent/ListBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ListBuilder.cs
@@ -1,20 +1,30 @@
+using OfficeIMO.Word;
+
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
     /// Builder for lists.
     /// </summary>
     public class ListBuilder {
         private readonly WordFluentDocument _fluent;
+        private readonly WordList? _list;
 
         internal ListBuilder(WordFluentDocument fluent) {
             _fluent = fluent;
         }
 
-        public WordFluentDocument AddBulletedList(params string[] items) {
+        internal ListBuilder(WordFluentDocument fluent, WordList list) {
+            _fluent = fluent;
+            _list = list;
+        }
+
+        public WordList? List => _list;
+
+        public ListBuilder AddBulletedList(params string[] items) {
             var list = _fluent.Document.AddListBulleted();
             foreach (var item in items) {
                 list.AddItem(item);
             }
-            return _fluent;
+            return new ListBuilder(_fluent, list);
         }
     }
 }

--- a/OfficeIMO.Word/Fluent/PageBuilder.cs
+++ b/OfficeIMO.Word/Fluent/PageBuilder.cs
@@ -11,9 +11,9 @@ namespace OfficeIMO.Word.Fluent {
             _fluent = fluent;
         }
 
-        public WordFluentDocument SetOrientation(PageOrientationValues orientation) {
+        public PageBuilder SetOrientation(PageOrientationValues orientation) {
             _fluent.Document.PageOrientation = orientation;
-            return _fluent;
+            return this;
         }
     }
 }

--- a/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
@@ -19,9 +19,9 @@ namespace OfficeIMO.Word.Fluent {
 
         public WordParagraph? Paragraph => _paragraph;
 
-        public WordFluentDocument AddParagraph(string text) {
-            _fluent.Document.AddParagraph(text);
-            return _fluent;
+        public ParagraphBuilder AddParagraph(string text) {
+            var paragraph = _fluent.Document.AddParagraph(text);
+            return new ParagraphBuilder(_fluent, paragraph);
         }
     }
 }

--- a/OfficeIMO.Word/Fluent/RunBuilder.cs
+++ b/OfficeIMO.Word/Fluent/RunBuilder.cs
@@ -1,20 +1,30 @@
+using OfficeIMO.Word;
+
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
     /// Builder for text runs.
     /// </summary>
     public class RunBuilder {
         private readonly WordFluentDocument _fluent;
+        private readonly WordParagraph? _paragraph;
 
         internal RunBuilder(WordFluentDocument fluent) {
             _fluent = fluent;
         }
 
-        public WordFluentDocument AddRun(string text, bool bold = false) {
+        internal RunBuilder(WordFluentDocument fluent, WordParagraph paragraph) {
+            _fluent = fluent;
+            _paragraph = paragraph;
+        }
+
+        public WordParagraph? Paragraph => _paragraph;
+
+        public RunBuilder AddRun(string text, bool bold = false) {
             var paragraph = _fluent.Document.AddParagraph(text);
             if (bold) {
                 paragraph.SetBold();
             }
-            return _fluent;
+            return new RunBuilder(_fluent, paragraph);
         }
     }
 }

--- a/OfficeIMO.Word/Fluent/SectionBuilder.cs
+++ b/OfficeIMO.Word/Fluent/SectionBuilder.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
 
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
@@ -6,14 +7,22 @@ namespace OfficeIMO.Word.Fluent {
     /// </summary>
     public class SectionBuilder {
         private readonly WordFluentDocument _fluent;
+        private readonly WordSection? _section;
 
         internal SectionBuilder(WordFluentDocument fluent) {
             _fluent = fluent;
         }
 
-        public WordFluentDocument AddSection(SectionMarkValues? mark = null) {
-            _fluent.Document.AddSection(mark);
-            return _fluent;
+        internal SectionBuilder(WordFluentDocument fluent, WordSection section) {
+            _fluent = fluent;
+            _section = section;
+        }
+
+        public WordSection? Section => _section;
+
+        public SectionBuilder AddSection(SectionMarkValues? mark = null) {
+            var section = _fluent.Document.AddSection(mark);
+            return new SectionBuilder(_fluent, section);
         }
     }
 }

--- a/OfficeIMO.Word/Fluent/TableBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TableBuilder.cs
@@ -1,17 +1,27 @@
+using OfficeIMO.Word;
+
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
     /// Builder for tables.
     /// </summary>
     public class TableBuilder {
         private readonly WordFluentDocument _fluent;
+        private readonly WordTable? _table;
 
         internal TableBuilder(WordFluentDocument fluent) {
             _fluent = fluent;
         }
 
-        public WordFluentDocument AddTable(int rows, int columns) {
-            _fluent.Document.AddTable(rows, columns);
-            return _fluent;
+        internal TableBuilder(WordFluentDocument fluent, WordTable table) {
+            _fluent = fluent;
+            _table = table;
+        }
+
+        public WordTable? Table => _table;
+
+        public TableBuilder AddTable(int rows, int columns) {
+            var table = _fluent.Document.AddTable(rows, columns);
+            return new TableBuilder(_fluent, table);
         }
     }
 }

--- a/OfficeIMO.Word/Fluent/WordFluentDocument.cs
+++ b/OfficeIMO.Word/Fluent/WordFluentDocument.cs
@@ -12,16 +12,55 @@ namespace OfficeIMO.Word.Fluent {
             Document = document ?? throw new ArgumentNullException(nameof(document));
         }
 
-        public InfoBuilder Info => new InfoBuilder(this);
-        public SectionBuilder Sections => new SectionBuilder(this);
-        public PageBuilder Pages => new PageBuilder(this);
-        public ParagraphBuilder Paragraphs => new ParagraphBuilder(this);
-        public RunBuilder Runs => new RunBuilder(this);
-        public ListBuilder Lists => new ListBuilder(this);
-        public TableBuilder Tables => new TableBuilder(this);
-        public ImageBuilder Images => new ImageBuilder(this);
-        public HeadersBuilder Headers => new HeadersBuilder(this);
-        public FootersBuilder Footers => new FootersBuilder(this);
+        public WordFluentDocument Info(Action<InfoBuilder> action) {
+            action(new InfoBuilder(this));
+            return this;
+        }
+
+        public WordFluentDocument Section(Action<SectionBuilder> action) {
+            action(new SectionBuilder(this));
+            return this;
+        }
+
+        public WordFluentDocument Page(Action<PageBuilder> action) {
+            action(new PageBuilder(this));
+            return this;
+        }
+
+        public WordFluentDocument Paragraph(Action<ParagraphBuilder> action) {
+            action(new ParagraphBuilder(this));
+            return this;
+        }
+
+        public WordFluentDocument Run(Action<RunBuilder> action) {
+            action(new RunBuilder(this));
+            return this;
+        }
+
+        public WordFluentDocument List(Action<ListBuilder> action) {
+            action(new ListBuilder(this));
+            return this;
+        }
+
+        public WordFluentDocument Table(Action<TableBuilder> action) {
+            action(new TableBuilder(this));
+            return this;
+        }
+
+        public WordFluentDocument Image(Action<ImageBuilder> action) {
+            action(new ImageBuilder(this));
+            return this;
+        }
+
+        public WordFluentDocument Header(Action<HeadersBuilder> action) {
+            action(new HeadersBuilder(this));
+            return this;
+        }
+
+        public WordFluentDocument Footer(Action<FootersBuilder> action) {
+            action(new FootersBuilder(this));
+            return this;
+        }
 
         public WordFluentDocument ForEachParagraph(Action<ParagraphBuilder> action) {
             Document.ForEachParagraph(p => action(new ParagraphBuilder(this, p)));


### PR DESCRIPTION
## Summary
- expose fluent API via methods like `Paragraph(Action<ParagraphBuilder>)` and `Section(Action<SectionBuilder>)`
- return element-specific builders from `AddParagraph`, `AddTable`, `AddSection`, etc. to enable chaining
- update examples and tests for the new method-based API

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a3975725ec832ebc223905dd4c5625