### PR TITLE
feat: add formatting options to PowerPoint text boxes

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/TextFormattingPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/TextFormattingPowerPoint.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.Examples.PowerPoint {
+    /// <summary>
+    /// Demonstrates text formatting within a textbox.
+    /// </summary>
+    public static class TextFormattingPowerPoint {
+        public static void Example_TextFormattingPowerPoint(string folderPath, bool openPowerPoint) {
+            Console.WriteLine("[*] PowerPoint - Text formatting");
+            string filePath = Path.Combine(folderPath, "Text Formatting PowerPoint.pptx");
+
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+            PowerPointSlide slide = presentation.AddSlide();
+            PPTextBox text = slide.AddTextBox("Hello World");
+            text.Bold = true;
+            text.Italic = true;
+            text.FontSize = 24;
+            text.FontName = "Arial";
+            text.Color = "FF0000";
+            text.AddBullet("First bullet");
+            text.AddBullet("Second bullet");
+            presentation.Save();
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PPTextBox.cs
+++ b/OfficeIMO.PowerPoint/PPTextBox.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using DocumentFormat.OpenXml.Presentation;
 using A = DocumentFormat.OpenXml.Drawing;
 
@@ -10,6 +12,8 @@ namespace OfficeIMO.PowerPoint {
         }
 
         private Shape Shape => (Shape)Element;
+
+        private IEnumerable<A.Run> Runs => Shape.TextBody!.Elements<A.Paragraph>().SelectMany(p => p.Elements<A.Run>());
 
         /// <summary>
         /// Text contained in the textbox.
@@ -28,12 +32,105 @@ namespace OfficeIMO.PowerPoint {
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the text is bold.
+        /// </summary>
+        public bool Bold {
+            get {
+                A.Run? run = Runs.FirstOrDefault();
+                return run?.RunProperties?.Bold == true;
+            }
+            set {
+                foreach (A.Run run in Runs) {
+                    A.RunProperties runProps = run.RunProperties ??= new A.RunProperties();
+                    runProps.Bold = value ? true : null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the text is italic.
+        /// </summary>
+        public bool Italic {
+            get {
+                A.Run? run = Runs.FirstOrDefault();
+                return run?.RunProperties?.Italic == true;
+            }
+            set {
+                foreach (A.Run run in Runs) {
+                    A.RunProperties runProps = run.RunProperties ??= new A.RunProperties();
+                    runProps.Italic = value ? true : null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the font size in points.
+        /// </summary>
+        public int? FontSize {
+            get {
+                A.Run? run = Runs.FirstOrDefault();
+                int? size = run?.RunProperties?.FontSize?.Value;
+                return size != null ? size / 100 : null;
+            }
+            set {
+                foreach (A.Run run in Runs) {
+                    A.RunProperties runProps = run.RunProperties ??= new A.RunProperties();
+                    runProps.FontSize = value != null ? value * 100 : null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the font name.
+        /// </summary>
+        public string? FontName {
+            get {
+                A.Run? run = Runs.FirstOrDefault();
+                return run?.RunProperties?.GetFirstChild<A.LatinFont>()?.Typeface;
+            }
+            set {
+                foreach (A.Run run in Runs) {
+                    A.RunProperties runProps = run.RunProperties ??= new A.RunProperties();
+                    runProps.RemoveAllChildren<A.LatinFont>();
+                    if (value != null) {
+                        runProps.Append(new A.LatinFont { Typeface = value });
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the text color in hexadecimal format (e.g. "FF0000").
+        /// </summary>
+        public string? Color {
+            get {
+                A.Run? run = Runs.FirstOrDefault();
+                return run?.RunProperties?.GetFirstChild<A.SolidFill>()?.RgbColorModelHex?.Val;
+            }
+            set {
+                foreach (A.Run run in Runs) {
+                    A.RunProperties runProps = run.RunProperties ??= new A.RunProperties();
+                    runProps.RemoveAllChildren<A.SolidFill>();
+                    if (value != null) {
+                        runProps.Append(new A.SolidFill(new A.RgbColorModelHex { Val = value }));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Adds a new bulleted paragraph to the textbox.
         /// </summary>
         public void AddBullet(string text) {
+            A.Run run = new(new A.Text(text));
+            A.Run? template = Runs.FirstOrDefault();
+            if (template?.RunProperties != null) {
+                run.RunProperties = (A.RunProperties)template.RunProperties.CloneNode(true);
+            }
+
             A.Paragraph paragraph = new(
                 new A.ParagraphProperties(new A.CharacterBullet()),
-                new A.Run(new A.Text(text))
+                run
             );
             Shape.TextBody!.AppendChild(paragraph);
         }

--- a/OfficeIMO.Tests/PowerPoint.TextFormatting.cs
+++ b/OfficeIMO.Tests/PowerPoint.TextFormatting.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using A = DocumentFormat.OpenXml.Drawing;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointTextFormatting {
+        [Fact]
+        public void CanApplyFormattingToTextBoxAndBullets() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                PowerPointSlide slide = presentation.AddSlide();
+                PPTextBox box = slide.AddTextBox("Hello");
+                box.Bold = true;
+                box.Italic = true;
+                box.FontSize = 24;
+                box.FontName = "Arial";
+                box.Color = "FF0000";
+                box.AddBullet("Bullet1");
+                box.AddBullet("Bullet2");
+                presentation.Save();
+            }
+
+            using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                SlidePart slidePart = document.PresentationPart!.SlideParts.First();
+                Shape shape = slidePart.Slide.Descendants<Shape>().First();
+                var paragraphs = shape.TextBody!.Elements<A.Paragraph>().ToList();
+                foreach (var paragraph in paragraphs) {
+                    A.Run run = paragraph.GetFirstChild<A.Run>()!;
+                    A.RunProperties rp = run.RunProperties!;
+                    Assert.True(rp.Bold == true);
+                    Assert.True(rp.Italic == true);
+                    Assert.Equal(2400, rp.FontSize!.Value);
+                    Assert.Equal("Arial", rp.GetFirstChild<A.LatinFont>()?.Typeface);
+                    Assert.Equal("FF0000", rp.GetFirstChild<A.SolidFill>()?.RgbColorModelHex?.Val);
+                }
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support bold, italic, font size, font name and color for `PPTextBox`
- ensure new bullet items clone formatting
- add example and tests for formatted text boxes

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a7c8c998832e856ef5f96fdfe0c4