### PR TITLE
Refine Visio page and shape serialization

### DIFF
--- a/OfficeIMO.Examples/Visio/PageViewSettings.cs
+++ b/OfficeIMO.Examples/Visio/PageViewSettings.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    /// <summary>
+    /// Demonstrates configuring page view settings and basic shape cells.
+    /// </summary>
+    public static class PageViewSettings {
+        public static void Example_PageViewSettings(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Page view settings");
+            string filePath = Path.Combine(folderPath, "Page view settings.vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            page.ViewScale = 1.5;
+            page.ViewCenterX = 4;
+            page.ViewCenterY = 5;
+            page.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "Rectangle"));
+            document.Save(filePath);
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Visio.Masters.cs
+++ b/OfficeIMO.Tests/Visio.Masters.cs
@@ -45,6 +45,15 @@ namespace OfficeIMO.Tests {
                 XElement[] shapes = pageDoc.Root?.Element(ns + "Shapes")?.Elements(ns + "Shape").ToArray() ?? Array.Empty<XElement>();
                 Assert.Equal("1", shapes[0].Attribute("Master")?.Value);
                 Assert.Equal("2", shapes[1].Attribute("Master")?.Value);
+
+                PackagePart masterPart1 = package.GetPart(new Uri("/visio/masters/master1.xml", UriKind.Relative));
+                XDocument master1Doc = XDocument.Load(masterPart1.GetStream());
+                XElement? masterShape = master1Doc.Root?.Element(ns + "Shapes")?.Element(ns + "Shape");
+                Assert.NotNull(masterShape);
+                Assert.NotNull(masterShape?.Attribute("Name"));
+                Assert.NotNull(masterShape?.Attribute("NameU"));
+                Assert.Equal("Shape", masterShape?.Attribute("Type")?.Value);
+                Assert.NotNull(masterShape?.Elements(ns + "Cell").FirstOrDefault(e => e.Attribute("N")?.Value == "PinX"));
             }
 
             using FileStream zipStream = File.OpenRead(filePath);

--- a/OfficeIMO.Tests/Visio.PackageCreation.cs
+++ b/OfficeIMO.Tests/Visio.PackageCreation.cs
@@ -60,6 +60,17 @@ namespace OfficeIMO.Tests {
                 PackageRelationship windowsRel = documentPart.GetRelationshipsByType("http://schemas.microsoft.com/visio/2010/relationships/windows").Single();
                 Uri windowsUri = PackUriHelper.ResolvePartUri(documentPart.Uri, windowsRel.TargetUri);
                 Assert.Equal("/visio/windows.xml", windowsUri.OriginalString);
+                PackagePart windowsPart = package.GetPart(windowsUri);
+                XDocument windowsDoc = XDocument.Load(windowsPart.GetStream());
+                XElement windowsRoot = windowsDoc.Root!;
+                Assert.NotNull(windowsRoot.Attribute("ClientWidth"));
+                Assert.NotNull(windowsRoot.Attribute("ClientHeight"));
+                XElement? window = windowsRoot.Element(ns + "Window");
+                Assert.NotNull(window);
+                Assert.NotNull(window?.Attribute("WindowType"));
+                Assert.NotNull(window?.Attribute("WindowState"));
+                Assert.NotNull(window?.Attribute("ClientWidth"));
+                Assert.NotNull(window?.Attribute("ClientHeight"));
 
                 PackagePart pagesPart = package.GetPart(pagesUri);
                 PackageRelationship pageRel = pagesPart.GetRelationshipsByType("http://schemas.microsoft.com/visio/2010/relationships/page").Single();
@@ -69,7 +80,11 @@ namespace OfficeIMO.Tests {
 
                 XDocument pagesDoc = XDocument.Load(pagesPart.GetStream());
                 XElement? pageElement = pagesDoc.Root?.Element(ns + "Page");
-                Assert.Equal("1", pageElement?.Attribute("ID")?.Value);
+                Assert.Equal("0", pageElement?.Attribute("ID")?.Value);
+                Assert.Equal("Page-1", pageElement?.Attribute("NameU")?.Value);
+                Assert.NotNull(pageElement?.Attribute("ViewScale"));
+                Assert.NotNull(pageElement?.Attribute("ViewCenterX"));
+                Assert.NotNull(pageElement?.Attribute("ViewCenterY"));
                 Assert.Null(pageElement?.Attribute("RelId"));
                 string? relId = pageElement?.Element(ns + "Rel")?.Attribute(rNs + "id")?.Value;
                 Assert.Equal(pageRel.Id, relId);
@@ -100,6 +115,10 @@ namespace OfficeIMO.Tests {
 
                 XElement shape = pageDoc.Root?.Element(ns + "Shapes")?.Element(ns + "Shape");
                 Assert.Equal("1", shape?.Attribute("ID")?.Value);
+                Assert.NotNull(shape?.Attribute("Name"));
+                Assert.NotNull(shape?.Attribute("NameU"));
+                Assert.Equal("Shape", shape?.Attribute("Type")?.Value);
+                Assert.NotNull(shape?.Elements(ns + "Cell").FirstOrDefault(e => e.Attribute("N")?.Value == "PinX"));
                 Assert.Equal("Rectangle", shape?.Element(ns + "Text")?.Value);
             }
 

--- a/OfficeIMO.Visio/VisioPage.cs
+++ b/OfficeIMO.Visio/VisioPage.cs
@@ -10,12 +10,24 @@ namespace OfficeIMO.Visio {
 
         public VisioPage(string name) {
             Name = name;
+            NameU = name;
+            ViewScale = 1;
         }
+
+        public int Id { get; internal set; }
 
         /// <summary>
         /// Gets the page name.
         /// </summary>
         public string Name { get; }
+
+        public string? NameU { get; set; }
+
+        public double ViewScale { get; set; }
+
+        public double ViewCenterX { get; set; }
+
+        public double ViewCenterY { get; set; }
 
         /// <summary>
         /// Shapes placed on the page.

--- a/OfficeIMO.Visio/VisioShape.cs
+++ b/OfficeIMO.Visio/VisioShape.cs
@@ -20,6 +20,8 @@ namespace OfficeIMO.Visio {
         /// </summary>
         public string Id { get; }
 
+        public string? Name { get; set; }
+
         public string? NameU { get; set; }
 
         public VisioMaster? Master { get; set; }

--- a/OfficeIMO.Visio/VisioValidator.cs
+++ b/OfficeIMO.Visio/VisioValidator.cs
@@ -71,8 +71,8 @@ namespace OfficeIMO.Visio {
             if (page == null) {
                 issues.Add("pages.xml must contain a Page element.");
             } else {
-                if (!int.TryParse((string?)page.Attribute("ID"), out int pageId) || pageId < 1) {
-                    issues.Add("Page/@ID must be numeric and 1-based (e.g., 1).");
+                if (!int.TryParse((string?)page.Attribute("ID"), out int pageId) || pageId < 0) {
+                    issues.Add("Page/@ID must be numeric and zero-based (e.g., 0).");
                 }
 
                 XElement? relChild = page.Element(v + "Rel");


### PR DESCRIPTION
## Summary
- serialize Visio shapes using Cell elements and include Name/NameU/Type/Master attributes
- support zero-based page IDs with view settings and window geometry
- add tests and example for new Visio serialization

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Visio`

------
https://chatgpt.com/codex/tasks/task_e_68a49fee5220832e8021dd4863352b3b