### PR TITLE
Fix null reference warnings in PowerPoint project

### DIFF
--- a/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
+++ b/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
@@ -5,6 +5,10 @@ namespace OfficeIMO.PowerPoint.Fluent {
     public class PowerPointFluentPresentation {
         internal PowerPointPresentation Presentation { get; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PowerPointFluentPresentation"/> class.
+        /// </summary>
+        /// <param name="presentation">Presentation to wrap.</param>
         public PowerPointFluentPresentation(PowerPointPresentation presentation) {
             Presentation = presentation ?? throw new System.ArgumentNullException(nameof(presentation));
         }

--- a/OfficeIMO.PowerPoint/PPNotes.cs
+++ b/OfficeIMO.PowerPoint/PPNotes.cs
@@ -41,18 +41,20 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public string Text {
             get {
-                A.Run run = NotesSlide.CommonSlideData!.ShapeTree.GetFirstChild<Shape>()!
-                    .TextBody!.GetFirstChild<A.Paragraph>()!
-                    .GetFirstChild<A.Run>()!;
-                A.Text text = run.GetFirstChild<A.Text>()!;
-                return text.Text ?? string.Empty;
+                Shape? shape = NotesSlide.CommonSlideData?.ShapeTree?.GetFirstChild<Shape>();
+                A.Paragraph? paragraph = shape?.TextBody?.GetFirstChild<A.Paragraph>();
+                A.Run? run = paragraph?.GetFirstChild<A.Run>();
+                A.Text? text = run?.GetFirstChild<A.Text>();
+                return text?.Text ?? string.Empty;
             }
             set {
-                A.Run run = NotesSlide.CommonSlideData!.ShapeTree.GetFirstChild<Shape>()!
-                    .TextBody!.GetFirstChild<A.Paragraph>()!
-                    .GetFirstChild<A.Run>()!;
-                A.Text text = run.GetFirstChild<A.Text>()!;
-                text.Text = value;
+                Shape? shape = NotesSlide.CommonSlideData?.ShapeTree?.GetFirstChild<Shape>();
+                A.Paragraph? paragraph = shape?.TextBody?.GetFirstChild<A.Paragraph>();
+                A.Run? run = paragraph?.GetFirstChild<A.Run>();
+                A.Text? text = run?.GetFirstChild<A.Text>();
+                if (text != null) {
+                    text.Text = value;
+                }
             }
         }
 

--- a/OfficeIMO.PowerPoint/PPShape.cs
+++ b/OfficeIMO.PowerPoint/PPShape.cs
@@ -20,11 +20,11 @@ namespace OfficeIMO.PowerPoint {
             get {
                 switch (Element) {
                     case Shape s:
-                        return s.NonVisualShapeProperties?.NonVisualDrawingProperties.Name?.Value;
+                        return s.NonVisualShapeProperties?.NonVisualDrawingProperties?.Name?.Value;
                     case Picture p:
-                        return p.NonVisualPictureProperties?.NonVisualDrawingProperties.Name?.Value;
+                        return p.NonVisualPictureProperties?.NonVisualDrawingProperties?.Name?.Value;
                     case GraphicFrame g:
-                        return g.NonVisualGraphicFrameProperties?.NonVisualDrawingProperties.Name?.Value;
+                        return g.NonVisualGraphicFrameProperties?.NonVisualDrawingProperties?.Name?.Value;
                     default:
                         return null;
                 }

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -27,8 +27,11 @@ namespace OfficeIMO.PowerPoint {
 
             if (_presentationPart.Presentation.SlideIdList != null) {
                 foreach (SlideId slideId in _presentationPart.Presentation.SlideIdList.Elements<SlideId>()) {
-                    SlidePart slidePart = (SlidePart)_presentationPart.GetPartById(slideId.RelationshipId);
-                    _slides.Add(new PowerPointSlide(slidePart));
+                    string? relId = slideId.RelationshipId;
+                    if (!string.IsNullOrEmpty(relId)) {
+                        SlidePart slidePart = (SlidePart)_presentationPart.GetPartById(relId);
+                        _slides.Add(new PowerPointSlide(slidePart));
+                    }
                 }
             }
         }
@@ -82,7 +85,7 @@ namespace OfficeIMO.PowerPoint {
 
             uint maxId = 255;
             if (_presentationPart.Presentation.SlideIdList.Elements<SlideId>().Any()) {
-                maxId = _presentationPart.Presentation.SlideIdList.Elements<SlideId>().Max(s => s.Id!.Value);
+                maxId = _presentationPart.Presentation.SlideIdList.Elements<SlideId>().Max(s => s.Id?.Value ?? 0);
             }
             SlideId slideId = new SlideId {
                 Id = maxId + 1,
@@ -157,7 +160,7 @@ namespace OfficeIMO.PowerPoint {
         public string ThemeName {
             get {
                 SlideMasterPart master = _presentationPart.SlideMasterParts.First();
-                return master.ThemePart?.Theme?.Name ?? string.Empty;
+                return master.ThemePart?.Theme?.Name?.Value ?? string.Empty;
             }
             set {
                 SlideMasterPart master = _presentationPart.SlideMasterParts.First();

--- a/OfficeIMO.PowerPoint/PowerPointSlide.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.cs
@@ -90,22 +90,24 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public string? BackgroundColor {
             get {
-                Background? bg = _slidePart.Slide.CommonSlideData!.Background;
+                CommonSlideData? common = _slidePart.Slide.CommonSlideData;
+                Background? bg = common?.Background;
                 A.SolidFill? solid = bg?.BackgroundProperties?.GetFirstChild<A.SolidFill>();
                 return solid?.RgbColorModelHex?.Val;
             }
             set {
+                CommonSlideData common = _slidePart.Slide.CommonSlideData ??= new CommonSlideData(new ShapeTree());
                 if (value == null) {
-                    _slidePart.Slide.CommonSlideData!.Background = null;
+                    common.Background = null;
                     return;
                 }
 
-                Background bg = _slidePart.Slide.CommonSlideData!.Background ?? new Background();
+                Background bg = common.Background ?? new Background();
                 BackgroundProperties props = bg.BackgroundProperties ?? new BackgroundProperties();
                 props.RemoveAllChildren<A.SolidFill>();
                 props.Append(new A.SolidFill(new A.RgbColorModelHex { Val = value }));
                 bg.BackgroundProperties = props;
-                _slidePart.Slide.CommonSlideData!.Background = bg;
+                common.Background = bg;
             }
         }
 
@@ -154,7 +156,10 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public int LayoutIndex {
             get {
-                SlideLayoutPart layoutPart = _slidePart.SlideLayoutPart!;
+                SlideLayoutPart? layoutPart = _slidePart.SlideLayoutPart;
+                if (layoutPart == null) {
+                    return -1;
+                }
                 SlideMasterPart master = layoutPart.GetParentParts().OfType<SlideMasterPart>().First();
                 SlideLayoutPart[] layouts = master.SlideLayoutParts.ToArray();
                 for (int i = 0; i < layouts.Length; i++) {
@@ -194,7 +199,9 @@ namespace OfficeIMO.PowerPoint {
                 )
             );
 
-            _slidePart.Slide.CommonSlideData!.ShapeTree.AppendChild(shape);
+            CommonSlideData data = _slidePart.Slide.CommonSlideData ??= new CommonSlideData(new ShapeTree());
+            ShapeTree tree = data.ShapeTree ??= new ShapeTree();
+            tree.AppendChild(shape);
             PPTextBox textBox = new(shape);
             _shapes.Add(textBox);
             return textBox;
@@ -224,7 +231,9 @@ namespace OfficeIMO.PowerPoint {
                     new A.PresetGeometry(new A.AdjustValueList()) { Preset = A.ShapeTypeValues.Rectangle })
             );
 
-            _slidePart.Slide.CommonSlideData!.ShapeTree.AppendChild(picture);
+            CommonSlideData data = _slidePart.Slide.CommonSlideData ??= new CommonSlideData(new ShapeTree());
+            ShapeTree tree = data.ShapeTree ??= new ShapeTree();
+            tree.AppendChild(picture);
             PPPicture pic = new(picture);
             _shapes.Add(pic);
             return pic;
@@ -268,7 +277,9 @@ namespace OfficeIMO.PowerPoint {
                 new A.Graphic(new A.GraphicData(table) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/table" })
             );
 
-            _slidePart.Slide.CommonSlideData!.ShapeTree.AppendChild(frame);
+            CommonSlideData data = _slidePart.Slide.CommonSlideData ??= new CommonSlideData(new ShapeTree());
+            ShapeTree tree = data.ShapeTree ??= new ShapeTree();
+            tree.AppendChild(frame);
             PPTable tbl = new(frame);
             _shapes.Add(tbl);
             return tbl;
@@ -293,7 +304,9 @@ namespace OfficeIMO.PowerPoint {
                 new A.Graphic(new A.GraphicData(new C.ChartReference { Id = relId }) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/chart" })
             );
 
-            _slidePart.Slide.CommonSlideData!.ShapeTree.AppendChild(frame);
+            CommonSlideData data = _slidePart.Slide.CommonSlideData ??= new CommonSlideData(new ShapeTree());
+            ShapeTree tree = data.ShapeTree ??= new ShapeTree();
+            tree.AppendChild(frame);
             PPChart chart = new(frame);
             _shapes.Add(chart);
             return chart;
@@ -361,7 +374,10 @@ namespace OfficeIMO.PowerPoint {
         }
 
         private void LoadExistingShapes() {
-            ShapeTree tree = _slidePart.Slide.CommonSlideData!.ShapeTree;
+            ShapeTree? tree = _slidePart.Slide.CommonSlideData?.ShapeTree;
+            if (tree == null) {
+                return;
+            }
             foreach (OpenXmlElement element in tree.ChildElements) {
                 switch (element) {
                     case Shape s when s.TextBody != null:

--- a/OfficeIMO.PowerPoint/SlideTransition.cs
+++ b/OfficeIMO.PowerPoint/SlideTransition.cs
@@ -3,8 +3,11 @@ namespace OfficeIMO.PowerPoint {
     /// Represents simple slide transitions.
     /// </summary>
     public enum SlideTransition {
+        /// <summary>No transition is applied.</summary>
         None,
+        /// <summary>Fade between slides.</summary>
         Fade,
+        /// <summary>Wipe transition between slides.</summary>
         Wipe
     }
 }


### PR DESCRIPTION
## Summary
- guard PowerPoint slide part lookups against missing relationship IDs
- avoid null dereferences across PowerPoint shapes, notes, and slides
- document slide transition options and fluent wrapper constructor

## Testing
- `dotnet build OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a4111e8c4c832e954d697a33de723d