### PR TITLE
fix: address nullable warnings

### DIFF
--- a/OfficeIMO.Word/WordField.PublicMethods.cs
+++ b/OfficeIMO.Word/WordField.PublicMethods.cs
@@ -18,7 +18,7 @@ namespace OfficeIMO.Word {
         /// <param name="advanced">Whether to use advanced field representation.</param>
         /// <param name="parameters">Additional switch parameters.</param>
         /// <returns>The <see cref="WordParagraph"/> containing the field.</returns>
-        public static WordParagraph AddField(WordParagraph paragraph, WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, string customFormat = null, bool advanced = false, List<String> parameters = null) {
+        public static WordParagraph AddField(WordParagraph paragraph, WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, string? customFormat = null, bool advanced = false, List<string>? parameters = null) {
             if (advanced) {
                 var runStart = AddFieldStart();
                 var runField = AddAdvancedField(wordFieldType: wordFieldType, wordFieldFormat: wordFieldFormat, customFormat: customFormat, parameters: parameters);
@@ -51,7 +51,7 @@ namespace OfficeIMO.Word {
         /// <param name="customFormat">Custom format string for date or time fields.</param>
         /// <param name="advanced">Whether to use advanced field representation.</param>
         /// <returns>The <see cref="WordParagraph"/> containing the field.</returns>
-        public static WordParagraph AddField(WordParagraph paragraph, WordFieldCode fieldCode, WordFieldFormat? wordFieldFormat = null, string customFormat = null, bool advanced = false) {
+        public static WordParagraph AddField(WordParagraph paragraph, WordFieldCode fieldCode, WordFieldFormat? wordFieldFormat = null, string? customFormat = null, bool advanced = false) {
             if (fieldCode == null) throw new ArgumentNullException(nameof(fieldCode));
 
             var parameters = fieldCode.GetParameters();

--- a/OfficeIMO.Word/WordHeaderFooter.Methods.cs
+++ b/OfficeIMO.Word/WordHeaderFooter.Methods.cs
@@ -93,7 +93,7 @@ namespace OfficeIMO.Word {
         /// <param name="customFormat">Custom format string for date or time fields.</param>
         /// <param name="advanced">Whether to use advanced formatting.</param>
         /// <returns>The created <see cref="WordParagraph"/> instance.</returns>
-        public WordParagraph AddField(WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, string customFormat = null, bool advanced = false) {
+        public WordParagraph AddField(WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, string? customFormat = null, bool advanced = false) {
             return this.AddParagraph().AddField(wordFieldType, wordFieldFormat, customFormat, advanced);
         }
 
@@ -105,7 +105,7 @@ namespace OfficeIMO.Word {
         /// <param name="customFormat">Custom format string for date or time fields.</param>
         /// <param name="advanced">Whether to use advanced formatting.</param>
         /// <returns>The created <see cref="WordParagraph"/> instance.</returns>
-        public WordParagraph AddField(WordFieldCode fieldCode, WordFieldFormat? wordFieldFormat = null, string customFormat = null, bool advanced = false) {
+        public WordParagraph AddField(WordFieldCode fieldCode, WordFieldFormat? wordFieldFormat = null, string? customFormat = null, bool advanced = false) {
             return this.AddParagraph().AddField(fieldCode, wordFieldFormat, customFormat, advanced);
         }
 

--- a/OfficeIMO.Word/WordParagraph.Equality.cs
+++ b/OfficeIMO.Word/WordParagraph.Equality.cs
@@ -8,7 +8,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="other">The paragraph to compare with the current instance.</param>
         /// <returns><c>true</c> if the paragraphs are equal; otherwise, <c>false</c>.</returns>
-        public bool Equals(WordParagraph other) {
+        public bool Equals(WordParagraph? other) {
             if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
             if (ReferenceEquals(_paragraph, other._paragraph)) return true;
@@ -27,7 +27,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="obj">The object to compare with the current instance.</param>
         /// <returns><c>true</c> if the objects are equal; otherwise, <c>false</c>.</returns>
-        public override bool Equals(object obj) {
+        public override bool Equals(object? obj) {
             return obj is WordParagraph other && Equals(other);
         }
 
@@ -53,7 +53,7 @@ namespace OfficeIMO.Word {
         /// <param name="left">The left-hand instance.</param>
         /// <param name="right">The right-hand instance.</param>
         /// <returns><c>true</c> if the instances are equal; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(WordParagraph left, WordParagraph right) {
+        public static bool operator ==(WordParagraph? left, WordParagraph? right) {
             if (left is null) return right is null;
             return left.Equals(right);
         }
@@ -64,7 +64,7 @@ namespace OfficeIMO.Word {
         /// <param name="left">The left-hand instance.</param>
         /// <param name="right">The right-hand instance.</param>
         /// <returns><c>true</c> if the instances are not equal; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(WordParagraph left, WordParagraph right) {
+        public static bool operator !=(WordParagraph? left, WordParagraph? right) {
             return !(left == right);
         }
     }

--- a/OfficeIMO.Word/WordParagraphStyle.cs
+++ b/OfficeIMO.Word/WordParagraphStyle.cs
@@ -84,7 +84,7 @@ namespace OfficeIMO.Word {
         /// <param name="fontName">Font family to apply to runs.</param>
         /// <param name="styleName">Optional friendly style name.</param>
         /// <returns>The created style.</returns>
-        public static Style CreateFontStyle(string styleId, string fontName, string styleName = null) {
+        public static Style CreateFontStyle(string styleId, string fontName, string? styleName = null) {
             if (string.IsNullOrWhiteSpace(styleId)) throw new ArgumentException("StyleId cannot be empty", nameof(styleId));
             if (string.IsNullOrWhiteSpace(fontName)) throw new ArgumentException("Font name cannot be empty", nameof(fontName));
 
@@ -99,7 +99,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Registers a paragraph style that applies the specified font to all runs.
         /// </summary>
-        public static void RegisterFontStyle(string styleId, string fontName, string styleName = null) {
+        public static void RegisterFontStyle(string styleId, string fontName, string? styleName = null) {
             var style = CreateFontStyle(styleId, fontName, styleName);
             RegisterCustomStyle(styleId, style);
         }
@@ -116,25 +116,24 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Returns the Open XML style definition for the specified style.
         /// </summary>
-        public static Style GetStyleDefinition(WordParagraphStyles style) {
-            if (_overrides.TryGetValue(style, out var overrideStyle)) return (Style) overrideStyle.CloneNode(true);
-            if (_customStyles.TryGetValue(style.ToStringStyle(), out var customStyle)) return (Style) customStyle.CloneNode(true);
-            switch (style) {
-                case WordParagraphStyles.Normal: return StyleNormal;
-                case WordParagraphStyles.Heading1: return StyleHeading1;
-                case WordParagraphStyles.Heading2: return StyleHeading2;
-                case WordParagraphStyles.Heading3: return StyleHeading3;
-                case WordParagraphStyles.Heading4: return StyleHeading4;
-                case WordParagraphStyles.Heading5: return StyleHeading5;
-                case WordParagraphStyles.Heading6: return StyleHeading6;
-                case WordParagraphStyles.Heading7: return StyleHeading7;
-                case WordParagraphStyles.Heading8: return StyleHeading8;
-                case WordParagraphStyles.Heading9: return StyleHeading9;
-                case WordParagraphStyles.ListParagraph: return StyleListParagraph;
-                case WordParagraphStyles.Custom: return null;
-            }
-
-            throw new ArgumentOutOfRangeException(nameof(style));
+        public static Style? GetStyleDefinition(WordParagraphStyles style) {
+            if (_overrides.TryGetValue(style, out var overrideStyle)) return (Style)overrideStyle.CloneNode(true);
+            if (_customStyles.TryGetValue(style.ToStringStyle(), out var customStyle)) return (Style)customStyle.CloneNode(true);
+            return style switch {
+                WordParagraphStyles.Normal => StyleNormal,
+                WordParagraphStyles.Heading1 => StyleHeading1,
+                WordParagraphStyles.Heading2 => StyleHeading2,
+                WordParagraphStyles.Heading3 => StyleHeading3,
+                WordParagraphStyles.Heading4 => StyleHeading4,
+                WordParagraphStyles.Heading5 => StyleHeading5,
+                WordParagraphStyles.Heading6 => StyleHeading6,
+                WordParagraphStyles.Heading7 => StyleHeading7,
+                WordParagraphStyles.Heading8 => StyleHeading8,
+                WordParagraphStyles.Heading9 => StyleHeading9,
+                WordParagraphStyles.ListParagraph => StyleListParagraph,
+                WordParagraphStyles.Custom => null,
+                _ => throw new ArgumentOutOfRangeException(nameof(style)),
+            };
         }
 
         /// <summary>
@@ -162,21 +161,21 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Converts a style name string to its enumeration value.
         /// </summary>
-        public static WordParagraphStyles GetStyle(string style) {
-            switch (style) {
-                case "Normal": return WordParagraphStyles.Normal;
-                case "Heading1": return WordParagraphStyles.Heading1;
-                case "Heading2": return WordParagraphStyles.Heading2;
-                case "Heading3": return WordParagraphStyles.Heading3;
-                case "Heading4": return WordParagraphStyles.Heading4;
-                case "Heading5": return WordParagraphStyles.Heading5;
-                case "Heading6": return WordParagraphStyles.Heading6;
-                case "Heading7": return WordParagraphStyles.Heading7;
-                case "Heading8": return WordParagraphStyles.Heading8;
-                case "Heading9": return WordParagraphStyles.Heading9;
-                case "ListParagraph": return WordParagraphStyles.ListParagraph;
-                default: return WordParagraphStyles.Custom;
-            }
+        public static WordParagraphStyles GetStyle(string? style) {
+            return style switch {
+                "Normal" => WordParagraphStyles.Normal,
+                "Heading1" => WordParagraphStyles.Heading1,
+                "Heading2" => WordParagraphStyles.Heading2,
+                "Heading3" => WordParagraphStyles.Heading3,
+                "Heading4" => WordParagraphStyles.Heading4,
+                "Heading5" => WordParagraphStyles.Heading5,
+                "Heading6" => WordParagraphStyles.Heading6,
+                "Heading7" => WordParagraphStyles.Heading7,
+                "Heading8" => WordParagraphStyles.Heading8,
+                "Heading9" => WordParagraphStyles.Heading9,
+                "ListParagraph" => WordParagraphStyles.ListParagraph,
+                _ => WordParagraphStyles.Custom,
+            };
         }
         /// <summary>
         /// This method is used to simplify creating TOC List with Headings


### PR DESCRIPTION
## Summary
- mark optional text parameters nullable
- adjust WordParagraph equality operators for null-safety
- return nullable style definitions

## Testing
- `dotnet build OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a41ab57058832e96640f0113833f65