### PR TITLE
Add RowsFrom object export for Excel fluent API

### DIFF
--- a/OfficeIMO.Examples/Excel/RowsFromObjects.cs
+++ b/OfficeIMO.Examples/Excel/RowsFromObjects.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Fluent;
+
+namespace OfficeIMO.Examples.Excel {
+    public static class RowsFromObjects {
+        private class Address {
+            public string? City { get; set; }
+            public string? Street { get; set; }
+        }
+
+        private class Person {
+            public string Name { get; set; } = string.Empty;
+            public int Age { get; set; }
+            public Address? Address { get; set; }
+        }
+
+        public static void Example(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - Rows from objects");
+            string filePath = System.IO.Path.Combine(folderPath, "RowsFromObjects.xlsx");
+
+            var data = new List<Person> {
+                new Person { Name = "Alice", Age = 30, Address = new Address { City = "New York", Street = "1st Ave" } },
+                new Person { Name = "Bob", Age = 25, Address = new Address { City = "Los Angeles", Street = "Main St" } },
+                new Person { Name = "Charlie", Age = 40, Address = null }
+            };
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Sheet("People", s => s
+                        .RowsFrom(data, o => o.ExpandProperties.Add(nameof(Person.Address)))
+                        .AutoFit(columns: true, rows: true))
+                    .End()
+                    .Save(openExcel);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Excel/RowsFromObjects.cs
+++ b/OfficeIMO.Examples/Excel/RowsFromObjects.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using OfficeIMO.Excel;
 using OfficeIMO.Excel.Fluent;
+using OfficeIMO.Excel.Utilities;
 
 namespace OfficeIMO.Examples.Excel {
     public static class RowsFromObjects {
@@ -29,8 +30,15 @@ namespace OfficeIMO.Examples.Excel {
             using (var document = ExcelDocument.Create(filePath)) {
                 document.AsFluent()
                     .Sheet("People", s => s
-                        .RowsFrom(data, o => o.ExpandProperties.Add(nameof(Person.Address)))
-                        .AutoFit(columns: true, rows: true))
+                        .RowsFrom(data, o => {
+                            o.ExpandProperties.Add(nameof(Person.Address));
+                            o.HeaderPrefixTrimPaths = new[] { "Address." };
+                            o.HeaderCase = HeaderCase.Title;
+                            o.NullPolicy = NullPolicy.EmptyString;
+                            o.Formatters["Age"] = v => $"{v} years";
+                        })
+                        .Table("People", t => t.Style(TableStyle.TableStyleMedium9))
+                        .AutoFit(columns: true, rows: false))
                     .End()
                     .Save(openExcel);
             }

--- a/OfficeIMO.Excel/Fluent/RowBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/RowBuilder.cs
@@ -16,7 +16,7 @@ namespace OfficeIMO.Excel.Fluent {
             return this;
         }
 
-        public RowBuilder Values(params object[] values) {
+        public RowBuilder Values(params object?[] values) {
             for (int i = 0; i < values.Length; i++) {
                 _sheet.SetCellValue(_rowIndex, i + 1, values[i]);
             }

--- a/OfficeIMO.Excel/Fluent/TableBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/TableBuilder.cs
@@ -2,9 +2,25 @@ using OfficeIMO.Excel;
 namespace OfficeIMO.Excel.Fluent {
     public class TableBuilder {
         private readonly ExcelSheet _sheet;
+        private TableStyle _style = TableStyle.TableStyleLight9;
+        private bool _hasHeader = true;
 
         internal TableBuilder(ExcelSheet sheet) {
             _sheet = sheet;
+        }
+
+        public TableBuilder Style(TableStyle style) {
+            _style = style;
+            return this;
+        }
+
+        public TableBuilder HasHeader(bool hasHeader = true) {
+            _hasHeader = hasHeader;
+            return this;
+        }
+
+        internal void Build(string range, string name) {
+            _sheet.AddTable(range, _hasHeader, name, _style);
         }
 
         public TableBuilder Add(string range, bool hasHeader = true, string name = "", TableStyle style = TableStyle.TableStyleLight9) {

--- a/OfficeIMO.Excel/OfficeIMO.Excel.csproj
+++ b/OfficeIMO.Excel/OfficeIMO.Excel.csproj
@@ -38,6 +38,7 @@
         <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
         <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+        <PackageReference Include="System.Text.Json" Version="7.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OfficeIMO.Excel/Utilities/ObjectFlattener.cs
+++ b/OfficeIMO.Excel/Utilities/ObjectFlattener.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace OfficeIMO.Excel.Utilities {
+    public class ObjectFlattenerOptions {
+        public List<string> ExpandProperties { get; } = new List<string>();
+        public bool IncludeFullObjects { get; set; }
+        public int MaxDepth { get; set; } = int.MaxValue;
+    }
+
+    public class ObjectFlattener {
+        public Dictionary<string, object?> Flatten<T>(T item, ObjectFlattenerOptions opts) {
+            var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+            if (item == null) return result;
+            FlattenInternal(item!, result, string.Empty, 0, opts);
+            return result;
+        }
+
+        private static void FlattenInternal(object obj, Dictionary<string, object?> dict, string prefix, int depth, ObjectFlattenerOptions opts) {
+            if (depth >= opts.MaxDepth) return;
+            var props = obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            foreach (var prop in props) {
+                var value = prop.GetValue(obj);
+                var path = string.IsNullOrEmpty(prefix) ? prop.Name : prefix + "." + prop.Name;
+                bool expand = opts.ExpandProperties.Contains(prop.Name) || opts.ExpandProperties.Contains(path);
+                if (value == null || IsSimple(prop.PropertyType) || !expand) {
+                    dict[path] = value;
+                    continue;
+                }
+                if (opts.IncludeFullObjects) {
+                    dict[path] = value;
+                }
+                if (depth + 1 < opts.MaxDepth) {
+                    FlattenInternal(value, dict, path, depth + 1, opts);
+                }
+            }
+        }
+
+        private static bool IsSimple(Type type) {
+            return type.IsPrimitive || type.IsEnum || type == typeof(string) || type == typeof(decimal) || type == typeof(DateTime) || type == typeof(DateTimeOffset) || type == typeof(TimeSpan) || type == typeof(Guid);
+        }
+    }
+}

--- a/OfficeIMO.Excel/Utilities/ObjectFlattener.cs
+++ b/OfficeIMO.Excel/Utilities/ObjectFlattener.cs
@@ -1,15 +1,48 @@
 using System;
+using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 
 namespace OfficeIMO.Excel.Utilities {
+    public enum HeaderCase {
+        Raw,
+        Pascal,
+        Title
+    }
+
+    public enum NullPolicy {
+        EmptyString,
+        NullLiteral,
+        DefaultValue
+    }
+
+    public enum CollectionMode {
+        JoinWith,
+        ExpandRows,
+        Json
+    }
+
     public class ObjectFlattenerOptions {
-        public List<string> ExpandProperties { get; } = new List<string>();
+        public List<string> ExpandProperties { get; } = new();
         public bool IncludeFullObjects { get; set; }
         public int MaxDepth { get; set; } = int.MaxValue;
+        public HeaderCase HeaderCase { get; set; } = HeaderCase.Raw;
+        public string[] HeaderPrefixTrimPaths { get; set; } = Array.Empty<string>();
+        public string[]? Columns { get; set; }
+        public string[] Ignore { get; set; } = Array.Empty<string>();
+        public NullPolicy NullPolicy { get; set; } = NullPolicy.NullLiteral;
+        public Dictionary<string, object?> DefaultValues { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, Func<object?, object?>> Formatters { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public CollectionMode CollectionMode { get; set; } = CollectionMode.JoinWith;
+        public string CollectionJoinWith { get; set; } = ",";
     }
 
     public class ObjectFlattener {
+        private static readonly ConcurrentDictionary<Type, PropertyInfo[]> _cache = new();
+
         public Dictionary<string, object?> Flatten<T>(T item, ObjectFlattenerOptions opts) {
             var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
             if (item == null) return result;
@@ -17,24 +50,101 @@ namespace OfficeIMO.Excel.Utilities {
             return result;
         }
 
+        public List<string> GetPaths(Type type, ObjectFlattenerOptions opts) {
+            var paths = new List<string>();
+            BuildPaths(type, string.Empty, 0, opts, paths);
+            return paths
+                .Where(p => !opts.Ignore.Any(i => p.StartsWith(i, StringComparison.OrdinalIgnoreCase)))
+                .ToList();
+        }
+
         private static void FlattenInternal(object obj, Dictionary<string, object?> dict, string prefix, int depth, ObjectFlattenerOptions opts) {
             if (depth >= opts.MaxDepth) return;
-            var props = obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+            var props = _cache.GetOrAdd(obj.GetType(), t => t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                                                                .OrderBy(p => p.MetadataToken).ToArray());
             foreach (var prop in props) {
                 var value = prop.GetValue(obj);
                 var path = string.IsNullOrEmpty(prefix) ? prop.Name : prefix + "." + prop.Name;
+                if (opts.Ignore.Any(i => path.StartsWith(i, StringComparison.OrdinalIgnoreCase))) continue;
+
                 bool expand = opts.ExpandProperties.Contains(prop.Name) || opts.ExpandProperties.Contains(path);
-                if (value == null || IsSimple(prop.PropertyType) || !expand) {
-                    dict[path] = value;
+                bool isCollection = value is IEnumerable && value is not string;
+
+                if (value == null) {
+                    dict[path] = ApplyNullPolicy(path, null, opts);
                     continue;
                 }
+
+                if (isCollection) {
+                    dict[path] = HandleCollection(path, (IEnumerable)value, opts);
+                    continue;
+                }
+
+                if (!expand || IsSimple(prop.PropertyType)) {
+                    dict[path] = ApplyFormatting(path, value, opts);
+                    continue;
+                }
+
                 if (opts.IncludeFullObjects) {
                     dict[path] = value;
                 }
+
                 if (depth + 1 < opts.MaxDepth) {
                     FlattenInternal(value, dict, path, depth + 1, opts);
                 }
             }
+        }
+
+        private static void BuildPaths(Type type, string prefix, int depth, ObjectFlattenerOptions opts, List<string> paths) {
+            if (depth >= opts.MaxDepth) return;
+            var props = _cache.GetOrAdd(type, t => t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                                                   .OrderBy(p => p.MetadataToken).ToArray());
+            foreach (var prop in props) {
+                var path = string.IsNullOrEmpty(prefix) ? prop.Name : prefix + "." + prop.Name;
+                if (opts.Ignore.Any(i => path.StartsWith(i, StringComparison.OrdinalIgnoreCase))) continue;
+                bool expand = opts.ExpandProperties.Contains(prop.Name) || opts.ExpandProperties.Contains(path);
+                bool isCollection = typeof(IEnumerable).IsAssignableFrom(prop.PropertyType) && prop.PropertyType != typeof(string);
+                if (isCollection) {
+                    paths.Add(path);
+                    continue;
+                }
+                if (!expand || opts.IncludeFullObjects || IsSimple(prop.PropertyType)) {
+                    paths.Add(path);
+                }
+                if (expand && !IsSimple(prop.PropertyType)) {
+                    BuildPaths(prop.PropertyType, path, depth + 1, opts, paths);
+                }
+            }
+        }
+
+        private static object? HandleCollection(string path, IEnumerable enumerable, ObjectFlattenerOptions opts) {
+            if (opts.CollectionMode == CollectionMode.JoinWith) {
+                var list = enumerable.Cast<object?>().Select(v => v?.ToString()).ToArray();
+                var joined = string.Join(opts.CollectionJoinWith, list);
+                return ApplyFormatting(path, joined, opts);
+            }
+            if (opts.CollectionMode == CollectionMode.Json) {
+                return JsonSerializer.Serialize(enumerable);
+            }
+            // ExpandRows handled in SheetBuilder
+            return enumerable;
+        }
+
+        private static object? ApplyFormatting(string path, object? value, ObjectFlattenerOptions opts) {
+            if (value == null) return ApplyNullPolicy(path, null, opts);
+            if (opts.Formatters.TryGetValue(path, out var formatter)) {
+                return formatter(value);
+            }
+            return value;
+        }
+
+        private static object? ApplyNullPolicy(string path, object? value, ObjectFlattenerOptions opts) {
+            return opts.NullPolicy switch {
+                NullPolicy.EmptyString => string.Empty,
+                NullPolicy.DefaultValue => opts.DefaultValues.TryGetValue(path, out var v) ? v : null,
+                _ => null
+            };
         }
 
         private static bool IsSimple(Type type) {

--- a/OfficeIMO.Tests/Excel.RowsFromObjectsTests.cs
+++ b/OfficeIMO.Tests/Excel.RowsFromObjectsTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class ExcelRowsFromObjectsTests {
+        private static string GetCellValue(SpreadsheetDocument document, WorksheetPart worksheetPart, string cellReference) {
+            var cell = worksheetPart.Worksheet.Descendants<Cell>().First(c => c.CellReference != null && c.CellReference.Value == cellReference);
+            var value = cell.CellValue?.Text ?? string.Empty;
+            if (cell.DataType != null && cell.DataType.Value == CellValues.SharedString) {
+                var table = document.WorkbookPart.SharedStringTablePart.SharedStringTable;
+                if (int.TryParse(value, out int id)) {
+                    return table.ChildElements[id].InnerText;
+                }
+            }
+            return value;
+        }
+
+        private class Address {
+            public string? City { get; set; }
+            public string? Street { get; set; }
+        }
+
+        private class Person {
+            public string Name { get; set; } = string.Empty;
+            public int Age { get; set; }
+            public Address? Address { get; set; }
+        }
+
+        [Fact]
+        public void RowsFrom_WritesHeadersAndValues() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            var data = new[] {
+                new Person { Name = "Alice", Age = 30, Address = new Address { City = "NY", Street = "1st" } },
+                new Person { Name = "Bob", Age = 25, Address = new Address { City = "LA", Street = "Main" } }
+            };
+
+            using (var doc = ExcelDocument.Create(filePath)) {
+                doc.AsFluent()
+                    .Sheet("People", s => s.RowsFrom(data, o => o.ExpandProperties.Add(nameof(Person.Address))))
+                    .End()
+                    .Save();
+            }
+
+            using (var document = SpreadsheetDocument.Open(filePath, false)) {
+                var wsPart = document.WorkbookPart.WorksheetParts.First();
+
+                Assert.Equal("Name", GetCellValue(document, wsPart, "A1"));
+                Assert.Equal("Age", GetCellValue(document, wsPart, "B1"));
+                Assert.Equal("Address.City", GetCellValue(document, wsPart, "C1"));
+                Assert.Equal("Address.Street", GetCellValue(document, wsPart, "D1"));
+
+                Assert.Equal("Alice", GetCellValue(document, wsPart, "A2"));
+                Assert.Equal("30", GetCellValue(document, wsPart, "B2"));
+                Assert.Equal("NY", GetCellValue(document, wsPart, "C2"));
+                Assert.Equal("1st", GetCellValue(document, wsPart, "D2"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void RowsFrom_HandlesNulls() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            var data = new[] {
+                new Person { Name = "Alice", Age = 30, Address = new Address { City = "NY", Street = "1st" } },
+                new Person { Name = "Bob", Age = 25, Address = null }
+            };
+
+            using (var doc = ExcelDocument.Create(filePath)) {
+                doc.AsFluent()
+                    .Sheet("People", s => s.RowsFrom(data, o => o.ExpandProperties.Add(nameof(Person.Address))))
+                    .End()
+                    .Save();
+            }
+
+            using (var document = SpreadsheetDocument.Open(filePath, false)) {
+                var wsPart = document.WorkbookPart.WorksheetParts.First();
+                Assert.Equal(string.Empty, GetCellValue(document, wsPart, "C3"));
+                Assert.Equal(string.Empty, GetCellValue(document, wsPart, "D3"));
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.RowsFromObjectsTests.cs
+++ b/OfficeIMO.Tests/Excel.RowsFromObjectsTests.cs
@@ -6,6 +6,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
 using OfficeIMO.Excel.Fluent;
+using OfficeIMO.Excel.Utilities;
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -31,59 +32,101 @@ namespace OfficeIMO.Tests {
             public string Name { get; set; } = string.Empty;
             public int Age { get; set; }
             public Address? Address { get; set; }
+            public List<string>? Tags { get; set; }
         }
 
         [Fact]
-        public void RowsFrom_WritesHeadersAndValues() {
+        public void RowsFrom_WritesHeadersAndValues_DeterministicOrder() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             var data = new[] {
-                new Person { Name = "Alice", Age = 30, Address = new Address { City = "NY", Street = "1st" } },
-                new Person { Name = "Bob", Age = 25, Address = new Address { City = "LA", Street = "Main" } }
+                new Person { Name = "Alice", Age = 30, Address = new Address { City = "NY", Street = "1st" }, Tags = new List<string>{"a","b"} },
+                new Person { Name = "Bob", Age = 25, Address = new Address { City = "LA", Street = "Main" }, Tags = new List<string>{"c"} }
             };
 
             using (var doc = ExcelDocument.Create(filePath)) {
                 doc.AsFluent()
-                    .Sheet("People", s => s.RowsFrom(data, o => o.ExpandProperties.Add(nameof(Person.Address))))
+                    .Sheet("People", s => s.RowsFrom(data, o => {
+                        o.ExpandProperties.Add(nameof(Person.Address));
+                    }))
                     .End()
                     .Save();
             }
 
             using (var document = SpreadsheetDocument.Open(filePath, false)) {
                 var wsPart = document.WorkbookPart.WorksheetParts.First();
-
                 Assert.Equal("Name", GetCellValue(document, wsPart, "A1"));
                 Assert.Equal("Age", GetCellValue(document, wsPart, "B1"));
                 Assert.Equal("Address.City", GetCellValue(document, wsPart, "C1"));
                 Assert.Equal("Address.Street", GetCellValue(document, wsPart, "D1"));
+                Assert.Equal("Tags", GetCellValue(document, wsPart, "E1"));
 
                 Assert.Equal("Alice", GetCellValue(document, wsPart, "A2"));
                 Assert.Equal("30", GetCellValue(document, wsPart, "B2"));
                 Assert.Equal("NY", GetCellValue(document, wsPart, "C2"));
                 Assert.Equal("1st", GetCellValue(document, wsPart, "D2"));
+                Assert.Equal("a,b", GetCellValue(document, wsPart, "E2"));
             }
 
             File.Delete(filePath);
         }
 
         [Fact]
-        public void RowsFrom_HandlesNulls() {
+        public void RowsFrom_NullPolicyAndFormatter() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             var data = new[] {
-                new Person { Name = "Alice", Age = 30, Address = new Address { City = "NY", Street = "1st" } },
-                new Person { Name = "Bob", Age = 25, Address = null }
+                new Person { Name = "Alice", Age = 30, Address = new Address { City = "NY", Street = null }, Tags = null },
+                new Person { Name = "Bob", Age = 25, Address = null, Tags = null }
             };
 
             using (var doc = ExcelDocument.Create(filePath)) {
                 doc.AsFluent()
-                    .Sheet("People", s => s.RowsFrom(data, o => o.ExpandProperties.Add(nameof(Person.Address))))
+                    .Sheet("People", s => s.RowsFrom(data, o => {
+                        o.ExpandProperties.Add(nameof(Person.Address));
+                        o.NullPolicy = NullPolicy.DefaultValue;
+                        o.DefaultValues["Address.City"] = "N/A";
+                        o.Formatters["Age"] = v => $"{v}y";
+                    }))
                     .End()
                     .Save();
             }
 
             using (var document = SpreadsheetDocument.Open(filePath, false)) {
                 var wsPart = document.WorkbookPart.WorksheetParts.First();
-                Assert.Equal(string.Empty, GetCellValue(document, wsPart, "C3"));
-                Assert.Equal(string.Empty, GetCellValue(document, wsPart, "D3"));
+                Assert.Equal("N/A", GetCellValue(document, wsPart, "C3"));
+                Assert.Equal("", GetCellValue(document, wsPart, "D2"));
+                Assert.Equal("30y", GetCellValue(document, wsPart, "B2"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void RowsFrom_CollectionExpandRows_CreatesTable() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            var data = new[] {
+                new Person { Name = "Alice", Age = 30, Tags = new List<string>{"a","b"} }
+            };
+
+            using (var doc = ExcelDocument.Create(filePath)) {
+                doc.AsFluent()
+                    .Sheet("People", s => s
+                        .RowsFrom(data, o => {
+                            o.ExpandProperties.Add(nameof(Person.Tags));
+                            o.CollectionMode = CollectionMode.ExpandRows;
+                        })
+                        .Table("People", t => t.Style(OfficeIMO.Excel.TableStyle.TableStyleMedium9)))
+                    .End()
+                    .Save();
+            }
+
+            using (var document = SpreadsheetDocument.Open(filePath, false)) {
+                var wsPart = document.WorkbookPart.WorksheetParts.First();
+                // two rows for tags -> name repeats twice
+                Assert.Equal("Alice", GetCellValue(document, wsPart, "A2"));
+                Assert.Equal("Alice", GetCellValue(document, wsPart, "A3"));
+                var table = wsPart.TableDefinitionParts.First();
+                Assert.Equal("People", table.Table.DisplayName.Value);
+                Assert.Equal("TableStyleMedium9", table.Table.TableStyleInfo?.Name?.Value);
             }
 
             File.Delete(filePath);


### PR DESCRIPTION
## Summary
- add `ObjectFlattener` utility with configurable expansion
- extend `SheetBuilder` with `RowsFrom` to write rows from objects
- demonstrate object export in new example and add unit tests

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a5ba34638c832e8f09a6a5d8a8821d