### PR TITLE
Address nullability warnings in Word helpers

### DIFF
--- a/OfficeIMO.Word/WordHyperLink.cs
+++ b/OfficeIMO.Word/WordHyperLink.cs
@@ -238,20 +238,23 @@ namespace OfficeIMO.Word {
         public void RemoveHyperLink(bool includingParagraph = true) {
             if (!string.IsNullOrEmpty(_hyperlink.Id)) {
                 OpenXmlElement? parent = _paragraph.Parent;
-                while (parent != null && !(parent is Body) && !(parent is Header) && !(parent is Footer)) {
+                while (parent != null && parent is not Body && parent is not Header && parent is not Footer) {
                     parent = parent.Parent;
                 }
 
-                OpenXmlPart part = _document._wordprocessingDocument!.MainDocumentPart!;
-                if (parent is Header header && header.HeaderPart != null) {
-                    part = header.HeaderPart;
-                } else if (parent is Footer footer && footer.FooterPart != null) {
-                    part = footer.FooterPart;
+                OpenXmlPart? part = _document._wordprocessingDocument?.MainDocumentPart;
+                var headerPart = (parent as Header)?.HeaderPart;
+                var footerPart = (parent as Footer)?.FooterPart;
+
+                if (headerPart != null) {
+                    part = headerPart;
+                } else if (footerPart != null) {
+                    part = footerPart;
                 }
 
-                var rel = part.HyperlinkRelationships?.FirstOrDefault(r => r.Id == _hyperlink.Id);
+                var rel = part?.HyperlinkRelationships?.FirstOrDefault(r => r.Id == _hyperlink.Id);
                 if (rel != null) {
-                    part.DeleteReferenceRelationship(rel);
+                    part!.DeleteReferenceRelationship(rel);
                 }
             }
 
@@ -308,13 +311,13 @@ namespace OfficeIMO.Word {
             HyperlinkRelationship rel;
 
             // Determine if the paragraph belongs to a header or footer by checking the ancestors.
-            var header = paragraph._paragraph.Ancestors<Header>().FirstOrDefault();
-            var footer = paragraph._paragraph.Ancestors<Footer>().FirstOrDefault();
+            var headerPart = paragraph._paragraph.Ancestors<Header>().FirstOrDefault()?.HeaderPart;
+            var footerPart = paragraph._paragraph.Ancestors<Footer>().FirstOrDefault()?.FooterPart;
 
-            if (header?.HeaderPart != null) {
-                rel = header.HeaderPart.AddHyperlinkRelationship(uri, true);
-            } else if (footer?.FooterPart != null) {
-                rel = footer.FooterPart.AddHyperlinkRelationship(uri, true);
+            if (headerPart != null) {
+                rel = headerPart.AddHyperlinkRelationship(uri, true);
+            } else if (footerPart != null) {
+                rel = footerPart.AddHyperlinkRelationship(uri, true);
             } else {
                 // Default to the main document part for paragraphs that are
                 // located in the body or in elements such as text boxes or tables.
@@ -376,13 +379,13 @@ namespace OfficeIMO.Word {
             if (newUri == null) throw new ArgumentNullException(nameof(newUri));
 
             HyperlinkRelationship rel;
-            var header = _paragraph.Ancestors<Header>().FirstOrDefault();
-            var footer = _paragraph.Ancestors<Footer>().FirstOrDefault();
+            var headerPart = _paragraph.Ancestors<Header>().FirstOrDefault()?.HeaderPart;
+            var footerPart = _paragraph.Ancestors<Footer>().FirstOrDefault()?.FooterPart;
 
-            if (header?.HeaderPart != null) {
-                rel = header.HeaderPart.AddHyperlinkRelationship(newUri, true);
-            } else if (footer?.FooterPart != null) {
-                rel = footer.FooterPart.AddHyperlinkRelationship(newUri, true);
+            if (headerPart != null) {
+                rel = headerPart.AddHyperlinkRelationship(newUri, true);
+            } else if (footerPart != null) {
+                rel = footerPart.AddHyperlinkRelationship(newUri, true);
             } else {
                 rel = _document._wordprocessingDocument!.MainDocumentPart!.AddHyperlinkRelationship(newUri, true);
             }
@@ -418,13 +421,13 @@ namespace OfficeIMO.Word {
             if (newUri == null) throw new ArgumentNullException(nameof(newUri));
 
             HyperlinkRelationship rel;
-            var header = _paragraph.Ancestors<Header>().FirstOrDefault();
-            var footer = _paragraph.Ancestors<Footer>().FirstOrDefault();
+            var headerPart = _paragraph.Ancestors<Header>().FirstOrDefault()?.HeaderPart;
+            var footerPart = _paragraph.Ancestors<Footer>().FirstOrDefault()?.FooterPart;
 
-            if (header?.HeaderPart != null) {
-                rel = header.HeaderPart.AddHyperlinkRelationship(newUri, true);
-            } else if (footer?.FooterPart != null) {
-                rel = footer.FooterPart.AddHyperlinkRelationship(newUri, true);
+            if (headerPart != null) {
+                rel = headerPart.AddHyperlinkRelationship(newUri, true);
+            } else if (footerPart != null) {
+                rel = footerPart.AddHyperlinkRelationship(newUri, true);
             } else {
                 rel = _document._wordprocessingDocument!.MainDocumentPart!.AddHyperlinkRelationship(newUri, true);
             }

--- a/OfficeIMO.Word/WordMargins.cs
+++ b/OfficeIMO.Word/WordMargins.cs
@@ -59,12 +59,8 @@ namespace OfficeIMO.Word {
         /// </summary>
         public UInt32Value Left {
             get {
-                var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
-                if (pageMargin?.Left != null) {
-                    return pageMargin.Left!;
-                }
-
-                return WordMargins.Normal.Left!;
+                var left = _section._sectionProperties.GetFirstChild<PageMargin>()?.Left ?? WordMargins.Normal.Left;
+                return left ?? new UInt32Value();
             }
             set {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -82,12 +78,8 @@ namespace OfficeIMO.Word {
         /// </summary>
         public UInt32Value Right {
             get {
-                var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
-                if (pageMargin?.Right != null) {
-                    return pageMargin.Right!;
-                }
-
-                return WordMargins.Normal.Right!;
+                var right = _section._sectionProperties.GetFirstChild<PageMargin>()?.Right ?? WordMargins.Normal.Right;
+                return right ?? new UInt32Value();
             }
             set {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -105,9 +97,8 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? Top {
             get {
-                var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
-                var top = pageMargin?.Top?.Value;
-                return top ?? WordMargins.Normal.Top!.Value;
+                return _section._sectionProperties.GetFirstChild<PageMargin>()?.Top?.Value
+                       ?? WordMargins.Normal.Top?.Value;
             }
             set {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -125,9 +116,8 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? Bottom {
             get {
-                var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
-                var bottom = pageMargin?.Bottom?.Value;
-                return bottom ?? WordMargins.Normal.Bottom!.Value;
+                return _section._sectionProperties.GetFirstChild<PageMargin>()?.Bottom?.Value
+                       ?? WordMargins.Normal.Bottom?.Value;
             }
             set {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -201,12 +191,8 @@ namespace OfficeIMO.Word {
         /// </summary>
         public UInt32Value HeaderDistance {
             get {
-                var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
-                if (pageMargin?.Header != null) {
-                    return pageMargin.Header!;
-                }
-
-                return WordMargins.Normal.Header!;
+                var header = _section._sectionProperties.GetFirstChild<PageMargin>()?.Header ?? WordMargins.Normal.Header;
+                return header ?? new UInt32Value();
             }
             set {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -224,12 +210,8 @@ namespace OfficeIMO.Word {
         /// </summary>
         public UInt32Value FooterDistance {
             get {
-                var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
-                if (pageMargin?.Footer != null) {
-                    return pageMargin.Footer!;
-                }
-
-                return WordMargins.Normal.Footer!;
+                var footer = _section._sectionProperties.GetFirstChild<PageMargin>()?.Footer ?? WordMargins.Normal.Footer;
+                return footer ?? new UInt32Value();
             }
             set {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
@@ -247,12 +229,8 @@ namespace OfficeIMO.Word {
         /// </summary>
         public UInt32Value Gutter {
             get {
-                var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();
-                if (pageMargin?.Gutter != null) {
-                    return pageMargin.Gutter!;
-                }
-
-                return WordMargins.Normal.Gutter!;
+                var gutter = _section._sectionProperties.GetFirstChild<PageMargin>()?.Gutter ?? WordMargins.Normal.Gutter;
+                return gutter ?? new UInt32Value();
             }
             set {
                 var pageMargin = _section._sectionProperties.GetFirstChild<PageMargin>();

--- a/OfficeIMO.Word/WordSection.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordSection.PrivateMethods.cs
@@ -86,7 +86,7 @@ namespace OfficeIMO.Word {
                 var docPartGallery = docPartObject?.ChildElements.OfType<DocPartGallery>().FirstOrDefault();
 
                 if (docPartGallery != null && docPartGallery.Val == "Cover Pages") {
-                    return new WordCoverPage(document, sdtBlock);
+                    return new WordCoverPage(document, sdtBlock!);
                 }
             }
 
@@ -109,7 +109,7 @@ namespace OfficeIMO.Word {
                 var docPartGallery = docPartObject?.ChildElements.OfType<DocPartGallery>().FirstOrDefault();
 
                 if (docPartGallery != null && docPartGallery.Val == "Table of Contents") {
-                    return new WordTableOfContent(document, sdtBlock);
+                    return new WordTableOfContent(document, sdtBlock!);
                 }
             }
             return null;
@@ -131,9 +131,9 @@ namespace OfficeIMO.Word {
             var docPartGallery = docPartObject?.ChildElements.OfType<DocPartGallery>().FirstOrDefault();
 
             if (docPartGallery != null && docPartGallery.Val == "Cover Pages") {
-                return new WordCoverPage(document, sdtBlock);
+                return new WordCoverPage(document, sdtBlock!);
             } else if (docPartGallery != null && docPartGallery.Val == "Table of Contents") {
-                return new WordTableOfContent(document, sdtBlock);
+                return new WordTableOfContent(document, sdtBlock!);
             }
 
             var watermark = ConvertStdBlockToWatermark(document, sdtBlock);
@@ -141,7 +141,7 @@ namespace OfficeIMO.Word {
                 return watermark;
             }
 
-            return new WordStructuredDocumentTag(document, sdtBlock);
+            return new WordStructuredDocumentTag(document, sdtBlock!);
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordShape.cs
+++ b/OfficeIMO.Word/WordShape.cs
@@ -17,11 +17,11 @@ namespace OfficeIMO.Word {
     /// </summary>
     public class WordShape : WordElement {
         /// <summary>Parent document.</summary>
-        internal WordDocument _document;
+        internal WordDocument _document = null!;
         /// <summary>Parent paragraph.</summary>
-        internal WordParagraph _wordParagraph;
+        internal WordParagraph _wordParagraph = null!;
         /// <summary>Run that hosts the shape.</summary>
-        internal Run _run;
+        internal Run _run = null!;
         /// <summary>The rectangle element if present.</summary>
         internal V.Rectangle? _rectangle;
         /// <summary>The rounded rectangle element if present.</summary>


### PR DESCRIPTION
## Summary
- guard hyperlink removal against missing header/footer parts
- relax WordMargins getters with null-coalescing defaults
- initialize internal WordShape fields to satisfy nullable analysis
- assert non-null SdtBlock usage when converting structured blocks

## Testing
- `dotnet build OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a41abc3320832e83e6518c1f87e048