### PR TITLE
fix: address nullable and obsolete API warnings

### DIFF
--- a/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
+++ b/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Word.Pdf {
         /// <summary>
         /// Optional font family applied to created runs during conversion.
         /// </summary>
-        public string FontFamily { get; set; }
+        public string? FontFamily { get; set; }
         /// <summary>
         /// Optional mapping of font family names to font file paths.
         /// </summary>

--- a/OfficeIMO.Word.Pdf/TableLayoutCache.cs
+++ b/OfficeIMO.Word.Pdf/TableLayoutCache.cs
@@ -9,8 +9,8 @@ namespace OfficeIMO.Word.Pdf {
         private static readonly ConditionalWeakTable<WordTable, TableLayout> _cache = new();
 
         internal static TableLayout GetLayout(WordTable table) {
-            if (_cache.TryGetValue(table, out TableLayout layout)) {
-                return layout;
+            if (_cache.TryGetValue(table, out TableLayout? existingLayout) && existingLayout != null) {
+                return existingLayout;
             }
 
             List<IReadOnlyList<WordTableCell>> rows = TableBuilder.Map(table).ToList();
@@ -41,7 +41,7 @@ namespace OfficeIMO.Word.Pdf {
                 }
             }
 
-            layout = new TableLayout(rows, widths);
+            TableLayout layout = new(rows, widths);
             _cache.Add(table, layout);
             return layout;
         }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
@@ -239,24 +239,12 @@ namespace OfficeIMO.Word.Pdf {
             var line = lineField?.GetValue(shape) as Line;
 
             if (line != null) {
-                container.Canvas((canvasObj, size) => {
-                    var canvasType = canvasObj.GetType();
-                    var positionType = canvasType.Assembly.GetType("QuestPDF.Infrastructure.Position");
-                    var ctor = positionType!.GetConstructor(new[] { typeof(float), typeof(float) });
+                (float x1, float y1) = ParsePoint(line.From?.Value ?? "0pt,0pt");
+                (float x2, float y2) = ParsePoint(line.To?.Value ?? "0pt,0pt");
 
-                    (float x1, float y1) = ParsePoint(line.From?.Value ?? "0pt,0pt");
-                    (float x2, float y2) = ParsePoint(line.To?.Value ?? "0pt,0pt");
-                    object start = ctor!.Invoke(new object[] { x1, y1 });
-                    object end = ctor.Invoke(new object[] { x2, y2 });
+                string svg = $"<svg xmlns='http://www.w3.org/2000/svg' width='{width.ToString(CultureInfo.InvariantCulture)}' height='{height.ToString(CultureInfo.InvariantCulture)}' viewBox='0 0 {width.ToString(CultureInfo.InvariantCulture)} {height.ToString(CultureInfo.InvariantCulture)}'><line x1='{x1.ToString(CultureInfo.InvariantCulture)}' y1='{y1.ToString(CultureInfo.InvariantCulture)}' x2='{x2.ToString(CultureInfo.InvariantCulture)}' y2='{y2.ToString(CultureInfo.InvariantCulture)}' stroke='#{stroke ?? "000000"}' stroke-width='{strokeWidth.ToString(CultureInfo.InvariantCulture)}' /></svg>";
 
-                    var paint = new SKPaint {
-                        Style = SKPaintStyle.Stroke,
-                        Color = SKColor.Parse("#" + (stroke ?? "000000")),
-                        StrokeWidth = strokeWidth
-                    };
-
-                    canvasType.GetMethod("DrawLine")!.Invoke(canvasObj, new object[] { start, end, paint });
-                });
+                container.Svg(svg);
 
                 return container;
             }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -189,18 +189,18 @@ namespace OfficeIMO.Word.Pdf {
             Document pdf = Document.Create(container => {
                 foreach (WordSection section in document.Sections) {
                     container.Page(page => {
-                        if (!string.IsNullOrEmpty(options?.FontFamily)) {
-                            page.DefaultTextStyle(t => t.FontFamily(options.FontFamily));
+                        if (options?.FontFamily is { Length: > 0 } fontFamily) {
+                            page.DefaultTextStyle(t => t.FontFamily(fontFamily));
                         }
 
                         if (options?.MarginLeft != null || options?.MarginRight != null || options?.MarginTop != null || options?.MarginBottom != null) {
-                            float left = options.MarginLeft ?? options.Margin ?? (section.Margins.Left.Value / 20f);
+                            float left = options.MarginLeft ?? options.Margin ?? (section.Margins.Left?.Value ?? 0) / 20f;
                             Unit leftUnit = options.MarginLeft != null ? options.MarginLeftUnit : options.Margin != null ? options.MarginUnit : Unit.Point;
-                            float right = options.MarginRight ?? options.Margin ?? (section.Margins.Right.Value / 20f);
+                            float right = options.MarginRight ?? options.Margin ?? (section.Margins.Right?.Value ?? 0) / 20f;
                             Unit rightUnit = options.MarginRight != null ? options.MarginRightUnit : options.Margin != null ? options.MarginUnit : Unit.Point;
-                            float top = options.MarginTop ?? options.Margin ?? (section.Margins.Top.Value / 20f);
+                            float top = options.MarginTop ?? options.Margin ?? (section.Margins.Top ?? 0) / 20f;
                             Unit topUnit = options.MarginTop != null ? options.MarginTopUnit : options.Margin != null ? options.MarginUnit : Unit.Point;
-                            float bottom = options.MarginBottom ?? options.Margin ?? (section.Margins.Bottom.Value / 20f);
+                            float bottom = options.MarginBottom ?? options.Margin ?? (section.Margins.Bottom ?? 0) / 20f;
                             Unit bottomUnit = options.MarginBottom != null ? options.MarginBottomUnit : options.Margin != null ? options.MarginUnit : Unit.Point;
 
                             page.MarginLeft(left, leftUnit);
@@ -210,10 +210,10 @@ namespace OfficeIMO.Word.Pdf {
                         } else if (options?.Margin != null) {
                             page.Margin(options.Margin.Value, options.MarginUnit);
                         } else {
-                            float leftMargin = section.Margins.Left.Value / 20f;
-                            float rightMargin = section.Margins.Right.Value / 20f;
-                            float topMargin = section.Margins.Top.Value / 20f;
-                            float bottomMargin = section.Margins.Bottom.Value / 20f;
+                            float leftMargin = (section.Margins.Left?.Value ?? 0) / 20f;
+                            float rightMargin = (section.Margins.Right?.Value ?? 0) / 20f;
+                            float topMargin = (section.Margins.Top ?? 0) / 20f;
+                            float bottomMargin = (section.Margins.Bottom ?? 0) / 20f;
                             page.MarginLeft(leftMargin, Unit.Point);
                             page.MarginRight(rightMargin, Unit.Point);
                             page.MarginTop(topMargin, Unit.Point);


### PR DESCRIPTION
## Summary
- handle optional font/margin values when exporting Word to PDF
- update PDF options with nullable font family
- remove deprecated QuestPDF Canvas API usage
- guard table layout cache retrieval

## Testing
- `dotnet build OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a437677bd8832eac55828fa1d68f03