### PR TITLE
Add Visio page shape and connector helpers

### DIFF
--- a/OfficeIMO.Examples/Visio/PageHelpers.cs
+++ b/OfficeIMO.Examples/Visio/PageHelpers.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    /// <summary>
+    /// Demonstrates page helpers for size, grid, shapes, and connectors.
+    /// </summary>
+    public static class PageHelpers {
+        public static void Example_PageHelpers(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Page helpers");
+            string filePath = Path.Combine(folderPath, "Page Helpers.vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            page.Size(11, 8.5).Grid(visible: true, snap: true);
+
+            VisioMaster master = new("1", "Rectangle", new VisioShape("1"));
+            VisioShape from = page.AddShape("1", master, 1, 1, 2, 1, "Start");
+            VisioShape to = page.AddShape("2", master, 4, 1, 2, 1, "End");
+            page.AddConnector("3", from, to, ConnectorKind.Straight);
+
+            document.Save(filePath);
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.PageHelpers.cs
+++ b/OfficeIMO.Tests/Visio.PageHelpers.cs
@@ -1,0 +1,36 @@
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioPageHelpers {
+        [Fact]
+        public void AddShapeAndConnectorPopulateCollections() {
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            VisioMaster master = new("1", "Rectangle", new VisioShape("1"));
+
+            VisioShape shape1 = page.AddShape("1", master, 1, 1, 1, 1, "Start");
+            VisioShape shape2 = page.AddShape("2", master, 2, 1, 1, 1, "End");
+
+            Assert.Equal(2, page.Shapes.Count);
+            Assert.Contains(shape1, page.Shapes);
+            Assert.Contains(shape2, page.Shapes);
+
+            VisioConnector connector = page.AddConnector("3", shape1, shape2, ConnectorKind.Straight);
+
+            Assert.Single(page.Connectors);
+            Assert.Contains(connector, page.Connectors);
+            Assert.Equal(ConnectorKind.Straight, connector.Kind);
+        }
+
+        [Fact]
+        public void SizeAndGridHelpersSetProperties() {
+            VisioPage page = new("Page-1");
+            page.Size(10, 5).Grid(true, false);
+            Assert.Equal(10, page.PageWidth);
+            Assert.Equal(5, page.PageHeight);
+            Assert.True(page.GridVisible);
+            Assert.False(page.Snap);
+        }
+    }
+}

--- a/OfficeIMO.Visio/VisioConnector.cs
+++ b/OfficeIMO.Visio/VisioConnector.cs
@@ -2,6 +2,13 @@ using System;
 using System.Globalization;
 
 namespace OfficeIMO.Visio {
+    public enum ConnectorKind {
+        Straight,
+        RightAngle,
+        Curved,
+        Dynamic
+    }
+
     /// <summary>
     /// Connects two shapes together.
     /// </summary>
@@ -35,6 +42,8 @@ namespace OfficeIMO.Visio {
         public VisioConnectionPoint? FromConnectionPoint { get; set; }
 
         public VisioConnectionPoint? ToConnectionPoint { get; set; }
+
+        public ConnectorKind Kind { get; set; } = ConnectorKind.Straight;
 
         private static string GetNextId(VisioShape from, VisioShape to) {
             int fromId = int.TryParse(from.Id, out int fi) ? fi : 0;

--- a/OfficeIMO.Visio/VisioPage.cs
+++ b/OfficeIMO.Visio/VisioPage.cs
@@ -9,6 +9,8 @@ namespace OfficeIMO.Visio {
         private readonly List<VisioConnector> _connectors = new();
         private double _pageWidth = 8.26771653543307; // A4 width in inches
         private double _pageHeight = 11.69291338582677; // A4 height in inches
+        private bool _gridVisible;
+        private bool _snap = true;
 
         public VisioPage(string name) {
             Name = name;
@@ -49,6 +51,16 @@ namespace OfficeIMO.Visio {
             }
         }
 
+        public bool GridVisible {
+            get => _gridVisible;
+            set => _gridVisible = value;
+        }
+
+        public bool Snap {
+            get => _snap;
+            set => _snap = value;
+        }
+
         /// <summary>
         /// Shapes placed on the page.
         /// </summary>
@@ -58,6 +70,30 @@ namespace OfficeIMO.Visio {
         /// Connectors placed on the page.
         /// </summary>
         public IList<VisioConnector> Connectors => _connectors;
+
+        public VisioPage Size(double w, double h) {
+            PageWidth = w;
+            PageHeight = h;
+            return this;
+        }
+
+        public VisioPage Grid(bool visible, bool snap) {
+            GridVisible = visible;
+            Snap = snap;
+            return this;
+        }
+
+        public VisioShape AddShape(string id, VisioMaster master, double x, double y, double w, double h, string? text = null) {
+            VisioShape shape = new VisioShape(id, x, y, w, h, text ?? string.Empty) { Master = master };
+            _shapes.Add(shape);
+            return shape;
+        }
+
+        public VisioConnector AddConnector(string id, VisioShape from, VisioShape to, ConnectorKind kind) {
+            VisioConnector connector = new VisioConnector(id, from, to) { Kind = kind };
+            _connectors.Add(connector);
+            return connector;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- extend VisioConnector with ConnectorKind enum and Kind property
- add AddShape/AddConnector, Size, and Grid helpers on VisioPage
- include example and tests for new VisioPage helpers

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a5ada8a7e4832e9c8be14c8d25f566