### PR TITLE
Fix nullable warnings in tests

### DIFF
--- a/OfficeIMO.Tests/Word.MergeDocuments.cs
+++ b/OfficeIMO.Tests/Word.MergeDocuments.cs
@@ -33,10 +33,15 @@ namespace OfficeIMO.Tests {
 
             using (var merged = WordDocument.Load(filePath1)) {
                 Assert.Equal(2, merged.Lists.Count);
-                var numbering = merged._wordprocessingDocument.MainDocumentPart
-                    .NumberingDefinitionsPart!.Numbering;
-                var ids = numbering.Elements<NumberingInstance>()
-                    .Select(n => n.NumberID.Value).Distinct().ToList();
+                var mainPart = merged._wordprocessingDocument.MainDocumentPart;
+                Assert.NotNull(mainPart);
+                var numberingPart = mainPart.NumberingDefinitionsPart;
+                Assert.NotNull(numberingPart);
+                var numbering = numberingPart.Numbering;
+                Assert.NotNull(numbering);
+                var numberingInstances = numbering.Elements<NumberingInstance>().ToList();
+                Assert.All(numberingInstances, n => Assert.NotNull(n.NumberID));
+                var ids = numberingInstances.Select(n => n.NumberID!.Value).Distinct().ToList();
                 Assert.Equal(2, ids.Count);
             }
         }
@@ -68,10 +73,15 @@ namespace OfficeIMO.Tests {
 
         using (var merged = WordDocument.Load(filePath1)) {
             Assert.Equal(2, merged.Lists.Count);
-            var numbering = merged._wordprocessingDocument.MainDocumentPart
-                .NumberingDefinitionsPart!.Numbering;
-            var ids = numbering.Elements<NumberingInstance>()
-                .Select(n => n.NumberID.Value).Distinct().ToList();
+            var mainPart = merged._wordprocessingDocument.MainDocumentPart;
+            Assert.NotNull(mainPart);
+            var numberingPart = mainPart.NumberingDefinitionsPart;
+            Assert.NotNull(numberingPart);
+            var numbering = numberingPart.Numbering;
+            Assert.NotNull(numbering);
+            var numberingInstances = numbering.Elements<NumberingInstance>().ToList();
+            Assert.All(numberingInstances, n => Assert.NotNull(n.NumberID));
+            var ids = numberingInstances.Select(n => n.NumberID!.Value).Distinct().ToList();
             Assert.Equal(2, ids.Count);
             Assert.Equal(4, merged.Paragraphs.Count(p => p.IsListItem));
         }
@@ -110,10 +120,15 @@ namespace OfficeIMO.Tests {
         }
 
         using (var merged = WordDocument.Load(filePath1)) {
-            var numbering = merged._wordprocessingDocument.MainDocumentPart
-                .NumberingDefinitionsPart!.Numbering;
-            var ids = numbering.Elements<NumberingInstance>()
-                .Select(n => n.NumberID.Value).Distinct().ToList();
+            var mainPart = merged._wordprocessingDocument.MainDocumentPart;
+            Assert.NotNull(mainPart);
+            var numberingPart = mainPart.NumberingDefinitionsPart;
+            Assert.NotNull(numberingPart);
+            var numbering = numberingPart.Numbering;
+            Assert.NotNull(numbering);
+            var numberingInstances = numbering.Elements<NumberingInstance>().ToList();
+            Assert.All(numberingInstances, n => Assert.NotNull(n.NumberID));
+            var ids = numberingInstances.Select(n => n.NumberID!.Value).Distinct().ToList();
             Assert.Equal(3, ids.Count);
         }
     }

--- a/OfficeIMO.Tests/Word.PageNumbers.cs
+++ b/OfficeIMO.Tests/Word.PageNumbers.cs
@@ -37,7 +37,12 @@ namespace OfficeIMO.Tests {
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Equal(NumberFormatValues.LowerRoman, document.Sections[0].PageNumberType.Format.Value);
+                var section = document.Sections[0];
+                var pageNumberType = section.PageNumberType;
+                Assert.NotNull(pageNumberType);
+                var format = pageNumberType.Format;
+                Assert.NotNull(format);
+                Assert.Equal(NumberFormatValues.LowerRoman, format.Value);
                 var errors = document.ValidateDocument();
                 errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();
                 Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
@@ -89,7 +94,9 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var headerPart = document._wordprocessingDocument.MainDocumentPart.HeaderParts.First();
+                var mainPart = document._wordprocessingDocument.MainDocumentPart;
+                Assert.NotNull(mainPart);
+                var headerPart = mainPart.HeaderParts.First();
                 string text = headerPart.Header.InnerText;
                 Assert.Contains("custom", text);
                 var errors = document.ValidateDocument();
@@ -110,7 +117,9 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var footerPart = document._wordprocessingDocument.MainDocumentPart.FooterParts.First();
+                var mainPart = document._wordprocessingDocument.MainDocumentPart;
+                Assert.NotNull(mainPart);
+                var footerPart = mainPart.FooterParts.First();
                 string text = footerPart.Footer.InnerText;
                 Assert.Contains(" of ", text);
                 var errors = document.ValidateDocument();
@@ -137,7 +146,12 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.Equal(2, document.Sections.Count);
                 Assert.NotNull(document.Sections[1].PageNumberType);
-                Assert.Equal(1, document.Sections[1].PageNumberType.Start.Value);
+                var section1 = document.Sections[1];
+                var pageNumberType1 = section1.PageNumberType;
+                Assert.NotNull(pageNumberType1);
+                var start = pageNumberType1.Start;
+                Assert.NotNull(start);
+                Assert.Equal(1, start.Value);
                 var errors = document.ValidateDocument();
                 errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();
                 Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
@@ -155,7 +169,12 @@ namespace OfficeIMO.Tests {
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Equal(NumberFormatValues.UpperRoman, document.Sections[0].PageNumberType.Format.Value);
+                var sectionA = document.Sections[0];
+                var pageNumberTypeA = sectionA.PageNumberType;
+                Assert.NotNull(pageNumberTypeA);
+                var formatA = pageNumberTypeA.Format;
+                Assert.NotNull(formatA);
+                Assert.Equal(NumberFormatValues.UpperRoman, formatA.Value);
                 Assert.Contains(document.Sections[0].Footer.Default.Fields, f => f.FieldType == WordFieldType.Page && f.FieldFormat.Contains(WordFieldFormat.Roman));
                 var errors = document.ValidateDocument();
                 errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();
@@ -189,7 +208,9 @@ namespace OfficeIMO.Tests {
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var footerPart = document._wordprocessingDocument.MainDocumentPart.FooterParts.First();
+                var mainPart2 = document._wordprocessingDocument.MainDocumentPart;
+                Assert.NotNull(mainPart2);
+                var footerPart = mainPart2.FooterParts.First();
                 string xml = footerPart.Footer.InnerXml;
                 Assert.Contains($"\\@ \"{format}\"", xml);
                 var errors = document.ValidateDocument();

--- a/OfficeIMO.Tests/Word.TablesBorders.cs
+++ b/OfficeIMO.Tests/Word.TablesBorders.cs
@@ -27,9 +27,9 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[1].Borders.LeftSpace = 5U;
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftStyle == BorderValues.Dotted);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSpace == 5U);
+                Assert.Equal(Color.Gold, wordTable.Rows[1].Cells[1].Borders.LeftColor);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.LeftSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.LeftSpace?.Value);
 
 
 
@@ -43,10 +43,10 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[1].Borders.RightSize = 4;
                 wordTable.Rows[1].Cells[1].Borders.RightSpace = 5U;
 
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightStyle == BorderValues.Double);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSize == 4);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSpace == 5U);
+                Assert.Equal(BorderValues.Double, wordTable.Rows[1].Cells[1].Borders.RightStyle);
+                Assert.Equal(Color.Gold, wordTable.Rows[1].Cells[1].Borders.RightColor);
+                Assert.Equal(4U, wordTable.Rows[1].Cells[1].Borders.RightSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.RightSpace?.Value);
 
 
 
@@ -58,10 +58,10 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[1].Borders.TopSize = 6;
                 wordTable.Rows[1].Cells[1].Borders.TopSpace = 5U;
 
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopStyle == BorderValues.CirclesRectangles);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSize == 6);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSpace == 5U);
+                Assert.Equal(BorderValues.CirclesRectangles, wordTable.Rows[1].Cells[1].Borders.TopStyle);
+                Assert.Equal(Color.Gold, wordTable.Rows[1].Cells[1].Borders.TopColor);
+                Assert.Equal(6U, wordTable.Rows[1].Cells[1].Borders.TopSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.TopSpace?.Value);
 
 
 
@@ -72,10 +72,10 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[1].Borders.BottomSize = 8;
                 wordTable.Rows[1].Cells[1].Borders.BottomSpace = 5U;
 
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomStyle == BorderValues.Safari);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomColor == Color.Cyan);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSize == 8);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSpace == 5U);
+                Assert.Equal(BorderValues.Safari, wordTable.Rows[1].Cells[1].Borders.BottomStyle);
+                Assert.Equal(Color.Cyan, wordTable.Rows[1].Cells[1].Borders.BottomColor);
+                Assert.Equal(8U, wordTable.Rows[1].Cells[1].Borders.BottomSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.BottomSpace?.Value);
 
                 wordTable.Rows[1].Cells[1].Borders.StartStyle = BorderValues.DashSmallGap;
                 wordTable.Rows[1].Cells[1].Borders.StartColorHex = SixLabors.ImageSharp.Color.Orange.ToHexColor();
@@ -84,10 +84,10 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[1].Borders.StartSize = 24;
                 wordTable.Rows[1].Cells[1].Borders.StartSpace = 10U;
 
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartStyle == BorderValues.DashSmallGap);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartColor == Color.Yellow);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSpace == 10U);
+                Assert.Equal(BorderValues.DashSmallGap, wordTable.Rows[1].Cells[1].Borders.StartStyle);
+                Assert.Equal(Color.Yellow, wordTable.Rows[1].Cells[1].Borders.StartColor);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.StartSize?.Value);
+                Assert.Equal(10U, wordTable.Rows[1].Cells[1].Borders.StartSpace?.Value);
 
                 wordTable.Rows[1].Cells[1].Borders.EndStyle = BorderValues.Dotted;
                 wordTable.Rows[1].Cells[1].Borders.EndColorHex = SixLabors.ImageSharp.Color.OrangeRed.ToHexColor();
@@ -96,10 +96,10 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[1].Borders.EndSize = 24;
                 //wordTable.Rows[1].Cells[1].Borders.EndSpace = 5U;
 
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndStyle == BorderValues.Dotted);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSpace == null);
+                Assert.Equal(BorderValues.Dotted, wordTable.Rows[1].Cells[1].Borders.EndStyle);
+                Assert.Equal(Color.Gold, wordTable.Rows[1].Cells[1].Borders.EndColor);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.EndSize?.Value);
+                Assert.Null(wordTable.Rows[1].Cells[1].Borders.EndSpace);
 
 
                 wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle = BorderValues.Dotted;
@@ -109,10 +109,10 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize = 24;
                 wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace = 5U;
 
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle == BorderValues.Dotted);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace == 5U);
+                Assert.Equal(BorderValues.Dotted, wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle);
+                Assert.Equal(Color.Gold, wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightColor);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace?.Value);
 
 
                 wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle = BorderValues.Dotted;
@@ -189,10 +189,10 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[1].Borders.BottomSize = 8;
                 wordTable.Rows[1].Cells[1].Borders.BottomSpace = 5U;
 
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomStyle == BorderValues.Safari);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomColor == Color.Cyan);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSize == 8);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSpace == 5U);
+                  Assert.Equal(BorderValues.Safari, wordTable.Rows[1].Cells[1].Borders.BottomStyle);
+                  Assert.Equal(Color.Cyan, wordTable.Rows[1].Cells[1].Borders.BottomColor);
+                  Assert.Equal(8U, wordTable.Rows[1].Cells[1].Borders.BottomSize?.Value);
+                  Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.BottomSpace?.Value);
 
                 wordTable.Rows[1].Cells[1].Borders.StartStyle = BorderValues.DashSmallGap;
                 wordTable.Rows[1].Cells[1].Borders.StartColorHex = SixLabors.ImageSharp.Color.Orange.ToHexColor();
@@ -201,10 +201,10 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[1].Borders.StartSize = 24;
                 wordTable.Rows[1].Cells[1].Borders.StartSpace = 10U;
 
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartStyle == BorderValues.DashSmallGap);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartColor == Color.Yellow);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSpace == 10U);
+                  Assert.Equal(BorderValues.DashSmallGap, wordTable.Rows[1].Cells[1].Borders.StartStyle);
+                  Assert.Equal(Color.Yellow, wordTable.Rows[1].Cells[1].Borders.StartColor);
+                  Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.StartSize?.Value);
+                  Assert.Equal(10U, wordTable.Rows[1].Cells[1].Borders.StartSpace?.Value);
 
                 wordTable.Rows[1].Cells[1].Borders.EndStyle = BorderValues.Dotted;
                 wordTable.Rows[1].Cells[1].Borders.EndColorHex = SixLabors.ImageSharp.Color.OrangeRed.ToHexColor();
@@ -213,10 +213,10 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[1].Borders.EndSize = 24;
                 //wordTable.Rows[1].Cells[1].Borders.EndSpace = 5U;
 
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndStyle == BorderValues.Dotted);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSpace == null);
+                  Assert.Equal(BorderValues.Dotted, wordTable.Rows[1].Cells[1].Borders.EndStyle);
+                  Assert.Equal(Color.Gold, wordTable.Rows[1].Cells[1].Borders.EndColor);
+                  Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.EndSize?.Value);
+                  Assert.Null(wordTable.Rows[1].Cells[1].Borders.EndSpace);
 
 
                 wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle = BorderValues.Dotted;
@@ -226,10 +226,10 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize = 24;
                 wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace = 5U;
 
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle == BorderValues.Dotted);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace == 5U);
+                  Assert.Equal(BorderValues.Dotted, wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle);
+                  Assert.Equal(Color.Gold, wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightColor);
+                  Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize?.Value);
+                  Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace?.Value);
 
 
                 wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle = BorderValues.Dotted;
@@ -239,10 +239,10 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize = 16;
                 wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace = 1U;
 
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle == BorderValues.Dotted);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftColor == Color.Aqua);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize == 16);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace == 1U);
+                  Assert.Equal(BorderValues.Dotted, wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle);
+                  Assert.Equal(Color.Aqua, wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftColor);
+                  Assert.Equal(16U, wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize?.Value);
+                  Assert.Equal(1U, wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace?.Value);
 
                 document.Save();
             }
@@ -366,10 +366,10 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[1].Borders.InsideVerticalSize = 15;
                 wordTable.Rows[1].Cells[1].Borders.InsideVerticalSpace = 3U;
 
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideVerticalStyle == BorderValues.DecoBlocks);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideVerticalColor == Color.DarkSlateBlue);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideVerticalSize == 15);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideVerticalSpace == 3U);
+                  Assert.Equal(BorderValues.DecoBlocks, wordTable.Rows[1].Cells[1].Borders.InsideVerticalStyle);
+                  Assert.Equal(Color.DarkSlateBlue, wordTable.Rows[1].Cells[1].Borders.InsideVerticalColor);
+                  Assert.Equal(15U, wordTable.Rows[1].Cells[1].Borders.InsideVerticalSize?.Value);
+                  Assert.Equal(3U, wordTable.Rows[1].Cells[1].Borders.InsideVerticalSpace?.Value);
 
                 wordTable.Rows[1].Cells[1].Borders.InsideHorizontalStyle = BorderValues.DecoBlocks;
                 wordTable.Rows[1].Cells[1].Borders.InsideHorizontalColorHex = SixLabors.ImageSharp.Color.YellowGreen.ToHexColor();
@@ -378,10 +378,10 @@ namespace OfficeIMO.Tests {
                 wordTable.Rows[1].Cells[1].Borders.InsideHorizontalSize = 15;
                 wordTable.Rows[1].Cells[1].Borders.InsideHorizontalSpace = 3U;
 
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideHorizontalStyle == BorderValues.DecoBlocks);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideHorizontalColor == Color.DarkSlateBlue);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideHorizontalSize == 15);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideHorizontalSpace == 3U);
+                  Assert.Equal(BorderValues.DecoBlocks, wordTable.Rows[1].Cells[1].Borders.InsideHorizontalStyle);
+                  Assert.Equal(Color.DarkSlateBlue, wordTable.Rows[1].Cells[1].Borders.InsideHorizontalColor);
+                  Assert.Equal(15U, wordTable.Rows[1].Cells[1].Borders.InsideHorizontalSize?.Value);
+                  Assert.Equal(3U, wordTable.Rows[1].Cells[1].Borders.InsideHorizontalSpace?.Value);
 
                 document.Save();
             }

--- a/OfficeIMO.Tests/Word.TextBox.cs
+++ b/OfficeIMO.Tests/Word.TextBox.cs
@@ -22,7 +22,7 @@ namespace OfficeIMO.Tests {
                 textBox.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
                 textBox.HorizontalPositionOffsetCentimeters = 3;
 
-                Assert.Equal(document.TextBoxes[0].HorizontalPositionOffsetCentimeters, 3);
+                Assert.Equal(3, document.TextBoxes[0].HorizontalPositionOffsetCentimeters ?? 0);
 
                 textBox.HorizontalAlignment = WordHorizontalAlignmentValues.Left;
 
@@ -64,7 +64,7 @@ namespace OfficeIMO.Tests {
 
                 textBox.VerticalPositionOffsetCentimeters = 3;
 
-                Assert.True(document.TextBoxes[0].VerticalPositionOffsetCentimeters == 3);
+                Assert.Equal(3, document.TextBoxes[0].VerticalPositionOffsetCentimeters ?? 0);
 
                 document.Save(false);
 
@@ -115,22 +115,22 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs.Count == 2);
                 Assert.True(document.Sections[0].TextBoxes.Count == 1);
 
-                Assert.True(textBox3.Paragraphs[0].Borders.BottomStyle == BorderValues.BasicWideOutline);
-                Assert.True(textBox3.Paragraphs[0].Borders.BottomSize == 10);
-                Assert.True(textBox3.Paragraphs[0].Borders.BottomColor == Color.Red);
-                Assert.True(textBox3.Paragraphs[0].Borders.BottomShadow == false);
-                Assert.True(textBox3.Paragraphs[0].Borders.TopStyle == BorderValues.BasicWideOutline);
-                Assert.True(textBox3.Paragraphs[0].Borders.LeftStyle == BorderValues.BasicWideOutline);
-                Assert.True(textBox3.Paragraphs[0].Borders.RightStyle == BorderValues.BasicWideOutline);
+                Assert.Equal(BorderValues.BasicWideOutline, textBox3.Paragraphs[0].Borders.BottomStyle);
+                Assert.Equal(10U, textBox3.Paragraphs[0].Borders.BottomSize?.Value);
+                Assert.Equal(Color.Red, textBox3.Paragraphs[0].Borders.BottomColor);
+                Assert.False(textBox3.Paragraphs[0].Borders.BottomShadow ?? true);
+                Assert.Equal(BorderValues.BasicWideOutline, textBox3.Paragraphs[0].Borders.TopStyle);
+                Assert.Equal(BorderValues.BasicWideOutline, textBox3.Paragraphs[0].Borders.LeftStyle);
+                Assert.Equal(BorderValues.BasicWideOutline, textBox3.Paragraphs[0].Borders.RightStyle);
 
                 textBox3.Paragraphs[0].Borders.SetBorder(WordParagraphBorderType.Left, BorderValues.BasicThinLines, Color.Green, 15, false);
 
-                Assert.True(textBox3.Paragraphs[0].Borders.LeftStyle == BorderValues.BasicThinLines);
-                Assert.True(textBox3.Paragraphs[0].Borders.LeftSize == 15);
-                Assert.True(textBox3.Paragraphs[0].Borders.LeftColor == Color.Green);
-                Assert.True(textBox3.Paragraphs[0].Borders.LeftShadow == false);
+                Assert.Equal(BorderValues.BasicThinLines, textBox3.Paragraphs[0].Borders.LeftStyle);
+                Assert.Equal(15U, textBox3.Paragraphs[0].Borders.LeftSize?.Value);
+                Assert.Equal(Color.Green, textBox3.Paragraphs[0].Borders.LeftColor);
+                Assert.False(textBox3.Paragraphs[0].Borders.LeftShadow ?? true);
 
-                Assert.True(document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftColorHex == "008000");
+                Assert.Equal("008000", document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftColorHex);
 
 
                 document.Save(false);
@@ -141,52 +141,52 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs.Count == 2);
                 Assert.True(document.TextBoxes.Count == 1);
 
-                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.BottomStyle == BorderValues.BasicWideOutline);
-                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.BottomSize == 10);
-                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.BottomColor == Color.Red);
-                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.BottomShadow == false);
-                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.TopStyle == BorderValues.BasicWideOutline);
-                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.RightStyle == BorderValues.BasicWideOutline);
+                Assert.Equal(BorderValues.BasicWideOutline, document.TextBoxes[0].Paragraphs[0].Borders.BottomStyle);
+                Assert.Equal(10U, document.TextBoxes[0].Paragraphs[0].Borders.BottomSize?.Value);
+                Assert.Equal(Color.Red, document.TextBoxes[0].Paragraphs[0].Borders.BottomColor);
+                Assert.False(document.TextBoxes[0].Paragraphs[0].Borders.BottomShadow ?? true);
+                Assert.Equal(BorderValues.BasicWideOutline, document.TextBoxes[0].Paragraphs[0].Borders.TopStyle);
+                Assert.Equal(BorderValues.BasicWideOutline, document.TextBoxes[0].Paragraphs[0].Borders.RightStyle);
 
-                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.LeftStyle == BorderValues.BasicThinLines);
-                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.LeftSize == 15);
-                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.LeftColor == Color.Green);
-                Assert.True(document.TextBoxes[0].Paragraphs[0].Borders.LeftShadow == false);
+                Assert.Equal(BorderValues.BasicThinLines, document.TextBoxes[0].Paragraphs[0].Borders.LeftStyle);
+                Assert.Equal(15U, document.TextBoxes[0].Paragraphs[0].Borders.LeftSize?.Value);
+                Assert.Equal(Color.Green, document.TextBoxes[0].Paragraphs[0].Borders.LeftColor);
+                Assert.False(document.TextBoxes[0].Paragraphs[0].Borders.LeftShadow ?? true);
 
-                Assert.True(document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftStyle == BorderValues.BasicThinLines);
-                Assert.True(document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftSize == 15);
-                Assert.True(document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftColor == Color.Green);
-                Assert.True(document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftShadow == false);
+                Assert.Equal(BorderValues.BasicThinLines, document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftStyle);
+                Assert.Equal(15U, document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftSize?.Value);
+                Assert.Equal(Color.Green, document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftColor);
+                Assert.False(document.Sections[0].TextBoxes[0].Paragraphs[0].Borders.LeftShadow ?? true);
 
 
-                var borders = document.ParagraphsTextBoxes[0].TextBox!.Paragraphs[0].Borders!;
-                borders.Type = WordBorder.Shadow;
+                var borders = document.ParagraphsTextBoxes[0].TextBox?.Paragraphs[0].Borders;
+                Assert.NotNull(borders);
+                borders!.Type = WordBorder.Shadow;
 
                 Assert.Equal(WordBorder.Shadow, borders.Type);
                 Assert.Equal(BorderValues.Single, borders.BottomStyle);
-                Assert.True(borders.BottomSize == 4);
+                Assert.Equal(4U, borders.BottomSize?.Value);
                 Assert.Null(borders.BottomColor);
-                Assert.True(borders.BottomShadow);
-                Assert.True(borders.BottomSpace == 24);
+                Assert.True(borders.BottomShadow ?? false);
+                Assert.Equal(24U, borders.BottomSpace?.Value);
 
                 Assert.Equal(BorderValues.Single, borders.TopStyle);
-                Assert.True(borders.TopSize == 4);
+                Assert.Equal(4U, borders.TopSize?.Value);
                 Assert.Null(borders.TopColor);
-                Assert.True(borders.TopShadow);
-                Assert.True(borders.TopSpace == 24);
+                Assert.True(borders.TopShadow ?? false);
+                Assert.Equal(24U, borders.TopSpace?.Value);
 
                 Assert.Equal(BorderValues.Single, borders.LeftStyle);
-                Assert.True(borders.LeftSize == 4);
+                Assert.Equal(4U, borders.LeftSize?.Value);
                 Assert.Null(borders.LeftColor);
-                Assert.True(borders.LeftShadow);
-                Assert.True(borders.LeftSpace == 24);
+                Assert.True(borders.LeftShadow ?? false);
+                Assert.Equal(24U, borders.LeftSpace?.Value);
 
                 Assert.Equal(BorderValues.Single, borders.RightStyle);
-                Assert.NotNull(borders.RightSize);
-                Assert.Equal(4U, borders.RightSize!.Value);
+                Assert.Equal(4U, borders.RightSize?.Value);
                 Assert.Null(borders.RightColor);
-                Assert.True(borders.RightShadow);
-                Assert.True(borders.RightSpace == 24);
+                Assert.True(borders.RightShadow ?? false);
+                Assert.Equal(24U, borders.RightSpace?.Value);
 
                 var textBox1 = document.AddTextBox("My textbox in the center with borders");
 
@@ -228,30 +228,29 @@ namespace OfficeIMO.Tests {
 
                 document.TextBoxes[1].Paragraphs[0].Borders.Type = WordBorder.Box;
 
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomStyle == BorderValues.Single);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomSize == 4);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomColor == null);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomShadow == null);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomSpace == 24);
+                Assert.Equal(BorderValues.Single, document.TextBoxes[1].Paragraphs[0].Borders.BottomStyle);
+                Assert.Equal(4U, document.TextBoxes[1].Paragraphs[0].Borders.BottomSize?.Value);
+                Assert.Null(document.TextBoxes[1].Paragraphs[0].Borders.BottomColor);
+                Assert.Null(document.TextBoxes[1].Paragraphs[0].Borders.BottomShadow);
+                Assert.Equal(24U, document.TextBoxes[1].Paragraphs[0].Borders.BottomSpace?.Value);
                 Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.BottomFrame == null);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopStyle == BorderValues.Single);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopSize == 4);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopColor == null);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopShadow == null);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopSpace == 24);
+                Assert.Equal(BorderValues.Single, document.TextBoxes[1].Paragraphs[0].Borders.TopStyle);
+                Assert.Equal(4U, document.TextBoxes[1].Paragraphs[0].Borders.TopSize?.Value);
+                Assert.Null(document.TextBoxes[1].Paragraphs[0].Borders.TopColor);
+                Assert.Null(document.TextBoxes[1].Paragraphs[0].Borders.TopShadow);
+                Assert.Equal(24U, document.TextBoxes[1].Paragraphs[0].Borders.TopSpace?.Value);
                 Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.TopFrame == null);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftStyle == BorderValues.Single);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftSize == 4);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftColor == null);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftShadow == null);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftSpace == 24);
+                Assert.Equal(BorderValues.Single, document.TextBoxes[1].Paragraphs[0].Borders.LeftStyle);
+                Assert.Equal(4U, document.TextBoxes[1].Paragraphs[0].Borders.LeftSize?.Value);
+                Assert.Null(document.TextBoxes[1].Paragraphs[0].Borders.LeftColor);
+                Assert.Null(document.TextBoxes[1].Paragraphs[0].Borders.LeftShadow);
+                Assert.Equal(24U, document.TextBoxes[1].Paragraphs[0].Borders.LeftSpace?.Value);
                 Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.LeftFrame == null);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightStyle == BorderValues.Single);
-                Assert.NotNull(document.TextBoxes[1].Paragraphs[0].Borders.RightSize);
-                Assert.Equal(4U, document.TextBoxes[1].Paragraphs[0].Borders.RightSize!.Value);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightColor == null);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightShadow == null);
-                Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightSpace == 24);
+                Assert.Equal(BorderValues.Single, document.TextBoxes[1].Paragraphs[0].Borders.RightStyle);
+                Assert.Equal(4U, document.TextBoxes[1].Paragraphs[0].Borders.RightSize?.Value);
+                Assert.Null(document.TextBoxes[1].Paragraphs[0].Borders.RightColor);
+                Assert.Null(document.TextBoxes[1].Paragraphs[0].Borders.RightShadow);
+                Assert.Equal(24U, document.TextBoxes[1].Paragraphs[0].Borders.RightSpace?.Value);
                 Assert.True(document.TextBoxes[1].Paragraphs[0].Borders.RightFrame == null);
 
                 document.Save();


### PR DESCRIPTION
## Summary
- add null checks and safe value handling to Word textbox tests
- ensure document parts are validated before use in merge and page number tests
- replace unchecked border assertions with nullable-friendly assertions

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a5afd00cf8832e97b186c042ecdb42