### PR TITLE
fix: suppress nullable warnings in tests

### DIFF
--- a/OfficeIMO.Tests/Excel.AutoFilter.cs
+++ b/OfficeIMO.Tests/Excel.AutoFilter.cs
@@ -34,16 +34,16 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                AutoFilter autoFilter = wsPart.Worksheet.Elements<AutoFilter>().FirstOrDefault();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                AutoFilter? autoFilter = wsPart.Worksheet.Elements<AutoFilter>().FirstOrDefault();
                 Assert.NotNull(autoFilter);
-                Assert.Equal("A1:B3", autoFilter.Reference.Value);
-                FilterColumn filterColumn = autoFilter.Elements<FilterColumn>().FirstOrDefault();
+                Assert.Equal("A1:B3", autoFilter!.Reference!.Value!);
+                FilterColumn? filterColumn = autoFilter.Elements<FilterColumn>().FirstOrDefault();
                 Assert.NotNull(filterColumn);
-                Filters filters = filterColumn.GetFirstChild<Filters>();
+                Filters? filters = filterColumn!.GetFirstChild<Filters>();
                 Assert.NotNull(filters);
-                Filter filter = filters.Elements<Filter>().First();
-                Assert.Equal("A", filter.Val.Value);
+                Filter filter = filters!.Elements<Filter>().First();
+                Assert.Equal("A", filter.Val!.Value!);
             }
         }
     }

--- a/OfficeIMO.Tests/Excel.AutoFit.cs
+++ b/OfficeIMO.Tests/Excel.AutoFit.cs
@@ -21,21 +21,21 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 var columns = wsPart.Worksheet.GetFirstChild<Columns>();
                 Assert.NotNull(columns);
-                var column = columns.Elements<Column>().First();
-                Assert.True(column.BestFit.Value);
-                Assert.True(column.Width.HasValue && column.Width.Value > 0);
+                var column = columns!.Elements<Column>().First();
+                Assert.True(column.BestFit?.Value ?? false);
+                Assert.True(column.Width is { } w && w.Value > 0);
 
                 var sheetFormat = wsPart.Worksheet.GetFirstChild<SheetFormatProperties>();
                 Assert.NotNull(sheetFormat);
-                Assert.True(sheetFormat.CustomHeight);
-                Assert.True(sheetFormat.DefaultRowHeight > 0);
+                Assert.True(sheetFormat.CustomHeight!.Value);
+                Assert.True(sheetFormat.DefaultRowHeight!.Value > 0);
 
-                var row = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex == 1);
-                Assert.True(row.CustomHeight);
-                Assert.True(row.Height.HasValue && row.Height.Value > 0);
+                var row = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex != null && r.RowIndex.Value == 1)!;
+                Assert.True(row.CustomHeight!.Value);
+                Assert.True(row.Height is { } h && h.Value > 0);
             }
         }
     }

--- a/OfficeIMO.Tests/Excel.LoadExceptions.cs
+++ b/OfficeIMO.Tests/Excel.LoadExceptions.cs
@@ -15,7 +15,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void Test_LoadNullPath_ThrowsArgumentNullException() {
-            var ex = Assert.Throws<ArgumentNullException>(() => ExcelDocument.Load(null));
+            var ex = Assert.Throws<ArgumentNullException>(() => ExcelDocument.Load(null!));
             Assert.Equal("filePath", ex.ParamName);
         }
 
@@ -28,7 +28,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public async Task Test_LoadAsyncNullPath_ThrowsArgumentNullException() {
-            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => ExcelDocument.LoadAsync(null));
+            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => ExcelDocument.LoadAsync(null!));
             Assert.Equal("path", ex.ParamName);
         }
     }

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -14,8 +14,8 @@ namespace OfficeIMO.Tests;
 public partial class Html {
     private static void RemoveCustomStyle(string styleId) {
         var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static);
-        var dict = (IDictionary<string, Style>)field!.GetValue(null);
-        dict.Remove(styleId);
+        var dict = (IDictionary<string, Style>?)field!.GetValue(null);
+        dict?.Remove(styleId);
     }
     [Fact]
     public void Test_Html_RoundTrip() {
@@ -176,7 +176,7 @@ public partial class Html {
         ms.Position = 0;
         using WordprocessingDocument docx = WordprocessingDocument.Open(ms, false);
         Paragraph p = docx.MainDocumentPart!.Document.Body!.Elements<Paragraph>().First();
-        string styleId = p.ParagraphProperties?.ParagraphStyleId?.Val;
+        string? styleId = p.ParagraphProperties?.ParagraphStyleId?.Val;
         Assert.Equal(WordParagraphStyles.Heading1.ToString(), styleId);
     }
 
@@ -276,7 +276,7 @@ public partial class Html {
         var doc = html.LoadFromHtml(new HtmlToWordOptions());
 
         Assert.Equal(5, doc.Lists[0].Numbering.Levels[0].StartNumberingValue);
-        Assert.Equal(NumberFormatValues.LowerLetter, doc.Lists[0].Numbering.Levels[0]._level.NumberingFormat.Val.Value);
+        Assert.Equal(NumberFormatValues.LowerLetter, doc.Lists[0].Numbering.Levels[0]._level!.NumberingFormat!.Val!.Value);
     }
 
     [Fact]
@@ -285,7 +285,7 @@ public partial class Html {
 
         var doc = html.LoadFromHtml(new HtmlToWordOptions());
 
-        Assert.Equal("o", doc.Lists[0].Numbering.Levels[0]._level.LevelText.Val);
+        Assert.Equal("o", doc.Lists[0].Numbering.Levels[0]._level!.LevelText!.Val!);
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -84,7 +84,7 @@ namespace OfficeIMO.Tests {
             var doc = html.LoadFromHtml(new HtmlToWordOptions());
             Assert.Collection(doc.Images, _ => { }, _ => { });
             Assert.Equal(doc.Images[0].RelationshipId, doc.Images[1].RelationshipId);
-            Assert.Single(doc._wordprocessingDocument.MainDocumentPart.ImageParts);
+            Assert.Single(doc._wordprocessingDocument!.MainDocumentPart!.ImageParts);
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace OfficeIMO.Tests {
             var doc = html.LoadFromHtml(new HtmlToWordOptions());
             Assert.Equal(2, doc.Images.Count);
             Assert.Equal(doc.Images[0].RelationshipId, doc.Images[1].RelationshipId);
-            Assert.Single(doc._wordprocessingDocument.MainDocumentPart.ImageParts);
+            Assert.Single(doc._wordprocessingDocument!.MainDocumentPart!.ImageParts);
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Html.TableCaptions.cs
+++ b/OfficeIMO.Tests/Html.TableCaptions.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Tests {
         public void HtmlToWord_TableCaptionAbove() {
             string html = "<table><caption>Above</caption><tr><td>A</td></tr></table>";
             var doc = html.LoadFromHtml(new HtmlToWordOptions { TableCaptionPosition = TableCaptionPosition.Above });
-            var bodyXml = doc._wordprocessingDocument.MainDocumentPart.Document.Body.OuterXml;
+            var bodyXml = doc._wordprocessingDocument!.MainDocumentPart!.Document.Body!.OuterXml;
             Assert.True(bodyXml.IndexOf("Above", StringComparison.Ordinal) < bodyXml.IndexOf("<w:tbl", StringComparison.Ordinal));
         }
 
@@ -18,7 +18,7 @@ namespace OfficeIMO.Tests {
         public void HtmlToWord_TableCaptionBelow() {
             string html = "<table><caption>Below</caption><tr><td>A</td></tr></table>";
             var doc = html.LoadFromHtml(new HtmlToWordOptions { TableCaptionPosition = TableCaptionPosition.Below });
-            var bodyXml = doc._wordprocessingDocument.MainDocumentPart.Document.Body.OuterXml;
+            var bodyXml = doc._wordprocessingDocument!.MainDocumentPart!.Document.Body!.OuterXml;
             Assert.True(bodyXml.IndexOf("Below", StringComparison.Ordinal) > bodyXml.IndexOf("<w:tbl", StringComparison.Ordinal));
         }
     }

--- a/OfficeIMO.Tests/Html.WordToHtml.cs
+++ b/OfficeIMO.Tests/Html.WordToHtml.cs
@@ -74,7 +74,7 @@ namespace OfficeIMO.Tests {
             var paragraph = doc.AddParagraph();
             paragraph.AddImage(assetPath, 40, 40, description: "Company logo");
 
-            Assert.Equal("Company logo", paragraph.Image.Description);
+            Assert.Equal("Company logo", paragraph.Image!.Description);
 
             string html = doc.ToHtml();
 
@@ -129,7 +129,7 @@ namespace OfficeIMO.Tests {
         public void Test_WordToHtml_BulletType() {
             using var doc = WordDocument.Create();
             var list = doc.AddList(WordListStyle.Bulleted);
-            list.Numbering.Levels[0]._level.LevelText.Val = "o";
+            list.Numbering.Levels[0]._level.LevelText!.Val = "o";
             list.AddItem("One");
             list.AddItem("Two");
 
@@ -142,7 +142,7 @@ namespace OfficeIMO.Tests {
         public void Test_WordToHtml_LowerLetter() {
             using var doc = WordDocument.Create();
             var list = doc.AddList(WordListStyle.ArticleSections);
-            list.Numbering.Levels[0]._level.NumberingFormat.Val = NumberFormatValues.LowerLetter;
+            list.Numbering.Levels[0]._level.NumberingFormat!.Val = NumberFormatValues.LowerLetter;
             list.AddItem("alpha");
             list.AddItem("beta");
 
@@ -156,7 +156,7 @@ namespace OfficeIMO.Tests {
         public void Test_WordToHtml_DecimalLeadingZero() {
             using var doc = WordDocument.Create();
             var list = doc.AddList(WordListStyle.ArticleSections);
-            list.Numbering.Levels[0]._level.NumberingFormat.Val = NumberFormatValues.DecimalZero;
+            list.Numbering.Levels[0]._level.NumberingFormat!.Val = NumberFormatValues.DecimalZero;
             list.Numbering.Levels[0].SetStartNumberingValue(3);
             list.AddItem("three");
             list.AddItem("four");

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.CustomFonts.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.CustomFonts.cs
@@ -30,10 +30,10 @@ namespace OfficeIMO.Tests {
                     FontFilePaths = new Dictionary<string, string> { { "FileFont", fontPath } }
                 };
                 byte[] pdf = document.SaveAsPdf(options);
-                using (PdfDocument pdfDoc = PdfDocument.Open(new MemoryStream(pdf))) {
-                    var fonts = pdfDoc.GetPage(1).Letters.Select(l => l.FontName).Distinct();
-                    Assert.Contains(fonts, f => f.Contains(expectedFont));
-                }
+                    using (PdfDocument pdfDoc = PdfDocument.Open(new MemoryStream(pdf))) {
+                        var fonts = pdfDoc.GetPage(1).Letters.Select(l => l.FontName).Distinct();
+                        Assert.Contains(fonts, f => f != null && f.Contains(expectedFont));
+                    }
             }
         }
 
@@ -58,10 +58,10 @@ namespace OfficeIMO.Tests {
                     FontStreams = new Dictionary<string, Stream> { { "StreamFont", fs } }
                 };
                 byte[] pdf = document.SaveAsPdf(options);
-                using (PdfDocument pdfDoc = PdfDocument.Open(new MemoryStream(pdf))) {
-                    var fonts = pdfDoc.GetPage(1).Letters.Select(l => l.FontName).Distinct();
-                    Assert.Contains(fonts, f => f.Contains(expectedFont));
-                }
+                    using (PdfDocument pdfDoc = PdfDocument.Open(new MemoryStream(pdf))) {
+                        var fonts = pdfDoc.GetPage(1).Letters.Select(l => l.FontName).Distinct();
+                        Assert.Contains(fonts, f => f != null && f.Contains(expectedFont));
+                    }
             }
         }
     }

--- a/OfficeIMO.Tests/Visio.PackageCreation.cs
+++ b/OfficeIMO.Tests/Visio.PackageCreation.cs
@@ -57,9 +57,9 @@ namespace OfficeIMO.Tests {
 
             using FileStream zipStream = File.OpenRead(filePath);
             using ZipArchive archive = new(zipStream, ZipArchiveMode.Read);
-            ZipArchiveEntry entry = archive.GetEntry("[Content_Types].xml");
+            ZipArchiveEntry? entry = archive.GetEntry("[Content_Types].xml");
             Assert.NotNull(entry);
-            using Stream entryStream = entry.Open();
+            using Stream entryStream = entry!.Open();
             XDocument contentTypes = XDocument.Load(entryStream);
             XNamespace ct = "http://schemas.openxmlformats.org/package/2006/content-types";
             bool hasDocOverride = contentTypes.Root?.Elements(ct + "Override").Any(e => e.Attribute("PartName")?.Value == "/visio/document.xml" && e.Attribute("ContentType")?.Value == "application/vnd.ms-visio.drawing.main+xml") == true;
@@ -68,7 +68,7 @@ namespace OfficeIMO.Tests {
             Assert.NotNull(contentTypes.Root?.Elements(ct + "Override").FirstOrDefault(e => e.Attribute("PartName")?.Value == "/visio/pages/pages.xml"));
             Assert.NotNull(contentTypes.Root?.Elements(ct + "Override").FirstOrDefault(e => e.Attribute("PartName")?.Value == "/visio/pages/page1.xml"));
 
-            XElement shape = pageDoc.Root?.Element(ns + "Shapes")?.Element(ns + "Shape");
+            XElement? shape = pageDoc.Root?.Element(ns + "Shapes")?.Element(ns + "Shape");
             Assert.Equal("1", shape?.Attribute("ID")?.Value);
             Assert.Equal("Rectangle", shape?.Element(ns + "Text")?.Value);
         }

--- a/OfficeIMO.Tests/Word.AddCustomBulletList.cs
+++ b/OfficeIMO.Tests/Word.AddCustomBulletList.cs
@@ -25,12 +25,12 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("■", list.Numbering.Levels[3].LevelText);
                 Assert.Equal("●", list.Numbering.Levels[4].LevelText);
 
-                var level1Props = list.Numbering.Levels[0]._level.NumberingSymbolRunProperties;
+                var level1Props = list.Numbering.Levels[0]._level.NumberingSymbolRunProperties!;
                 Assert.Equal("Courier New", level1Props.GetFirstChild<RunFonts>()?.Ascii);
                 Assert.Equal("ff0000", level1Props.GetFirstChild<Color>()?.Val);
                 Assert.Equal("28", level1Props.GetFirstChild<FontSize>()?.Val);
 
-                var level5Props = list.Numbering.Levels[4]._level.NumberingSymbolRunProperties;
+                var level5Props = list.Numbering.Levels[4]._level.NumberingSymbolRunProperties!;
                 Assert.Equal("Arial", level5Props.GetFirstChild<RunFonts>()?.Ascii);
                 Assert.Equal("00ff00", level5Props.GetFirstChild<Color>()?.Val);
                 Assert.Equal("20", level5Props.GetFirstChild<FontSize>()?.Val);
@@ -51,7 +51,7 @@ namespace OfficeIMO.Tests {
                 Assert.Single(list.Numbering.Levels);
                 Assert.Equal("◆", list.Numbering.Levels[0].LevelText);
 
-                var props = list.Numbering.Levels[0]._level.NumberingSymbolRunProperties;
+                var props = list.Numbering.Levels[0]._level.NumberingSymbolRunProperties!;
                 Assert.Equal("Wingdings", props.GetFirstChild<RunFonts>()?.Ascii);
                 Assert.Equal("0000ff", props.GetFirstChild<Color>()?.Val);
                 Assert.Equal("24", props.GetFirstChild<FontSize>()?.Val);

--- a/OfficeIMO.Tests/Word.Background.cs
+++ b/OfficeIMO.Tests/Word.Background.cs
@@ -16,14 +16,14 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.Background.SetImage(imagePath, 600, 800);
 
-                var background = document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground;
+                var background = document._wordprocessingDocument!.MainDocumentPart!.Document.DocumentBackground;
                 Assert.NotNull(background);
 
                 document.Save(false);
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var background = document._wordprocessingDocument.MainDocumentPart.Document.DocumentBackground;
+                var background = document._wordprocessingDocument!.MainDocumentPart!.Document.DocumentBackground;
                 Assert.NotNull(background);
             }
         }

--- a/OfficeIMO.Tests/Word.EmbeddedDocuments.cs
+++ b/OfficeIMO.Tests/Word.EmbeddedDocuments.cs
@@ -121,7 +121,7 @@ public partial class Word {
             Assert.True(document.EmbeddedDocuments[3].ContentType == "application/rtf");
             Assert.True(document.EmbeddedDocuments[4].ContentType == "application/rtf");
 
-            var list1 = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            var list1 = document._document!.MainDocumentPart!.AlternativeFormatImportParts;
             Assert.True(list1.Count() == 5);
 
             // lets delete last 3 embedded documents 
@@ -135,7 +135,7 @@ public partial class Word {
             Assert.True(document.Sections[0].EmbeddedDocuments.Count == 2);
             Assert.True(document.Sections[1].EmbeddedDocuments.Count == 0);
 
-            var list2 = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            var list2 = document._document!.MainDocumentPart!.AlternativeFormatImportParts;
             Assert.True(list2.Count() == 2);
 
 
@@ -165,7 +165,7 @@ public partial class Word {
             Assert.True(document.Sections[0].EmbeddedDocuments.Count == 2);
             Assert.True(document.Sections[1].EmbeddedDocuments.Count == 1);
 
-            var list3 = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            var list3 = document._document!.MainDocumentPart!.AlternativeFormatImportParts;
             Assert.True(list3.Count() == 3);
         }
     }
@@ -218,8 +218,8 @@ public partial class Word {
             document.AddEmbeddedDocument(rtfFilePath);
             document.AddEmbeddedDocument(rtfFilePath);
 
-            var ids = document._wordprocessingDocument.MainDocumentPart.AlternativeFormatImportParts
-                .Select(p => document._wordprocessingDocument.MainDocumentPart.GetIdOfPart(p))
+            var ids = document._wordprocessingDocument!.MainDocumentPart!.AlternativeFormatImportParts
+                .Select(p => document._wordprocessingDocument.MainDocumentPart!.GetIdOfPart(p))
                 .ToList();
 
             Assert.Equal(ids.Count, ids.Distinct().Count());
@@ -228,8 +228,8 @@ public partial class Word {
         }
 
         using (var document = WordDocument.Load(filePath)) {
-            var ids = document._wordprocessingDocument.MainDocumentPart.AlternativeFormatImportParts
-                .Select(p => document._wordprocessingDocument.MainDocumentPart.GetIdOfPart(p))
+            var ids = document._wordprocessingDocument!.MainDocumentPart!.AlternativeFormatImportParts
+                .Select(p => document._wordprocessingDocument.MainDocumentPart!.GetIdOfPart(p))
                 .ToList();
 
             Assert.Equal(ids.Count, ids.Distinct().Count());
@@ -267,7 +267,7 @@ public partial class Word {
 
             Assert.True(document.EmbeddedDocuments.Count == 2);
 
-            var listBefore = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            var listBefore = document._document!.MainDocumentPart!.AlternativeFormatImportParts;
             Assert.True(listBefore.Count() == 2);
 
             document.EmbeddedDocuments[0].Remove();
@@ -275,7 +275,7 @@ public partial class Word {
             Assert.True(document.EmbeddedDocuments.Count == 1);
             Assert.True(document.EmbeddedDocuments[0].ContentType == "text/html");
 
-            var listAfter = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            var listAfter = document._document!.MainDocumentPart!.AlternativeFormatImportParts;
             Assert.True(listAfter.Count() == 1);
 
             document.Save(false);
@@ -285,7 +285,7 @@ public partial class Word {
             Assert.True(document.EmbeddedDocuments.Count == 1);
             Assert.True(document.EmbeddedDocuments[0].ContentType == "text/html");
 
-            var listAfter = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            var listAfter = document._document!.MainDocumentPart!.AlternativeFormatImportParts;
             Assert.True(listAfter.Count() == 1);
         }
     }

--- a/OfficeIMO.Tests/Word.FontEmbedding.cs
+++ b/OfficeIMO.Tests/Word.FontEmbedding.cs
@@ -19,9 +19,9 @@ namespace OfficeIMO.Tests {
             }
 
             using var word = WordprocessingDocument.Open(filePath, false);
-            var fontTablePart = word.MainDocumentPart.FontTablePart;
+            var fontTablePart = word.MainDocumentPart!.FontTablePart;
             Assert.NotNull(fontTablePart);
-            Assert.True(fontTablePart.FontParts.Any());
+            Assert.True(fontTablePart!.FontParts.Any());
             File.Delete(fontPath);
         }
 
@@ -37,7 +37,7 @@ namespace OfficeIMO.Tests {
             }
 
             using var word = WordprocessingDocument.Open(filePath, false);
-            var styles = word.MainDocumentPart.StyleDefinitionsPart!.Styles;
+            var styles = word.MainDocumentPart!.StyleDefinitionsPart!.Styles!;
             Assert.NotNull(styles.Elements<Style>().FirstOrDefault(s => s.StyleId == "DejaVuStyle"));
             File.Delete(fontPath);
         }

--- a/OfficeIMO.Tests/Word.FootnoteEndnoteProperties.cs
+++ b/OfficeIMO.Tests/Word.FootnoteEndnoteProperties.cs
@@ -27,15 +27,15 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Equal(NumberFormatValues.LowerRoman, document.Sections[0].FootnoteProperties.NumberingFormat.Val.Value);
-                Assert.Equal(FootnotePositionValues.PageBottom, document.Sections[0].FootnoteProperties.FootnotePosition.Val.Value);
-                Assert.Equal(RestartNumberValues.EachSection, document.Sections[0].FootnoteProperties.NumberingRestart.Val.Value);
-                Assert.Equal(5, document.Sections[0].FootnoteProperties.NumberingStart.Val.Value);
+                Assert.Equal(NumberFormatValues.LowerRoman, document.Sections[0].FootnoteProperties!.NumberingFormat!.Val!.Value);
+                Assert.Equal(FootnotePositionValues.PageBottom, document.Sections[0].FootnoteProperties.FootnotePosition!.Val!.Value);
+                Assert.Equal(RestartNumberValues.EachSection, document.Sections[0].FootnoteProperties.NumberingRestart!.Val!.Value);
+                Assert.Equal(5, document.Sections[0].FootnoteProperties.NumberingStart!.Val!.Value);
 
-                Assert.Equal(NumberFormatValues.Decimal, document.Sections[0].EndnoteProperties.NumberingFormat.Val.Value);
-                Assert.Equal(EndnotePositionValues.SectionEnd, document.Sections[0].EndnoteProperties.EndnotePosition.Val.Value);
-                Assert.Equal(RestartNumberValues.EachSection, document.Sections[0].EndnoteProperties.NumberingRestart.Val.Value);
-                Assert.Equal(5, document.Sections[0].EndnoteProperties.NumberingStart.Val.Value);
+                Assert.Equal(NumberFormatValues.Decimal, document.Sections[0].EndnoteProperties!.NumberingFormat!.Val!.Value);
+                Assert.Equal(EndnotePositionValues.SectionEnd, document.Sections[0].EndnoteProperties.EndnotePosition!.Val!.Value);
+                Assert.Equal(RestartNumberValues.EachSection, document.Sections[0].EndnoteProperties.NumberingRestart!.Val!.Value);
+                Assert.Equal(5, document.Sections[0].EndnoteProperties.NumberingStart!.Val!.Value);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.Hyperlinks.InvalidInputs.cs
+++ b/OfficeIMO.Tests/Word.Hyperlinks.InvalidInputs.cs
@@ -8,10 +8,10 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void Test_AddHyperLink_InvalidTextThrows() {
             using var document = WordDocument.Create();
-            Assert.Throws<ArgumentException>(() => document.AddHyperLink(null, new Uri("https://example.com")));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink(null!, new Uri("https://example.com")));
             Assert.Throws<ArgumentException>(() => document.AddHyperLink(string.Empty, new Uri("https://example.com")));
             Assert.Throws<ArgumentException>(() => document.AddHyperLink(" ", new Uri("https://example.com")));
-            Assert.Throws<ArgumentException>(() => document.AddHyperLink(null, "Bookmark"));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink(null!, "Bookmark"));
             Assert.Throws<ArgumentException>(() => document.AddHyperLink(string.Empty, "Bookmark"));
             Assert.Throws<ArgumentException>(() => document.AddHyperLink(" ", "Bookmark"));
         }
@@ -19,8 +19,8 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void Test_AddHyperLink_InvalidUriOrAnchorThrows() {
             using var document = WordDocument.Create();
-            Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", (Uri)null));
-            Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", (string)null));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", (Uri)null!));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", (string)null!));
             Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", string.Empty));
             Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", " "));
         }

--- a/OfficeIMO.Tests/Word.Hyperlinks.cs
+++ b/OfficeIMO.Tests/Word.Hyperlinks.cs
@@ -46,7 +46,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(hyperlink.Color == Color.Red);
                 Assert.True(hyperlink.Underline == UnderlineValues.Dash);
 
-                Assert.True(hyperlink.Hyperlink.Text == "bookmark below");
+                Assert.True(hyperlink.Hyperlink!.Text == "bookmark below");
 
                 Assert.True(document.Paragraphs.Count == 3);
                 Assert.True(document.HyperLinks.Count == 1);
@@ -60,7 +60,7 @@ namespace OfficeIMO.Tests {
 
                 var hyperlink1 = document.AddParagraph("Test Email Address ").AddHyperLink("Przemysław Klys", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
 
-                Assert.True(hyperlink1.Hyperlink.EmailAddress == "kontakt@evotec.pl");
+                Assert.True(hyperlink1.Hyperlink!.EmailAddress == "kontakt@evotec.pl");
 
 
                 Assert.True(document.Paragraphs.Count == 7);
@@ -222,7 +222,7 @@ namespace OfficeIMO.Tests {
                 var hyperlink = document.AddParagraph("Hello users! Please visit ").AddHyperLink("bookmark below",
                     "TestBookmark", true, "This is link to bookmark below shown within Tooltip");
 
-                Assert.True(hyperlink.Hyperlink._runProperties.Bold == null);
+                Assert.True(hyperlink.Hyperlink!._runProperties?.Bold == null);
 
                 Assert.True(hyperlink.Underline == UnderlineValues.Single);
                 Assert.True(hyperlink.Bold == false);
@@ -244,13 +244,13 @@ namespace OfficeIMO.Tests {
                 var hyperlinkWithoutStyle = document.AddParagraph("Hello users! Please visit ").AddHyperLink("bookmark below",
                     "TestBookmark", false, "This is link to bookmark below shown within Tooltip");
 
-                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties == null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink!._runProperties == null);
 
                 hyperlinkWithoutStyle.Bold = true;
                 Assert.True(hyperlinkWithoutStyle.Bold == true);
-                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Bold != null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink!._runProperties!.Bold != null);
 
-                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Italic == null);
+                Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties!.Italic == null);
                 Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Underline == null);
                 Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Color == null);
                 Assert.True(hyperlinkWithoutStyle.Hyperlink._runProperties.Spacing == null);
@@ -325,8 +325,8 @@ namespace OfficeIMO.Tests {
                 document.Tables[0].Rows[0].Cells[0].Paragraphs[0].AddHyperLink(" to website?", new Uri("https://evotec.xyz"), addStyle: true);
 
                 Assert.True(document.Tables[0].Rows[0].Cells[0].Paragraphs[1].IsHyperLink == true);
-                Assert.True(document.Tables[0].Rows[0].Cells[0].Paragraphs[1].Hyperlink.IsHttp == true);
-                Assert.True(document.Tables[0].Rows[0].Cells[0].Paragraphs[1].Hyperlink.Text == " to website?");
+                Assert.True(document.Tables[0].Rows[0].Cells[0].Paragraphs[1].Hyperlink!.IsHttp == true);
+                Assert.True(document.Tables[0].Rows[0].Cells[0].Paragraphs[1].Hyperlink!.Text == " to website?");
 
                 Assert.True(document.HyperLinks.Count == 1);
 
@@ -345,12 +345,12 @@ namespace OfficeIMO.Tests {
                 paragraph.AddText(" after");
 
                 Assert.Single(document.HyperLinks);
-                Assert.Single(document._wordprocessingDocument.MainDocumentPart.HyperlinkRelationships);
+                Assert.Single(document._wordprocessingDocument!.MainDocumentPart!.HyperlinkRelationships);
 
                 paragraph.RemoveHyperLink();
 
                 Assert.Empty(document.HyperLinks);
-                Assert.Empty(document._wordprocessingDocument.MainDocumentPart.HyperlinkRelationships);
+                Assert.Empty(document._wordprocessingDocument!.MainDocumentPart!.HyperlinkRelationships);
                 Assert.Equal(2, paragraph._paragraph.ChildElements.OfType<Run>().Count());
 
                 document.Save(false);
@@ -370,16 +370,16 @@ namespace OfficeIMO.Tests {
                 paragraph.AddHyperLink("Google", new Uri("https://google.com"), addStyle: true);
 
                 var reference = paragraph.Hyperlink;
-                var created = WordHyperLink.CreateFormattedHyperlink(reference, "Bing", new Uri("https://bing.com"));
+                var created = WordHyperLink.CreateFormattedHyperlink(reference!, "Bing", new Uri("https://bing.com"));
 
                 Assert.Equal("Bing", created.Text);
                 Assert.Equal(new Uri("https://bing.com"), created.Uri);
                 Assert.NotNull(created._runProperties);
                 Assert.NotNull(created._runProperties.Color);
-                Assert.Equal(reference._runProperties.Color.Val, created._runProperties.Color.Val);
+                Assert.Equal(reference!._runProperties!.Color!.Val, created._runProperties!.Color!.Val);
                 Assert.Equal(reference._runProperties.Color.ThemeColor, created._runProperties.Color.ThemeColor);
-                Assert.Equal(reference._runProperties.Underline.Val, created._runProperties.Underline.Val);
-                Assert.Equal(reference._runProperties.RunStyle.Val, created._runProperties.RunStyle.Val);
+                Assert.Equal(reference._runProperties.Underline!.Val, created._runProperties.Underline!.Val);
+                Assert.Equal(reference._runProperties.RunStyle!.Val, created._runProperties.RunStyle!.Val);
                 Assert.Equal(2, paragraph._paragraph.Elements<Hyperlink>().Count());
 
                 document.Save(false);
@@ -400,10 +400,10 @@ namespace OfficeIMO.Tests {
                 paragraph.AddHyperLink("Google", new Uri("https://google.com"), addStyle: true);
                 var reference = paragraph.Hyperlink;
 
-                var duplicate = WordHyperLink.DuplicateHyperlink(reference);
+                var duplicate = WordHyperLink.DuplicateHyperlink(reference!);
 
-                Assert.Equal(reference.Text, duplicate.Text);
-                Assert.Equal(reference.Uri, duplicate.Uri);
+                  Assert.Equal(reference!.Text, duplicate.Text);
+                  Assert.Equal(reference.Uri, duplicate.Uri);
                 Assert.Equal(2, paragraph._paragraph.Elements<Hyperlink>().Count());
 
                 document.Save(false);
@@ -422,7 +422,7 @@ namespace OfficeIMO.Tests {
                 paragraph.AddHyperLink("Google", new Uri("https://google.com"), addStyle: true);
 
                 var reference = paragraph.Hyperlink;
-                var created = reference.InsertFormattedHyperlinkBefore("Bing", new Uri("https://bing.com"));
+                var created = reference!.InsertFormattedHyperlinkBefore("Bing", new Uri("https://bing.com"));
 
                 Assert.Equal(2, paragraph._paragraph.Elements<Hyperlink>().Count());
                 Assert.Equal("Bing", paragraph._paragraph.Elements<Hyperlink>().First().InnerText);
@@ -444,14 +444,14 @@ namespace OfficeIMO.Tests {
                 var header = document.Header.Default;
                 var paraHeader = header.AddParagraph("Search using ");
                 paraHeader.AddHyperLink("Google", new Uri("https://google.com"), addStyle: true);
-                var refHeader = paraHeader.Hyperlink;
-                refHeader.InsertFormattedHyperlinkAfter("Bing", new Uri("https://bing.com"));
+                  var refHeader = paraHeader.Hyperlink;
+                  refHeader!.InsertFormattedHyperlinkAfter("Bing", new Uri("https://bing.com"));
 
                 var footer = document.Footer.Default;
                 var paraFooter = footer.AddParagraph("Find us on ");
                 paraFooter.AddHyperLink("Yahoo", new Uri("https://yahoo.com"), addStyle: true);
-                var refFooter = paraFooter.Hyperlink;
-                refFooter.InsertFormattedHyperlinkAfter("DuckDuckGo", new Uri("https://duckduckgo.com"));
+                  var refFooter = paraFooter.Hyperlink;
+                  refFooter!.InsertFormattedHyperlinkAfter("DuckDuckGo", new Uri("https://duckduckgo.com"));
 
                 Assert.Equal(2, paraHeader._paragraph.Elements<Hyperlink>().Count());
                 Assert.Equal(2, paraFooter._paragraph.Elements<Hyperlink>().Count());
@@ -474,15 +474,20 @@ namespace OfficeIMO.Tests {
                 var paragraph = document.AddParagraph("Go to ");
                 var refPara = paragraph.AddHyperLink("Google", new Uri("https://google.com"), addStyle: true);
                 refPara.Bold = true;
-                var reference = refPara.Hyperlink;
+                  var reference = refPara.Hyperlink;
 
                 paragraph.AddHyperLink("Bing", new Uri("https://bing.com"));
-                var target = paragraph.Hyperlink;
-                target.CopyFormattingFrom(reference);
+                  var target = paragraph.Hyperlink!;
+                  target.CopyFormattingFrom(reference!);
 
-                Assert.NotNull(target._runProperties);
-                Assert.Equal(reference._runProperties.Color.Val, target._runProperties.Color.Val);
-                Assert.Equal(reference._runProperties.Underline.Val, target._runProperties.Underline.Val);
+                  Assert.NotNull(target._runProperties);
+                  RunProperties targetProps = target._runProperties!;
+                  RunProperties? referenceProps = reference._runProperties;
+                  Assert.NotNull(referenceProps);
+                  if (referenceProps != null) {
+                      Assert.Equal(referenceProps.Color!.Val, targetProps.Color!.Val);
+                      Assert.Equal(referenceProps.Underline!.Val, targetProps.Underline!.Val);
+                  }
 
                 document.Save(false);
             }
@@ -497,21 +502,21 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "ListFormatting.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var first = document.AddList(WordListStyle.Bulleted);
-                var google = first.AddItem("").AddHyperLink("Google", new Uri("https://google.com"), addStyle: true);
-                google.Bold = true;
-                var googleRef = google.Hyperlink;
+                  var google = first.AddItem("").AddHyperLink("Google", new Uri("https://google.com"), addStyle: true);
+                  google.Bold = true;
+                  var googleRef = google.Hyperlink;
 
-                var bing = first.AddItem("").AddHyperLink("Bing", new Uri("https://bing.com"), addStyle: true);
-                bing.Italic = true;
-                var bingRef = bing.Hyperlink;
+                  var bing = first.AddItem("").AddHyperLink("Bing", new Uri("https://bing.com"), addStyle: true);
+                  bing.Italic = true;
+                  var bingRef = bing.Hyperlink;
 
                 document.AddParagraph("separator");
 
                 var second = document.AddList(WordListStyle.Bulleted);
                 var duck = second.AddItem("").AddHyperLink("DuckDuckGo", new Uri("https://duckduckgo.com"));
-                duck.Hyperlink.CopyFormattingFrom(googleRef);
+                  duck.Hyperlink!.CopyFormattingFrom(googleRef!);
                 var start = second.AddItem("").AddHyperLink("Startpage", new Uri("https://startpage.com"));
-                start.Hyperlink.CopyFormattingFrom(bingRef);
+                  start.Hyperlink!.CopyFormattingFrom(bingRef!);
 
                 Assert.True(duck.Bold);
                 Assert.True(start.Italic);

--- a/OfficeIMO.Tests/Word.ListConversion.cs
+++ b/OfficeIMO.Tests/Word.ListConversion.cs
@@ -16,7 +16,7 @@ namespace OfficeIMO.Tests {
                 list.AddItem("Two");
                 indent = list.Numbering.Levels.First().IndentationLeft;
                 list.ConvertToNumbered();
-                Assert.Equal(NumberFormatValues.Decimal, list.Numbering.Levels.First()._level.NumberingFormat.Val.Value);
+                Assert.Equal(NumberFormatValues.Decimal, list.Numbering.Levels.First()._level!.NumberingFormat!.Val!.Value);
                 Assert.Equal(indent, list.Numbering.Levels.First().IndentationLeft);
                 document.Save(false);
             }
@@ -24,7 +24,7 @@ namespace OfficeIMO.Tests {
             using (var document = WordDocument.Load(filePath)) {
                 var list = document.Lists.First();
                 Assert.Equal(new[] { "One", "Two" }, list.ListItems.Select(i => i.Text).ToArray());
-                Assert.Equal(NumberFormatValues.Decimal, list.Numbering.Levels.First()._level.NumberingFormat.Val.Value);
+                Assert.Equal(NumberFormatValues.Decimal, list.Numbering.Levels.First()._level!.NumberingFormat!.Val!.Value);
                 Assert.Equal(indent, list.Numbering.Levels.First().IndentationLeft);
             }
         }
@@ -39,7 +39,7 @@ namespace OfficeIMO.Tests {
                 list.AddItem("Two");
                 indent = list.Numbering.Levels.First().IndentationLeft;
                 list.ConvertToBulleted();
-                Assert.Equal(NumberFormatValues.Bullet, list.Numbering.Levels.First()._level.NumberingFormat.Val.Value);
+                Assert.Equal(NumberFormatValues.Bullet, list.Numbering.Levels.First()._level!.NumberingFormat!.Val!.Value);
                 Assert.Equal(indent, list.Numbering.Levels.First().IndentationLeft);
                 document.Save(false);
             }
@@ -47,7 +47,7 @@ namespace OfficeIMO.Tests {
             using (var document = WordDocument.Load(filePath)) {
                 var list = document.Lists.First();
                 Assert.Equal(new[] { "One", "Two" }, list.ListItems.Select(i => i.Text).ToArray());
-                Assert.Equal(NumberFormatValues.Bullet, list.Numbering.Levels.First()._level.NumberingFormat.Val.Value);
+                Assert.Equal(NumberFormatValues.Bullet, list.Numbering.Levels.First()._level!.NumberingFormat!.Val!.Value);
                 Assert.Equal(indent, list.Numbering.Levels.First().IndentationLeft);
             }
         }

--- a/OfficeIMO.Tests/Word.MergeDocuments.cs
+++ b/OfficeIMO.Tests/Word.MergeDocuments.cs
@@ -33,10 +33,10 @@ namespace OfficeIMO.Tests {
 
             using (var merged = WordDocument.Load(filePath1)) {
                 Assert.Equal(2, merged.Lists.Count);
-                var numbering = merged._wordprocessingDocument.MainDocumentPart
+                var numbering = merged._wordprocessingDocument!.MainDocumentPart!
                     .NumberingDefinitionsPart!.Numbering;
                 var ids = numbering.Elements<NumberingInstance>()
-                    .Select(n => n.NumberID.Value).Distinct().ToList();
+                    .Select(n => n.NumberID!.Value).Distinct().ToList();
                 Assert.Equal(2, ids.Count);
             }
         }
@@ -68,10 +68,10 @@ namespace OfficeIMO.Tests {
 
         using (var merged = WordDocument.Load(filePath1)) {
             Assert.Equal(2, merged.Lists.Count);
-            var numbering = merged._wordprocessingDocument.MainDocumentPart
+            var numbering = merged._wordprocessingDocument!.MainDocumentPart!
                 .NumberingDefinitionsPart!.Numbering;
             var ids = numbering.Elements<NumberingInstance>()
-                .Select(n => n.NumberID.Value).Distinct().ToList();
+                .Select(n => n.NumberID!.Value).Distinct().ToList();
             Assert.Equal(2, ids.Count);
             Assert.Equal(4, merged.Paragraphs.Count(p => p.IsListItem));
         }
@@ -110,10 +110,10 @@ namespace OfficeIMO.Tests {
         }
 
         using (var merged = WordDocument.Load(filePath1)) {
-            var numbering = merged._wordprocessingDocument.MainDocumentPart
+            var numbering = merged._wordprocessingDocument!.MainDocumentPart!
                 .NumberingDefinitionsPart!.Numbering;
             var ids = numbering.Elements<NumberingInstance>()
-                .Select(n => n.NumberID.Value).Distinct().ToList();
+                .Select(n => n.NumberID!.Value).Distinct().ToList();
             Assert.Equal(3, ids.Count);
         }
     }

--- a/OfficeIMO.Tests/Word.PageNumbers.cs
+++ b/OfficeIMO.Tests/Word.PageNumbers.cs
@@ -37,7 +37,7 @@ namespace OfficeIMO.Tests {
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Equal(NumberFormatValues.LowerRoman, document.Sections[0].PageNumberType.Format.Value);
+                Assert.Equal(NumberFormatValues.LowerRoman, document.Sections[0].PageNumberType!.Format!.Value);
                 var errors = document.ValidateDocument();
                 errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();
                 Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
@@ -89,7 +89,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var headerPart = document._wordprocessingDocument.MainDocumentPart.HeaderParts.First();
+                var headerPart = document._wordprocessingDocument!.MainDocumentPart!.HeaderParts.First();
                 string text = headerPart.Header.InnerText;
                 Assert.Contains("custom", text);
                 var errors = document.ValidateDocument();
@@ -110,7 +110,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var footerPart = document._wordprocessingDocument.MainDocumentPart.FooterParts.First();
+                var footerPart = document._wordprocessingDocument!.MainDocumentPart!.FooterParts.First();
                 string text = footerPart.Footer.InnerText;
                 Assert.Contains(" of ", text);
                 var errors = document.ValidateDocument();
@@ -137,7 +137,7 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.Equal(2, document.Sections.Count);
                 Assert.NotNull(document.Sections[1].PageNumberType);
-                Assert.Equal(1, document.Sections[1].PageNumberType.Start.Value);
+                Assert.Equal(1, document.Sections[1].PageNumberType!.Start!.Value);
                 var errors = document.ValidateDocument();
                 errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();
                 Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
@@ -155,8 +155,8 @@ namespace OfficeIMO.Tests {
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Equal(NumberFormatValues.UpperRoman, document.Sections[0].PageNumberType.Format.Value);
-                Assert.Contains(document.Sections[0].Footer.Default.Fields, f => f.FieldType == WordFieldType.Page && f.FieldFormat.Contains(WordFieldFormat.Roman));
+                Assert.Equal(NumberFormatValues.UpperRoman, document.Sections[0].PageNumberType!.Format!.Value);
+                Assert.Contains(document.Sections[0].Footer!.Default!.Fields, f => f.FieldType == WordFieldType.Page && f.FieldFormat.Contains(WordFieldFormat.Roman));
                 var errors = document.ValidateDocument();
                 errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();
                 Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
@@ -189,7 +189,7 @@ namespace OfficeIMO.Tests {
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var footerPart = document._wordprocessingDocument.MainDocumentPart.FooterParts.First();
+                var footerPart = document._wordprocessingDocument!.MainDocumentPart!.FooterParts.First();
                 string xml = footerPart.Footer.InnerXml;
                 Assert.Contains($"\\@ \"{format}\"", xml);
                 var errors = document.ValidateDocument();

--- a/OfficeIMO.Tests/Word.Properties.cs
+++ b/OfficeIMO.Tests/Word.Properties.cs
@@ -209,8 +209,8 @@ namespace OfficeIMO.Tests {
                 p1.Text = "Chapter1";
                 p1.SetStyleId(WordParagraphStyles.Heading1.ToString());
                 var p2 = document.AddParagraph("Chatper2").SetStyle(WordParagraphStyles.Heading1);
-                var style1= p1.Style.Value;
-                var style2= p2.Style.Value;
+                var style1= p1.Style!.Value;
+                var style2= p2.Style!.Value;
                 Assert.True(style1 == style2);
                 document.Save(tempFile);    
                
@@ -218,8 +218,8 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(tempFile)) {
                 var p3 = document.Paragraphs[0];
                 var p4 = document.Paragraphs[1];
-                var style3 = p3.Style.Value;
-                var style4 = p4.Style.Value;
+                var style3 = p3.Style!.Value;
+                var style4 = p4.Style!.Value;
                 Assert.True(style3 == style4);
             }
         }

--- a/OfficeIMO.Tests/Word.Revisions.cs
+++ b/OfficeIMO.Tests/Word.Revisions.cs
@@ -23,13 +23,13 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Contains(document._document.Body.Descendants<InsertedRun>(), run => run.InnerText == "Added");
-                Assert.Contains(document._document.Body.Descendants<DeletedRun>(), run => run.InnerText == "Removed");
+                Assert.Contains(document._document!.Body!.Descendants<InsertedRun>(), run => run.InnerText == "Added");
+                Assert.Contains(document._document.Body!.Descendants<DeletedRun>(), run => run.InnerText == "Removed");
 
                 document.AcceptRevisions();
 
-                Assert.DoesNotContain(document._document.Body.Descendants<InsertedRun>(), run => run.InnerText == "Added");
-                Assert.DoesNotContain(document._document.Body.Descendants<DeletedRun>(), run => run.InnerText == "Removed");
+                Assert.DoesNotContain(document._document!.Body!.Descendants<InsertedRun>(), run => run.InnerText == "Added");
+                Assert.DoesNotContain(document._document.Body!.Descendants<DeletedRun>(), run => run.InnerText == "Removed");
                 Assert.Contains(document.Paragraphs, p => p.Text == "Before");
                 Assert.Contains(document.Paragraphs, p => p.Text == "Added");
             }
@@ -49,8 +49,8 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 document.RejectRevisions();
-                Assert.DoesNotContain(document._document.Body.Descendants<InsertedRun>(), run => run.InnerText == "Added");
-                Assert.DoesNotContain(document._document.Body.Descendants<DeletedRun>(), run => run.InnerText == "Removed");
+                Assert.DoesNotContain(document._document!.Body!.Descendants<InsertedRun>(), run => run.InnerText == "Added");
+                Assert.DoesNotContain(document._document.Body!.Descendants<DeletedRun>(), run => run.InnerText == "Removed");
                 Assert.Contains(document.Paragraphs, p => p.Text == "Removed");
             }
         }
@@ -86,8 +86,8 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(filePath)) {
                 document.ConvertRevisionsToMarkup();
 
-                Assert.DoesNotContain(document._document.Body.Descendants<InsertedRun>(), r => r.InnerText == "Added");
-                Assert.DoesNotContain(document._document.Body.Descendants<DeletedRun>(), r => r.InnerText == "Removed");
+                Assert.DoesNotContain(document._document!.Body!.Descendants<InsertedRun>(), r => r.InnerText == "Added");
+                Assert.DoesNotContain(document._document.Body!.Descendants<DeletedRun>(), r => r.InnerText == "Removed");
 
                 var insertedRun = document._document.Body.Descendants<Run>().FirstOrDefault(r => r.InnerText == "Added");
                 Assert.NotNull(insertedRun);

--- a/OfficeIMO.Tests/Word.ShapeTextBoxRecognition.cs
+++ b/OfficeIMO.Tests/Word.ShapeTextBoxRecognition.cs
@@ -19,13 +19,13 @@ namespace OfficeIMO.Tests {
                 doc.AddShape(ShapeType.Ellipse, 40, 40, Color.Red, Color.Blue);
                 doc.Save(false);
             }
-            using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
-                var oval = wDoc.MainDocumentPart.Document.Body.Descendants<V.Oval>().First();
-                var textBox = new V.TextBox();
-                textBox.Append(new TextBoxContent(new Paragraph(new Run(new Text("Text")))));
-                oval.Append(textBox);
-                wDoc.MainDocumentPart.Document.Save();
-            }
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
+                    var oval = wDoc.MainDocumentPart!.Document.Body!.Descendants<V.Oval>().First();
+                    var textBox = new V.TextBox();
+                    textBox.Append(new TextBoxContent(new Paragraph(new Run(new Text("Text")))));
+                    oval.Append(textBox);
+                    wDoc.MainDocumentPart.Document.Save();
+                }
             using (WordDocument doc = WordDocument.Load(filePath)) {
                 Assert.Empty(doc.Shapes);
                 Assert.Single(doc.TextBoxes);
@@ -39,17 +39,17 @@ namespace OfficeIMO.Tests {
                 doc.AddShapeDrawing(ShapeType.Rectangle, 40, 40);
                 doc.Save(false);
             }
-            using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
-                var run = wDoc.MainDocumentPart.Document.Body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
-                var drawing = run.Descendants<Drawing>().First();
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
+                    var run = wDoc.MainDocumentPart!.Document.Body!.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
+                    var drawing = run.Descendants<Drawing>().First();
                 drawing.Remove();
                 var choice = new AlternateContentChoice() { Requires = "wps" };
                 choice.Append(drawing);
                 var alt = new AlternateContent();
                 alt.Append(choice);
                 run.Append(alt);
-                wDoc.MainDocumentPart.Document.Save();
-            }
+                    wDoc.MainDocumentPart.Document.Save();
+                }
             using (WordDocument doc = WordDocument.Load(filePath)) {
                 Assert.Single(doc.Shapes);
                 Assert.Empty(doc.TextBoxes);
@@ -63,9 +63,9 @@ namespace OfficeIMO.Tests {
                 doc.AddShapeDrawing(ShapeType.Rectangle, 40, 40);
                 doc.Save(false);
             }
-            using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
-                var run = wDoc.MainDocumentPart.Document.Body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
-                var drawing = run.Descendants<Drawing>().First();
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
+                    var run = wDoc.MainDocumentPart!.Document.Body!.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
+                    var drawing = run.Descendants<Drawing>().First();
                 var fallbackDrawing = (Drawing)drawing.CloneNode(true);
                 drawing.Remove();
                 var choice = new AlternateContentChoice() { Requires = "wps" };
@@ -76,8 +76,8 @@ namespace OfficeIMO.Tests {
                 alt.Append(choice);
                 alt.Append(fallback);
                 run.Append(alt);
-                wDoc.MainDocumentPart.Document.Save();
-            }
+                    wDoc.MainDocumentPart.Document.Save();
+                }
             using (WordDocument doc = WordDocument.Load(filePath)) {
                 Assert.Single(doc.Shapes);
                 Assert.Empty(doc.TextBoxes);
@@ -92,10 +92,10 @@ namespace OfficeIMO.Tests {
                 doc.AddTextBox("Text");
                 doc.Save(false);
             }
-            using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
-                var body = wDoc.MainDocumentPart.Document.Body;
-                var shapeRun = body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any() && !r.Descendants<Wps.TextBoxInfo2>().Any());
-                var textBoxRun = body.Descendants<Run>().First(r => r.Descendants<Wps.TextBoxInfo2>().Any());
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
+                    var body = wDoc.MainDocumentPart!.Document.Body!;
+                    var shapeRun = body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any() && !r.Descendants<Wps.TextBoxInfo2>().Any());
+                    var textBoxRun = body.Descendants<Run>().First(r => r.Descendants<Wps.TextBoxInfo2>().Any());
                 var shapeDrawing = shapeRun.Descendants<Drawing>().First();
                 var textBoxDrawing = textBoxRun.Descendants<Drawing>().First();
                 shapeDrawing.Remove();
@@ -108,7 +108,7 @@ namespace OfficeIMO.Tests {
                 alt.Append(fallback);
                 shapeRun.Append(alt);
                 textBoxRun.Remove();
-                var document = wDoc.MainDocumentPart.Document;
+                    var document = wDoc.MainDocumentPart.Document;
                 if (document.LookupNamespace("wps") == null) {
                     document.AddNamespaceDeclaration("wps", "http://schemas.microsoft.com/office/word/2010/wordprocessingShape");
                 }
@@ -129,10 +129,10 @@ namespace OfficeIMO.Tests {
                 doc.AddTextBox("Text");
                 doc.Save(false);
             }
-            using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
-                var body = wDoc.MainDocumentPart.Document.Body;
-                var shapeRun = body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any() && !r.Descendants<Wps.TextBoxInfo2>().Any());
-                var textBoxRun = body.Descendants<Run>().First(r => r.Descendants<Wps.TextBoxInfo2>().Any());
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
+                    var body = wDoc.MainDocumentPart!.Document.Body!;
+                    var shapeRun = body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any() && !r.Descendants<Wps.TextBoxInfo2>().Any());
+                    var textBoxRun = body.Descendants<Run>().First(r => r.Descendants<Wps.TextBoxInfo2>().Any());
                 var shapeDrawing = (Drawing)shapeRun.Descendants<Drawing>().First().CloneNode(true);
                 var textBoxDrawing = (Drawing)textBoxRun.Descendants<Drawing>().First().CloneNode(true);
 
@@ -150,7 +150,7 @@ namespace OfficeIMO.Tests {
                 run.Append(shapeAc);
                 run.Append(textBoxAc);
 
-                shapeRun.Parent.InsertBefore(run, shapeRun);
+                  shapeRun.Parent!.InsertBefore(run, shapeRun);
                 shapeRun.Remove();
                 textBoxRun.Remove();
 


### PR DESCRIPTION
## Summary
- address nullable warnings across test suite
- ensure safer hyperlink, Excel and HTML tests

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a43746d614832ea7baab4e54dbc047