### PR TITLE
Fix nullability warnings in Word core classes

### DIFF
--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -26,7 +26,9 @@ namespace OfficeIMO.Word {
             get {
                 List<int> bookmarksList = new List<int>() { 0 };
                 foreach (var paragraph in this.ParagraphsBookmarks) {
-                    bookmarksList.Add(paragraph.Bookmark.Id);
+                    if (paragraph.Bookmark != null) {
+                        bookmarksList.Add(paragraph.Bookmark.Id);
+                    }
                 }
 
                 return bookmarksList.Max() + 1;
@@ -36,7 +38,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the table of contents defined in the document.
         /// </summary>
-        public WordTableOfContent TableOfContent {
+        public WordTableOfContent? TableOfContent {
             get {
                 var sdtBlocks = _document.Body?.ChildElements.OfType<SdtBlock>() ?? Enumerable.Empty<SdtBlock>();
                 return WordSection.ConvertStdBlockToTableOfContent(this, sdtBlocks);
@@ -46,7 +48,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the cover page if one is defined in the document.
         /// </summary>
-        public WordCoverPage CoverPage {
+        public WordCoverPage? CoverPage {
             get {
                 var sdtBlocks = _document.Body?.ChildElements.OfType<SdtBlock>() ?? Enumerable.Empty<SdtBlock>();
                 return WordSection.ConvertStdBlockToCoverPage(this, sdtBlocks);

--- a/OfficeIMO.Word/WordSection.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordSection.PrivateMethods.cs
@@ -529,33 +529,33 @@ namespace OfficeIMO.Word {
             foreach (var element in listElements) {
                 if (element is WordParagraph wordParagraph) {
                     if (wordParagraph.IsBookmark) {
-                        additionalElements.Add(wordParagraph.Bookmark);
+                        additionalElements.Add(wordParagraph.Bookmark!);
                     } else if (wordParagraph.IsBreak) {
-                        additionalElements.Add(wordParagraph.Break);
+                        additionalElements.Add(wordParagraph.Break!);
                     } else if (wordParagraph.IsChart) {
-                        additionalElements.Add(wordParagraph.Chart);
+                        additionalElements.Add(wordParagraph.Chart!);
                     } else if (wordParagraph.IsEndNote) {
-                        additionalElements.Add(wordParagraph.EndNote);
+                        additionalElements.Add(wordParagraph.EndNote!);
                     } else if (wordParagraph.IsEquation) {
-                        additionalElements.Add(wordParagraph.Equation);
+                        additionalElements.Add(wordParagraph.Equation!);
                     } else if (wordParagraph.IsField) {
-                        additionalElements.Add(wordParagraph.Field);
+                        additionalElements.Add(wordParagraph.Field!);
                     } else if (wordParagraph.IsFootNote) {
-                        additionalElements.Add(wordParagraph.FootNote);
+                        additionalElements.Add(wordParagraph.FootNote!);
                     } else if (wordParagraph.IsImage) {
-                        additionalElements.Add(wordParagraph.Image);
+                        additionalElements.Add(wordParagraph.Image!);
                     } else if (wordParagraph.IsListItem) {
                         additionalElements.Add(wordParagraph);
                     } else if (wordParagraph.IsPageBreak) {
-                        additionalElements.Add(wordParagraph.PageBreak);
+                        additionalElements.Add(wordParagraph.PageBreak!);
                     } else if (wordParagraph.IsStructuredDocumentTag) {
-                        additionalElements.Add(wordParagraph.StructuredDocumentTag);
+                        additionalElements.Add(wordParagraph.StructuredDocumentTag!);
                     } else if (wordParagraph.IsTab) {
-                        additionalElements.Add(wordParagraph.Tab);
+                        additionalElements.Add(wordParagraph.Tab!);
                     } else if (wordParagraph.IsTextBox) {
-                        additionalElements.Add(wordParagraph.TextBox);
+                        additionalElements.Add(wordParagraph.TextBox!);
                     } else if (wordParagraph.IsHyperLink) {
-                        additionalElements.Add(wordParagraph.Hyperlink);
+                        additionalElements.Add(wordParagraph.Hyperlink!);
                     } else {
                         additionalElements.Add(wordParagraph);
                     }


### PR DESCRIPTION
## Summary
- prevent null reference in bookmark ID generator
- mark TableOfContent and CoverPage as nullable
- suppress false null warnings when collecting paragraph elements

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj -p:TargetFrameworks=net9.0`
- `dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj -f net472` *(fails: reference assemblies for .NETFramework 4.7.2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b3d6c614832eabe0edd642f3160d