### PR TITLE
Improve thread safety for Excel sheets

### DIFF
--- a/OfficeIMO.Tests/Excel.SheetsEnumeration.cs
+++ b/OfficeIMO.Tests/Excel.SheetsEnumeration.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_SheetsEnumerationConcurrent() {
+            string filePath = Path.Combine(_directoryWithFiles, "SheetsEnum.xlsx");
+            using var document = ExcelDocument.Create(filePath);
+            document.AddWorkSheet("S1");
+            document.AddWorkSheet("S2");
+            document.AddWorkSheet("S3");
+
+            var tasks = Enumerable.Range(0, 10)
+                .Select(_ => Task.Run(() => {
+                    var sheets = document.Sheets;
+                    Assert.Equal(3, sheets.Count);
+                }))
+                .ToArray();
+            Task.WaitAll(tasks);
+            document.Save();
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.Tables.cs
+++ b/OfficeIMO.Tests/Excel.Tables.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Excel;
 using Xunit;
@@ -25,6 +26,31 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("A1:B2", tablePart.Table.Reference.Value);
                 Assert.Equal("MyTable", tablePart.Table.Name);
                 Assert.Equal("TableStyleMedium9", tablePart.Table.TableStyleInfo.Name.Value);
+            }
+        }
+
+        [Fact]
+        public void Test_AddTableConcurrent() {
+            string filePath = Path.Combine(_directoryWithFiles, "Table.Concurrent.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.SetCellValue(1, 1, "Name");
+                sheet.SetCellValue(1, 2, "Value");
+                sheet.SetCellValue(2, 1, "A");
+                sheet.SetCellValue(2, 2, 1d);
+                sheet.SetCellValue(3, 1, "B");
+                sheet.SetCellValue(3, 2, 2d);
+
+                var tasks = Enumerable.Range(0, 5)
+                    .Select(i => Task.Run(() => sheet.AddTable("A1:B3", true, $"MyTable{i}", TableStyle.TableStyleMedium9)))
+                    .ToArray();
+                Task.WaitAll(tasks);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                Assert.Equal(5, wsPart.TableDefinitionParts.Count());
             }
         }
     }


### PR DESCRIPTION
## Summary
- guard AddAutoFilter, AddTable and conditional formatting helpers with reentrant write locks
- allow concurrent access to document.Sheets by switching to an upgradeable read lock
- add multithreaded tests for sheet operations and sheet enumeration

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68a4de12b8b0832eb48d840eda8eb856