### PR TITLE
Add slide layout and text box configuration

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/FluentPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/FluentPowerPoint.cs
@@ -14,11 +14,12 @@ namespace OfficeIMO.Examples.PowerPoint {
 
             using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
                 presentation.AsFluent()
-                    .Slide()
+                    .Slide(s => s
+                        .Layout(0, 0)
                         .Title("Fluent Presentation")
-                        .Text("Hello from fluent API")
+                        .TextBox("Hello from fluent API")
                         .Bullets("First", "Second")
-                        .Notes("Example notes");
+                        .Notes("Example notes"));
                 presentation.Save();
             }
         }

--- a/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
+++ b/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace OfficeIMO.PowerPoint.Fluent {
     /// <summary>
     ///     Provides a fluent API wrapper around <see cref="PowerPointPresentation" />.
@@ -21,6 +23,15 @@ namespace OfficeIMO.PowerPoint.Fluent {
         public PowerPointSlideBuilder Slide(int masterIndex = 0, int layoutIndex = 0) {
             PowerPointSlide slide = Presentation.AddSlide(masterIndex, layoutIndex);
             return new PowerPointSlideBuilder(slide);
+        }
+
+        /// <summary>
+        ///     Adds and configures a new slide using a builder action.
+        /// </summary>
+        public PowerPointFluentPresentation Slide(Action<PowerPointSlideBuilder> configure) {
+            PowerPointSlideBuilder builder = Slide();
+            configure(builder);
+            return this;
         }
     }
 }

--- a/OfficeIMO.PowerPoint/Fluent/PowerPointSlideBuilder.cs
+++ b/OfficeIMO.PowerPoint/Fluent/PowerPointSlideBuilder.cs
@@ -13,15 +13,23 @@ namespace OfficeIMO.PowerPoint.Fluent {
         ///     Adds a title textbox to the slide.
         /// </summary>
         public PowerPointSlideBuilder Title(string text) {
-            _slide.AddTextBox(text);
+            _slide.AddTitle(text);
             return this;
         }
 
         /// <summary>
         ///     Adds a textbox with the specified text.
         /// </summary>
-        public PowerPointSlideBuilder Text(string text) {
+        public PowerPointSlideBuilder TextBox(string text) {
             _slide.AddTextBox(text);
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets the slide layout.
+        /// </summary>
+        public PowerPointSlideBuilder Layout(int masterIndex, int layoutIndex) {
+            _slide.SetLayout(masterIndex, layoutIndex);
             return this;
         }
 

--- a/OfficeIMO.Tests/PowerPoint.Fluent.cs
+++ b/OfficeIMO.Tests/PowerPoint.Fluent.cs
@@ -14,13 +14,14 @@ namespace OfficeIMO.Tests {
 
             using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
                 presentation.AsFluent()
-                    .Slide()
+                    .Slide(s => s
+                        .Layout(0, 1)
                         .Title("Fluent Title")
-                        .Text("Hello")
+                        .TextBox("Hello")
                         .Bullets("One", "Two")
                         .Image(imagePath)
                         .Table(2, 2)
-                        .Notes("Notes text");
+                        .Notes("Notes text"));
                 presentation.Save();
             }
 
@@ -33,6 +34,7 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(3, textBoxes.Count);
                 Assert.Equal("Fluent Title", textBoxes[0].Text);
                 Assert.Equal("Hello", textBoxes[1].Text);
+                Assert.Equal(1, slide.LayoutIndex);
             }
 
             File.Delete(filePath);


### PR DESCRIPTION
## Summary
- add `Layout`, `Title`, and `TextBox` fluent helpers for slides
- support changing slide layouts internally
- update sample and tests for new fluent slide configuration

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a5ad8c39c4832e8f2dc557eb79d8a9