### PR TITLE
Improve Excel AutoFit for empty cells

### DIFF
--- a/OfficeIMO.Examples/Excel/AutoFit.cs
+++ b/OfficeIMO.Examples/Excel/AutoFit.cs
@@ -15,6 +15,7 @@ namespace OfficeIMO.Examples.Excel {
                 sheet.SetCellValue(1, 1, "This is a very long piece of text", autoFitColumns: true, autoFitRows: true);
                 sheet.SetCellValue(2, 1, "Second line\nwith newline", autoFitColumns: true, autoFitRows: true);
                 sheet.SetCellValue(3, 1, "Line1\nLine2\nLine3", autoFitColumns: true, autoFitRows: true);
+                sheet.SetCellValue(4, 1, "Temporary", autoFitColumns: true, autoFitRows: true);
                 sheet.SetCellValue(4, 1, string.Empty, autoFitColumns: true, autoFitRows: true);
                 document.Save(openExcel);
             }

--- a/OfficeIMO.Excel/ExcelSheet.cs
+++ b/OfficeIMO.Excel/ExcelSheet.cs
@@ -235,6 +235,7 @@ namespace OfficeIMO.Excel {
                     if (cell.CellReference == null) continue;
                     int columnIndex = GetColumnIndex(cell.CellReference.Value);
                     string text = GetCellText(cell);
+                    if (string.IsNullOrWhiteSpace(text)) continue;
                     var size = TextMeasurer.MeasureSize(text ?? string.Empty, options);
                     double cellWidth = size.Width / zeroWidth + 1;
                     if (widths.ContainsKey(columnIndex)) {
@@ -242,6 +243,20 @@ namespace OfficeIMO.Excel {
                     } else {
                         widths[columnIndex] = cellWidth;
                     }
+                }
+            }
+
+            var existingColumns = columns.Elements<Column>().ToList();
+            foreach (var column in existingColumns) {
+                bool hasContent = false;
+                for (uint i = column.Min?.Value ?? 0; i <= (column.Max?.Value ?? 0); i++) {
+                    if (widths.ContainsKey((int)i)) {
+                        hasContent = true;
+                        break;
+                    }
+                }
+                if (!hasContent) {
+                    column.Remove();
                 }
             }
 
@@ -290,6 +305,9 @@ namespace OfficeIMO.Excel {
                     row.Height = maxHeight + 2;
                     row.CustomHeight = true;
                     hasVisibleContent = true;
+                } else {
+                    row.Height = null;
+                    row.CustomHeight = null;
                 }
             }
 

--- a/OfficeIMO.Tests/Excel.AutoFit.cs
+++ b/OfficeIMO.Tests/Excel.AutoFit.cs
@@ -67,5 +67,50 @@ namespace OfficeIMO.Tests {
                 Assert.False(row2.Height?.HasValue ?? false);
             }
         }
+
+        [Fact]
+        public void Test_AutoFitRows_RemovesCustomHeightWhenCleared() {
+            string filePath = Path.Combine(_directoryWithFiles, "AutoFit.ClearRow.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.SetCellValue(1, 1, "Content", autoFitRows: true);
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var sheet = document.Sheets.First();
+                sheet.SetCellValue(1, 1, string.Empty, autoFitRows: true);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                var row1 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex == 1);
+                Assert.False(row1.CustomHeight?.Value ?? false);
+                Assert.False(row1.Height?.HasValue ?? false);
+            }
+        }
+
+        [Fact]
+        public void Test_AutoFitColumns_RemovesCustomWidthWhenCleared() {
+            string filePath = Path.Combine(_directoryWithFiles, "AutoFit.ClearColumn.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.SetCellValue(1, 1, "Long text", autoFitColumns: true);
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var sheet = document.Sheets.First();
+                sheet.SetCellValue(1, 1, string.Empty, autoFitColumns: true);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                var columns = wsPart.Worksheet.GetFirstChild<Columns>();
+                Assert.True(columns == null || !columns.Elements<Column>().Any(c => c.Min == 1 && c.Max == 1));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- avoid calculating column width for empty cells and remove unused column definitions
- reset row height when content is cleared and ensure default height remains
- add tests and example demonstrating AutoFit cleanup

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a4a5c3de58832ea701cc4471d87a80