### PR TITLE
Add End method for Excel and PowerPoint fluent builders

### DIFF
--- a/OfficeIMO.Examples/Excel/Fluent/Fluent.Example.cs
+++ b/OfficeIMO.Examples/Excel/Fluent/Fluent.Example.cs
@@ -19,8 +19,9 @@ namespace OfficeIMO.Examples.Excel {
                         .AutoFilter("A1:B3")
                         .ConditionalColorScale("B2:B3", Color.Red, Color.Green)
                         .ConditionalDataBar("B2:B3", Color.Blue)
-                        .AutoFit(columns: true, rows: true));
-                document.Save(openExcel);
+                        .AutoFit(columns: true, rows: true))
+                    .End()
+                    .Save(openExcel);
             }
         }
     }

--- a/OfficeIMO.Examples/PowerPoint/FluentPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/FluentPowerPoint.cs
@@ -19,8 +19,9 @@ namespace OfficeIMO.Examples.PowerPoint {
                         .Title("Fluent Presentation")
                         .TextBox("Hello from fluent API")
                         .Bullets("First", "Second")
-                        .Notes("Example notes"));
-                presentation.Save();
+                        .Notes("Example notes"))
+                    .End()
+                    .Save();
             }
         }
     }

--- a/OfficeIMO.Excel/Fluent/ExcelFluentWorkbook.cs
+++ b/OfficeIMO.Excel/Fluent/ExcelFluentWorkbook.cs
@@ -20,5 +20,9 @@ namespace OfficeIMO.Excel.Fluent {
             action(builder);
             return this;
         }
+
+        public ExcelDocument End() {
+            return Workbook;
+        }
     }
 }

--- a/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
+++ b/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
@@ -33,5 +33,9 @@ namespace OfficeIMO.PowerPoint.Fluent {
             configure(builder);
             return this;
         }
+
+        public PowerPointPresentation End() {
+            return Presentation;
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.Fluent.cs
+++ b/OfficeIMO.Tests/Excel.Fluent.cs
@@ -34,8 +34,9 @@ namespace OfficeIMO.Tests {
                         .Row(r => r.Values("Alice", 93))
                         .Row(r => r.Values("Bob", 88))
                         .Table(t => t.Add("A1:B3", true, "Scores"))
-                        .Column(c => c.AutoFit()));
-                document.Save();
+                        .Column(c => c.AutoFit()))
+                    .End()
+                    .Save();
             }
 
             using (ExcelDocument document = ExcelDocument.Load(filePath)) {
@@ -66,8 +67,9 @@ namespace OfficeIMO.Tests {
                         .AutoFilter("A1:B3", criteria)
                         .ConditionalColorScale("B2:B3", SixLaborsColor.Red, SixLaborsColor.Lime)
                         .ConditionalDataBar("B2:B3", SixLaborsColor.Blue)
-                        .AutoFit(columns: true, rows: true));
-                document.Save();
+                        .AutoFit(columns: true, rows: true))
+                    .End()
+                    .Save();
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {

--- a/OfficeIMO.Tests/PowerPoint.Fluent.cs
+++ b/OfficeIMO.Tests/PowerPoint.Fluent.cs
@@ -21,8 +21,9 @@ namespace OfficeIMO.Tests {
                         .Bullets("One", "Two")
                         .Image(imagePath)
                         .Table(2, 2)
-                        .Notes("Notes text"));
-                presentation.Save();
+                        .Notes("Notes text"))
+                    .End()
+                    .Save();
             }
 
             using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {


### PR DESCRIPTION
## Summary
- Implement End() in ExcelFluentWorkbook and PowerPointFluentPresentation to return underlying documents
- Update Excel and PowerPoint examples and tests to chain `.End().Save()`

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a5b2e56f14832ebe6c296b3b8a3273