### PR TITLE
Fix analyzer warnings in tests

### DIFF
--- a/OfficeIMO.Tests/Word.Fluent.HeadersFooters.cs
+++ b/OfficeIMO.Tests/Word.Fluent.HeadersFooters.cs
@@ -36,8 +36,8 @@ namespace OfficeIMO.Tests {
 
             var defaultHeader = loaded.Sections[0].Header.Default;
             Assert.Equal(3, defaultHeader.Paragraphs.Count);
-            Assert.Equal(1, defaultHeader.Tables.Count);
-            Assert.Equal(1, defaultHeader.ParagraphsImages.Count);
+            Assert.Single(defaultHeader.Tables);
+            Assert.Single(defaultHeader.ParagraphsImages);
 
             Assert.Equal("First header", loaded.Sections[0].Header.First.Paragraphs[0].Text);
             Assert.Equal("Even header", loaded.Sections[0].Header.Even.Paragraphs[0].Text);

--- a/OfficeIMO.Tests/Word.TOC.cs
+++ b/OfficeIMO.Tests/Word.TOC.cs
@@ -186,7 +186,7 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddTableOfContent();
                 document.AddParagraph("Heading 1").Style = WordParagraphStyles.Heading1;
-                document.TableOfContent.Remove();
+                document.TableOfContent!.Remove();
                 Assert.True(document.TableOfContent == null);
                 document.RegenerateTableOfContent();
                 Assert.True(document.TableOfContent != null);

--- a/OfficeIMO.Tests/Word.TextBox.cs
+++ b/OfficeIMO.Tests/Word.TextBox.cs
@@ -159,34 +159,34 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftShadow == false);
 
 
-                document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.Type = WordBorder.Shadow;
+                var borders = document.ParagraphsTextBoxes[0].TextBox!.Paragraphs[0].Borders!;
+                borders.Type = WordBorder.Shadow;
 
+                Assert.Equal(WordBorder.Shadow, borders.Type);
+                Assert.Equal(BorderValues.Single, borders.BottomStyle);
+                Assert.True(borders.BottomSize == 4);
+                Assert.Null(borders.BottomColor);
+                Assert.True(borders.BottomShadow);
+                Assert.True(borders.BottomSpace == 24);
 
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.Type == WordBorder.Shadow);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.BottomStyle == BorderValues.Single);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.BottomSize == 4);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.BottomColor == null);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.BottomShadow == true);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.BottomSpace == 24);
+                Assert.Equal(BorderValues.Single, borders.TopStyle);
+                Assert.True(borders.TopSize == 4);
+                Assert.Null(borders.TopColor);
+                Assert.True(borders.TopShadow);
+                Assert.True(borders.TopSpace == 24);
 
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.TopStyle == BorderValues.Single);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.TopSize == 4);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.TopColor == null);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.TopShadow == true);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.TopSpace == 24);
+                Assert.Equal(BorderValues.Single, borders.LeftStyle);
+                Assert.True(borders.LeftSize == 4);
+                Assert.Null(borders.LeftColor);
+                Assert.True(borders.LeftShadow);
+                Assert.True(borders.LeftSpace == 24);
 
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.LeftStyle == BorderValues.Single);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.LeftSize == 4);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.LeftColor == null);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.LeftShadow == true);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.LeftSpace == 24);
-
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightStyle == BorderValues.Single);
-                Assert.NotNull(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightSize);
-                Assert.Equal(4U, document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightSize!.Value);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightColor == null);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightShadow == true);
-                Assert.True(document.ParagraphsTextBoxes[0].TextBox.Paragraphs[0].Borders.RightSpace == 24);
+                Assert.Equal(BorderValues.Single, borders.RightStyle);
+                Assert.NotNull(borders.RightSize);
+                Assert.Equal(4U, borders.RightSize!.Value);
+                Assert.Null(borders.RightColor);
+                Assert.True(borders.RightShadow);
+                Assert.True(borders.RightSpace == 24);
 
                 var textBox1 = document.AddTextBox("My textbox in the center with borders");
 


### PR DESCRIPTION
## Summary
- remove nullable reference warnings in Word.TextBox and TOC tests
- use Assert.Single in header/footer tests to satisfy xUnit analyzer

## Testing
- `dotnet build OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a4d11cb6bc832e93ee7ac8ae0a1d18