### PR TITLE
Add object collection insertion for Excel sheets

### DIFF
--- a/OfficeIMO.Examples/Excel/InsertObjects.cs
+++ b/OfficeIMO.Examples/Excel/InsertObjects.cs
@@ -14,8 +14,16 @@ namespace OfficeIMO.Examples.Excel {
             using (var document = ExcelDocument.Create(filePath)) {
                 var sheet = document.AddWorkSheet("Data");
                 var people = new List<Person> {
-                    new Person { Name = "Alice", Age = 30 },
-                    new Person { Name = "Bob", Age = 40 }
+                    new Person {
+                        Name = "Alice",
+                        Age = 30,
+                        Address = new Address { City = "London", ZipCode = "SW1" }
+                    },
+                    new Person {
+                        Name = "Bob",
+                        Age = 40,
+                        Address = new Address { City = "Paris", ZipCode = "75001" }
+                    }
                 };
                 sheet.InsertObjects(people);
                 document.Save(openExcel);
@@ -25,6 +33,12 @@ namespace OfficeIMO.Examples.Excel {
         private class Person {
             public string Name { get; set; } = string.Empty;
             public int Age { get; set; }
+            public Address? Address { get; set; }
+        }
+
+        private class Address {
+            public string City { get; set; } = string.Empty;
+            public string ZipCode { get; set; } = string.Empty;
         }
     }
 }

--- a/OfficeIMO.Examples/Excel/InsertObjects.cs
+++ b/OfficeIMO.Examples/Excel/InsertObjects.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using OfficeIMO.Excel;
+
+namespace OfficeIMO.Examples.Excel {
+    /// <summary>
+    /// Demonstrates inserting objects into a worksheet.
+    /// </summary>
+    public static class InsertObjects {
+        public static void Example(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - Insert objects");
+            string filePath = System.IO.Path.Combine(folderPath, "InsertObjects.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                var people = new List<Person> {
+                    new Person { Name = "Alice", Age = 30 },
+                    new Person { Name = "Bob", Age = 40 }
+                };
+                sheet.InsertObjects(people);
+                document.Save(openExcel);
+            }
+        }
+
+        private class Person {
+            public string Name { get; set; } = string.Empty;
+            public int Age { get; set; }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.InsertObjects.cs
+++ b/OfficeIMO.Tests/Excel.InsertObjects.cs
@@ -11,6 +11,12 @@ namespace OfficeIMO.Tests {
         private class Person {
             public string Name { get; set; } = string.Empty;
             public int Age { get; set; }
+            public Address? Address { get; set; }
+        }
+
+        private class Address {
+            public string City { get; set; } = string.Empty;
+            public string Zip { get; set; } = string.Empty;
         }
 
         [Fact]
@@ -20,8 +26,16 @@ namespace OfficeIMO.Tests {
             using (var document = ExcelDocument.Create(filePath)) {
                 var sheet = document.AddWorkSheet("Data");
                 var people = new List<Person> {
-                    new Person { Name = "Alice", Age = 30 },
-                    new Person { Name = "Bob", Age = 40 }
+                    new Person {
+                        Name = "Alice",
+                        Age = 30,
+                        Address = new Address { City = "London", Zip = "SW1" }
+                    },
+                    new Person {
+                        Name = "Bob",
+                        Age = 40,
+                        Address = new Address { City = "Paris", Zip = "75001" }
+                    }
                 };
                 sheet.InsertObjects(people);
                 document.Save();
@@ -33,18 +47,30 @@ namespace OfficeIMO.Tests {
 
                 Cell header1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "A1");
                 Cell header2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "B1");
+                Cell header3 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "C1");
+                Cell header4 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "D1");
                 Assert.Equal("Name", shared.SharedStringTable!.ElementAt(int.Parse(header1.CellValue!.Text)).InnerText);
                 Assert.Equal("Age", shared.SharedStringTable!.ElementAt(int.Parse(header2.CellValue!.Text)).InnerText);
+                Assert.Equal("Address.City", shared.SharedStringTable!.ElementAt(int.Parse(header3.CellValue!.Text)).InnerText);
+                Assert.Equal("Address.Zip", shared.SharedStringTable!.ElementAt(int.Parse(header4.CellValue!.Text)).InnerText);
 
                 Cell name1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "A2");
                 Cell age1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "B2");
+                Cell city1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "C2");
+                Cell zip1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "D2");
                 Assert.Equal("Alice", shared.SharedStringTable!.ElementAt(int.Parse(name1.CellValue!.Text)).InnerText);
                 Assert.Equal("30", age1.CellValue!.Text);
+                Assert.Equal("London", shared.SharedStringTable!.ElementAt(int.Parse(city1.CellValue!.Text)).InnerText);
+                Assert.Equal("SW1", shared.SharedStringTable!.ElementAt(int.Parse(zip1.CellValue!.Text)).InnerText);
 
                 Cell name2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "A3");
                 Cell age2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "B3");
+                Cell city2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "C3");
+                Cell zip2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "D3");
                 Assert.Equal("Bob", shared.SharedStringTable!.ElementAt(int.Parse(name2.CellValue!.Text)).InnerText);
                 Assert.Equal("40", age2.CellValue!.Text);
+                Assert.Equal("Paris", shared.SharedStringTable!.ElementAt(int.Parse(city2.CellValue!.Text)).InnerText);
+                Assert.Equal("75001", shared.SharedStringTable!.ElementAt(int.Parse(zip2.CellValue!.Text)).InnerText);
             }
         }
 
@@ -55,8 +81,16 @@ namespace OfficeIMO.Tests {
             using (var document = ExcelDocument.Create(filePath)) {
                 var sheet = document.AddWorkSheet("Data");
                 var items = new List<Dictionary<string, object>> {
-                    new Dictionary<string, object> { { "Name", "Alice" }, { "Age", 30 } },
-                    new Dictionary<string, object> { { "Name", "Bob" }, { "Age", 40 } }
+                    new Dictionary<string, object> {
+                        { "Name", "Alice" },
+                        { "Age", 30 },
+                        { "Address", new Dictionary<string, object> { { "City", "London" }, { "Zip", "SW1" } } }
+                    },
+                    new Dictionary<string, object> {
+                        { "Name", "Bob" },
+                        { "Age", 40 },
+                        { "Address", new Dictionary<string, object> { { "City", "Paris" }, { "Zip", "75001" } } }
+                    }
                 };
                 sheet.InsertObjects(items);
                 document.Save();
@@ -68,18 +102,30 @@ namespace OfficeIMO.Tests {
 
                 Cell header1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "A1");
                 Cell header2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "B1");
+                Cell header3 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "C1");
+                Cell header4 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "D1");
                 Assert.Equal("Name", shared.SharedStringTable!.ElementAt(int.Parse(header1.CellValue!.Text)).InnerText);
                 Assert.Equal("Age", shared.SharedStringTable!.ElementAt(int.Parse(header2.CellValue!.Text)).InnerText);
+                Assert.Equal("Address.City", shared.SharedStringTable!.ElementAt(int.Parse(header3.CellValue!.Text)).InnerText);
+                Assert.Equal("Address.Zip", shared.SharedStringTable!.ElementAt(int.Parse(header4.CellValue!.Text)).InnerText);
 
                 Cell name1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "A2");
                 Cell age1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "B2");
+                Cell city1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "C2");
+                Cell zip1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "D2");
                 Assert.Equal("Alice", shared.SharedStringTable!.ElementAt(int.Parse(name1.CellValue!.Text)).InnerText);
                 Assert.Equal("30", age1.CellValue!.Text);
+                Assert.Equal("London", shared.SharedStringTable!.ElementAt(int.Parse(city1.CellValue!.Text)).InnerText);
+                Assert.Equal("SW1", shared.SharedStringTable!.ElementAt(int.Parse(zip1.CellValue!.Text)).InnerText);
 
                 Cell name2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "A3");
                 Cell age2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "B3");
+                Cell city2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "C3");
+                Cell zip2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "D3");
                 Assert.Equal("Bob", shared.SharedStringTable!.ElementAt(int.Parse(name2.CellValue!.Text)).InnerText);
                 Assert.Equal("40", age2.CellValue!.Text);
+                Assert.Equal("Paris", shared.SharedStringTable!.ElementAt(int.Parse(city2.CellValue!.Text)).InnerText);
+                Assert.Equal("75001", shared.SharedStringTable!.ElementAt(int.Parse(zip2.CellValue!.Text)).InnerText);
             }
         }
     }

--- a/OfficeIMO.Tests/Excel.InsertObjects.cs
+++ b/OfficeIMO.Tests/Excel.InsertObjects.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        private class Person {
+            public string Name { get; set; } = string.Empty;
+            public int Age { get; set; }
+        }
+
+        [Fact]
+        public void Test_InsertObjectsFromClass() {
+            string filePath = Path.Combine(_directoryWithFiles, "InsertObjectsClass.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                var people = new List<Person> {
+                    new Person { Name = "Alice", Age = 30 },
+                    new Person { Name = "Bob", Age = 40 }
+                };
+                sheet.InsertObjects(people);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                SharedStringTablePart shared = spreadsheet.WorkbookPart!.SharedStringTablePart!;
+
+                Cell header1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "A1");
+                Cell header2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "B1");
+                Assert.Equal("Name", shared.SharedStringTable!.ElementAt(int.Parse(header1.CellValue!.Text)).InnerText);
+                Assert.Equal("Age", shared.SharedStringTable!.ElementAt(int.Parse(header2.CellValue!.Text)).InnerText);
+
+                Cell name1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "A2");
+                Cell age1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "B2");
+                Assert.Equal("Alice", shared.SharedStringTable!.ElementAt(int.Parse(name1.CellValue!.Text)).InnerText);
+                Assert.Equal("30", age1.CellValue!.Text);
+
+                Cell name2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "A3");
+                Cell age2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "B3");
+                Assert.Equal("Bob", shared.SharedStringTable!.ElementAt(int.Parse(name2.CellValue!.Text)).InnerText);
+                Assert.Equal("40", age2.CellValue!.Text);
+            }
+        }
+
+        [Fact]
+        public void Test_InsertObjectsFromDictionary() {
+            string filePath = Path.Combine(_directoryWithFiles, "InsertObjectsDictionary.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                var items = new List<Dictionary<string, object>> {
+                    new Dictionary<string, object> { { "Name", "Alice" }, { "Age", 30 } },
+                    new Dictionary<string, object> { { "Name", "Bob" }, { "Age", 40 } }
+                };
+                sheet.InsertObjects(items);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                SharedStringTablePart shared = spreadsheet.WorkbookPart!.SharedStringTablePart!;
+
+                Cell header1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "A1");
+                Cell header2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "B1");
+                Assert.Equal("Name", shared.SharedStringTable!.ElementAt(int.Parse(header1.CellValue!.Text)).InnerText);
+                Assert.Equal("Age", shared.SharedStringTable!.ElementAt(int.Parse(header2.CellValue!.Text)).InnerText);
+
+                Cell name1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "A2");
+                Cell age1 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "B2");
+                Assert.Equal("Alice", shared.SharedStringTable!.ElementAt(int.Parse(name1.CellValue!.Text)).InnerText);
+                Assert.Equal("30", age1.CellValue!.Text);
+
+                Cell name2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "A3");
+                Cell age2 = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "B3");
+                Assert.Equal("Bob", shared.SharedStringTable!.ElementAt(int.Parse(name2.CellValue!.Text)).InnerText);
+                Assert.Equal("40", age2.CellValue!.Text);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow inserting collections of objects or dictionaries into worksheets
- add example demonstrating object insertion
- add tests covering class and dictionary data

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -q` *(failed: Building target "GenerateTargetFrameworkMonikerAttribute" completely)*

------
https://chatgpt.com/codex/tasks/task_e_68a57f0ed37c832eac3383c43599cda6