### PR TITLE
Add table cell access and editing

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/TablesPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/TablesPowerPoint.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.Examples.PowerPoint {
+    /// <summary>
+    /// Demonstrates table cell manipulation and row/column management.
+    /// </summary>
+    public static class TablesPowerPoint {
+        public static void Example_PowerPointTables(string folderPath, bool openPowerPoint) {
+            Console.WriteLine("[*] PowerPoint - Table operations");
+            string filePath = Path.Combine(folderPath, "Table Operations.pptx");
+
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+            PowerPointSlide slide = presentation.AddSlide();
+            PPTable table = slide.AddTable(2, 2);
+            PPTableCell cell = table.GetCell(0, 0);
+            cell.Text = "Hello";
+            cell.FillColor = "FFFF00";
+            cell.Merge = (1, 2);
+            table.AddRow();
+            table.AddColumn();
+            table.RemoveRow(2);
+            table.RemoveColumn(2);
+            presentation.Save();
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PPTable.cs
+++ b/OfficeIMO.PowerPoint/PPTable.cs
@@ -21,6 +21,94 @@ namespace OfficeIMO.PowerPoint {
         /// Returns number of columns in the table.
         /// </summary>
         public int Columns => Frame.Graphic!.GraphicData!.GetFirstChild<A.Table>()!.TableGrid!.Elements<A.GridColumn>().Count();
+
+        /// <summary>
+        /// Retrieves a cell at the specified row and column index.
+        /// </summary>
+        /// <param name="row">Zero-based row index.</param>
+        /// <param name="column">Zero-based column index.</param>
+        public PPTableCell GetCell(int row, int column) {
+            A.Table table = Frame.Graphic!.GraphicData!.GetFirstChild<A.Table>()!;
+            A.TableRow tableRow = table.Elements<A.TableRow>().ElementAt(row);
+            A.TableCell cell = tableRow.Elements<A.TableCell>().ElementAt(column);
+            return new PPTableCell(cell);
+        }
+
+        /// <summary>
+        /// Adds a new row to the table.
+        /// </summary>
+        /// <param name="index">Optional zero-based index where the row should be inserted. If omitted, row is appended.</param>
+        public void AddRow(int? index = null) {
+            A.Table table = Frame.Graphic!.GraphicData!.GetFirstChild<A.Table>()!;
+            int columns = Columns;
+            A.TableRow row = new() { Height = 370840L };
+            for (int c = 0; c < columns; c++) {
+                A.TableCell cell = new(
+                    new A.TextBody(new A.BodyProperties(), new A.ListStyle(), new A.Paragraph(new A.Run(new A.Text(string.Empty)))) ,
+                    new A.TableCellProperties()
+                );
+                row.Append(cell);
+            }
+
+            if (index.HasValue && index.Value < Rows) {
+                A.TableRow refRow = table.Elements<A.TableRow>().ElementAt(index.Value);
+                table.InsertBefore(row, refRow);
+            } else {
+                table.Append(row);
+            }
+        }
+
+        /// <summary>
+        /// Removes a row at the specified index.
+        /// </summary>
+        public void RemoveRow(int index) {
+            A.Table table = Frame.Graphic!.GraphicData!.GetFirstChild<A.Table>()!;
+            A.TableRow row = table.Elements<A.TableRow>().ElementAt(index);
+            row.Remove();
+        }
+
+        /// <summary>
+        /// Adds a new column to the table.
+        /// </summary>
+        /// <param name="index">Optional zero-based index where the column should be inserted. If omitted, column is appended.</param>
+        public void AddColumn(int? index = null) {
+            A.Table table = Frame.Graphic!.GraphicData!.GetFirstChild<A.Table>()!;
+            A.TableGrid grid = table.TableGrid!;
+            A.GridColumn gridColumn = new() { Width = 3708400L };
+
+            if (index.HasValue && index.Value < Columns) {
+                A.GridColumn refCol = grid.Elements<A.GridColumn>().ElementAt(index.Value);
+                grid.InsertBefore(gridColumn, refCol);
+            } else {
+                grid.Append(gridColumn);
+            }
+
+            foreach (A.TableRow row in table.Elements<A.TableRow>()) {
+                A.TableCell cell = new(
+                    new A.TextBody(new A.BodyProperties(), new A.ListStyle(), new A.Paragraph(new A.Run(new A.Text(string.Empty)))) ,
+                    new A.TableCellProperties()
+                );
+
+                if (index.HasValue && index.Value < Columns) {
+                    A.TableCell refCell = row.Elements<A.TableCell>().ElementAt(index.Value);
+                    row.InsertBefore(cell, refCell);
+                } else {
+                    row.Append(cell);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes a column at the specified index.
+        /// </summary>
+        public void RemoveColumn(int index) {
+            A.Table table = Frame.Graphic!.GraphicData!.GetFirstChild<A.Table>()!;
+            A.TableGrid grid = table.TableGrid!;
+            grid.Elements<A.GridColumn>().ElementAt(index).Remove();
+            foreach (A.TableRow row in table.Elements<A.TableRow>()) {
+                row.Elements<A.TableCell>().ElementAt(index).Remove();
+            }
+        }
     }
 }
 

--- a/OfficeIMO.PowerPoint/PPTableCell.cs
+++ b/OfficeIMO.PowerPoint/PPTableCell.cs
@@ -1,0 +1,73 @@
+using DocumentFormat.OpenXml.Drawing;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    /// Represents a cell within a PowerPoint table.
+    /// </summary>
+    public class PPTableCell {
+        internal TableCell Cell { get; }
+
+        internal PPTableCell(TableCell cell) {
+            Cell = cell;
+        }
+
+        /// <summary>
+        /// Gets or sets the text contained in the cell.
+        /// </summary>
+        public string Text {
+            get {
+                return Cell.TextBody?.InnerText ?? string.Empty;
+            }
+            set {
+                Cell.TextBody ??= new TextBody(new BodyProperties(), new ListStyle());
+                Paragraph paragraph = Cell.TextBody.GetFirstChild<Paragraph>() ?? new Paragraph();
+                Cell.TextBody.RemoveAllChildren<Paragraph>();
+                paragraph.RemoveAllChildren<Run>();
+                paragraph.Append(new Run(new Text(value ?? string.Empty)));
+                Cell.TextBody.Append(paragraph);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the merge information for this cell.
+        /// Tuple is in format (rows, columns).
+        /// </summary>
+        public (int rows, int columns) Merge {
+            get {
+                int rows = Cell.RowSpan?.Value ?? 1;
+                int cols = Cell.GridSpan?.Value ?? 1;
+                return (rows, cols);
+            }
+            set {
+                if (value.rows <= 1) {
+                    Cell.RowSpan = null;
+                } else {
+                    Cell.RowSpan = value.rows;
+                }
+
+                if (value.columns <= 1) {
+                    Cell.GridSpan = null;
+                } else {
+                    Cell.GridSpan = value.columns;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the fill color of the cell in hex format (e.g. "FF0000").
+        /// </summary>
+        public string? FillColor {
+            get {
+                SolidFill? solid = Cell.TableCellProperties?.GetFirstChild<SolidFill>();
+                return solid?.RgbColorModelHex?.Val;
+            }
+            set {
+                Cell.TableCellProperties ??= new TableCellProperties();
+                Cell.TableCellProperties.RemoveAllChildren<SolidFill>();
+                if (value != null) {
+                    Cell.TableCellProperties.Append(new SolidFill(new RgbColorModelHex { Val = value }));
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/PowerPoint.Tables.cs
+++ b/OfficeIMO.Tests/PowerPoint.Tables.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using A = DocumentFormat.OpenXml.Drawing;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointTables {
+        [Fact]
+        public void CanManipulateTableCellsAndPreserveStyle() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                PowerPointSlide slide = presentation.AddSlide();
+                PPTable table = slide.AddTable(2, 2);
+                PPTableCell cell = table.GetCell(0, 0);
+                cell.Text = "Test";
+                cell.FillColor = "FF0000";
+                cell.Merge = (1, 2);
+                table.AddRow();
+                table.AddColumn();
+                table.RemoveRow(2);
+                table.RemoveColumn(2);
+                presentation.Save();
+            }
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                PPTable table = presentation.Slides[0].Tables.First();
+                Assert.Equal(2, table.Rows);
+                Assert.Equal(2, table.Columns);
+                PPTableCell cell = table.GetCell(0, 0);
+                Assert.Equal("Test", cell.Text);
+                Assert.Equal((1, 2), cell.Merge);
+            }
+
+            using (PresentationDocument doc = PresentationDocument.Open(filePath, false)) {
+                A.Table table = doc.PresentationPart!.SlideParts.First().Slide.Descendants<A.Table>().First();
+                string? styleId = table.TableProperties?.GetFirstChild<A.TableStyleId>()?.Text;
+                Assert.Equal("{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}", styleId);
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose table cell access with text, merge, and fill color support
- allow adding and removing table rows and columns
- ensure table style persists when manipulating cells

## Testing
- `dotnet build`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter PowerPointTables`

------
https://chatgpt.com/codex/tasks/task_e_68a4a7c0ff54832eacddd7348b4ae227