### PR TITLE
Ensure shapes inherit Visio master dimensions

### DIFF
--- a/OfficeIMO.Tests/Visio.Load.cs
+++ b/OfficeIMO.Tests/Visio.Load.cs
@@ -27,8 +27,8 @@ namespace OfficeIMO.Tests {
             Assert.Equal("Rectangle", loadedShape.Text);
             Assert.Equal(1d, loadedShape.PinX);
             Assert.Equal(2d, loadedShape.PinY);
-            Assert.Equal(0d, loadedShape.Width);
-            Assert.Equal(0d, loadedShape.Height);
+            Assert.Equal(1d, loadedShape.Width);
+            Assert.Equal(1d, loadedShape.Height);
             Assert.NotNull(loadedShape.Master);
 
             string secondPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
@@ -36,7 +36,8 @@ namespace OfficeIMO.Tests {
             VisioDocument roundTrip = VisioDocument.Load(secondPath);
             VisioShape roundTripShape = roundTrip.Pages[0].Shapes[0];
             Assert.Equal(loadedShape.Text, roundTripShape.Text);
-            Assert.Equal(0d, roundTripShape.Width);
+            Assert.Equal(1d, roundTripShape.Width);
+            Assert.Equal(1d, roundTripShape.Height);
         }
     }
 }

--- a/OfficeIMO.Tests/Visio.MasterShapeSize.cs
+++ b/OfficeIMO.Tests/Visio.MasterShapeSize.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+using System.Linq;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioMasterShapeSize {
+        private static string AssetsPath => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets"));
+
+        [Fact]
+        public void ShapesInheritMasterSize() {
+            string file = Path.Combine(AssetsPath, "DrawingWithShapes.vsdx");
+            VisioDocument doc = VisioDocument.Load(file);
+            VisioPage page = doc.Pages[0];
+
+            VisioShape rectangle = page.Shapes.First(s => s.NameU == "Rectangle");
+            Assert.NotNull(rectangle.Master);
+            Assert.Equal(rectangle.Master.Shape.Width, rectangle.Width);
+            Assert.Equal(rectangle.Master.Shape.Height, rectangle.Height);
+            Assert.Equal(rectangle.Master.Shape.LocPinX, rectangle.LocPinX);
+            Assert.Equal(rectangle.Master.Shape.LocPinY, rectangle.LocPinY);
+
+            VisioShape square = page.Shapes.First(s => s.NameU == "Square");
+            Assert.NotNull(square.Master);
+            Assert.Equal(square.Master.Shape.Width, square.Width);
+            Assert.Equal(square.Master.Shape.Height, square.Height);
+            Assert.Equal(square.Master.Shape.LocPinX, square.LocPinX);
+            Assert.Equal(square.Master.Shape.LocPinY, square.LocPinY);
+        }
+    }
+}

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -136,6 +136,21 @@ namespace OfficeIMO.Visio {
                     string? masterIdAttr = shapeElement.Attribute("Master")?.Value;
                     if (!string.IsNullOrEmpty(masterIdAttr) && masters.TryGetValue(masterIdAttr, out VisioMaster master)) {
                         shape.Master = master;
+                        if (shape.Width == 0 || shape.Height == 0) {
+                            VisioShape masterShape = shape.Master.Shape;
+                            if (shape.Width == 0) {
+                                shape.Width = masterShape.Width;
+                            }
+                            if (shape.Height == 0) {
+                                shape.Height = masterShape.Height;
+                            }
+                            if (shape.LocPinX == 0) {
+                                shape.LocPinX = masterShape.LocPinX;
+                            }
+                            if (shape.LocPinY == 0) {
+                                shape.LocPinY = masterShape.LocPinY;
+                            }
+                        }
                     }
 
                     page.Shapes.Add(shape);


### PR DESCRIPTION
## Summary
- fix VisioDocument loading to apply master shape size when width or height is missing
- adjust load test expectations for inherited dimensions
- add regression test using DrawingWithShapes.vsdx to verify shapes copy master width, height and LocPin values

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a5955da03c832ea06f83ce1357e60f