### PR TITLE
Add fluent paragraph formatting and style methods

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.ParagraphFormatting.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.ParagraphFormatting.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class FluentDocument {
+        public static void Example_FluentParagraphFormatting(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with formatted paragraphs using fluent API");
+            string filePath = Path.Combine(folderPath, "FluentParagraphFormatting.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Paragraph(p => p.Text("Left aligned paragraph").AlignLeft())
+                    .Paragraph(p => p.Text("Centered paragraph").AlignCenter())
+                    .Paragraph(p => p.Text("Right aligned paragraph").AlignRight())
+                    .Paragraph(p => p.Text("Justified heading with spacing and indentation")
+                        .AlignJustified()
+                        .SpacingBefore(12)
+                        .SpacingAfter(12)
+                        .LineSpacing(24)
+                        .Indentation(left: 24, firstLine: 24)
+                        .Style(WordParagraphStyles.Heading2))
+                    .Paragraph(p => p.Text("Bullet list item").AddList(WordListStyle.Bulleted))
+                    .Paragraph(p => p.Text("Table below").AddTableAfter(2, 2))
+                    .End();
+                document.Save(false);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Fluent.ParagraphBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ParagraphBuilder.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        private static void RemoveCustomStyle(string styleId) {
+            var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static);
+            var dict = (IDictionary<string, Style>)field!.GetValue(null);
+            dict.Remove(styleId);
+        }
+
+        [Fact]
+        public void Test_FluentParagraphBuilderStylePersistence() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentParagraphBuilder.docx");
+            string customStyleId = "MyStyle";
+            var style = WordParagraphStyle.CreateFontStyle(customStyleId, "Arial");
+            WordParagraphStyle.RegisterCustomStyle(customStyleId, style);
+
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Paragraph(p => p.Text("Heading").Style(WordParagraphStyles.Heading1))
+                    .Paragraph(p => p.Text("Custom style").Style(customStyleId))
+                    .End();
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(WordParagraphStyles.Heading1, document.Paragraphs[0].Style);
+                Assert.Equal(customStyleId, document.Paragraphs[1].StyleId);
+            }
+
+            RemoveCustomStyle(customStyleId);
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using OfficeIMO.Word;
+using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
@@ -28,5 +29,81 @@ namespace OfficeIMO.Word.Fluent {
         }
 
         public ParagraphBuilder Run(string text, Action<TextBuilder>? configure = null) => Text(text, configure);
+
+        public ParagraphBuilder AlignLeft() {
+            _paragraph.ParagraphAlignment = JustificationValues.Left;
+            return this;
+        }
+
+        public ParagraphBuilder AlignCenter() {
+            _paragraph.ParagraphAlignment = JustificationValues.Center;
+            return this;
+        }
+
+        public ParagraphBuilder AlignRight() {
+            _paragraph.ParagraphAlignment = JustificationValues.Right;
+            return this;
+        }
+
+        public ParagraphBuilder AlignJustified() {
+            _paragraph.ParagraphAlignment = JustificationValues.Both;
+            return this;
+        }
+
+        public ParagraphBuilder SpacingBefore(double points) {
+            _paragraph.LineSpacingBeforePoints = points;
+            return this;
+        }
+
+        public ParagraphBuilder SpacingAfter(double points) {
+            _paragraph.LineSpacingAfterPoints = points;
+            return this;
+        }
+
+        public ParagraphBuilder LineSpacing(double points) {
+            _paragraph.LineSpacingPoints = points;
+            return this;
+        }
+
+        public ParagraphBuilder Indentation(double? left = null, double? firstLine = null, double? right = null) {
+            if (left != null) {
+                _paragraph.IndentationBeforePoints = left.Value;
+            }
+
+            if (firstLine != null) {
+                _paragraph.IndentationFirstLinePoints = firstLine.Value;
+            }
+
+            if (right != null) {
+                _paragraph.IndentationAfterPoints = right.Value;
+            }
+
+            return this;
+        }
+
+        public ParagraphBuilder Style(WordParagraphStyles style) {
+            _paragraph.SetStyle(style);
+            return this;
+        }
+
+        public ParagraphBuilder Style(string styleId) {
+            _paragraph.SetStyleId(styleId);
+            return this;
+        }
+
+        public ListBuilder AddList(WordListStyle style) {
+            var list = _paragraph.AddList(style);
+            return new ListBuilder(_fluent, list);
+        }
+
+        public TableBuilder AddTableAfter(int rows, int columns, WordTableStyle tableStyle = WordTableStyle.TableGrid) {
+            var table = _paragraph.AddTableAfter(rows, columns, tableStyle);
+            return new TableBuilder(_fluent, table);
+        }
+
+        public TableBuilder AddTableBefore(int rows, int columns, WordTableStyle tableStyle = WordTableStyle.TableGrid) {
+            var table = _paragraph.AddTableBefore(rows, columns, tableStyle);
+            return new TableBuilder(_fluent, table);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend ParagraphBuilder with alignment, spacing, indentation, and style helpers
- allow starting lists and tables from paragraph builder
- add example and tests showing formatted paragraphs and style persistence

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4aea05884832e8064e2ce1bfa98f6