### PR TITLE
Add basic Visio connector routing and reroute flag

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -17,6 +17,7 @@ namespace OfficeIMO.Examples {
             // Visio/BasicVisioDocument
             OfficeIMO.Examples.Visio.BasicVisioDocument.Example_BasicVisio(folderPath, false);
             OfficeIMO.Examples.Visio.ReadVisioDocument.Example_ReadVisio(folderPath, false);
+            OfficeIMO.Examples.Visio.ConnectRectangles.Example_ConnectRectangles(folderPath, false);
 
             // Excel/BasicExcelFunctionality
             OfficeIMO.Examples.Excel.BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);

--- a/OfficeIMO.Examples/Visio/ConnectRectangles.cs
+++ b/OfficeIMO.Examples/Visio/ConnectRectangles.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    /// <summary>
+    /// Demonstrates connecting two rectangles with an orthogonal connector.
+    /// </summary>
+    public static class ConnectRectangles {
+        public static void Example_ConnectRectangles(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Connecting rectangles");
+            string filePath = Path.Combine(folderPath, "Connect Rectangles.vsdx");
+
+            VisioDocument document = new();
+            document.RequestRecalcOnOpen();
+            VisioPage page = document.AddPage("Page-1");
+            VisioShape start = new("1", 1, 1, 2, 1, "Start");
+            VisioShape end = new("2", 4, 1, 2, 1, "End");
+            page.Shapes.Add(start);
+            page.Shapes.Add(end);
+            page.Connectors.Add(new VisioConnector(start, end));
+            document.Save(filePath);
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.Connectors.cs
+++ b/OfficeIMO.Tests/Visio.Connectors.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.IO.Packaging;
+using System.Linq;
+using System.Xml.Linq;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioConnectors {
+        [Fact]
+        public void ConnectorBetweenRectanglesEmitsGeometryAndRecalcFlag() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = new();
+            document.RequestRecalcOnOpen();
+            VisioPage page = document.AddPage("Page-1");
+            VisioShape start = new("1", 1, 1, 1, 1, "Start");
+            VisioShape end = new("2", 3, 2, 1, 1, "End");
+            page.Shapes.Add(start);
+            page.Shapes.Add(end);
+            VisioConnector connector = new(start, end);
+            page.Connectors.Add(connector);
+            document.Save(filePath);
+
+            using Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read);
+            XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
+
+            PackagePart documentPart = package.GetPart(new Uri("/visio/document.xml", UriKind.Relative));
+            XDocument docXml = XDocument.Load(documentPart.GetStream());
+            Assert.Equal("1", docXml.Root?.Element(ns + "DocumentSettings")?.Element(ns + "RelayoutAndRerouteUponOpen")?.Value);
+
+            PackagePart pagePart = package.GetPart(new Uri("/visio/pages/page1.xml", UriKind.Relative));
+            XDocument pageXml = XDocument.Load(pagePart.GetStream());
+            XElement connectorShape = pageXml.Root?
+                .Element(ns + "Shapes")?
+                .Elements(ns + "Shape")
+                .First(e => e.Attribute("ID")?.Value == connector.Id);
+
+            XElement[] segments = connectorShape.Element(ns + "Geom")?.Elements().ToArray() ?? Array.Empty<XElement>();
+            Assert.Equal("MoveTo", segments[0].Name.LocalName);
+            Assert.Equal(1.5, double.Parse(segments[0].Attribute("X")!.Value, CultureInfo.InvariantCulture));
+            Assert.Equal(1, double.Parse(segments[0].Attribute("Y")!.Value, CultureInfo.InvariantCulture));
+            Assert.Equal("LineTo", segments[1].Name.LocalName);
+            Assert.Equal(1.5, double.Parse(segments[1].Attribute("X")!.Value, CultureInfo.InvariantCulture));
+            Assert.Equal(2, double.Parse(segments[1].Attribute("Y")!.Value, CultureInfo.InvariantCulture));
+            Assert.Equal("LineTo", segments[2].Name.LocalName);
+            Assert.Equal(2.5, double.Parse(segments[2].Attribute("X")!.Value, CultureInfo.InvariantCulture));
+            Assert.Equal(2, double.Parse(segments[2].Attribute("Y")!.Value, CultureInfo.InvariantCulture));
+
+            XElement connects = pageXml.Root?.Element(ns + "Connects") ?? new XElement("none");
+            XElement[] entries = connects.Elements(ns + "Connect").ToArray();
+            Assert.Equal(2, entries.Length);
+            Assert.Contains(entries, e => e.Attribute("FromSheet")?.Value == connector.Id && e.Attribute("FromCell")?.Value == "BeginX" && e.Attribute("ToSheet")?.Value == start.Id);
+            Assert.Contains(entries, e => e.Attribute("FromSheet")?.Value == connector.Id && e.Attribute("FromCell")?.Value == "EndX" && e.Attribute("ToSheet")?.Value == end.Id);
+        }
+    }
+}

--- a/OfficeIMO.Visio/VisioConnector.cs
+++ b/OfficeIMO.Visio/VisioConnector.cs
@@ -3,10 +3,21 @@ namespace OfficeIMO.Visio {
     /// Connects two shapes together.
     /// </summary>
     public class VisioConnector {
-        public VisioConnector(VisioShape from, VisioShape to) {
+        private static int _idCounter = 1;
+
+        public VisioConnector(VisioShape from, VisioShape to) : this($"C{_idCounter++}", from, to) {
+        }
+
+        public VisioConnector(string id, VisioShape from, VisioShape to) {
+            Id = id;
             From = from;
             To = to;
         }
+
+        /// <summary>
+        /// Identifier of the connector.
+        /// </summary>
+        public string Id { get; }
 
         /// <summary>
         /// Shape from which the connector starts.


### PR DESCRIPTION
## Summary
- enable VisioDocument to request reroute on open
- generate orthogonal connector geometry between shapes
- add example and unit test for connectors

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build` *(fails: The argument /workspace/OfficeIMO/OfficeIMO.Tests/bin/Debug/net9.0/OfficeIMO.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68a416c64a14832e8aaaa01faa8552e5