### PR TITLE
Skip theme creation for empty Visio documents

### DIFF
--- a/OfficeIMO.Examples/Visio/EmptyVisioDocument.cs
+++ b/OfficeIMO.Examples/Visio/EmptyVisioDocument.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    /// <summary>
+    /// Demonstrates creating an empty Visio document without theme.
+    /// </summary>
+    public static class EmptyVisioDocument {
+        public static void Example_EmptyVisio(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Creating empty document");
+            string filePath = Path.Combine(folderPath, "Empty Visio.vsdx");
+
+            VisioDocument document = new();
+            document.AddPage("Page-1");
+            document.Save(filePath);
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.Theme.cs
+++ b/OfficeIMO.Tests/Visio.Theme.cs
@@ -35,5 +35,29 @@ namespace OfficeIMO.Tests {
             XNamespace ct = "http://schemas.openxmlformats.org/package/2006/content-types";
             Assert.NotNull(contentTypes.Root?.Elements(ct + "Override").FirstOrDefault(e => e.Attribute("PartName")?.Value == "/visio/theme/theme1.xml" && e.Attribute("ContentType")?.Value == "application/vnd.ms-visio.theme+xml"));
         }
+
+        [Fact]
+        public void DoesNotAddThemeWhenNoShapes() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = new();
+            document.AddPage("Page-1");
+            document.Save(filePath);
+
+            using (Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read)) {
+                Assert.False(package.PartExists(new Uri("/visio/theme/theme1.xml", UriKind.Relative)));
+
+                PackagePart documentPart = package.GetPart(new Uri("/visio/document.xml", UriKind.Relative));
+                Assert.Empty(documentPart.GetRelationshipsByType("http://schemas.microsoft.com/visio/2010/relationships/theme"));
+            }
+
+            using FileStream zipStream = File.OpenRead(filePath);
+            using ZipArchive archive = new(zipStream, ZipArchiveMode.Read);
+            ZipArchiveEntry entry = archive.GetEntry("[Content_Types].xml")!;
+            using Stream entryStream = entry.Open();
+            XDocument contentTypes = XDocument.Load(entryStream);
+            XNamespace ct = "http://schemas.openxmlformats.org/package/2006/content-types";
+            Assert.Null(contentTypes.Root?.Elements(ct + "Override").FirstOrDefault(e => e.Attribute("PartName")?.Value == "/visio/theme/theme1.xml"));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- avoid creating theme part when Visio document has no shapes
- validate theme absence and add sample for empty Visio file

## Testing
- `dotnet build`
- `dotnet test --filter Visio`


------
https://chatgpt.com/codex/tasks/task_e_68a4a5a29210832e9119e0007e815b49