### PR TITLE
Add conditional formatting helpers for Excel

### DIFF
--- a/OfficeIMO.Examples/Excel/ConditionalFormatting.cs
+++ b/OfficeIMO.Examples/Excel/ConditionalFormatting.cs
@@ -1,5 +1,6 @@
 using System;
 using OfficeIMO.Excel;
+using SixLabors.ImageSharp;
 
 namespace OfficeIMO.Examples.Excel {
     public static class ConditionalFormatting {
@@ -12,7 +13,7 @@ namespace OfficeIMO.Examples.Excel {
                 sheet.SetCellValue(1, 1, 10d);
                 sheet.SetCellValue(2, 1, 20d);
                 sheet.SetCellValue(3, 1, 30d);
-                sheet.AddConditionalColorScale("A1:A3", "FFFF0000", "FF00FF00");
+                sheet.AddConditionalColorScale("A1:A3", Color.Red, Color.Green);
                 document.Save(openExcel);
             }
         }

--- a/OfficeIMO.Excel/ExcelSheet.cs
+++ b/OfficeIMO.Excel/ExcelSheet.cs
@@ -8,6 +8,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using SixLabors.Fonts;
+using SixLaborsColor = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Excel {
     /// <summary>
@@ -419,6 +420,14 @@ namespace OfficeIMO.Excel {
             worksheet.Save();
         }
 
+        private static string ConvertColor(SixLaborsColor color) {
+            return "FF" + color.ToHexColor();
+        }
+
+        public void AddConditionalColorScale(string range, SixLaborsColor startColor, SixLaborsColor endColor) {
+            AddConditionalColorScale(range, ConvertColor(startColor), ConvertColor(endColor));
+        }
+
         public void AddConditionalColorScale(string range, string startColor, string endColor) {
             if (string.IsNullOrEmpty(range)) {
                 throw new ArgumentNullException(nameof(range));
@@ -451,6 +460,10 @@ namespace OfficeIMO.Excel {
             conditionalFormatting.Append(rule);
             worksheet.Append(conditionalFormatting);
             worksheet.Save();
+        }
+
+        public void AddConditionalDataBar(string range, SixLaborsColor color) {
+            AddConditionalDataBar(range, ConvertColor(color));
         }
 
         public void AddConditionalDataBar(string range, string color) {


### PR DESCRIPTION
## Summary
- add helpers for conditional rules, color scales and data bars
- cover conditional formatting with unit tests
- include example demonstrating conditional color scales

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a47239d904832e8c7ff0ef9f50c5b9