### PR TITLE
Make code coverage reporting informational

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -108,6 +108,8 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: '**/coverage.cobertura.xml'
+          fail_ci_if_error: false
+        continue-on-error: true
 
   test-ubuntu:
     name: 'Ubuntu'
@@ -183,6 +185,8 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: '**/coverage.cobertura.xml'
+          fail_ci_if_error: false
+        continue-on-error: true
 
   test-macos:
     name: 'macOS'
@@ -258,4 +262,6 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: '**/coverage.cobertura.xml'
+          fail_ci_if_error: false
+        continue-on-error: true
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Summary
- avoid failing CI when Codecov upload has issues
- mark Codecov project and patch statuses as informational

## Testing
- `dotnet restore OfficeImo.sln`
- `dotnet build OfficeImo.sln --configuration Release`
- `dotnet test OfficeImo.sln --configuration Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68a40ccef89c832e8c2db2405741eee5