### PR TITLE
Ensure width and height saved for Visio master shapes

### DIFF
--- a/OfficeIMO.Tests/Visio.Masters.cs
+++ b/OfficeIMO.Tests/Visio.Masters.cs
@@ -31,6 +31,10 @@ namespace OfficeIMO.Tests {
             VisioDocument loaded = VisioDocument.Load(filePath);
             Assert.NotNull(loaded.Pages[0].Shapes[0].Master);
             Assert.Equal("Rectangle", loaded.Pages[0].Shapes[0].Master?.NameU);
+            Assert.Equal(2, loaded.Pages[0].Shapes[0].Width, 5);
+            Assert.Equal(1, loaded.Pages[0].Shapes[0].Height, 5);
+            Assert.Equal(2, loaded.Pages[0].Shapes[1].Width, 5);
+            Assert.Equal(1, loaded.Pages[0].Shapes[1].Height, 5);
 
             using (Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read)) {
                 Assert.True(package.PartExists(new Uri("/visio/masters/masters.xml", UriKind.Relative)));

--- a/OfficeIMO.Tests/Visio.ShapeProperties.cs
+++ b/OfficeIMO.Tests/Visio.ShapeProperties.cs
@@ -26,6 +26,8 @@ namespace OfficeIMO.Tests {
             Assert.Equal(1.5, loaded.LocPinX, 5);
             Assert.Equal(2.5, loaded.LocPinY, 5);
             Assert.Equal(0.3, loaded.Angle, 5);
+            Assert.Equal(4, loaded.Width, 5);
+            Assert.Equal(6, loaded.Height, 5);
         }
 
         [Fact]

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -692,10 +692,20 @@ namespace OfficeIMO.Visio {
                                 writer.WriteAttributeString("Master", shape.Master.Id);
                                 WriteCell(writer, "PinX", shape.PinX);
                                 WriteCell(writer, "PinY", shape.PinY);
-                                double width = shape.Width > 0 ? shape.Width :
-                                    (shape.Master.Shape.Width > 0 ? shape.Master.Shape.Width : 1);
-                                double height = shape.Height > 0 ? shape.Height :
-                                    (shape.Master.Shape.Height > 0 ? shape.Master.Shape.Height : 1);
+                                double width = shape.Width;
+                                if (width <= 0 && shape.Master.Shape.Width > 0) {
+                                    width = shape.Master.Shape.Width;
+                                }
+                                if (width <= 0) {
+                                    width = 1;
+                                }
+                                double height = shape.Height;
+                                if (height <= 0 && shape.Master.Shape.Height > 0) {
+                                    height = shape.Master.Shape.Height;
+                                }
+                                if (height <= 0) {
+                                    height = 1;
+                                }
                                 shape.Width = width;
                                 shape.Height = height;
                                 WriteCell(writer, "Width", width);


### PR DESCRIPTION
## Summary
- always emit Width and Height cells for shapes even when a master is present
- verify save/load round-trips retain shape sizes

## Testing
- `dotnet test > /tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68a5b510ee30832ebf5fde46d45d5b19