### PR TITLE
Fix nullability warnings in Word helpers

### DIFF
--- a/OfficeIMO.Word/Table/WordTableStyleDetails.Methods.cs
+++ b/OfficeIMO.Word/Table/WordTableStyleDetails.Methods.cs
@@ -206,67 +206,67 @@ public partial class WordTableStyleDetails {
             // Top border
             if (TableBorders.TopBorder != null) {
                 if (TableBorders.TopBorder.Val != null) {
-                    cell.Borders.TopStyle = TableBorders.TopBorder.Val!;
+                    cell.Borders.TopStyle = TableBorders.TopBorder.Val.Value;
                 }
                 if (TableBorders.TopBorder.Size != null)
                     cell.Borders.TopSize = TableBorders.TopBorder.Size;
                 if (TableBorders.TopBorder.Color != null)
-                    cell.Borders.TopColorHex = TableBorders.TopBorder.Color!;
+                    cell.Borders.TopColorHex = TableBorders.TopBorder.Color.Value;
             }
 
             // Bottom border
             if (TableBorders.BottomBorder != null) {
                 if (TableBorders.BottomBorder.Val != null) {
-                    cell.Borders.BottomStyle = TableBorders.BottomBorder.Val!;
+                    cell.Borders.BottomStyle = TableBorders.BottomBorder.Val.Value;
                 }
                 if (TableBorders.BottomBorder.Size != null)
                     cell.Borders.BottomSize = TableBorders.BottomBorder.Size;
                 if (TableBorders.BottomBorder.Color != null)
-                    cell.Borders.BottomColorHex = TableBorders.BottomBorder.Color!;
+                    cell.Borders.BottomColorHex = TableBorders.BottomBorder.Color.Value;
             }
 
             // Left border
             if (TableBorders.LeftBorder != null) {
                 if (TableBorders.LeftBorder.Val != null) {
-                    cell.Borders.LeftStyle = TableBorders.LeftBorder.Val!;
+                    cell.Borders.LeftStyle = TableBorders.LeftBorder.Val.Value;
                 }
                 if (TableBorders.LeftBorder.Size != null)
                     cell.Borders.LeftSize = TableBorders.LeftBorder.Size;
                 if (TableBorders.LeftBorder.Color != null)
-                    cell.Borders.LeftColorHex = TableBorders.LeftBorder.Color!;
+                    cell.Borders.LeftColorHex = TableBorders.LeftBorder.Color.Value;
             }
 
             // Right border
             if (TableBorders.RightBorder != null) {
                 if (TableBorders.RightBorder.Val != null) {
-                    cell.Borders.RightStyle = TableBorders.RightBorder.Val!;
+                    cell.Borders.RightStyle = TableBorders.RightBorder.Val.Value;
                 }
                 if (TableBorders.RightBorder.Size != null)
                     cell.Borders.RightSize = TableBorders.RightBorder.Size;
                 if (TableBorders.RightBorder.Color != null)
-                    cell.Borders.RightColorHex = TableBorders.RightBorder.Color!;
+                    cell.Borders.RightColorHex = TableBorders.RightBorder.Color.Value;
             }
 
             // Inside horizontal border
             if (TableBorders.InsideHorizontalBorder != null) {
                 if (TableBorders.InsideHorizontalBorder.Val != null) {
-                    cell.Borders.InsideHorizontalStyle = TableBorders.InsideHorizontalBorder.Val!;
+                    cell.Borders.InsideHorizontalStyle = TableBorders.InsideHorizontalBorder.Val.Value;
                 }
                 if (TableBorders.InsideHorizontalBorder.Size != null)
                     cell.Borders.InsideHorizontalSize = TableBorders.InsideHorizontalBorder.Size;
                 if (TableBorders.InsideHorizontalBorder.Color != null)
-                    cell.Borders.InsideHorizontalColorHex = TableBorders.InsideHorizontalBorder.Color!;
+                    cell.Borders.InsideHorizontalColorHex = TableBorders.InsideHorizontalBorder.Color.Value;
             }
 
             // Inside vertical border
             if (TableBorders.InsideVerticalBorder != null) {
                 if (TableBorders.InsideVerticalBorder.Val != null) {
-                    cell.Borders.InsideVerticalStyle = TableBorders.InsideVerticalBorder.Val!;
+                    cell.Borders.InsideVerticalStyle = TableBorders.InsideVerticalBorder.Val.Value;
                 }
                 if (TableBorders.InsideVerticalBorder.Size != null)
                     cell.Borders.InsideVerticalSize = TableBorders.InsideVerticalBorder.Size;
                 if (TableBorders.InsideVerticalBorder.Color != null)
-                    cell.Borders.InsideVerticalColorHex = TableBorders.InsideVerticalBorder.Color!;
+                    cell.Borders.InsideVerticalColorHex = TableBorders.InsideVerticalBorder.Color.Value;
             }
         }
     }

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.cs
@@ -355,7 +355,7 @@ namespace OfficeIMO.Word {
         /// <returns>The paragraph that this was called on.</returns>
         public WordParagraph AddCitation(string sourceTag) {
             var field = new CitationField { SourceTag = sourceTag };
-            WordField.AddField(this, field, null!, null!, false);
+            WordField.AddField(this, field, null, string.Empty, false);
             return this;
         }
 
@@ -371,7 +371,7 @@ namespace OfficeIMO.Word {
         /// <see>https://support.microsoft.com/en-us/office/list-of-field-codes-in-word-1ad6d91a-55a7-4a8d-b535-cf7888659a51 </see></param>
         /// <returns>The paragraph that this was called on.</returns>
         public WordParagraph AddField(WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, string? customFormat = null, bool advanced = false, List<string>? parameters = null) {
-            var field = WordField.AddField(this, wordFieldType, wordFieldFormat, customFormat!, advanced, parameters!);
+            WordField.AddField(this, wordFieldType, wordFieldFormat, customFormat ?? string.Empty, advanced, parameters ?? new List<string>());
             return this;
         }
 
@@ -384,7 +384,7 @@ namespace OfficeIMO.Word {
         /// <param name="advanced">Use advanced field representation.</param>
         /// <returns>The paragraph that this was called on.</returns>
         public WordParagraph AddField(WordFieldCode fieldCode, WordFieldFormat? wordFieldFormat = null, string? customFormat = null, bool advanced = false) {
-            WordField.AddField(this, fieldCode, wordFieldFormat, customFormat!, advanced);
+            WordField.AddField(this, fieldCode, wordFieldFormat, customFormat ?? string.Empty, advanced);
             return this;
         }
 
@@ -946,7 +946,7 @@ namespace OfficeIMO.Word {
         /// <param name="alias">Optional alias for the control.</param>
         /// <param name="tag">Optional tag for the control.</param>
         /// <returns>The created <see cref="WordDropDownList"/> instance.</returns>
-        public WordDropDownList AddDropDownList(System.Collections.Generic.IEnumerable<string> items, string? alias = null, string? tag = null) {
+        public WordDropDownList AddDropDownList(System.Collections.Generic.IEnumerable<string>? items, string? alias = null, string? tag = null) {
             var sdtRun = new SdtRun();
 
             var props = new SdtProperties();
@@ -983,7 +983,7 @@ namespace OfficeIMO.Word {
         /// <param name="alias">Optional alias for the control.</param>
         /// <param name="tag">Optional tag for the control.</param>
         /// <returns>The created <see cref="WordComboBox"/> instance.</returns>
-        public WordComboBox AddComboBox(System.Collections.Generic.IEnumerable<string> items, string? alias = null, string? tag = null) {
+        public WordComboBox AddComboBox(System.Collections.Generic.IEnumerable<string>? items, string? alias = null, string? tag = null) {
             var sdtRun = new SdtRun();
 
             var props = new SdtProperties();


### PR DESCRIPTION
## Summary
- remove null-forgiving operators in table border application
- allow optional parameters when adding fields and controls
- harden document creation and loading against missing parts

## Testing
- `dotnet build OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a41abfb5f4832ea554def0774b4717