### PR TITLE
Fix nullability warnings in tests

### DIFF
--- a/OfficeIMO.Tests/Converters.Helpers.cs
+++ b/OfficeIMO.Tests/Converters.Helpers.cs
@@ -52,6 +52,7 @@ namespace OfficeIMO.Tests {
                 Assert.False(bulletInfo.Value.Ordered);
 
                 var orderedInfo = DocumentTraversal.GetListInfo(orderedItem);
+                Assert.NotNull(orderedInfo);
                 Assert.True(orderedInfo.Value.Ordered);
 
                 var markers = DocumentTraversal.BuildListMarkers(document);

--- a/OfficeIMO.Tests/Html.StylesheetCache.cs
+++ b/OfficeIMO.Tests/Html.StylesheetCache.cs
@@ -11,9 +11,9 @@ namespace OfficeIMO.Tests {
     public partial class Html {
         private static IDictionary GetCache() {
             var assembly = typeof(HtmlToWordOptions).Assembly;
-            var converterType = assembly.GetType("OfficeIMO.Word.Html.Converters.HtmlToWordConverter", true);
-            var field = converterType.GetField("_stylesheetCache", BindingFlags.NonPublic | BindingFlags.Static);
-            return (IDictionary)field!.GetValue(null)!;
+            var converterType = assembly.GetType("OfficeIMO.Word.Html.Converters.HtmlToWordConverter", true)!;
+            var field = converterType.GetField("_stylesheetCache", BindingFlags.NonPublic | BindingFlags.Static)!;
+            return (IDictionary)field.GetValue(null)!;
         }
 
         private static string ComputeHash(string css) {

--- a/OfficeIMO.Tests/Word.AddEmbeddedFragmentAfter.cs
+++ b/OfficeIMO.Tests/Word.AddEmbeddedFragmentAfter.cs
@@ -20,7 +20,7 @@ namespace OfficeIMO.Tests {
                 document.AddEmbeddedFragmentAfter(p1, "<html><p>frag</p></html>");
 
                 Assert.Single(document.EmbeddedDocuments);
-                var body = document._document.Body;
+                var body = document._document.Body!;
                 Assert.IsType<SectionProperties>(body.ChildElements[0]);
                 Assert.IsType<Paragraph>(body.ChildElements[1]);
                 Assert.IsType<AltChunk>(body.ChildElements[2]);

--- a/OfficeIMO.Tests/Word.DigitalSignature.cs
+++ b/OfficeIMO.Tests/Word.DigitalSignature.cs
@@ -19,7 +19,9 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Create(tempFile)) {
                 document.ApplicationProperties.DigitalSignature = new DigitalSignature();
                 Assert.True(document.ApplicationProperties.DigitalSignature != null);
-                document._wordprocessingDocument.DeletePart(document._wordprocessingDocument.ExtendedFilePropertiesPart);
+                var extendedPart = document._wordprocessingDocument.ExtendedFilePropertiesPart;
+                Assert.NotNull(extendedPart);
+                document._wordprocessingDocument.DeletePart(extendedPart);
                 Assert.True(document.ApplicationProperties.DigitalSignature == null);
             }
         }

--- a/OfficeIMO.Tests/Word.EmbeddedDocumentFailures.cs
+++ b/OfficeIMO.Tests/Word.EmbeddedDocumentFailures.cs
@@ -13,6 +13,7 @@ public partial class Word {
         string missingPath = Path.Combine(_directoryWithFiles, "does-not-exist.rtf");
 
         Assert.Throws<FileNotFoundException>(() => document.AddEmbeddedDocument(missingPath));
-        Assert.Empty(document._document.MainDocumentPart.AlternativeFormatImportParts);
+        Assert.NotNull(document._document.MainDocumentPart);
+        Assert.Empty(document._document.MainDocumentPart!.AlternativeFormatImportParts);
     }
 }

--- a/OfficeIMO.Tests/Word.EmbeddedObjects.cs
+++ b/OfficeIMO.Tests/Word.EmbeddedObjects.cs
@@ -62,10 +62,10 @@ public partial class Word {
         }
 
         using var word = WordprocessingDocument.Open(filePath, false);
-        var shape = word.MainDocumentPart.Document.Descendants<V.Shape>().FirstOrDefault();
+        var shape = word.MainDocumentPart?.Document?.Descendants<V.Shape>().FirstOrDefault();
         Assert.NotNull(shape);
-        Assert.Contains("width:32pt", shape.Style);
-        Assert.Contains("height:32pt", shape.Style);
+        Assert.Contains("width:32pt", shape!.Style);
+        Assert.Contains("height:32pt", shape!.Style);
     }
 
     [Fact]
@@ -81,9 +81,9 @@ public partial class Word {
         }
 
         using (var word = WordprocessingDocument.Open(filePath, false)) {
-            var embeddedPart = word.MainDocumentPart.EmbeddedPackageParts.FirstOrDefault();
+            var embeddedPart = word.MainDocumentPart?.EmbeddedPackageParts.FirstOrDefault();
             Assert.NotNull(embeddedPart);
-            using var stream = embeddedPart.GetStream(FileMode.Open, FileAccess.Read);
+            using var stream = embeddedPart!.GetStream(FileMode.Open, FileAccess.Read);
             using var ms = new MemoryStream();
             stream.CopyTo(ms);
             ms.Position = 0;

--- a/OfficeIMO.Tests/Word.HelpersConversions.cs
+++ b/OfficeIMO.Tests/Word.HelpersConversions.cs
@@ -18,9 +18,12 @@ public partial class Word {
         var emus = Helpers.ConvertCentimetersToEmus(centimeters);
         var emus64 = Helpers.ConvertCentimetersToEmusInt64(centimeters);
 
+        Assert.True(emus.HasValue);
         Assert.Equal(expectedEmus, emus);
         Assert.Equal(expectedEmus64, emus64);
-        Assert.Equal(centimeters, Helpers.ConvertEmusToCentimeters(emus.Value).Value, 5);
+        var cm = Helpers.ConvertEmusToCentimeters(emus.Value);
+        Assert.True(cm.HasValue);
+        Assert.Equal(centimeters, cm.Value, 5);
         Assert.Equal(centimeters, Helpers.ConvertEmusToCentimeters(emus64), 5);
     }
 

--- a/OfficeIMO.Tests/Word.ImageClone.cs
+++ b/OfficeIMO.Tests/Word.ImageClone.cs
@@ -17,7 +17,8 @@ namespace OfficeIMO.Tests {
 
             Assert.Equal(paragraph1.Image.RelationshipId, clone.RelationshipId);
             Assert.Equal(2, document.Images.Count);
-            Assert.Single(document._wordprocessingDocument.MainDocumentPart.ImageParts);
+            Assert.NotNull(document._wordprocessingDocument.MainDocumentPart);
+            Assert.Single(document._wordprocessingDocument.MainDocumentPart!.ImageParts);
 
             document.Save(false);
         }

--- a/OfficeIMO.Tests/Word.ImageEmbedder.cs
+++ b/OfficeIMO.Tests/Word.ImageEmbedder.cs
@@ -17,7 +17,9 @@ namespace OfficeIMO.Tests {
 
             string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
             Run run = ImageEmbedder.CreateImageRun(mainPart, assetPath);
-            mainPart.Document.Body.Append(new Paragraph(run));
+            Assert.NotNull(mainPart.Document);
+            Assert.NotNull(mainPart.Document.Body);
+            mainPart.Document.Body!.Append(new Paragraph(run));
             mainPart.Document.Save();
 
             Assert.NotEmpty(mainPart.ImageParts);

--- a/OfficeIMO.Tests/Word.InlineRunHelper.cs
+++ b/OfficeIMO.Tests/Word.InlineRunHelper.cs
@@ -34,7 +34,7 @@ public partial class Word {
         var hyperlink = paragraph._paragraph.Elements<Hyperlink>().FirstOrDefault();
         Assert.NotNull(hyperlink);
         Assert.Equal("http://example.com", hyperlink.InnerText);
-        var rel = document._wordprocessingDocument.MainDocumentPart.HyperlinkRelationships.First();
+        var rel = document._wordprocessingDocument.MainDocumentPart!.HyperlinkRelationships.First();
         Assert.StartsWith("http://example.com", rel.Uri.ToString());
     }
 }

--- a/OfficeIMO.Tests/Word.Insertion.cs
+++ b/OfficeIMO.Tests/Word.Insertion.cs
@@ -21,7 +21,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = WordDocument.Load(filePath)) {
-                var body = document._document.Body;
+                var body = document._document.Body!;
                 Assert.Equal("Paragraph 1", body.Elements<Paragraph>().ElementAt(0).InnerText);
                 Assert.Equal("Inserted", body.Elements<Paragraph>().ElementAt(1).InnerText);
                 Assert.Equal("Paragraph 2", body.Elements<Paragraph>().ElementAt(2).InnerText);
@@ -46,7 +46,7 @@ namespace OfficeIMO.Tests {
                 Assert.Single(document.Tables);
                 Assert.Equal("Test", document.Tables[0].Rows[0].Cells[0].Paragraphs[0].Text);
 
-                var body = document._document.Body;
+                var body = document._document.Body!;
                 Assert.IsType<Paragraph>(body.ChildElements[0]);
                 Assert.IsType<Table>(body.ChildElements[1]);
                 Assert.IsType<Paragraph>(body.ChildElements[2]);

--- a/OfficeIMO.Tests/Word.Lists.cs
+++ b/OfficeIMO.Tests/Word.Lists.cs
@@ -847,14 +847,14 @@ public partial class Word {
 
             Assert.Single(document.Lists);
             Assert.Equal("Two", document.Lists[0].ListItems[0].Text);
-            Assert.NotNull(document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart);
+            Assert.NotNull(document._wordprocessingDocument.MainDocumentPart?.NumberingDefinitionsPart);
 
             document.Save(false);
         }
 
         using (var wordDoc = WordprocessingDocument.Open(filePath, false)) {
-            Assert.NotNull(wordDoc.MainDocumentPart.NumberingDefinitionsPart);
-            Assert.Single(wordDoc.MainDocumentPart.NumberingDefinitionsPart.Numbering.Elements<NumberingInstance>());
+            Assert.NotNull(wordDoc.MainDocumentPart?.NumberingDefinitionsPart);
+            Assert.Single(wordDoc.MainDocumentPart!.NumberingDefinitionsPart!.Numbering.Elements<NumberingInstance>());
         }
     }
 }

--- a/OfficeIMO.Tests/Word.MailMerge.cs
+++ b/OfficeIMO.Tests/Word.MailMerge.cs
@@ -19,7 +19,10 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                string xml = document._document.MainDocumentPart.Document.InnerText;
+                var mainPart = document._document.MainDocumentPart;
+                Assert.NotNull(mainPart);
+                var xml = mainPart!.Document?.InnerText;
+                Assert.NotNull(xml);
                 Assert.Contains("Alice", xml);
                 Assert.DoesNotContain("MERGEFIELD", xml);
             }

--- a/OfficeIMO.Tests/Word.PictureBulletList.cs
+++ b/OfficeIMO.Tests/Word.PictureBulletList.cs
@@ -18,8 +18,9 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = WordDocument.Load(filePath)) {
-                var numbering = document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart.Numbering;
-                Assert.NotNull(numbering.Elements<NumberingPictureBullet>().FirstOrDefault());
+                var numbering = document._wordprocessingDocument.MainDocumentPart?.NumberingDefinitionsPart?.Numbering;
+                Assert.NotNull(numbering);
+                Assert.NotNull(numbering!.Elements<NumberingPictureBullet>().FirstOrDefault());
                 Assert.Single(document.Lists);
             }
         }
@@ -36,8 +37,9 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = WordDocument.Load(filePath)) {
-                var numbering = document._wordprocessingDocument.MainDocumentPart.NumberingDefinitionsPart.Numbering;
-                Assert.NotNull(numbering.Elements<NumberingPictureBullet>().FirstOrDefault());
+                var numbering = document._wordprocessingDocument.MainDocumentPart?.NumberingDefinitionsPart?.Numbering;
+                Assert.NotNull(numbering);
+                Assert.NotNull(numbering!.Elements<NumberingPictureBullet>().FirstOrDefault());
                 Assert.Single(document.Lists);
             }
         }

--- a/OfficeIMO.Tests/Word.ReplaceTextWithHtml.cs
+++ b/OfficeIMO.Tests/Word.ReplaceTextWithHtml.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(1, count);
                 Assert.Single(document.EmbeddedDocuments);
                 Assert.DoesNotContain("replaceTarget", document.Paragraphs[0].Text);
-                var body = document._document.Body;
+                var body = document._document.Body!;
                 Assert.IsType<SectionProperties>(body.ChildElements[0]);
                 Assert.IsType<Paragraph>(body.ChildElements[1]);
                 Assert.IsType<AltChunk>(body.ChildElements[2]);
@@ -36,7 +36,7 @@ namespace OfficeIMO.Tests {
                 Assert.Single(document.EmbeddedDocuments);
                 Assert.Equal("Intro ", document.Paragraphs[0].Text);
                 Assert.Equal(" end", document.Paragraphs[1].Text);
-                var body = document._document.Body;
+                var body = document._document.Body!;
                 Assert.IsType<SectionProperties>(body.ChildElements[0]);
                 Assert.IsType<Paragraph>(body.ChildElements[1]);
                 Assert.IsType<AltChunk>(body.ChildElements[2]);

--- a/OfficeIMO.Tests/Word.Settings.cs
+++ b/OfficeIMO.Tests/Word.Settings.cs
@@ -78,10 +78,10 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Settings.FontFamilyEastAsia == "Times New Roman");
                 Assert.True(document.Settings.FontFamilyComplexScript == "Times New Roman");
 
-                document.Settings.FontFamilyEastAsia = null;
+                document.Settings.FontFamilyEastAsia = null!;
                 Assert.True(document.Settings.FontFamilyEastAsia == null);
 
-                document.Settings.FontFamilyComplexScript = null;
+                document.Settings.FontFamilyComplexScript = null!;
                 Assert.True(document.Settings.FontFamilyComplexScript == null);
 
                 document.CompatibilitySettings.CompatibilityMode = CompatibilityMode.Word2003;
@@ -213,7 +213,7 @@ namespace OfficeIMO.Tests {
         [Theory]
         [InlineData("1", true)]
         [InlineData("0", false)]
-        [InlineData(null, false)]
+        [InlineData(null!, false)]
         public void Test_FinalDocument_CustomPropertyValues(string? value, bool expected) {
             string filePath = Path.Combine(_directoryWithFiles, $"Test_FinalDocument_Value_{expected}.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {

--- a/OfficeIMO.Tests/Word.StructuredDocumentTag.cs
+++ b/OfficeIMO.Tests/Word.StructuredDocumentTag.cs
@@ -105,8 +105,9 @@ namespace OfficeIMO.Tests {
                 sdt.Text = "New text";
 
                 Assert.Equal("New text", sdt.Text);
-                Assert.NotNull(sdtRun.SdtContentRun.GetFirstChild<Run>());
-                Assert.Equal("New text", sdtRun.SdtContentRun.GetFirstChild<Run>().GetFirstChild<Text>().Text);
+                var run = sdtRun.SdtContentRun?.GetFirstChild<Run>();
+                Assert.NotNull(run);
+                Assert.Equal("New text", run!.GetFirstChild<Text>()?.Text);
 
                 document.Save(false);
                 Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");

--- a/OfficeIMO.Tests/Word.StructuredDocumentTagBody.cs
+++ b/OfficeIMO.Tests/Word.StructuredDocumentTagBody.cs
@@ -22,7 +22,7 @@ namespace OfficeIMO.Tests {
                 );
                 var body = document._wordprocessingDocument?.MainDocumentPart?.Document?.Body;
                 Assert.NotNull(body);
-                body.Append(block);
+                body!.Append(block);
                 document.Save(false);
                 Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
             }

--- a/OfficeIMO.Tests/Word.TablesNested.cs
+++ b/OfficeIMO.Tests/Word.TablesNested.cs
@@ -69,8 +69,10 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.TablesIncludingNestedTables.Count == 7);
                 Assert.True(document.Sections[0].TablesIncludingNestedTables.Count == 7);
 
-                Assert.True(table1.ParentTable.Rows[1].Cells[0].Paragraphs[0].Text == "Test 2");
-                Assert.True(table3.ParentTable.Rows[1].Cells[0].Paragraphs[0].Text == "Test 2.2");
+                Assert.NotNull(table1.ParentTable);
+                Assert.True(table1.ParentTable!.Rows[1].Cells[0].Paragraphs[0].Text == "Test 2");
+                Assert.NotNull(table3.ParentTable);
+                Assert.True(table3.ParentTable!.Rows[1].Cells[0].Paragraphs[0].Text == "Test 2.2");
                 document.Save(false);
             }
 
@@ -86,23 +88,25 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Tables.Count == 3);
                 Assert.True(document.TablesIncludingNestedTables.Count == 7);
 
-                foreach (var table in document.TablesIncludingNestedTables) {
-                    if (table.IsNestedTable) {
-                        Assert.NotNull(table.ParentTable);
-                        Assert.True(table.ParentTable.RowsCount > 0);
-                    } else {
-                        Assert.Null(table.ParentTable);
+                    foreach (var table in document.TablesIncludingNestedTables) {
+                        if (table.IsNestedTable) {
+                            var parentTable = table.ParentTable;
+                            Assert.NotNull(parentTable);
+                            Assert.True(parentTable!.RowsCount > 0);
+                        } else {
+                            Assert.Null(table.ParentTable);
+                        }
                     }
-                }
 
-                foreach (var table in document.Sections[0].TablesIncludingNestedTables) {
-                    if (table.IsNestedTable) {
-                        Assert.NotNull(table.ParentTable);
-                        Assert.True(table.ParentTable.RowsCount > 0);
-                    } else {
-                        Assert.Null(table.ParentTable);
+                    foreach (var table in document.Sections[0].TablesIncludingNestedTables) {
+                        if (table.IsNestedTable) {
+                            var parentTable = table.ParentTable;
+                            Assert.NotNull(parentTable);
+                            Assert.True(parentTable!.RowsCount > 0);
+                        } else {
+                            Assert.Null(table.ParentTable);
+                        }
                     }
-                }
                 Assert.True(document.Sections[0].TablesIncludingNestedTables.Count == 7);
 
                 document.Save();

--- a/OfficeIMO.Tests/Word.Validation.cs
+++ b/OfficeIMO.Tests/Word.Validation.cs
@@ -86,8 +86,9 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var numbering = document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart!.Numbering;
-                Assert.NotNull(numbering.LookupNamespace("w15"));
+                var numbering = document._wordprocessingDocument.MainDocumentPart?.NumberingDefinitionsPart?.Numbering;
+                Assert.NotNull(numbering);
+                Assert.NotNull(numbering!.LookupNamespace("w15"));
                 var ignorable = numbering.MCAttributes?.Ignorable?.Value;
                 Assert.NotNull(ignorable);
                 Assert.Contains("w15", ignorable.Split(' '));


### PR DESCRIPTION
## Summary
- add explicit null checks and null-forgiving operators to remove nullable reference warnings across tests
- guard reflection access in `Html.StylesheetCache`

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a41aafed6c832ea92e45d5ee4597fb