### PR TITLE
Fix Visio content types and add validator

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -18,6 +18,7 @@ namespace OfficeIMO.Examples {
             OfficeIMO.Examples.Visio.BasicVisioDocument.Example_BasicVisio(folderPath, false);
             OfficeIMO.Examples.Visio.ReadVisioDocument.Example_ReadVisio(folderPath, false);
             OfficeIMO.Examples.Visio.ConnectRectangles.Example_ConnectRectangles(folderPath, false);
+            OfficeIMO.Examples.Visio.ValidateVisio.Example_ValidateVisio(folderPath, false);
 
             // Excel/BasicExcelFunctionality
             OfficeIMO.Examples.Excel.BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);

--- a/OfficeIMO.Examples/Visio/ValidateVisio.cs
+++ b/OfficeIMO.Examples/Visio/ValidateVisio.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    public static class ValidateVisio {
+        public static void Example_ValidateVisio(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Validate package");
+            string filePath = Path.Combine(folderPath, "Validated.vsdx");
+
+            VisioWriter.Create(filePath);
+            var issues = VisioValidator.Validate(filePath);
+            Console.WriteLine(issues.Count == 0 ? "Package valid" : string.Join(Environment.NewLine, issues));
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.Connectors.cs
+++ b/OfficeIMO.Tests/Visio.Connectors.cs
@@ -21,6 +21,7 @@ namespace OfficeIMO.Tests {
             page.Shapes.Add(start);
             page.Shapes.Add(end);
             VisioConnector connector = new(start, end);
+            Assert.True(int.TryParse(connector.Id, out _));
             page.Connectors.Add(connector);
             document.Save(filePath);
 

--- a/OfficeIMO.Tests/Visio.PackageCreation.cs
+++ b/OfficeIMO.Tests/Visio.PackageCreation.cs
@@ -34,13 +34,13 @@ namespace OfficeIMO.Tests {
 
                 PackagePart documentPart = package.GetPart(new Uri("/visio/document.xml", UriKind.Relative));
                 PackageRelationship pagesRel = documentPart.GetRelationshipsByType("http://schemas.microsoft.com/visio/2010/relationships/pages").Single();
-                Assert.Equal("rId2", pagesRel.Id);
+                Assert.Equal("rId1", pagesRel.Id);
                 Uri pagesUri = PackUriHelper.ResolvePartUri(documentPart.Uri, pagesRel.TargetUri);
                 Assert.Equal("/visio/pages/pages.xml", pagesUri.OriginalString);
 
                 PackagePart pagesPart = package.GetPart(pagesUri);
                 PackageRelationship pageRel = pagesPart.GetRelationshipsByType("http://schemas.microsoft.com/visio/2010/relationships/page").Single();
-                Assert.Equal("rId3", pageRel.Id);
+                Assert.Equal("rId1", pageRel.Id);
                 pageUri = PackUriHelper.ResolvePartUri(pagesPart.Uri, pageRel.TargetUri);
                 Assert.Equal("/visio/pages/page1.xml", pageUri.OriginalString);
 
@@ -74,8 +74,8 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Rectangle", shape?.Element(ns + "Text")?.Value);
             }
 
-            // Additional validation can be performed via VisioValidator.Validate(filePath)
-            // but is omitted here to avoid file access conflicts during testing.
+            var issues = VisioValidator.Validate(filePath);
+            Assert.Empty(issues);
         }
     }
 }

--- a/OfficeIMO.Tests/Visio.PackageCreation.cs
+++ b/OfficeIMO.Tests/Visio.PackageCreation.cs
@@ -52,25 +52,30 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(pageRel.Id, relId);
 
                 PackagePart pagePart = package.GetPart(pageUri);
-                pageDoc = XDocument.Load(pagePart.GetStream());
+                using (Stream pageStream = pagePart.GetStream()) {
+                    pageDoc = XDocument.Load(pageStream);
+                }
             }
 
-            using FileStream zipStream = File.OpenRead(filePath);
-            using ZipArchive archive = new(zipStream, ZipArchiveMode.Read);
-            ZipArchiveEntry entry = archive.GetEntry("[Content_Types].xml");
-            Assert.NotNull(entry);
-            using Stream entryStream = entry.Open();
-            XDocument contentTypes = XDocument.Load(entryStream);
-            XNamespace ct = "http://schemas.openxmlformats.org/package/2006/content-types";
-            bool hasDocOverride = contentTypes.Root?.Elements(ct + "Override").Any(e => e.Attribute("PartName")?.Value == "/visio/document.xml" && e.Attribute("ContentType")?.Value == "application/vnd.ms-visio.drawing.main+xml") == true;
-            bool hasDocDefault = contentTypes.Root?.Elements(ct + "Default").Any(e => e.Attribute("Extension")?.Value == "xml" && e.Attribute("ContentType")?.Value == "application/vnd.ms-visio.drawing.main+xml") == true;
-            Assert.True(hasDocOverride || hasDocDefault);
-            Assert.NotNull(contentTypes.Root?.Elements(ct + "Override").FirstOrDefault(e => e.Attribute("PartName")?.Value == "/visio/pages/pages.xml"));
-            Assert.NotNull(contentTypes.Root?.Elements(ct + "Override").FirstOrDefault(e => e.Attribute("PartName")?.Value == "/visio/pages/page1.xml"));
+            using (FileStream zipStream = File.OpenRead(filePath))
+            using (ZipArchive archive = new(zipStream, ZipArchiveMode.Read)) {
+                ZipArchiveEntry entry = archive.GetEntry("[Content_Types].xml");
+                Assert.NotNull(entry);
+                using Stream entryStream = entry.Open();
+                XDocument contentTypes = XDocument.Load(entryStream);
+                XNamespace ct = "http://schemas.openxmlformats.org/package/2006/content-types";
+                Assert.NotNull(contentTypes.Root?.Elements(ct + "Default").FirstOrDefault(e => e.Attribute("Extension")?.Value == "xml" && e.Attribute("ContentType")?.Value == "application/xml"));
+                Assert.NotNull(contentTypes.Root?.Elements(ct + "Override").FirstOrDefault(e => e.Attribute("PartName")?.Value == "/visio/document.xml" && e.Attribute("ContentType")?.Value == "application/vnd.ms-visio.drawing.main+xml"));
+                Assert.NotNull(contentTypes.Root?.Elements(ct + "Override").FirstOrDefault(e => e.Attribute("PartName")?.Value == "/visio/pages/pages.xml" && e.Attribute("ContentType")?.Value == "application/vnd.ms-visio.pages+xml"));
+                Assert.NotNull(contentTypes.Root?.Elements(ct + "Override").FirstOrDefault(e => e.Attribute("PartName")?.Value == "/visio/pages/page1.xml" && e.Attribute("ContentType")?.Value == "application/vnd.ms-visio.page+xml"));
 
-            XElement shape = pageDoc.Root?.Element(ns + "Shapes")?.Element(ns + "Shape");
-            Assert.Equal("1", shape?.Attribute("ID")?.Value);
-            Assert.Equal("Rectangle", shape?.Element(ns + "Text")?.Value);
+                XElement shape = pageDoc.Root?.Element(ns + "Shapes")?.Element(ns + "Shape");
+                Assert.Equal("1", shape?.Attribute("ID")?.Value);
+                Assert.Equal("Rectangle", shape?.Element(ns + "Text")?.Value);
+            }
+
+            // Additional validation can be performed via VisioValidator.Validate(filePath)
+            // but is omitted here to avoid file access conflicts during testing.
         }
     }
 }

--- a/OfficeIMO.Visio/OfficeIMO.Visio.csproj
+++ b/OfficeIMO.Visio/OfficeIMO.Visio.csproj
@@ -64,6 +64,7 @@
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
         <Reference Include="System.Net.Http" />
+        <Reference Include="System.IO.Compression" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OfficeIMO.Visio/VisioConnector.cs
+++ b/OfficeIMO.Visio/VisioConnector.cs
@@ -1,11 +1,14 @@
+using System;
+using System.Globalization;
+
 namespace OfficeIMO.Visio {
     /// <summary>
     /// Connects two shapes together.
     /// </summary>
     public class VisioConnector {
-        private static int _idCounter = 1;
+        private static int _idCounter;
 
-        public VisioConnector(VisioShape from, VisioShape to) : this($"C{_idCounter++}", from, to) {
+        public VisioConnector(VisioShape from, VisioShape to) : this(GetNextId(from, to), from, to) {
         }
 
         public VisioConnector(string id, VisioShape from, VisioShape to) {
@@ -28,6 +31,14 @@ namespace OfficeIMO.Visio {
         /// Shape at which the connector ends.
         /// </summary>
         public VisioShape To { get; }
+
+        private static string GetNextId(VisioShape from, VisioShape to) {
+            int fromId = int.TryParse(from.Id, out int fi) ? fi : 0;
+            int toId = int.TryParse(to.Id, out int ti) ? ti : 0;
+            int newId = Math.Max(Math.Max(fromId, toId) + 1, _idCounter + 1);
+            _idCounter = newId;
+            return newId.ToString(CultureInfo.InvariantCulture);
+        }
     }
 }
 

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.IO.Packaging;
 using System.Linq;
 using System.Text;
@@ -123,126 +124,145 @@ namespace OfficeIMO.Visio {
         /// Saves the document to a <c>.vsdx</c> package.
         /// </summary>
         public void Save(string filePath) {
-            using Package package = Package.Open(filePath, FileMode.Create);
+            using (Package package = Package.Open(filePath, FileMode.Create)) {
+                int relIdCounter = 1;
 
-            int relIdCounter = 1;
+                Uri documentUri = new("/visio/document.xml", UriKind.Relative);
+                PackagePart documentPart = package.CreatePart(documentUri, DocumentContentType);
+                package.CreateRelationship(documentUri, TargetMode.Internal, DocumentRelationshipType, $"rId{relIdCounter++}");
 
-            Uri documentUri = new("/visio/document.xml", UriKind.Relative);
-            PackagePart documentPart = package.CreatePart(documentUri, DocumentContentType);
-            package.CreateRelationship(documentUri, TargetMode.Internal, DocumentRelationshipType, $"rId{relIdCounter++}");
+                Uri pagesUri = new("/visio/pages/pages.xml", UriKind.Relative);
+                PackagePart pagesPart = package.CreatePart(pagesUri, "application/vnd.ms-visio.pages+xml");
+                documentPart.CreateRelationship(new Uri("pages/pages.xml", UriKind.Relative), TargetMode.Internal, "http://schemas.microsoft.com/visio/2010/relationships/pages", $"rId{relIdCounter++}");
 
-            Uri pagesUri = new("/visio/pages/pages.xml", UriKind.Relative);
-            PackagePart pagesPart = package.CreatePart(pagesUri, "application/vnd.ms-visio.pages+xml");
-            documentPart.CreateRelationship(new Uri("pages/pages.xml", UriKind.Relative), TargetMode.Internal, "http://schemas.microsoft.com/visio/2010/relationships/pages", $"rId{relIdCounter++}");
+                Uri page1Uri = new("/visio/pages/page1.xml", UriKind.Relative);
+                PackagePart page1Part = package.CreatePart(page1Uri, "application/vnd.ms-visio.page+xml");
+                PackageRelationship pageRel = pagesPart.CreateRelationship(new Uri("page1.xml", UriKind.Relative), TargetMode.Internal, "http://schemas.microsoft.com/visio/2010/relationships/page", $"rId{relIdCounter++}");
 
-            Uri page1Uri = new("/visio/pages/page1.xml", UriKind.Relative);
-            PackagePart page1Part = package.CreatePart(page1Uri, "application/vnd.ms-visio.page+xml");
-            PackageRelationship pageRel = pagesPart.CreateRelationship(new Uri("page1.xml", UriKind.Relative), TargetMode.Internal, "http://schemas.microsoft.com/visio/2010/relationships/page", $"rId{relIdCounter++}");
+                XmlWriterSettings settings = new() {
+                    Encoding = new UTF8Encoding(false),
+                    CloseOutput = true,
+                    Indent = true,
+                };
+                const string ns = VisioNamespace;
 
-            XmlWriterSettings settings = new() {
-                Encoding = new UTF8Encoding(false),
-                CloseOutput = true,
-                Indent = true,
-            };
-            const string ns = VisioNamespace;
-
-            using (Stream stream = documentPart.GetStream(FileMode.Create, FileAccess.Write)) {
-                CreateVisioDocumentXml(_requestRecalcOnOpen).Save(stream);
-            }
-
-            string pageName = _pages.Count > 0 ? _pages[0].Name : "Page-1";
-            using (XmlWriter writer = XmlWriter.Create(pagesPart.GetStream(FileMode.Create, FileAccess.Write), settings)) {
-                writer.WriteStartDocument();
-                writer.WriteStartElement("Pages", ns);
-                writer.WriteAttributeString("xmlns", "r", null, "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
-                writer.WriteStartElement("Page", ns);
-                writer.WriteAttributeString("ID", "1");
-                writer.WriteAttributeString("Name", pageName);
-                writer.WriteStartElement("Rel", ns);
-                writer.WriteAttributeString("r", "id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships", pageRel.Id);
-                writer.WriteEndElement();
-                writer.WriteEndElement();
-                writer.WriteEndElement();
-                writer.WriteEndDocument();
-            }
-
-            VisioPage page = _pages.Count > 0 ? _pages[0] : new VisioPage(pageName);
-
-            using (XmlWriter writer = XmlWriter.Create(page1Part.GetStream(FileMode.Create, FileAccess.Write), settings)) {
-                writer.WriteStartDocument();
-                writer.WriteStartElement("PageContents", ns);
-                writer.WriteStartElement("Shapes", ns);
-
-                foreach (VisioShape shape in page.Shapes) {
-                    writer.WriteStartElement("Shape", ns);
-                    writer.WriteAttributeString("ID", shape.Id);
-                    if (!string.IsNullOrEmpty(shape.NameU)) {
-                        writer.WriteAttributeString("NameU", shape.NameU);
-                    }
-                    writer.WriteStartElement("XForm", ns);
-                    writer.WriteElementString("PinX", ns, shape.PinX.ToString(CultureInfo.InvariantCulture));
-                    writer.WriteElementString("PinY", ns, shape.PinY.ToString(CultureInfo.InvariantCulture));
-                    writer.WriteElementString("Width", ns, shape.Width.ToString(CultureInfo.InvariantCulture));
-                    writer.WriteElementString("Height", ns, shape.Height.ToString(CultureInfo.InvariantCulture));
-                    writer.WriteEndElement();
-                    if (!string.IsNullOrEmpty(shape.Text)) {
-                        writer.WriteElementString("Text", ns, shape.Text);
-                    }
-                    writer.WriteEndElement();
+                using (Stream stream = documentPart.GetStream(FileMode.Create, FileAccess.Write)) {
+                    CreateVisioDocumentXml(_requestRecalcOnOpen).Save(stream);
                 }
 
-                foreach (VisioConnector connector in page.Connectors) {
-                    VisioShape from = connector.From;
-                    VisioShape to = connector.To;
-                    double startX = from.PinX + from.Width / 2;
-                    double startY = from.PinY;
-                    double endX = to.PinX - to.Width / 2;
-                    double endY = to.PinY;
-
-                    writer.WriteStartElement("Shape", ns);
-                    writer.WriteAttributeString("ID", connector.Id);
-                    writer.WriteAttributeString("NameU", "Connector");
-                    writer.WriteStartElement("Geom", ns);
-                    writer.WriteStartElement("MoveTo", ns);
-                    writer.WriteAttributeString("X", startX.ToString(CultureInfo.InvariantCulture));
-                    writer.WriteAttributeString("Y", startY.ToString(CultureInfo.InvariantCulture));
-                    writer.WriteEndElement();
-                    writer.WriteStartElement("LineTo", ns);
-                    writer.WriteAttributeString("X", startX.ToString(CultureInfo.InvariantCulture));
-                    writer.WriteAttributeString("Y", endY.ToString(CultureInfo.InvariantCulture));
-                    writer.WriteEndElement();
-                    writer.WriteStartElement("LineTo", ns);
-                    writer.WriteAttributeString("X", endX.ToString(CultureInfo.InvariantCulture));
-                    writer.WriteAttributeString("Y", endY.ToString(CultureInfo.InvariantCulture));
+                string pageName = _pages.Count > 0 ? _pages[0].Name : "Page-1";
+                using (XmlWriter writer = XmlWriter.Create(pagesPart.GetStream(FileMode.Create, FileAccess.Write), settings)) {
+                    writer.WriteStartDocument();
+                    writer.WriteStartElement("Pages", ns);
+                    writer.WriteAttributeString("xmlns", "r", null, "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+                    writer.WriteStartElement("Page", ns);
+                    writer.WriteAttributeString("ID", "1");
+                    writer.WriteAttributeString("Name", pageName);
+                    writer.WriteStartElement("Rel", ns);
+                    writer.WriteAttributeString("r", "id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships", pageRel.Id);
                     writer.WriteEndElement();
                     writer.WriteEndElement();
                     writer.WriteEndElement();
+                    writer.WriteEndDocument();
                 }
 
-                writer.WriteEndElement(); // Shapes
+                VisioPage page = _pages.Count > 0 ? _pages[0] : new VisioPage(pageName);
 
-                if (page.Connectors.Count > 0) {
-                    writer.WriteStartElement("Connects", ns);
+                using (XmlWriter writer = XmlWriter.Create(page1Part.GetStream(FileMode.Create, FileAccess.Write), settings)) {
+                    writer.WriteStartDocument();
+                    writer.WriteStartElement("PageContents", ns);
+                    writer.WriteStartElement("Shapes", ns);
+
+                    foreach (VisioShape shape in page.Shapes) {
+                        writer.WriteStartElement("Shape", ns);
+                        writer.WriteAttributeString("ID", shape.Id);
+                        if (!string.IsNullOrEmpty(shape.NameU)) {
+                            writer.WriteAttributeString("NameU", shape.NameU);
+                        }
+                        writer.WriteStartElement("XForm", ns);
+                        writer.WriteElementString("PinX", ns, shape.PinX.ToString(CultureInfo.InvariantCulture));
+                        writer.WriteElementString("PinY", ns, shape.PinY.ToString(CultureInfo.InvariantCulture));
+                        writer.WriteElementString("Width", ns, shape.Width.ToString(CultureInfo.InvariantCulture));
+                        writer.WriteElementString("Height", ns, shape.Height.ToString(CultureInfo.InvariantCulture));
+                        writer.WriteEndElement();
+                        if (!string.IsNullOrEmpty(shape.Text)) {
+                            writer.WriteElementString("Text", ns, shape.Text);
+                        }
+                        writer.WriteEndElement();
+                    }
+
                     foreach (VisioConnector connector in page.Connectors) {
-                        writer.WriteStartElement("Connect", ns);
-                        writer.WriteAttributeString("FromSheet", connector.Id);
-                        writer.WriteAttributeString("FromCell", "BeginX");
-                        writer.WriteAttributeString("ToSheet", connector.From.Id);
-                        writer.WriteAttributeString("ToCell", "PinX");
+                        VisioShape from = connector.From;
+                        VisioShape to = connector.To;
+                        double startX = from.PinX + from.Width / 2;
+                        double startY = from.PinY;
+                        double endX = to.PinX - to.Width / 2;
+                        double endY = to.PinY;
+
+                        writer.WriteStartElement("Shape", ns);
+                        writer.WriteAttributeString("ID", connector.Id);
+                        writer.WriteAttributeString("NameU", "Connector");
+                        writer.WriteStartElement("Geom", ns);
+                        writer.WriteStartElement("MoveTo", ns);
+                        writer.WriteAttributeString("X", startX.ToString(CultureInfo.InvariantCulture));
+                        writer.WriteAttributeString("Y", startY.ToString(CultureInfo.InvariantCulture));
                         writer.WriteEndElement();
-                        writer.WriteStartElement("Connect", ns);
-                        writer.WriteAttributeString("FromSheet", connector.Id);
-                        writer.WriteAttributeString("FromCell", "EndX");
-                        writer.WriteAttributeString("ToSheet", connector.To.Id);
-                        writer.WriteAttributeString("ToCell", "PinX");
+                        writer.WriteStartElement("LineTo", ns);
+                        writer.WriteAttributeString("X", startX.ToString(CultureInfo.InvariantCulture));
+                        writer.WriteAttributeString("Y", endY.ToString(CultureInfo.InvariantCulture));
+                        writer.WriteEndElement();
+                        writer.WriteStartElement("LineTo", ns);
+                        writer.WriteAttributeString("X", endX.ToString(CultureInfo.InvariantCulture));
+                        writer.WriteAttributeString("Y", endY.ToString(CultureInfo.InvariantCulture));
+                        writer.WriteEndElement();
+                        writer.WriteEndElement();
                         writer.WriteEndElement();
                     }
-                    writer.WriteEndElement(); // Connects
-                }
 
-                writer.WriteEndElement(); // PageContents
-                writer.WriteEndDocument();
+                    writer.WriteEndElement(); // Shapes
+
+                    if (page.Connectors.Count > 0) {
+                        writer.WriteStartElement("Connects", ns);
+                        foreach (VisioConnector connector in page.Connectors) {
+                            writer.WriteStartElement("Connect", ns);
+                            writer.WriteAttributeString("FromSheet", connector.Id);
+                            writer.WriteAttributeString("FromCell", "BeginX");
+                            writer.WriteAttributeString("ToSheet", connector.From.Id);
+                            writer.WriteAttributeString("ToCell", "PinX");
+                            writer.WriteEndElement();
+                            writer.WriteStartElement("Connect", ns);
+                            writer.WriteAttributeString("FromSheet", connector.Id);
+                            writer.WriteAttributeString("FromCell", "EndX");
+                            writer.WriteAttributeString("ToSheet", connector.To.Id);
+                            writer.WriteAttributeString("ToCell", "PinX");
+                            writer.WriteEndElement();
+                        }
+                        writer.WriteEndElement(); // Connects
+                    }
+
+                    writer.WriteEndElement(); // PageContents
+                    writer.WriteEndDocument();
+                }
             }
+
+            FixContentTypes(filePath);
+        }
+
+        private static void FixContentTypes(string filePath) {
+            using FileStream zipStream = File.Open(filePath, FileMode.Open, FileAccess.ReadWrite);
+            using ZipArchive archive = new(zipStream, ZipArchiveMode.Update);
+            ZipArchiveEntry? entry = archive.GetEntry("[Content_Types].xml");
+            entry?.Delete();
+            entry = archive.CreateEntry("[Content_Types].xml");
+            XNamespace ct = "http://schemas.openxmlformats.org/package/2006/content-types";
+            XDocument doc = new(new XElement(ct + "Types",
+                new XElement(ct + "Default", new XAttribute("Extension", "rels"), new XAttribute("ContentType", "application/vnd.openxmlformats-package.relationships+xml")),
+                new XElement(ct + "Default", new XAttribute("Extension", "xml"), new XAttribute("ContentType", "application/xml")),
+                new XElement(ct + "Override", new XAttribute("PartName", "/visio/document.xml"), new XAttribute("ContentType", "application/vnd.ms-visio.drawing.main+xml")),
+                new XElement(ct + "Override", new XAttribute("PartName", "/visio/pages/pages.xml"), new XAttribute("ContentType", "application/vnd.ms-visio.pages+xml")),
+                new XElement(ct + "Override", new XAttribute("PartName", "/visio/pages/page1.xml"), new XAttribute("ContentType", "application/vnd.ms-visio.page+xml"))));
+            using StreamWriter writer = new(entry.Open());
+            writer.Write(doc.Declaration + Environment.NewLine + doc.ToString(SaveOptions.DisableFormatting));
         }
     }
 }

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -251,7 +251,7 @@ namespace OfficeIMO.Visio {
             using ZipArchive archive = new(zipStream, ZipArchiveMode.Update);
             ZipArchiveEntry? entry = archive.GetEntry("[Content_Types].xml");
             entry?.Delete();
-            entry = archive.CreateEntry("[Content_Types].xml");
+            ZipArchiveEntry newEntry = archive.CreateEntry("[Content_Types].xml");
             XNamespace ct = "http://schemas.openxmlformats.org/package/2006/content-types";
             XDocument doc = new(new XElement(ct + "Types",
                 new XElement(ct + "Default", new XAttribute("Extension", "rels"), new XAttribute("ContentType", "application/vnd.openxmlformats-package.relationships+xml")),
@@ -259,7 +259,7 @@ namespace OfficeIMO.Visio {
                 new XElement(ct + "Override", new XAttribute("PartName", "/visio/document.xml"), new XAttribute("ContentType", "application/vnd.ms-visio.drawing.main+xml")),
                 new XElement(ct + "Override", new XAttribute("PartName", "/visio/pages/pages.xml"), new XAttribute("ContentType", "application/vnd.ms-visio.pages+xml")),
                 new XElement(ct + "Override", new XAttribute("PartName", "/visio/pages/page1.xml"), new XAttribute("ContentType", "application/vnd.ms-visio.page+xml"))));
-            using StreamWriter writer = new(entry.Open());
+            using StreamWriter writer = new(newEntry.Open());
             writer.Write(doc.Declaration + Environment.NewLine + doc.ToString(SaveOptions.DisableFormatting));
         }
     }

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -125,19 +125,17 @@ namespace OfficeIMO.Visio {
         /// </summary>
         public void Save(string filePath) {
             using (Package package = Package.Open(filePath, FileMode.Create)) {
-                int relIdCounter = 1;
-
                 Uri documentUri = new("/visio/document.xml", UriKind.Relative);
                 PackagePart documentPart = package.CreatePart(documentUri, DocumentContentType);
-                package.CreateRelationship(documentUri, TargetMode.Internal, DocumentRelationshipType, $"rId{relIdCounter++}");
+                package.CreateRelationship(documentUri, TargetMode.Internal, DocumentRelationshipType, "rId1");
 
                 Uri pagesUri = new("/visio/pages/pages.xml", UriKind.Relative);
                 PackagePart pagesPart = package.CreatePart(pagesUri, "application/vnd.ms-visio.pages+xml");
-                documentPart.CreateRelationship(new Uri("pages/pages.xml", UriKind.Relative), TargetMode.Internal, "http://schemas.microsoft.com/visio/2010/relationships/pages", $"rId{relIdCounter++}");
+                documentPart.CreateRelationship(new Uri("pages/pages.xml", UriKind.Relative), TargetMode.Internal, "http://schemas.microsoft.com/visio/2010/relationships/pages", "rId1");
 
                 Uri page1Uri = new("/visio/pages/page1.xml", UriKind.Relative);
                 PackagePart page1Part = package.CreatePart(page1Uri, "application/vnd.ms-visio.page+xml");
-                PackageRelationship pageRel = pagesPart.CreateRelationship(new Uri("page1.xml", UriKind.Relative), TargetMode.Internal, "http://schemas.microsoft.com/visio/2010/relationships/page", $"rId{relIdCounter++}");
+                PackageRelationship pageRel = pagesPart.CreateRelationship(new Uri("page1.xml", UriKind.Relative), TargetMode.Internal, "http://schemas.microsoft.com/visio/2010/relationships/page", "rId1");
 
                 XmlWriterSettings settings = new() {
                     Encoding = new UTF8Encoding(false),

--- a/OfficeIMO.Visio/VisioValidator.cs
+++ b/OfficeIMO.Visio/VisioValidator.cs
@@ -23,7 +23,7 @@ namespace OfficeIMO.Visio {
 
         public static IReadOnlyList<string> Validate(string vsdxPath) {
             List<string> issues = new();
-            using Package pkg = Package.Open(vsdxPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using Package pkg = Package.Open(vsdxPath, FileMode.Open, FileAccess.Read, FileShare.Read);
 
             XDocument ctDoc;
             using (FileStream zipStream = File.OpenRead(vsdxPath))

--- a/OfficeIMO.Visio/VisioValidator.cs
+++ b/OfficeIMO.Visio/VisioValidator.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Packaging;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace OfficeIMO.Visio {
+    public static class VisioValidator {
+        private static readonly XNamespace ct = "http://schemas.openxmlformats.org/package/2006/content-types";
+        private static readonly XNamespace rel = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+        private static readonly XNamespace pr = "http://schemas.openxmlformats.org/package/2006/relationships";
+        private static readonly XNamespace v = "http://schemas.microsoft.com/office/visio/2012/main";
+
+        private const string RT_Document = "http://schemas.microsoft.com/visio/2010/relationships/document";
+        private const string RT_Pages = "http://schemas.microsoft.com/visio/2010/relationships/pages";
+        private const string RT_Page = "http://schemas.microsoft.com/visio/2010/relationships/page";
+
+        private const string CT_Document = "application/vnd.ms-visio.drawing.main+xml";
+        private const string CT_Pages = "application/vnd.ms-visio.pages+xml";
+        private const string CT_Page = "application/vnd.ms-visio.page+xml";
+
+        public static IReadOnlyList<string> Validate(string vsdxPath) {
+            List<string> issues = new();
+            using Package pkg = Package.Open(vsdxPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+            XDocument ctDoc = GetContentTypes(pkg);
+            var defaults = ctDoc.Root!.Elements(ct + "Default").ToList();
+            var overrides = ctDoc.Root!.Elements(ct + "Override").ToList();
+
+            XElement? xmlDefault = defaults.FirstOrDefault(d => (string?)d.Attribute("Extension") == "xml");
+            if (xmlDefault == null || (string?)xmlDefault.Attribute("ContentType") != "application/xml") {
+                issues.Add("Default for '.xml' must be 'application/xml' with per-part Overrides.");
+            }
+
+            bool HasOverride(string partName, string type) =>
+                overrides.Any(o => (string?)o.Attribute("PartName") == partName && (string?)o.Attribute("ContentType") == type);
+
+            if (!HasOverride("/visio/document.xml", CT_Document)) {
+                issues.Add("Missing Override for /visio/document.xml -> application/vnd.ms-visio.drawing.main+xml.");
+            }
+
+            if (!HasOverride("/visio/pages/pages.xml", CT_Pages)) {
+                issues.Add("Missing Override for /visio/pages/pages.xml -> application/vnd.ms-visio.pages+xml.");
+            }
+
+            if (!HasOverride("/visio/pages/page1.xml", CT_Page)) {
+                issues.Add("Missing Override for /visio/pages/page1.xml -> application/vnd.ms-visio.page+xml.");
+            }
+
+            XDocument rootRels = GetRels(pkg, "/_rels/.rels");
+            XElement? docRel = rootRels.Elements(pr + "Relationship").FirstOrDefault(r => (string?)r.Attribute("Target") == "/visio/document.xml");
+            if (docRel == null || (string?)docRel.Attribute("Type") != RT_Document) {
+                issues.Add("Root relationship must target /visio/document.xml with Visio document type.");
+            }
+
+            XDocument docRels = GetRels(pkg, "/visio/_rels/document.xml.rels");
+            XElement? pagesRel = docRels.Elements(pr + "Relationship").FirstOrDefault(r => (string?)r.Attribute("Target") == "pages/pages.xml");
+            if (pagesRel == null || (string?)pagesRel.Attribute("Type") != RT_Pages) {
+                issues.Add("document.xml must relate to pages/pages.xml with visio/2010/relationships/pages.");
+            }
+
+            XDocument pagesXml = LoadXml(pkg, "/visio/pages/pages.xml");
+            XElement? page = pagesXml.Root!.Element(v + "Page");
+            if (page == null) {
+                issues.Add("pages.xml must contain a Page element.");
+            } else {
+                if (!int.TryParse((string?)page.Attribute("ID"), out int pageId) || pageId < 1) {
+                    issues.Add("Page/@ID must be numeric and 1-based (e.g., 1).");
+                }
+
+                XElement? relChild = page.Element(v + "Rel");
+                string? rid = (string?)relChild?.Attribute(rel + "id");
+                if (relChild == null || string.IsNullOrWhiteSpace(rid) || !rid.StartsWith("rId")) {
+                    issues.Add("Page must contain <Rel r:id=\"rId#\"> child (not an attribute).");
+                }
+            }
+
+            XDocument pagesRels = GetRels(pkg, "/visio/pages/_rels/pages.xml.rels");
+            XElement? pageRel = pagesRels.Elements(pr + "Relationship").FirstOrDefault(r => (string?)r.Attribute("Type") == RT_Page);
+            if (pageRel == null) {
+                issues.Add("pages.xml.rels must have a relationship of type visio/2010/relationships/page.");
+            }
+
+            XDocument page1Xml = LoadXml(pkg, "/visio/pages/page1.xml");
+            string? badId = page1Xml.Descendants(v + "Shape").Select(x => (string?)x.Attribute("ID")).FirstOrDefault(id => !int.TryParse(id, out _));
+            if (badId != null) {
+                issues.Add($"Shape/@ID must be numeric. Found non-numeric ID: '{badId}'.");
+            }
+
+            return issues;
+        }
+
+        private static XDocument GetContentTypes(Package pkg) {
+            using Stream s = pkg.GetPart(new Uri("/[Content_Types].xml", UriKind.Relative)).GetStream();
+            return XDocument.Load(s);
+        }
+
+        private static XDocument LoadXml(Package pkg, string partName) {
+            using Stream s = pkg.GetPart(new Uri(partName, UriKind.Relative)).GetStream();
+            return XDocument.Load(s);
+        }
+
+        private static XDocument GetRels(Package pkg, string relsPath) {
+            using Stream s = pkg.GetPart(new Uri(relsPath, UriKind.Relative)).GetStream();
+            return XDocument.Load(s);
+        }
+    }
+}

--- a/OfficeIMO.Visio/VisioWriter.cs
+++ b/OfficeIMO.Visio/VisioWriter.cs
@@ -1,0 +1,117 @@
+using System;
+using System.IO;
+using System.IO.Packaging;
+using System.Xml.Linq;
+
+namespace OfficeIMO.Visio {
+    public static class VisioWriter {
+        private static readonly XNamespace v = "http://schemas.microsoft.com/office/visio/2012/main";
+        private static readonly XNamespace rel = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+        private const string RT_Document = "http://schemas.microsoft.com/visio/2010/relationships/document";
+        private const string RT_Pages = "http://schemas.microsoft.com/visio/2010/relationships/pages";
+        private const string RT_Page = "http://schemas.microsoft.com/visio/2010/relationships/page";
+
+        private const string CT_Document = "application/vnd.ms-visio.drawing.main+xml";
+        private const string CT_Pages = "application/vnd.ms-visio.pages+xml";
+        private const string CT_Page = "application/vnd.ms-visio.page+xml";
+
+        public static void Create(string filePath) {
+            if (File.Exists(filePath)) {
+                File.Delete(filePath);
+            }
+
+            using Package package = Package.Open(filePath, FileMode.Create, FileAccess.ReadWrite);
+
+            Uri documentUri = PackUriHelper.CreatePartUri(new Uri("/visio/document.xml", UriKind.Relative));
+            Uri pagesUri = PackUriHelper.CreatePartUri(new Uri("/visio/pages/pages.xml", UriKind.Relative));
+            Uri page1Uri = PackUriHelper.CreatePartUri(new Uri("/visio/pages/page1.xml", UriKind.Relative));
+
+            PackagePart documentPart = package.CreatePart(documentUri, CT_Document, CompressionOption.Maximum);
+            PackagePart pagesPart = package.CreatePart(pagesUri, CT_Pages, CompressionOption.Maximum);
+            PackagePart page1Part = package.CreatePart(page1Uri, CT_Page, CompressionOption.Maximum);
+
+            package.CreateRelationship(documentUri, TargetMode.Internal, RT_Document, "rId1");
+
+            documentPart.CreateRelationship(pagesUri, TargetMode.Internal, RT_Pages, "rId1");
+            pagesPart.CreateRelationship(page1Uri, TargetMode.Internal, RT_Page, "rId1");
+
+            WriteDocumentXml(documentPart.GetStream(FileMode.Create, FileAccess.Write));
+            WritePagesXml(pagesPart.GetStream(FileMode.Create, FileAccess.Write));
+            WritePage1Xml(page1Part.GetStream(FileMode.Create, FileAccess.Write));
+        }
+
+        private static void WriteDocumentXml(Stream stream) {
+            XDocument doc = new(new XDeclaration("1.0", "utf-8", null),
+                new XElement(v + "VisioDocument",
+                    new XElement(v + "DocumentSettings",
+                        new XElement(v + "RelayoutAndRerouteUponOpen", 1)
+                    ),
+                    new XElement(v + "Colors"),
+                    new XElement(v + "FaceNames"),
+                    new XElement(v + "StyleSheets")));
+            using StreamWriter writer = new(stream);
+            writer.Write(doc.Declaration + Environment.NewLine + doc.ToString(SaveOptions.DisableFormatting));
+        }
+
+        private static void WritePagesXml(Stream stream) {
+            XDocument doc = new(new XDeclaration("1.0", "utf-8", null),
+                new XElement(v + "Pages",
+                    new XAttribute(XNamespace.Xmlns + "r", rel),
+                    new XElement(v + "Page",
+                        new XAttribute("ID", 1),
+                        new XAttribute("Name", "Page-1"),
+                        new XElement(v + "Rel",
+                            new XAttribute(rel + "id", "rId1")))));
+            using StreamWriter writer = new(stream);
+            writer.Write(doc.Declaration + Environment.NewLine + doc.ToString(SaveOptions.DisableFormatting));
+        }
+
+        private static void WritePage1Xml(Stream stream) {
+            XDocument doc = new(new XDeclaration("1.0", "utf-8", null),
+                new XElement(v + "PageContents",
+                    new XElement(v + "Shapes",
+                        new XElement(v + "Shape",
+                            new XAttribute("ID", 1),
+                            new XAttribute("NameU", "Start"),
+                            new XElement(v + "XForm",
+                                new XElement(v + "PinX", 1.0),
+                                new XElement(v + "PinY", 1.0),
+                                new XElement(v + "Width", 2.0),
+                                new XElement(v + "Height", 1.0)),
+                            new XElement(v + "Text", "Start")),
+                        new XElement(v + "Shape",
+                            new XAttribute("ID", 2),
+                            new XAttribute("NameU", "End"),
+                            new XElement(v + "XForm",
+                                new XElement(v + "PinX", 4.0),
+                                new XElement(v + "PinY", 1.0),
+                                new XElement(v + "Width", 2.0),
+                                new XElement(v + "Height", 1.0)),
+                            new XElement(v + "Text", "End")),
+                        new XElement(v + "Shape",
+                            new XAttribute("ID", 3),
+                            new XAttribute("NameU", "Connector"),
+                            new XElement(v + "Geom",
+                                new XElement(v + "MoveTo",
+                                    new XAttribute("X", 2.0),
+                                    new XAttribute("Y", 1.0)),
+                                new XElement(v + "LineTo",
+                                    new XAttribute("X", 3.0),
+                                    new XAttribute("Y", 1.0))))),
+                    new XElement(v + "Connects",
+                        new XElement(v + "Connect",
+                            new XAttribute("FromSheet", 3),
+                            new XAttribute("FromCell", "BeginX"),
+                            new XAttribute("ToSheet", 1),
+                            new XAttribute("ToCell", "PinX")),
+                        new XElement(v + "Connect",
+                            new XAttribute("FromSheet", 3),
+                            new XAttribute("FromCell", "EndX"),
+                            new XAttribute("ToSheet", 2),
+                            new XAttribute("ToCell", "PinX")))));
+            using StreamWriter writer = new(stream);
+            writer.Write(doc.Declaration + Environment.NewLine + doc.ToString(SaveOptions.DisableFormatting));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure Visio connectors use numeric IDs
- rewrite Visio package content types with proper defaults and overrides
- add VisioWriter/VisioValidator helpers and example usage

## Testing
- `dotnet build`
- `dotnet test --filter VisioPackageCreation`


------
https://chatgpt.com/codex/tasks/task_e_68a429f929b4832e9ba35d53ffc61c6e