### PR TITLE
Fix nullable warnings in tests

### DIFF
--- a/OfficeIMO.Tests/Html.TableCaptions.cs
+++ b/OfficeIMO.Tests/Html.TableCaptions.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Tests {
         public void HtmlToWord_TableCaptionAbove() {
             string html = "<table><caption>Above</caption><tr><td>A</td></tr></table>";
             var doc = html.LoadFromHtml(new HtmlToWordOptions { TableCaptionPosition = TableCaptionPosition.Above });
-            var bodyXml = doc._wordprocessingDocument.MainDocumentPart.Document.Body.OuterXml;
+            var bodyXml = doc._wordprocessingDocument!.MainDocumentPart!.Document.Body!.OuterXml;
             Assert.True(bodyXml.IndexOf("Above", StringComparison.Ordinal) < bodyXml.IndexOf("<w:tbl", StringComparison.Ordinal));
         }
 
@@ -18,7 +18,7 @@ namespace OfficeIMO.Tests {
         public void HtmlToWord_TableCaptionBelow() {
             string html = "<table><caption>Below</caption><tr><td>A</td></tr></table>";
             var doc = html.LoadFromHtml(new HtmlToWordOptions { TableCaptionPosition = TableCaptionPosition.Below });
-            var bodyXml = doc._wordprocessingDocument.MainDocumentPart.Document.Body.OuterXml;
+            var bodyXml = doc._wordprocessingDocument!.MainDocumentPart!.Document.Body!.OuterXml;
             Assert.True(bodyXml.IndexOf("Below", StringComparison.Ordinal) > bodyXml.IndexOf("<w:tbl", StringComparison.Ordinal));
         }
     }

--- a/OfficeIMO.Tests/Word.Background.cs
+++ b/OfficeIMO.Tests/Word.Background.cs
@@ -16,14 +16,14 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.Background.SetImage(imagePath, 600, 800);
 
-                var background = document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground;
+                var background = document._wordprocessingDocument!.MainDocumentPart!.Document.DocumentBackground;
                 Assert.NotNull(background);
 
                 document.Save(false);
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var background = document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground;
+                var background = document._wordprocessingDocument!.MainDocumentPart!.Document.DocumentBackground;
                 Assert.NotNull(background);
             }
         }

--- a/OfficeIMO.Tests/Word.DigitalSignature.cs
+++ b/OfficeIMO.Tests/Word.DigitalSignature.cs
@@ -19,9 +19,9 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Create(tempFile)) {
                 document.ApplicationProperties.DigitalSignature = new DigitalSignature();
                 Assert.True(document.ApplicationProperties.DigitalSignature != null);
-                var extendedPart = document._wordprocessingDocument.ExtendedFilePropertiesPart;
+                var extendedPart = document._wordprocessingDocument!.ExtendedFilePropertiesPart;
                 Assert.NotNull(extendedPart);
-                document._wordprocessingDocument.DeletePart(extendedPart);
+                document._wordprocessingDocument!.DeletePart(extendedPart);
                 Assert.True(document.ApplicationProperties.DigitalSignature == null);
             }
         }

--- a/OfficeIMO.Tests/Word.ImageClone.cs
+++ b/OfficeIMO.Tests/Word.ImageClone.cs
@@ -13,12 +13,12 @@ namespace OfficeIMO.Tests {
             paragraph1.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 50, 50);
 
             var paragraph2 = document.AddParagraph();
-            var clone = paragraph1.Image.Clone(paragraph2);
+            var clone = paragraph1.Image!.Clone(paragraph2);
 
             Assert.Equal(paragraph1.Image.RelationshipId, clone.RelationshipId);
             Assert.Equal(2, document.Images.Count);
-            Assert.NotNull(document._wordprocessingDocument.MainDocumentPart);
-            Assert.Single(document._wordprocessingDocument.MainDocumentPart!.ImageParts);
+            Assert.NotNull(document._wordprocessingDocument!.MainDocumentPart);
+            Assert.Single(document._wordprocessingDocument!.MainDocumentPart!.ImageParts);
 
             document.Save(false);
         }

--- a/OfficeIMO.Tests/Word.InlineRunHelper.cs
+++ b/OfficeIMO.Tests/Word.InlineRunHelper.cs
@@ -34,7 +34,7 @@ public partial class Word {
         var hyperlink = paragraph._paragraph.Elements<Hyperlink>().FirstOrDefault();
         Assert.NotNull(hyperlink);
         Assert.Equal("http://example.com", hyperlink.InnerText);
-        var rel = document._wordprocessingDocument.MainDocumentPart!.HyperlinkRelationships.First();
+        var rel = document._wordprocessingDocument!.MainDocumentPart!.HyperlinkRelationships.First();
         Assert.StartsWith("http://example.com", rel.Uri.ToString());
     }
 }

--- a/OfficeIMO.Tests/Word.Lists.cs
+++ b/OfficeIMO.Tests/Word.Lists.cs
@@ -400,7 +400,7 @@ public partial class Word {
 
         using (var document = WordDocument.Load(filePath)) {
             Assert.Equal(wordListStyles.Length, document.Lists.Count);
-            var abstractNums = document._wordprocessingDocument.MainDocumentPart!.NumberingDefinitionsPart!
+            var abstractNums = document._wordprocessingDocument!.MainDocumentPart!.NumberingDefinitionsPart!
                 .Numbering.ChildElements.OfType<AbstractNum>().ToArray();
             for (var idx = 0; idx < abstractNums.Length; idx++) {
                 var style = WordListStyles.GetStyle(wordListStyles[idx]);
@@ -847,7 +847,7 @@ public partial class Word {
 
             Assert.Single(document.Lists);
             Assert.Equal("Two", document.Lists[0].ListItems[0].Text);
-            Assert.NotNull(document._wordprocessingDocument.MainDocumentPart?.NumberingDefinitionsPart);
+            Assert.NotNull(document._wordprocessingDocument!.MainDocumentPart?.NumberingDefinitionsPart);
 
             document.Save(false);
         }

--- a/OfficeIMO.Tests/Word.PictureBulletList.cs
+++ b/OfficeIMO.Tests/Word.PictureBulletList.cs
@@ -18,7 +18,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = WordDocument.Load(filePath)) {
-                var numbering = document._wordprocessingDocument.MainDocumentPart?.NumberingDefinitionsPart?.Numbering;
+                var numbering = document._wordprocessingDocument?.MainDocumentPart?.NumberingDefinitionsPart?.Numbering;
                 Assert.NotNull(numbering);
                 Assert.NotNull(numbering!.Elements<NumberingPictureBullet>().FirstOrDefault());
                 Assert.Single(document.Lists);
@@ -37,7 +37,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = WordDocument.Load(filePath)) {
-                var numbering = document._wordprocessingDocument.MainDocumentPart?.NumberingDefinitionsPart?.Numbering;
+                var numbering = document._wordprocessingDocument?.MainDocumentPart?.NumberingDefinitionsPart?.Numbering;
                 Assert.NotNull(numbering);
                 Assert.NotNull(numbering!.Elements<NumberingPictureBullet>().FirstOrDefault());
                 Assert.Single(document.Lists);

--- a/OfficeIMO.Tests/Word.StructuredDocumentTag.cs
+++ b/OfficeIMO.Tests/Word.StructuredDocumentTag.cs
@@ -100,7 +100,8 @@ namespace OfficeIMO.Tests {
                 document.AddParagraph(wordParagraph);
 
                 var sdt = wordParagraph.StructuredDocumentTag;
-                Assert.Null(sdt.Text);
+                Assert.NotNull(sdt);
+                Assert.Null(sdt!.Text);
 
                 sdt.Text = "New text";
 

--- a/OfficeIMO.Tests/Word.Validation.cs
+++ b/OfficeIMO.Tests/Word.Validation.cs
@@ -86,7 +86,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var numbering = document._wordprocessingDocument.MainDocumentPart?.NumberingDefinitionsPart?.Numbering;
+                var numbering = document._wordprocessingDocument?.MainDocumentPart?.NumberingDefinitionsPart?.Numbering;
                 Assert.NotNull(numbering);
                 Assert.NotNull(numbering!.LookupNamespace("w15"));
                 var ignorable = numbering.MCAttributes?.Ignorable?.Value;


### PR DESCRIPTION
## Summary
- ensure WordprocessingDocument references are checked before use in tests
- prevent null dereference warnings across HTML and Word-related test helpers

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a4374bd728832e94cca92f437a7a83