### PR TITLE
fix: resolve nullable warnings in tests

### DIFF
--- a/OfficeIMO.Tests/Excel.SetCellValues.cs
+++ b/OfficeIMO.Tests/Excel.SetCellValues.cs
@@ -28,35 +28,35 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                var cells = wsPart.Worksheet.Descendants<Cell>().ToList();
-                SharedStringTablePart shared = spreadsheet.WorkbookPart.SharedStringTablePart;
-                Assert.NotNull(shared);
-                Assert.Equal("Hello", shared.SharedStringTable.ElementAt(0).InnerText);
+                  WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                  var cells = wsPart.Worksheet.Descendants<Cell>().ToList();
+                  SharedStringTablePart shared = spreadsheet.WorkbookPart!.SharedStringTablePart!;
+                  Assert.NotNull(shared);
+                  Assert.Equal("Hello", shared.SharedStringTable!.ElementAt(0).InnerText);
 
                 Cell cellString = cells.First(c => c.CellReference == "A1");
-                Assert.Equal(CellValues.SharedString, cellString.DataType.Value);
-                Assert.Equal("0", cellString.CellValue.Text);
+                  Assert.Equal(CellValues.SharedString, cellString.DataType!.Value);
+                  Assert.Equal("0", cellString.CellValue!.Text);
 
                 Cell cellDouble = cells.First(c => c.CellReference == "A2");
-                Assert.Equal(CellValues.Number, cellDouble.DataType.Value);
-                Assert.Equal("123.45", cellDouble.CellValue.Text);
+                  Assert.Equal(CellValues.Number, cellDouble.DataType!.Value);
+                  Assert.Equal("123.45", cellDouble.CellValue!.Text);
 
                 Cell cellDecimal = cells.First(c => c.CellReference == "A3");
-                Assert.Equal(CellValues.Number, cellDecimal.DataType.Value);
-                Assert.Equal("678.90", cellDecimal.CellValue.Text);
+                  Assert.Equal(CellValues.Number, cellDecimal.DataType!.Value);
+                  Assert.Equal("678.90", cellDecimal.CellValue!.Text);
 
                 Cell cellDate = cells.First(c => c.CellReference == "A4");
-                Assert.Equal(CellValues.Number, cellDate.DataType.Value);
-                Assert.Equal(date.ToOADate().ToString(CultureInfo.InvariantCulture), cellDate.CellValue.Text);
+                  Assert.Equal(CellValues.Number, cellDate.DataType!.Value);
+                  Assert.Equal(date.ToOADate().ToString(CultureInfo.InvariantCulture), cellDate.CellValue!.Text);
 
                 Cell cellBool = cells.First(c => c.CellReference == "A5");
-                Assert.Equal(CellValues.Boolean, cellBool.DataType.Value);
-                Assert.Equal("1", cellBool.CellValue.Text);
+                  Assert.Equal(CellValues.Boolean, cellBool.DataType!.Value);
+                  Assert.Equal("1", cellBool.CellValue!.Text);
 
                 Cell cellFormula = cells.First(c => c.CellReference == "A6");
-                Assert.NotNull(cellFormula.CellFormula);
-                Assert.Equal("SUM(A2:A3)", cellFormula.CellFormula.Text);
+                  Assert.NotNull(cellFormula.CellFormula);
+                  Assert.Equal("SUM(A2:A3)", cellFormula.CellFormula!.Text);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.Charts.cs
+++ b/OfficeIMO.Tests/Word.Charts.cs
@@ -72,12 +72,12 @@ namespace OfficeIMO.Tests {
                 Assert.True(paragraph4.IsChart == false);
 
                 Assert.True(document.Paragraphs[7].IsChart == true);
-                Assert.True(document.Paragraphs[7].Chart.RoundedCorners == false);
+                  Assert.True(document.Paragraphs[7].Chart!.RoundedCorners == false);
                 lineChart4.RoundedCorners = true;
-                Assert.True(document.Paragraphs[7].Chart.RoundedCorners == true);
+                  Assert.True(document.Paragraphs[7].Chart!.RoundedCorners == true);
 
-                document.Paragraphs[7].Chart.RoundedCorners = false;
-                Assert.True(document.Paragraphs[7].Chart.RoundedCorners == false);
+                  document.Paragraphs[7].Chart!.RoundedCorners = false;
+                  Assert.True(document.Paragraphs[7].Chart!.RoundedCorners == false);
 
                 Assert.True(lineChart4.RoundedCorners == false);
 
@@ -106,29 +106,29 @@ namespace OfficeIMO.Tests {
 
                 var scatter = document.AddChart();
                 scatter.AddScatter("data", new List<double> { 1, 2 }, new List<double> { 2, 1 }, Color.Red);
-                var scatterPart = document._wordprocessingDocument.MainDocumentPart.ChartParts.Last();
-                var scatterXml = scatterPart.ChartSpace.GetFirstChild<Chart>().PlotArea.GetFirstChild<ScatterChart>();
+                  var scatterPart = document._wordprocessingDocument.MainDocumentPart!.ChartParts.Last();
+                  var scatterXml = scatterPart.ChartSpace.GetFirstChild<Chart>()!.PlotArea!.GetFirstChild<ScatterChart>();
                 Assert.NotNull(scatterXml);
 
                 var radar = document.AddChart();
                 radar.AddCategories(categories);
                 radar.AddRadar("USA", new List<int> { 1, 2, 3, 4 }, Color.Green);
-                var radarPart = document._wordprocessingDocument.MainDocumentPart.ChartParts.Last();
-                var radarXml = radarPart.ChartSpace.GetFirstChild<Chart>().PlotArea.GetFirstChild<RadarChart>();
+                  var radarPart = document._wordprocessingDocument.MainDocumentPart!.ChartParts.Last();
+                  var radarXml = radarPart.ChartSpace.GetFirstChild<Chart>()!.PlotArea!.GetFirstChild<RadarChart>();
                 Assert.NotNull(radarXml);
 
                 var bar3d = document.AddChart();
                 bar3d.AddCategories(categories);
                 bar3d.AddBar3D("USA", new List<int> { 1, 2, 3, 4 }, Color.Blue);
-                var bar3dPart = document._wordprocessingDocument.MainDocumentPart.ChartParts.Last();
-                var bar3dXml = bar3dPart.ChartSpace.GetFirstChild<Chart>().PlotArea.GetFirstChild<Bar3DChart>();
+                  var bar3dPart = document._wordprocessingDocument.MainDocumentPart!.ChartParts.Last();
+                  var bar3dXml = bar3dPart.ChartSpace.GetFirstChild<Chart>()!.PlotArea!.GetFirstChild<Bar3DChart>();
                 Assert.NotNull(bar3dXml);
 
                 var pie3d = document.AddChart();
                 pie3d.AddPie3D("Poland", 10);
                 pie3d.AddPie3D("USA", 20);
-                var pie3dPart = document._wordprocessingDocument.MainDocumentPart.ChartParts.Last();
-                var pie3dXml = pie3dPart.ChartSpace.GetFirstChild<Chart>().PlotArea.GetFirstChild<Pie3DChart>();
+                  var pie3dPart = document._wordprocessingDocument.MainDocumentPart!.ChartParts.Last();
+                  var pie3dXml = pie3dPart.ChartSpace.GetFirstChild<Chart>()!.PlotArea!.GetFirstChild<Pie3DChart>();
                 Assert.NotNull(pie3dXml);
 
                 // TODO: Line3DChart temporarily commented out due to OpenXML schema validation issue
@@ -157,18 +157,18 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var maxId = document._wordprocessingDocument.MainDocumentPart
-                    .ChartParts.SelectMany(p => p.ChartSpace.GetFirstChild<Chart>()
-                    .Descendants<AxisId>())
+                  var maxId = document._wordprocessingDocument.MainDocumentPart!
+                      .ChartParts.SelectMany(p => p.ChartSpace.GetFirstChild<Chart>()!
+                      .Descendants<AxisId>())
                     .Max(a => a.Val!.Value);
 
-                var chart = document.AddChart();
+                  var chart = document.AddChart();
                 chart.AddCategories(new List<string> { "A", "B" });
                 chart.AddBar("T", new List<int> { 1, 2 }, Color.Blue);
 
-                var newIds = document._wordprocessingDocument.MainDocumentPart
-                    .ChartParts.Last().ChartSpace.GetFirstChild<Chart>()
-                    .Descendants<AxisId>().Select(a => a.Val!.Value);
+                  var newIds = document._wordprocessingDocument.MainDocumentPart!
+                      .ChartParts.Last().ChartSpace.GetFirstChild<Chart>()!
+                      .Descendants<AxisId>().Select(a => a.Val!.Value);
 
                 Assert.True(newIds.Min() > maxId);
                 var validation = document.ValidateDocument();

--- a/OfficeIMO.Tests/Word.CompareDocuments.cs
+++ b/OfficeIMO.Tests/Word.CompareDocuments.cs
@@ -27,9 +27,9 @@ namespace OfficeIMO.Tests {
             }
 
             using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-            InsertedRun ins = word.MainDocumentPart.Document.Body.Descendants<InsertedRun>().FirstOrDefault();
-            Assert.NotNull(ins);
-            Assert.Equal(" World", ins.InnerText);
+              InsertedRun? ins = word.MainDocumentPart!.Document!.Body!.Descendants<InsertedRun>().FirstOrDefault();
+              Assert.NotNull(ins);
+              Assert.Equal(" World", ins!.InnerText);
         }
 
         [Fact]
@@ -52,9 +52,9 @@ namespace OfficeIMO.Tests {
             }
 
             using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-            DeletedRun del = word.MainDocumentPart.Document.Body.Descendants<DeletedRun>().FirstOrDefault();
-            Assert.NotNull(del);
-            Assert.Equal(" World", del.InnerText);
+              DeletedRun? del = word.MainDocumentPart!.Document!.Body!.Descendants<DeletedRun>().FirstOrDefault();
+              Assert.NotNull(del);
+              Assert.Equal(" World", del!.InnerText);
         }
 
         [Fact]
@@ -78,9 +78,9 @@ namespace OfficeIMO.Tests {
             }
 
             using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-            Run run = word.MainDocumentPart.Document.Body.Descendants<Run>().First();
-            Assert.NotNull(run.RunProperties);
-            Assert.NotNull(run.RunProperties.RunPropertiesChange);
+              Run run = word.MainDocumentPart!.Document!.Body!.Descendants<Run>().First();
+              Assert.NotNull(run.RunProperties);
+              Assert.NotNull(run.RunProperties!.RunPropertiesChange);
         }
 
         [Fact]
@@ -106,8 +106,8 @@ namespace OfficeIMO.Tests {
             }
 
             using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-            InsertedRun ins = word.MainDocumentPart.Document.Body.Descendants<InsertedRun>().FirstOrDefault(r => r.InnerText == "Row2");
-            Assert.NotNull(ins);
+              InsertedRun? ins = word.MainDocumentPart!.Document!.Body!.Descendants<InsertedRun>().FirstOrDefault(r => r.InnerText == "Row2");
+              Assert.NotNull(ins);
         }
 
         [Fact]
@@ -133,8 +133,8 @@ namespace OfficeIMO.Tests {
             }
 
             using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-            DeletedRun del = word.MainDocumentPart.Document.Body.Descendants<DeletedRun>().FirstOrDefault(r => r.InnerText == "Row2");
-            Assert.NotNull(del);
+              DeletedRun? del = word.MainDocumentPart!.Document!.Body!.Descendants<DeletedRun>().FirstOrDefault(r => r.InnerText == "Row2");
+              Assert.NotNull(del);
         }
 
         [Fact]
@@ -157,10 +157,10 @@ namespace OfficeIMO.Tests {
             }
 
             using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-            InsertedRun ins = word.MainDocumentPart.Document.Body.Descendants<InsertedRun>().FirstOrDefault(r => r.InnerText == "[Image]");
-            DeletedRun del = word.MainDocumentPart.Document.Body.Descendants<DeletedRun>().FirstOrDefault(r => r.InnerText == "[Image]");
-            Assert.NotNull(ins);
-            Assert.NotNull(del);
+              InsertedRun? ins = word.MainDocumentPart!.Document!.Body!.Descendants<InsertedRun>().FirstOrDefault(r => r.InnerText == "[Image]");
+              DeletedRun? del = word.MainDocumentPart!.Document!.Body!.Descendants<DeletedRun>().FirstOrDefault(r => r.InnerText == "[Image]");
+              Assert.NotNull(ins);
+              Assert.NotNull(del);
         }
 
     }

--- a/OfficeIMO.Tests/Word.Images.cs
+++ b/OfficeIMO.Tests/Word.Images.cs
@@ -679,7 +679,8 @@ namespace OfficeIMO.Tests {
             Assert.False(stream is MemoryStream);
             Assert.Equal(new FileInfo(imagePath).Length, stream.Length);
             var buffer = new byte[1];
-            stream.Read(buffer, 0, 1);
+            var bytesRead = stream.Read(buffer, 0, 1);
+            Assert.Equal(1, bytesRead);
         }
 
     }

--- a/OfficeIMO.Tests/Word.ParagraphCustomStyles.cs
+++ b/OfficeIMO.Tests/Word.ParagraphCustomStyles.cs
@@ -23,7 +23,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var styles = document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles;
+                var styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;
                 Assert.NotNull(styles.Elements<Style>().FirstOrDefault(s => s.StyleId == "MyStyle"));
             }
 
@@ -60,15 +60,15 @@ namespace OfficeIMO.Tests {
             WordParagraphStyle.RegisterCustomStyle("MyStyle", updated);
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var styles = document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles;
+                var styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;
                 var loaded = styles.Elements<Style>().First(s => s.StyleId == "MyStyle");
-                Assert.Equal("Original", loaded.StyleName.Val);
+                Assert.Equal("Original", loaded.StyleName!.Val);
             }
 
             using (WordDocument document = WordDocument.Load(filePath, overrideStyles: true)) {
-                var styles = document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles;
+                var styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;
                 var loaded = styles.Elements<Style>().First(s => s.StyleId == "MyStyle");
-                Assert.Equal("Updated", loaded.StyleName.Val);
+                Assert.Equal("Updated", loaded.StyleName!.Val);
             }
 
             // cleanup
@@ -94,9 +94,9 @@ namespace OfficeIMO.Tests {
             WordParagraphStyle.RegisterCustomStyle("MyStyle", updated);
 
             using (WordDocument document = WordDocument.Load(filePath, readOnly: true, overrideStyles: true)) {
-                var styles = document._wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart.Styles;
+                var styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;
                 var loaded = styles.Elements<Style>().First(s => s.StyleId == "MyStyle");
-                Assert.Equal("Original", loaded.StyleName.Val);
+                Assert.Equal("Original", loaded.StyleName!.Val);
             }
 
             // cleanup

--- a/OfficeIMO.Tests/Word.Tables.Margins.cs
+++ b/OfficeIMO.Tests/Word.Tables.Margins.cs
@@ -22,22 +22,22 @@ namespace OfficeIMO.Tests {
                 table1.Rows[0].Cells[0].Paragraphs[0].Text = "Centimeter Test";
 
                 // Set all margins to 0.2 cm
-                table1.StyleDetails.MarginDefaultTopCentimeters = 0.2;
-                table1.StyleDetails.MarginDefaultBottomCentimeters = 0.2;
-                table1.StyleDetails.MarginDefaultLeftCentimeters = 0.2;
-                table1.StyleDetails.MarginDefaultRightCentimeters = 0.2;
+                table1.StyleDetails!.MarginDefaultTopCentimeters = 0.2;
+                table1.StyleDetails!.MarginDefaultBottomCentimeters = 0.2;
+                table1.StyleDetails!.MarginDefaultLeftCentimeters = 0.2;
+                table1.StyleDetails!.MarginDefaultRightCentimeters = 0.2;
 
                 // Verify the centimeter values
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftCentimeters.GetValueOrDefault() - 0.2) < 0.01);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails!.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails!.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails!.MarginDefaultLeftCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                Assert.True(Math.Abs(table1.StyleDetails!.MarginDefaultRightCentimeters.GetValueOrDefault() - 0.2) < 0.01);
 
                 // Verify the twips values (0.2 cm should be approximately 113.4 twips)
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopWidth.GetValueOrDefault() - 113) <= 1);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomWidth.GetValueOrDefault() - 113) <= 1);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftWidth.GetValueOrDefault() - 113) <= 1);
-                Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightWidth.GetValueOrDefault() - 113) <= 1);
+                Assert.True(Math.Abs(table1.StyleDetails!.MarginDefaultTopWidth.GetValueOrDefault() - 113) <= 1);
+                Assert.True(Math.Abs(table1.StyleDetails!.MarginDefaultBottomWidth.GetValueOrDefault() - 113) <= 1);
+                Assert.True(Math.Abs(table1.StyleDetails!.MarginDefaultLeftWidth.GetValueOrDefault() - 113) <= 1);
+                Assert.True(Math.Abs(table1.StyleDetails!.MarginDefaultRightWidth.GetValueOrDefault() - 113) <= 1);
 
                 document.AddParagraph();
 
@@ -46,18 +46,18 @@ namespace OfficeIMO.Tests {
                 table2.Rows[0].Cells[0].Paragraphs[0].Text = "Mixed Units Test";
 
                 // Set top and bottom in centimeters, left and right in twips
-                table2.StyleDetails.MarginDefaultTopCentimeters = 0.3;
-                table2.StyleDetails.MarginDefaultBottomCentimeters = 0.3;
-                table2.StyleDetails.MarginDefaultLeftWidth = 170;
-                table2.StyleDetails.MarginDefaultRightWidth = 170;
+                table2.StyleDetails!.MarginDefaultTopCentimeters = 0.3;
+                table2.StyleDetails!.MarginDefaultBottomCentimeters = 0.3;
+                table2.StyleDetails!.MarginDefaultLeftWidth = 170;
+                table2.StyleDetails!.MarginDefaultRightWidth = 170;
 
                 // Verify centimeter values
-                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.3) < 0.01);
-                Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.3) < 0.01);
+                Assert.True(Math.Abs(table2.StyleDetails!.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.3) < 0.01);
+                Assert.True(Math.Abs(table2.StyleDetails!.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.3) < 0.01);
 
                 // Verify twips values
-                Assert.True(table2.StyleDetails.MarginDefaultLeftWidth == 170);
-                Assert.True(table2.StyleDetails.MarginDefaultRightWidth == 170);
+                Assert.True(table2.StyleDetails!.MarginDefaultLeftWidth == 170);
+                Assert.True(table2.StyleDetails!.MarginDefaultRightWidth == 170);
 
                 document.AddParagraph();
 
@@ -66,13 +66,13 @@ namespace OfficeIMO.Tests {
                 table3.Rows[0].Cells[0].Paragraphs[0].Text = "Cell Spacing Test";
 
                 // Set cell spacing in centimeters
-                table3.StyleDetails.CellSpacingCentimeters = 0.15;
+                table3.StyleDetails!.CellSpacingCentimeters = 0.15;
 
                 // Verify centimeter value
-                Assert.True(Math.Abs(table3.StyleDetails.CellSpacingCentimeters.GetValueOrDefault() - 0.15) < 0.01);
+                Assert.True(Math.Abs(table3.StyleDetails!.CellSpacingCentimeters.GetValueOrDefault() - 0.15) < 0.01);
 
                 // Verify twips value (0.15 cm should be approximately 85 twips)
-                Assert.True(Math.Abs(table3.StyleDetails.CellSpacing.GetValueOrDefault() - 85) <= 1);
+                Assert.True(Math.Abs(table3.StyleDetails!.CellSpacing.GetValueOrDefault() - 85) <= 1);
 
                 document.AddParagraph();
 
@@ -81,24 +81,24 @@ namespace OfficeIMO.Tests {
                 table4.Rows[0].Cells[0].Paragraphs[0].Text = "Null Values Test";
 
                 // Set values and then clear them
-                table4.StyleDetails.MarginDefaultTopCentimeters = 0.2;
-                table4.StyleDetails.MarginDefaultBottomCentimeters = 0.2;
-                table4.StyleDetails.CellSpacingCentimeters = 0.1;
+                table4.StyleDetails!.MarginDefaultTopCentimeters = 0.2;
+                table4.StyleDetails!.MarginDefaultBottomCentimeters = 0.2;
+                table4.StyleDetails!.CellSpacingCentimeters = 0.1;
 
                 // Verify values are set
-                  Assert.True(Math.Abs(table4.StyleDetails.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.2) < 0.01);
-                  Assert.True(Math.Abs(table4.StyleDetails.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.2) < 0.01);
-                  Assert.True(Math.Abs(table4.StyleDetails.CellSpacingCentimeters.GetValueOrDefault() - 0.1) < 0.01);
+                  Assert.True(Math.Abs(table4.StyleDetails!.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                  Assert.True(Math.Abs(table4.StyleDetails!.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                  Assert.True(Math.Abs(table4.StyleDetails!.CellSpacingCentimeters.GetValueOrDefault() - 0.1) < 0.01);
 
                 // Clear values
-                table4.StyleDetails.MarginDefaultTopCentimeters = null;
-                table4.StyleDetails.MarginDefaultBottomCentimeters = null;
-                table4.StyleDetails.CellSpacingCentimeters = null;
+                table4.StyleDetails!.MarginDefaultTopCentimeters = null;
+                table4.StyleDetails!.MarginDefaultBottomCentimeters = null;
+                table4.StyleDetails!.CellSpacingCentimeters = null;
 
                 // Verify values are cleared
-                Assert.True(table4.StyleDetails.MarginDefaultTopCentimeters == null);
-                Assert.True(table4.StyleDetails.MarginDefaultBottomCentimeters == null);
-                Assert.True(table4.StyleDetails.CellSpacingCentimeters == null);
+                Assert.True(table4.StyleDetails!.MarginDefaultTopCentimeters == null);
+                Assert.True(table4.StyleDetails!.MarginDefaultBottomCentimeters == null);
+                Assert.True(table4.StyleDetails!.CellSpacingCentimeters == null);
 
                 document.Save(false);
             }
@@ -107,27 +107,27 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithTableMargins.docx"))) {
                 // Verify table 1 values
                 var table1 = document.Tables[0];
-                  Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.2) < 0.01);
-                  Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.2) < 0.01);
-                  Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultLeftCentimeters.GetValueOrDefault() - 0.2) < 0.01);
-                  Assert.True(Math.Abs(table1.StyleDetails.MarginDefaultRightCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                  Assert.True(Math.Abs(table1.StyleDetails!.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                  Assert.True(Math.Abs(table1.StyleDetails!.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                  Assert.True(Math.Abs(table1.StyleDetails!.MarginDefaultLeftCentimeters.GetValueOrDefault() - 0.2) < 0.01);
+                  Assert.True(Math.Abs(table1.StyleDetails!.MarginDefaultRightCentimeters.GetValueOrDefault() - 0.2) < 0.01);
 
                 // Verify table 2 values
                 var table2 = document.Tables[1];
-                  Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.3) < 0.01);
-                  Assert.True(Math.Abs(table2.StyleDetails.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.3) < 0.01);
-                Assert.True(table2.StyleDetails.MarginDefaultLeftWidth == 170);
-                Assert.True(table2.StyleDetails.MarginDefaultRightWidth == 170);
+                  Assert.True(Math.Abs(table2.StyleDetails!.MarginDefaultTopCentimeters.GetValueOrDefault() - 0.3) < 0.01);
+                  Assert.True(Math.Abs(table2.StyleDetails!.MarginDefaultBottomCentimeters.GetValueOrDefault() - 0.3) < 0.01);
+                Assert.True(table2.StyleDetails!.MarginDefaultLeftWidth == 170);
+                Assert.True(table2.StyleDetails!.MarginDefaultRightWidth == 170);
 
                 // Verify table 3 values
                 var table3 = document.Tables[2];
-                  Assert.True(Math.Abs(table3.StyleDetails.CellSpacingCentimeters.GetValueOrDefault() - 0.15) < 0.01);
+                  Assert.True(Math.Abs(table3.StyleDetails!.CellSpacingCentimeters.GetValueOrDefault() - 0.15) < 0.01);
 
                 // Verify table 4 values are cleared
                 var table4 = document.Tables[3];
-                Assert.True(table4.StyleDetails.MarginDefaultTopCentimeters == null);
-                Assert.True(table4.StyleDetails.MarginDefaultBottomCentimeters == null);
-                Assert.True(table4.StyleDetails.CellSpacingCentimeters == null);
+                Assert.True(table4.StyleDetails!.MarginDefaultTopCentimeters == null);
+                Assert.True(table4.StyleDetails!.MarginDefaultBottomCentimeters == null);
+                Assert.True(table4.StyleDetails!.CellSpacingCentimeters == null);
 
                 document.Save();
             }


### PR DESCRIPTION
## Summary
- address nullable analysis warnings across chart, image, table, and style tests
- verify stream reads exact bytes to avoid CA2022
- tighten spreadsheet cell assertions

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68a437423494832e98c1f2c83403c9b3