### PR TITLE
feat(fluent): expand header and footer builders

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.HeadersFooters.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.HeadersFooters.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class FluentDocument {
+        public static void Example_FluentHeadersAndFooters(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with fluent headers and footers");
+            string filePath = Path.Combine(folderPath, "FluentHeadersAndFooters.docx");
+            string imagesPath = Path.Combine(Directory.GetCurrentDirectory(), "Images");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .PageSetup(p => p.DifferentFirstPage().DifferentOddAndEvenPages())
+                    .Header(h => h
+                        .Default(d => d
+                            .Paragraph("Default header")
+                            .Paragraph(pb => pb.Text("Second header paragraph"))
+                            .Image(Path.Combine(imagesPath, "Kulek.jpg"), 50, 50)
+                            .Table(2, 2))
+                        .First(f => f.Paragraph("First page header"))
+                        .Even(e => e.Paragraph("Even page header")))
+                    .Footer(f => f
+                        .Default(d => d.Paragraph("Default footer"))
+                        .First(ft => ft.Paragraph("First page footer"))
+                        .Even(ev => ev.Paragraph("Even page footer")))
+                    .Paragraph(p => p.Text("Body paragraph"))
+                    .Section(s => s.New())
+                    .Paragraph(p => p.Text("Second section paragraph"))
+                    .End();
+                document.Save(false);
+            }
+
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Word.Fluent.HeadersFooters.cs
+++ b/OfficeIMO.Tests/Word.Fluent.HeadersFooters.cs
@@ -1,0 +1,54 @@
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_FluentHeadersAndFootersPersist() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentHeadersFootersPersist.docx");
+            string imagePath = Path.Combine(_directoryWithImages, "Kulek.jpg");
+
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .PageSetup(p => p.DifferentFirstPage().DifferentOddAndEvenPages())
+                    .Header(h => h
+                        .Default(d => d
+                            .Paragraph("Default header paragraph 1")
+                            .Paragraph("Default header paragraph 2")
+                            .Image(imagePath, 50, 50)
+                            .Table(1, 1))
+                        .First(f => f.Paragraph("First header"))
+                        .Even(e => e.Paragraph("Even header")))
+                    .Footer(f => f
+                        .Default(d => d.Paragraph("Default footer"))
+                        .First(ft => ft.Paragraph("First footer"))
+                        .Even(ev => ev.Paragraph("Even footer")))
+                    .Section(s => s.New())
+                    .Paragraph(p => p.Text("Body"))
+                    .End();
+                document.Save(false);
+            }
+
+            using var loaded = WordDocument.Load(filePath);
+            Assert.Equal(2, loaded.Sections.Count);
+
+            var defaultHeader = loaded.Sections[0].Header.Default;
+            Assert.Equal(3, defaultHeader.Paragraphs.Count);
+            Assert.Equal(1, defaultHeader.Tables.Count);
+            Assert.Equal(1, defaultHeader.ParagraphsImages.Count);
+
+            Assert.Equal("First header", loaded.Sections[0].Header.First.Paragraphs[0].Text);
+            Assert.Equal("Even header", loaded.Sections[0].Header.Even.Paragraphs[0].Text);
+
+            Assert.Equal("Default footer", loaded.Sections[0].Footer.Default.Paragraphs[0].Text);
+            Assert.Equal("First footer", loaded.Sections[0].Footer.First.Paragraphs[0].Text);
+            Assert.Equal("Even footer", loaded.Sections[0].Footer.Even.Paragraphs[0].Text);
+
+            Assert.Null(loaded.Sections[1].Header.Default);
+            Assert.Null(loaded.Sections[1].Footer.Default);
+        }
+    }
+}
+

--- a/OfficeIMO.Word/Fluent/FootersBuilder.cs
+++ b/OfficeIMO.Word/Fluent/FootersBuilder.cs
@@ -1,3 +1,5 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Word.Fluent {
@@ -6,23 +8,99 @@ namespace OfficeIMO.Word.Fluent {
     /// </summary>
     public class FootersBuilder {
         private readonly WordFluentDocument _fluent;
-        private readonly WordParagraph? _paragraph;
 
         internal FootersBuilder(WordFluentDocument fluent) {
             _fluent = fluent;
         }
 
-        internal FootersBuilder(WordFluentDocument fluent, WordParagraph? paragraph) {
-            _fluent = fluent;
-            _paragraph = paragraph;
+        private WordFooter GetOrCreate(HeaderFooterValues type) {
+            var document = _fluent.Document;
+            var section = document.Sections[0];
+
+            WordFooter? footer;
+            if (type == HeaderFooterValues.First) {
+                footer = document.Footer?.First;
+            } else if (type == HeaderFooterValues.Even) {
+                footer = document.Footer?.Even;
+            } else {
+                footer = document.Footer?.Default;
+            }
+
+            if (footer == null) {
+                WordHeadersAndFooters.AddFooterReference(document, section, type);
+                if (type == HeaderFooterValues.First) {
+                    footer = document.Footer.First;
+                } else if (type == HeaderFooterValues.Even) {
+                    footer = document.Footer.Even;
+                } else {
+                    footer = document.Footer.Default;
+                }
+            }
+
+            return footer;
         }
 
-        public WordParagraph? Paragraph => _paragraph;
+        public FootersBuilder Default(Action<FooterContentBuilder> action) {
+            var footer = GetOrCreate(HeaderFooterValues.Default);
+            action(new FooterContentBuilder(_fluent, footer));
+            return this;
+        }
+
+        public FootersBuilder First(Action<FooterContentBuilder> action) {
+            var footer = GetOrCreate(HeaderFooterValues.First);
+            action(new FooterContentBuilder(_fluent, footer));
+            return this;
+        }
+
+        public FootersBuilder Even(Action<FooterContentBuilder> action) {
+            var footer = GetOrCreate(HeaderFooterValues.Even);
+            action(new FooterContentBuilder(_fluent, footer));
+            return this;
+        }
+
+        public FootersBuilder Odd(Action<FooterContentBuilder> action) {
+            return Default(action);
+        }
 
         public FootersBuilder AddFooter(string text) {
-            var footer = _fluent.Document.Footer;
-            var paragraph = footer?.Default?.AddParagraph(text);
-            return new FootersBuilder(_fluent, paragraph);
+            return Default(f => f.Paragraph(text));
+        }
+    }
+
+    /// <summary>
+    /// Allows adding content to a specific footer.
+    /// </summary>
+    public class FooterContentBuilder {
+        private readonly WordFluentDocument _fluent;
+        private readonly WordFooter _footer;
+
+        internal FooterContentBuilder(WordFluentDocument fluent, WordFooter footer) {
+            _fluent = fluent;
+            _footer = footer;
+        }
+
+        public FooterContentBuilder Paragraph(string text) {
+            _footer.AddParagraph(text);
+            return this;
+        }
+
+        public FooterContentBuilder Paragraph(Action<ParagraphBuilder> action) {
+            var paragraph = _footer.AddParagraph();
+            action(new ParagraphBuilder(_fluent, paragraph));
+            return this;
+        }
+
+        public FooterContentBuilder Image(string path, double? width = null, double? height = null, WrapTextImage wrapImage = WrapTextImage.InLineWithText, string description = "") {
+            var paragraph = _footer.AddParagraph();
+            paragraph.AddImage(path, width, height, wrapImage, description);
+            return this;
+        }
+
+        public FooterContentBuilder Table(int rows, int columns, WordTableStyle tableStyle = WordTableStyle.TableGrid, Action<WordTable>? configure = null) {
+            var table = _footer.AddTable(rows, columns, tableStyle);
+            configure?.Invoke(table);
+            return this;
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- allow choosing default, first, even and odd headers/footers
- support adding multiple paragraphs, images and tables to each region
- add examples and tests for header/footer persistence

## Testing
- `dotnet build`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FluentHeadersAndFooters`


------
https://chatgpt.com/codex/tasks/task_e_68a4b4ca7c00832e9064bbd00762dd57