### PR TITLE
Add theme part and per-shape masters to Visio documents

### DIFF
--- a/OfficeIMO.Examples/Visio/AllNamedShapesHaveMasters.cs
+++ b/OfficeIMO.Examples/Visio/AllNamedShapesHaveMasters.cs
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    public static class AllNamedShapesHaveMasters {
+        public static void Run() {
+            string filePath = Path.Combine(Path.GetTempPath(), "AllNamedShapesHaveMasters.vsdx");
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            page.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "First") { NameU = "Rectangle1" });
+            page.Shapes.Add(new VisioShape("2", 4, 1, 2, 1, "Second") { NameU = "Rectangle2" });
+            document.Save(filePath);
+            Console.WriteLine(filePath);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.Theme.cs
+++ b/OfficeIMO.Tests/Visio.Theme.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.IO.Packaging;
+using System.Linq;
+using System.Xml.Linq;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioTheme {
+        [Fact]
+        public void AddsThemePart() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            page.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, string.Empty));
+            document.Save(filePath);
+
+            using (Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read)) {
+                Assert.True(package.PartExists(new Uri("/visio/theme/theme1.xml", UriKind.Relative)));
+
+                PackagePart documentPart = package.GetPart(new Uri("/visio/document.xml", UriKind.Relative));
+                PackageRelationship themeRel = documentPart.GetRelationshipsByType("http://schemas.microsoft.com/visio/2010/relationships/theme").Single();
+                Uri themeUri = PackUriHelper.ResolvePartUri(documentPart.Uri, themeRel.TargetUri);
+                Assert.Equal("/visio/theme/theme1.xml", themeUri.OriginalString);
+            }
+
+            using FileStream zipStream = File.OpenRead(filePath);
+            using ZipArchive archive = new(zipStream, ZipArchiveMode.Read);
+            ZipArchiveEntry entry = archive.GetEntry("[Content_Types].xml")!;
+            using Stream entryStream = entry.Open();
+            XDocument contentTypes = XDocument.Load(entryStream);
+            XNamespace ct = "http://schemas.openxmlformats.org/package/2006/content-types";
+            Assert.NotNull(contentTypes.Root?.Elements(ct + "Override").FirstOrDefault(e => e.Attribute("PartName")?.Value == "/visio/theme/theme1.xml" && e.Attribute("ContentType")?.Value == "application/vnd.ms-visio.theme+xml"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- always add Visio theme part with relationship and content type override
- generate a distinct master for each shape using NameU
- add examples and tests for theme parts and per-shape masters

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68a48662b69c832e89d38be26d9a014d