### PR TITLE
feat(word): add run enumeration and regex search

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.ReadHelpers.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.ReadHelpers.cs
@@ -18,6 +18,10 @@ namespace OfficeIMO.Examples.Word {
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
                 document.AsFluent().Find("Second", p => Console.WriteLine($"Found: {p.Paragraph?.Text}"));
+                document.AsFluent().FindRegex("Sec.*", p => Console.WriteLine($"Regex found: {p.Paragraph?.Text}"));
+                int totalRuns = 0;
+                document.AsFluent().ForEachRun(r => totalRuns++);
+                Console.WriteLine($"Total runs: {totalRuns}");
                 int total = document.AsFluent().Select(p => p.Paragraph?.Text.Contains("ir") == true).Count();
                 Console.WriteLine($"Paragraphs containing 'ir': {total}");
             }

--- a/OfficeIMO.Tests/Word.Fluent.ReadHelpers.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ReadHelpers.cs
@@ -22,9 +22,17 @@ namespace OfficeIMO.Tests {
                 document.AsFluent().ForEachParagraph(p => count++);
                 Assert.Equal(3, count);
 
+                int runCount = 0;
+                document.AsFluent().ForEachRun(r => runCount++);
+                Assert.Equal(3, runCount);
+
                 int found = 0;
                 document.AsFluent().Find("match", p => found++);
                 Assert.Equal(1, found);
+
+                int regexFound = 0;
+                document.AsFluent().FindRegex("Sec.*match", p => regexFound++);
+                Assert.Equal(1, regexFound);
 
                 var selected = document.AsFluent().Select(p => p.Paragraph?.Text.Contains("Third") == true).ToList();
                 Assert.Single(selected);

--- a/OfficeIMO.Word/Fluent/RunBuilder.cs
+++ b/OfficeIMO.Word/Fluent/RunBuilder.cs
@@ -1,0 +1,16 @@
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Word.Fluent {
+    /// <summary>
+    /// Builder for runs.
+    /// </summary>
+    public class RunBuilder {
+        private readonly WordParagraph _run;
+
+        internal RunBuilder(WordParagraph run) {
+            _run = run;
+        }
+
+        public WordParagraph Run => _run;
+    }
+}

--- a/OfficeIMO.Word/Fluent/WordFluentDocument.cs
+++ b/OfficeIMO.Word/Fluent/WordFluentDocument.cs
@@ -126,6 +126,15 @@ namespace OfficeIMO.Word.Fluent {
         }
 
         /// <summary>
+        /// Executes an action for each run in the document.
+        /// </summary>
+        /// <param name="action">Action to execute for every run.</param>
+        public WordFluentDocument ForEachRun(Action<RunBuilder> action) {
+            Document.ForEachRun(r => action(new RunBuilder(r)));
+            return this;
+        }
+
+        /// <summary>
         /// Finds paragraphs containing the specified text.
         /// </summary>
         /// <param name="text">Text to search for.</param>
@@ -134,6 +143,18 @@ namespace OfficeIMO.Word.Fluent {
         public WordFluentDocument Find(string text, Action<ParagraphBuilder> action, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase) {
             foreach (var paragraph in Document.FindParagraphs(text, stringComparison)) {
                 action(new ParagraphBuilder(this, paragraph));
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Finds runs matching the specified regular expression pattern.
+        /// </summary>
+        /// <param name="pattern">Regular expression pattern.</param>
+        /// <param name="action">Action executed for each matching run.</param>
+        public WordFluentDocument FindRegex(string pattern, Action<ParagraphBuilder> action) {
+            foreach (var run in Document.FindRunsRegex(pattern)) {
+                action(new ParagraphBuilder(this, run));
             }
             return this;
         }

--- a/OfficeIMO.Word/WordDocument.Enumerators.cs
+++ b/OfficeIMO.Word/WordDocument.Enumerators.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace OfficeIMO.Word {
     /// <summary>
@@ -44,10 +45,29 @@ namespace OfficeIMO.Word {
             }
         }
 
+        internal void ForEachRun(Action<WordParagraph> action) {
+            foreach (var paragraph in EnumerateAllParagraphs()) {
+                foreach (var run in paragraph.GetRuns()) {
+                    action(run);
+                }
+            }
+        }
+
         internal IEnumerable<WordParagraph> FindParagraphs(string text, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase) {
             foreach (var paragraph in EnumerateAllParagraphs()) {
                 if (paragraph.Text?.IndexOf(text, stringComparison) >= 0) {
                     yield return paragraph;
+                }
+            }
+        }
+
+        internal IEnumerable<WordParagraph> FindRunsRegex(string pattern) {
+            var regex = new Regex(pattern);
+            foreach (var paragraph in EnumerateAllParagraphs()) {
+                foreach (var run in paragraph.GetRuns()) {
+                    if (run.Text != null && regex.IsMatch(run.Text)) {
+                        yield return run;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add run enumeration helper to fluent API
- allow regex-based run search
- test fluent run enumeration and regex search

## Testing
- `dotnet build`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68a5687ae0fc832ea760f9180c4945a1