### PR TITLE
Ensure VisioDocument root includes basic children

### DIFF
--- a/OfficeIMO.Examples/Visio/DocumentStructure.cs
+++ b/OfficeIMO.Examples/Visio/DocumentStructure.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+using System.IO.Packaging;
+using System.Xml.Linq;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    public static class DocumentStructure {
+        public static void Example_DocumentStructure(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Document structure");
+            string filePath = Path.Combine(folderPath, "Document Structure.vsdx");
+
+            VisioDocument document = new();
+            document.Save(filePath);
+
+            using Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read);
+            PackagePart documentPart = package.GetPart(new Uri("/visio/document.xml", UriKind.Relative));
+            XDocument xml = XDocument.Load(documentPart.GetStream());
+            XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
+
+            Console.WriteLine(xml.Root?.Element(ns + "DocumentSettings") != null);
+            Console.WriteLine(xml.Root?.Element(ns + "Colors") != null);
+            Console.WriteLine(xml.Root?.Element(ns + "FaceNames") != null);
+            Console.WriteLine(xml.Root?.Element(ns + "StyleSheets") != null);
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Visio.DocumentStructure.cs
+++ b/OfficeIMO.Tests/Visio.DocumentStructure.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.IO.Packaging;
+using System.Xml.Linq;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioDocumentStructure {
+        [Fact]
+        public void VisioDocumentIncludesRequiredChildren() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = new();
+            document.Save(filePath);
+
+            using Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read);
+            PackagePart documentPart = package.GetPart(new Uri("/visio/document.xml", UriKind.Relative));
+            XDocument xml = XDocument.Load(documentPart.GetStream());
+            XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
+
+            Assert.NotNull(xml.Root?.Element(ns + "DocumentSettings"));
+            Assert.NotNull(xml.Root?.Element(ns + "Colors"));
+            Assert.NotNull(xml.Root?.Element(ns + "FaceNames"));
+            Assert.NotNull(xml.Root?.Element(ns + "StyleSheets"));
+        }
+    }
+}
+

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -17,6 +17,7 @@ namespace OfficeIMO.Visio {
 
         private const string DocumentRelationshipType = "http://schemas.microsoft.com/visio/2010/relationships/document";
         private const string DocumentContentType = "application/vnd.ms-visio.drawing.main+xml";
+        private const string VisioNamespace = "http://schemas.microsoft.com/office/visio/2012/main";
 
         /// <summary>
         /// Collection of pages in the document.
@@ -53,7 +54,7 @@ namespace OfficeIMO.Visio {
             Uri pagesUri = PackUriHelper.ResolvePartUri(documentPart.Uri, pagesRel.TargetUri);
             PackagePart pagesPart = package.GetPart(pagesUri);
 
-            XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
+            XNamespace ns = VisioNamespace;
             XNamespace rNs = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
             XDocument pagesDoc = XDocument.Load(pagesPart.GetStream());
 
@@ -95,6 +96,17 @@ namespace OfficeIMO.Visio {
             return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double result) ? result : 0;
         }
 
+        private static void WriteVisioDocumentRoot(XmlWriter writer) {
+            writer.WriteStartDocument();
+            writer.WriteStartElement("VisioDocument", VisioNamespace);
+            writer.WriteElementString("DocumentSettings", VisioNamespace, string.Empty);
+            writer.WriteElementString("Colors", VisioNamespace, string.Empty);
+            writer.WriteElementString("FaceNames", VisioNamespace, string.Empty);
+            writer.WriteElementString("StyleSheets", VisioNamespace, string.Empty);
+            writer.WriteEndElement();
+            writer.WriteEndDocument();
+        }
+
         /// <summary>
         /// Saves the document to a <c>.vsdx</c> package.
         /// </summary>
@@ -120,13 +132,10 @@ namespace OfficeIMO.Visio {
                 CloseOutput = true,
                 Indent = true,
             };
-            const string ns = "http://schemas.microsoft.com/office/visio/2012/main";
+            const string ns = VisioNamespace;
 
             using (XmlWriter writer = XmlWriter.Create(documentPart.GetStream(FileMode.Create, FileAccess.Write), settings)) {
-                writer.WriteStartDocument();
-                writer.WriteStartElement("VisioDocument", ns);
-                writer.WriteEndElement();
-                writer.WriteEndDocument();
+                WriteVisioDocumentRoot(writer);
             }
 
             string pageName = _pages.Count > 0 ? _pages[0].Name : "Page-1";


### PR DESCRIPTION
## Summary
- add VisioNamespace constant and helper to author VisioDocument with required child nodes
- verify VisioDocument includes DocumentSettings, Colors, FaceNames, and StyleSheets
- demonstrate document structure in example project

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a396f967ac832e8c9454db8476a4ef