### PR TITLE
Add Cell and Range builders for Excel

### DIFF
--- a/OfficeIMO.Excel/Fluent/SheetBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/SheetBuilder.cs
@@ -33,6 +33,42 @@ namespace OfficeIMO.Excel.Fluent {
             return this;
         }
 
+        public SheetBuilder Cell(int row, int column, object value) {
+            if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
+            if (row <= 0) throw new ArgumentOutOfRangeException(nameof(row));
+            if (column <= 0) throw new ArgumentOutOfRangeException(nameof(column));
+            Sheet.SetCellValue(row, column, value);
+            return this;
+        }
+
+        public SheetBuilder Range(int fromRow, int fromCol, int toRow, int toCol, object[,]? values = null) {
+            if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
+            if (fromRow <= 0) throw new ArgumentOutOfRangeException(nameof(fromRow));
+            if (fromCol <= 0) throw new ArgumentOutOfRangeException(nameof(fromCol));
+            if (toRow <= 0) throw new ArgumentOutOfRangeException(nameof(toRow));
+            if (toCol <= 0) throw new ArgumentOutOfRangeException(nameof(toCol));
+            if (toRow < fromRow) throw new ArgumentOutOfRangeException(nameof(toRow));
+            if (toCol < fromCol) throw new ArgumentOutOfRangeException(nameof(toCol));
+
+            int rowCount = toRow - fromRow + 1;
+            int colCount = toCol - fromCol + 1;
+
+            if (values != null && (values.GetLength(0) != rowCount || values.GetLength(1) != colCount)) {
+                throw new ArgumentException("Values array dimensions must match the specified range.", nameof(values));
+            }
+
+            var cells = new List<(int Row, int Column, object Value)>();
+            for (int r = 0; r < rowCount; r++) {
+                for (int c = 0; c < colCount; c++) {
+                    object cellValue = values != null ? values[r, c] : string.Empty;
+                    cells.Add((fromRow + r, fromCol + c, cellValue));
+                }
+            }
+
+            Sheet.SetCellValuesParallel(cells);
+            return this;
+        }
+
         public SheetBuilder Column(Action<ColumnBuilder> action) {
             if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
             var builder = new ColumnBuilder(Sheet);

--- a/OfficeIMO.Tests/Excel.CellAndRange.cs
+++ b/OfficeIMO.Tests/Excel.CellAndRange.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class ExcelCellAndRangeTests {
+        private static string GetCellValue(SpreadsheetDocument document, WorksheetPart worksheetPart, string cellReference) {
+            var cell = worksheetPart.Worksheet.Descendants<Cell>().First(c => c.CellReference != null && c.CellReference.Value == cellReference);
+            var value = cell.CellValue?.Text ?? string.Empty;
+            if (cell.DataType != null && cell.DataType.Value == CellValues.SharedString) {
+                var table = document.WorkbookPart.SharedStringTablePart.SharedStringTable;
+                if (int.TryParse(value, out int id)) {
+                    return table.ChildElements[id].InnerText;
+                }
+            }
+            return value;
+        }
+
+        [Fact]
+        public void CanSetSingleCell() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AsFluent().Sheet("Data", s => s.Cell(2, 3, "Hello"));
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                var sheetPart = document._spreadSheetDocument.WorkbookPart.WorksheetParts.First();
+                Assert.Equal("Hello", GetCellValue(document._spreadSheetDocument, sheetPart, "C2"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void CellEnforces1BasedIndexing() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                Assert.Throws<ArgumentOutOfRangeException>(() => document.AsFluent().Sheet("Data", s => s.Cell(0, 1, "X")));
+            }
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void CanSetRangeOfValues() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            object[,] values = {
+                { "A", "B" },
+                { "C", "D" }
+            };
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AsFluent().Sheet("Data", s => s.Range(1, 1, 2, 2, values));
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                var sheetPart = document._spreadSheetDocument.WorkbookPart.WorksheetParts.First();
+                Assert.Equal("A", GetCellValue(document._spreadSheetDocument, sheetPart, "A1"));
+                Assert.Equal("D", GetCellValue(document._spreadSheetDocument, sheetPart, "B2"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void RangeEnforces1BasedIndexing() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                Assert.Throws<ArgumentOutOfRangeException>(() => document.AsFluent().Sheet("Data", s => s.Range(0, 1, 1, 1, null)));
+            }
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support setting individual cells through fluent API
- add range builder that writes 2D arrays and validates 1-based indices
- cover cell and range builders with unit tests

## Testing
- `dotnet test --filter FullyQualifiedName~ExcelCellAndRangeTests`


------
https://chatgpt.com/codex/tasks/task_e_68a5ad7b175c832eb18393f4bc3b5405