### PR TITLE
feat: extend table builder operations

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.SectionLayout.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.SectionLayout.cs
@@ -22,13 +22,13 @@ namespace OfficeIMO.Examples.Word {
                             .Size(WordPageSize.Legal)
                             .PageNumbering(restart: true)
                             .Paragraph(p => p.Text("Section 1"))
-                            .Table(t => t.AddTable(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 1"))
+                            .Table(t => t.Create(1, 1).Cell(1, 1).Text("Cell 1"))
                         .New(SectionMarkValues.NextPage)
                             .Margins(WordMargin.Wide)
                             .Size(WordPageSize.A3)
                             .PageNumbering(restart: false)
                             .Paragraph(p => p.Text("Section 2"))
-                            .Table(t => t.AddTable(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 2")))
+                            .Table(t => t.Create(1, 1).Cell(1, 1).Text("Cell 2")))
                     .End();
                 document.Save(false);
             }

--- a/OfficeIMO.Examples/Word/Fluent/Fluent.TableBuilder.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.TableBuilder.cs
@@ -11,19 +11,30 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AsFluent()
                     .Table(t => t
-                        .Columns(3).PreferredWidth(Percent: 100)
+                        .Columns(3).PreferredWidth(percent: 100)
                         .Header("Name", "Role", "Score")
                         .Row("Alice", "Dev", 98)
                         .Row("Bob", "Ops", 91)
                         .Style(WordTableStyle.TableGrid)
-                        .Align(WordHorizontalAlignmentValues.Center))
+                        .Align(HorizontalAlignment.Center))
                     .Table(t => t
                         .From2D(new object[,] {
-                            { "Q", "Revenue", "Churn" },
-                            { "Q1", "1.1M", "2.1%" },
-                            { "Q2", "1.3M", "1.8%" }
-                        }).HeaderRow(0))
-                    .Table(t => t.AddTable(2, 2).Table!.Rows[0].Cells[0].AddParagraph("TopLeft"))
+                            { "Q",  "Revenue", "Churn" },
+                            { "Q1", "1.1M",    "2.1%" },
+                            { "Q2", "1.3M",    "1.8%" }
+                        })
+                        .HeaderRow(1))
+                    .Table(t => t
+                        .Create(rows: 2, cols: 3)
+                        .ForEachCell((r, c, cell) => cell.Text($"R{r}C{c}"))
+                        .Cell(1, 3).Text("Last")
+                        .InsertRow(2, "A", "B", "C")
+                        .InsertColumn(2, "X", "Y", "Z")
+                        .Row(1).EachCell(c => c.Shading("#ffcccc"))
+                        .Column(3).Shading("#ccffcc")
+                        .Merge(fromRow: 1, fromCol: 1, toRow: 2, toCol: 2)
+                        .DeleteRow(2)
+                        .DeleteColumn(2))
                     .End();
                 document.Save(false);
             }
@@ -31,4 +42,3 @@ namespace OfficeIMO.Examples.Word {
         }
     }
 }
-

--- a/OfficeIMO.Examples/Word/Sections/Sections_Overrides_MarginsSizeNumbering.cs
+++ b/OfficeIMO.Examples/Word/Sections/Sections_Overrides_MarginsSizeNumbering.cs
@@ -23,13 +23,13 @@ namespace OfficeIMO.Examples.Word {
                             .Size(WordPageSize.Legal)
                             .PageNumbering(restart: true)
                             .Paragraph(p => p.Text("Section 1"))
-                            .Table(t => t.AddTable(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 1"))
+                            .Table(t => t.Create(1, 1).Cell(1, 1).Text("Cell 1"))
                         .New(SectionMarkValues.NextPage)
                             .Margins(WordMargin.Wide)
                             .Size(WordPageSize.A3)
                             .PageNumbering(restart: false)
                             .Paragraph(p => p.Text("Section 2"))
-                            .Table(t => t.AddTable(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 2")))
+                            .Table(t => t.Create(1, 1).Cell(1, 1).Text("Cell 2")))
                     .End();
 
                 document.Save(false);

--- a/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
@@ -11,18 +11,19 @@ namespace OfficeIMO.Tests {
             using (var document = WordDocument.Create(filePath)) {
                 document.AsFluent()
                     .Table(t => t
-                        .Columns(3).PreferredWidth(Percent: 100)
+                        .Columns(3).PreferredWidth(percent: 100)
                         .Header("Name", "Role", "Score")
                         .Row("Alice", "Dev", 98)
                         .Row("Bob", "Ops", 91)
                         .Style(WordTableStyle.TableGrid)
-                        .Align(WordHorizontalAlignmentValues.Center))
+                        .Align(HorizontalAlignment.Center))
                     .Table(t => t
                         .From2D(new object[,] {
-                            { "Q", "Revenue", "Churn" },
-                            { "Q1", "1.1M", "2.1%" },
-                            { "Q2", "1.3M", "1.8%" }
-                        }).HeaderRow(0))
+                            { "Q",  "Revenue", "Churn" },
+                            { "Q1", "1.1M",    "2.1%" },
+                            { "Q2", "1.3M",    "1.8%" }
+                        })
+                        .HeaderRow(1))
                     .End();
                 document.Save(false);
             }
@@ -48,11 +49,13 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void Test_FluentTableBuilder_AddTable() {
-            string filePath = Path.Combine(_directoryWithFiles, "FluentAddTable.docx");
+        public void Test_FluentTableBuilder_CreateTable() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentCreateTable.docx");
             using (var document = WordDocument.Create(filePath)) {
                 document.AsFluent()
-                    .Table(t => t.AddTable(2, 2).Table!.Rows[1].Cells[1].AddParagraph("B"))
+                    .Table(t => t
+                        .Create(2, 2)
+                        .Cell(2, 2).Text("B"))
                     .End();
                 document.Save(false);
             }
@@ -61,9 +64,40 @@ namespace OfficeIMO.Tests {
                 Assert.Single(document.Tables);
                 var table = document.Tables[0];
                 Assert.Equal(2, table.Rows.Count);
-                Assert.Equal("B", table.Rows[1].Cells[1].Paragraphs[1].Text);
+                Assert.Equal("B", table.Rows[1].Cells[1].Paragraphs[0].Text);
+            }
+        }
+
+        [Fact]
+        public void Test_FluentTableBuilder_ExtendedOperations() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentTableBuilderExtended.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Table(t => t
+                        .Create(rows: 2, cols: 3)
+                        .ForEachCell((r, c, cell) => cell.Text($"R{r}C{c}"))
+                        .Cell(1, 3).Text("Done")
+                        .InsertRow(2, "A", "B", "C")
+                        .InsertColumn(2, "X", "Y", "Z")
+                        .Row(1).EachCell(c => c.Shading("#ff0000"))
+                        .Column(3).Shading("#00ff00")
+                        .Merge(fromRow: 1, fromCol: 1, toRow: 2, toCol: 2)
+                        .DeleteRow(2)
+                        .DeleteColumn(2))
+                    .End();
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Single(document.Tables);
+                var table = document.Tables[0];
+                Assert.Equal(2, table.Rows.Count);
+                Assert.Equal(3, table.Rows[0].CellsCount);
+                Assert.Equal("R2C3", table.Rows[1].Cells[2].Paragraphs[0].Text);
+                Assert.Equal(MergedCellValues.Restart, table.Rows[0].Cells[0].HorizontalMerge);
+                Assert.Equal("ff0000", table.Rows[0].Cells[0].ShadingFillColorHex);
+                Assert.Equal("00ff00", table.Rows[0].Cells[1].ShadingFillColorHex);
             }
         }
     }
 }
-

--- a/OfficeIMO.Word/Fluent/Alignment.cs
+++ b/OfficeIMO.Word/Fluent/Alignment.cs
@@ -1,0 +1,13 @@
+namespace OfficeIMO.Word.Fluent {
+    public enum HorizontalAlignment {
+        Left,
+        Center,
+        Right
+    }
+
+    public enum VerticalAlignment {
+        Top,
+        Center,
+        Bottom
+    }
+}

--- a/OfficeIMO.Word/Fluent/TableBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TableBuilder.cs
@@ -1,6 +1,7 @@
+using System;
+using System.Linq;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
-using System.Linq;
 
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
@@ -8,10 +9,10 @@ namespace OfficeIMO.Word.Fluent {
     /// </summary>
     public class TableBuilder {
         private readonly WordFluentDocument _fluent;
-        private WordTable? _table;
+        internal WordTable? _table;
         private int _columns;
-        private int? _preferredWidthPct;
-        private int? _preferredWidthDxa;
+        private double? _preferredWidthPercent;
+        private double? _preferredWidthPoints;
 
         internal TableBuilder(WordFluentDocument fluent) {
             _fluent = fluent;
@@ -25,31 +26,27 @@ namespace OfficeIMO.Word.Fluent {
 
         public WordTable? Table => _table;
 
-        /// <summary>
-        /// Creates the table with the specified size.
-        /// </summary>
-        /// <param name="rows">Number of rows.</param>
-        /// <param name="columns">Number of columns.</param>
-        /// <returns>The current <see cref="TableBuilder"/>.</returns>
-        public TableBuilder AddTable(int rows, int columns) {
-            _columns = columns;
-            _table = _fluent.Document.AddTable(rows, columns);
-            if (_preferredWidthPct.HasValue) {
-                _table.WidthType = TableWidthUnitValues.Pct;
-                _table.Width = _preferredWidthPct.Value * 50;
-            } else if (_preferredWidthDxa.HasValue) {
-                _table.WidthType = TableWidthUnitValues.Dxa;
-                _table.Width = _preferredWidthDxa.Value;
-            }
+        public TableBuilder Columns(int count) {
+            _columns = count;
             return this;
         }
 
-        /// <summary>
-        /// Sets the number of columns for the table.
-        /// </summary>
-        public TableBuilder Columns(int columns) {
-            _columns = columns;
+        public TableBuilder Create(int rows, int cols) {
+            _columns = cols;
+            _table = _fluent.Document.AddTable(rows, cols);
+            ApplyPreferredWidth();
             return this;
+        }
+
+        private void ApplyPreferredWidth() {
+            if (_table == null) return;
+            if (_preferredWidthPercent.HasValue) {
+                _table.WidthType = TableWidthUnitValues.Pct;
+                _table.Width = (int)(_preferredWidthPercent.Value * 50);
+            } else if (_preferredWidthPoints.HasValue) {
+                _table.WidthType = TableWidthUnitValues.Dxa;
+                _table.Width = (int)(_preferredWidthPoints.Value);
+            }
         }
 
         private void EnsureTable(int rows = 1) {
@@ -58,38 +55,26 @@ namespace OfficeIMO.Word.Fluent {
                     _columns = 1;
                 }
                 _table = _fluent.Document.AddTable(rows, _columns);
-                if (_preferredWidthPct.HasValue) {
-                    _table.WidthType = TableWidthUnitValues.Pct;
-                    _table.Width = _preferredWidthPct.Value * 50;
-                } else if (_preferredWidthDxa.HasValue) {
-                    _table.WidthType = TableWidthUnitValues.Dxa;
-                    _table.Width = _preferredWidthDxa.Value;
+                ApplyPreferredWidth();
+            } else {
+                while (_table.Rows.Count < rows) {
+                    _table.AddRow(_columns);
                 }
             }
         }
 
-        /// <summary>
-        /// Sets the preferred width of the table.
-        /// </summary>
-        public TableBuilder PreferredWidth(int? Percent = null, int? Dxa = null) {
+        public TableBuilder PreferredWidth(double? percent = null, double? points = null) {
             if (_table != null) {
-                if (Percent.HasValue) {
-                    _table.WidthType = TableWidthUnitValues.Pct;
-                    _table.Width = Percent.Value * 50;
-                } else if (Dxa.HasValue) {
-                    _table.WidthType = TableWidthUnitValues.Dxa;
-                    _table.Width = Dxa.Value;
-                }
+                _preferredWidthPercent = percent;
+                _preferredWidthPoints = points;
+                ApplyPreferredWidth();
             } else {
-                _preferredWidthPct = Percent;
-                _preferredWidthDxa = Dxa;
+                _preferredWidthPercent = percent;
+                _preferredWidthPoints = points;
             }
             return this;
         }
 
-        /// <summary>
-        /// Adds a header row to the table.
-        /// </summary>
         public TableBuilder Header(params object[] cells) {
             if (_columns == 0) {
                 _columns = cells.Length;
@@ -104,58 +89,25 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
-        /// <summary>
-        /// Adds a row to the table.
-        /// </summary>
         public TableBuilder Row(params object[] cells) {
             if (_columns == 0) {
                 _columns = cells.Length;
             }
-            EnsureTable(1);
-            WordTableRow row;
-            if (_table!.Rows.Count == 1 && _table.Rows[0].Cells.All(c => c.Paragraphs.Count == 0 || string.IsNullOrEmpty(c.Paragraphs[0].Text))) {
-                row = _table.Rows[0];
-            } else {
-                row = _table.AddRow(_columns);
-            }
+            EnsureTable((_table?.Rows.Count ?? 0) + 1);
+            var rowIndex = _table!.Rows.Count - 1;
+            var row = _table.Rows[rowIndex];
             for (int i = 0; i < _columns && i < cells.Length; i++) {
                 row.Cells[i].AddParagraph(cells[i]?.ToString() ?? string.Empty, true);
             }
             return this;
         }
 
-        /// <summary>
-        /// Applies a built-in table style.
-        /// </summary>
-        public TableBuilder Style(WordTableStyle style) {
-            if (_table != null) {
-                _table.Style = style;
-            }
-            return this;
-        }
-
-        /// <summary>
-        /// Sets horizontal alignment for the table.
-        /// </summary>
-        public TableBuilder Align(WordHorizontalAlignmentValues alignment) {
-            if (_table != null) {
-                _table.Alignment = alignment switch {
-                    WordHorizontalAlignmentValues.Center => TableRowAlignmentValues.Center,
-                    WordHorizontalAlignmentValues.Right => TableRowAlignmentValues.Right,
-                    _ => TableRowAlignmentValues.Left,
-                };
-            }
-            return this;
-        }
-
-        /// <summary>
-        /// Creates the table from a two-dimensional array.
-        /// </summary>
         public TableBuilder From2D(object[,] data) {
             int rows = data.GetLength(0);
             int cols = data.GetLength(1);
             _columns = cols;
             _table = _fluent.Document.AddTable(rows, cols);
+            ApplyPreferredWidth();
             for (int r = 0; r < rows; r++) {
                 for (int c = 0; c < cols; c++) {
                     _table.Rows[r].Cells[c].AddParagraph(data[r, c]?.ToString() ?? string.Empty, true);
@@ -164,16 +116,250 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
-        /// <summary>
-        /// Marks a specified row as the header row.
-        /// </summary>
-        public TableBuilder HeaderRow(int index) {
-            if (_table != null && index >= 0 && index < _table.Rows.Count) {
-                _table.Rows[index].RepeatHeaderRowAtTheTopOfEachPage = true;
+        public TableBuilder HeaderRow(int rowIndex) {
+            if (_table != null && rowIndex > 0 && rowIndex <= _table.Rows.Count) {
+                var row = _table.Rows[rowIndex - 1];
+                row.RepeatHeaderRowAtTheTopOfEachPage = true;
                 _table.ConditionalFormattingFirstRow = true;
             }
             return this;
         }
+
+        public TableBuilder InsertRow(int index, params object[] cells) {
+            EnsureTable(index);
+            if (_table == null) return this;
+            var row = new WordTableRow(_fluent.Document, _table);
+            for (int i = 0; i < _columns; i++) {
+                new WordTableCell(_fluent.Document, _table, row);
+            }
+            _table._table.InsertAt(row._tableRow, index - 1);
+            for (int i = 0; i < _columns && i < cells.Length; i++) {
+                row.Cells[i].AddParagraph(cells[i]?.ToString() ?? string.Empty, true);
+            }
+            return this;
+        }
+
+        public TableBuilder DeleteRow(int index) {
+            if (_table != null && index > 0 && index <= _table.Rows.Count) {
+                _table.Rows[index - 1].Remove();
+            }
+            return this;
+        }
+
+        public TableBuilder InsertColumn(int index, params object[] cells) {
+            EnsureTable();
+            if (_table == null) return this;
+            int rowIdx = 0;
+            foreach (var row in _table.Rows) {
+                var cell = new WordTableCell(_fluent.Document, _table, row);
+                row._tableRow.RemoveChild(cell._tableCell);
+                row._tableRow.InsertAt(cell._tableCell, index - 1);
+                if (rowIdx < cells.Length) {
+                    row.Cells[index - 1].AddParagraph(cells[rowIdx]?.ToString() ?? string.Empty, true);
+                }
+                rowIdx++;
+            }
+            _columns++;
+            return this;
+        }
+
+        public TableBuilder DeleteColumn(int index) {
+            if (_table != null) {
+                foreach (var row in _table.Rows) {
+                    if (index > 0 && index <= row.CellsCount) {
+                        row.Cells[index - 1].Remove();
+                    }
+                }
+                if (_columns > 0) _columns--;
+            }
+            return this;
+        }
+
+        public TableBuilder Merge(int fromRow, int fromCol, int toRow, int toCol) {
+            if (_table != null) {
+                int rowSpan = toRow - fromRow + 1;
+                int colSpan = toCol - fromCol + 1;
+                _table.MergeCells(fromRow - 1, fromCol - 1, rowSpan, colSpan);
+            }
+            return this;
+        }
+
+        public TableBuilder Style(WordTableStyle style) {
+            if (_table != null) {
+                _table.Style = style;
+            }
+            return this;
+        }
+
+        public TableBuilder Align(HorizontalAlignment align) {
+            if (_table != null) {
+                _table.Alignment = align switch {
+                    HorizontalAlignment.Center => TableRowAlignmentValues.Center,
+                    HorizontalAlignment.Right => TableRowAlignmentValues.Right,
+                    _ => TableRowAlignmentValues.Left,
+                };
+            }
+            return this;
+        }
+
+        public RowBuilder Row(int index) {
+            EnsureTable(index);
+            return new RowBuilder(this, index - 1);
+        }
+
+        public ColumnBuilder Column(int index) {
+            EnsureTable();
+            return new ColumnBuilder(this, index - 1);
+        }
+
+        public CellBuilder Cell(int row, int col) {
+            EnsureTable(row);
+            return new CellBuilder(this, row - 1, col - 1);
+        }
+
+        public TableBuilder Cell(int row, int col, Action<CellBuilder> action) {
+            var builder = Cell(row, col);
+            action(builder);
+            return this;
+        }
+
+        public TableBuilder ForEachCell(Func<int, int, string> textFactory) {
+            EnsureTable();
+            if (_table == null) return this;
+            for (int r = 0; r < _table.Rows.Count; r++) {
+                for (int c = 0; c < _table.Rows[r].CellsCount; c++) {
+                    var text = textFactory(r + 1, c + 1);
+                    _table.Rows[r].Cells[c].AddParagraph(text ?? string.Empty, true);
+                }
+            }
+            return this;
+        }
+
+        public TableBuilder ForEachCell(Action<int, int, CellBuilder> action) {
+            EnsureTable();
+            if (_table == null) return this;
+            for (int r = 0; r < _table.Rows.Count; r++) {
+                for (int c = 0; c < _table.Rows[r].CellsCount; c++) {
+                    action(r + 1, c + 1, new CellBuilder(this, r, c));
+                }
+            }
+            return this;
+        }
+    }
+
+    public sealed class RowBuilder {
+        private readonly TableBuilder _parent;
+        private readonly int _index;
+
+        internal RowBuilder(TableBuilder parent, int index) {
+            _parent = parent;
+            _index = index;
+        }
+
+        private WordTableRow Row => _parent._table!.Rows[_index];
+
+        public TableBuilder EachCell(Action<CellBuilder> cell) {
+            for (int c = 0; c < Row.CellsCount; c++) {
+                cell(new CellBuilder(_parent, _index, c));
+            }
+            return _parent;
+        }
+
+        public TableBuilder Shading(string hex) {
+            foreach (var c in Row.Cells) {
+                c.ShadingFillColorHex = hex.TrimStart('#');
+            }
+            return _parent;
+        }
+
+        public TableBuilder Align(HorizontalAlignment align) {
+            for (int c = 0; c < Row.CellsCount; c++) {
+                new CellBuilder(_parent, _index, c).Align(align);
+            }
+            return _parent;
+        }
+    }
+
+    public sealed class ColumnBuilder {
+        private readonly TableBuilder _parent;
+        private readonly int _index;
+
+        internal ColumnBuilder(TableBuilder parent, int index) {
+            _parent = parent;
+            _index = index;
+        }
+
+        public TableBuilder Shading(string hex) {
+            foreach (var row in _parent._table!.Rows) {
+                if (_index < row.CellsCount) {
+                    row.Cells[_index].ShadingFillColorHex = hex.TrimStart('#');
+                }
+            }
+            return _parent;
+        }
+
+        public TableBuilder Align(HorizontalAlignment align) {
+            for (int r = 0; r < _parent._table!.Rows.Count; r++) {
+                if (_index < _parent._table.Rows[r].CellsCount) {
+                    new CellBuilder(_parent, r, _index).Align(align);
+                }
+            }
+            return _parent;
+        }
+    }
+
+    public sealed class CellBuilder {
+        private readonly TableBuilder _parent;
+        private readonly WordTableCell _cell;
+
+        internal CellBuilder(TableBuilder parent, int rowIndex, int colIndex) {
+            _parent = parent;
+            _cell = parent._table!.Rows[rowIndex].Cells[colIndex];
+        }
+
+        public TableBuilder Text(string text) {
+            _cell.AddParagraph(text, true);
+            return _parent;
+        }
+
+        public TableBuilder Shading(string hex) {
+            _cell.ShadingFillColorHex = hex.TrimStart('#');
+            return _parent;
+        }
+
+        public TableBuilder Align(HorizontalAlignment hAlign, VerticalAlignment vAlign = VerticalAlignment.Center) {
+            var paragraph = _cell.Paragraphs.FirstOrDefault() ?? _cell.AddParagraph("", true);
+            paragraph.SetAlignment(hAlign switch {
+                HorizontalAlignment.Center => JustificationValues.Center,
+                HorizontalAlignment.Right => JustificationValues.Right,
+                _ => JustificationValues.Left,
+            });
+            _cell.VerticalAlignment = vAlign switch {
+                VerticalAlignment.Top => TableVerticalAlignmentValues.Top,
+                VerticalAlignment.Bottom => TableVerticalAlignmentValues.Bottom,
+                _ => TableVerticalAlignmentValues.Center,
+            };
+            return _parent;
+        }
+
+        public TableBuilder Padding(double top, double right, double bottom, double left) {
+            var tcPr = _cell._tableCellProperties ?? (_cell._tableCellProperties = new TableCellProperties());
+            var margin = tcPr.GetFirstChild<TableCellMargin>() ?? tcPr.AppendChild(new TableCellMargin());
+            margin.TopMargin = new TopMargin { Width = ((int)(top * 20)).ToString(), Type = TableWidthUnitValues.Dxa };
+            margin.RightMargin = new RightMargin { Width = ((int)(right * 20)).ToString(), Type = TableWidthUnitValues.Dxa };
+            margin.BottomMargin = new BottomMargin { Width = ((int)(bottom * 20)).ToString(), Type = TableWidthUnitValues.Dxa };
+            margin.LeftMargin = new LeftMargin { Width = ((int)(left * 20)).ToString(), Type = TableWidthUnitValues.Dxa };
+            return _parent;
+        }
+
+        public TableBuilder MergeRight(int count = 1) {
+            _cell.MergeHorizontally(count, false);
+            return _parent;
+        }
+
+        public TableBuilder MergeDown(int count = 1) {
+            _cell.MergeVertically(count, false);
+            return _parent;
+        }
     }
 }
-


### PR DESCRIPTION
## Summary
- unify fluent table builder around 1-based row/column APIs
- add alignment enums and scoped row/column/cell helpers
- update examples and tests to demonstrate new table operations

## Testing
- `~/.dotnet/dotnet build OfficeImo.sln`
- `~/.dotnet/dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a4d80cf65c832ea0bc1e101ba79b40