### PR TITLE
Expose fluent End methods for Excel and PowerPoint

### DIFF
--- a/OfficeIMO.Examples/Excel/Fluent/Fluent.Example.cs
+++ b/OfficeIMO.Examples/Excel/Fluent/Fluent.Example.cs
@@ -19,8 +19,9 @@ namespace OfficeIMO.Examples.Excel {
                         .AutoFilter("A1:B3")
                         .ConditionalColorScale("B2:B3", Color.Red, Color.Green)
                         .ConditionalDataBar("B2:B3", Color.Blue)
-                        .AutoFit(columns: true, rows: true));
-                document.Save(openExcel);
+                        .AutoFit(columns: true, rows: true))
+                    .End()
+                    .Save(openExcel);
             }
         }
     }

--- a/OfficeIMO.Examples/PowerPoint/FluentPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/FluentPowerPoint.cs
@@ -13,13 +13,13 @@ namespace OfficeIMO.Examples.PowerPoint {
             string filePath = Path.Combine(folderPath, "FluentPowerPoint.pptx");
 
             using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
-                presentation.AsFluent()
-                    .Slide()
-                        .Title("Fluent Presentation")
-                        .Text("Hello from fluent API")
-                        .Bullets("First", "Second")
-                        .Notes("Example notes");
-                presentation.Save();
+                PowerPointFluentPresentation fluent = presentation.AsFluent();
+                fluent.Slide()
+                    .Title("Fluent Presentation")
+                    .Text("Hello from fluent API")
+                    .Bullets("First", "Second")
+                    .Notes("Example notes");
+                fluent.End().Save();
             }
         }
     }

--- a/OfficeIMO.Excel/Fluent/ExcelFluentWorkbook.cs
+++ b/OfficeIMO.Excel/Fluent/ExcelFluentWorkbook.cs
@@ -20,5 +20,13 @@ namespace OfficeIMO.Excel.Fluent {
             action(builder);
             return this;
         }
+
+        /// <summary>
+        /// Ends fluent configuration and returns the underlying <see cref="ExcelDocument"/>.
+        /// </summary>
+        /// <returns>The wrapped <see cref="ExcelDocument"/> for further processing.</returns>
+        public ExcelDocument End() {
+            return Workbook;
+        }
     }
 }

--- a/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
+++ b/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
@@ -22,5 +22,13 @@ namespace OfficeIMO.PowerPoint.Fluent {
             PowerPointSlide slide = Presentation.AddSlide(masterIndex, layoutIndex);
             return new PowerPointSlideBuilder(slide);
         }
+
+        /// <summary>
+        /// Ends fluent configuration and returns the underlying <see cref="PowerPointPresentation"/>.
+        /// </summary>
+        /// <returns>The wrapped <see cref="PowerPointPresentation"/> for further processing.</returns>
+        public PowerPointPresentation End() {
+            return Presentation;
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.Fluent.cs
+++ b/OfficeIMO.Tests/Excel.Fluent.cs
@@ -34,8 +34,9 @@ namespace OfficeIMO.Tests {
                         .Row(r => r.Values("Alice", 93))
                         .Row(r => r.Values("Bob", 88))
                         .Table(t => t.Add("A1:B3", true, "Scores"))
-                        .Column(c => c.AutoFit()));
-                document.Save();
+                        .Column(c => c.AutoFit()))
+                    .End()
+                    .Save();
             }
 
             using (ExcelDocument document = ExcelDocument.Load(filePath)) {
@@ -66,8 +67,9 @@ namespace OfficeIMO.Tests {
                         .AutoFilter("A1:B3", criteria)
                         .ConditionalColorScale("B2:B3", SixLaborsColor.Red, SixLaborsColor.Lime)
                         .ConditionalDataBar("B2:B3", SixLaborsColor.Blue)
-                        .AutoFit(columns: true, rows: true));
-                document.Save();
+                        .AutoFit(columns: true, rows: true))
+                    .End()
+                    .Save();
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {

--- a/OfficeIMO.Tests/PowerPoint.Fluent.cs
+++ b/OfficeIMO.Tests/PowerPoint.Fluent.cs
@@ -13,15 +13,15 @@ namespace OfficeIMO.Tests {
             string imagePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", "BackgroundImage.png");
 
             using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
-                presentation.AsFluent()
-                    .Slide()
-                        .Title("Fluent Title")
-                        .Text("Hello")
-                        .Bullets("One", "Two")
-                        .Image(imagePath)
-                        .Table(2, 2)
-                        .Notes("Notes text");
-                presentation.Save();
+                var fluent = presentation.AsFluent();
+                fluent.Slide()
+                    .Title("Fluent Title")
+                    .Text("Hello")
+                    .Bullets("One", "Two")
+                    .Image(imagePath)
+                    .Table(2, 2)
+                    .Notes("Notes text");
+                fluent.End().Save();
             }
 
             using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {


### PR DESCRIPTION
## Summary
- return ExcelDocument from ExcelFluentWorkbook.End
- return PowerPointPresentation from PowerPointFluentPresentation.End
- use End().Save(...) across fluent examples and tests

## Testing
- `dotnet test`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68a5ad6e5f04832e8784a60971f2bc15