### PR TITLE
Add thread-safe Excel operations

### DIFF
--- a/OfficeIMO.Examples/Excel/ConcurrentWrites.cs
+++ b/OfficeIMO.Examples/Excel/ConcurrentWrites.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+using OfficeIMO.Excel;
+
+namespace OfficeIMO.Examples.Excel {
+    /// <summary>
+    /// Demonstrates writing to a worksheet from multiple threads.
+    /// </summary>
+    public static class ConcurrentWrites {
+        public static void Example(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - Concurrent writes");
+            string filePath = System.IO.Path.Combine(folderPath, "ConcurrentWrites.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                Parallel.For(1, 101, i => {
+                    sheet.SetCellValue(i, 1, $"Value {i}");
+                });
+                document.Save(openExcel);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.ConcurrentWrites.cs
+++ b/OfficeIMO.Tests/Excel.ConcurrentWrites.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    /// <summary>
+    /// Tests concurrent writes to a single worksheet.
+    /// </summary>
+    public partial class Excel {
+        [Fact]
+        public void Test_ConcurrentWrites() {
+            string filePath = Path.Combine(_directoryWithFiles, "ConcurrentWrites.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                Parallel.For(1, 1001, i => {
+                    sheet.SetCellValue(i, 1, $"Value {i}");
+                });
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                SharedStringTablePart shared = spreadsheet.WorkbookPart!.SharedStringTablePart!;
+                for (int i = 1; i <= 1000; i++) {
+                    Cell cell = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == $"A{i}");
+                    Assert.Equal(CellValues.SharedString, cell.DataType!.Value);
+                    int index = int.Parse(cell.CellValue!.Text);
+                    Assert.Equal($"Value {i}", shared.SharedStringTable!.ElementAt(index).InnerText);
+                }
+                Assert.Equal(1000, shared.SharedStringTable!.Count());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ReaderWriterLockSlim guards to ExcelDocument shared strings and worksheet list
- wrap ExcelSheet cell updates and formulas in write locks
- demonstrate safe concurrent writes and add regression test

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4575f0b04832e9afa1e29a2b711e2