### PR TITLE
Refactor Word APIs to reduce nullable warnings

### DIFF
--- a/OfficeIMO.Word/ExtensionsHeadersAndFooters.cs
+++ b/OfficeIMO.Word/ExtensionsHeadersAndFooters.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
@@ -40,7 +39,7 @@ namespace OfficeIMO.Word {
             var sectionProperties = section._sectionProperties;
 
             foreach (var element in sectionProperties.ChildElements.OfType<HeaderReference>()) {
-                if (element.Type == headerFooterValue) {
+                if (element.Type?.Value == headerFooterValue) {
                     // we found the header reference already exists; we do nothing;
                     return true;
                 }
@@ -59,7 +58,7 @@ namespace OfficeIMO.Word {
         internal static bool GetFooterReference(WordDocument document, WordSection section, HeaderFooterValues headerFooterValue) {
             var sectionProperties = section._sectionProperties;
             foreach (var element in sectionProperties.ChildElements.OfType<FooterReference>()) {
-                if (element.Type == headerFooterValue) {
+                if (element.Type?.Value == headerFooterValue) {
                     return true;
                 }
             }
@@ -76,19 +75,19 @@ namespace OfficeIMO.Word {
             var sectionProperties = section._sectionProperties;
 
             foreach (var element in sectionProperties.ChildElements.OfType<HeaderReference>()) {
-                if (element.Type == headerFooterValue) {
+                if (element.Type?.Value == headerFooterValue) {
                     // we found the header reference already exists; we do nothing;
                     return;
                 }
             }
 
-            var headerPart = document._wordprocessingDocument.MainDocumentPart.AddNewPart<HeaderPart>();
+            var headerPart = document._wordprocessingDocument.MainDocumentPart!.AddNewPart<HeaderPart>();
 
             var header = new Header();
             header.Save(headerPart);
 
             if (headerPart != null) {
-                var id = document._wordprocessingDocument.MainDocumentPart.GetIdOfPart(headerPart);
+                var id = document._wordprocessingDocument.MainDocumentPart!.GetIdOfPart(headerPart);
                 //var id1 = document._wordprocessingDocument.MainDocumentPart.GetIdOfPart(part.HeaderParts.FirstOrDefault());
 
                 if (id != null) {
@@ -121,22 +120,19 @@ namespace OfficeIMO.Word {
         internal static void AddFooterReference(WordDocument document, WordSection section, HeaderFooterValues headerFooterValue) {
             var sectionProperties = section._sectionProperties;
             foreach (var element in sectionProperties.ChildElements.OfType<FooterReference>()) {
-                if (element.Type == headerFooterValue) {
+                if (element.Type?.Value == headerFooterValue) {
                     // we found the footer reference already exists; we do nothing;
                     return;
                 }
             }
 
-            var footerPart = document._wordprocessingDocument.MainDocumentPart.AddNewPart<FooterPart>();
-
-            MainDocumentPart part = document._wordprocessingDocument.MainDocumentPart;
-            Body body = document._wordprocessingDocument.MainDocumentPart.Document.Body;
+            var footerPart = document._wordprocessingDocument.MainDocumentPart!.AddNewPart<FooterPart>();
 
             var footer = new Footer();
             footer.Save(footerPart);
 
             if (footerPart != null) {
-                var id = document._wordprocessingDocument.MainDocumentPart.GetIdOfPart(footerPart);
+                var id = document._wordprocessingDocument.MainDocumentPart!.GetIdOfPart(footerPart);
                 if (id != null) {
                     var footerReference = new FooterReference() {
                         Type = headerFooterValue,
@@ -165,7 +161,7 @@ namespace OfficeIMO.Word {
         /// <returns></returns>
         internal static SectionProperties AddSectionProperties(this WordprocessingDocument wordDocument) {
             var sectionProperties = CreateSectionProperties();
-            wordDocument.MainDocumentPart.Document.Body.Append(sectionProperties);
+            wordDocument.MainDocumentPart!.Document!.Body!.Append(sectionProperties);
             return sectionProperties;
         }
 

--- a/OfficeIMO.Word/Fluent/WordFluentDocument.cs
+++ b/OfficeIMO.Word/Fluent/WordFluentDocument.cs
@@ -8,65 +8,119 @@ namespace OfficeIMO.Word.Fluent {
     public class WordFluentDocument {
         internal WordDocument Document { get; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WordFluentDocument"/> class.
+        /// </summary>
+        /// <param name="document">The underlying <see cref="WordDocument"/>.</param>
         public WordFluentDocument(WordDocument document) {
             Document = document ?? throw new ArgumentNullException(nameof(document));
         }
 
+        /// <summary>
+        /// Provides fluent access to document information.
+        /// </summary>
+        /// <param name="action">Action that receives an <see cref="InfoBuilder"/>.</param>
         public WordFluentDocument Info(Action<InfoBuilder> action) {
             action(new InfoBuilder(this));
             return this;
         }
 
+        /// <summary>
+        /// Configures document sections.
+        /// </summary>
+        /// <param name="action">Action that receives a <see cref="SectionBuilder"/>.</param>
         public WordFluentDocument Section(Action<SectionBuilder> action) {
             action(new SectionBuilder(this));
             return this;
         }
 
+        /// <summary>
+        /// Configures page settings.
+        /// </summary>
+        /// <param name="action">Action that receives a <see cref="PageBuilder"/>.</param>
         public WordFluentDocument Page(Action<PageBuilder> action) {
             action(new PageBuilder(this));
             return this;
         }
 
+        /// <summary>
+        /// Adds or modifies a paragraph.
+        /// </summary>
+        /// <param name="action">Action that receives a <see cref="ParagraphBuilder"/>.</param>
         public WordFluentDocument Paragraph(Action<ParagraphBuilder> action) {
             action(new ParagraphBuilder(this));
             return this;
         }
 
+        /// <summary>
+        /// Adds or modifies a text run.
+        /// </summary>
+        /// <param name="action">Action that receives a <see cref="RunBuilder"/>.</param>
         public WordFluentDocument Run(Action<RunBuilder> action) {
             action(new RunBuilder(this));
             return this;
         }
 
+        /// <summary>
+        /// Adds or modifies a list.
+        /// </summary>
+        /// <param name="action">Action that receives a <see cref="ListBuilder"/>.</param>
         public WordFluentDocument List(Action<ListBuilder> action) {
             action(new ListBuilder(this));
             return this;
         }
 
+        /// <summary>
+        /// Adds or modifies a table.
+        /// </summary>
+        /// <param name="action">Action that receives a <see cref="TableBuilder"/>.</param>
         public WordFluentDocument Table(Action<TableBuilder> action) {
             action(new TableBuilder(this));
             return this;
         }
 
+        /// <summary>
+        /// Adds or modifies an image.
+        /// </summary>
+        /// <param name="action">Action that receives an <see cref="ImageBuilder"/>.</param>
         public WordFluentDocument Image(Action<ImageBuilder> action) {
             action(new ImageBuilder(this));
             return this;
         }
 
+        /// <summary>
+        /// Configures document headers.
+        /// </summary>
+        /// <param name="action">Action that receives a <see cref="HeadersBuilder"/>.</param>
         public WordFluentDocument Header(Action<HeadersBuilder> action) {
             action(new HeadersBuilder(this));
             return this;
         }
 
+        /// <summary>
+        /// Configures document footers.
+        /// </summary>
+        /// <param name="action">Action that receives a <see cref="FootersBuilder"/>.</param>
         public WordFluentDocument Footer(Action<FootersBuilder> action) {
             action(new FootersBuilder(this));
             return this;
         }
 
+        /// <summary>
+        /// Executes an action for each paragraph in the document.
+        /// </summary>
+        /// <param name="action">Action to execute for every paragraph.</param>
         public WordFluentDocument ForEachParagraph(Action<ParagraphBuilder> action) {
             Document.ForEachParagraph(p => action(new ParagraphBuilder(this, p)));
             return this;
         }
 
+        /// <summary>
+        /// Finds paragraphs containing the specified text.
+        /// </summary>
+        /// <param name="text">Text to search for.</param>
+        /// <param name="action">Action executed for each matching paragraph.</param>
+        /// <param name="stringComparison">String comparison option.</param>
         public WordFluentDocument Find(string text, Action<ParagraphBuilder> action, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase) {
             foreach (var paragraph in Document.FindParagraphs(text, stringComparison)) {
                 action(new ParagraphBuilder(this, paragraph));
@@ -74,6 +128,10 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Selects paragraphs that match the specified predicate.
+        /// </summary>
+        /// <param name="predicate">Filter predicate.</param>
         public IEnumerable<ParagraphBuilder> Select(Func<ParagraphBuilder, bool> predicate) {
             foreach (var paragraph in Document.SelectParagraphs(p => predicate(new ParagraphBuilder(this, p)))) {
                 yield return new ParagraphBuilder(this, paragraph);

--- a/OfficeIMO.Word/WordBackground.cs
+++ b/OfficeIMO.Word/WordBackground.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.IO;
 using DocumentFormat.OpenXml.Wordprocessing;
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
@@ -16,20 +14,25 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the background color as a hex string.
         /// </summary>
-        public string Color {
+        public string? Color {
             get {
-                if (_document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground != null) {
-                    return _document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground.Color;
+                var mainPart = _document._wordprocessingDocument.MainDocumentPart;
+                if (mainPart?.Document?.DocumentBackground != null) {
+                    return mainPart.Document.DocumentBackground.Color;
                 }
 
                 return null;
             }
             set {
-                _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings.DisplayBackgroundShape = new DisplayBackgroundShape();
-                if (_document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground == null) {
-                    _document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground = new DocumentBackground();
+                var mainPart = _document._wordprocessingDocument.MainDocumentPart;
+                var settings = mainPart?.DocumentSettingsPart?.Settings;
+                if (settings != null) {
+                    settings.DisplayBackgroundShape = new DisplayBackgroundShape();
                 }
-                _document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground.Color = value;
+                if (mainPart?.Document?.DocumentBackground == null) {
+                    mainPart!.Document!.DocumentBackground = new DocumentBackground();
+                }
+                mainPart!.Document!.DocumentBackground!.Color = value;
             }
         }
 
@@ -53,7 +56,7 @@ namespace OfficeIMO.Word {
 
             DocumentBackground documentBackground = new DocumentBackground() { Color = color.ToHexColor() };
 
-            document._document.Body.Append(documentBackground);
+            document._document.Body!.Append(documentBackground);
 
             //DocumentBackground documentBackground2 = new DocumentBackground() { Color = "BF8F00", ThemeColor = ThemeColorValues.Accent4, ThemeShade = "BF" };
         }
@@ -101,17 +104,17 @@ namespace OfficeIMO.Word {
             if (string.IsNullOrEmpty(fileName)) throw new ArgumentNullException(nameof(fileName));
 
             var paragraph = new DocumentFormat.OpenXml.Wordprocessing.Paragraph();
-            _document._document.Body.Append(paragraph);
+            _document._document.Body!.Append(paragraph);
             var wordParagraph = new WordParagraph(_document, paragraph);
             var wordImage = new WordImage(_document, wordParagraph, imageStream, fileName, width, height, WrapTextImage.BehindText);
             paragraph.Remove();
 
-            _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings.DisplayBackgroundShape = new DisplayBackgroundShape();
-            if (_document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground == null) {
-                _document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground = new DocumentBackground();
+            _document._wordprocessingDocument.MainDocumentPart!.DocumentSettingsPart!.Settings!.DisplayBackgroundShape = new DisplayBackgroundShape();
+            if (_document._wordprocessingDocument.MainDocumentPart!.Document!.DocumentBackground == null) {
+                _document._wordprocessingDocument.MainDocumentPart!.Document!.DocumentBackground = new DocumentBackground();
             }
 
-            var background = _document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground;
+            var background = _document._wordprocessingDocument.MainDocumentPart!.Document!.DocumentBackground!;
             background.RemoveAllChildren<DocumentFormat.OpenXml.Wordprocessing.Drawing>();
             background.Color = null;
             background.Append((DocumentFormat.OpenXml.Wordprocessing.Drawing)wordImage._Image.CloneNode(true));

--- a/OfficeIMO.Word/WordChart.Properties.cs
+++ b/OfficeIMO.Word/WordChart.Properties.cs
@@ -11,15 +11,15 @@ namespace OfficeIMO.Word {
         private const long EnglishMetricUnitsPerInch = 914400;
         private const long PixelsPerInch = 96;
         private readonly WordDocument _document;
-        private WordParagraph _paragraph;
-        private ChartPart _chartPart {
+        private WordParagraph? _paragraph;
+        private ChartPart? _chartPart {
             get {
                 if (_drawing == null) {
                     return null;
-                } else {
-                    var id = _drawing.Inline.Graphic.GraphicData.GetFirstChild<ChartReference>().Id;
-                    return (ChartPart)_document._wordprocessingDocument.MainDocumentPart.GetPartById(id);
                 }
+                var chartRef = _drawing.Inline?.Graphic?.GraphicData?.GetFirstChild<ChartReference>();
+                var id = chartRef?.Id;
+                return id != null ? (ChartPart?)_document._wordprocessingDocument.MainDocumentPart!.GetPartById(id) : null;
             }
         }
         private Drawing _drawing;
@@ -46,11 +46,9 @@ namespace OfficeIMO.Word {
             get {
                 if (_chartPart != null) {
                     var chart = _chartPart.ChartSpace.GetFirstChild<Chart>();
-                    if (chart != null) {
-                        var barChart = chart.PlotArea.GetFirstChild<BarChart>();
-                        if (barChart != null) {
-                            return barChart.BarGrouping.Val;
-                        }
+                    var barChart = chart?.PlotArea?.GetFirstChild<BarChart>();
+                    if (barChart?.BarGrouping != null) {
+                        return barChart.BarGrouping.Val;
                     }
                 }
 
@@ -59,13 +57,9 @@ namespace OfficeIMO.Word {
             set {
                 if (_chartPart != null) {
                     var chart = _chartPart.ChartSpace.GetFirstChild<Chart>();
-                    if (chart != null) {
-                        var barChart = chart.PlotArea.GetFirstChild<BarChart>();
-                        if (barChart != null) {
-                            if (barChart.BarGrouping != null) {
-                                barChart.BarGrouping.Val = value;
-                            }
-                        }
+                    var barChart = chart?.PlotArea?.GetFirstChild<BarChart>();
+                    if (barChart?.BarGrouping != null) {
+                        barChart.BarGrouping.Val = value;
                     }
                 }
             }
@@ -77,11 +71,9 @@ namespace OfficeIMO.Word {
             get {
                 if (_chartPart != null) {
                     var chart = _chartPart.ChartSpace.GetFirstChild<Chart>();
-                    if (chart != null) {
-                        var barChart = chart.PlotArea.GetFirstChild<BarChart>();
-                        if (barChart != null) {
-                            return barChart.BarDirection.Val;
-                        }
+                    var barChart = chart?.PlotArea?.GetFirstChild<BarChart>();
+                    if (barChart?.BarDirection != null) {
+                        return barChart.BarDirection.Val;
                     }
                 }
 
@@ -90,15 +82,9 @@ namespace OfficeIMO.Word {
             set {
                 if (_chartPart != null) {
                     var chart = _chartPart.ChartSpace.GetFirstChild<Chart>();
-                    if (chart != null) {
-                        if (chart.PlotArea != null) {
-                            var barChart = chart.PlotArea.GetFirstChild<BarChart>();
-                            if (barChart != null) {
-                                if (barChart.BarDirection != null) {
-                                    barChart.BarDirection.Val = value;
-                                }
-                            }
-                        }
+                    var barChart = chart?.PlotArea?.GetFirstChild<BarChart>();
+                    if (barChart?.BarDirection != null) {
+                        barChart.BarDirection.Val = value;
                     }
                 }
             }
@@ -108,14 +94,15 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool RoundedCorners {
             get {
-                var roundedCorners = _chartPart.ChartSpace.GetFirstChild<RoundedCorners>();
-                if (roundedCorners != null) {
+                var roundedCorners = _chartPart?.ChartSpace.GetFirstChild<RoundedCorners>();
+                if (roundedCorners?.Val != null) {
                     return roundedCorners.Val;
                 }
 
                 return true;
             }
             set {
+                if (_chartPart == null) return;
                 var roundedCorners = _chartPart.ChartSpace.GetFirstChild<RoundedCorners>();
                 if (roundedCorners == null) {
                     roundedCorners = new RoundedCorners() { Val = value };
@@ -140,9 +127,9 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Get or set the title of the chart
         /// </summary>
-        public string Title {
+        public string? Title {
             get {
-                if (_chart != null && _chart.Title != null) {
+                if (_chart?.Title != null) {
                     var text = _chart.Title.Descendants<DocumentFormat.OpenXml.Drawing.Text>().FirstOrDefault();
                     if (text != null) {
                         return text.Text;
@@ -155,7 +142,7 @@ namespace OfficeIMO.Word {
             }
             set {
                 if (_chart != null) {
-                    SetTitle(value);
+                    SetTitle(value!);
                 }
                 PrivateTitle = value;
             }

--- a/OfficeIMO.Word/WordChart.PublicMethods.cs
+++ b/OfficeIMO.Word/WordChart.PublicMethods.cs
@@ -56,12 +56,10 @@ namespace OfficeIMO.Word {
         /// <param name="color">Line color.</param>
         public void AddChartLine<T>(string name, int[] values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsLine();
-            if (_chart != null) {
-                var lineChart = _chart.PlotArea.GetFirstChild<LineChart>();
-                if (lineChart != null) {
-                    LineChartSeries lineChartSeries = AddLineChartSeries(this._index, name, color, this.Categories, values.ToList());
-                    InsertSeries(lineChart, lineChartSeries);
-                }
+            var lineChart = _chart?.PlotArea?.GetFirstChild<LineChart>();
+            if (lineChart != null) {
+                LineChartSeries lineChartSeries = AddLineChartSeries(this._index, name, color, this.Categories, values.ToList());
+                InsertSeries(lineChart, lineChartSeries);
             }
         }
 
@@ -76,7 +74,7 @@ namespace OfficeIMO.Word {
         /// <param name="color"></param>
         public void AddLine<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsLine();
-            var lineChart = _chart.PlotArea.GetFirstChild<LineChart>();
+            var lineChart = _chart?.PlotArea?.GetFirstChild<LineChart>();
             if (lineChart != null) {
                 LineChartSeries lineChartSeries = AddLineChartSeries(this._index, name, color, this.Categories, values);
                 InsertSeries(lineChart, lineChartSeries);
@@ -100,7 +98,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public void AddBar(string name, int values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsBar();
-            var barChart = _chart.PlotArea.GetFirstChild<BarChart>();
+            var barChart = _chart?.PlotArea?.GetFirstChild<BarChart>();
             if (barChart != null) {
                 BarChartSeries barChartSeries = AddBarChartSeries(this._index, name, color, this.Categories, new List<int>() { values });
                 InsertSeries(barChart, barChartSeries);
@@ -114,7 +112,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public void AddBar<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsBar();
-            var barChart = _chart.PlotArea.GetFirstChild<BarChart>();
+            var barChart = _chart?.PlotArea?.GetFirstChild<BarChart>();
             if (barChart != null) {
                 BarChartSeries barChartSeries = AddBarChartSeries(this._index, name, color, this.Categories, values);
                 InsertSeries(barChart, barChartSeries);
@@ -197,12 +195,10 @@ namespace OfficeIMO.Word {
         /// <param name="color">Color of the series.</param>
         public void AddRadar<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsRadar();
-            if (_chart != null) {
-                var radarChart = _chart.PlotArea.GetFirstChild<RadarChart>();
-                if (radarChart != null) {
-                    var series = AddRadarChartSeries(this._index, name, color, this.Categories, values);
-                    InsertSeries(radarChart, series);
-                }
+            var radarChart = _chart?.PlotArea?.GetFirstChild<RadarChart>();
+            if (radarChart != null) {
+                var series = AddRadarChartSeries(this._index, name, color, this.Categories, values);
+                InsertSeries(radarChart, series);
             }
         }
         /// <summary>
@@ -214,26 +210,24 @@ namespace OfficeIMO.Word {
         /// <param name="color">Color of the bars.</param>
         public void AddBar3D<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsBar3D();
-            if (_chart != null) {
-                var chart3d = _chart.PlotArea.GetFirstChild<Bar3DChart>();
-                if (chart3d != null) {
-                    var series = AddBar3DChartSeries(this._index, name, color, this.Categories, values);
+            var chart3d = _chart?.PlotArea?.GetFirstChild<Bar3DChart>();
+            if (chart3d != null) {
+                var series = AddBar3DChartSeries(this._index, name, color, this.Categories, values);
 
-                    // For Bar3DChart, we need special handling to maintain correct element order:
-                    // barDir, grouping, varyColors, ser, dLbls, gapWidth, gapDepth, shape, axId, extLst
-                    var axis = chart3d.Elements<AxisId>().FirstOrDefault();
-                    if (axis != null) {
-                        chart3d.InsertBefore(series, axis);
+                // For Bar3DChart, we need special handling to maintain correct element order:
+                // barDir, grouping, varyColors, ser, dLbls, gapWidth, gapDepth, shape, axId, extLst
+                var axis = chart3d.Elements<AxisId>().FirstOrDefault();
+                if (axis != null) {
+                    chart3d.InsertBefore(series, axis);
 
-                        // Ensure gapWidth is present and in correct position (after all ser elements, before axId)
-                        var gapWidth = chart3d.GetFirstChild<GapWidth>();
-                        if (gapWidth == null) {
-                            gapWidth = new GapWidth() { Val = (UInt16Value)150U };
-                            chart3d.InsertBefore(gapWidth, axis);
-                        }
-                    } else {
-                        chart3d.Append(series);
+                    // Ensure gapWidth is present and in correct position (after all ser elements, before axId)
+                    var gapWidth = chart3d.GetFirstChild<GapWidth>();
+                    if (gapWidth == null) {
+                        gapWidth = new GapWidth() { Val = (UInt16Value)150U };
+                        chart3d.InsertBefore(gapWidth, axis);
                     }
+                } else {
+                    chart3d.Append(series);
                 }
             }
         }
@@ -255,13 +249,11 @@ namespace OfficeIMO.Word {
         /// </remarks>
         public void AddLine3D<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsLine3D();
-            if (_chart != null) {
-                var line3d = _chart.PlotArea.GetFirstChild<Line3DChart>();
-                if (line3d != null) {
-                    var series = AddLine3DChartSeries(this._index, name, color, this.Categories, values);
-                    // Insert series in the correct schema position (after varyColors, before dLbls)
-                    InsertSeries(line3d, series);
-                }
+            var line3d = _chart?.PlotArea?.GetFirstChild<Line3DChart>();
+            if (line3d != null) {
+                var series = AddLine3DChartSeries(this._index, name, color, this.Categories, values);
+                // Insert series in the correct schema position (after varyColors, before dLbls)
+                InsertSeries(line3d, series);
             }
         }
 
@@ -274,12 +266,10 @@ namespace OfficeIMO.Word {
         /// <param name="color">Series color.</param>
         public void AddArea3D<T>(string name, List<T> values, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsArea3D();
-            if (_chart != null) {
-                var area3d = _chart.PlotArea.GetFirstChild<Area3DChart>();
-                if (area3d != null) {
-                    var series = AddArea3DChartSeries(this._index, name, color, this.Categories, values);
-                    InsertSeries(area3d, series);
-                }
+            var area3d = _chart?.PlotArea?.GetFirstChild<Area3DChart>();
+            if (area3d != null) {
+                var series = AddArea3DChartSeries(this._index, name, color, this.Categories, values);
+                InsertSeries(area3d, series);
             }
         }
 

--- a/OfficeIMO.Word/WordEndNote.cs
+++ b/OfficeIMO.Word/WordEndNote.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
@@ -31,43 +30,45 @@ namespace OfficeIMO.Word {
         /// Zero based object should be skipped, as it's EndNoteReference
         /// However for sake of completion and potential ability to modify it we expose it as well
         /// </summary>
-        public List<WordParagraph> Paragraphs {
-            get {
-                if (_paragraph != null && _run != null) {
-                    long referenceId = 0;
-                    var endNoteReference = _run.ChildElements.OfType<EndnoteReference>().FirstOrDefault();
-                    if (endNoteReference != null) {
-                        referenceId = endNoteReference.Id;
-                    }
+          public List<WordParagraph>? Paragraphs {
+              get {
+                  if (_paragraph != null && _run != null) {
+                      long referenceId = 0;
+                      var endNoteReference = _run.ChildElements.OfType<EndnoteReference>().FirstOrDefault();
+                      if (endNoteReference != null) {
+                          referenceId = endNoteReference.Id;
+                      }
 
-                    if (referenceId != 0) {
-                        var endNotesPart = _document._wordprocessingDocument.MainDocumentPart.EndnotesPart;
-                        var endNotes = endNotesPart.Endnotes.ChildElements.OfType<Endnote>().ToList();
-                        foreach (var endNote in endNotes) {
-                            if (endNote != null) {
-                                if (endNote.Id == referenceId.ToString()) {
-                                    return WordSection.ConvertParagraphsToWordParagraphs(_document, endNote.OfType<Paragraph>());
-                                }
-                            }
-                        }
-                    }
-                }
-                return null;
-            }
-        }
+                      if (referenceId != 0) {
+                          var endNotesPart = _document._wordprocessingDocument.MainDocumentPart?.EndnotesPart;
+                          var endNotes = endNotesPart?.Endnotes?.ChildElements.OfType<Endnote>().ToList();
+                          if (endNotes != null) {
+                              foreach (var endNote in endNotes) {
+                                  if (endNote != null) {
+                                      if (endNote.Id == referenceId.ToString()) {
+                                          return WordSection.ConvertParagraphsToWordParagraphs(_document, endNote.OfType<Paragraph>());
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                  }
+                  return null;
+              }
+          }
 
         /// <summary>
         /// Parent paragraph containing the endnote reference.
         /// </summary>
-        public WordParagraph ParentParagraph {
-            get {
-                var previousRun = _run.PreviousSibling<Run>();
-                if (previousRun != null) {
-                    return new WordParagraph(_document, _paragraph, previousRun);
-                }
-                return null;
-            }
-        }
+          public WordParagraph? ParentParagraph {
+              get {
+                  var previousRun = _run.PreviousSibling<Run>();
+                  if (previousRun != null) {
+                      return new WordParagraph(_document, _paragraph, previousRun);
+                  }
+                  return null;
+              }
+          }
 
         /// <summary>
         /// Gets the endnote reference identifier if available.
@@ -93,15 +94,17 @@ namespace OfficeIMO.Word {
             if (endNoteReference != null) {
                 referenceId = endNoteReference.Id;
             }
-            var endNotesPart = _document._wordprocessingDocument.MainDocumentPart.EndnotesPart;
-            var footNotes = endNotesPart.Endnotes.ChildElements.OfType<Endnote>().ToList();
-            foreach (var footNote in footNotes) {
-                if (footNote != null) {
-                    if (footNote.Id == referenceId.ToString()) {
-                        footNote.Remove();
-                    }
-                }
-            }
+              var endNotesPart = _document._wordprocessingDocument.MainDocumentPart?.EndnotesPart;
+              var footNotes = endNotesPart?.Endnotes?.ChildElements.OfType<Endnote>().ToList();
+              if (footNotes != null) {
+                  foreach (var footNote in footNotes) {
+                      if (footNote != null) {
+                          if (footNote.Id == referenceId.ToString()) {
+                              footNote.Remove();
+                          }
+                      }
+                  }
+              }
             this._run.Remove();
         }
 

--- a/OfficeIMO.Word/WordFootNote.cs
+++ b/OfficeIMO.Word/WordFootNote.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;


### PR DESCRIPTION
## Summary
- add XML comments and fluent helpers for `WordFluentDocument`
- improve null-safety across Word chart/list/section helpers
- add guarded header/footer utilities and background handling

## Testing
- `dotnet build OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a4114bfd3c832eaeb7360a46a2aa90