### PR TITLE
fix: harden PowerPoint slide helpers

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointNotes.cs
+++ b/OfficeIMO.PowerPoint/PowerPointNotes.cs
@@ -49,13 +49,27 @@ namespace OfficeIMO.PowerPoint {
                 return text?.Text ?? string.Empty;
             }
             set {
-                Shape? shape = NotesSlide.CommonSlideData?.ShapeTree?.GetFirstChild<Shape>();
-                A.Paragraph? paragraph = shape?.TextBody?.GetFirstChild<A.Paragraph>();
-                A.Run? run = paragraph?.GetFirstChild<A.Run>();
-                A.Text? text = run?.GetFirstChild<A.Text>();
-                if (text != null) {
-                    text.Text = value;
+                NotesSlide notesSlide = NotesSlide;
+                CommonSlideData common = notesSlide.CommonSlideData ??= new CommonSlideData(new ShapeTree());
+                ShapeTree tree = common.ShapeTree ??= new ShapeTree();
+                Shape shape = tree.GetFirstChild<Shape>();
+                if (shape == null) {
+                    shape = new Shape(
+                        new NonVisualShapeProperties(
+                            new NonVisualDrawingProperties { Id = 1U, Name = "Notes Placeholder" },
+                            new NonVisualShapeDrawingProperties(),
+                            new ApplicationNonVisualDrawingProperties(new PlaceholderShape())
+                        ),
+                        new ShapeProperties(),
+                        new TextBody(new A.BodyProperties(), new A.ListStyle(), new A.Paragraph())
+                    );
+                    tree.AppendChild(shape);
                 }
+
+                A.Paragraph paragraph = shape.TextBody!.GetFirstChild<A.Paragraph>() ?? shape.TextBody.AppendChild(new A.Paragraph());
+                A.Run run = paragraph.GetFirstChild<A.Run>() ?? paragraph.AppendChild(new A.Run());
+                A.Text text = run.GetFirstChild<A.Text>() ?? run.AppendChild(new A.Text());
+                text.Text = value;
             }
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -24,7 +24,7 @@ namespace OfficeIMO.PowerPoint {
                 foreach (SlideId slideId in _presentationPart.Presentation.SlideIdList.Elements<SlideId>()) {
                     string? relId = slideId.RelationshipId;
                     if (!string.IsNullOrEmpty(relId)) {
-                        SlidePart slidePart = (SlidePart)_presentationPart.GetPartById(relId);
+                        SlidePart slidePart = (SlidePart)_presentationPart.GetPartById(relId!);
                         _slides.Add(new PowerPointSlide(slidePart));
                     }
                 }

--- a/OfficeIMO.PowerPoint/PowerPointSlide.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.cs
@@ -140,6 +140,10 @@ namespace OfficeIMO.PowerPoint {
         ///     Retrieves a shape by its name.
         /// </summary>
         public PowerPointShape? GetShape(string name) {
+            if (name == null) {
+                throw new ArgumentNullException(nameof(name));
+            }
+
             return _shapes.FirstOrDefault(s => s.Name == name);
         }
 
@@ -147,6 +151,10 @@ namespace OfficeIMO.PowerPoint {
         ///     Retrieves a textbox by its name.
         /// </summary>
         public PowerPointTextBox? GetTextBox(string name) {
+            if (name == null) {
+                throw new ArgumentNullException(nameof(name));
+            }
+
             return TextBoxes.FirstOrDefault(tb => tb.Name == name);
         }
 
@@ -154,6 +162,10 @@ namespace OfficeIMO.PowerPoint {
         ///     Retrieves a picture by its name.
         /// </summary>
         public PowerPointPicture? GetPicture(string name) {
+            if (name == null) {
+                throw new ArgumentNullException(nameof(name));
+            }
+
             return Pictures.FirstOrDefault(p => p.Name == name);
         }
 
@@ -161,6 +173,10 @@ namespace OfficeIMO.PowerPoint {
         ///     Retrieves a table by its name.
         /// </summary>
         public PowerPointTable? GetTable(string name) {
+            if (name == null) {
+                throw new ArgumentNullException(nameof(name));
+            }
+
             return Tables.FirstOrDefault(t => t.Name == name);
         }
 
@@ -168,6 +184,10 @@ namespace OfficeIMO.PowerPoint {
         ///     Retrieves a chart by its name.
         /// </summary>
         public PowerPointChart? GetChart(string name) {
+            if (name == null) {
+                throw new ArgumentNullException(nameof(name));
+            }
+
             return Charts.FirstOrDefault(c => c.Name == name);
         }
 
@@ -175,6 +195,10 @@ namespace OfficeIMO.PowerPoint {
         ///     Removes the specified shape from the slide.
         /// </summary>
         public void RemoveShape(PowerPointShape shape) {
+            if (shape == null) {
+                throw new ArgumentNullException(nameof(shape));
+            }
+
             shape.Element.Remove();
             _shapes.Remove(shape);
         }
@@ -194,6 +218,10 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public PowerPointTextBox AddTextBox(string text, long left = 0L, long top = 0L, long width = 914400L,
             long height = 914400L) {
+            if (text == null) {
+                throw new ArgumentNullException(nameof(text));
+            }
+
             string name = GenerateUniqueName("TextBox");
             Shape shape = new(
                 new NonVisualShapeProperties(
@@ -225,6 +253,14 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public PowerPointPicture AddPicture(string imagePath, long left = 0L, long top = 0L, long width = 914400L,
             long height = 914400L) {
+            if (imagePath == null) {
+                throw new ArgumentNullException(nameof(imagePath));
+            }
+
+            if (!File.Exists(imagePath)) {
+                throw new FileNotFoundException("Image file not found.", imagePath);
+            }
+
             ImagePart imagePart = _slidePart.AddImagePart(ImagePartType.Png);
             using FileStream stream = new(imagePath, FileMode.Open, FileAccess.Read);
             imagePart.FeedData(stream);
@@ -260,6 +296,14 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public PowerPointTable AddTable(int rows, int columns, long left = 0L, long top = 0L, long width = 5000000L,
             long height = 3000000L) {
+            if (rows <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(rows));
+            }
+
+            if (columns <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(columns));
+            }
+
             A.Table table = new();
             A.TableProperties props = new();
             props.Append(new A.TableStyleId { Text = "{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}" });


### PR DESCRIPTION
## Summary
- add argument validation for slide shape helpers
- ensure notes text setter creates required XML elements
- guard against null relationship IDs when loading slides

## Testing
- `dotnet build OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a5782cddf0832e82a176bb42391dbc