### PR TITLE
Add fluent metadata configuration and tests

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.Example.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.Example.cs
@@ -10,7 +10,12 @@ namespace OfficeIMO.Examples.Word {
             string filePath = Path.Combine(folderPath, "FluentDocument.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AsFluent()
-                    .Info(i => i.SetTitle("Fluent Document"))
+                    .Info(i => i.SetTitle("Fluent Document")
+                        .SetAuthor("Fluent Author")
+                        .SetSubject("Fluent Subject")
+                        .SetKeywords("fluent, api")
+                        .SetComments("Created via fluent API")
+                        .SetCustomProperty("Reviewed", true))
                     .Section(s => s.AddSection())
                     .Paragraph(p => p.Text("Hello from fluent API"));
                 document.Save(false);

--- a/OfficeIMO.Tests/Word.Fluent.InfoBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.InfoBuilder.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_FluentInfoBuilderProperties() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentInfoBuilder.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Info(i => i.SetTitle("Title")
+                        .SetAuthor("Author")
+                        .SetSubject("Subject")
+                        .SetKeywords("k1, k2")
+                        .SetComments("Some comments")
+                        .SetCustomProperty("Custom1", "Value1"))
+                    .Paragraph(p => p.Text("Test"));
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal("Title", document.BuiltinDocumentProperties.Title);
+                Assert.Equal("Author", document.BuiltinDocumentProperties.Creator);
+                Assert.Equal("Subject", document.BuiltinDocumentProperties.Subject);
+                Assert.Equal("k1, k2", document.BuiltinDocumentProperties.Keywords);
+                Assert.Equal("Some comments", document.BuiltinDocumentProperties.Description);
+                Assert.True(document.CustomDocumentProperties.ContainsKey("Custom1"));
+                Assert.Equal("Value1", document.CustomDocumentProperties["Custom1"].Value);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/InfoBuilder.cs
+++ b/OfficeIMO.Word/Fluent/InfoBuilder.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
     /// Builder for document information such as properties.
@@ -9,8 +11,67 @@ namespace OfficeIMO.Word.Fluent {
             _fluent = fluent;
         }
 
+        /// <summary>
+        /// Sets the document title.
+        /// </summary>
+        /// <param name="title">Title to assign.</param>
         public InfoBuilder SetTitle(string title) {
             _fluent.Document.BuiltinDocumentProperties.Title = title;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the document author.
+        /// </summary>
+        /// <param name="author">Author name.</param>
+        public InfoBuilder SetAuthor(string author) {
+            _fluent.Document.BuiltinDocumentProperties.Creator = author;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the document subject.
+        /// </summary>
+        /// <param name="subject">Subject text.</param>
+        public InfoBuilder SetSubject(string subject) {
+            _fluent.Document.BuiltinDocumentProperties.Subject = subject;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the document keywords.
+        /// </summary>
+        /// <param name="keywords">Keywords list.</param>
+        public InfoBuilder SetKeywords(string keywords) {
+            _fluent.Document.BuiltinDocumentProperties.Keywords = keywords;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the document comments.
+        /// </summary>
+        /// <param name="comments">Comments text.</param>
+        public InfoBuilder SetComments(string comments) {
+            _fluent.Document.BuiltinDocumentProperties.Description = comments;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds or updates a custom document property.
+        /// </summary>
+        /// <param name="name">Property name.</param>
+        /// <param name="value">Property value.</param>
+        public InfoBuilder SetCustomProperty(string name, object value) {
+            var property = value switch {
+                bool b => new WordCustomProperty(b),
+                DateTime dt => new WordCustomProperty(dt),
+                double d => new WordCustomProperty(d),
+                int i => new WordCustomProperty(i),
+                string s => new WordCustomProperty(s),
+                _ => new WordCustomProperty(value.ToString() ?? string.Empty)
+            };
+
+            _fluent.Document.CustomDocumentProperties[name] = property;
             return this;
         }
     }


### PR DESCRIPTION
## Summary
- extend fluent InfoBuilder with author, subject, keywords, comments, and custom property methods
- demonstrate metadata configuration in fluent example
- test persistence of fluent metadata after save and load

## Testing
- `dotnet build OfficeImo.sln -c Release -p:TargetFrameworks=net8.0`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release -p:TargetFrameworks=net8.0`

------
https://chatgpt.com/codex/tasks/task_e_68a46d5f784c832e925a2c46a7c2f3bd