### PR TITLE
Add null safety to WordSettings

### DIFF
--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -15,15 +15,17 @@ namespace OfficeIMO.Word {
     /// fonts and view options.
     /// </summary>
     public class WordSettings {
-        private WordDocument _document;
+        private readonly WordDocument _document;
 
         /// <summary>
         /// Remove protection from document (if it's set).
         /// </summary>
         public void RemoveProtection() {
-            if (this.ProtectionType != null) {
-                DocumentProtection documentProtection = this._document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings.OfType<DocumentProtection>().FirstOrDefault();
-                documentProtection.Remove();
+            if (ProtectionType != null) {
+                DocumentProtection? documentProtection = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings?
+                    .OfType<DocumentProtection>().FirstOrDefault();
+                documentProtection?.Remove();
             }
         }
 
@@ -32,20 +34,30 @@ namespace OfficeIMO.Word {
         /// </summary>
         public DocumentProtectionValues? ProtectionType {
             get {
-                if (this._document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings != null) {
-                    DocumentProtection documentProtection = this._document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings.OfType<DocumentProtection>().FirstOrDefault();
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                if (settings != null) {
+                    DocumentProtection? documentProtection = settings
+                        .OfType<DocumentProtection>()
+                        .FirstOrDefault();
                     if (documentProtection != null) {
-                        return documentProtection.Edit;
+                        return documentProtection.Edit?.Value;
                     }
                 }
 
                 return null;
             }
             set {
-                if (this._document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings == null) {
-                    this._document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings = new Settings();
+                var settingsPart = _document._wordprocessingDocument.MainDocumentPart?.DocumentSettingsPart;
+                if (settingsPart == null) {
+                    return;
                 }
-                DocumentProtection documentProtection = this._document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings.OfType<DocumentProtection>().FirstOrDefault();
+                if (settingsPart.Settings == null) {
+                    settingsPart.Settings = new Settings();
+                }
+                DocumentProtection? documentProtection = settingsPart.Settings
+                    .OfType<DocumentProtection>()
+                    .FirstOrDefault();
                 if (documentProtection != null) {
                     documentProtection.Edit = value;
                 } else {
@@ -59,7 +71,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string ProtectionPassword {
             set {
-                Security.ProtectWordDoc(this._document._wordprocessingDocument, value);
+                Security.ProtectWordDoc(_document._wordprocessingDocument, value);
             }
         }
 
@@ -68,19 +80,20 @@ namespace OfficeIMO.Word {
         /// </summary>
         public PresetZoomValues? ZoomPreset {
             get {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
-                if (settings.Zoom == null) {
-                    return null;
-                }
-
-                if (settings.Zoom.Val == null) {
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                if (settings?.Zoom?.Val == null) {
                     return null;
                 }
                 return settings.Zoom.Val;
 
             }
             set {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                if (settings == null) {
+                    return;
+                }
                 if (settings.Zoom == null) {
                     settings.Zoom = new Zoom();
                 }
@@ -93,18 +106,27 @@ namespace OfficeIMO.Word {
         /// </summary>
         public CharacterSpacingValues? CharacterSpacingControl {
             get {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
-                var characterSpacingControl = settings.OfType<CharacterSpacingControl>().FirstOrDefault();
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                var characterSpacingControl = settings?
+                    .OfType<CharacterSpacingControl>()
+                    .FirstOrDefault();
                 if (characterSpacingControl == null) {
                     return null;
                 }
 
-                return characterSpacingControl.Val;
+                return characterSpacingControl.Val?.Value;
 
             }
             set {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
-                var characterSpacingControl = settings.OfType<CharacterSpacingControl>().FirstOrDefault();
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                if (settings == null) {
+                    return;
+                }
+                var characterSpacingControl = settings
+                    .OfType<CharacterSpacingControl>()
+                    .FirstOrDefault();
                 if (characterSpacingControl == null) {
                     characterSpacingControl = new CharacterSpacingControl();
                     settings.Append(characterSpacingControl);
@@ -119,20 +141,26 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int DefaultTabStop {
             get {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
-                var defaultStop = settings.OfType<DefaultTabStop>().FirstOrDefault();
-                if (defaultStop == null) {
-                    return 0;
-                }
-                if (defaultStop.Val == null) {
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                var defaultStop = settings?
+                    .OfType<DefaultTabStop>()
+                    .FirstOrDefault();
+                if (defaultStop?.Val == null) {
                     return 0;
                 }
                 return defaultStop.Val;
 
             }
             set {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
-                var defaultStop = settings.OfType<DefaultTabStop>().FirstOrDefault();
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                if (settings == null) {
+                    return;
+                }
+                var defaultStop = settings
+                    .OfType<DefaultTabStop>()
+                    .FirstOrDefault();
                 if (defaultStop == null) {
                     defaultStop = new DefaultTabStop();
                     settings.Append(defaultStop);
@@ -146,21 +174,24 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? ZoomPercentage {
             get {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
-                if (settings.Zoom == null) {
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                var percent = settings?.Zoom?.Percent;
+                if (percent == null) {
                     return null;
                 }
-                if (settings.Zoom.Percent == null) {
-                    return null;
-                }
-                return int.Parse(settings.Zoom.Percent);
+                return int.Parse(percent!);
             }
             set {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                if (settings == null) {
+                    return;
+                }
                 if (settings.Zoom == null) {
                     settings.Zoom = new Zoom();
                 }
-                settings.Zoom.Percent = value.ToString();
+                settings.Zoom.Percent = value?.ToString();
             }
         }
 
@@ -170,19 +201,25 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool UpdateFieldsOnOpen {
             get {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
-                var updateFieldsOnOpen = settings.GetFirstChild<UpdateFieldsOnOpen>();
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                var updateFieldsOnOpen = settings?
+                    .GetFirstChild<UpdateFieldsOnOpen>();
                 if (updateFieldsOnOpen == null) {
                     return false;
                 }
-                return updateFieldsOnOpen.Val;
+                return updateFieldsOnOpen.Val?.Value ?? false;
             }
             set {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                if (settings == null) {
+                    return;
+                }
                 var updateFieldsOnOpen = settings.GetFirstChild<UpdateFieldsOnOpen>();
                 if (updateFieldsOnOpen == null) {
                     updateFieldsOnOpen = new UpdateFieldsOnOpen();
-                    settings.PrependChild<UpdateFieldsOnOpen>(updateFieldsOnOpen);
+                    settings.PrependChild(updateFieldsOnOpen);
                 }
                 updateFieldsOnOpen.Val = value;
             }
@@ -193,13 +230,18 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="document">Document whose settings are managed.</param>
         public WordSettings(WordDocument document) {
+            _ = document ?? throw new ArgumentNullException(nameof(document));
             if (document.FileOpenAccess != FileAccess.Read) {
-                var documentSettingsPart = document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart;
+                var mainPart = document._wordprocessingDocument.MainDocumentPart;
+                if (mainPart == null) {
+                    throw new InvalidOperationException("MainDocumentPart is missing.");
+                }
+                var documentSettingsPart = mainPart.DocumentSettingsPart;
                 if (documentSettingsPart == null) {
-                    documentSettingsPart = document._wordprocessingDocument.MainDocumentPart.AddNewPart<DocumentSettingsPart>();
+                    documentSettingsPart = mainPart.AddNewPart<DocumentSettingsPart>();
                 }
 
-                var settings = document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                var settings = documentSettingsPart.Settings;
                 if (settings == null) {
                     settings = new Settings();
                     settings.Save(documentSettingsPart);
@@ -209,39 +251,32 @@ namespace OfficeIMO.Word {
             document.Settings = this;
         }
 
-        private RunPropertiesBaseStyle GetDefaultStyleProperties() {
-            if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles != null) {
-                if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults != null) {
-                    if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault != null) {
-                        if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle != null) {
-                            if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle != null) {
-                                return this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle;
-                            }
-                        }
-                    }
-                }
-            }
-            return null;
+        private RunPropertiesBaseStyle? GetDefaultStyleProperties() {
+            return _document._wordprocessingDocument.MainDocumentPart?
+                .StyleDefinitionsPart?.Styles?
+                .DocDefaults?.RunPropertiesDefault?.RunPropertiesBaseStyle;
         }
 
-        private RunPropertiesBaseStyle SetDefaultStyleProperties() {
-            if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles != null) {
-                if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults == null) {
-                    this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults = new DocDefaults();
-                }
-
-                if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault == null) {
-                    this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault = new RunPropertiesDefault();
-                }
-
-                if (this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle == null) {
-                    this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle = new RunPropertiesBaseStyle();
-                }
-
-                return this._document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle;
+        private RunPropertiesBaseStyle? SetDefaultStyleProperties() {
+            var styles = _document._wordprocessingDocument.MainDocumentPart?
+                .StyleDefinitionsPart?.Styles;
+            if (styles == null) {
+                return null;
             }
 
-            return null;
+            if (styles.DocDefaults == null) {
+                styles.DocDefaults = new DocDefaults();
+            }
+
+            if (styles.DocDefaults.RunPropertiesDefault == null) {
+                styles.DocDefaults.RunPropertiesDefault = new RunPropertiesDefault();
+            }
+
+            if (styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle == null) {
+                styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle = new RunPropertiesBaseStyle();
+            }
+
+            return styles.DocDefaults.RunPropertiesDefault.RunPropertiesBaseStyle;
         }
 
         /// <summary>
@@ -251,9 +286,9 @@ namespace OfficeIMO.Word {
             get {
                 var runPropertiesBaseStyle = GetDefaultStyleProperties();
                 if (runPropertiesBaseStyle != null) {
-                    if (runPropertiesBaseStyle.FontSize != null) {
-                        var fontSize = runPropertiesBaseStyle.FontSize.Val;
-                        return int.Parse(fontSize) / 2;
+                    var fontSize = runPropertiesBaseStyle.FontSize?.Val;
+                    if (fontSize != null) {
+                        return int.Parse(fontSize!) / 2;
                     }
                 }
                 return null;
@@ -278,9 +313,9 @@ namespace OfficeIMO.Word {
             get {
                 var runPropertiesBaseStyle = GetDefaultStyleProperties();
                 if (runPropertiesBaseStyle != null) {
-                    if (runPropertiesBaseStyle.FontSizeComplexScript != null) {
-                        var fontSize = runPropertiesBaseStyle.FontSizeComplexScript.Val;
-                        return int.Parse(fontSize) / 2;
+                    var fontSize = runPropertiesBaseStyle.FontSizeComplexScript?.Val;
+                    if (fontSize != null) {
+                        return int.Parse(fontSize!) / 2;
                     }
                 }
                 return null;
@@ -302,34 +337,23 @@ namespace OfficeIMO.Word {
         /// Gets or Sets default font family for the whole document.
         /// </summary>
         /// <seealso href="http://officeopenxml.com/WPtextFonts.php">WordProcessingText Fonts </seealso>
-        public string FontFamily {
+        public string? FontFamily {
             get {
                 var runPropertiesBaseStyle = GetDefaultStyleProperties();
-                if (runPropertiesBaseStyle != null) {
-                    if (runPropertiesBaseStyle.RunFonts != null) {
-                        var fontFamily = runPropertiesBaseStyle.RunFonts.Ascii;
-                        return fontFamily;
-                    }
-                }
-                return null;
+                return runPropertiesBaseStyle?.RunFonts?.Ascii;
             }
             set {
                 var runPropertiesBaseStyle = SetDefaultStyleProperties();
                 if (runPropertiesBaseStyle != null) {
-                    //runPropertiesBaseStyle.RunFonts = new RunFonts();
                     if (runPropertiesBaseStyle.RunFonts == null) {
                         runPropertiesBaseStyle.RunFonts = new RunFonts() { AsciiTheme = ThemeFontValues.MinorHighAnsi, HighAnsiTheme = ThemeFontValues.MinorHighAnsi, EastAsiaTheme = ThemeFontValues.MinorHighAnsi, ComplexScriptTheme = ThemeFontValues.MinorBidi };
                     }
-                    // we need to reset default AsciiTheme, before applying Ascii
                     runPropertiesBaseStyle.RunFonts.AsciiTheme = null;
                     runPropertiesBaseStyle.RunFonts.Ascii = value;
-                    // we also set HighAnsi to the same value
                     runPropertiesBaseStyle.RunFonts.HighAnsi = value;
                     runPropertiesBaseStyle.RunFonts.HighAnsiTheme = null;
-                    // we also set EastAsia to the same value
                     runPropertiesBaseStyle.RunFonts.EastAsia = value;
                     runPropertiesBaseStyle.RunFonts.EastAsiaTheme = null;
-                    // we also set ComplexScript to the same value
                     runPropertiesBaseStyle.RunFonts.ComplexScript = value;
                     runPropertiesBaseStyle.RunFonts.ComplexScriptTheme = null;
                 } else {
@@ -342,25 +366,17 @@ namespace OfficeIMO.Word {
         /// Gets or Sets default font family for the whole document in HighAnsi.
         /// </summary>
         /// <seealso href="http://officeopenxml.com/WPtextFonts.php">WordProcessingText Fonts </seealso>
-        public string FontFamilyHighAnsi {
+        public string? FontFamilyHighAnsi {
             get {
                 var runPropertiesBaseStyle = GetDefaultStyleProperties();
-                if (runPropertiesBaseStyle != null) {
-                    if (runPropertiesBaseStyle.RunFonts != null) {
-                        var fontFamily = runPropertiesBaseStyle.RunFonts.HighAnsi;
-                        return fontFamily;
-                    }
-                }
-                return null;
+                return runPropertiesBaseStyle?.RunFonts?.HighAnsi;
             }
             set {
                 var runPropertiesBaseStyle = SetDefaultStyleProperties();
                 if (runPropertiesBaseStyle != null) {
-                    //runPropertiesBaseStyle.RunFonts = new RunFonts();
                     if (runPropertiesBaseStyle.RunFonts == null) {
                         runPropertiesBaseStyle.RunFonts = new RunFonts() { AsciiTheme = ThemeFontValues.MinorHighAnsi, HighAnsiTheme = ThemeFontValues.MinorHighAnsi, EastAsiaTheme = ThemeFontValues.MinorHighAnsi, ComplexScriptTheme = ThemeFontValues.MinorBidi };
                     }
-                    // we also need to change it in highAnsi to fix https://github.com/EvotecIT/OfficeIMO/issues/54
                     if (string.IsNullOrEmpty(value)) {
                         runPropertiesBaseStyle.RunFonts.HighAnsi = null;
                     } else {
@@ -377,16 +393,10 @@ namespace OfficeIMO.Word {
         /// Gets or Sets default font family for the whole document in EastAsia.
         /// </summary>
         /// <seealso href="http://officeopenxml.com/WPtextFonts.php">WordProcessingText Fonts </seealso>
-        public string FontFamilyEastAsia {
+        public string? FontFamilyEastAsia {
             get {
                 var runPropertiesBaseStyle = GetDefaultStyleProperties();
-                if (runPropertiesBaseStyle != null) {
-                    if (runPropertiesBaseStyle.RunFonts != null) {
-                        var fontFamily = runPropertiesBaseStyle.RunFonts.EastAsia;
-                        return fontFamily;
-                    }
-                }
-                return null;
+                return runPropertiesBaseStyle?.RunFonts?.EastAsia;
             }
             set {
                 var runPropertiesBaseStyle = SetDefaultStyleProperties();
@@ -410,16 +420,10 @@ namespace OfficeIMO.Word {
         /// Gets or Sets default font family for the whole document in ComplexScript.
         /// </summary>
         /// <seealso href="http://officeopenxml.com/WPtextFonts.php">WordProcessingText Fonts </seealso>
-        public string FontFamilyComplexScript {
+        public string? FontFamilyComplexScript {
             get {
                 var runPropertiesBaseStyle = GetDefaultStyleProperties();
-                if (runPropertiesBaseStyle != null) {
-                    if (runPropertiesBaseStyle.RunFonts != null) {
-                        var fontFamily = runPropertiesBaseStyle.RunFonts.ComplexScript;
-                        return fontFamily;
-                    }
-                }
-                return null;
+                return runPropertiesBaseStyle?.RunFonts?.ComplexScript;
             }
             set {
                 var runPropertiesBaseStyle = SetDefaultStyleProperties();
@@ -442,15 +446,10 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or Sets default language for the whole document. Default is en-Us.
         /// </summary>
-        public string Language {
+        public string? Language {
             get {
                 var runPropertiesBaseStyle = GetDefaultStyleProperties();
-                if (runPropertiesBaseStyle != null) {
-                    if (runPropertiesBaseStyle.Languages != null) {
-                        return runPropertiesBaseStyle.Languages.Val;
-                    }
-                }
-                return null;
+                return runPropertiesBaseStyle?.Languages?.Val;
             }
             set {
                 var runPropertiesBaseStyle = SetDefaultStyleProperties();
@@ -459,7 +458,6 @@ namespace OfficeIMO.Word {
                         runPropertiesBaseStyle.Languages = new Languages();
                     }
                     runPropertiesBaseStyle.Languages.Val = value;
-                    //runPropertiesBaseStyle.Languages.EastAsia = value;
                 } else {
                     throw new InvalidOperationException("Could not set language. Styles not found.");
                 }
@@ -469,20 +467,27 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or Sets default Background Color for the whole document
         /// </summary>
-        public string BackgroundColor {
+        public string? BackgroundColor {
             get {
-                if (_document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground != null) {
-                    return _document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground.Color.Value.ToLowerInvariant();
-                }
-
-                return null;
+                var background = _document._wordprocessingDocument.MainDocumentPart?
+                    .Document?.DocumentBackground;
+                return background?.Color?.Value?.ToLowerInvariant();
             }
             set {
-                _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings.DisplayBackgroundShape = new DisplayBackgroundShape();
-                if (_document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground == null) {
-                    _document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground = new DocumentBackground();
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                if (settings == null) {
+                    return;
                 }
-                _document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground.Color = value;
+                settings.DisplayBackgroundShape = new DisplayBackgroundShape();
+                var document = _document._wordprocessingDocument.MainDocumentPart?.Document;
+                if (document == null) {
+                    return;
+                }
+                if (document.DocumentBackground == null) {
+                    document.DocumentBackground = new DocumentBackground();
+                }
+                document.DocumentBackground.Color = value;
             }
         }
         /// <summary>
@@ -491,7 +496,7 @@ namespace OfficeIMO.Word {
         /// <param name="backgroundColor">Hexadecimal color value.</param>
         /// <returns>The current <see cref="WordSettings"/> instance.</returns>
         public WordSettings SetBackgroundColor(string backgroundColor) {
-            this.BackgroundColor = backgroundColor;
+            BackgroundColor = backgroundColor;
             return this;
         }
 
@@ -501,7 +506,7 @@ namespace OfficeIMO.Word {
         /// <param name="backgroundColor">Color value.</param>
         /// <returns>The current <see cref="WordSettings"/> instance.</returns>
         public WordSettings SetBackgroundColor(SixLabors.ImageSharp.Color backgroundColor) {
-            this.BackgroundColor = backgroundColor.ToHexColor();
+            BackgroundColor = backgroundColor.ToHexColor();
             return this;
         }
 
@@ -511,14 +516,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool? ReadOnlyRecommended {
             get {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
-                if (settings.WriteProtection == null) {
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                if (settings?.WriteProtection?.Recommended == null) {
                     return false;
                 }
-                if (settings.WriteProtection.Recommended == null) {
-                    return false;
-                }
-                // Defensive: treat any value other than "1" as false
                 var recommended = settings.WriteProtection.Recommended;
                 if (recommended.Value == true && (recommended.InnerText == "1" || string.IsNullOrEmpty(recommended.InnerText))) {
                     return true;
@@ -526,21 +528,22 @@ namespace OfficeIMO.Word {
                 return false;
             }
             set {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                if (settings == null) {
+                    return;
+                }
                 if (settings.WriteProtection == null && value != null && value != false) {
                     settings.WriteProtection = new WriteProtection();
                 }
                 if (settings.WriteProtection != null) {
                     if (value == null || value == false) {
                         settings.WriteProtection.Recommended = null;
-                        // Only remove WriteProtection element if it is empty (no hash, no recommended)
                         if (string.IsNullOrEmpty(settings.WriteProtection.Hash) && settings.WriteProtection.Recommended == null) {
                             settings.WriteProtection.Remove();
                         }
                     } else {
-                        // Use OnOffValue to ensure w:recommended="1" in XML (workaround for OpenXML 3.3.0)
-                        var onOff = new DocumentFormat.OpenXml.OnOffValue(true);
-                        onOff.InnerText = "1";
+                        var onOff = new DocumentFormat.OpenXml.OnOffValue(true) { InnerText = "1" };
                         settings.WriteProtection.Recommended = onOff;
                     }
                 }
@@ -577,15 +580,20 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool GutterAtTop {
             get {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
-                var gutterAtTop = settings.GetFirstChild<GutterAtTop>();
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                var gutterAtTop = settings?.GetFirstChild<GutterAtTop>();
                 if (gutterAtTop == null) {
                     return false;
                 }
-                return gutterAtTop.Val;
+                return gutterAtTop.Val?.Value ?? false;
             }
             set {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                if (settings == null) {
+                    return;
+                }
                 var gutterAtTop = settings.GetFirstChild<GutterAtTop>();
                 if (gutterAtTop == null) {
                     gutterAtTop = new GutterAtTop();
@@ -600,11 +608,16 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool TrackRevisions {
             get {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
-                return settings.GetFirstChild<TrackRevisions>() != null;
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                return settings?.GetFirstChild<TrackRevisions>() != null;
             }
             set {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                if (settings == null) {
+                    return;
+                }
                 var track = settings.GetFirstChild<TrackRevisions>();
                 if (value) {
                     if (track == null) {
@@ -630,11 +643,16 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool TrackFormatting {
             get {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
-                return settings.GetFirstChild<DoNotTrackFormatting>() == null;
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                return settings?.GetFirstChild<DoNotTrackFormatting>() == null;
             }
             set {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                if (settings == null) {
+                    return;
+                }
                 var formatting = settings.GetFirstChild<DoNotTrackFormatting>();
                 if (value) {
                     formatting?.Remove();
@@ -649,11 +667,16 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool TrackMoves {
             get {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
-                return settings.GetFirstChild<DoNotTrackMoves>() == null;
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                return settings?.GetFirstChild<DoNotTrackMoves>() == null;
             }
             set {
-                var settings = _document._wordprocessingDocument.MainDocumentPart.DocumentSettingsPart.Settings;
+                var settings = _document._wordprocessingDocument.MainDocumentPart?
+                    .DocumentSettingsPart?.Settings;
+                if (settings == null) {
+                    return;
+                }
                 var moves = settings.GetFirstChild<DoNotTrackMoves>();
                 if (value) {
                     moves?.Remove();


### PR DESCRIPTION
## Summary
- add null-conditional checks to `WordSettings` to satisfy nullable reference warnings
- guard against missing document parts when modifying document settings

## Testing
- `dotnet build OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a41116a6c0832e8c66d3e672d5da24