### PR TITLE
Adopt natural fluent syntax for Word lists and tables

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.ListBuilder.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.ListBuilder.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class FluentDocument {
+        public static void Example_FluentListBuilder(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with fluent lists");
+            string filePath = Path.Combine(folderPath, "FluentListBuilder.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .List(l => l.Numbered().StartAt(3)
+                                 .Item("First")
+                                 .Item("Second")
+                                 .Indent().Item("Second.Child"))
+                    .List(l => l.Bulleted()
+                                 .Item("Alpha")
+                                 .Item("Beta").Indent().Item("Beta.Child").Outdent()
+                                 .Item("Gamma"))
+                    .End();
+                document.Save(false);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Fluent/Fluent.TableBuilder.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.TableBuilder.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class FluentDocument {
+        public static void Example_FluentTableBuilder(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with fluent tables");
+            string filePath = Path.Combine(folderPath, "FluentTableBuilder.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Table(t => t
+                        .Columns(3).PreferredWidth(Percent: 100)
+                        .Header("Name", "Role", "Score")
+                        .Row("Alice", "Dev", 98)
+                        .Row("Bob", "Ops", 91)
+                        .Style(WordTableStyle.TableGrid)
+                        .Align(WordHorizontalAlignmentValues.Center))
+                    .Table(t => t
+                        .From2D(new object[,] {
+                            { "Q", "Revenue", "Churn" },
+                            { "Q1", "1.1M", "2.1%" },
+                            { "Q2", "1.3M", "1.8%" }
+                        }).HeaderRow(0))
+                    .End();
+                document.Save(false);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Word.Fluent.ListBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ListBuilder.cs
@@ -1,0 +1,43 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_FluentListBuilder() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentListBuilder.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .List(l => l.Numbered().StartAt(3)
+                                 .Item("First")
+                                 .Item("Second")
+                                 .Indent().Item("Second.Child"))
+                    .List(l => l.Bulleted()
+                                 .Item("Alpha")
+                                 .Item("Beta").Indent().Item("Beta.Child").Outdent()
+                                 .Item("Gamma"))
+                    .End();
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(2, document.Lists.Count);
+
+                var numbered = document.Lists[0];
+                Assert.Equal(3, numbered.Numbering.Levels[0].StartNumberingValue);
+                Assert.Equal(3, numbered.ListItems.Count);
+                Assert.Equal(0, numbered.ListItems[0].ListItemLevel);
+                Assert.Equal(0, numbered.ListItems[1].ListItemLevel);
+                Assert.Equal(1, numbered.ListItems[2].ListItemLevel);
+
+                var bulleted = document.Lists[1];
+                Assert.Equal(4, bulleted.ListItems.Count);
+                Assert.Equal(0, bulleted.ListItems[0].ListItemLevel);
+                Assert.Equal(0, bulleted.ListItems[1].ListItemLevel);
+                Assert.Equal(1, bulleted.ListItems[2].ListItemLevel);
+                Assert.Equal(0, bulleted.ListItems[3].ListItemLevel);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Fluent.SectionLayout.cs
+++ b/OfficeIMO.Tests/Word.Fluent.SectionLayout.cs
@@ -23,13 +23,13 @@ namespace OfficeIMO.Tests {
                             .Size(WordPageSize.Legal)
                             .PageNumbering(restart: true)
                             .Paragraph(p => p.Text("Section 1"))
-                            .Table(t => t.AddTable(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 1"))
+                            .Table(t => t.Columns(1).Row("Cell 1"))
                         .New(SectionMarkValues.NextPage)
                             .Margins(WordMargin.Wide)
                             .Size(WordPageSize.A3)
                             .PageNumbering(restart: false)
                             .Paragraph(p => p.Text("Section 2"))
-                            .Table(t => t.AddTable(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 2")))
+                            .Table(t => t.Columns(1).Row("Cell 2")))
                     .End();
                 document.Save(false);
             }

--- a/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
@@ -1,0 +1,51 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_FluentTableBuilder() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentTableBuilder.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Table(t => t
+                        .Columns(3).PreferredWidth(Percent: 100)
+                        .Header("Name", "Role", "Score")
+                        .Row("Alice", "Dev", 98)
+                        .Row("Bob", "Ops", 91)
+                        .Style(WordTableStyle.TableGrid)
+                        .Align(WordHorizontalAlignmentValues.Center))
+                    .Table(t => t
+                        .From2D(new object[,] {
+                            { "Q", "Revenue", "Churn" },
+                            { "Q1", "1.1M", "2.1%" },
+                            { "Q2", "1.3M", "1.8%" }
+                        }).HeaderRow(0))
+                    .End();
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(2, document.Tables.Count);
+
+                var table1 = document.Tables[0];
+                Assert.Equal(3, table1.Rows.Count);
+                Assert.Equal(3, table1.Rows[0].CellsCount);
+                Assert.Equal(5000, table1.Width);
+                Assert.Equal(TableWidthUnitValues.Pct, table1.WidthType);
+                Assert.Equal(WordTableStyle.TableGrid, table1.Style);
+                Assert.Equal(TableRowAlignmentValues.Center, table1.Alignment);
+                Assert.True(table1.ConditionalFormattingFirstRow);
+                Assert.Equal("Name", table1.Rows[0].Cells[0].Paragraphs[0].Text);
+
+                var table2 = document.Tables[1];
+                Assert.Equal(3, table2.Rows.Count);
+                Assert.True(table2.Rows[0].RepeatHeaderRowAtTheTopOfEachPage);
+                Assert.Equal("Q1", table2.Rows[1].Cells[0].Paragraphs[0].Text);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Word.Fluent.cs
+++ b/OfficeIMO.Tests/Word.Fluent.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Tests {
                     .Info(i => i.Title("Fluent"))
                     .Section(s => s.New())
                     .Paragraph(p => p.Text("Test"))
-                    .Table(t => t.AddTable(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell"))
+                    .Table(t => t.Columns(1).Row("Cell"))
                     .End();
                 document.Save(false);
             }

--- a/OfficeIMO.Word/Fluent/ListBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ListBuilder.cs
@@ -6,25 +6,67 @@ namespace OfficeIMO.Word.Fluent {
     /// </summary>
     public class ListBuilder {
         private readonly WordFluentDocument _fluent;
-        private readonly WordList? _list;
+        private WordList? _list;
+        private int _level;
 
         internal ListBuilder(WordFluentDocument fluent) {
             _fluent = fluent;
         }
 
-        internal ListBuilder(WordFluentDocument fluent, WordList list) {
-            _fluent = fluent;
-            _list = list;
+        /// <summary>
+        /// Starts a bulleted list using the specified style.
+        /// </summary>
+        /// <param name="style">Optional list style.</param>
+        public ListBuilder Bulleted(WordListStyle style = WordListStyle.Bulleted) {
+            _list = _fluent.Document.AddList(style);
+            _level = 0;
+            return this;
         }
 
-        public WordList? List => _list;
+        /// <summary>
+        /// Starts a numbered list using the specified style.
+        /// </summary>
+        /// <param name="style">Optional numbered list style.</param>
+        public ListBuilder Numbered(WordListStyle style = WordListStyle.Headings111) {
+            _list = _fluent.Document.AddList(style);
+            _level = 0;
+            return this;
+        }
 
-        public ListBuilder AddBulletedList(params string[] items) {
-            var list = _fluent.Document.AddListBulleted();
-            foreach (var item in items) {
-                list.AddItem(item);
+        /// <summary>
+        /// Sets the starting number for the list.
+        /// </summary>
+        /// <param name="start">Starting number.</param>
+        public ListBuilder StartAt(int start) {
+            _list?.Numbering.Levels[0].SetStartNumberingValue(start);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds an item to the list at the current level.
+        /// </summary>
+        /// <param name="text">Item text.</param>
+        public ListBuilder Item(string text) {
+            _list?.AddItem(text, _level);
+            return this;
+        }
+
+        /// <summary>
+        /// Increases nesting level for subsequent items.
+        /// </summary>
+        public ListBuilder Indent() {
+            _level++;
+            return this;
+        }
+
+        /// <summary>
+        /// Decreases nesting level for subsequent items.
+        /// </summary>
+        public ListBuilder Outdent() {
+            if (_level > 0) {
+                _level--;
             }
-            return new ListBuilder(_fluent, list);
+            return this;
         }
     }
 }

--- a/OfficeIMO.Word/Fluent/TableBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TableBuilder.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Word.Fluent {
@@ -6,22 +7,147 @@ namespace OfficeIMO.Word.Fluent {
     /// </summary>
     public class TableBuilder {
         private readonly WordFluentDocument _fluent;
-        private readonly WordTable? _table;
+        private WordTable? _table;
+        private int _columns;
+        private int? _preferredWidthPct;
+        private int? _preferredWidthDxa;
 
         internal TableBuilder(WordFluentDocument fluent) {
             _fluent = fluent;
         }
 
-        internal TableBuilder(WordFluentDocument fluent, WordTable table) {
-            _fluent = fluent;
-            _table = table;
-        }
-
         public WordTable? Table => _table;
 
-        public TableBuilder AddTable(int rows, int columns) {
-            var table = _fluent.Document.AddTable(rows, columns);
-            return new TableBuilder(_fluent, table);
+        /// <summary>
+        /// Sets the number of columns for the table.
+        /// </summary>
+        public TableBuilder Columns(int columns) {
+            _columns = columns;
+            return this;
+        }
+
+        private void EnsureTable(int rows = 1) {
+            if (_table == null) {
+                if (_columns == 0) {
+                    _columns = 1;
+                }
+                _table = _fluent.Document.AddTable(rows, _columns);
+                if (_preferredWidthPct.HasValue) {
+                    _table.WidthType = TableWidthUnitValues.Pct;
+                    _table.Width = _preferredWidthPct.Value * 50;
+                } else if (_preferredWidthDxa.HasValue) {
+                    _table.WidthType = TableWidthUnitValues.Dxa;
+                    _table.Width = _preferredWidthDxa.Value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sets the preferred width of the table.
+        /// </summary>
+        public TableBuilder PreferredWidth(int? Percent = null, int? Dxa = null) {
+            if (_table != null) {
+                if (Percent.HasValue) {
+                    _table.WidthType = TableWidthUnitValues.Pct;
+                    _table.Width = Percent.Value * 50;
+                } else if (Dxa.HasValue) {
+                    _table.WidthType = TableWidthUnitValues.Dxa;
+                    _table.Width = Dxa.Value;
+                }
+            } else {
+                _preferredWidthPct = Percent;
+                _preferredWidthDxa = Dxa;
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a header row to the table.
+        /// </summary>
+        public TableBuilder Header(params object[] cells) {
+            if (_columns == 0) {
+                _columns = cells.Length;
+            }
+            EnsureTable(1);
+            var row = _table!.Rows[0];
+            for (int i = 0; i < _columns && i < cells.Length; i++) {
+                row.Cells[i].AddParagraph(cells[i]?.ToString() ?? string.Empty, true);
+            }
+            _table.ConditionalFormattingFirstRow = true;
+            row.RepeatHeaderRowAtTheTopOfEachPage = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a row to the table.
+        /// </summary>
+        public TableBuilder Row(params object[] cells) {
+            if (_columns == 0) {
+                _columns = cells.Length;
+            }
+            EnsureTable(1);
+            WordTableRow row;
+            if (_table!.Rows.Count == 0) {
+                row = _table.Rows[0];
+            } else {
+                row = _table.AddRow(_columns);
+            }
+            for (int i = 0; i < _columns && i < cells.Length; i++) {
+                row.Cells[i].AddParagraph(cells[i]?.ToString() ?? string.Empty, true);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Applies a built-in table style.
+        /// </summary>
+        public TableBuilder Style(WordTableStyle style) {
+            if (_table != null) {
+                _table.Style = style;
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Sets horizontal alignment for the table.
+        /// </summary>
+        public TableBuilder Align(WordHorizontalAlignmentValues alignment) {
+            if (_table != null) {
+                _table.Alignment = alignment switch {
+                    WordHorizontalAlignmentValues.Center => TableRowAlignmentValues.Center,
+                    WordHorizontalAlignmentValues.Right => TableRowAlignmentValues.Right,
+                    _ => TableRowAlignmentValues.Left,
+                };
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Creates the table from a two-dimensional array.
+        /// </summary>
+        public TableBuilder From2D(object[,] data) {
+            int rows = data.GetLength(0);
+            int cols = data.GetLength(1);
+            _columns = cols;
+            _table = _fluent.Document.AddTable(rows, cols);
+            for (int r = 0; r < rows; r++) {
+                for (int c = 0; c < cols; c++) {
+                    _table.Rows[r].Cells[c].AddParagraph(data[r, c]?.ToString() ?? string.Empty, true);
+                }
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Marks a specified row as the header row.
+        /// </summary>
+        public TableBuilder HeaderRow(int index) {
+            if (_table != null && index >= 0 && index < _table.Rows.Count) {
+                _table.Rows[index].RepeatHeaderRowAtTheTopOfEachPage = true;
+                _table.ConditionalFormattingFirstRow = true;
+            }
+            return this;
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- redesign list builder to use Bulleted(), Numbered(), StartAt(), Item(), Indent(), and Outdent for nested lists
- expand table builder with column counts, preferred width, headers, rows, style, alignment, array loading, and header row selection
- update examples and tests to demonstrate and validate new fluent list and table APIs

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FullyQualifiedName~Test_FluentListBuilder --verbosity minimal 2>&1 | grep -v "warning" | tail -n 20`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FullyQualifiedName~Test_FluentTableBuilder --verbosity minimal 2>&1 | grep -v "warning" | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68a4b3310260832e9ac3de8fdfe8e1e6