### PR TITLE
Fix Visio content types and enforce numeric IDs

### DIFF
--- a/OfficeIMO.Tests/Visio.BasicDocument.cs
+++ b/OfficeIMO.Tests/Visio.BasicDocument.cs
@@ -7,8 +7,8 @@ namespace OfficeIMO.Tests {
         public void CanCreateBasicVisioDocument() {
             VisioDocument document = new();
             VisioPage page = document.AddPage("Page1");
-            VisioShape shape1 = new("S1");
-            VisioShape shape2 = new("S2");
+            VisioShape shape1 = new("1");
+            VisioShape shape2 = new("2");
             page.Shapes.Add(shape1);
             page.Shapes.Add(shape2);
             page.Connectors.Add(new VisioConnector(shape1, shape2));

--- a/OfficeIMO.Tests/Visio.PackageCreation.cs
+++ b/OfficeIMO.Tests/Visio.PackageCreation.cs
@@ -29,7 +29,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(package.PartExists(new Uri("/visio/pages/page1.xml", UriKind.Relative)));
 
                 PackageRelationship rel = package.GetRelationshipsByType("http://schemas.microsoft.com/visio/2010/relationships/document").Single();
-                Assert.Equal("/visio/document.xml", rel.TargetUri.OriginalString);
+                Assert.Equal("visio/document.xml", rel.TargetUri.OriginalString);
                 Assert.Equal("rId1", rel.Id);
 
                 PackagePart documentPart = package.GetPart(new Uri("/visio/document.xml", UriKind.Relative));

--- a/OfficeIMO.Visio/VisioConnector.cs
+++ b/OfficeIMO.Visio/VisioConnector.cs
@@ -12,6 +12,9 @@ namespace OfficeIMO.Visio {
         }
 
         public VisioConnector(string id, VisioShape from, VisioShape to) {
+            if (!int.TryParse(id, out _)) {
+                throw new ArgumentException("Connector ID must be numeric.", nameof(id));
+            }
             Id = id;
             From = from;
             To = to;

--- a/OfficeIMO.Visio/VisioShape.cs
+++ b/OfficeIMO.Visio/VisioShape.cs
@@ -1,9 +1,14 @@
+using System;
+
 namespace OfficeIMO.Visio {
     /// <summary>
     /// Represents a shape on a Visio page.
     /// </summary>
     public class VisioShape {
         public VisioShape(string id) {
+            if (!int.TryParse(id, out _)) {
+                throw new ArgumentException("Shape ID must be numeric.", nameof(id));
+            }
             Id = id;
         }
 

--- a/OfficeIMO.Visio/VisioValidator.cs
+++ b/OfficeIMO.Visio/VisioValidator.cs
@@ -55,15 +55,17 @@ namespace OfficeIMO.Visio {
             }
 
             XDocument rootRels = GetRels(pkg, "/_rels/.rels");
-            XElement? docRel = rootRels.Root!.Elements(pr + "Relationship").FirstOrDefault(r => (string?)r.Attribute("Target") == "/visio/document.xml");
+            XElement? docRel = rootRels.Root!.Elements(pr + "Relationship")
+                .FirstOrDefault(r => (string?)r.Attribute("Target") == "/visio/document.xml" || (string?)r.Attribute("Target") == "visio/document.xml");
             if (docRel == null || (string?)docRel.Attribute("Type") != RT_Document) {
-                issues.Add("Root relationship must target /visio/document.xml with Visio document type.");
+                issues.Add("Package → /visio/document.xml must use Visio document rel type.");
             }
 
             XDocument docRels = GetRels(pkg, "/visio/_rels/document.xml.rels");
-            XElement? pagesRel = docRels.Root!.Elements(pr + "Relationship").FirstOrDefault(r => (string?)r.Attribute("Target") == "pages/pages.xml");
+            XElement? pagesRel = docRels.Root!.Elements(pr + "Relationship")
+                .FirstOrDefault(r => (string?)r.Attribute("Target") == "pages/pages.xml" || (string?)r.Attribute("Target") == "/visio/pages/pages.xml");
             if (pagesRel == null || (string?)pagesRel.Attribute("Type") != RT_Pages) {
-                issues.Add("document.xml must relate to pages/pages.xml with visio/2010/relationships/pages.");
+                issues.Add("document.xml → pages/pages.xml must use Visio pages rel type.");
             }
 
             XDocument pagesXml = LoadXml(pkg, "/visio/pages/pages.xml");
@@ -83,9 +85,10 @@ namespace OfficeIMO.Visio {
             }
 
             XDocument pagesRels = GetRels(pkg, "/visio/pages/_rels/pages.xml.rels");
-            XElement? pageRel = pagesRels.Root!.Elements(pr + "Relationship").FirstOrDefault(r => (string?)r.Attribute("Type") == RT_Page);
-            if (pageRel == null) {
-                issues.Add("pages.xml.rels must have a relationship of type visio/2010/relationships/page.");
+            XElement? pageRel = pagesRels.Root!.Elements(pr + "Relationship")
+                .FirstOrDefault(r => ((string?)r.Attribute("Target"))?.EndsWith("page1.xml", StringComparison.OrdinalIgnoreCase) == true);
+            if (pageRel == null || (string?)pageRel.Attribute("Type") != RT_Page) {
+                issues.Add("pages.xml → page1.xml must use Visio page rel type.");
             }
 
             XDocument page1Xml = LoadXml(pkg, "/visio/pages/page1.xml");


### PR DESCRIPTION
## Summary
- ensure Visio shape and connector IDs are numeric
- generate content types via OPC with proper overrides and relative relationships
- validate relationships and IDs with updated tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a45b6d64b4832ebd8ef0c449cc553c