### PR TITLE
Allow positioning and sizing of PowerPoint shapes

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/ShapesPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/ShapesPowerPoint.cs
@@ -4,7 +4,7 @@ using OfficeIMO.PowerPoint;
 
 namespace OfficeIMO.Examples.PowerPoint {
     /// <summary>
-    /// Demonstrates retrieving and removing shapes.
+    /// Demonstrates retrieving, positioning, and removing shapes.
     /// </summary>
     public static class ShapesPowerPoint {
         public static void Example_PowerPointShapes(string folderPath, bool openPowerPoint) {
@@ -14,8 +14,11 @@ namespace OfficeIMO.Examples.PowerPoint {
 
             using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
             PowerPointSlide slide = presentation.AddSlide();
-            PPTextBox textBox = slide.AddTextBox("Hello");
-            PPPicture picture = slide.AddPicture(imagePath);
+            PPTextBox textBox = slide.AddTextBox("Hello", left: 914400, top: 914400, width: 1828800, height: 914400);
+            PPPicture picture = slide.AddPicture(imagePath, left: 2743200, top: 914400, width: 1828800, height: 1828800);
+
+            // Move the textbox 1 inch to the right
+            textBox.Left += 914400;
 
             PPShape? shape = slide.GetShape("TextBox 1");
             Console.WriteLine("Found shape: " + shape?.Name);

--- a/OfficeIMO.PowerPoint/PPShape.cs
+++ b/OfficeIMO.PowerPoint/PPShape.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml;
 using A = DocumentFormat.OpenXml.Drawing;
 using DocumentFormat.OpenXml.Presentation;
@@ -51,6 +52,80 @@ namespace OfficeIMO.PowerPoint {
                     }
                 }
             }
+        }
+
+        private A.Offset GetOffset() {
+            switch (Element) {
+                case Shape s:
+                    s.ShapeProperties ??= new ShapeProperties();
+                    s.ShapeProperties.Transform2D ??= new A.Transform2D();
+                    s.ShapeProperties.Transform2D.Offset ??= new A.Offset();
+                    return s.ShapeProperties.Transform2D.Offset;
+                case Picture p:
+                    p.ShapeProperties ??= new ShapeProperties();
+                    p.ShapeProperties.Transform2D ??= new A.Transform2D();
+                    p.ShapeProperties.Transform2D.Offset ??= new A.Offset();
+                    return p.ShapeProperties.Transform2D.Offset;
+                case GraphicFrame g:
+                    g.Transform ??= new Transform();
+                    g.Transform.Offset ??= new A.Offset();
+                    return g.Transform.Offset;
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        private A.Extents GetExtents() {
+            switch (Element) {
+                case Shape s:
+                    s.ShapeProperties ??= new ShapeProperties();
+                    s.ShapeProperties.Transform2D ??= new A.Transform2D();
+                    s.ShapeProperties.Transform2D.Extents ??= new A.Extents();
+                    return s.ShapeProperties.Transform2D.Extents;
+                case Picture p:
+                    p.ShapeProperties ??= new ShapeProperties();
+                    p.ShapeProperties.Transform2D ??= new A.Transform2D();
+                    p.ShapeProperties.Transform2D.Extents ??= new A.Extents();
+                    return p.ShapeProperties.Transform2D.Extents;
+                case GraphicFrame g:
+                    g.Transform ??= new Transform();
+                    g.Transform.Extents ??= new A.Extents();
+                    return g.Transform.Extents;
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        /// <summary>
+        /// Horizontal position of the shape in EMUs.
+        /// </summary>
+        public long Left {
+            get => GetOffset().X?.Value ?? 0L;
+            set => GetOffset().X = value;
+        }
+
+        /// <summary>
+        /// Vertical position of the shape in EMUs.
+        /// </summary>
+        public long Top {
+            get => GetOffset().Y?.Value ?? 0L;
+            set => GetOffset().Y = value;
+        }
+
+        /// <summary>
+        /// Width of the shape in EMUs.
+        /// </summary>
+        public long Width {
+            get => GetExtents().Cx?.Value ?? 0L;
+            set => GetExtents().Cx = value;
+        }
+
+        /// <summary>
+        /// Height of the shape in EMUs.
+        /// </summary>
+        public long Height {
+            get => GetExtents().Cy?.Value ?? 0L;
+            set => GetExtents().Cy = value;
         }
     }
 }

--- a/OfficeIMO.PowerPoint/PowerPointSlide.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.cs
@@ -178,7 +178,7 @@ namespace OfficeIMO.PowerPoint {
         /// <summary>
         /// Adds a textbox with the specified text.
         /// </summary>
-        public PPTextBox AddTextBox(string text) {
+        public PPTextBox AddTextBox(string text, long left = 0L, long top = 0L, long width = 914400L, long height = 914400L) {
             string name = GenerateUniqueName("TextBox");
             Shape shape = new(
                 new NonVisualShapeProperties(
@@ -186,7 +186,10 @@ namespace OfficeIMO.PowerPoint {
                     new NonVisualShapeDrawingProperties(new A.ShapeLocks { NoGrouping = true }),
                     new ApplicationNonVisualDrawingProperties(new PlaceholderShape())
                 ),
-                new ShapeProperties(),
+                new ShapeProperties(
+                    new A.Transform2D(new A.Offset { X = left, Y = top }, new A.Extents { Cx = width, Cy = height }),
+                    new A.PresetGeometry(new A.AdjustValueList()) { Preset = A.ShapeTypeValues.Rectangle }
+                ),
                 new TextBody(
                     new A.BodyProperties(),
                     new A.ListStyle(),
@@ -203,7 +206,7 @@ namespace OfficeIMO.PowerPoint {
         /// <summary>
         /// Adds an image from the given file path.
         /// </summary>
-        public PPPicture AddPicture(string imagePath) {
+        public PPPicture AddPicture(string imagePath, long left = 0L, long top = 0L, long width = 914400L, long height = 914400L) {
             ImagePart imagePart = _slidePart.AddImagePart(ImagePartType.Png);
             using FileStream stream = new(imagePath, FileMode.Open, FileAccess.Read);
             imagePart.FeedData(stream);
@@ -220,8 +223,10 @@ namespace OfficeIMO.PowerPoint {
                     new A.Blip { Embed = relationshipId },
                     new A.Stretch(new A.FillRectangle())
                 ),
-                new ShapeProperties(new A.Transform2D(new A.Offset { X = 0, Y = 0 }, new A.Extents { Cx = 914400L, Cy = 914400L }),
-                    new A.PresetGeometry(new A.AdjustValueList()) { Preset = A.ShapeTypeValues.Rectangle })
+                new ShapeProperties(
+                    new A.Transform2D(new A.Offset { X = left, Y = top }, new A.Extents { Cx = width, Cy = height }),
+                    new A.PresetGeometry(new A.AdjustValueList()) { Preset = A.ShapeTypeValues.Rectangle }
+                )
             );
 
             _slidePart.Slide.CommonSlideData!.ShapeTree.AppendChild(picture);
@@ -233,7 +238,7 @@ namespace OfficeIMO.PowerPoint {
         /// <summary>
         /// Adds a table with the specified rows and columns.
         /// </summary>
-        public PPTable AddTable(int rows, int columns) {
+        public PPTable AddTable(int rows, int columns, long left = 0L, long top = 0L, long width = 5000000L, long height = 3000000L) {
             A.Table table = new();
             A.TableProperties props = new();
             props.Append(new A.TableStyleId { Text = "{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}" });
@@ -264,7 +269,7 @@ namespace OfficeIMO.PowerPoint {
                     new NonVisualGraphicFrameDrawingProperties(),
                     new ApplicationNonVisualDrawingProperties()
                 ),
-                new Transform(new A.Offset { X = 0L, Y = 0L }, new A.Extents { Cx = 5000000L, Cy = 3000000L }),
+                new Transform(new A.Offset { X = left, Y = top }, new A.Extents { Cx = width, Cy = height }),
                 new A.Graphic(new A.GraphicData(table) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/table" })
             );
 

--- a/OfficeIMO.Tests/PowerPoint.ShapePosition.cs
+++ b/OfficeIMO.Tests/PowerPoint.ShapePosition.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Linq;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointShapePosition {
+        [Fact]
+        public void CanSetShapePositions() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string imagePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", "BackgroundImage.png");
+
+            long left = 1000000L;
+            long top = 2000000L;
+            long width = 3000000L;
+            long height = 4000000L;
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                PowerPointSlide slide = presentation.AddSlide();
+                PPTextBox textBox = slide.AddTextBox("Hello", left, top, width, height);
+                PPPicture picture = slide.AddPicture(imagePath, left, top, width, height);
+                PPTable table = slide.AddTable(2, 2, left, top, width, height);
+
+                Assert.Equal(left, textBox.Left);
+                Assert.Equal(top, textBox.Top);
+                Assert.Equal(width, textBox.Width);
+                Assert.Equal(height, textBox.Height);
+
+                textBox.Left += 1000;
+                picture.Top += 2000;
+                table.Width += 3000;
+
+                presentation.Save();
+            }
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                PowerPointSlide slide = presentation.Slides.Single();
+                PPTextBox textBox = slide.TextBoxes.First();
+                PPPicture picture = slide.Pictures.First();
+                PPTable table = slide.Tables.First();
+
+                Assert.Equal(left + 1000, textBox.Left);
+                Assert.Equal(top, textBox.Top);
+                Assert.Equal(top + 2000, picture.Top);
+                Assert.Equal(left, picture.Left);
+                Assert.Equal(width + 3000, table.Width);
+                Assert.Equal(height, table.Height);
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow specifying left/top/width/height when adding text boxes, pictures, and tables
- expose Left/Top/Width/Height on PPShape for later adjustment
- add example and tests demonstrating shape positioning

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter PowerPointShapePosition`


------
https://chatgpt.com/codex/tasks/task_e_68a40c6ecaa4832eb0218eebe53d3f83