### PR TITLE
Fix nullability warnings in Word utilities

### DIFF
--- a/OfficeIMO.Word/WordField.cs
+++ b/OfficeIMO.Word/WordField.cs
@@ -203,7 +203,7 @@ namespace OfficeIMO.Word {
         private readonly WordDocument _document;
         private readonly Paragraph _paragraph;
         private readonly List<Run> _runs = new List<Run>();
-        private readonly SimpleField _simpleField;
+        private readonly SimpleField? _simpleField;
 
         /// <summary>
         /// Gets the type of the current field.
@@ -251,7 +251,7 @@ namespace OfficeIMO.Word {
         public string Field {
             get {
                 if (_simpleField != null) {
-                    return _simpleField.Instruction;
+                    return _simpleField.Instruction?.Value ?? string.Empty;
                 } else {
                     var instruction = "";
                     foreach (var run in _runs) {
@@ -367,13 +367,16 @@ namespace OfficeIMO.Word {
             }
         }
 
-        internal WordField(WordDocument document, Paragraph paragraph, SimpleField simpleField, List<Run> runs) {
+        internal WordField(WordDocument document, Paragraph paragraph, SimpleField? simpleField, List<Run>? runs) {
             this._document = document;
             this._paragraph = paragraph;
             this._simpleField = simpleField;
             if (simpleField != null) {
-                this._runs.Add(simpleField.GetFirstChild<Run>());
-            } else {
+                var run = simpleField.GetFirstChild<Run>();
+                if (run != null) {
+                    this._runs.Add(run);
+                }
+            } else if (runs != null) {
                 this._runs = runs;
             }
         }

--- a/OfficeIMO.Word/WordParagraph.cs
+++ b/OfficeIMO.Word/WordParagraph.cs
@@ -22,8 +22,8 @@ namespace OfficeIMO.Word {
     /// Represents a paragraph within a Word document.
     /// </summary>
     public partial class WordParagraph : WordElement {
-        internal WordDocument _document;
-        internal Paragraph _paragraph;
+        internal WordDocument _document = null!;
+        internal Paragraph _paragraph = null!;
 
         /// <summary>
         /// This allows to know where the paragraph is located. Useful for hyperlinks or other stuff.
@@ -69,8 +69,11 @@ namespace OfficeIMO.Word {
         public bool IsLastRun {
             get {
                 if (_run != null) {
-                    var runs = _run.Parent.ChildElements.OfType<Run>();
-                    return runs.Last() == _run;
+                    var parent = _run.Parent;
+                    if (parent != null) {
+                        var runs = parent.ChildElements.OfType<Run>();
+                        return runs.LastOrDefault() == _run;
+                    }
                 }
                 return false;
             }
@@ -82,14 +85,17 @@ namespace OfficeIMO.Word {
         public bool IsFirstRun {
             get {
                 if (_run != null) {
-                    var runs = _run.Parent.ChildElements.OfType<Run>();
-                    return runs.First() == _run;
+                    var parent = _run.Parent;
+                    if (parent != null) {
+                        var runs = parent.ChildElements.OfType<Run>();
+                        return runs.FirstOrDefault() == _run;
+                    }
                 }
                 return false;
             }
         }
 
-        internal RunProperties _runProperties {
+        internal RunProperties? _runProperties {
             get {
                 if (_run != null) {
                     return _run.RunProperties;
@@ -104,7 +110,7 @@ namespace OfficeIMO.Word {
             }
         }
 
-        internal Text _text {
+        internal Text? _text {
             get {
                 if (_run != null) {
                     return _run.ChildElements.OfType<Text>().FirstOrDefault();
@@ -113,9 +119,9 @@ namespace OfficeIMO.Word {
                 return null;
             }
         }
-        internal Run _run;
+        internal Run? _run;
 
-        internal ParagraphProperties _paragraphProperties {
+        internal ParagraphProperties? _paragraphProperties {
             get {
                 if (_paragraph != null && _paragraph.ParagraphProperties != null) {
                     return _paragraph.ParagraphProperties;
@@ -128,7 +134,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the first image associated with this run, if any.
         /// </summary>
-        public WordImage Image {
+        public WordImage? Image {
             get {
                 if (_run != null) {
                     // DrawingML pictures
@@ -172,7 +178,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the embedded object associated with this run, if any.
         /// </summary>
-        public WordEmbeddedObject EmbeddedObject {
+        public WordEmbeddedObject? EmbeddedObject {
             get {
                 if (_run != null) {
                     var ole = _run.Descendants<Ovml.OleObject>().FirstOrDefault();
@@ -202,17 +208,13 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? ListItemLevel {
             get {
-                if (_paragraphProperties != null && _paragraphProperties.NumberingProperties != null) {
-                    return _paragraphProperties.NumberingProperties.NumberingLevelReference.Val;
-                } else {
-                    return null;
-                }
+                var val = _paragraphProperties?.NumberingProperties?.NumberingLevelReference?.Val;
+                return val?.Value;
             }
             set {
-                if (_paragraphProperties != null && _paragraphProperties.NumberingProperties != null) {
-                    if (_paragraphProperties.NumberingProperties.NumberingLevelReference != null) {
-                        _paragraphProperties.NumberingProperties.NumberingLevelReference.Val = value;
-                    }
+                var levelRef = _paragraphProperties?.NumberingProperties?.NumberingLevelReference;
+                if (levelRef != null) {
+                    levelRef.Val = value;
                 } else {
                     // should throw?
                 }
@@ -221,11 +223,8 @@ namespace OfficeIMO.Word {
 
         internal int? _listNumberId {
             get {
-                if (_paragraphProperties != null && _paragraphProperties.NumberingProperties != null) {
-                    return _paragraphProperties.NumberingProperties.NumberingId.Val;
-                } else {
-                    return null;
-                }
+                var val = _paragraphProperties?.NumberingProperties?.NumberingId?.Val;
+                return val?.Value;
             }
         }
 
@@ -257,37 +256,37 @@ namespace OfficeIMO.Word {
         /// </summary>
         public WordParagraphStyles? Style {
             get {
-                if (_paragraphProperties != null && _paragraphProperties.ParagraphStyleId != null) {
-                    return WordParagraphStyle.GetStyle(_paragraphProperties.ParagraphStyleId.Val);
-                }
-
-                return null;
+                var styleId = _paragraphProperties?.ParagraphStyleId?.Val;
+                return styleId != null ? WordParagraphStyle.GetStyle(styleId.Value!) : null;
             }
             set {
                 if (value != null) {
                     if (_paragraphProperties == null) {
                         _paragraph.ParagraphProperties = new ParagraphProperties();
                     }
-                    if (_paragraphProperties.ParagraphStyleId == null) {
-                        _paragraphProperties.ParagraphStyleId = new ParagraphStyleId();
-                    }
-                    _paragraphProperties.ParagraphStyleId.Val = value.Value.ToStringStyle();
-                    if (value.Value >= WordParagraphStyles.Heading1 && value.Value <= WordParagraphStyles.Heading9) {
-                        _document?.HeadingModified();
+                    var paragraphProperties = _paragraphProperties;
+                    if (paragraphProperties != null) {
+                        if (paragraphProperties.ParagraphStyleId == null) {
+                            paragraphProperties.ParagraphStyleId = new ParagraphStyleId();
+                        }
+                        paragraphProperties.ParagraphStyleId.Val = value.Value.ToStringStyle();
+                        if (value.Value >= WordParagraphStyles.Heading1 && value.Value <= WordParagraphStyles.Heading9) {
+                            _document?.HeadingModified();
+                        }
                     }
                 }
             }
         }
 
 
-        internal WordList _list;
-        internal List<Run> _runs;
-        internal Hyperlink _hyperlink;
-        internal SimpleField _simpleField;
-        internal BookmarkStart _bookmarkStart;
-        internal readonly OfficeMath _officeMath;
-        internal readonly SdtRun _stdRun;
-        internal readonly DocumentFormat.OpenXml.Math.Paragraph _mathParagraph;
+        internal WordList? _list;
+        internal List<Run>? _runs;
+        internal Hyperlink? _hyperlink;
+        internal SimpleField? _simpleField;
+        internal BookmarkStart? _bookmarkStart;
+        internal readonly OfficeMath? _officeMath;
+        internal readonly SdtRun? _stdRun;
+        internal readonly DocumentFormat.OpenXml.Math.Paragraph? _mathParagraph;
 
         /// <summary>
         /// Get or set a text within Paragraph
@@ -301,15 +300,15 @@ namespace OfficeIMO.Word {
                 return _text.Text;
             }
             set {
-                VerifyText();
-                _text.Text = value;
+                var text = VerifyText();
+                text.Text = value;
             }
         }
 
         /// <summary>
         /// Get PageBreaks within Paragraph
         /// </summary>
-        public WordBreak PageBreak {
+        public WordBreak? PageBreak {
             get {
                 if (_run != null) {
                     var brake = _run.ChildElements.OfType<Break>().FirstOrDefault();
@@ -325,7 +324,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Get Breaks within Paragraph
         /// </summary>
-        public WordBreak Break {
+        public WordBreak? Break {
             get {
                 if (_run != null) {
                     var brake = _run.ChildElements.OfType<Break>().FirstOrDefault();
@@ -341,7 +340,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the <see cref="WordTabChar"/> representing a tab character in the current run, or <c>null</c> if none is present.
         /// </summary>
-        public WordTabChar Tab {
+        public WordTabChar? Tab {
             get {
                 if (_run != null) {
                     var tabChar = _run.ChildElements.OfType<TabChar>().FirstOrDefault();
@@ -360,8 +359,8 @@ namespace OfficeIMO.Word {
         /// <param name="document">Parent document.</param>
         /// <param name="newParagraph">Create a new paragraph element.</param>
         /// <param name="newRun">Create a new run inside the paragraph.</param>
-        public WordParagraph(WordDocument document = null, bool newParagraph = true, bool newRun = true) {
-            this._document = document;
+        public WordParagraph(WordDocument? document = null, bool newParagraph = true, bool newRun = true) {
+            this._document = document!;
 
             if (newParagraph) {
                 this._paragraph = new Paragraph();
@@ -462,7 +461,7 @@ namespace OfficeIMO.Word {
             //  this.Equation = new WordEquation(document, paragraph, mathParagraph);
         }
 
-        internal WordStructuredDocumentTag StructuredDocumentTag {
+        internal WordStructuredDocumentTag? StructuredDocumentTag {
             get {
                 if (_stdRun != null) {
                     return new WordStructuredDocumentTag(_document, _paragraph, _stdRun);
@@ -475,7 +474,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the checkbox contained in this paragraph, if present.
         /// </summary>
-        public WordCheckBox CheckBox {
+        public WordCheckBox? CheckBox {
             get {
                 if (_stdRun != null && _stdRun.SdtProperties?.Elements<DocumentFormat.OpenXml.Office2010.Word.SdtContentCheckBox>().Any() == true) {
                     return new WordCheckBox(_document, _paragraph, _stdRun);
@@ -489,7 +488,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the date picker contained in this paragraph, if present.
         /// </summary>
-        public WordDatePicker DatePicker {
+        public WordDatePicker? DatePicker {
             get {
                 if (_stdRun != null && _stdRun.SdtProperties?.Elements<SdtContentDate>().Any() == true) {
                     return new WordDatePicker(_document, _paragraph, _stdRun);
@@ -502,7 +501,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the dropdown list contained in this paragraph, if present.
         /// </summary>
-        public WordDropDownList DropDownList {
+        public WordDropDownList? DropDownList {
             get {
                 if (_stdRun != null && _stdRun.SdtProperties?.Elements<SdtContentDropDownList>().Any() == true) {
                     return new WordDropDownList(_document, _paragraph, _stdRun);
@@ -515,7 +514,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the combo box contained in this paragraph, if present.
         /// </summary>
-        public WordComboBox ComboBox {
+        public WordComboBox? ComboBox {
             get {
                 if (_stdRun != null && _stdRun.SdtProperties?.Elements<SdtContentComboBox>().Any() == true) {
                     return new WordComboBox(_document, _paragraph, _stdRun);
@@ -528,7 +527,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the picture content control contained in this paragraph, if present.
         /// </summary>
-        public WordPictureControl PictureControl {
+        public WordPictureControl? PictureControl {
             get {
                 if (_stdRun != null && _stdRun.SdtProperties?.Elements<SdtContentPicture>().Any() == true) {
                     return new WordPictureControl(_document, _paragraph, _stdRun);
@@ -541,7 +540,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the repeating section contained in this paragraph, if present.
         /// </summary>
-        public WordRepeatingSection RepeatingSection {
+        public WordRepeatingSection? RepeatingSection {
             get {
                 if (_stdRun != null && _stdRun.SdtProperties?.Elements<W15.SdtRepeatedSection>().Any() == true) {
                     return new WordRepeatingSection(_document, _paragraph, _stdRun);
@@ -553,7 +552,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the bookmark associated with this paragraph, if present.
         /// </summary>
-        public WordBookmark Bookmark {
+        public WordBookmark? Bookmark {
             get {
                 if (_bookmarkStart != null) {
                     return new WordBookmark(_document, _paragraph, _bookmarkStart);
@@ -566,12 +565,17 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the mathematical equation contained in this paragraph, if any.
         /// </summary>
-        public WordEquation Equation {
+        public WordEquation? Equation {
             get {
-                if (_officeMath != null || _mathParagraph != null) {
+                if (_officeMath != null && _mathParagraph != null) {
                     return new WordEquation(_document, _paragraph, _officeMath, _mathParagraph);
                 }
-
+                if (_officeMath != null) {
+                    return new WordEquation(_document, _paragraph, _officeMath);
+                }
+                if (_mathParagraph != null) {
+                    return new WordEquation(_document, _paragraph, _mathParagraph);
+                }
                 return null;
             }
         }
@@ -579,7 +583,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the field contained in this paragraph, if any.
         /// </summary>
-        public WordField Field {
+        public WordField? Field {
             get {
                 if (_simpleField != null || _runs != null) {
                     return new WordField(_document, _paragraph, _simpleField, _runs);
@@ -592,7 +596,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the chart contained in this paragraph, if present.
         /// </summary>
-        public WordChart Chart {
+        public WordChart? Chart {
             get {
                 if (_run != null) {
                     var drawing = _run.ChildElements.OfType<Drawing>().FirstOrDefault();
@@ -616,7 +620,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the SmartArt diagram contained in this paragraph, if present.
         /// </summary>
-        public WordSmartArt SmartArt {
+        public WordSmartArt? SmartArt {
             get {
                 if (_run != null) {
                     var drawing = _run.ChildElements.OfType<Drawing>().FirstOrDefault();
@@ -634,7 +638,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the hyperlink contained in this paragraph, if present.
         /// </summary>
-        public WordHyperLink Hyperlink {
+        public WordHyperLink? Hyperlink {
             get {
                 if (_hyperlink != null) {
                     return new WordHyperLink(_document, _paragraph, _hyperlink);
@@ -647,7 +651,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the footnote associated with this paragraph, if any.
         /// </summary>
-        public WordFootNote FootNote {
+        public WordFootNote? FootNote {
             get {
                 if (_run != null && _runProperties != null) {
                     var footReference = _run.ChildElements.OfType<FootnoteReference>().FirstOrDefault();
@@ -662,7 +666,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the endnote associated with this paragraph, if any.
         /// </summary>
-        public WordEndNote EndNote {
+        public WordEndNote? EndNote {
             get {
                 if (_run != null && _runProperties != null) {
                     var endNoteReference = _run.ChildElements.OfType<EndnoteReference>().FirstOrDefault();
@@ -692,7 +696,8 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool IsField {
             get {
-                if (this.Field != null && this.Field.Field != null) {
+                var field = Field;
+                if (field != null && field.Field != null) {
                     return true;
                 }
 
@@ -705,7 +710,8 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool IsBookmark {
             get {
-                if (this.Bookmark != null && this.Bookmark.Name != null) {
+                var bookmark = Bookmark;
+                if (bookmark != null && bookmark.Name != null) {
                     return true;
                 }
 
@@ -924,7 +930,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the <see cref="WordTextBox"/> contained within the paragraph, if any.
         /// </summary>
-        public WordTextBox TextBox {
+        public WordTextBox? TextBox {
             get {
                 if (_run != null) {
                     // DrawingML text boxes
@@ -974,7 +980,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Returns a <see cref="WordShape"/> instance when the paragraph contains shapes.
         /// </summary>
-        public WordShape Shape {
+        public WordShape? Shape {
             get {
                 if (_run != null) {
                     if (TextBox != null) {
@@ -1026,7 +1032,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the line shape contained in this paragraph, if present.
         /// </summary>
-        public WordLine Line {
+        public WordLine? Line {
             get {
                 if (_run != null) {
                     var line = _run.Descendants<V.Line>().FirstOrDefault();

--- a/OfficeIMO.Word/WordTableCellBorder.cs
+++ b/OfficeIMO.Word/WordTableCellBorder.cs
@@ -32,7 +32,7 @@ namespace OfficeIMO.Word {
         public BorderValues? LeftStyle {
             get {
                 if (_tableCellProperties.TableCellBorders != null && _tableCellProperties.TableCellBorders.LeftBorder != null) {
-                    return _tableCellProperties.TableCellBorders.LeftBorder.Val;
+                    return _tableCellProperties.TableCellBorders.LeftBorder.Val?.Value;
                 }
                 return null;
             }
@@ -44,20 +44,18 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.LeftBorder == null) {
                     _tableCellProperties.TableCellBorders.LeftBorder = new LeftBorder();
                 }
-                _tableCellProperties.TableCellBorders.LeftBorder.Val = value;
+
+                _tableCellProperties.TableCellBorders.LeftBorder.Val = value.HasValue ? value.Value : null;
             }
         }
 
         /// <summary>
         /// Get or set left table cell border color using hex color codes
         /// </summary>
-        public string LeftColorHex {
+        public string? LeftColorHex {
             get {
-                if (_tableCellProperties.TableCellBorders != null
-                    && _tableCellProperties.TableCellBorders.LeftBorder != null
-                    && _tableCellProperties.TableCellBorders.LeftBorder.Color != null
-                    && _tableCellProperties.TableCellBorders.LeftBorder.Color.Value != null) {
-                    return _tableCellProperties.TableCellBorders.LeftBorder.Color.Value.Replace("#", "").ToLowerInvariant();
+                if (_tableCellProperties.TableCellBorders?.LeftBorder?.Color?.Value is string color) {
+                    return color.Replace("#", "").ToLowerInvariant();
                 }
                 return null;
             }
@@ -69,7 +67,7 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.LeftBorder == null) {
                     _tableCellProperties.TableCellBorders.LeftBorder = new LeftBorder();
                 }
-                _tableCellProperties.TableCellBorders.LeftBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                _tableCellProperties.TableCellBorders.LeftBorder.Color = value?.Replace("#", "").ToLowerInvariant();
             }
         }
 
@@ -77,14 +75,17 @@ namespace OfficeIMO.Word {
         /// Get or set left table cell border color using named colors
         /// </summary>
         public SixLabors.ImageSharp.Color LeftColor {
-            get { return Helpers.ParseColor(LeftColorHex); }
+            get {
+                var hex = LeftColorHex;
+                return Helpers.ParseColor(hex ?? throw new InvalidOperationException("LeftColorHex is null"));
+            }
             set { this.LeftColorHex = value.ToHexColor(); }
         }
 
         /// <summary>
         /// Get or set left table cell border space
         /// </summary>
-        public UInt32Value LeftSpace {
+        public UInt32Value? LeftSpace {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.LeftBorder != null
@@ -109,7 +110,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Get or set left table cell border size
         /// </summary>
-        public UInt32Value LeftSize {
+        public UInt32Value? LeftSize {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.LeftBorder != null
@@ -139,7 +140,7 @@ namespace OfficeIMO.Word {
         public BorderValues? RightStyle {
             get {
                 if (_tableCellProperties.TableCellBorders != null && _tableCellProperties.TableCellBorders.RightBorder != null) {
-                    return _tableCellProperties.TableCellBorders.RightBorder.Val;
+                    return _tableCellProperties.TableCellBorders.RightBorder.Val?.Value;
                 }
                 return null;
             }
@@ -151,20 +152,18 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.RightBorder == null) {
                     _tableCellProperties.TableCellBorders.RightBorder = new RightBorder();
                 }
-                _tableCellProperties.TableCellBorders.RightBorder.Val = value;
+
+                _tableCellProperties.TableCellBorders.RightBorder.Val = value.HasValue ? value.Value : null;
             }
         }
 
         /// <summary>
         /// Get or set right table cell border color using hex color codes
         /// </summary>
-        public string RightColorHex {
+        public string? RightColorHex {
             get {
-                if (_tableCellProperties.TableCellBorders != null
-                    && _tableCellProperties.TableCellBorders.RightBorder != null
-                    && _tableCellProperties.TableCellBorders.RightBorder.Color != null
-                    && _tableCellProperties.TableCellBorders.RightBorder.Color.Value != null) {
-                    return _tableCellProperties.TableCellBorders.RightBorder.Color.Value.Replace("#", "").ToLowerInvariant();
+                if (_tableCellProperties.TableCellBorders?.RightBorder?.Color?.Value is string color) {
+                    return color.Replace("#", "").ToLowerInvariant();
                 }
                 return null;
             }
@@ -176,7 +175,7 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.RightBorder == null) {
                     _tableCellProperties.TableCellBorders.RightBorder = new RightBorder();
                 }
-                _tableCellProperties.TableCellBorders.RightBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                _tableCellProperties.TableCellBorders.RightBorder.Color = value?.Replace("#", "").ToLowerInvariant();
             }
         }
 
@@ -184,14 +183,17 @@ namespace OfficeIMO.Word {
         /// Get or set right table cell border color using named colors
         /// </summary>
         public SixLabors.ImageSharp.Color RightColor {
-            get { return Helpers.ParseColor(RightColorHex); }
+            get {
+                var hex = RightColorHex;
+                return Helpers.ParseColor(hex ?? throw new InvalidOperationException("RightColorHex is null"));
+            }
             set { this.RightColorHex = value.ToHexColor(); }
         }
 
         /// <summary>
         /// Get or set right table cell border space
         /// </summary>
-        public UInt32Value RightSpace {
+        public UInt32Value? RightSpace {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.RightBorder != null
@@ -216,7 +218,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Get or set right table cell border size
         /// </summary>
-        public UInt32Value RightSize {
+        public UInt32Value? RightSize {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.RightBorder != null
@@ -248,7 +250,7 @@ namespace OfficeIMO.Word {
         public BorderValues? TopStyle {
             get {
                 if (_tableCellProperties.TableCellBorders != null && _tableCellProperties.TableCellBorders.TopBorder != null) {
-                    return _tableCellProperties.TableCellBorders.TopBorder.Val;
+                    return _tableCellProperties.TableCellBorders.TopBorder.Val?.Value;
                 }
                 return null;
             }
@@ -260,20 +262,18 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.TopBorder == null) {
                     _tableCellProperties.TableCellBorders.TopBorder = new TopBorder();
                 }
-                _tableCellProperties.TableCellBorders.TopBorder.Val = value;
+
+                _tableCellProperties.TableCellBorders.TopBorder.Val = value.HasValue ? value.Value : null;
             }
         }
 
         /// <summary>
         /// Get or set top table cell border color using hex color codes
         /// </summary>
-        public string TopColorHex {
+        public string? TopColorHex {
             get {
-                if (_tableCellProperties.TableCellBorders != null
-                    && _tableCellProperties.TableCellBorders.TopBorder != null
-                    && _tableCellProperties.TableCellBorders.TopBorder.Color != null
-                    && _tableCellProperties.TableCellBorders.TopBorder.Color.Value != null) {
-                    return _tableCellProperties.TableCellBorders.TopBorder.Color.Value.Replace("#", "").ToLowerInvariant();
+                if (_tableCellProperties.TableCellBorders?.TopBorder?.Color?.Value is string color) {
+                    return color.Replace("#", "").ToLowerInvariant();
                 }
                 return null;
             }
@@ -285,7 +285,7 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.TopBorder == null) {
                     _tableCellProperties.TableCellBorders.TopBorder = new TopBorder();
                 }
-                _tableCellProperties.TableCellBorders.TopBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                _tableCellProperties.TableCellBorders.TopBorder.Color = value?.Replace("#", "").ToLowerInvariant();
             }
         }
 
@@ -293,14 +293,17 @@ namespace OfficeIMO.Word {
         /// Get or set top table cell border color using named colors
         /// </summary>
         public SixLabors.ImageSharp.Color TopColor {
-            get { return Helpers.ParseColor(TopColorHex); }
+            get {
+                var hex = TopColorHex;
+                return Helpers.ParseColor(hex ?? throw new InvalidOperationException("TopColorHex is null"));
+            }
             set { this.TopColorHex = value.ToHexColor(); }
         }
 
         /// <summary>
         /// Get or set top table cell border space
         /// </summary>
-        public UInt32Value TopSpace {
+        public UInt32Value? TopSpace {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.TopBorder != null
@@ -325,7 +328,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Get or set top table cell border size
         /// </summary>
-        public UInt32Value TopSize {
+        public UInt32Value? TopSize {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.TopBorder != null
@@ -360,7 +363,7 @@ namespace OfficeIMO.Word {
         public BorderValues? BottomStyle {
             get {
                 if (_tableCellProperties.TableCellBorders != null && _tableCellProperties.TableCellBorders.BottomBorder != null) {
-                    return _tableCellProperties.TableCellBorders.BottomBorder.Val;
+                    return _tableCellProperties.TableCellBorders.BottomBorder.Val?.Value;
                 }
                 return null;
             }
@@ -372,20 +375,18 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.BottomBorder == null) {
                     _tableCellProperties.TableCellBorders.BottomBorder = new BottomBorder();
                 }
-                _tableCellProperties.TableCellBorders.BottomBorder.Val = value;
+
+                _tableCellProperties.TableCellBorders.BottomBorder.Val = value.HasValue ? value.Value : null;
             }
         }
 
         /// <summary>
         /// Get or set bottom table cell border color using hex color codes
         /// </summary>
-        public string BottomColorHex {
+        public string? BottomColorHex {
             get {
-                if (_tableCellProperties.TableCellBorders != null
-                    && _tableCellProperties.TableCellBorders.BottomBorder != null
-                    && _tableCellProperties.TableCellBorders.BottomBorder.Color != null
-                    && _tableCellProperties.TableCellBorders.BottomBorder.Color.Value != null) {
-                    return _tableCellProperties.TableCellBorders.BottomBorder.Color.Value.Replace("#", "").ToLowerInvariant();
+                if (_tableCellProperties.TableCellBorders?.BottomBorder?.Color?.Value is string color) {
+                    return color.Replace("#", "").ToLowerInvariant();
                 }
                 return null;
             }
@@ -397,7 +398,7 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.BottomBorder == null) {
                     _tableCellProperties.TableCellBorders.BottomBorder = new BottomBorder();
                 }
-                _tableCellProperties.TableCellBorders.BottomBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                _tableCellProperties.TableCellBorders.BottomBorder.Color = value?.Replace("#", "").ToLowerInvariant();
             }
         }
 
@@ -405,14 +406,17 @@ namespace OfficeIMO.Word {
         /// Get or set bottom table cell border color using named colors
         /// </summary>
         public SixLabors.ImageSharp.Color BottomColor {
-            get { return Helpers.ParseColor(BottomColorHex); }
+            get {
+                var hex = BottomColorHex;
+                return Helpers.ParseColor(hex ?? throw new InvalidOperationException("BottomColorHex is null"));
+            }
             set { this.BottomColorHex = value.ToHexColor(); }
         }
 
         /// <summary>
         /// Get or set bottom table cell border space
         /// </summary>
-        public UInt32Value BottomSpace {
+        public UInt32Value? BottomSpace {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.BottomBorder != null
@@ -437,7 +441,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Get or set bottom table cell border size
         /// </summary>
-        public UInt32Value BottomSize {
+        public UInt32Value? BottomSize {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.BottomBorder != null
@@ -474,7 +478,7 @@ namespace OfficeIMO.Word {
         public BorderValues? InsideHorizontalStyle {
             get {
                 if (_tableCellProperties.TableCellBorders != null && _tableCellProperties.TableCellBorders.InsideHorizontalBorder != null) {
-                    return _tableCellProperties.TableCellBorders.InsideHorizontalBorder.Val;
+                    return _tableCellProperties.TableCellBorders.InsideHorizontalBorder.Val?.Value;
                 }
                 return null;
             }
@@ -486,20 +490,18 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.InsideHorizontalBorder == null) {
                     _tableCellProperties.TableCellBorders.InsideHorizontalBorder = new InsideHorizontalBorder();
                 }
-                _tableCellProperties.TableCellBorders.InsideHorizontalBorder.Val = value;
+
+                _tableCellProperties.TableCellBorders.InsideHorizontalBorder.Val = value.HasValue ? value.Value : null;
             }
         }
 
         /// <summary>
         /// Get or set inside horizontal table cell border color using hex color codes
         /// </summary>
-        public string InsideHorizontalColorHex {
+        public string? InsideHorizontalColorHex {
             get {
-                if (_tableCellProperties.TableCellBorders != null
-                    && _tableCellProperties.TableCellBorders.InsideHorizontalBorder != null
-                    && _tableCellProperties.TableCellBorders.InsideHorizontalBorder.Color != null
-                    && _tableCellProperties.TableCellBorders.InsideHorizontalBorder.Color.Value != null) {
-                    return _tableCellProperties.TableCellBorders.InsideHorizontalBorder.Color.Value.Replace("#", "").ToLowerInvariant();
+                if (_tableCellProperties.TableCellBorders?.InsideHorizontalBorder?.Color?.Value is string color) {
+                    return color.Replace("#", "").ToLowerInvariant();
                 }
                 return null;
             }
@@ -511,7 +513,7 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.InsideHorizontalBorder == null) {
                     _tableCellProperties.TableCellBorders.InsideHorizontalBorder = new InsideHorizontalBorder();
                 }
-                _tableCellProperties.TableCellBorders.InsideHorizontalBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                _tableCellProperties.TableCellBorders.InsideHorizontalBorder.Color = value?.Replace("#", "").ToLowerInvariant();
             }
         }
 
@@ -519,14 +521,17 @@ namespace OfficeIMO.Word {
         /// Get or set inside horizontal table cell border color using named colors
         /// </summary>
         public SixLabors.ImageSharp.Color InsideHorizontalColor {
-            get { return Helpers.ParseColor(InsideHorizontalColorHex); }
+            get {
+                var hex = InsideHorizontalColorHex;
+                return Helpers.ParseColor(hex ?? throw new InvalidOperationException("InsideHorizontalColorHex is null"));
+            }
             set { this.InsideHorizontalColorHex = value.ToHexColor(); }
         }
 
         /// <summary>
         /// Get or set inside horizontal table cell border space
         /// </summary>
-        public UInt32Value InsideHorizontalSpace {
+        public UInt32Value? InsideHorizontalSpace {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.InsideHorizontalBorder != null
@@ -551,7 +556,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Get or set inside horizontal table cell border size
         /// </summary>
-        public UInt32Value InsideHorizontalSize {
+        public UInt32Value? InsideHorizontalSize {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.InsideHorizontalBorder != null
@@ -588,7 +593,7 @@ namespace OfficeIMO.Word {
         public BorderValues? InsideVerticalStyle {
             get {
                 if (_tableCellProperties.TableCellBorders != null && _tableCellProperties.TableCellBorders.InsideVerticalBorder != null) {
-                    return _tableCellProperties.TableCellBorders.InsideVerticalBorder.Val;
+                    return _tableCellProperties.TableCellBorders.InsideVerticalBorder.Val?.Value;
                 }
                 return null;
             }
@@ -600,20 +605,18 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.InsideVerticalBorder == null) {
                     _tableCellProperties.TableCellBorders.InsideVerticalBorder = new InsideVerticalBorder();
                 }
-                _tableCellProperties.TableCellBorders.InsideVerticalBorder.Val = value;
+
+                _tableCellProperties.TableCellBorders.InsideVerticalBorder.Val = value.HasValue ? value.Value : null;
             }
         }
 
         /// <summary>
         /// Get or set inside vertical table cell border color using hex color codes
         /// </summary>
-        public string InsideVerticalColorHex {
+        public string? InsideVerticalColorHex {
             get {
-                if (_tableCellProperties.TableCellBorders != null
-                    && _tableCellProperties.TableCellBorders.InsideVerticalBorder != null
-                    && _tableCellProperties.TableCellBorders.InsideVerticalBorder.Color != null
-                    && _tableCellProperties.TableCellBorders.InsideVerticalBorder.Color.Value != null) {
-                    return _tableCellProperties.TableCellBorders.InsideVerticalBorder.Color.Value.Replace("#", "").ToLowerInvariant();
+                if (_tableCellProperties.TableCellBorders?.InsideVerticalBorder?.Color?.Value is string color) {
+                    return color.Replace("#", "").ToLowerInvariant();
                 }
                 return null;
             }
@@ -625,7 +628,7 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.InsideVerticalBorder == null) {
                     _tableCellProperties.TableCellBorders.InsideVerticalBorder = new InsideVerticalBorder();
                 }
-                _tableCellProperties.TableCellBorders.InsideVerticalBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                _tableCellProperties.TableCellBorders.InsideVerticalBorder.Color = value?.Replace("#", "").ToLowerInvariant();
             }
         }
 
@@ -633,14 +636,17 @@ namespace OfficeIMO.Word {
         /// Get or set inside vertical table cell border color using named colors
         /// </summary>
         public SixLabors.ImageSharp.Color InsideVerticalColor {
-            get { return Helpers.ParseColor(InsideVerticalColorHex); }
+            get {
+                var hex = InsideVerticalColorHex;
+                return Helpers.ParseColor(hex ?? throw new InvalidOperationException("InsideVerticalColorHex is null"));
+            }
             set { this.InsideVerticalColorHex = value.ToHexColor(); }
         }
 
         /// <summary>
         /// Get or set inside vertical table cell border space
         /// </summary>
-        public UInt32Value InsideVerticalSpace {
+        public UInt32Value? InsideVerticalSpace {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.InsideVerticalBorder != null
@@ -665,7 +671,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Get or set inside vertical table cell border size
         /// </summary>
-        public UInt32Value InsideVerticalSize {
+        public UInt32Value? InsideVerticalSize {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.InsideVerticalBorder != null
@@ -699,7 +705,7 @@ namespace OfficeIMO.Word {
         public BorderValues? StartStyle {
             get {
                 if (_tableCellProperties.TableCellBorders != null && _tableCellProperties.TableCellBorders.StartBorder != null) {
-                    return _tableCellProperties.TableCellBorders.StartBorder.Val;
+                    return _tableCellProperties.TableCellBorders.StartBorder.Val?.Value;
                 }
                 return null;
             }
@@ -711,20 +717,18 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.StartBorder == null) {
                     _tableCellProperties.TableCellBorders.StartBorder = new StartBorder();
                 }
-                _tableCellProperties.TableCellBorders.StartBorder.Val = value;
+
+                _tableCellProperties.TableCellBorders.StartBorder.Val = value.HasValue ? value.Value : null;
             }
         }
 
         /// <summary>
         /// Get or set start table cell border color using hex color codes
         /// </summary>
-        public string StartColorHex {
+        public string? StartColorHex {
             get {
-                if (_tableCellProperties.TableCellBorders != null
-                    && _tableCellProperties.TableCellBorders.StartBorder != null
-                    && _tableCellProperties.TableCellBorders.StartBorder.Color != null
-                    && _tableCellProperties.TableCellBorders.StartBorder.Color.Value != null) {
-                    return _tableCellProperties.TableCellBorders.StartBorder.Color.Value.Replace("#", "").ToLowerInvariant();
+                if (_tableCellProperties.TableCellBorders?.StartBorder?.Color?.Value is string color) {
+                    return color.Replace("#", "").ToLowerInvariant();
                 }
                 return null;
             }
@@ -736,7 +740,7 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.StartBorder == null) {
                     _tableCellProperties.TableCellBorders.StartBorder = new StartBorder();
                 }
-                _tableCellProperties.TableCellBorders.StartBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                _tableCellProperties.TableCellBorders.StartBorder.Color = value?.Replace("#", "").ToLowerInvariant();
             }
         }
 
@@ -744,14 +748,17 @@ namespace OfficeIMO.Word {
         /// Get or set start table cell border color using named colors
         /// </summary>
         public SixLabors.ImageSharp.Color StartColor {
-            get { return Helpers.ParseColor(StartColorHex); }
+            get {
+                var hex = StartColorHex;
+                return Helpers.ParseColor(hex ?? throw new InvalidOperationException("StartColorHex is null"));
+            }
             set { this.StartColorHex = value.ToHexColor(); }
         }
 
         /// <summary>
         /// Get or set start table cell border space
         /// </summary>
-        public UInt32Value StartSpace {
+        public UInt32Value? StartSpace {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.StartBorder != null
@@ -776,7 +783,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Get or set start table cell border size
         /// </summary>
-        public UInt32Value StartSize {
+        public UInt32Value? StartSize {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.StartBorder != null
@@ -810,7 +817,7 @@ namespace OfficeIMO.Word {
         public BorderValues? EndStyle {
             get {
                 if (_tableCellProperties.TableCellBorders != null && _tableCellProperties.TableCellBorders.EndBorder != null) {
-                    return _tableCellProperties.TableCellBorders.EndBorder.Val;
+                    return _tableCellProperties.TableCellBorders.EndBorder.Val?.Value;
                 }
                 return null;
             }
@@ -822,20 +829,18 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.EndBorder == null) {
                     _tableCellProperties.TableCellBorders.EndBorder = new EndBorder();
                 }
-                _tableCellProperties.TableCellBorders.EndBorder.Val = value;
+
+                _tableCellProperties.TableCellBorders.EndBorder.Val = value.HasValue ? value.Value : null;
             }
         }
 
         /// <summary>
         /// Get or set end table cell border color using hex color codes
         /// </summary>
-        public string EndColorHex {
+        public string? EndColorHex {
             get {
-                if (_tableCellProperties.TableCellBorders != null
-                    && _tableCellProperties.TableCellBorders.EndBorder != null
-                    && _tableCellProperties.TableCellBorders.EndBorder.Color != null
-                    && _tableCellProperties.TableCellBorders.EndBorder.Color.Value != null) {
-                    return _tableCellProperties.TableCellBorders.EndBorder.Color.Value.Replace("#", "").ToLowerInvariant();
+                if (_tableCellProperties.TableCellBorders?.EndBorder?.Color?.Value is string color) {
+                    return color.Replace("#", "").ToLowerInvariant();
                 }
                 return null;
             }
@@ -847,7 +852,7 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.EndBorder == null) {
                     _tableCellProperties.TableCellBorders.EndBorder = new EndBorder();
                 }
-                _tableCellProperties.TableCellBorders.EndBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                _tableCellProperties.TableCellBorders.EndBorder.Color = value?.Replace("#", "").ToLowerInvariant();
             }
         }
 
@@ -855,14 +860,17 @@ namespace OfficeIMO.Word {
         /// Get or set end table cell border color using named colors
         /// </summary>
         public SixLabors.ImageSharp.Color EndColor {
-            get { return Helpers.ParseColor(EndColorHex); }
+            get {
+                var hex = EndColorHex;
+                return Helpers.ParseColor(hex ?? throw new InvalidOperationException("EndColorHex is null"));
+            }
             set { this.EndColorHex = value.ToHexColor(); }
         }
 
         /// <summary>
         /// Get or set end table cell border space
         /// </summary>
-        public UInt32Value EndSpace {
+        public UInt32Value? EndSpace {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.EndBorder != null
@@ -887,7 +895,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Get or set end table cell border size
         /// </summary>
-        public UInt32Value EndSize {
+        public UInt32Value? EndSize {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.EndBorder != null
@@ -928,7 +936,7 @@ namespace OfficeIMO.Word {
         public BorderValues? TopLeftToBottomRightStyle {
             get {
                 if (_tableCellProperties.TableCellBorders != null && _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder != null) {
-                    return _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder.Val;
+                    return _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder.Val?.Value;
                 }
                 return null;
             }
@@ -940,20 +948,18 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder == null) {
                     _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder = new TopLeftToBottomRightCellBorder();
                 }
-                _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder.Val = value;
+
+                _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder.Val = value.HasValue ? value.Value : null;
             }
         }
 
         /// <summary>
         /// Get or set top left to bottom right table cell border color using hex color codes
         /// </summary>
-        public string TopLeftToBottomRightColorHex {
+        public string? TopLeftToBottomRightColorHex {
             get {
-                if (_tableCellProperties.TableCellBorders != null
-                    && _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder != null
-                    && _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder.Color != null
-                    && _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder.Color.Value != null) {
-                    return _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder.Color.Value.Replace("#", "").ToLowerInvariant();
+                if (_tableCellProperties.TableCellBorders?.TopLeftToBottomRightCellBorder?.Color?.Value is string color) {
+                    return color.Replace("#", "").ToLowerInvariant();
                 }
                 return null;
             }
@@ -965,7 +971,7 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder == null) {
                     _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder = new TopLeftToBottomRightCellBorder();
                 }
-                _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder.Color = value?.Replace("#", "").ToLowerInvariant();
             }
         }
 
@@ -973,14 +979,17 @@ namespace OfficeIMO.Word {
         /// Get or set top left to bottom right table cell border color using named colors
         /// </summary>
         public SixLabors.ImageSharp.Color TopLeftToBottomRightColor {
-            get { return Helpers.ParseColor(TopLeftToBottomRightColorHex); }
+            get {
+                var hex = TopLeftToBottomRightColorHex;
+                return Helpers.ParseColor(hex ?? throw new InvalidOperationException("TopLeftToBottomRightColorHex is null"));
+            }
             set { this.TopLeftToBottomRightColorHex = value.ToHexColor(); }
         }
 
         /// <summary>
         /// Get or set top left to bottom right table cell border space
         /// </summary>
-        public UInt32Value TopLeftToBottomRightSpace {
+        public UInt32Value? TopLeftToBottomRightSpace {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder != null
@@ -1005,7 +1014,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Get or set top left to bottom right table cell border size
         /// </summary>
-        public UInt32Value TopLeftToBottomRightSize {
+        public UInt32Value? TopLeftToBottomRightSize {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.TopLeftToBottomRightCellBorder != null
@@ -1037,7 +1046,7 @@ namespace OfficeIMO.Word {
         public BorderValues? TopRightToBottomLeftStyle {
             get {
                 if (_tableCellProperties.TableCellBorders != null && _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder != null) {
-                    return _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder.Val;
+                    return _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder.Val?.Value;
                 }
                 return null;
             }
@@ -1049,20 +1058,18 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder == null) {
                     _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder = new TopRightToBottomLeftCellBorder();
                 }
-                _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder.Val = value;
+
+                _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder.Val = value.HasValue ? value.Value : null;
             }
         }
 
         /// <summary>
         /// Get or set top right to bottom left table cell border color using hex color codes
         /// </summary>
-        public string TopRightToBottomLeftColorHex {
+        public string? TopRightToBottomLeftColorHex {
             get {
-                if (_tableCellProperties.TableCellBorders != null
-                    && _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder != null
-                    && _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder.Color != null
-                    && _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder.Color.Value != null) {
-                    return _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder.Color.Value.Replace("#", "").ToLowerInvariant();
+                if (_tableCellProperties.TableCellBorders?.TopRightToBottomLeftCellBorder?.Color?.Value is string color) {
+                    return color.Replace("#", "").ToLowerInvariant();
                 }
                 return null;
             }
@@ -1074,7 +1081,7 @@ namespace OfficeIMO.Word {
                 if (_tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder == null) {
                     _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder = new TopRightToBottomLeftCellBorder();
                 }
-                _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder.Color = value.Replace("#", "").ToLowerInvariant();
+                _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder.Color = value?.Replace("#", "").ToLowerInvariant();
             }
         }
 
@@ -1082,14 +1089,17 @@ namespace OfficeIMO.Word {
         /// Get or set top right to bottom left table cell border color using named colors
         /// </summary>
         public SixLabors.ImageSharp.Color TopRightToBottomLeftColor {
-            get { return Helpers.ParseColor(TopRightToBottomLeftColorHex); }
+            get {
+                var hex = TopRightToBottomLeftColorHex;
+                return Helpers.ParseColor(hex ?? throw new InvalidOperationException("TopRightToBottomLeftColorHex is null"));
+            }
             set { this.TopRightToBottomLeftColorHex = value.ToHexColor(); }
         }
 
         /// <summary>
         /// Get or set top right to bottom left table cell border space
         /// </summary>
-        public UInt32Value TopRightToBottomLeftSpace {
+        public UInt32Value? TopRightToBottomLeftSpace {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder != null
@@ -1114,7 +1124,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Get or set top right to bottom left table cell border size
         /// </summary>
-        public UInt32Value TopRightToBottomLeftSize {
+        public UInt32Value? TopRightToBottomLeftSize {
             get {
                 if (_tableCellProperties.TableCellBorders != null
                     && _tableCellProperties.TableCellBorders.TopRightToBottomLeftCellBorder != null


### PR DESCRIPTION
## Summary
- annotate optional WordParagraph members and expose safe accessors
- add null-safe border styling helpers
- tighten WordField constructor to guard against nulls

## Testing
- `dotnet build OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a41ac894b4832e998e4da0fa160397