### PR TITLE
Fix nullability warnings in HTML converter

### DIFF
--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -189,7 +189,7 @@ namespace OfficeIMO.Word.Html.Converters {
             var widths = new List<int>();
             TableWidthUnitValues? widthType = null;
             foreach (var col in colElements) {
-                string width = null;
+                string? width = null;
                 var style = col.GetAttribute("style");
                 if (!string.IsNullOrEmpty(style)) {
                     foreach (var part in style.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
@@ -254,10 +254,10 @@ namespace OfficeIMO.Word.Html.Converters {
                 return;
             }
 
-            string background = null;
+            string? background = null;
             int? padTop = null, padRight = null, padBottom = null, padLeft = null;
             BorderValues? tableBorderStyle = null;
-            UInt32Value tableBorderSize = null;
+            UInt32Value? tableBorderSize = null;
             SixColor tableBorderColor = default;
             bool borderSpecified = false;
             bool collapse = true;
@@ -349,9 +349,9 @@ namespace OfficeIMO.Word.Html.Converters {
                 }
             }
 
-            if (borderSpecified) {
+            if (borderSpecified && tableBorderStyle.HasValue && tableBorderSize != null) {
                 if (collapse) {
-                    wordTable.StyleDetails.SetBordersForAllSides(tableBorderStyle.Value, tableBorderSize, tableBorderColor);
+                    wordTable.StyleDetails?.SetBordersForAllSides(tableBorderStyle.Value, tableBorderSize, tableBorderColor);
                 } else {
                     var hex = tableBorderColor.ToHexColor();
                     foreach (var row in wordTable.Rows) {
@@ -372,10 +372,13 @@ namespace OfficeIMO.Word.Html.Converters {
                 }
             }
 
-            if (padTop != null) wordTable.StyleDetails.MarginDefaultTopWidth = (short)padTop.Value;
-            if (padBottom != null) wordTable.StyleDetails.MarginDefaultBottomWidth = (short)padBottom.Value;
-            if (padLeft != null) wordTable.StyleDetails.MarginDefaultLeftWidth = (short)padLeft.Value;
-            if (padRight != null) wordTable.StyleDetails.MarginDefaultRightWidth = (short)padRight.Value;
+            var styleDetails = wordTable.StyleDetails;
+            if (styleDetails != null) {
+                if (padTop != null) styleDetails.MarginDefaultTopWidth = (short)padTop.Value;
+                if (padBottom != null) styleDetails.MarginDefaultBottomWidth = (short)padBottom.Value;
+                if (padLeft != null) styleDetails.MarginDefaultLeftWidth = (short)padLeft.Value;
+                if (padRight != null) styleDetails.MarginDefaultRightWidth = (short)padRight.Value;
+            }
         }
 
         private static void ApplyRowStyles(WordTableRow row, IHtmlTableRowElement htmlRow) {
@@ -384,9 +387,9 @@ namespace OfficeIMO.Word.Html.Converters {
                 return;
             }
 
-            string background = null;
+            string? background = null;
             BorderValues? borderStyle = null;
-            UInt32Value borderSize = null;
+            UInt32Value? borderSize = null;
             SixColor borderColor = default;
 
             foreach (var part in style.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
@@ -415,7 +418,7 @@ namespace OfficeIMO.Word.Html.Converters {
                 if (background != null) {
                     cell.ShadingFillColorHex = background;
                 }
-                if (borderStyle != null) {
+                if (borderStyle != null && borderSize != null) {
                     cell.Borders.LeftStyle = cell.Borders.RightStyle = cell.Borders.TopStyle = cell.Borders.BottomStyle = borderStyle;
                     cell.Borders.LeftSize = cell.Borders.RightSize = cell.Borders.TopSize = cell.Borders.BottomSize = borderSize;
                     var hex = borderColor.ToHexColor();
@@ -541,7 +544,7 @@ namespace OfficeIMO.Word.Html.Converters {
         }
 
         private static bool TryParseBorderWidth(string token, out UInt32Value size) {
-            size = null;
+            size = 0;
             var raw = token.Trim().ToLowerInvariant();
             if (raw.EndsWith("px") && double.TryParse(raw.Substring(0, raw.Length - 2), out double px)) {
                 size = (UInt32Value)(uint)Math.Max(1, Math.Round(px * 6));

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -152,9 +152,11 @@ namespace OfficeIMO.Word.Html.Converters {
             var section = wordDoc.Sections.First();
             var listStack = new Stack<WordList>();
             WordList? headingList = options.SupportsHeadingNumbering ? wordDoc.AddList(WordListStyle.Headings111) : null;
-            foreach (var child in document.Body.ChildNodes) {
-                cancellationToken.ThrowIfCancellationRequested();
-                ProcessNode(child, wordDoc, section, options, null, listStack, new TextFormatting(), null, null, headingList);
+            if (document.Body != null) {
+                foreach (var child in document.Body.ChildNodes) {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    ProcessNode(child, wordDoc, section, options, null, listStack, new TextFormatting(), null, null, headingList);
+                }
             }
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -254,9 +256,11 @@ namespace OfficeIMO.Word.Html.Converters {
 
             var listStack = new Stack<WordList>();
             WordList? headingList = options.SupportsHeadingNumbering ? doc.AddList(WordListStyle.Headings111) : null;
-            foreach (var child in document.Body.ChildNodes) {
-                cancellationToken.ThrowIfCancellationRequested();
-                ProcessNode(child, doc, section, options, null, listStack, new TextFormatting(), null, null, headingList);
+            if (document.Body != null) {
+                foreach (var child in document.Body.ChildNodes) {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    ProcessNode(child, doc, section, options, null, listStack, new TextFormatting(), null, null, headingList);
+                }
             }
         }
 
@@ -362,9 +366,11 @@ namespace OfficeIMO.Word.Html.Converters {
             var section = doc.Sections.First();
             var listStack = new Stack<WordList>();
             WordList? headingList = options.SupportsHeadingNumbering ? headerFooter.AddList(WordListStyle.Headings111) : null;
-            foreach (var child in document.Body.ChildNodes) {
-                cancellationToken.ThrowIfCancellationRequested();
-                ProcessNode(child, doc, section, options, null, listStack, new TextFormatting(), null, headerFooter, headingList);
+            if (document.Body != null) {
+                foreach (var child in document.Body.ChildNodes) {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    ProcessNode(child, doc, section, options, null, listStack, new TextFormatting(), null, headerFooter, headingList);
+                }
             }
         }
 
@@ -373,7 +379,7 @@ namespace OfficeIMO.Word.Html.Converters {
             if (loader == null) {
                 return;
             }
-            var request = new ResourceRequest(null, url);
+            var request = new ResourceRequest(null!, url);
             var download = loader.FetchAsync(request);
             var response = await download.Task.ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
@@ -782,11 +788,13 @@ namespace OfficeIMO.Word.Html.Converters {
                                         linkPara.SetFontFamily(options.FontFamily);
                                     }
                                     var link = linkPara.Hyperlink;
-                                    if (!string.IsNullOrEmpty(title)) {
-                                        link.Tooltip = title;
-                                    }
-                                    if (!string.IsNullOrEmpty(target) && Enum.TryParse<TargetFrame>(target, true, out var frame)) {
-                                        link.TargetFrame = frame;
+                                    if (link != null) {
+                                        if (!string.IsNullOrEmpty(title)) {
+                                            link.Tooltip = title;
+                                        }
+                                        if (!string.IsNullOrEmpty(target) && Enum.TryParse<TargetFrame>(target, true, out var frame)) {
+                                            link.TargetFrame = frame;
+                                        }
                                     }
                                 } else {
                                     var uri = new Uri(href, UriKind.RelativeOrAbsolute);
@@ -795,11 +803,13 @@ namespace OfficeIMO.Word.Html.Converters {
                                         linkPara.SetFontFamily(options.FontFamily);
                                     }
                                     var link = linkPara.Hyperlink;
-                                    if (!string.IsNullOrEmpty(title)) {
-                                        link.Tooltip = title;
-                                    }
-                                    if (!string.IsNullOrEmpty(target) && Enum.TryParse<TargetFrame>(target, true, out var frame)) {
-                                        link.TargetFrame = frame;
+                                    if (link != null) {
+                                        if (!string.IsNullOrEmpty(title)) {
+                                            link.Tooltip = title;
+                                        }
+                                        if (!string.IsNullOrEmpty(target) && Enum.TryParse<TargetFrame>(target, true, out var frame)) {
+                                            link.TargetFrame = frame;
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
- guard against missing document bodies and hyperlinks in HTML converter
- handle nullable table styling values in HtmlToWordConverter.Tables

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.VerifyTests/OfficeIMO.VerifyTests.csproj --no-build`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d11190f0832ea9fcee56ab04f7b0