### PR TITLE
Refactor Visio writer helpers

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -23,6 +23,7 @@ namespace OfficeIMO.Examples {
             OfficeIMO.Examples.Visio.DocumentStructure.Example_DocumentStructure(folderPath, false);
             OfficeIMO.Examples.Visio.PageViewSettings.Example_PageViewSettings(folderPath, false);
             OfficeIMO.Examples.Visio.ShapeProperties.Example_ShapeProperties(folderPath, false);
+            OfficeIMO.Examples.Visio.ShapeDataWithText.Example_ShapeDataWithText(folderPath, false);
             OfficeIMO.Examples.Visio.RotatedShapeBounds.Example_RotatedShapeBounds(folderPath, false);
             OfficeIMO.Examples.Visio.ReadVisioDocument.Example_ReadVisio(folderPath, false);
             OfficeIMO.Examples.Visio.ThemeAndWindows.Example_ThemeAndWindows(folderPath, false);

--- a/OfficeIMO.Examples/Visio/ShapeDataWithText.cs
+++ b/OfficeIMO.Examples/Visio/ShapeDataWithText.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    /// <summary>
+    /// Demonstrates adding shape data along with text.
+    /// </summary>
+    public static class ShapeDataWithText {
+        public static void Example_ShapeDataWithText(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Shape Data with Text");
+            string filePath = Path.Combine(folderPath, "Shape Data with Text.vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            VisioShape shape = new("1", 2, 2, 3, 2, "A");
+            shape.Data["Key"] = "Value";
+            shape.Text = "Hello";
+            page.Shapes.Add(shape);
+            document.Save(filePath);
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.ShapeDataAndText.cs
+++ b/OfficeIMO.Tests/Visio.ShapeDataAndText.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioShapeDataAndText {
+        [Fact]
+        public void RoundTripsShapeDataAndText() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            VisioShape shape = new("1", 2, 3, 4, 5, string.Empty);
+            shape.Data["Key"] = "Value";
+            shape.Text = "Hello";
+            page.Shapes.Add(shape);
+            document.Save(filePath);
+
+            VisioDocument roundTrip = VisioDocument.Load(filePath);
+            VisioShape loaded = roundTrip.Pages[0].Shapes[0];
+            Assert.True(loaded.Data.TryGetValue("Key", out string? value));
+            Assert.Equal("Value", value);
+            Assert.Equal("Hello", loaded.Text);
+        }
+    }
+}

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -454,6 +454,30 @@ namespace OfficeIMO.Visio {
                     writer.WriteEndElement();
                 }
 
+                void WriteDataSection(XmlWriter writer, IDictionary<string, string> data) {
+                    if (data.Count == 0) {
+                        return;
+                    }
+                    writer.WriteStartElement("Section", ns);
+                    writer.WriteAttributeString("N", "Prop");
+                    foreach (KeyValuePair<string, string> kv in data) {
+                        writer.WriteStartElement("Row", ns);
+                        writer.WriteAttributeString("N", kv.Key);
+                        writer.WriteStartElement("Cell", ns);
+                        writer.WriteAttributeString("N", "Value");
+                        writer.WriteAttributeString("V", kv.Value);
+                        writer.WriteEndElement();
+                        writer.WriteEndElement();
+                    }
+                    writer.WriteEndElement();
+                }
+
+                void WriteTextElement(XmlWriter writer, string? text) {
+                    if (!string.IsNullOrEmpty(text)) {
+                        writer.WriteElementString("Text", ns, text);
+                    }
+                }
+
                 string GetConnectionCell(VisioShape shape, VisioConnectionPoint? point) {
                     if (point == null) {
                         return "PinX";
@@ -527,23 +551,8 @@ namespace OfficeIMO.Visio {
                             }
                             WriteRectangleGeometry(writer, masterWidth, masterHeight);
                             WriteConnectionSection(writer, s.ConnectionPoints);
-                            if (s.Data.Count > 0) {
-                                writer.WriteStartElement("Section", ns);
-                                writer.WriteAttributeString("N", "Prop");
-                                foreach (KeyValuePair<string, string> kv in s.Data) {
-                                    writer.WriteStartElement("Row", ns);
-                                    writer.WriteAttributeString("N", kv.Key);
-                                    writer.WriteStartElement("Cell", ns);
-                                    writer.WriteAttributeString("N", "Value");
-                                    writer.WriteAttributeString("V", kv.Value);
-                                    writer.WriteEndElement();
-                                    writer.WriteEndElement();
-                                }
-                                writer.WriteEndElement();
-                            }
-                            if (!string.IsNullOrEmpty(s.Text)) {
-                                writer.WriteElementString("Text", ns, s.Text);
-                            }
+                            WriteDataSection(writer, s.Data);
+                            WriteTextElement(writer, s.Text);
                             writer.WriteEndElement();
                             writer.WriteEndElement();
                             writer.WriteEndElement();
@@ -739,23 +748,8 @@ namespace OfficeIMO.Visio {
                                     WriteCell(writer, "LineWeight", shape.LineWeight);
                                 }
                                 WriteConnectionSection(writer, shape.ConnectionPoints);
-                                if (shape.Data.Count > 0) {
-                                    writer.WriteStartElement("Section", ns);
-                                    writer.WriteAttributeString("N", "Prop");
-                                    foreach (KeyValuePair<string, string> kv in shape.Data) {
-                                        writer.WriteStartElement("Row", ns);
-                                        writer.WriteAttributeString("N", kv.Key);
-                                        writer.WriteStartElement("Cell", ns);
-                                        writer.WriteAttributeString("N", "Value");
-                                        writer.WriteAttributeString("V", kv.Value);
-                                        writer.WriteEndElement();
-                                        writer.WriteEndElement();
-                                    }
-                                    writer.WriteEndElement();
-                                }
-                                if (!string.IsNullOrEmpty(shape.Text)) {
-                                    writer.WriteElementString("Text", ns, shape.Text);
-                                }
+                                WriteDataSection(writer, shape.Data);
+                                WriteTextElement(writer, shape.Text);
                             } else {
                                 WriteCell(writer, "PinX", shape.PinX);
                                 WriteCell(writer, "PinY", shape.PinY);
@@ -779,23 +773,8 @@ namespace OfficeIMO.Visio {
                                 }
                                 WriteRectangleGeometry(writer, width, height);
                                 WriteConnectionSection(writer, shape.ConnectionPoints);
-                                if (shape.Data.Count > 0) {
-                                    writer.WriteStartElement("Section", ns);
-                                    writer.WriteAttributeString("N", "Prop");
-                                    foreach (KeyValuePair<string, string> kv in shape.Data) {
-                                        writer.WriteStartElement("Row", ns);
-                                        writer.WriteAttributeString("N", kv.Key);
-                                        writer.WriteStartElement("Cell", ns);
-                                        writer.WriteAttributeString("N", "Value");
-                                        writer.WriteAttributeString("V", kv.Value);
-                                        writer.WriteEndElement();
-                                        writer.WriteEndElement();
-                                    }
-                                    writer.WriteEndElement();
-                                }
-                                if (!string.IsNullOrEmpty(shape.Text)) {
-                                    writer.WriteElementString("Text", ns, shape.Text);
-                                }
+                                WriteDataSection(writer, shape.Data);
+                                WriteTextElement(writer, shape.Text);
                             }
                             writer.WriteEndElement();
                         }


### PR DESCRIPTION
## Summary
- add helper methods to simplify Visio XML writing
- cover shape data and text round-trip with a new test
- document shape data and text usage in examples

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b8b7861c832ea056b3937be66c90