### PR TITLE
feat(word): extend fluent table builder

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.TableBuilder.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.TableBuilder.cs
@@ -23,7 +23,14 @@ namespace OfficeIMO.Examples.Word {
                             { "Q1", "1.1M", "2.1%" },
                             { "Q2", "1.3M", "1.8%" }
                         }).HeaderRow(0))
-                    .Table(t => t.AddTable(2, 2).Table!.Rows[0].Cells[0].AddParagraph("TopLeft"))
+                    .Table(t => t
+                        .AddTable(2, 3)
+                        .ForEachCell((r, c, cell) => cell.AddParagraph($"R{r}C{c}", true))
+                        .Cell(1, 3, cell => cell.AddParagraph("Last", true))
+                        .InsertRow(3, "A", "B", "C")
+                        .InsertColumn(4, "X", "Y", "Z")
+                        .RowStyle(1, r => r.Cells.ForEach(c => c.ShadingFillColorHex = "ffcccc"))
+                        .ColumnStyle(2, c => c.ShadingFillColorHex = "ccffcc"))
                     .End()
                     .Save(false);
             }

--- a/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
@@ -64,6 +64,39 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("B", table.Rows[1].Cells[1].Paragraphs[1].Text);
             }
         }
+
+        [Fact]
+        public void Test_FluentTableBuilder_AdvancedOperations() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentTableBuilderAdvanced.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Table(t => t
+                        .AddTable(2, 3)
+                        .ForEachCell((r, c, cell) => cell.AddParagraph($"R{r}C{c}", true))
+                        .Cell(1, 3, cell => cell.AddParagraph("Last", true))
+                        .InsertRow(3, "A", "B", "C")
+                        .InsertColumn(4, "X", "Y", "Z")
+                        .RowStyle(1, r => r.Cells.ForEach(c => c.ShadingFillColorHex = "ffcccc"))
+                        .ColumnStyle(2, c => c.ShadingFillColorHex = "ccffcc")
+                        .Merge(1, 1, 2, 2)
+                        .DeleteRow(3)
+                        .DeleteColumn(4))
+                    .End()
+                    .Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                var table = document.Tables[0];
+                Assert.Equal(2, table.Rows.Count);
+                Assert.Equal(3, table.Rows[0].CellsCount);
+                Assert.Equal("Last", table.Rows[0].Cells[2].Paragraphs[0].Text);
+                Assert.Equal("R2C3", table.Rows[1].Cells[2].Paragraphs[0].Text);
+                Assert.Equal("ffcccc", table.Rows[0].Cells[0].ShadingFillColorHex);
+                Assert.Equal("ccffcc", table.Rows[0].Cells[1].ShadingFillColorHex);
+                Assert.True(table.Rows[0].Cells[0].HasHorizontalMerge);
+                Assert.True(table.Rows[0].Cells[0].HasVerticalMerge);
+            }
+        }
     }
 }
 

--- a/OfficeIMO.Word/Fluent/TableBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TableBuilder.cs
@@ -1,5 +1,6 @@
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
+using System;
 using System.Linq;
 
 namespace OfficeIMO.Word.Fluent {
@@ -171,6 +172,173 @@ namespace OfficeIMO.Word.Fluent {
             if (_table != null && index >= 0 && index < _table.Rows.Count) {
                 _table.Rows[index].RepeatHeaderRowAtTheTopOfEachPage = true;
                 _table.ConditionalFormattingFirstRow = true;
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Performs an action on the specified cell using 1-based row and column indices.
+        /// </summary>
+        public TableBuilder Cell(int row, int column, Action<WordTableCell> action) {
+            EnsureTable(row);
+            if (_table == null) {
+                return this;
+            }
+
+            while (_table.Rows.Count < row) {
+                _table.AddRow(_columns);
+            }
+
+            var wordRow = _table.Rows[row - 1];
+            if (column > wordRow.CellsCount) {
+                for (int i = wordRow.CellsCount; i < column; i++) {
+                    new WordTableCell(_fluent.Document, _table, wordRow);
+                }
+            }
+
+            action(wordRow.Cells[column - 1]);
+            return this;
+        }
+
+        /// <summary>
+        /// Populates all cells using the provided text factory.
+        /// </summary>
+        public TableBuilder ForEachCell(Func<int, int, string> textFactory) {
+            if (_table != null) {
+                for (int r = 0; r < _table.Rows.Count; r++) {
+                    var row = _table.Rows[r];
+                    for (int c = 0; c < row.CellsCount; c++) {
+                        row.Cells[c].AddParagraph(textFactory(r + 1, c + 1), true);
+                    }
+                }
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Executes an action for each cell in the table.
+        /// </summary>
+        public TableBuilder ForEachCell(Action<int, int, WordTableCell> action) {
+            if (_table != null) {
+                for (int r = 0; r < _table.Rows.Count; r++) {
+                    var row = _table.Rows[r];
+                    for (int c = 0; c < row.CellsCount; c++) {
+                        action(r + 1, c + 1, row.Cells[c]);
+                    }
+                }
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Inserts a row at the specified 1-based index.
+        /// </summary>
+        public TableBuilder InsertRow(int index, params object[] cells) {
+            EnsureTable();
+            if (_table == null) {
+                return this;
+            }
+
+            var row = _table.AddRow(_columns);
+            if (index - 1 < _table._table.Elements<TableRow>().Count() - 1) {
+                row._tableRow.Remove();
+                _table._table.InsertAt(row._tableRow, index - 1);
+            }
+
+            for (int i = 0; i < _columns && i < cells.Length; i++) {
+                row.Cells[i].AddParagraph(cells[i]?.ToString() ?? string.Empty, true);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Inserts a column at the specified 1-based index.
+        /// </summary>
+        public TableBuilder InsertColumn(int index, params object[] cells) {
+            EnsureTable();
+            if (_table == null) {
+                return this;
+            }
+
+            int rowCount = _table.Rows.Count;
+            for (int r = 0; r < rowCount; r++) {
+                var row = _table.Rows[r];
+                var tableCell = new TableCell(new TableCellProperties(new TableCellWidth() { Type = TableWidthUnitValues.Dxa, Width = "2400" }), new Paragraph());
+                if (index - 1 < row.CellsCount) {
+                    row._tableRow.InsertAt(tableCell, index - 1);
+                } else {
+                    row._tableRow.Append(tableCell);
+                }
+                var wordCell = new WordTableCell(_fluent.Document, _table, row, tableCell);
+                if (r < cells.Length) {
+                    wordCell.AddParagraph(cells[r]?.ToString() ?? string.Empty, true);
+                }
+            }
+
+            _columns++;
+            return this;
+        }
+
+        /// <summary>
+        /// Deletes the row at the specified 1-based index.
+        /// </summary>
+        public TableBuilder DeleteRow(int index) {
+            if (_table != null && index >= 1 && index <= _table.Rows.Count) {
+                _table.Rows[index - 1].Remove();
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Deletes the column at the specified 1-based index.
+        /// </summary>
+        public TableBuilder DeleteColumn(int index) {
+            if (_table != null && index >= 1) {
+                foreach (var row in _table.Rows) {
+                    if (index <= row.CellsCount) {
+                        row.Cells[index - 1]._tableCell.Remove();
+                    }
+                }
+                if (index <= _columns) {
+                    _columns--;
+                }
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Merges a rectangular range of cells using 1-based coordinates.
+        /// </summary>
+        public TableBuilder Merge(int fromRow, int fromColumn, int toRow, int toColumn) {
+            if (_table != null) {
+                int rowSpan = toRow - fromRow + 1;
+                int colSpan = toColumn - fromColumn + 1;
+                _table.MergeCells(fromRow - 1, fromColumn - 1, rowSpan, colSpan);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Applies an action to a specified row.
+        /// </summary>
+        public TableBuilder RowStyle(int index, Action<WordTableRow> action) {
+            if (_table != null && index >= 1 && index <= _table.Rows.Count) {
+                action(_table.Rows[index - 1]);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Applies an action to each cell in a specified column.
+        /// </summary>
+        public TableBuilder ColumnStyle(int index, Action<WordTableCell> action) {
+            if (_table != null && index >= 1) {
+                foreach (var row in _table.Rows) {
+                    if (index <= row.CellsCount) {
+                        action(row.Cells[index - 1]);
+                    }
+                }
             }
             return this;
         }


### PR DESCRIPTION
## Summary
- expand fluent table builder with cell addressing, iteration, row/column insertion/removal, merging, and row/column styling
- showcase advanced table operations in examples
- add unit tests covering new table builder features

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a5615be5cc832e9d0ed1f61e0ba4b6