### PR TITLE
Add table creation to fluent API

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.TableBuilder.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.TableBuilder.cs
@@ -23,6 +23,7 @@ namespace OfficeIMO.Examples.Word {
                             { "Q1", "1.1M", "2.1%" },
                             { "Q2", "1.3M", "1.8%" }
                         }).HeaderRow(0))
+                    .Table(t => t.AddTable(2, 2).Table!.Rows[0].Cells[0].AddParagraph("TopLeft"))
                     .End();
                 document.Save(false);
             }

--- a/OfficeIMO.Tests/Word.Fluent.SectionLayout.cs
+++ b/OfficeIMO.Tests/Word.Fluent.SectionLayout.cs
@@ -38,9 +38,9 @@ namespace OfficeIMO.Tests {
 
                 Assert.Equal(3, document.Sections.Count);
                 Assert.Equal("Section 1", document.Sections[1].Paragraphs[0].Text);
-                Assert.Equal("Cell 1", document.Sections[1].Tables[0].Rows[0].Cells[0].Paragraphs[1].Text);
+                Assert.Equal("Cell 1", document.Sections[1].Tables[0].Rows[0].Cells[0].Paragraphs[0].Text);
                 Assert.Equal("Section 2", document.Sections[2].Paragraphs[0].Text);
-                Assert.Equal("Cell 2", document.Sections[2].Tables[0].Rows[0].Cells[0].Paragraphs[1].Text);
+                Assert.Equal("Cell 2", document.Sections[2].Tables[0].Rows[0].Cells[0].Paragraphs[0].Text);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
@@ -46,6 +46,24 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Q1", table2.Rows[1].Cells[0].Paragraphs[0].Text);
             }
         }
+
+        [Fact]
+        public void Test_FluentTableBuilder_AddTable() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentAddTable.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Table(t => t.AddTable(2, 2).Table!.Rows[1].Cells[1].AddParagraph("B"))
+                    .End();
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Single(document.Tables);
+                var table = document.Tables[0];
+                Assert.Equal(2, table.Rows.Count);
+                Assert.Equal("B", table.Rows[1].Cells[1].Paragraphs[1].Text);
+            }
+        }
     }
 }
 

--- a/OfficeIMO.Tests/Word.Fluent.cs
+++ b/OfficeIMO.Tests/Word.Fluent.cs
@@ -24,7 +24,7 @@ namespace OfficeIMO.Tests {
                 Assert.Single(document.Paragraphs);
                 Assert.Equal("Test", document.Paragraphs[0].Text);
                 Assert.Single(document.Tables);
-                Assert.Equal("Cell", document.Tables[0].Rows[0].Cells[0].Paragraphs[1].Text);
+                Assert.Equal("Cell", document.Tables[0].Rows[0].Cells[0].Paragraphs[0].Text);
             }
         }
     }

--- a/OfficeIMO.Word/Fluent/TableBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TableBuilder.cs
@@ -1,5 +1,6 @@
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
+using System.Linq;
 
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
@@ -23,6 +24,25 @@ namespace OfficeIMO.Word.Fluent {
         }
 
         public WordTable? Table => _table;
+
+        /// <summary>
+        /// Creates the table with the specified size.
+        /// </summary>
+        /// <param name="rows">Number of rows.</param>
+        /// <param name="columns">Number of columns.</param>
+        /// <returns>The current <see cref="TableBuilder"/>.</returns>
+        public TableBuilder AddTable(int rows, int columns) {
+            _columns = columns;
+            _table = _fluent.Document.AddTable(rows, columns);
+            if (_preferredWidthPct.HasValue) {
+                _table.WidthType = TableWidthUnitValues.Pct;
+                _table.Width = _preferredWidthPct.Value * 50;
+            } else if (_preferredWidthDxa.HasValue) {
+                _table.WidthType = TableWidthUnitValues.Dxa;
+                _table.Width = _preferredWidthDxa.Value;
+            }
+            return this;
+        }
 
         /// <summary>
         /// Sets the number of columns for the table.
@@ -93,7 +113,7 @@ namespace OfficeIMO.Word.Fluent {
             }
             EnsureTable(1);
             WordTableRow row;
-            if (_table!.Rows.Count == 0) {
+            if (_table!.Rows.Count == 1 && _table.Rows[0].Cells.All(c => c.Paragraphs.Count == 0 || string.IsNullOrEmpty(c.Paragraphs[0].Text))) {
                 row = _table.Rows[0];
             } else {
                 row = _table.AddRow(_columns);


### PR DESCRIPTION
## Summary
- add `AddTable` method to fluent `TableBuilder`
- fix row creation to fill initial row if empty
- add unit test and example using `AddTable`

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68a4cc77ed80832ebe8911e212159346