### PR TITLE
Always write shape dimensions when saving Visio files

### DIFF
--- a/OfficeIMO.Examples/Visio/MasterShapesDifferentSizes.cs
+++ b/OfficeIMO.Examples/Visio/MasterShapesDifferentSizes.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    public static class MasterShapesDifferentSizes {
+        public static void Run() {
+            string filePath = Path.Combine(Path.GetTempPath(), "MasterShapesDifferentSizes.vsdx");
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+
+            VisioShape masterShape = new("0", 0, 0, 2, 1, string.Empty);
+            VisioMaster rectangle = new("2", "Rectangle", masterShape);
+
+            VisioShape shape1 = new("1", 1, 1, 2, 1, "Same") { Master = rectangle };
+            VisioShape shape2 = new("2", 4, 1, 3, 2, "Different") { Master = rectangle };
+
+            page.Shapes.Add(shape1);
+            page.Shapes.Add(shape2);
+
+            document.Save(filePath);
+            Console.WriteLine(filePath);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.Load.cs
+++ b/OfficeIMO.Tests/Visio.Load.cs
@@ -11,33 +11,36 @@ namespace OfficeIMO.Tests {
 
             VisioDocument document = new();
             VisioPage page = document.AddPage("Page-1");
-            VisioShape shape = new("1", 1, 2, 1, 1, "Rectangle");
-            VisioMaster master = new("2", "Rectangle", shape);
-            shape.Master = master;
-            page.Shapes.Add(shape);
+            VisioShape masterShape = new("0", 0, 0, 1, 1, string.Empty);
+            VisioMaster master = new("2", "Rectangle", masterShape);
+
+            VisioShape shape1 = new("1", 1, 2, 1, 1, "Rectangle") { Master = master };
+            VisioShape shape2 = new("3", 3, 4, 2, 3, "Rectangle") { Master = master };
+            page.Shapes.Add(shape1);
+            page.Shapes.Add(shape2);
             document.Save(filePath);
 
             VisioDocument loaded = VisioDocument.Load(filePath);
             Assert.Single(loaded.Pages);
             VisioPage loadedPage = loaded.Pages[0];
-            Assert.Single(loadedPage.Shapes);
-            VisioShape loadedShape = loadedPage.Shapes[0];
-            Assert.Equal("1", loadedShape.Id);
-            Assert.Equal("Rectangle", loadedShape.NameU);
-            Assert.Equal("Rectangle", loadedShape.Text);
-            Assert.Equal(1d, loadedShape.PinX);
-            Assert.Equal(2d, loadedShape.PinY);
-            Assert.Equal(1d, loadedShape.Width);
-            Assert.Equal(1d, loadedShape.Height);
-            Assert.NotNull(loadedShape.Master);
+            Assert.Equal(2, loadedPage.Shapes.Count);
+            VisioShape loadedShape1 = loadedPage.Shapes[0];
+            VisioShape loadedShape2 = loadedPage.Shapes[1];
+            Assert.Equal("1", loadedShape1.Id);
+            Assert.Equal(1d, loadedShape1.Width);
+            Assert.Equal(1d, loadedShape1.Height);
+            Assert.Equal(2d, loadedShape2.Width);
+            Assert.Equal(3d, loadedShape2.Height);
 
             string secondPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
             loaded.Save(secondPath);
             VisioDocument roundTrip = VisioDocument.Load(secondPath);
-            VisioShape roundTripShape = roundTrip.Pages[0].Shapes[0];
-            Assert.Equal(loadedShape.Text, roundTripShape.Text);
-            Assert.Equal(1d, roundTripShape.Width);
-            Assert.Equal(1d, roundTripShape.Height);
+            VisioShape rtShape1 = roundTrip.Pages[0].Shapes[0];
+            VisioShape rtShape2 = roundTrip.Pages[0].Shapes[1];
+            Assert.Equal(1d, rtShape1.Width);
+            Assert.Equal(1d, rtShape1.Height);
+            Assert.Equal(2d, rtShape2.Width);
+            Assert.Equal(3d, rtShape2.Height);
         }
     }
 }

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -692,10 +692,18 @@ namespace OfficeIMO.Visio {
                                 writer.WriteAttributeString("Master", shape.Master.Id);
                                 WriteCell(writer, "PinX", shape.PinX);
                                 WriteCell(writer, "PinY", shape.PinY);
-                                if (Math.Abs(shape.LocPinX - shape.Width / 2) > 0) {
+                                double width = shape.Width > 0 ? shape.Width :
+                                    (shape.Master.Shape.Width > 0 ? shape.Master.Shape.Width : 1);
+                                double height = shape.Height > 0 ? shape.Height :
+                                    (shape.Master.Shape.Height > 0 ? shape.Master.Shape.Height : 1);
+                                shape.Width = width;
+                                shape.Height = height;
+                                WriteCell(writer, "Width", width);
+                                WriteCell(writer, "Height", height);
+                                if (Math.Abs(shape.LocPinX - width / 2) > 0) {
                                     WriteCell(writer, "LocPinX", shape.LocPinX);
                                 }
-                                if (Math.Abs(shape.LocPinY - shape.Height / 2) > 0) {
+                                if (Math.Abs(shape.LocPinY - height / 2) > 0) {
                                     WriteCell(writer, "LocPinY", shape.LocPinY);
                                 }
                                 if (Math.Abs(shape.Angle) > 0) {


### PR DESCRIPTION
## Summary
- ensure Visio shapes write Width and Height even when based on a master
- cover size persistence in Visio save/load round trips
- add example of master shapes with differing sizes

## Testing
- `dotnet build`
- `dotnet test --no-build --filter VisioLoad`


------
https://chatgpt.com/codex/tasks/task_e_68a5a1f5348c832ea28e97f488bacd13