### PR TITLE
Fix nullability warnings in WordTableCellBorder

### DIFF
--- a/OfficeIMO.Word/WordTableCellBorder.cs
+++ b/OfficeIMO.Word/WordTableCellBorder.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using DocumentFormat.OpenXml;
+﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
@@ -23,7 +20,7 @@ namespace OfficeIMO.Word {
             _wordTable = wordTable;
             _wordTableRow = wordTableRow;
             _wordTableCell = wordTableCell;
-            _tableCellProperties = wordTableCell._tableCellProperties;
+            _tableCellProperties = wordTableCell._tableCellProperties ??= new TableCellProperties();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- ensure `TableCellProperties` is always initialized in `WordTableCellBorder`
- drop unused `System` namespaces in `WordTableCellBorder`

## Testing
- `dotnet build OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a578496ddc832eaedffdf0bd641007