### PR TITLE
Refactor Excel auto-fit APIs

### DIFF
--- a/OfficeIMO.Examples/Excel/AutoFit.cs
+++ b/OfficeIMO.Examples/Excel/AutoFit.cs
@@ -12,11 +12,13 @@ namespace OfficeIMO.Examples.Excel {
 
             using (var document = ExcelDocument.Create(filePath)) {
                 var sheet = document.AddWorkSheet("Data");
-                sheet.SetCellValue(1, 1, "This is a very long piece of text", autoFitColumns: true, autoFitRows: true);
-                sheet.SetCellValue(2, 1, "Second line\nwith newline", autoFitColumns: true, autoFitRows: true);
-                sheet.SetCellValue(3, 1, "Line1\nLine2\nLine3", autoFitColumns: true, autoFitRows: true);
-                sheet.SetCellValue(4, 1, "Temporary", autoFitColumns: true, autoFitRows: true);
-                sheet.SetCellValue(4, 1, string.Empty, autoFitColumns: true, autoFitRows: true);
+                sheet.SetCellValue(1, 1, "This is a very long piece of text");
+                sheet.SetCellValue(2, 1, "Second line\nwith newline");
+                sheet.SetCellValue(3, 1, "Line1\nLine2\nLine3");
+                sheet.SetCellValue(4, 1, "Temporary");
+                sheet.SetCellValue(4, 1, string.Empty);
+                sheet.AutoFitAllColumns();
+                sheet.AutoFitAllRows();
                 document.Save(openExcel);
             }
         }

--- a/OfficeIMO.Excel/Fluent/ColumnBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/ColumnBuilder.cs
@@ -8,7 +8,7 @@ namespace OfficeIMO.Excel.Fluent {
         }
 
         public ColumnBuilder AutoFit() {
-            _sheet.AutoFitColumns();
+            _sheet.AutoFitAllColumns();
             return this;
         }
     }

--- a/OfficeIMO.Tests/Excel.AutoFit.cs
+++ b/OfficeIMO.Tests/Excel.AutoFit.cs
@@ -15,9 +15,11 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "AutoFit.xlsx");
             using (var document = ExcelDocument.Create(filePath)) {
                 var sheet = document.AddWorkSheet("Data");
-                sheet.SetCellValue(1, 1, "Long piece of text", autoFitColumns: true, autoFitRows: true);
-                sheet.SetCellValue(2, 1, "Second line\nwith newline", autoFitColumns: true, autoFitRows: true);
-                sheet.SetCellValue(3, 1, "Line1\nLine2\nLine3", autoFitColumns: true, autoFitRows: true);
+                sheet.SetCellValue(1, 1, "Long piece of text");
+                sheet.SetCellValue(2, 1, "Second line\nwith newline");
+                sheet.SetCellValue(3, 1, "Line1\nLine2\nLine3");
+                sheet.AutoFitAllColumns();
+                sheet.AutoFitAllRows();
                 document.Save();
             }
 
@@ -49,8 +51,9 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "AutoFit.Empty.xlsx");
             using (var document = ExcelDocument.Create(filePath)) {
                 var sheet = document.AddWorkSheet("Data");
-                sheet.SetCellValue(1, 1, "Content", autoFitRows: true);
-                sheet.SetCellValue(2, 1, " ", autoFitRows: true);
+                sheet.SetCellValue(1, 1, "Content");
+                sheet.SetCellValue(2, 1, " ");
+                sheet.AutoFitAllRows();
                 document.Save();
             }
 
@@ -73,13 +76,15 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "AutoFit.ClearRow.xlsx");
             using (var document = ExcelDocument.Create(filePath)) {
                 var sheet = document.AddWorkSheet("Data");
-                sheet.SetCellValue(1, 1, "Content", autoFitRows: true);
+                sheet.SetCellValue(1, 1, "Content");
+                sheet.AutoFitAllRows();
                 document.Save();
             }
 
             using (var document = ExcelDocument.Load(filePath)) {
                 var sheet = document.Sheets.First();
-                sheet.SetCellValue(1, 1, string.Empty, autoFitRows: true);
+                sheet.SetCellValue(1, 1, string.Empty);
+                sheet.AutoFitAllRows();
                 document.Save();
             }
 
@@ -96,13 +101,15 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "AutoFit.ClearColumn.xlsx");
             using (var document = ExcelDocument.Create(filePath)) {
                 var sheet = document.AddWorkSheet("Data");
-                sheet.SetCellValue(1, 1, "Long text", autoFitColumns: true);
+                sheet.SetCellValue(1, 1, "Long text");
+                sheet.AutoFitAllColumns();
                 document.Save();
             }
 
             using (var document = ExcelDocument.Load(filePath)) {
                 var sheet = document.Sheets.First();
-                sheet.SetCellValue(1, 1, string.Empty, autoFitColumns: true);
+                sheet.SetCellValue(1, 1, string.Empty);
+                sheet.AutoFitAllColumns();
                 document.Save();
             }
 


### PR DESCRIPTION
## Summary
- remove auto-fit flags from SetCellValue overloads
- add explicit AutoFitAllColumns/AutoFitAllRows and per-column/row helpers
- update examples and tests to invoke new auto-fit methods

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter AutoFit`


------
https://chatgpt.com/codex/tasks/task_e_68a4ad792f48832e8ed97d19fb3736b4