### PR TITLE
Add shared alignment enums and update Word fluent builders

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.ParagraphFormatting.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.ParagraphFormatting.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
 

--- a/OfficeIMO.Examples/Word/Fluent/Fluent.TableBuilder.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.TableBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
 
@@ -16,7 +17,7 @@ namespace OfficeIMO.Examples.Word {
                         .Row("Alice", "Dev", 98)
                         .Row("Bob", "Ops", 91)
                         .Style(WordTableStyle.TableGrid)
-                        .Align(WordHorizontalAlignmentValues.Center))
+                        .Align(HorizontalAlignment.Center))
                     .Table(t => t
                         .From2D(new object[,] {
                             { "Q", "Revenue", "Churn" },

--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.BlockLevel.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.BlockLevel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
 
@@ -17,7 +18,7 @@ namespace OfficeIMO.Examples.Word {
                         .Add(Path.Combine(imagesPath, "EvotecLogo.png"))
                         .Size(120, 120)
                         .Wrap(WrapTextImage.Square)
-                        .Align(JustificationValues.Center))
+                        .Align(HorizontalAlignment.Center))
                     .End();
                 document.Save(false);
             }

--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.FromUrl.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.FromUrl.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
 
@@ -15,7 +16,7 @@ namespace OfficeIMO.Examples.Word {
                     .Image(img => img
                         .AddFromUrl("https://raw.githubusercontent.com/EvotecIT/OfficeIMO/master/OfficeIMO.Examples/Images/Kulek.jpg")
                         .Size(400)
-                        .Align(JustificationValues.Center))
+                        .Align(HorizontalAlignment.Center))
                     .End();
                 document.Save(false);
             }

--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.FromUrlAsync.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.FromUrlAsync.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
 
@@ -15,7 +16,7 @@ namespace OfficeIMO.Examples.Word {
                 await document.AsFluent()
                     .ImageAsync(async img => {
                         await img.AddFromUrlAsync("https://raw.githubusercontent.com/EvotecIT/OfficeIMO/master/OfficeIMO.Examples/Images/Kulek.jpg");
-                        img.Wrap(WrapTextImage.Tight).Align(JustificationValues.Right);
+                        img.Wrap(WrapTextImage.Tight).Align(HorizontalAlignment.Right);
                     });
                 document.Save(false);
             }

--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.Mixed.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.Mixed.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
 
@@ -21,7 +22,7 @@ namespace OfficeIMO.Examples.Word {
                         .Add(Path.Combine(imagesPath, "Kulek.jpg"))
                         .Size(500)
                         .Wrap(WrapTextImage.Square)
-                        .Align(JustificationValues.Center))
+                        .Align(HorizontalAlignment.Center))
                     .End();
                 document.Save(false);
             }

--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.Multiple.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.Multiple.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
 
@@ -16,10 +17,10 @@ namespace OfficeIMO.Examples.Word {
                     .Image(img => img
                         .Add(Path.Combine(imagesPath, "PrzemyslawKlysAndKulkozaurr.jpg"))
                             .Size(200)
-                            .Align(JustificationValues.Left)
+                            .Align(HorizontalAlignment.Left)
                         .Add(Path.Combine(imagesPath, "Kulek.jpg"))
                             .MaxWidth(300)
-                            .Align(JustificationValues.Right))
+                            .Align(HorizontalAlignment.Right))
                     .End();
                 document.Save(false);
             }

--- a/OfficeIMO.Excel/OfficeIMO.Excel.csproj
+++ b/OfficeIMO.Excel/OfficeIMO.Excel.csproj
@@ -59,4 +59,5 @@
     <ItemGroup>
         <InternalsVisibleTo Include="OfficeIMO.Tests" />
     </ItemGroup>
+
 </Project>

--- a/OfficeIMO.Tests/Word.Fluent.ImageBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ImageBuilder.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Net;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
 using Xunit;
@@ -29,7 +30,7 @@ namespace OfficeIMO.Tests {
 
             using (var document = WordDocument.Create(filePath)) {
                 document.AsFluent()
-                    .Image(i => i.Add(imagePath).Size(50, 50).Wrap(WrapTextImage.Square).Align(JustificationValues.Center))
+                    .Image(i => i.Add(imagePath).Size(50, 50).Wrap(WrapTextImage.Square).Align(HorizontalAlignment.Center))
                     .Image(i => {
                         using var stream = File.OpenRead(imagePath);
                         i.Add(stream, "stream.jpg").Size(60, 60);

--- a/OfficeIMO.Tests/Word.Fluent.ParagraphBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ParagraphBuilder.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
 using Xunit;

--- a/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
 using Xunit;
@@ -16,7 +17,7 @@ namespace OfficeIMO.Tests {
                         .Row("Alice", "Dev", 98)
                         .Row("Bob", "Ops", 91)
                         .Style(WordTableStyle.TableGrid)
-                        .Align(WordHorizontalAlignmentValues.Center))
+                        .Align(HorizontalAlignment.Center))
                     .Table(t => t
                         .From2D(new object[,] {
                             { "Q", "Revenue", "Churn" },

--- a/OfficeIMO.Word/Enums/HorizontalAlignment.cs
+++ b/OfficeIMO.Word/Enums/HorizontalAlignment.cs
@@ -1,6 +1,6 @@
-namespace OfficeIMO.Word {
+namespace OfficeIMO {
     /// <summary>
-    /// Horizontal alignment options for paragraphs.
+    /// Represents horizontal alignment options.
     /// </summary>
     public enum HorizontalAlignment {
         Left,

--- a/OfficeIMO.Word/Enums/VerticalAlignment.cs
+++ b/OfficeIMO.Word/Enums/VerticalAlignment.cs
@@ -1,0 +1,10 @@
+namespace OfficeIMO {
+    /// <summary>
+    /// Represents vertical alignment options.
+    /// </summary>
+    public enum VerticalAlignment {
+        Top,
+        Center,
+        Bottom
+    }
+}

--- a/OfficeIMO.Word/Fluent/ImageBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ImageBuilder.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Word.Fluent {
@@ -81,8 +82,14 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
-        public ImageBuilder Align(JustificationValues alignment) {
-            _paragraph?.SetAlignment(alignment);
+        public ImageBuilder Align(HorizontalAlignment alignment) {
+            var justification = alignment switch {
+                HorizontalAlignment.Center => JustificationValues.Center,
+                HorizontalAlignment.Right => JustificationValues.Right,
+                HorizontalAlignment.Justified => JustificationValues.Both,
+                _ => JustificationValues.Left,
+            };
+            _paragraph?.SetAlignment(justification);
             return this;
         }
 

--- a/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
@@ -1,6 +1,7 @@
 using System;
-using OfficeIMO.Word;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO;
+using OfficeIMO.Word;
 
 namespace OfficeIMO.Word.Fluent {
     /// <summary>

--- a/OfficeIMO.Word/Fluent/TableBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TableBuilder.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO;
 using OfficeIMO.Word;
 using System;
 using System.Linq;
@@ -138,11 +139,11 @@ namespace OfficeIMO.Word.Fluent {
         /// <summary>
         /// Sets horizontal alignment for the table.
         /// </summary>
-        public TableBuilder Align(WordHorizontalAlignmentValues alignment) {
+        public TableBuilder Align(HorizontalAlignment alignment) {
             if (_table != null) {
                 _table.Alignment = alignment switch {
-                    WordHorizontalAlignmentValues.Center => TableRowAlignmentValues.Center,
-                    WordHorizontalAlignmentValues.Right => TableRowAlignmentValues.Right,
+                    HorizontalAlignment.Center => TableRowAlignmentValues.Center,
+                    HorizontalAlignment.Right => TableRowAlignmentValues.Right,
                     _ => TableRowAlignmentValues.Left,
                 };
             }

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -4,6 +4,7 @@ using DocumentFormat.OpenXml.Wordprocessing;
 using Graphic = DocumentFormat.OpenXml.Drawing.Graphic;
 using V = DocumentFormat.OpenXml.Vml;
 using DrawingHorizontalAlignment = DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalAlignment;
+using DrawingVerticalAlignment = DocumentFormat.OpenXml.Drawing.Wordprocessing.VerticalAlignment;
 
 namespace OfficeIMO.Word {
     /// <summary>
@@ -730,7 +731,7 @@ namespace OfficeIMO.Word {
                 if (verticalPosition == null) {
                     anchor.VerticalPosition = new VerticalPosition() {
                         RelativeFrom = VerticalRelativePositionValues.Page,
-                        VerticalAlignment = new VerticalAlignment() {
+                        VerticalAlignment = new DrawingVerticalAlignment() {
                             Text = "top"
                         }
                     };


### PR DESCRIPTION
## Summary
- introduce common HorizontalAlignment and VerticalAlignment enums
- refactor Word fluent builders to use shared alignment enums
- update examples and tests for new alignment enums
- relocate alignment enums into the Word project

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "Test_FluentTableBuilder|Test_FluentParagraphBuilderNewMethods|Test_FluentImageBuilderSources"`

------
https://chatgpt.com/codex/tasks/task_e_68a5ba5d5200832e96e317b7111281ca