### PR TITLE
Fix Visio shape coordinate formatting

### DIFF
--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -206,10 +206,15 @@ namespace OfficeIMO.Visio {
                 };
                 const string ns = VisioNamespace;
 
+                string ToVisioString(double value) {
+                    string text = Math.Round(value, 15).ToString("F15", CultureInfo.InvariantCulture);
+                    return text.TrimEnd('0').TrimEnd('.');
+                }
+
                 void WriteCell(XmlWriter writer, string name, double value) {
                     writer.WriteStartElement("Cell", ns);
                     writer.WriteAttributeString("N", name);
-                    writer.WriteAttributeString("V", XmlConvert.ToString(value));
+                    writer.WriteAttributeString("V", ToVisioString(value));
                     writer.WriteEndElement();
                 }
 
@@ -471,16 +476,16 @@ namespace OfficeIMO.Visio {
                             writer.WriteAttributeString("Type", "Shape");
                             writer.WriteStartElement("Geom", ns);
                             writer.WriteStartElement("MoveTo", ns);
-                            writer.WriteAttributeString("X", XmlConvert.ToString(startX));
-                            writer.WriteAttributeString("Y", XmlConvert.ToString(startY));
+                            writer.WriteAttributeString("X", ToVisioString(startX));
+                            writer.WriteAttributeString("Y", ToVisioString(startY));
                             writer.WriteEndElement();
                             writer.WriteStartElement("LineTo", ns);
-                            writer.WriteAttributeString("X", XmlConvert.ToString(startX));
-                            writer.WriteAttributeString("Y", XmlConvert.ToString(endY));
+                            writer.WriteAttributeString("X", ToVisioString(startX));
+                            writer.WriteAttributeString("Y", ToVisioString(endY));
                             writer.WriteEndElement();
                             writer.WriteStartElement("LineTo", ns);
-                            writer.WriteAttributeString("X", XmlConvert.ToString(endX));
-                            writer.WriteAttributeString("Y", XmlConvert.ToString(endY));
+                            writer.WriteAttributeString("X", ToVisioString(endX));
+                            writer.WriteAttributeString("Y", ToVisioString(endY));
                             writer.WriteEndElement();
                             writer.WriteEndElement();
                             writer.WriteEndElement();


### PR DESCRIPTION
## Summary
- ensure Visio shape and connector coordinates round to 15 decimal places with invariant culture

## Testing
- `dotnet test OfficeImo.sln --configuration Release --framework net9.0 --filter "FullyQualifiedName=OfficeIMO.Tests.VisioAssetSamples.RectangleDocumentMatchesAsset" --no-build --verbosity minimal`
- `dotnet test OfficeImo.sln --configuration Release --framework net8.0 --filter "FullyQualifiedName=OfficeIMO.Tests.VisioAssetSamples.RectangleDocumentMatchesAsset" --no-build --verbosity minimal`
- `dotnet test OfficeImo.sln --configuration Release --framework net472 --filter "FullyQualifiedName=OfficeIMO.Tests.VisioAssetSamples.RectangleDocumentMatchesAsset" --verbosity minimal` *(failed: No test files executed)*
- `dotnet build OfficeImo.sln --configuration Release`


------
https://chatgpt.com/codex/tasks/task_e_68a4cf94e794832eb1251f1259ca7ae2