### PR TITLE
Enhance fluent image builder with new sources and options

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.BlockLevel.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.BlockLevel.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class FluentDocument {
+        public static void Example_FluentImagesBlockLevel(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with a block-level image");
+            string filePath = Path.Combine(folderPath, "FluentBlockImage.docx");
+            string imagesPath = Path.Combine(Directory.GetCurrentDirectory(), "Images");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Image(img => img
+                        .Add(Path.Combine(imagesPath, "EvotecLogo.png"))
+                        .Size(120, 120)
+                        .Wrap(WrapTextImage.Square)
+                        .Align(JustificationValues.Center))
+                    .End();
+                document.Save(false);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.FromUrl.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.FromUrl.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class FluentDocument {
+        public static void Example_FluentImagesFromUrl(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with image from URL");
+            string filePath = Path.Combine(folderPath, "FluentImageFromUrl.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Image(img => img
+                        .AddFromUrl("https://raw.githubusercontent.com/EvotecIT/OfficeIMO/master/OfficeIMO.Examples/Images/Kulek.jpg")
+                        .Size(400)
+                        .Align(JustificationValues.Center))
+                    .End();
+                document.Save(false);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.FromUrlAsync.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.FromUrlAsync.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class FluentDocument {
+        public static async Task Example_FluentImagesFromUrlAsync(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with image from URL asynchronously");
+            string filePath = Path.Combine(folderPath, "FluentImageFromUrlAsync.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                await document.AsFluent()
+                    .ImageAsync(async img => {
+                        await img.AddFromUrlAsync("https://raw.githubusercontent.com/EvotecIT/OfficeIMO/master/OfficeIMO.Examples/Images/Kulek.jpg");
+                        img.Wrap(WrapTextImage.Tight).Align(JustificationValues.Right);
+                    });
+                document.Save(false);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.Inline.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.Inline.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class FluentDocument {
+        public static void Example_FluentImagesInline(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with inline image");
+            string filePath = Path.Combine(folderPath, "FluentInlineImage.docx");
+            string imagesPath = Path.Combine(Directory.GetCurrentDirectory(), "Images");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Paragraph(p => p
+                        .Text("Here is an inline icon ")
+                        .InlineImage(Path.Combine(imagesPath, "EvotecLogo.png"), widthPx: 16, heightPx: 16, alt: "icon")
+                        .Text(" followed by text."))
+                    .End();
+                document.Save(false);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.Mixed.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.Mixed.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class FluentDocument {
+        public static void Example_FluentImagesMixed(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with mixed images");
+            string filePath = Path.Combine(folderPath, "FluentMixedImages.docx");
+            string imagesPath = Path.Combine(Directory.GetCurrentDirectory(), "Images");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Paragraph(p => p
+                        .Text("Company report with ")
+                        .InlineImage(Path.Combine(imagesPath, "EvotecLogo.png"), widthPx: 24, heightPx: 24)
+                        .Text(" logo"))
+                    .Image(img => img
+                        .Add(Path.Combine(imagesPath, "Kulek.jpg"))
+                        .Size(500)
+                        .Wrap(WrapTextImage.Square)
+                        .Align(JustificationValues.Center))
+                    .End();
+                document.Save(false);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.Multiple.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.Multiple.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class FluentDocument {
+        public static void Example_FluentImagesMultiple(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with multiple block images");
+            string filePath = Path.Combine(folderPath, "FluentMultipleImages.docx");
+            string imagesPath = Path.Combine(Directory.GetCurrentDirectory(), "Images");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Image(img => img
+                        .Add(Path.Combine(imagesPath, "PrzemyslawKlysAndKulkozaurr.jpg"))
+                            .Size(200)
+                            .Align(JustificationValues.Left)
+                        .Add(Path.Combine(imagesPath, "Kulek.jpg"))
+                            .MaxWidth(300)
+                            .Align(JustificationValues.Right))
+                    .End();
+                document.Save(false);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Fluent.ImageBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ImageBuilder.cs
@@ -1,0 +1,57 @@
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public async Task Test_FluentImageBuilderSources() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentImageBuilderSources.docx");
+            string imagePath = Path.Combine(_directoryWithImages, "Kulek.jpg");
+            byte[] bytes = File.ReadAllBytes(imagePath);
+
+            int port = GetAvailablePort();
+            using var listener = new HttpListener();
+            listener.Prefixes.Add($"http://localhost:{port}/");
+            listener.Start();
+            var serverTask = Task.Run(async () => {
+                var context = await listener.GetContextAsync();
+                context.Response.ContentType = "image/jpeg";
+                context.Response.ContentLength64 = bytes.Length;
+                await context.Response.OutputStream.WriteAsync(bytes, 0, bytes.Length);
+                context.Response.OutputStream.Flush();
+                context.Response.OutputStream.Close();
+            });
+
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Image(i => i.Add(imagePath).Size(50, 50).Wrap(WrapTextImage.Square).Align(JustificationValues.Center))
+                    .Image(i => {
+                        using var stream = File.OpenRead(imagePath);
+                        i.Add(stream, "stream.jpg").Size(60, 60);
+                    })
+                    .Image(i => i.Add(bytes, "bytes.jpg").Size(70, 70))
+                    .Image(i => i.AddFromUrl($"http://localhost:{port}/").Size(80, 80))
+                    .End();
+                document.Save(false);
+            }
+
+            await serverTask;
+            listener.Stop();
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(4, document.Images.Count);
+                Assert.Equal(50, document.Images[0].Width);
+                Assert.Equal(WrapTextImage.Square, document.Images[0].WrapText);
+                Assert.Equal(JustificationValues.Center, document.Paragraphs[0].ParagraphAlignment);
+                Assert.Equal(60, document.Images[1].Width);
+                Assert.Equal(70, document.Images[2].Width);
+                Assert.Equal(80, document.Images[3].Width);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/ImageBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ImageBuilder.cs
@@ -1,3 +1,8 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Word.Fluent {
@@ -6,22 +11,89 @@ namespace OfficeIMO.Word.Fluent {
     /// </summary>
     public class ImageBuilder {
         private readonly WordFluentDocument _fluent;
-        private readonly WordImage? _image;
+        private WordImage? _image;
+        private WordParagraph? _paragraph;
 
         internal ImageBuilder(WordFluentDocument fluent) {
             _fluent = fluent;
         }
 
-        internal ImageBuilder(WordFluentDocument fluent, WordImage image) {
-            _fluent = fluent;
-            _image = image;
-        }
-
         public WordImage? Image => _image;
 
-        public ImageBuilder AddImage(string url) {
-            var image = _fluent.Document.AddImageFromUrl(url);
-            return new ImageBuilder(_fluent, image);
+        public ImageBuilder Add(string path) {
+            var paragraph = _fluent.Document.AddParagraph();
+            paragraph.AddImage(path);
+            _image = paragraph.Image;
+            _paragraph = paragraph;
+            return this;
+        }
+
+        public ImageBuilder Add(Stream stream, string fileName) {
+            var paragraph = _fluent.Document.AddParagraph();
+            paragraph.AddImage(stream, fileName, null, null);
+            _image = paragraph.Image;
+            _paragraph = paragraph;
+            return this;
+        }
+
+        public ImageBuilder Add(byte[] bytes, string fileName) {
+            using var ms = new MemoryStream(bytes);
+            return Add(ms, fileName);
+        }
+
+        public ImageBuilder AddFromUrl(string url) {
+            using HttpClient client = new HttpClient();
+            var data = client.GetByteArrayAsync(url).GetAwaiter().GetResult();
+            string fileName = GetFileName(url);
+            return Add(data, fileName);
+        }
+
+        public async Task<ImageBuilder> AddFromUrlAsync(string url) {
+            using HttpClient client = new HttpClient();
+            var data = await client.GetByteArrayAsync(url);
+            string fileName = GetFileName(url);
+            return Add(data, fileName);
+        }
+
+        public ImageBuilder Size(double width, double? height = null) {
+            if (_image != null) {
+                _image.Width = width;
+                if (height != null) {
+                    _image.Height = height.Value;
+                }
+            }
+            return this;
+        }
+
+        public ImageBuilder MaxWidth(double width) {
+            if (_image != null) {
+                if (_image.Width == null || _image.Width > width) {
+                    _image.Width = width;
+                }
+            }
+            return this;
+        }
+
+        public ImageBuilder Wrap(WrapTextImage wrapImage) {
+            if (_image != null) {
+                _image.WrapText = wrapImage;
+            }
+            return this;
+        }
+
+        public ImageBuilder Align(JustificationValues alignment) {
+            _paragraph?.SetAlignment(alignment);
+            return this;
+        }
+
+        private static string GetFileName(string url) {
+            try {
+                var uri = new Uri(url);
+                var fileName = Path.GetFileName(uri.LocalPath);
+                return string.IsNullOrEmpty(fileName) ? "image" : fileName;
+            } catch (UriFormatException) {
+                return "image";
+            }
         }
     }
 }

--- a/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
@@ -30,6 +30,11 @@ namespace OfficeIMO.Word.Fluent {
 
         public ParagraphBuilder Run(string text, Action<TextBuilder>? configure = null) => Text(text, configure);
 
+        public ParagraphBuilder InlineImage(string path, double? widthPx = null, double? heightPx = null, string alt = "") {
+            _paragraph.AddImage(path, widthPx, heightPx, WrapTextImage.InLineWithText, alt);
+            return this;
+        }
+
         /// <summary>
         /// Adds or modifies a list within the document context.
         /// </summary>

--- a/OfficeIMO.Word/Fluent/WordFluentDocument.cs
+++ b/OfficeIMO.Word/Fluent/WordFluentDocument.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
@@ -77,6 +78,15 @@ namespace OfficeIMO.Word.Fluent {
         /// <param name="action">Action that receives an <see cref="ImageBuilder"/>.</param>
         public WordFluentDocument Image(Action<ImageBuilder> action) {
             action(new ImageBuilder(this));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds or modifies an image asynchronously.
+        /// </summary>
+        /// <param name="action">Async action that receives an <see cref="ImageBuilder"/>.</param>
+        public async Task<WordFluentDocument> ImageAsync(Func<ImageBuilder, Task> action) {
+            await action(new ImageBuilder(this));
             return this;
         }
 


### PR DESCRIPTION
## Summary
- add chainable image builder methods for files, streams, bytes, and URLs with sizing, wrap, and alignment
- support async image downloads and inline paragraph images
- provide multiple fluent examples covering local, remote, inline, and mixed image scenarios

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a4d8134ab4832eb21a7904e98b3afd