### PR TITLE
chore: harden application property access

### DIFF
--- a/OfficeIMO.Word/ApplicationProperties.cs
+++ b/OfficeIMO.Word/ApplicationProperties.cs
@@ -18,23 +18,16 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string Application {
             get {
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
-                    return "";
-                }
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Application == null) {
-                    return "";
-                }
-                return _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Application.Text;
+                var properties = _wordprocessingDocument.ExtendedFilePropertiesPart?.Properties;
+                return properties?.Application?.Text ?? string.Empty;
             }
             set {
                 var properties = GetProperties();
                 if (properties == null) {
                     return;
                 }
-                if (properties.Application == null) {
-                    properties.Application = new Application();
-                }
 
+                properties.Application ??= new Application();
                 properties.Application.Text = value;
             }
         }
@@ -43,22 +36,16 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string ApplicationVersion {
             get {
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
-                    return "";
-                }
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart.Properties.ApplicationVersion == null) {
-                    return "";
-                }
-                return _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.ApplicationVersion.Text;
+                var properties = _wordprocessingDocument.ExtendedFilePropertiesPart?.Properties;
+                return properties?.ApplicationVersion?.Text ?? string.Empty;
             }
             set {
                 var properties = GetProperties();
                 if (properties == null) {
                     return;
                 }
-                if (properties.ApplicationVersion == null) {
-                    properties.ApplicationVersion = new ApplicationVersion();
-                }
+
+                properties.ApplicationVersion ??= new ApplicationVersion();
                 properties.ApplicationVersion.Text = value;
             }
         }
@@ -67,22 +54,16 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string Paragraphs {
             get {
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
-                    return "";
-                }
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Paragraphs == null) {
-                    return "";
-                }
-                return _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Paragraphs.Text;
+                var properties = _wordprocessingDocument.ExtendedFilePropertiesPart?.Properties;
+                return properties?.Paragraphs?.Text ?? string.Empty;
             }
             set {
                 var properties = GetProperties();
                 if (properties == null) {
                     return;
                 }
-                if (properties.Paragraphs == null) {
-                    properties.Paragraphs = new Paragraphs();
-                }
+
+                properties.Paragraphs ??= new Paragraphs();
                 properties.Paragraphs.Text = value;
             }
         }
@@ -91,22 +72,16 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string Pages {
             get {
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
-                    return "";
-                }
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Pages == null) {
-                    return "";
-                }
-                return _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Pages.Text;
+                var properties = _wordprocessingDocument.ExtendedFilePropertiesPart?.Properties;
+                return properties?.Pages?.Text ?? string.Empty;
             }
             set {
                 var properties = GetProperties();
                 if (properties == null) {
                     return;
                 }
-                if (properties.Pages == null) {
-                    properties.Pages = new Pages();
-                }
+
+                properties.Pages ??= new Pages();
                 properties.Pages.Text = value;
             }
         }
@@ -115,22 +90,16 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string Characters {
             get {
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
-                    return "";
-                }
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Characters == null) {
-                    return "";
-                }
-                return _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Characters.Text;
+                var properties = _wordprocessingDocument.ExtendedFilePropertiesPart?.Properties;
+                return properties?.Characters?.Text ?? string.Empty;
             }
             set {
                 var properties = GetProperties();
                 if (properties == null) {
                     return;
                 }
-                if (properties.Characters == null) {
-                    properties.Characters = new Characters();
-                }
+
+                properties.Characters ??= new Characters();
                 properties.Characters.Text = value;
             }
         }
@@ -139,22 +108,16 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string CharactersWithSpaces {
             get {
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
-                    return "";
-                }
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart.Properties.CharactersWithSpaces == null) {
-                    return "";
-                }
-                return _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.CharactersWithSpaces.Text;
+                var properties = _wordprocessingDocument.ExtendedFilePropertiesPart?.Properties;
+                return properties?.CharactersWithSpaces?.Text ?? string.Empty;
             }
             set {
                 var properties = GetProperties();
                 if (properties == null) {
                     return;
                 }
-                if (properties.CharactersWithSpaces == null) {
-                    properties.CharactersWithSpaces = new CharactersWithSpaces();
-                }
+
+                properties.CharactersWithSpaces ??= new CharactersWithSpaces();
                 properties.CharactersWithSpaces.Text = value;
             }
         }
@@ -163,22 +126,16 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string Company {
             get {
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
-                    return "";
-                }
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Company == null) {
-                    return "";
-                }
-                return _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.Company.Text;
+                var properties = _wordprocessingDocument.ExtendedFilePropertiesPart?.Properties;
+                return properties?.Company?.Text ?? string.Empty;
             }
             set {
                 var properties = GetProperties();
                 if (properties == null) {
                     return;
                 }
-                if (properties.Company == null) {
-                    properties.Company = new Company();
-                }
+
+                properties.Company ??= new Company();
                 properties.Company.Text = value;
             }
         }
@@ -186,21 +143,12 @@ namespace OfficeIMO.Word {
         /// Gets or sets the digital signature information for the document.
         /// </summary>
         public DigitalSignature? DigitalSignature {
-            get {
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart == null || _wordprocessingDocument.ExtendedFilePropertiesPart.Properties == null) {
-                    return null;
-                }
-                if (_wordprocessingDocument.ExtendedFilePropertiesPart.Properties.DigitalSignature == null) {
-                    return null;
-                }
-                return _wordprocessingDocument.ExtendedFilePropertiesPart.Properties.DigitalSignature;
-            }
+            get => _wordprocessingDocument.ExtendedFilePropertiesPart?.Properties?.DigitalSignature;
             set {
                 var properties = GetProperties();
-                if (properties == null) {
-                    return;
+                if (properties != null) {
+                    properties.DigitalSignature = value;
                 }
-                properties.DigitalSignature = value;
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- avoid potential null references in application property getters
- use null propagation to reduce nullable warnings

## Testing
- `dotnet build OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a43122814c832ea25ddb2320c48dc1