### PR TITLE
Add parallel bulk cell value setter with tests

### DIFF
--- a/OfficeIMO.Examples/Excel/SetCellValuesParallel.cs
+++ b/OfficeIMO.Examples/Excel/SetCellValuesParallel.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OfficeIMO.Excel;
+
+namespace OfficeIMO.Examples.Excel {
+    /// <summary>
+    /// Demonstrates bulk cell updates using SetCellValuesParallel.
+    /// </summary>
+    public static class SetCellValuesParallel {
+        public static void Example(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - Set cell values in parallel");
+            string filePath = System.IO.Path.Combine(folderPath, "SetCellValuesParallel.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+
+                var column1 = new List<(int Row, int Column, object Value)>();
+                var column2 = new List<(int Row, int Column, object Value)>();
+
+                for (int i = 1; i <= 50; i++) {
+                    column1.Add((i, 1, $"A{i}"));
+                    column2.Add((i, 2, $"B{i}"));
+                }
+
+                Task.WaitAll(
+                    Task.Run(() => sheet.SetCellValuesParallel(column1)),
+                    Task.Run(() => sheet.SetCellValuesParallel(column2))
+                );
+
+                document.Save(openExcel);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Excel/ExcelSheet.cs
+++ b/OfficeIMO.Excel/ExcelSheet.cs
@@ -3,7 +3,9 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Threading;
+using System.Threading.Tasks;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -587,6 +589,16 @@ namespace OfficeIMO.Excel {
                 conditionalFormatting.Append(rule);
                 worksheet.Append(conditionalFormatting);
                 worksheet.Save();
+            });
+        }
+
+        public void SetCellValuesParallel(IEnumerable<(int Row, int Column, object Value)> cells) {
+            if (cells == null) {
+                throw new ArgumentNullException(nameof(cells));
+            }
+
+            Parallel.ForEach(Partitioner.Create(cells), cell => {
+                SetCellValue(cell.Row, cell.Column, cell.Value);
             });
         }
 

--- a/OfficeIMO.Tests/Excel.SetCellValuesParallel.cs
+++ b/OfficeIMO.Tests/Excel.SetCellValuesParallel.cs
@@ -1,0 +1,53 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_SetCellValuesParallel() {
+            string filePath = Path.Combine(_directoryWithFiles, "SetCellValuesParallel.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+
+                var col1 = Enumerable.Range(1, 250).Select(i => (i, 1, (object)$"R{i}C1"));
+                var col2 = Enumerable.Range(1, 250).Select(i => (i, 2, (object)$"R{i}C2"));
+                var col3 = Enumerable.Range(1, 250).Select(i => (i, 3, (object)$"R{i}C3"));
+                var col4 = Enumerable.Range(1, 250).Select(i => (i, 4, (object)$"R{i}C4"));
+
+                Task.WaitAll(
+                    Task.Run(() => sheet.SetCellValuesParallel(col1)),
+                    Task.Run(() => sheet.SetCellValuesParallel(col2)),
+                    Task.Run(() => sheet.SetCellValuesParallel(col3)),
+                    Task.Run(() => sheet.SetCellValuesParallel(col4))
+                );
+
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                SharedStringTablePart shared = spreadsheet.WorkbookPart!.SharedStringTablePart!;
+
+                for (int row = 1; row <= 250; row++) {
+                    for (int col = 1; col <= 4; col++) {
+                        string expected = $"R{row}C{col}";
+                        string cellRef = $"{(char)('A' + col - 1)}{row}";
+                        Cell cell = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == cellRef);
+                        Assert.Equal(CellValues.SharedString, cell.DataType!.Value);
+                        int index = int.Parse(cell.CellValue!.Text);
+                        Assert.Equal(expected, shared.SharedStringTable!.ElementAt(index).InnerText);
+                    }
+                }
+
+                Assert.Equal(1000, shared.SharedStringTable!.Count());
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `ExcelSheet.SetCellValuesParallel` to perform thread-safe bulk cell updates in parallel
- document usage with a new Excel example
- verify parallel writes with new unit test

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --filter Test_SetCellValuesParallel`


------
https://chatgpt.com/codex/tasks/task_e_68a577717520832e82cc2933c92eb92a