### PR TITLE
Ensure PowerPoint presentations include required sizes

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointNotes.cs
+++ b/OfficeIMO.PowerPoint/PowerPointNotes.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using A = DocumentFormat.OpenXml.Drawing;
@@ -17,6 +18,10 @@ namespace OfficeIMO.PowerPoint {
             get {
                 if (_slidePart.NotesSlidePart == null) {
                     NotesSlidePart notesPart = _slidePart.AddNewPart<NotesSlidePart>();
+                    PresentationPart? presentationPart = _slidePart.GetParentParts().OfType<PresentationPart>().FirstOrDefault();
+                    if (presentationPart?.NotesMasterPart != null) {
+                        notesPart.AddPart(presentationPart.NotesMasterPart);
+                    }
                     notesPart.NotesSlide = new NotesSlide(
                         new CommonSlideData(new ShapeTree(
                             new Shape(

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -227,6 +227,25 @@ namespace OfficeIMO.PowerPoint {
             _presentationPart.Presentation.SlideMasterIdList = new SlideMasterIdList(new SlideMasterId {
                 Id = 1U, RelationshipId = _presentationPart.GetIdOfPart(slideMasterPart)
             });
+            NotesMasterPart notesMasterPart = _presentationPart.AddNewPart<NotesMasterPart>();
+            notesMasterPart.NotesMaster = new NotesMaster(new CommonSlideData(new ShapeTree()));
+
+            _presentationPart.Presentation.NotesMasterIdList = new NotesMasterIdList(new NotesMasterId {
+                Id = _presentationPart.GetIdOfPart(notesMasterPart)
+            });
+
+            _presentationPart.Presentation.SlideSize = new SlideSize {
+                Cx = 9144000,
+                Cy = 6858000,
+                Type = SlideSizeValues.Screen4x3
+            };
+
+            _presentationPart.Presentation.NotesSize = new NotesSize {
+                Cx = 6858000,
+                Cy = 9144000
+            };
+
+            _presentationPart.Presentation.DefaultTextStyle = new DefaultTextStyle();
 
             _presentationPart.Presentation.SlideIdList = new SlideIdList();
             _presentationPart.Presentation.Save();

--- a/OfficeIMO.Tests/PowerPoint.PresentationSizes.cs
+++ b/OfficeIMO.Tests/PowerPoint.PresentationSizes.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointPresentationSizes {
+        [Fact]
+        public void SlideAndNotesSizesAreSet() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                presentation.AddSlide();
+                presentation.Save();
+            }
+
+            using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                Assert.NotNull(document.PresentationPart?.Presentation?.SlideSize);
+                Assert.NotNull(document.PresentationPart?.Presentation?.NotesSize);
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure newly created PowerPoint files define slide and notes sizes
- link notes slides to presentation notes master when present
- test that slide and notes sizes are written

## Testing
- `dotnet test -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68a59367a24c832e8748dbb8cfb33de8