### PR TITLE
Add targeted AutoFit methods for Excel

### DIFF
--- a/OfficeIMO.Examples/Excel/AutoFit.cs
+++ b/OfficeIMO.Examples/Excel/AutoFit.cs
@@ -13,12 +13,20 @@ namespace OfficeIMO.Examples.Excel {
             using (var document = ExcelDocument.Create(filePath)) {
                 var sheet = document.AddWorkSheet("Data");
                 sheet.SetCellValue(1, 1, "This is a very long piece of text");
+                sheet.SetCellValue(1, 2, "Short");
                 sheet.SetCellValue(2, 1, "Second line\nwith newline");
                 sheet.SetCellValue(3, 1, "Line1\nLine2\nLine3");
                 sheet.SetCellValue(4, 1, "Temporary");
                 sheet.SetCellValue(4, 1, string.Empty);
-                sheet.AutoFitAllColumns();
-                sheet.AutoFitAllRows();
+
+                // Autofit a single column and a single row
+                sheet.AutoFitColumn(1);
+                sheet.AutoFitRow(3);
+
+                // Autofit the entire worksheet
+                sheet.AutoFitColumns();
+                sheet.AutoFitRows();
+
                 document.Save(openExcel);
             }
         }

--- a/OfficeIMO.Excel/Fluent/ColumnBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/ColumnBuilder.cs
@@ -8,7 +8,7 @@ namespace OfficeIMO.Excel.Fluent {
         }
 
         public ColumnBuilder AutoFit() {
-            _sheet.AutoFitAllColumns();
+            _sheet.AutoFitColumns();
             return this;
         }
     }


### PR DESCRIPTION
## Summary
- allow fitting individual columns and rows in Excel
- reuse per-column and per-row logic for sheet-wide auto-fit
- add example and tests for single-column and single-row auto-fit

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a4b2e78730832eacd1e835616cf514