### PR TITLE
Expose WordDocument from fluent End and update samples

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.Example.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.Example.cs
@@ -18,8 +18,8 @@ namespace OfficeIMO.Examples.Word {
                         .Custom("Reviewed", true))
                     .Section(s => s.New())
                     .Paragraph(p => p.Text("Hello from fluent API"))
-                    .End();
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
             Helpers.Open(filePath, openWord);
         }

--- a/OfficeIMO.Examples/Word/Fluent/Fluent.HeadersFooters.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.HeadersFooters.cs
@@ -28,8 +28,8 @@ namespace OfficeIMO.Examples.Word {
                     .Paragraph(p => p.Text("Body paragraph"))
                     .Section(s => s.New())
                     .Paragraph(p => p.Text("Second section paragraph"))
-                    .End();
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
 
             Helpers.Open(filePath, openWord);

--- a/OfficeIMO.Examples/Word/Fluent/Fluent.ListBuilder.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.ListBuilder.cs
@@ -18,8 +18,8 @@ namespace OfficeIMO.Examples.Word {
                                  .Item("Alpha")
                                  .Item("Beta").Indent().Item("Beta.Child").Outdent()
                                  .Item("Gamma"))
-                    .End();
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
             Helpers.Open(filePath, openWord);
         }

--- a/OfficeIMO.Examples/Word/Fluent/Fluent.ParagraphFormatting.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.ParagraphFormatting.cs
@@ -22,8 +22,8 @@ namespace OfficeIMO.Examples.Word {
                         .Style(WordParagraphStyles.Heading2))
                     .Paragraph(p => p.Text("Bullet list item").AddList(WordListStyle.Bulleted))
                     .Paragraph(p => p.Text("Table below").AddTableAfter(2, 2))
-                    .End();
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
             Helpers.Open(filePath, openWord);
         }

--- a/OfficeIMO.Examples/Word/Fluent/Fluent.SectionLayout.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.SectionLayout.cs
@@ -29,8 +29,8 @@ namespace OfficeIMO.Examples.Word {
                             .PageNumbering(restart: false)
                             .Paragraph(p => p.Text("Section 2"))
                             .Table(t => t.AddTable(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 2")))
-                    .End();
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
             Helpers.Open(filePath, openWord);
         }

--- a/OfficeIMO.Examples/Word/Fluent/Fluent.TableBuilder.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.TableBuilder.cs
@@ -24,8 +24,8 @@ namespace OfficeIMO.Examples.Word {
                             { "Q2", "1.3M", "1.8%" }
                         }).HeaderRow(0))
                     .Table(t => t.AddTable(2, 2).Table!.Rows[0].Cells[0].AddParagraph("TopLeft"))
-                    .End();
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
             Helpers.Open(filePath, openWord);
         }

--- a/OfficeIMO.Examples/Word/Fluent/Fluent.TextBuilder.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.TextBuilder.cs
@@ -12,8 +12,8 @@ namespace OfficeIMO.Examples.Word {
                 document.AsFluent()
                     .Paragraph(p => p.Text("Hello")
                         .Text(" World", t => t.BoldOn().ItalicOn().Color("#ff0000")))
-                    .End();
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
             Helpers.Open(filePath, openWord);
         }

--- a/OfficeIMO.Examples/Word/Paragraphs/Paragraph_TextAndFormatting.cs
+++ b/OfficeIMO.Examples/Word/Paragraphs/Paragraph_TextAndFormatting.cs
@@ -15,9 +15,8 @@ internal static partial class Paragraphs {
                     .Text("Hello")
                     .Text(" World", t => t.BoldOn().ItalicOn().Color("#ff0000"))
                     .Text("!", t => t.BoldOn()))
-                .End();
-
-            document.Save(false);
+                .End()
+                .Save(false);
         }
         Helpers.Open(filePath, openWord);
     }

--- a/OfficeIMO.Examples/Word/Sections/Sections_Overrides_MarginsSizeNumbering.cs
+++ b/OfficeIMO.Examples/Word/Sections/Sections_Overrides_MarginsSizeNumbering.cs
@@ -30,9 +30,8 @@ namespace OfficeIMO.Examples.Word {
                             .PageNumbering(restart: false)
                             .Paragraph(p => p.Text("Section 2"))
                             .Table(t => t.AddTable(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 2")))
-                    .End();
-
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
             Helpers.Open(filePath, openWord);
         }

--- a/OfficeIMO.Examples/Word/Sections/Sections_PageSetup_Defaults.cs
+++ b/OfficeIMO.Examples/Word/Sections/Sections_PageSetup_Defaults.cs
@@ -19,9 +19,8 @@ namespace OfficeIMO.Examples.Word {
                         .Margins(WordMargin.Normal)
                         .DifferentFirstPage()
                         .DifferentOddAndEvenPages())
-                    .End();
-
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
             Helpers.Open(filePath, openWord);
         }

--- a/OfficeIMO.Tests/Word.Fluent.HeadersFooters.cs
+++ b/OfficeIMO.Tests/Word.Fluent.HeadersFooters.cs
@@ -27,8 +27,8 @@ namespace OfficeIMO.Tests {
                         .Even(ev => ev.Paragraph("Even footer")))
                     .Section(s => s.New())
                     .Paragraph(p => p.Text("Body"))
-                    .End();
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
 
             using var loaded = WordDocument.Load(filePath);

--- a/OfficeIMO.Tests/Word.Fluent.ListBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ListBuilder.cs
@@ -17,8 +17,8 @@ namespace OfficeIMO.Tests {
                                  .Item("Alpha")
                                  .Item("Beta").Indent().Item("Beta.Child").Outdent()
                                  .Item("Gamma"))
-                    .End();
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
 
             using (var document = WordDocument.Load(filePath)) {

--- a/OfficeIMO.Tests/Word.Fluent.ParagraphBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ParagraphBuilder.cs
@@ -25,8 +25,8 @@ namespace OfficeIMO.Tests {
                 document.AsFluent()
                     .Paragraph(p => p.Text("Heading").Style(WordParagraphStyles.Heading1))
                     .Paragraph(p => p.Text("Custom style").Style(customStyleId))
-                    .End();
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
 
             using (var document = WordDocument.Load(filePath)) {

--- a/OfficeIMO.Tests/Word.Fluent.SectionLayout.cs
+++ b/OfficeIMO.Tests/Word.Fluent.SectionLayout.cs
@@ -30,8 +30,8 @@ namespace OfficeIMO.Tests {
                             .PageNumbering(restart: false)
                             .Paragraph(p => p.Text("Section 2"))
                             .Table(t => t.Columns(1).Row("Cell 2")))
-                    .End();
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {

--- a/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
@@ -23,8 +23,8 @@ namespace OfficeIMO.Tests {
                             { "Q1", "1.1M", "2.1%" },
                             { "Q2", "1.3M", "1.8%" }
                         }).HeaderRow(0))
-                    .End();
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
 
             using (var document = WordDocument.Load(filePath)) {
@@ -53,8 +53,8 @@ namespace OfficeIMO.Tests {
             using (var document = WordDocument.Create(filePath)) {
                 document.AsFluent()
                     .Table(t => t.AddTable(2, 2).Table!.Rows[1].Cells[1].AddParagraph("B"))
-                    .End();
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
 
             using (var document = WordDocument.Load(filePath)) {

--- a/OfficeIMO.Tests/Word.Fluent.TextBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.TextBuilder.cs
@@ -13,8 +13,8 @@ namespace OfficeIMO.Tests {
                     .Paragraph(p => p.Text("Hello")
                         .Text(" World", t => t.BoldOn().ItalicOn().Color("#ff0000"))
                         .Text("!", t => t.BoldOn()))
-                    .End();
-                document.Save(false);
+                    .End()
+                    .Save(false);
             }
 
             using (var document = WordDocument.Load(filePath)) {

--- a/OfficeIMO.Tests/Word.Fluent.cs
+++ b/OfficeIMO.Tests/Word.Fluent.cs
@@ -9,13 +9,15 @@ namespace OfficeIMO.Tests {
         public void Test_FluentDocumentBasic() {
             string filePath = Path.Combine(_directoryWithFiles, "FluentTest.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
-                document.AsFluent()
+                WordDocument fluentDocument = document.AsFluent()
                     .Info(i => i.Title("Fluent"))
                     .Section(s => s.New())
                     .Paragraph(p => p.Text("Test"))
                     .Table(t => t.Columns(1).Row("Cell"))
                     .End();
-                document.Save(false);
+
+                Assert.Same(document, fluentDocument);
+                fluentDocument.Save(false);
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {

--- a/OfficeIMO.Word/Fluent/WordFluentDocument.cs
+++ b/OfficeIMO.Word/Fluent/WordFluentDocument.cs
@@ -101,6 +101,7 @@ namespace OfficeIMO.Word.Fluent {
         /// <summary>
         /// Ends fluent configuration and returns the underlying <see cref="WordDocument"/>.
         /// </summary>
+        /// <returns>The wrapped <see cref="WordDocument"/> for further processing.</returns>
         public WordDocument End() {
             return Document;
         }


### PR DESCRIPTION
## Summary
- return the underlying `WordDocument` from `WordFluentDocument.End`
- demonstrate chaining normal API calls after `.End()` in examples and tests

## Testing
- `dotnet build`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68a4de97738c832e864889b5fc24fca3