### PR TITLE
Fix nullable warnings in word utilities

### DIFF
--- a/OfficeIMO.Word/Table/WordTableStyleDetails.Methods.cs
+++ b/OfficeIMO.Word/Table/WordTableStyleDetails.Methods.cs
@@ -62,12 +62,12 @@ public partial class WordTableStyleDetails {
     /// Creates a TableBorders object with custom settings for each side
     /// </summary>
     public void SetCustomBorders(
-        BorderValues? topStyle = null, UInt32Value topSize = null, SixLabors.ImageSharp.Color? topColor = null,
-        BorderValues? bottomStyle = null, UInt32Value bottomSize = null, SixLabors.ImageSharp.Color? bottomColor = null,
-        BorderValues? leftStyle = null, UInt32Value leftSize = null, SixLabors.ImageSharp.Color? leftColor = null,
-        BorderValues? rightStyle = null, UInt32Value rightSize = null, SixLabors.ImageSharp.Color? rightColor = null,
-        BorderValues? insideHStyle = null, UInt32Value insideHSize = null, SixLabors.ImageSharp.Color? insideHColor = null,
-        BorderValues? insideVStyle = null, UInt32Value insideVSize = null, SixLabors.ImageSharp.Color? insideVColor = null) {
+        BorderValues? topStyle = null, UInt32Value? topSize = null, SixLabors.ImageSharp.Color? topColor = null,
+        BorderValues? bottomStyle = null, UInt32Value? bottomSize = null, SixLabors.ImageSharp.Color? bottomColor = null,
+        BorderValues? leftStyle = null, UInt32Value? leftSize = null, SixLabors.ImageSharp.Color? leftColor = null,
+        BorderValues? rightStyle = null, UInt32Value? rightSize = null, SixLabors.ImageSharp.Color? rightColor = null,
+        BorderValues? insideHStyle = null, UInt32Value? insideHSize = null, SixLabors.ImageSharp.Color? insideHColor = null,
+        BorderValues? insideVStyle = null, UInt32Value? insideVSize = null, SixLabors.ImageSharp.Color? insideVColor = null) {
         _table.CheckTableProperties();
 
         // Get existing borders or create new
@@ -78,9 +78,9 @@ public partial class WordTableStyleDetails {
             var topBorder = borders.TopBorder ?? new TopBorder();
             if (topStyle != null) topBorder.Val = topStyle;
             if (topSize != null) topBorder.Size = topSize;
-            if (topColor != null)
-                if (topColor != null)
-                    topBorder.Color = topColor.Value.ToHexColor();
+            if (topColor != null) {
+                topBorder.Color = topColor.Value.ToHexColor();
+            }
             borders.TopBorder = topBorder;
         }
 
@@ -89,9 +89,9 @@ public partial class WordTableStyleDetails {
             var bottomBorder = borders.BottomBorder ?? new BottomBorder();
             if (bottomStyle != null) bottomBorder.Val = bottomStyle;
             if (bottomSize != null) bottomBorder.Size = bottomSize;
-            if (bottomColor != null)
-                if (bottomColor != null)
-                    bottomBorder.Color = bottomColor.Value.ToHexColor();
+            if (bottomColor != null) {
+                bottomBorder.Color = bottomColor.Value.ToHexColor();
+            }
             borders.BottomBorder = bottomBorder;
         }
 
@@ -100,9 +100,9 @@ public partial class WordTableStyleDetails {
             var leftBorder = borders.LeftBorder ?? new LeftBorder();
             if (leftStyle != null) leftBorder.Val = leftStyle;
             if (leftSize != null) leftBorder.Size = leftSize;
-            if (leftColor != null)
-                if (leftColor != null)
-                    leftBorder.Color = leftColor.Value.ToHexColor();
+            if (leftColor != null) {
+                leftBorder.Color = leftColor.Value.ToHexColor();
+            }
             borders.LeftBorder = leftBorder;
         }
 
@@ -111,9 +111,9 @@ public partial class WordTableStyleDetails {
             var rightBorder = borders.RightBorder ?? new RightBorder();
             if (rightStyle != null) rightBorder.Val = rightStyle;
             if (rightSize != null) rightBorder.Size = rightSize;
-            if (rightColor != null)
-                if (rightColor != null)
-                    rightBorder.Color = rightColor.Value.ToHexColor();
+            if (rightColor != null) {
+                rightBorder.Color = rightColor.Value.ToHexColor();
+            }
             borders.RightBorder = rightBorder;
         }
 
@@ -122,9 +122,9 @@ public partial class WordTableStyleDetails {
             var insideHBorder = borders.InsideHorizontalBorder ?? new InsideHorizontalBorder();
             if (insideHStyle != null) insideHBorder.Val = insideHStyle;
             if (insideHSize != null) insideHBorder.Size = insideHSize;
-            if (insideHColor != null)
-                if (insideHColor != null)
-                    insideHBorder.Color = insideHColor.Value.ToHexColor();
+            if (insideHColor != null) {
+                insideHBorder.Color = insideHColor.Value.ToHexColor();
+            }
             borders.InsideHorizontalBorder = insideHBorder;
         }
 
@@ -133,9 +133,9 @@ public partial class WordTableStyleDetails {
             var insideVBorder = borders.InsideVerticalBorder ?? new InsideVerticalBorder();
             if (insideVStyle != null) insideVBorder.Val = insideVStyle;
             if (insideVSize != null) insideVBorder.Size = insideVSize;
-            if (insideVColor != null)
-                if (insideVColor != null)
-                    insideVBorder.Color = insideVColor.Value.ToHexColor();
+            if (insideVColor != null) {
+                insideVBorder.Color = insideVColor.Value.ToHexColor();
+            }
             borders.InsideVerticalBorder = insideVBorder;
         }
 
@@ -147,7 +147,7 @@ public partial class WordTableStyleDetails {
     /// </summary>
     /// <param name="side">The border side to get properties for</param>
     /// <returns>A tuple with style, size, and color</returns>
-    public (BorderValues? Style, UInt32Value Size, string ColorHex) GetBorderProperties(WordTableBorderSide side) {
+    public (BorderValues? Style, UInt32Value? Size, string? ColorHex) GetBorderProperties(WordTableBorderSide side) {
         if (TableBorders == null) {
             return (null, null, null);
         }
@@ -155,37 +155,37 @@ public partial class WordTableStyleDetails {
         switch (side) {
             case WordTableBorderSide.Top:
                 return (
-                    TableBorders.TopBorder?.Val,
+                    TableBorders.TopBorder?.Val?.Value,
                     TableBorders.TopBorder?.Size,
                     TableBorders.TopBorder?.Color?.Value
                 );
             case WordTableBorderSide.Bottom:
                 return (
-                    TableBorders.BottomBorder?.Val,
+                    TableBorders.BottomBorder?.Val?.Value,
                     TableBorders.BottomBorder?.Size,
                     TableBorders.BottomBorder?.Color?.Value
                 );
             case WordTableBorderSide.Left:
                 return (
-                    TableBorders.LeftBorder?.Val,
+                    TableBorders.LeftBorder?.Val?.Value,
                     TableBorders.LeftBorder?.Size,
                     TableBorders.LeftBorder?.Color?.Value
                 );
             case WordTableBorderSide.Right:
                 return (
-                    TableBorders.RightBorder?.Val,
+                    TableBorders.RightBorder?.Val?.Value,
                     TableBorders.RightBorder?.Size,
                     TableBorders.RightBorder?.Color?.Value
                 );
             case WordTableBorderSide.InsideHorizontal:
                 return (
-                    TableBorders.InsideHorizontalBorder?.Val,
+                    TableBorders.InsideHorizontalBorder?.Val?.Value,
                     TableBorders.InsideHorizontalBorder?.Size,
                     TableBorders.InsideHorizontalBorder?.Color?.Value
                 );
             case WordTableBorderSide.InsideVertical:
                 return (
-                    TableBorders.InsideVerticalBorder?.Val,
+                    TableBorders.InsideVerticalBorder?.Val?.Value,
                     TableBorders.InsideVerticalBorder?.Size,
                     TableBorders.InsideVerticalBorder?.Color?.Value
                 );
@@ -205,56 +205,68 @@ public partial class WordTableStyleDetails {
         foreach (var cell in _table.Cells) {
             // Top border
             if (TableBorders.TopBorder != null) {
-                cell.Borders.TopStyle = TableBorders.TopBorder.Val;
+                if (TableBorders.TopBorder.Val != null) {
+                    cell.Borders.TopStyle = TableBorders.TopBorder.Val!;
+                }
                 if (TableBorders.TopBorder.Size != null)
                     cell.Borders.TopSize = TableBorders.TopBorder.Size;
                 if (TableBorders.TopBorder.Color != null)
-                    cell.Borders.TopColorHex = TableBorders.TopBorder.Color;
+                    cell.Borders.TopColorHex = TableBorders.TopBorder.Color!;
             }
 
             // Bottom border
             if (TableBorders.BottomBorder != null) {
-                cell.Borders.BottomStyle = TableBorders.BottomBorder.Val;
+                if (TableBorders.BottomBorder.Val != null) {
+                    cell.Borders.BottomStyle = TableBorders.BottomBorder.Val!;
+                }
                 if (TableBorders.BottomBorder.Size != null)
                     cell.Borders.BottomSize = TableBorders.BottomBorder.Size;
                 if (TableBorders.BottomBorder.Color != null)
-                    cell.Borders.BottomColorHex = TableBorders.BottomBorder.Color;
+                    cell.Borders.BottomColorHex = TableBorders.BottomBorder.Color!;
             }
 
             // Left border
             if (TableBorders.LeftBorder != null) {
-                cell.Borders.LeftStyle = TableBorders.LeftBorder.Val;
+                if (TableBorders.LeftBorder.Val != null) {
+                    cell.Borders.LeftStyle = TableBorders.LeftBorder.Val!;
+                }
                 if (TableBorders.LeftBorder.Size != null)
                     cell.Borders.LeftSize = TableBorders.LeftBorder.Size;
                 if (TableBorders.LeftBorder.Color != null)
-                    cell.Borders.LeftColorHex = TableBorders.LeftBorder.Color;
+                    cell.Borders.LeftColorHex = TableBorders.LeftBorder.Color!;
             }
 
             // Right border
             if (TableBorders.RightBorder != null) {
-                cell.Borders.RightStyle = TableBorders.RightBorder.Val;
+                if (TableBorders.RightBorder.Val != null) {
+                    cell.Borders.RightStyle = TableBorders.RightBorder.Val!;
+                }
                 if (TableBorders.RightBorder.Size != null)
                     cell.Borders.RightSize = TableBorders.RightBorder.Size;
                 if (TableBorders.RightBorder.Color != null)
-                    cell.Borders.RightColorHex = TableBorders.RightBorder.Color;
+                    cell.Borders.RightColorHex = TableBorders.RightBorder.Color!;
             }
 
             // Inside horizontal border
             if (TableBorders.InsideHorizontalBorder != null) {
-                cell.Borders.InsideHorizontalStyle = TableBorders.InsideHorizontalBorder.Val;
+                if (TableBorders.InsideHorizontalBorder.Val != null) {
+                    cell.Borders.InsideHorizontalStyle = TableBorders.InsideHorizontalBorder.Val!;
+                }
                 if (TableBorders.InsideHorizontalBorder.Size != null)
                     cell.Borders.InsideHorizontalSize = TableBorders.InsideHorizontalBorder.Size;
                 if (TableBorders.InsideHorizontalBorder.Color != null)
-                    cell.Borders.InsideHorizontalColorHex = TableBorders.InsideHorizontalBorder.Color;
+                    cell.Borders.InsideHorizontalColorHex = TableBorders.InsideHorizontalBorder.Color!;
             }
 
             // Inside vertical border
             if (TableBorders.InsideVerticalBorder != null) {
-                cell.Borders.InsideVerticalStyle = TableBorders.InsideVerticalBorder.Val;
+                if (TableBorders.InsideVerticalBorder.Val != null) {
+                    cell.Borders.InsideVerticalStyle = TableBorders.InsideVerticalBorder.Val!;
+                }
                 if (TableBorders.InsideVerticalBorder.Size != null)
                     cell.Borders.InsideVerticalSize = TableBorders.InsideVerticalBorder.Size;
                 if (TableBorders.InsideVerticalBorder.Color != null)
-                    cell.Borders.InsideVerticalColorHex = TableBorders.InsideVerticalBorder.Color;
+                    cell.Borders.InsideVerticalColorHex = TableBorders.InsideVerticalBorder.Color!;
             }
         }
     }

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -490,8 +490,8 @@ namespace OfficeIMO.Word {
         /// Gets the value of a document variable or <c>null</c> if the variable does not exist.
         /// </summary>
         /// <param name="name">Variable name.</param>
-        public string GetDocumentVariable(string name) {
-            return DocumentVariables.ContainsKey(name) ? DocumentVariables[name] : null;
+        public string? GetDocumentVariable(string name) {
+            return DocumentVariables.TryGetValue(name, out var value) ? value : null;
         }
 
         /// <summary>
@@ -886,27 +886,27 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Path to the file backing this document.
         /// </summary>
-        public string FilePath { get; set; }
+        public string FilePath { get; set; } = null!;
 
         /// <summary>
         /// Original stream where this document was created / loaded from.
         /// </summary>
-        internal Stream OriginalStream { get; set; }
+        internal Stream OriginalStream { get; set; } = null!;
 
         /// <summary>
         /// Provides access to document settings.
         /// </summary>
-        public WordSettings Settings;
+        public WordSettings Settings = null!;
 
         /// <summary>
         /// Manages application related properties.
         /// </summary>
-        public ApplicationProperties ApplicationProperties;
+        public ApplicationProperties ApplicationProperties = null!;
 
         /// <summary>
         /// Provides access to built-in document properties.
         /// </summary>
-        public BuiltinDocumentProperties BuiltinDocumentProperties;
+        public BuiltinDocumentProperties BuiltinDocumentProperties = null!;
 
         /// <summary>
         /// Collection of custom document properties.
@@ -925,7 +925,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Provides basic statistics for the document.
         /// </summary>
-        public WordDocumentStatistics Statistics { get; internal set; }
+        public WordDocumentStatistics Statistics { get; internal set; } = null!;
 
         /// <summary>
         /// Indicates whether the document is saved automatically.
@@ -942,12 +942,12 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Underlying Open XML word processing document.
         /// </summary>
-        public WordprocessingDocument _wordprocessingDocument;
+        public WordprocessingDocument _wordprocessingDocument = null!;
 
         /// <summary>
         /// Root document element.
         /// </summary>
-        public Document _document;
+        public Document _document = null!;
         //public WordCustomProperties _customDocumentProperties;
 
 
@@ -958,7 +958,7 @@ namespace OfficeIMO.Word {
 
         private static string GetUniqueFilePath(string filePath) {
             if (File.Exists(filePath)) {
-                string folderPath = Path.GetDirectoryName(filePath);
+                string folderPath = Path.GetDirectoryName(filePath)!;
                 string fileName = Path.GetFileNameWithoutExtension(filePath);
                 string fileExtension = Path.GetExtension(filePath);
                 int number = 1;
@@ -972,8 +972,8 @@ namespace OfficeIMO.Word {
 
                 do {
                     number++;
-                    string newFileName = $"{fileName} ({number}){fileExtension}";
-                    filePath = Path.Combine(folderPath, newFileName);
+                      string newFileName = $"{fileName} ({number}){fileExtension}";
+                      filePath = Path.Combine(folderPath, newFileName);
                 } while (File.Exists(filePath));
             }
 
@@ -1020,75 +1020,76 @@ namespace OfficeIMO.Word {
             WordprocessingDocument wordDocument = WordprocessingDocument.Create(new MemoryStream(), documentType, autoSave);
 
             wordDocument.AddMainDocumentPart();
-            wordDocument.MainDocumentPart.Document = new Document() {
+            var mainPart = wordDocument.MainDocumentPart!;
+            mainPart.Document = new Document() {
                 MCAttributes = new MarkupCompatibilityAttributes() { Ignorable = "w14 w15 w16se w16cid w16 w16cex w16sdtdh wp14" }
             };
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("wpc", "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("cx", "http://schemas.microsoft.com/office/drawing/2014/chartex");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("cx1", "http://schemas.microsoft.com/office/drawing/2015/9/8/chartex");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("cx2", "http://schemas.microsoft.com/office/drawing/2015/10/21/chartex");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("cx3", "http://schemas.microsoft.com/office/drawing/2016/5/9/chartex");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("cx4", "http://schemas.microsoft.com/office/drawing/2016/5/10/chartex");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("cx5", "http://schemas.microsoft.com/office/drawing/2016/5/11/chartex");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("cx6", "http://schemas.microsoft.com/office/drawing/2016/5/12/chartex");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("cx7", "http://schemas.microsoft.com/office/drawing/2016/5/13/chartex");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("cx8", "http://schemas.microsoft.com/office/drawing/2016/5/14/chartex");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("mc", "http://schemas.openxmlformats.org/markup-compatibility/2006");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("aink", "http://schemas.microsoft.com/office/drawing/2016/ink");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("am3d", "http://schemas.microsoft.com/office/drawing/2017/model3d");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("o", "urn:schemas-microsoft-com:office:office");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("oel", "http://schemas.microsoft.com/office/2019/extlst");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("m", "http://schemas.openxmlformats.org/officeDocument/2006/math");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("v", "urn:schemas-microsoft-com:vml");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("wp14", "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("wp", "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("w10", "urn:schemas-microsoft-com:office:word");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("w", "http://schemas.openxmlformats.org/wordprocessingml/2006/main");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("w14", "http://schemas.microsoft.com/office/word/2010/wordml");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("w15", "http://schemas.microsoft.com/office/word/2012/wordml");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("w16cex", "http://schemas.microsoft.com/office/word/2018/wordml/cex");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("w16cid", "http://schemas.microsoft.com/office/word/2016/wordml/cid");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("w16", "http://schemas.microsoft.com/office/word/2018/wordml");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("w16sdtdh", "http://schemas.microsoft.com/office/word/2020/wordml/sdtdatahash");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("w16se", "http://schemas.microsoft.com/office/word/2015/wordml/symex");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("wpg", "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("wpi", "http://schemas.microsoft.com/office/word/2010/wordprocessingInk");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("wne", "http://schemas.microsoft.com/office/word/2006/wordml");
-            wordDocument.MainDocumentPart.Document.AddNamespaceDeclaration("wps", "http://schemas.microsoft.com/office/word/2010/wordprocessingShape");
+            mainPart.Document.AddNamespaceDeclaration("wpc", "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas");
+            mainPart.Document.AddNamespaceDeclaration("cx", "http://schemas.microsoft.com/office/drawing/2014/chartex");
+            mainPart.Document.AddNamespaceDeclaration("cx1", "http://schemas.microsoft.com/office/drawing/2015/9/8/chartex");
+            mainPart.Document.AddNamespaceDeclaration("cx2", "http://schemas.microsoft.com/office/drawing/2015/10/21/chartex");
+            mainPart.Document.AddNamespaceDeclaration("cx3", "http://schemas.microsoft.com/office/drawing/2016/5/9/chartex");
+            mainPart.Document.AddNamespaceDeclaration("cx4", "http://schemas.microsoft.com/office/drawing/2016/5/10/chartex");
+            mainPart.Document.AddNamespaceDeclaration("cx5", "http://schemas.microsoft.com/office/drawing/2016/5/11/chartex");
+            mainPart.Document.AddNamespaceDeclaration("cx6", "http://schemas.microsoft.com/office/drawing/2016/5/12/chartex");
+            mainPart.Document.AddNamespaceDeclaration("cx7", "http://schemas.microsoft.com/office/drawing/2016/5/13/chartex");
+            mainPart.Document.AddNamespaceDeclaration("cx8", "http://schemas.microsoft.com/office/drawing/2016/5/14/chartex");
+            mainPart.Document.AddNamespaceDeclaration("mc", "http://schemas.openxmlformats.org/markup-compatibility/2006");
+            mainPart.Document.AddNamespaceDeclaration("aink", "http://schemas.microsoft.com/office/drawing/2016/ink");
+            mainPart.Document.AddNamespaceDeclaration("am3d", "http://schemas.microsoft.com/office/drawing/2017/model3d");
+            mainPart.Document.AddNamespaceDeclaration("o", "urn:schemas-microsoft-com:office:office");
+            mainPart.Document.AddNamespaceDeclaration("oel", "http://schemas.microsoft.com/office/2019/extlst");
+            mainPart.Document.AddNamespaceDeclaration("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+            mainPart.Document.AddNamespaceDeclaration("m", "http://schemas.openxmlformats.org/officeDocument/2006/math");
+            mainPart.Document.AddNamespaceDeclaration("v", "urn:schemas-microsoft-com:vml");
+            mainPart.Document.AddNamespaceDeclaration("wp14", "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing");
+            mainPart.Document.AddNamespaceDeclaration("wp", "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing");
+            mainPart.Document.AddNamespaceDeclaration("w10", "urn:schemas-microsoft-com:office:word");
+            mainPart.Document.AddNamespaceDeclaration("w", "http://schemas.openxmlformats.org/wordprocessingml/2006/main");
+            mainPart.Document.AddNamespaceDeclaration("w14", "http://schemas.microsoft.com/office/word/2010/wordml");
+            mainPart.Document.AddNamespaceDeclaration("w15", "http://schemas.microsoft.com/office/word/2012/wordml");
+            mainPart.Document.AddNamespaceDeclaration("w16cex", "http://schemas.microsoft.com/office/word/2018/wordml/cex");
+            mainPart.Document.AddNamespaceDeclaration("w16cid", "http://schemas.microsoft.com/office/word/2016/wordml/cid");
+            mainPart.Document.AddNamespaceDeclaration("w16", "http://schemas.microsoft.com/office/word/2018/wordml");
+            mainPart.Document.AddNamespaceDeclaration("w16sdtdh", "http://schemas.microsoft.com/office/word/2020/wordml/sdtdatahash");
+            mainPart.Document.AddNamespaceDeclaration("w16se", "http://schemas.microsoft.com/office/word/2015/wordml/symex");
+            mainPart.Document.AddNamespaceDeclaration("wpg", "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup");
+            mainPart.Document.AddNamespaceDeclaration("wpi", "http://schemas.microsoft.com/office/word/2010/wordprocessingInk");
+            mainPart.Document.AddNamespaceDeclaration("wne", "http://schemas.microsoft.com/office/word/2006/wordml");
+            mainPart.Document.AddNamespaceDeclaration("wps", "http://schemas.microsoft.com/office/word/2010/wordprocessingShape");
 
-            wordDocument.MainDocumentPart.Document.Body = new DocumentFormat.OpenXml.Wordprocessing.Body();
+            mainPart.Document.Body = new DocumentFormat.OpenXml.Wordprocessing.Body();
 
             word.FilePath = filePath ?? string.Empty;
             word._wordprocessingDocument = wordDocument;
-            word._document = wordDocument.MainDocumentPart.Document;
+            word._document = mainPart.Document;
 
-            StyleDefinitionsPart styleDefinitionsPart1 = wordDocument.MainDocumentPart.AddNewPart<StyleDefinitionsPart>("rId1");
+            StyleDefinitionsPart styleDefinitionsPart1 = mainPart.AddNewPart<StyleDefinitionsPart>("rId1");
             GenerateStyleDefinitionsPart1Content(styleDefinitionsPart1);
 
-            WebSettingsPart webSettingsPart1 = wordDocument.MainDocumentPart.AddNewPart<WebSettingsPart>("rId3");
+            WebSettingsPart webSettingsPart1 = mainPart.AddNewPart<WebSettingsPart>("rId3");
             GenerateWebSettingsPart1Content(webSettingsPart1);
 
-            DocumentSettingsPart documentSettingsPart1 = wordDocument.MainDocumentPart.AddNewPart<DocumentSettingsPart>("rId2");
+            DocumentSettingsPart documentSettingsPart1 = mainPart.AddNewPart<DocumentSettingsPart>("rId2");
             GenerateDocumentSettingsPart1Content(documentSettingsPart1);
 
-            EndnotesPart endnotesPart1 = wordDocument.MainDocumentPart.AddNewPart<EndnotesPart>("rId4");
+            EndnotesPart endnotesPart1 = mainPart.AddNewPart<EndnotesPart>("rId4");
             GenerateEndNotesPart1Content(endnotesPart1);
 
-            FootnotesPart footnotesPart1 = wordDocument.MainDocumentPart.AddNewPart<FootnotesPart>("rId5");
+            FootnotesPart footnotesPart1 = mainPart.AddNewPart<FootnotesPart>("rId5");
             GenerateFootNotesPart1Content(footnotesPart1);
 
-            FontTablePart fontTablePart1 = wordDocument.MainDocumentPart.AddNewPart<FontTablePart>("rId6");
+            FontTablePart fontTablePart1 = mainPart.AddNewPart<FontTablePart>("rId6");
             GenerateFontTablePart1Content(fontTablePart1);
 
-            ThemePart themePart1 = wordDocument.MainDocumentPart.AddNewPart<ThemePart>("rId7");
+            ThemePart themePart1 = mainPart.AddNewPart<ThemePart>("rId7");
             GenerateThemePart1Content(themePart1);
 
             WordSettings wordSettings = new WordSettings(word);
             WordCompatibilitySettings compatibilitySettings = new WordCompatibilitySettings(word);
             ApplicationProperties applicationProperties = new ApplicationProperties(word);
             BuiltinDocumentProperties builtinDocumentProperties = new BuiltinDocumentProperties(word);
-            WordSection wordSection = new WordSection(word, null);
+            WordSection wordSection = new WordSection(word, null!);
             WordBackground wordBackground = new WordBackground(word);
             WordDocumentStatistics statistics = new WordDocumentStatistics(word);
 
@@ -1148,9 +1149,9 @@ namespace OfficeIMO.Word {
             var compatibilitySettings = new WordCompatibilitySettings(this);
             //CustomDocumentProperties customDocumentProperties = new CustomDocumentProperties(this);
             // add a section that's assigned to top of the document
-            var wordSection = new WordSection(this, null, null);
+            var wordSection = new WordSection(this, null!, null!);
 
-            var list = this._wordprocessingDocument.MainDocumentPart.Document.Body.ChildElements.ToList(); //.OfType<Paragraph>().ToList();
+            var list = this._wordprocessingDocument.MainDocumentPart!.Document.Body!.ChildElements.ToList(); //.OfType<Paragraph>().ToList();
             foreach (var element in list) {
                 if (element is Paragraph) {
                     Paragraph paragraph = (Paragraph)element;
@@ -1218,10 +1219,11 @@ namespace OfficeIMO.Word {
         /// <returns></returns>
         /// <exception cref="FileNotFoundException"></exception>
         public static WordDocument Load(string filePath, bool readOnly = false, bool autoSave = false, bool overrideStyles = false) {
-            if (filePath != null) {
-                if (!File.Exists(filePath)) {
-                    throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
-                }
+            if (filePath is null) {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+            if (!File.Exists(filePath)) {
+                throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
             }
 
             var word = new WordDocument();
@@ -1230,7 +1232,7 @@ namespace OfficeIMO.Word {
                 AutoSave = autoSave
             };
 
-            using (var fileStream = new FileStream(filePath, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite)) {
+                using (var fileStream = new FileStream(filePath, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite)) {
                 var memoryStream = new MemoryStream();
                 fileStream.CopyTo(memoryStream);
                 memoryStream.Seek(0, SeekOrigin.Begin);
@@ -1242,7 +1244,7 @@ namespace OfficeIMO.Word {
 
                 word.FilePath = filePath;
                 word._wordprocessingDocument = wordDocument;
-                word._document = wordDocument.MainDocumentPart.Document;
+                    word._document = wordDocument.MainDocumentPart!.Document;
                 word.LoadDocument();
                 WordChart.InitializeAxisIdSeed(wordDocument);
                 WordChart.InitializeDocPrIdSeed(wordDocument);
@@ -1264,10 +1266,11 @@ namespace OfficeIMO.Word {
         /// <returns>Loaded <see cref="WordDocument"/> instance.</returns>
         /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
         public static async Task<WordDocument> LoadAsync(string filePath, bool readOnly = false, bool autoSave = false, bool overrideStyles = false, CancellationToken cancellationToken = default) {
-            if (filePath != null) {
-                if (!File.Exists(filePath)) {
-                    throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
-                }
+            if (filePath is null) {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+            if (!File.Exists(filePath)) {
+                throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
             }
 
             using var fileStream = new FileStream(filePath, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite, FileShare.Read, 4096, FileOptions.Asynchronous);
@@ -1284,7 +1287,7 @@ namespace OfficeIMO.Word {
             var word = new WordDocument {
                 FilePath = filePath,
                 _wordprocessingDocument = wordDocument,
-                _document = wordDocument.MainDocumentPart.Document
+                _document = wordDocument.MainDocumentPart!.Document
             };
 
             bool applyOverrideStyles = overrideStyles && !readOnly;
@@ -1318,7 +1321,7 @@ namespace OfficeIMO.Word {
             InitialiseStyleDefinitions(wordDocument, readOnly, applyOverrideStyles);
 
             document._wordprocessingDocument = wordDocument;
-            document._document = wordDocument.MainDocumentPart.Document;
+            document._document = wordDocument.MainDocumentPart!.Document;
             document.LoadDocument();
             WordChart.InitializeAxisIdSeed(wordDocument);
             WordChart.InitializeDocPrIdSeed(wordDocument);
@@ -1356,7 +1359,7 @@ namespace OfficeIMO.Word {
         /// <param name="dest"></param>
         // IPackageProperties is currently marked as experimental (OOXML0001).
         // There is no non-experimental alternative available yet.
-        #pragma warning disable 0618
+        #pragma warning disable OOXML0001
         private static void CopyPackageProperties(IPackageProperties src, IPackageProperties dest) {
             dest.Category = src.Category;
             dest.ContentStatus = src.ContentStatus;
@@ -1375,7 +1378,7 @@ namespace OfficeIMO.Word {
             dest.Title = src.Title;
             dest.Version = src.Version;
         }
-        #pragma warning restore 0618
+        #pragma warning restore OOXML0001
 
         /// <summary>
         /// Save WordDocument to filePath (SaveAs), and open the file in Microsoft Word
@@ -1670,7 +1673,7 @@ namespace OfficeIMO.Word {
         /// Needs more work, but this is what Word does all the time
         /// </summary>
         private void MoveSectionProperties() {
-            var body = this._wordprocessingDocument.MainDocumentPart.Document.Body;
+            var body = this._wordprocessingDocument.MainDocumentPart!.Document.Body!;
             var sectionProperties = body.Elements<SectionProperties>().LastOrDefault();
             if (sectionProperties != null) {
                 body.RemoveChild(sectionProperties);
@@ -1685,6 +1688,9 @@ namespace OfficeIMO.Word {
             DisposeAsync().GetAwaiter().GetResult();
         }
 
+        /// <summary>
+        /// Releases resources associated with the document asynchronously.
+        /// </summary>
         public async ValueTask DisposeAsync() {
             if (this._disposed) {
                 return;
@@ -1700,7 +1706,7 @@ namespace OfficeIMO.Word {
                 } catch {
                     // ignored
                 }
-                this._wordprocessingDocument = null;
+                this._wordprocessingDocument = null!;
             }
 
             if (this.OriginalStream != null) {
@@ -1714,13 +1720,14 @@ namespace OfficeIMO.Word {
         private static void InitialiseStyleDefinitions(WordprocessingDocument wordDocument, bool readOnly, bool overrideStyles) {
             // if document is read only we shouldn't be doing any new styles, hopefully it doesn't break anything
             if (readOnly == false) {
-                var styleDefinitionsPart = wordDocument.MainDocumentPart.GetPartsOfType<StyleDefinitionsPart>()
-                    .FirstOrDefault();
+            var styleDefinitionsPart = wordDocument.MainDocumentPart!
+                .GetPartsOfType<StyleDefinitionsPart>()
+                .FirstOrDefault();
                 if (styleDefinitionsPart != null) {
                     AddStyleDefinitions(styleDefinitionsPart, overrideStyles);
                 } else {
 
-                    var styleDefinitionsPart1 = wordDocument.MainDocumentPart.AddNewPart<StyleDefinitionsPart>("rId1");
+                    var styleDefinitionsPart1 = wordDocument.MainDocumentPart!.AddNewPart<StyleDefinitionsPart>("rId1");
                     GenerateStyleDefinitionsPart1Content(styleDefinitionsPart1);
 
                 }
@@ -1733,7 +1740,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Provides access to the document background settings.
         /// </summary>
-        public WordBackground Background { get; set; }
+        public WordBackground Background { get; set; } = null!;
 
         /// <summary>
         /// Indicates whether the document passes Open XML validation.
@@ -1782,7 +1789,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets compatibility settings for the document.
         /// </summary>
-        public WordCompatibilitySettings CompatibilitySettings { get; set; }
+        public WordCompatibilitySettings CompatibilitySettings { get; set; } = null!;
 
         internal void HeadingModified() {
             if (TableOfContent != null) {
@@ -1797,7 +1804,7 @@ namespace OfficeIMO.Word {
                 TableOfContent.Update();
             }
             _ = new WordCustomProperties(this, true);
-            var settingsPart = _wordprocessingDocument.MainDocumentPart.DocumentSettingsPart;
+            var settingsPart = _wordprocessingDocument.MainDocumentPart!.DocumentSettingsPart;
             bool hasVariables = settingsPart?.Settings?.GetFirstChild<DocumentVariables>() != null;
             if (hasVariables || DocumentVariables.Count > 0) {
                 _ = new WordDocumentVariables(this, true);

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -226,8 +226,8 @@ namespace OfficeIMO.Word {
         /// <param name="wordParagraph">Optional WordParagraph to insert after the
         /// given WordParagraph instead of at the end of the document.</param>
         /// <returns>The inserted WordParagraph.</returns>
-        public WordParagraph AddParagraph(WordParagraph wordParagraph = null) {
-            if (wordParagraph == null) {
+        public WordParagraph AddParagraph(WordParagraph? wordParagraph = null) {
+            if (wordParagraph is null) {
                 // we create paragraph (and within that add it to document)
                 wordParagraph = new WordParagraph(this._document, newParagraph: true, newRun: false);
             }
@@ -265,8 +265,8 @@ namespace OfficeIMO.Word {
         /// <param name="section">The section to add the paragraph to. When paragraph is given this has no effect.</param>
         /// <param name="paragraph">The optional paragraph to add the paragraph to.</param>
         /// <returns>The new WordParagraph</returns>
-        public WordParagraph AddParagraphAfterSelf(WordSection section, WordParagraph paragraph = null) {
-            if (paragraph == null) {
+        public WordParagraph AddParagraphAfterSelf(WordSection section, WordParagraph? paragraph = null) {
+            if (paragraph is null) {
                 paragraph = new WordParagraph(section._document, true, false);
             }
             this._paragraph.InsertAfterSelf(paragraph._paragraph);
@@ -355,7 +355,7 @@ namespace OfficeIMO.Word {
         /// <returns>The paragraph that this was called on.</returns>
         public WordParagraph AddCitation(string sourceTag) {
             var field = new CitationField { SourceTag = sourceTag };
-            WordField.AddField(this, field, null, null, false);
+            WordField.AddField(this, field, null!, null!, false);
             return this;
         }
 
@@ -370,8 +370,8 @@ namespace OfficeIMO.Word {
         /// Also see available List of switches per field code:
         /// <see>https://support.microsoft.com/en-us/office/list-of-field-codes-in-word-1ad6d91a-55a7-4a8d-b535-cf7888659a51 </see></param>
         /// <returns>The paragraph that this was called on.</returns>
-        public WordParagraph AddField(WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, string customFormat = null, bool advanced = false, List<String> parameters = null) {
-            var field = WordField.AddField(this, wordFieldType, wordFieldFormat, customFormat, advanced, parameters);
+        public WordParagraph AddField(WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, string? customFormat = null, bool advanced = false, List<string>? parameters = null) {
+            var field = WordField.AddField(this, wordFieldType, wordFieldFormat, customFormat!, advanced, parameters!);
             return this;
         }
 
@@ -383,8 +383,8 @@ namespace OfficeIMO.Word {
         /// <param name="customFormat">Custom format string for date or time fields.</param>
         /// <param name="advanced">Use advanced field representation.</param>
         /// <returns>The paragraph that this was called on.</returns>
-        public WordParagraph AddField(WordFieldCode fieldCode, WordFieldFormat? wordFieldFormat = null, string customFormat = null, bool advanced = false) {
-            WordField.AddField(this, fieldCode, wordFieldFormat, customFormat, advanced);
+        public WordParagraph AddField(WordFieldCode fieldCode, WordFieldFormat? wordFieldFormat = null, string? customFormat = null, bool advanced = false) {
+            WordField.AddField(this, fieldCode, wordFieldFormat, customFormat!, advanced);
             return this;
         }
 
@@ -476,26 +476,26 @@ namespace OfficeIMO.Word {
         public void RemoveHyperLink(bool includingParagraph = false) {
             if (_hyperlink != null) {
                 if (!string.IsNullOrEmpty(_hyperlink.Id)) {
-                    OpenXmlElement parent = _paragraph.Parent;
-                    while (parent != null && !(parent is Body) && !(parent is Header) && !(parent is Footer)) {
+                    OpenXmlElement? parent = _paragraph.Parent;
+                    while (parent != null && parent is not Body and not Header and not Footer) {
                         parent = parent.Parent;
                     }
 
-                    OpenXmlPart part = _document._wordprocessingDocument.MainDocumentPart;
+                    OpenXmlPart? part = _document._wordprocessingDocument.MainDocumentPart;
                     if (parent is Header header) {
                         part = header.HeaderPart;
                     } else if (parent is Footer footer) {
                         part = footer.FooterPart;
                     }
 
-                    var rel = part.HyperlinkRelationships.FirstOrDefault(r => r.Id == _hyperlink.Id);
-                    if (rel != null) {
+                    var rel = part?.HyperlinkRelationships.FirstOrDefault(r => r.Id == _hyperlink.Id);
+                    if (rel != null && part != null) {
                         part.DeleteReferenceRelationship(rel);
                     }
                 }
 
                 _hyperlink.Remove();
-                _hyperlink = null;
+                _hyperlink = null!;
 
                 if (includingParagraph) {
                     if (this._paragraph.ChildElements.Count == 0) {
@@ -701,7 +701,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public WordParagraph AddImageVml(string filePathImage, double? width = null, double? height = null) {
             var run = this.VerifyRun();
-            var mainPart = _document._wordprocessingDocument.MainDocumentPart;
+            MainDocumentPart mainPart = _document._wordprocessingDocument.MainDocumentPart!;
 
             var imagePart = mainPart.AddImagePart(ImagePartType.Png);
             using (var fs = File.OpenRead(filePathImage)) {
@@ -829,7 +829,7 @@ namespace OfficeIMO.Word {
         /// <param name="alias">Optional alias for the content control.</param>
         /// <param name="tag">Optional tag for the content control.</param>
         /// <returns>The created <see cref="WordStructuredDocumentTag"/> instance.</returns>
-        public WordStructuredDocumentTag AddStructuredDocumentTag(string text = "", string alias = null, string tag = null) {
+        public WordStructuredDocumentTag AddStructuredDocumentTag(string text = "", string? alias = null, string? tag = null) {
             var sdtRun = new SdtRun();
 
             var sdtProperties = new SdtProperties();
@@ -861,7 +861,7 @@ namespace OfficeIMO.Word {
         /// <param name="alias">Optional alias for the control.</param>
         /// <param name="tag">Optional tag for the control.</param>
         /// <returns>The created <see cref="WordCheckBox"/> instance.</returns>
-        public WordCheckBox AddCheckBox(bool isChecked = false, string alias = null, string tag = null) {
+        public WordCheckBox AddCheckBox(bool isChecked = false, string? alias = null, string? tag = null) {
             var sdtRun = new SdtRun();
 
             var props = new SdtProperties();
@@ -911,7 +911,7 @@ namespace OfficeIMO.Word {
         /// <param name="alias">Optional alias for the control.</param>
         /// <param name="tag">Optional tag for the control.</param>
         /// <returns>The created <see cref="WordDatePicker"/> instance.</returns>
-        public WordDatePicker AddDatePicker(System.DateTime? date = null, string alias = null, string tag = null) {
+        public WordDatePicker AddDatePicker(System.DateTime? date = null, string? alias = null, string? tag = null) {
             var sdtRun = new SdtRun();
 
             var props = new SdtProperties();
@@ -946,7 +946,7 @@ namespace OfficeIMO.Word {
         /// <param name="alias">Optional alias for the control.</param>
         /// <param name="tag">Optional tag for the control.</param>
         /// <returns>The created <see cref="WordDropDownList"/> instance.</returns>
-        public WordDropDownList AddDropDownList(System.Collections.Generic.IEnumerable<string> items, string alias = null, string tag = null) {
+        public WordDropDownList AddDropDownList(System.Collections.Generic.IEnumerable<string> items, string? alias = null, string? tag = null) {
             var sdtRun = new SdtRun();
 
             var props = new SdtProperties();
@@ -983,7 +983,7 @@ namespace OfficeIMO.Word {
         /// <param name="alias">Optional alias for the control.</param>
         /// <param name="tag">Optional tag for the control.</param>
         /// <returns>The created <see cref="WordComboBox"/> instance.</returns>
-        public WordComboBox AddComboBox(System.Collections.Generic.IEnumerable<string> items, string alias = null, string tag = null) {
+        public WordComboBox AddComboBox(System.Collections.Generic.IEnumerable<string> items, string? alias = null, string? tag = null) {
             var sdtRun = new SdtRun();
 
             var props = new SdtProperties();
@@ -1022,7 +1022,7 @@ namespace OfficeIMO.Word {
         /// <param name="alias">Optional alias for the control.</param>
         /// <param name="tag">Optional tag for the control.</param>
         /// <returns>The created <see cref="WordPictureControl"/> instance.</returns>
-        public WordPictureControl AddPictureControl(string filePath, double? width = null, double? height = null, string alias = null, string tag = null) {
+        public WordPictureControl AddPictureControl(string filePath, double? width = null, double? height = null, string? alias = null, string? tag = null) {
             var sdtRun = new SdtRun();
 
             var props = new SdtProperties();
@@ -1059,7 +1059,7 @@ namespace OfficeIMO.Word {
         /// <param name="alias">Optional alias for the control.</param>
         /// <param name="tag">Optional tag for the control.</param>
         /// <returns>The created <see cref="WordRepeatingSection"/> instance.</returns>
-        public WordRepeatingSection AddRepeatingSection(string sectionTitle = null, string alias = null, string tag = null) {
+        public WordRepeatingSection AddRepeatingSection(string? sectionTitle = null, string? alias = null, string? tag = null) {
             var sdtRun = new SdtRun();
 
             var props = new SdtProperties();


### PR DESCRIPTION
## Summary
- tighten null handling in table border helpers and return APIs
- clean up paragraph helpers for optional values
- add null checks and defaults across WordDocument

## Testing
- `dotnet build OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a3972d0eb0832ea340f491bc6a8936