### PR TITLE
Organize Visio project files and add XML docs

### DIFF
--- a/OfficeIMO.Visio/ConnectorKind.cs
+++ b/OfficeIMO.Visio/ConnectorKind.cs
@@ -1,0 +1,15 @@
+namespace OfficeIMO.Visio {
+    /// <summary>
+    /// Specifies the type of connector used to link shapes.
+    /// </summary>
+    public enum ConnectorKind {
+        /// <summary>Straight line connector.</summary>
+        Straight,
+        /// <summary>Right-angle connector.</summary>
+        RightAngle,
+        /// <summary>Curved connector.</summary>
+        Curved,
+        /// <summary>Connector whose type is determined dynamically.</summary>
+        Dynamic
+    }
+}

--- a/OfficeIMO.Visio/Fluent/VisioFluentDocument.cs
+++ b/OfficeIMO.Visio/Fluent/VisioFluentDocument.cs
@@ -30,17 +30,4 @@ namespace OfficeIMO.Visio.Fluent {
             return _document;
         }
     }
-
-    /// <summary>
-    /// Extension methods for <see cref="VisioDocument"/> to enable fluent configuration.
-    /// </summary>
-    public static class VisioFluentDocumentExtensions {
-        /// <summary>
-        /// Wraps the document in a <see cref="VisioFluentDocument"/> for fluent configuration.
-        /// </summary>
-        /// <param name="doc">The document to wrap.</param>
-        public static VisioFluentDocument AsFluent(this VisioDocument doc) {
-            return new VisioFluentDocument(doc);
-        }
-    }
 }

--- a/OfficeIMO.Visio/Fluent/VisioFluentDocumentExtensions.cs
+++ b/OfficeIMO.Visio/Fluent/VisioFluentDocumentExtensions.cs
@@ -1,0 +1,14 @@
+namespace OfficeIMO.Visio.Fluent {
+    /// <summary>
+    /// Extension methods for <see cref="VisioDocument"/> to enable fluent configuration.
+    /// </summary>
+    public static class VisioFluentDocumentExtensions {
+        /// <summary>
+        /// Wraps the document in a <see cref="VisioFluentDocument"/> for fluent configuration.
+        /// </summary>
+        /// <param name="doc">The document to wrap.</param>
+        public static VisioFluentDocument AsFluent(this VisioDocument doc) {
+            return new VisioFluentDocument(doc);
+        }
+    }
+}

--- a/OfficeIMO.Visio/VisioConnector.cs
+++ b/OfficeIMO.Visio/VisioConnector.cs
@@ -2,22 +2,26 @@ using System;
 using System.Globalization;
 
 namespace OfficeIMO.Visio {
-    public enum ConnectorKind {
-        Straight,
-        RightAngle,
-        Curved,
-        Dynamic
-    }
-
     /// <summary>
     /// Connects two shapes together.
     /// </summary>
     public class VisioConnector {
         private static int _idCounter;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisioConnector"/> class connecting two shapes.
+        /// </summary>
+        /// <param name="from">Shape from which the connector starts.</param>
+        /// <param name="to">Shape at which the connector ends.</param>
         public VisioConnector(VisioShape from, VisioShape to) : this(GetNextId(from, to), from, to) {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisioConnector"/> class with an explicit identifier.
+        /// </summary>
+        /// <param name="id">Identifier of the connector.</param>
+        /// <param name="from">Shape from which the connector starts.</param>
+        /// <param name="to">Shape at which the connector ends.</param>
         public VisioConnector(string id, VisioShape from, VisioShape to) {
             Id = id;
             From = from;
@@ -39,10 +43,19 @@ namespace OfficeIMO.Visio {
         /// </summary>
         public VisioShape To { get; }
 
+        /// <summary>
+        /// Connection point on the starting shape.
+        /// </summary>
         public VisioConnectionPoint? FromConnectionPoint { get; set; }
 
+        /// <summary>
+        /// Connection point on the ending shape.
+        /// </summary>
         public VisioConnectionPoint? ToConnectionPoint { get; set; }
 
+        /// <summary>
+        /// Gets or sets the kind of connector.
+        /// </summary>
         public ConnectorKind Kind { get; set; } = ConnectorKind.Straight;
 
         private static string GetNextId(VisioShape from, VisioShape to) {


### PR DESCRIPTION
## Summary
- move `ConnectorKind` enum into its own file with documentation
- split fluent extension class into separate file
- document `VisioConnector` constructors and properties

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b3e57918832e911746ff76a25d0c