### PR TITLE
Parse Visio masters and link shapes

### DIFF
--- a/OfficeIMO.Examples/Visio/AllNamedShapesHaveMasters.cs
+++ b/OfficeIMO.Examples/Visio/AllNamedShapesHaveMasters.cs
@@ -8,8 +8,16 @@ namespace OfficeIMO.Examples.Visio {
             string filePath = Path.Combine(Path.GetTempPath(), "AllNamedShapesHaveMasters.vsdx");
             VisioDocument document = new();
             VisioPage page = document.AddPage("Page-1");
-            page.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "First") { NameU = "Rectangle1" });
-            page.Shapes.Add(new VisioShape("2", 4, 1, 2, 1, "Second") { NameU = "Rectangle2" });
+
+            VisioShape master1Shape = new("0", 0, 0, 2, 1, string.Empty);
+            VisioMaster master1 = new("2", "Rectangle1", master1Shape);
+
+            VisioShape master2Shape = new("0", 0, 0, 2, 1, string.Empty);
+            VisioMaster master2 = new("3", "Rectangle2", master2Shape);
+
+            page.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "First") { Master = master1 });
+            page.Shapes.Add(new VisioShape("2", 4, 1, 2, 1, "Second") { Master = master2 });
+
             document.Save(filePath);
             Console.WriteLine(filePath);
         }

--- a/OfficeIMO.Examples/Visio/MasterShapes.cs
+++ b/OfficeIMO.Examples/Visio/MasterShapes.cs
@@ -8,8 +8,16 @@ namespace OfficeIMO.Examples.Visio {
             string filePath = Path.Combine(Path.GetTempPath(), "MasterShapes.vsdx");
             VisioDocument document = new();
             VisioPage page = document.AddPage("Page-1");
-            page.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "First") { NameU = "Rectangle" });
-            page.Shapes.Add(new VisioShape("2", 4, 1, 2, 1, "Second") { NameU = "Rectangle" });
+
+            VisioShape masterShape = new("0", 0, 0, 2, 1, string.Empty);
+            VisioMaster rectangle = new("2", "Rectangle", masterShape);
+
+            VisioShape shape1 = new("1", 1, 1, 2, 1, "First") { Master = rectangle };
+            VisioShape shape2 = new("2", 4, 1, 2, 1, "Second") { Master = rectangle };
+
+            page.Shapes.Add(shape1);
+            page.Shapes.Add(shape2);
+
             document.Save(filePath);
             Console.WriteLine(filePath);
         }

--- a/OfficeIMO.Examples/Visio/ReadVisioDocument.cs
+++ b/OfficeIMO.Examples/Visio/ReadVisioDocument.cs
@@ -15,7 +15,8 @@ namespace OfficeIMO.Examples.Visio {
             foreach (VisioPage page in document.Pages) {
                 Console.WriteLine($"Page: {page.Name}");
                 foreach (VisioShape shape in page.Shapes) {
-                    Console.WriteLine($"  Shape {shape.Id} {shape.NameU} {shape.Text}");
+                    string master = shape.Master?.NameU ?? "None";
+                    Console.WriteLine($"  Shape {shape.Id} {shape.NameU} {shape.Text} Master:{master}");
                 }
             }
 

--- a/OfficeIMO.Tests/Visio.Load.cs
+++ b/OfficeIMO.Tests/Visio.Load.cs
@@ -11,7 +11,9 @@ namespace OfficeIMO.Tests {
 
             VisioDocument document = new();
             VisioPage page = document.AddPage("Page-1");
-            VisioShape shape = new("1", 1, 2, 1, 1, "Rectangle") { NameU = "Rectangle" };
+            VisioShape shape = new("1", 1, 2, 1, 1, "Rectangle");
+            VisioMaster master = new("2", "Rectangle", shape);
+            shape.Master = master;
             page.Shapes.Add(shape);
             document.Save(filePath);
 
@@ -27,6 +29,7 @@ namespace OfficeIMO.Tests {
             Assert.Equal(2d, loadedShape.PinY);
             Assert.Equal(0d, loadedShape.Width);
             Assert.Equal(0d, loadedShape.Height);
+            Assert.NotNull(loadedShape.Master);
 
             string secondPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
             loaded.Save(secondPath);

--- a/OfficeIMO.Tests/Visio.Masters.cs
+++ b/OfficeIMO.Tests/Visio.Masters.cs
@@ -15,9 +15,22 @@ namespace OfficeIMO.Tests {
 
             VisioDocument document = new();
             VisioPage page = document.AddPage("Page-1");
-            page.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "A") { NameU = "Rectangle" });
-            page.Shapes.Add(new VisioShape("2", 4, 1, 2, 1, "B") { NameU = "Rectangle" });
+
+            VisioShape shape1 = new("1", 1, 1, 2, 1, "A");
+            VisioShape shape2 = new("2", 4, 1, 2, 1, "B");
+
+            VisioMaster master1 = new("2", "Rectangle", shape1);
+            VisioMaster master2 = new("3", "Rectangle", shape2);
+            shape1.Master = master1;
+            shape2.Master = master2;
+
+            page.Shapes.Add(shape1);
+            page.Shapes.Add(shape2);
             document.Save(filePath);
+
+            VisioDocument loaded = VisioDocument.Load(filePath);
+            Assert.NotNull(loaded.Pages[0].Shapes[0].Master);
+            Assert.Equal("Rectangle", loaded.Pages[0].Shapes[0].Master?.NameU);
 
             using (Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read)) {
                 Assert.True(package.PartExists(new Uri("/visio/masters/masters.xml", UriKind.Relative)));

--- a/OfficeIMO.Visio/VisioShape.cs
+++ b/OfficeIMO.Visio/VisioShape.cs
@@ -26,6 +26,8 @@ namespace OfficeIMO.Visio {
 
         public VisioMaster? Master { get; set; }
 
+        public string? MasterNameU => Master?.NameU;
+
         public double PinX { get; set; }
 
         public double PinY { get; set; }


### PR DESCRIPTION
## Summary
- Parse existing `masters.xml` and `masterN.xml` parts when loading Visio documents, linking shapes to their `VisioMaster`
- Track masters on shapes and emit corresponding master parts and relationships when saving
- Expose `MasterNameU` on `VisioShape` and add examples/tests for master handling

## Testing
- `dotnet build OfficeIMO.Visio/OfficeIMO.Visio.csproj -c Release`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Visio -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68a567e35ea8832e9368cda3aa38f566