### PR TITLE
Handle rotated Visio shapes

### DIFF
--- a/OfficeIMO.Examples/Visio/RotatedShapeBounds.cs
+++ b/OfficeIMO.Examples/Visio/RotatedShapeBounds.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    /// <summary>
+    /// Demonstrates computing bounds for a rotated shape.
+    /// </summary>
+    public static class RotatedShapeBounds {
+        public static void Example_RotatedShapeBounds(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Rotated Shape Bounds");
+            string filePath = Path.Combine(folderPath, "Rotated Shape Bounds.vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            VisioShape shape = new("1", 2, 2, 2, 1, "A") {
+                Angle = Math.PI / 4,
+            };
+            page.Shapes.Add(shape);
+
+            (double left, double bottom, double right, double top) = shape.GetBounds();
+            Console.WriteLine($"Bounds: L={left}, B={bottom}, R={right}, T={top}");
+
+            document.Save(filePath);
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Visio.ShapeBounds.cs
+++ b/OfficeIMO.Tests/Visio.ShapeBounds.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.IO.Packaging;
+using System.Linq;
+using System.Xml.Linq;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioShapeBounds {
+        [Fact]
+        public void ComputesBoundsForRotatedShapesAndConnectors() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            VisioShape start = new("1", 2, 2, 2, 1, "Start") {
+                Angle = Math.PI / 2,
+            };
+            VisioShape end = new("2", 5, 2, 2, 1, "End");
+            page.Shapes.Add(start);
+            page.Shapes.Add(end);
+            VisioConnector connector = new(start, end);
+            page.Connectors.Add(connector);
+
+            (double left, double bottom, double right, double top) = start.GetBounds();
+            Assert.Equal(1.5, left, 5);
+            Assert.Equal(1, bottom, 5);
+            Assert.Equal(2.5, right, 5);
+            Assert.Equal(3, top, 5);
+
+            document.Save(filePath);
+
+            using Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read);
+            XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
+            PackagePart pagePart = package.GetPart(new Uri("/visio/pages/page1.xml", UriKind.Relative));
+            XDocument pageXml = XDocument.Load(pagePart.GetStream());
+            XElement connectorShape = pageXml.Root?
+                .Element(ns + "Shapes")?
+                .Elements(ns + "Shape")
+                .First(e => e.Attribute("ID")?.Value == connector.Id);
+
+            XElement[] segments = connectorShape.Element(ns + "Geom")?.Elements().ToArray() ?? Array.Empty<XElement>();
+            Assert.Equal("MoveTo", segments[0].Name.LocalName);
+            Assert.Equal(2.5, double.Parse(segments[0].Attribute("X")!.Value, CultureInfo.InvariantCulture));
+            Assert.Equal(2, double.Parse(segments[0].Attribute("Y")!.Value, CultureInfo.InvariantCulture));
+            Assert.Equal("LineTo", segments[1].Name.LocalName);
+            Assert.Equal(2.5, double.Parse(segments[1].Attribute("X")!.Value, CultureInfo.InvariantCulture));
+            Assert.Equal(2, double.Parse(segments[1].Attribute("Y")!.Value, CultureInfo.InvariantCulture));
+            Assert.Equal("LineTo", segments[2].Name.LocalName);
+            Assert.Equal(4, double.Parse(segments[2].Attribute("X")!.Value, CultureInfo.InvariantCulture));
+            Assert.Equal(2, double.Parse(segments[2].Attribute("Y")!.Value, CultureInfo.InvariantCulture));
+        }
+    }
+}
+

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -205,7 +205,7 @@ namespace OfficeIMO.Visio {
                 }
             }
 
-            XElement? xform = shapeElement.Element(ns + "XForm");
+            XElement? xform = shapeElement.Element(ns + "XForm") ?? shapeElement.Element(ns + "XForm1D");
             if (xform != null) {
                 if (!pinXFound) {
                     XElement? pinX = xform.Element(ns + "PinX");
@@ -730,21 +730,21 @@ namespace OfficeIMO.Visio {
                             double startY;
                             if (connector.FromConnectionPoint != null) {
                                 VisioConnectionPoint cp = connector.FromConnectionPoint;
-                                startX = from.PinX - from.Width / 2 + cp.X;
-                                startY = from.PinY - from.Height / 2 + cp.Y;
+                                (startX, startY) = from.GetAbsolutePoint(cp.X, cp.Y);
                             } else {
-                                startX = from.PinX + from.Width / 2;
-                                startY = from.PinY;
+                                (double left, double bottom, double right, double top) = from.GetBounds();
+                                startX = right;
+                                startY = (top + bottom) / 2;
                             }
                             double endX;
                             double endY;
                             if (connector.ToConnectionPoint != null) {
                                 VisioConnectionPoint cp = connector.ToConnectionPoint;
-                                endX = to.PinX - to.Width / 2 + cp.X;
-                                endY = to.PinY - to.Height / 2 + cp.Y;
+                                (endX, endY) = to.GetAbsolutePoint(cp.X, cp.Y);
                             } else {
-                                endX = to.PinX - to.Width / 2;
-                                endY = to.PinY;
+                                (double left, double bottom, double right, double top) = to.GetBounds();
+                                endX = left;
+                                endY = (top + bottom) / 2;
                             }
 
                             writer.WriteStartElement("Shape", ns);

--- a/OfficeIMO.Visio/VisioShape.cs
+++ b/OfficeIMO.Visio/VisioShape.cs
@@ -51,5 +51,33 @@ namespace OfficeIMO.Visio {
         public string? Text { get; set; }
 
         public IList<VisioConnectionPoint> ConnectionPoints { get; } = new List<VisioConnectionPoint>();
+
+        /// <summary>
+        /// Transforms a point from the shape's local coordinate system to the page coordinate system.
+        /// </summary>
+        public (double X, double Y) GetAbsolutePoint(double x, double y) {
+            double cos = Math.Cos(Angle);
+            double sin = Math.Sin(Angle);
+            double dx = x - LocPinX;
+            double dy = y - LocPinY;
+            double absX = PinX + cos * dx - sin * dy;
+            double absY = PinY + sin * dx + cos * dy;
+            return (absX, absY);
+        }
+
+        /// <summary>
+        /// Computes the absolute bounds of the shape on the page.
+        /// </summary>
+        public (double Left, double Bottom, double Right, double Top) GetBounds() {
+            (double x1, double y1) = GetAbsolutePoint(0, 0);
+            (double x2, double y2) = GetAbsolutePoint(Width, 0);
+            (double x3, double y3) = GetAbsolutePoint(0, Height);
+            (double x4, double y4) = GetAbsolutePoint(Width, Height);
+            double left = Math.Min(Math.Min(x1, x2), Math.Min(x3, x4));
+            double right = Math.Max(Math.Max(x1, x2), Math.Max(x3, x4));
+            double bottom = Math.Min(Math.Min(y1, y2), Math.Min(y3, y4));
+            double top = Math.Max(Math.Max(y1, y2), Math.Max(y3, y4));
+            return (left, bottom, right, top);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- compute absolute Visio shape bounds using pin offsets and rotation
- account for shape rotation when emitting connector geometry
- add example and tests for rotated Visio shapes

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FullyQualifiedName~VisioShapeBounds --no-build --nologo`


------
https://chatgpt.com/codex/tasks/task_e_68a576eceb44832eaa5ef39734c1adc8