### PR TITLE
Improve AutoFit row height calculation

### DIFF
--- a/OfficeIMO.Examples/Excel/AutoFit.cs
+++ b/OfficeIMO.Examples/Excel/AutoFit.cs
@@ -14,6 +14,8 @@ namespace OfficeIMO.Examples.Excel {
                 var sheet = document.AddWorkSheet("Data");
                 sheet.SetCellValue(1, 1, "This is a very long piece of text", autoFitColumns: true, autoFitRows: true);
                 sheet.SetCellValue(2, 1, "Second line\nwith newline", autoFitColumns: true, autoFitRows: true);
+                sheet.SetCellValue(3, 1, "Line1\nLine2\nLine3", autoFitColumns: true, autoFitRows: true);
+                sheet.SetCellValue(4, 1, string.Empty, autoFitColumns: true, autoFitRows: true);
                 document.Save(openExcel);
             }
         }

--- a/OfficeIMO.Tests/Excel.AutoFit.cs
+++ b/OfficeIMO.Tests/Excel.AutoFit.cs
@@ -17,6 +17,7 @@ namespace OfficeIMO.Tests {
                 var sheet = document.AddWorkSheet("Data");
                 sheet.SetCellValue(1, 1, "Long piece of text", autoFitColumns: true, autoFitRows: true);
                 sheet.SetCellValue(2, 1, "Second line\nwith newline", autoFitColumns: true, autoFitRows: true);
+                sheet.SetCellValue(3, 1, "Line1\nLine2\nLine3", autoFitColumns: true, autoFitRows: true);
                 document.Save();
             }
 
@@ -33,9 +34,37 @@ namespace OfficeIMO.Tests {
                 Assert.True(sheetFormat.CustomHeight);
                 Assert.True(sheetFormat.DefaultRowHeight > 0);
 
-                var row = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex == 1);
-                Assert.True(row.CustomHeight);
-                Assert.True(row.Height.HasValue && row.Height.Value > 0);
+                var row1 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex == 1);
+                Assert.True(row1.CustomHeight);
+                Assert.True(row1.Height.HasValue && row1.Height.Value > 0);
+
+                var row3 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex == 3);
+                Assert.True(row3.CustomHeight);
+                Assert.True(row3.Height.HasValue && row3.Height.Value > row1.Height.Value);
+            }
+        }
+
+        [Fact]
+        public void Test_AutoFitRows_EmptyRowsRetainDefaultHeight() {
+            string filePath = Path.Combine(_directoryWithFiles, "AutoFit.Empty.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.SetCellValue(1, 1, "Content", autoFitRows: true);
+                sheet.SetCellValue(2, 1, " ", autoFitRows: true);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                var sheetFormat = wsPart.Worksheet.GetFirstChild<SheetFormatProperties>();
+                Assert.NotNull(sheetFormat);
+                Assert.True(sheetFormat.CustomHeight);
+                Assert.Equal(15.0, sheetFormat.DefaultRowHeight.Value);
+
+                var row2 = wsPart.Worksheet.Descendants<Row>().FirstOrDefault(r => r.RowIndex == 2);
+                Assert.NotNull(row2);
+                Assert.False(row2!.CustomHeight?.Value ?? false);
+                Assert.False(row2.Height?.HasValue ?? false);
             }
         }
     }


### PR DESCRIPTION
## Summary
- handle multiline cell text and convert measurements to Excel point units
- preserve default row height for empty rows
- expand AutoFit example and tests for multiline and empty cells

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --filter "Test_AutoFitRows_EmptyRowsRetainDefaultHeight"`


------
https://chatgpt.com/codex/tasks/task_e_68a48e7eee18832e80eced26c454be62