### PR TITLE
Add overloads for list and table builders

### DIFF
--- a/OfficeIMO.Word/Fluent/ListBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ListBuilder.cs
@@ -13,6 +13,12 @@ namespace OfficeIMO.Word.Fluent {
             _fluent = fluent;
         }
 
+        internal ListBuilder(WordFluentDocument fluent, WordList list) {
+            _fluent = fluent;
+            _list = list;
+            _level = 0;
+        }
+
         /// <summary>
         /// Starts a bulleted list using the specified style.
         /// </summary>

--- a/OfficeIMO.Word/Fluent/TableBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TableBuilder.cs
@@ -16,6 +16,12 @@ namespace OfficeIMO.Word.Fluent {
             _fluent = fluent;
         }
 
+        internal TableBuilder(WordFluentDocument fluent, WordTable table) {
+            _fluent = fluent;
+            _table = table;
+            _columns = table.Rows.Count > 0 ? table.Rows[0].Cells.Count : 0;
+        }
+
         public WordTable? Table => _table;
 
         /// <summary>


### PR DESCRIPTION
## Summary
- allow ListBuilder to wrap existing WordList
- allow TableBuilder to wrap existing WordTable

## Testing
- `dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj -c Debug`
- `dotnet test` *(fails: System.ArgumentOutOfRangeException at OfficeIMO.Tests.Word.Test_FluentSectionLayout)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c8c741b4832ea27234a15df2a40f