### PR TITLE
Add image update support for PowerPoint pictures

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/UpdatePicturePowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/UpdatePicturePowerPoint.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.Examples.PowerPoint {
+    /// <summary>
+    /// Demonstrates replacing an image in a PowerPoint slide.
+    /// </summary>
+    public static class UpdatePicturePowerPoint {
+        public static void Example_PowerPointUpdatePicture(string folderPath, bool openPowerPoint) {
+            Console.WriteLine("[*] PowerPoint - Update picture");
+            string filePath = Path.Combine(folderPath, "Update Picture.pptx");
+            string imagePath = Path.Combine(Directory.GetCurrentDirectory(), "Images", "BackgroundImage.png");
+            string newImagePath = Path.Combine(Directory.GetCurrentDirectory(), "Images", "Kulek.jpg");
+
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+            PowerPointSlide slide = presentation.AddSlide();
+            PPPicture picture = slide.AddPicture(imagePath);
+            Console.WriteLine("Original type: " + picture.ContentType);
+
+            using FileStream stream = new(newImagePath, FileMode.Open, FileAccess.Read);
+            picture.UpdateImage(stream, ImagePartType.Jpeg);
+            Console.WriteLine("Updated type: " + picture.ContentType);
+
+            presentation.Save();
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PPPicture.cs
+++ b/OfficeIMO.PowerPoint/PPPicture.cs
@@ -1,11 +1,69 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
+using A = DocumentFormat.OpenXml.Drawing;
+using ImagePartType = DocumentFormat.OpenXml.Packaging.PartTypeInfo;
 
 namespace OfficeIMO.PowerPoint {
     /// <summary>
     /// Represents an image placed on a slide.
     /// </summary>
     public class PPPicture : PPShape {
-        internal PPPicture(Picture picture) : base(picture) {
+        private readonly SlidePart _slidePart;
+
+        internal PPPicture(Picture picture, SlidePart slidePart) : base(picture) {
+            _slidePart = slidePart;
+        }
+
+        /// <summary>
+        /// Gets the MIME content type of the underlying image.
+        /// </summary>
+        public string? ContentType => GetImagePart()?.ContentType;
+
+        /// <summary>
+        /// Gets the MIME content type of the underlying image.
+        /// </summary>
+        public string? MimeType => ContentType;
+
+        private ImagePart? GetImagePart() {
+            Picture picture = (Picture)Element;
+            string? relationshipId = picture.BlipFill?.Blip?.Embed?.Value;
+            return relationshipId != null ? _slidePart.GetPartById(relationshipId) as ImagePart : null;
+        }
+
+        /// <summary>
+        /// Replaces the picture's underlying image with the provided stream.
+        /// </summary>
+        /// <param name="newImage">Stream containing the new image data.</param>
+        /// <param name="type">Image format of the new image.</param>
+        public void UpdateImage(Stream newImage, ImagePartType type) {
+            if (newImage == null) {
+                throw new ArgumentNullException(nameof(newImage));
+            }
+
+            if (type != DocumentFormat.OpenXml.Packaging.ImagePartType.Png &&
+                type != DocumentFormat.OpenXml.Packaging.ImagePartType.Jpeg &&
+                type != DocumentFormat.OpenXml.Packaging.ImagePartType.Gif &&
+                type != DocumentFormat.OpenXml.Packaging.ImagePartType.Bmp) {
+                throw new NotSupportedException($"Image type {type} is not supported.");
+            }
+
+            Picture picture = (Picture)Element;
+            A.Blip blip = picture.BlipFill?.Blip ?? throw new InvalidOperationException("Picture has no image");
+
+            if (blip.Embed != null) {
+                OpenXmlPart? oldPart = _slidePart.GetPartById(blip.Embed!);
+                if (oldPart != null) {
+                    _slidePart.DeletePart(oldPart);
+                }
+            }
+
+            ImagePart imagePart = _slidePart.AddImagePart(type);
+            newImage.Position = 0;
+            imagePart.FeedData(newImage);
+            string relId = _slidePart.GetIdOfPart(imagePart);
+            blip.Embed = relId;
         }
     }
 }

--- a/OfficeIMO.PowerPoint/PowerPointSlide.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.cs
@@ -239,7 +239,7 @@ namespace OfficeIMO.PowerPoint {
             CommonSlideData data = _slidePart.Slide.CommonSlideData ??= new CommonSlideData(new ShapeTree());
             ShapeTree tree = data.ShapeTree ??= new ShapeTree();
             tree.AppendChild(picture);
-            PPPicture pic = new(picture);
+            PPPicture pic = new(picture, _slidePart);
             _shapes.Add(pic);
             return pic;
         }
@@ -389,7 +389,7 @@ namespace OfficeIMO.PowerPoint {
                         _shapes.Add(new PPTextBox(s));
                         break;
                     case Picture p:
-                        _shapes.Add(new PPPicture(p));
+                        _shapes.Add(new PPPicture(p, _slidePart));
                         break;
                     case GraphicFrame g when g.Graphic?.GraphicData?.GetFirstChild<A.Table>() != null:
                         _shapes.Add(new PPTable(g));

--- a/OfficeIMO.Tests/PowerPoint.PictureUpdate.cs
+++ b/OfficeIMO.Tests/PowerPoint.PictureUpdate.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.PowerPoint;
+using Xunit;
+using ImagePartType = DocumentFormat.OpenXml.Packaging.PartTypeInfo;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointPictureUpdate {
+        public static IEnumerable<object[]> ImageData => new[] {
+            new object[] { "BackgroundImage.png", DocumentFormat.OpenXml.Packaging.ImagePartType.Png, "image/png" },
+            new object[] { "Kulek.jpg", DocumentFormat.OpenXml.Packaging.ImagePartType.Jpeg, "image/jpeg" },
+            new object[] { "example.gif", DocumentFormat.OpenXml.Packaging.ImagePartType.Gif, "image/gif" },
+            new object[] { "snail.bmp", DocumentFormat.OpenXml.Packaging.ImagePartType.Bmp, "image/bmp" },
+        };
+
+        [Theory]
+        [MemberData(nameof(ImageData))]
+        public void CanUpdatePicture(string newImage, ImagePartType type, string expectedContentType) {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string originalImage = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", "BackgroundImage.png");
+            string newImagePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", newImage);
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                PowerPointSlide slide = presentation.AddSlide();
+                PPPicture picture = slide.AddPicture(originalImage);
+                using FileStream stream = new(newImagePath, FileMode.Open, FileAccess.Read);
+                picture.UpdateImage(stream, type);
+                Assert.Equal(expectedContentType, picture.ContentType);
+                Assert.Equal(expectedContentType, picture.MimeType);
+                presentation.Save();
+            }
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                PowerPointSlide slide = presentation.Slides.Single();
+                PPPicture picture = slide.Pictures.First();
+                Assert.Equal(expectedContentType, picture.ContentType);
+                Assert.Equal(expectedContentType, picture.MimeType);
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow replacing an existing picture's ImagePart and expose its content type
- add example showing how to update images
- add tests covering updating to PNG, JPEG, GIF and BMP

## Testing
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj`
- `dotnet test --filter FullyQualifiedName~PowerPointPictureUpdate`


------
https://chatgpt.com/codex/tasks/task_e_68a45769af60832e9808c916129a35da