### PR TITLE
Add fluent API for Excel workbooks

### DIFF
--- a/OfficeIMO.Examples/Excel/Fluent/Fluent.Example.cs
+++ b/OfficeIMO.Examples/Excel/Fluent/Fluent.Example.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Fluent;
+
+namespace OfficeIMO.Examples.Excel {
+    internal static partial class FluentWorkbook {
+        public static void Example_FluentWorkbook(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - Creating workbook with fluent API");
+            string filePath = Path.Combine(folderPath, "FluentWorkbook.xlsx");
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Sheet("Data", s => s
+                        .HeaderRow("Name", "Score")
+                        .Row(r => r.Values("Alice", 93))
+                        .Row(r => r.Values("Bob", 88))
+                        .Table(t => t.Add("A1:B3", true, "Scores"))
+                        .Column(c => c.AutoFit()));
+                document.Save(openExcel);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.Fluent.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Fluent.cs
@@ -1,0 +1,9 @@
+using OfficeIMO.Excel.Fluent;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        public ExcelFluentWorkbook AsFluent() {
+            return new ExcelFluentWorkbook(this);
+        }
+    }
+}

--- a/OfficeIMO.Excel/Fluent/ColumnBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/ColumnBuilder.cs
@@ -1,0 +1,15 @@
+using OfficeIMO.Excel;
+namespace OfficeIMO.Excel.Fluent {
+    public class ColumnBuilder {
+        private readonly ExcelSheet _sheet;
+
+        internal ColumnBuilder(ExcelSheet sheet) {
+            _sheet = sheet;
+        }
+
+        public ColumnBuilder AutoFit() {
+            _sheet.AutoFitColumns();
+            return this;
+        }
+    }
+}

--- a/OfficeIMO.Excel/Fluent/ExcelFluentWorkbook.cs
+++ b/OfficeIMO.Excel/Fluent/ExcelFluentWorkbook.cs
@@ -1,0 +1,24 @@
+using System;
+using OfficeIMO.Excel;
+namespace OfficeIMO.Excel.Fluent {
+    public class ExcelFluentWorkbook {
+        internal ExcelDocument Workbook { get; }
+
+        public ExcelFluentWorkbook(ExcelDocument workbook) {
+            Workbook = workbook;
+        }
+
+        public ExcelFluentWorkbook Sheet(string name, Action<SheetBuilder> action) {
+            var builder = new SheetBuilder(this);
+            builder.AddSheet(name);
+            action(builder);
+            return this;
+        }
+
+        public ExcelFluentWorkbook Sheet(Action<SheetBuilder> action) {
+            var builder = new SheetBuilder(this);
+            action(builder);
+            return this;
+        }
+    }
+}

--- a/OfficeIMO.Excel/Fluent/RowBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/RowBuilder.cs
@@ -1,0 +1,26 @@
+using OfficeIMO.Excel;
+using System;
+
+namespace OfficeIMO.Excel.Fluent {
+    public class RowBuilder {
+        private readonly ExcelSheet _sheet;
+        private readonly int _rowIndex;
+
+        internal RowBuilder(SheetBuilder sheetBuilder, ExcelSheet sheet, int rowIndex) {
+            _sheet = sheet;
+            _rowIndex = rowIndex;
+        }
+
+        public RowBuilder Cell(int column, object value) {
+            _sheet.SetCellValue(_rowIndex, column, value);
+            return this;
+        }
+
+        public RowBuilder Values(params object[] values) {
+            for (int i = 0; i < values.Length; i++) {
+                _sheet.SetCellValue(_rowIndex, i + 1, values[i]);
+            }
+            return this;
+        }
+    }
+}

--- a/OfficeIMO.Excel/Fluent/SheetBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/SheetBuilder.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace OfficeIMO.Excel.Fluent {
+    public class SheetBuilder {
+        private readonly ExcelFluentWorkbook _fluent;
+        internal ExcelSheet? Sheet { get; private set; }
+        private int _currentRow = 1;
+
+        internal SheetBuilder(ExcelFluentWorkbook fluent) {
+            _fluent = fluent;
+        }
+
+        public SheetBuilder AddSheet(string name = "") {
+            Sheet = _fluent.Workbook.AddWorkSheet(name);
+            return this;
+        }
+
+        public SheetBuilder HeaderRow(params object[] values) {
+            if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
+            var row = new RowBuilder(this, Sheet, _currentRow);
+            row.Values(values);
+            _currentRow++;
+            return this;
+        }
+
+        public SheetBuilder Row(Action<RowBuilder> action) {
+            if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
+            var builder = new RowBuilder(this, Sheet, _currentRow);
+            action(builder);
+            _currentRow++;
+            return this;
+        }
+
+        public SheetBuilder Column(Action<ColumnBuilder> action) {
+            if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
+            var builder = new ColumnBuilder(Sheet);
+            action(builder);
+            return this;
+        }
+
+        public SheetBuilder Table(Action<TableBuilder> action) {
+            if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
+            var builder = new TableBuilder(Sheet);
+            action(builder);
+            return this;
+        }
+
+        public SheetBuilder Style(Action<StyleBuilder> action) {
+            if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
+            var builder = new StyleBuilder(Sheet);
+            action(builder);
+            return this;
+        }
+    }
+}

--- a/OfficeIMO.Excel/Fluent/StyleBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/StyleBuilder.cs
@@ -1,0 +1,15 @@
+using OfficeIMO.Excel;
+namespace OfficeIMO.Excel.Fluent {
+    public class StyleBuilder {
+        private readonly ExcelSheet _sheet;
+
+        internal StyleBuilder(ExcelSheet sheet) {
+            _sheet = sheet;
+        }
+
+        public StyleBuilder SetCellFormat(int row, int column, string numberFormat) {
+            _sheet.SetCellFormat(row, column, numberFormat);
+            return this;
+        }
+    }
+}

--- a/OfficeIMO.Excel/Fluent/TableBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/TableBuilder.cs
@@ -1,0 +1,15 @@
+using OfficeIMO.Excel;
+namespace OfficeIMO.Excel.Fluent {
+    public class TableBuilder {
+        private readonly ExcelSheet _sheet;
+
+        internal TableBuilder(ExcelSheet sheet) {
+            _sheet = sheet;
+        }
+
+        public TableBuilder Add(string range, bool hasHeader = true, string name = "", TableStyle style = TableStyle.TableStyleLight9) {
+            _sheet.AddTable(range, hasHeader, name, style);
+            return this;
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.Fluent.cs
+++ b/OfficeIMO.Tests/Excel.Fluent.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class ExcelFluentWorkbookTests {
+        private static string GetCellValue(SpreadsheetDocument document, WorksheetPart worksheetPart, string cellReference) {
+            var cell = worksheetPart.Worksheet.Descendants<Cell>().First(c => c.CellReference != null && c.CellReference.Value == cellReference);
+            var value = cell.CellValue?.Text ?? string.Empty;
+            if (cell.DataType != null && cell.DataType.Value == CellValues.SharedString) {
+                var table = document.WorkbookPart.SharedStringTablePart.SharedStringTable;
+                if (int.TryParse(value, out int id)) {
+                    return table.ChildElements[id].InnerText;
+                }
+            }
+            return value;
+        }
+
+        [Fact]
+        public void CanBuildWorkbookFluently() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Sheet("Data", s => s
+                        .HeaderRow("Name", "Score")
+                        .Row(r => r.Values("Alice", 93))
+                        .Row(r => r.Values("Bob", 88))
+                        .Table(t => t.Add("A1:B3", true, "Scores"))
+                        .Column(c => c.AutoFit()));
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                Assert.Single(document.Sheets);
+                var sheetPart = document._spreadSheetDocument.WorkbookPart.WorksheetParts.First();
+                Assert.Equal("Name", GetCellValue(document._spreadSheetDocument, sheetPart, "A1"));
+                Assert.Equal("93", GetCellValue(document._spreadSheetDocument, sheetPart, "B2"));
+                Assert.True(sheetPart.TableDefinitionParts.Any());
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ExcelFluentWorkbook and builders for sheets, rows, columns, tables, and styling
- expose `ExcelDocument.AsFluent()` to start fluent chains
- provide example and unit test demonstrating fluent workbook creation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a46be4e658832e8fb257d1f7d46965