### PR TITLE
Add fluent chaining for PowerPoint slides

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/FluentPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/FluentPowerPoint.cs
@@ -20,6 +20,7 @@ namespace OfficeIMO.Examples.PowerPoint {
                         .TextBox("Hello from fluent API")
                         .Bullets("First", "Second")
                         .Notes("Example notes"))
+                    .Slide(s => s.Title("Second Slide"))
                     .End()
                     .Save();
             }

--- a/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
+++ b/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
@@ -16,22 +16,26 @@ namespace OfficeIMO.PowerPoint.Fluent {
         internal PowerPointPresentation Presentation { get; }
 
         /// <summary>
-        ///     Adds a new slide to the presentation.
+        ///     Adds and optionally configures a new slide to the presentation.
         /// </summary>
         /// <param name="masterIndex">Index of the slide master.</param>
         /// <param name="layoutIndex">Index of the slide layout.</param>
-        public PowerPointSlideBuilder Slide(int masterIndex = 0, int layoutIndex = 0) {
+        /// <param name="configure">Optional action used to configure the slide via a <see cref="PowerPointSlideBuilder"/>.</param>
+        public PowerPointFluentPresentation Slide(int masterIndex = 0, int layoutIndex = 0, Action<PowerPointSlideBuilder> configure = null) {
             PowerPointSlide slide = Presentation.AddSlide(masterIndex, layoutIndex);
-            return new PowerPointSlideBuilder(slide);
+            if (configure != null) {
+                PowerPointSlideBuilder builder = new PowerPointSlideBuilder(slide);
+                configure(builder);
+            }
+            return this;
         }
 
         /// <summary>
         ///     Adds and configures a new slide using a builder action.
         /// </summary>
+        /// <param name="configure">Action used to configure the slide.</param>
         public PowerPointFluentPresentation Slide(Action<PowerPointSlideBuilder> configure) {
-            PowerPointSlideBuilder builder = Slide();
-            configure(builder);
-            return this;
+            return Slide(0, 0, configure);
         }
 
         public PowerPointPresentation End() {

--- a/OfficeIMO.Tests/PowerPoint.Fluent.cs
+++ b/OfficeIMO.Tests/PowerPoint.Fluent.cs
@@ -22,12 +22,13 @@ namespace OfficeIMO.Tests {
                         .Image(imagePath)
                         .Table(2, 2)
                         .Notes("Notes text"))
+                    .Slide(s => s.Title("Second Slide"))
                     .End()
                     .Save();
             }
 
             using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
-                Assert.Single(presentation.Slides);
+                Assert.Equal(2, presentation.Slides.Count);
                 PowerPointSlide slide = presentation.Slides[0];
                 Assert.Equal("Notes text", slide.Notes.Text);
                 Assert.Equal(5, slide.Shapes.Count);
@@ -36,6 +37,11 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Fluent Title", textBoxes[0].Text);
                 Assert.Equal("Hello", textBoxes[1].Text);
                 Assert.Equal(1, slide.LayoutIndex);
+
+                PowerPointSlide slide2 = presentation.Slides[1];
+                var textBoxes2 = slide2.Shapes.OfType<PowerPointTextBox>().ToList();
+                Assert.Single(textBoxes2);
+                Assert.Equal("Second Slide", textBoxes2[0].Text);
             }
 
             File.Delete(filePath);


### PR DESCRIPTION
## Summary
- enable chaining in PowerPoint fluent API by having `Slide` return the fluent presentation
- add `End()` to exit fluent mode and return `PowerPointPresentation`
- update example and tests to use `presentation.AsFluent()...End().Save(...)`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a5ba6933e8832eaf559ac18622d64c