### PR TITLE
Rename fluent table builder AddTable to Create and support point widths

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.SectionLayout.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.SectionLayout.cs
@@ -22,13 +22,13 @@ namespace OfficeIMO.Examples.Word {
                             .Size(WordPageSize.Legal)
                             .PageNumbering(restart: true)
                             .Paragraph(p => p.Text("Section 1"))
-                            .Table(t => t.AddTable(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 1"))
+                            .Table(t => t.Create(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 1"))
                         .New(SectionMarkValues.NextPage)
                             .Margins(WordMargin.Wide)
                             .Size(WordPageSize.A3)
                             .PageNumbering(restart: false)
                             .Paragraph(p => p.Text("Section 2"))
-                            .Table(t => t.AddTable(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 2")))
+                            .Table(t => t.Create(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 2")))
                     .End()
                     .Save(false);
             }

--- a/OfficeIMO.Examples/Word/Fluent/Fluent.TableBuilder.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.TableBuilder.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AsFluent()
                     .Table(t => t
-                        .Columns(3).PreferredWidth(Percent: 100)
+                        .Columns(3).PreferredWidth(percent: 100)
                         .Header("Name", "Role", "Score")
                         .Row("Alice", "Dev", 98)
                         .Row("Bob", "Ops", 91)
@@ -25,7 +25,7 @@ namespace OfficeIMO.Examples.Word {
                             { "Q2", "1.3M", "1.8%" }
                         }).HeaderRow(0))
                     .Table(t => t
-                        .AddTable(2, 3)
+                        .Create(2, 3)
                         .ForEachCell((r, c, cell) => cell.AddParagraph($"R{r}C{c}", true))
                         .Cell(1, 3, cell => cell.AddParagraph("Last", true))
                         .InsertRow(3, "A", "B", "C")

--- a/OfficeIMO.Examples/Word/Sections/Sections_Overrides_MarginsSizeNumbering.cs
+++ b/OfficeIMO.Examples/Word/Sections/Sections_Overrides_MarginsSizeNumbering.cs
@@ -23,13 +23,13 @@ namespace OfficeIMO.Examples.Word {
                             .Size(WordPageSize.Legal)
                             .PageNumbering(restart: true)
                             .Paragraph(p => p.Text("Section 1"))
-                            .Table(t => t.AddTable(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 1"))
+                            .Table(t => t.Create(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 1"))
                         .New(SectionMarkValues.NextPage)
                             .Margins(WordMargin.Wide)
                             .Size(WordPageSize.A3)
                             .PageNumbering(restart: false)
                             .Paragraph(p => p.Text("Section 2"))
-                            .Table(t => t.AddTable(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 2")))
+                            .Table(t => t.Create(1, 1).Table!.Rows[0].Cells[0].AddParagraph("Cell 2")))
                     .End()
                     .Save(false);
             }

--- a/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Tests {
             using (var document = WordDocument.Create(filePath)) {
                 document.AsFluent()
                     .Table(t => t
-                        .Columns(3).PreferredWidth(Percent: 100)
+                        .Columns(3).PreferredWidth(percent: 100)
                         .Header("Name", "Role", "Score")
                         .Row("Alice", "Dev", 98)
                         .Row("Bob", "Ops", 91)
@@ -49,11 +49,11 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void Test_FluentTableBuilder_AddTable() {
-            string filePath = Path.Combine(_directoryWithFiles, "FluentAddTable.docx");
+        public void Test_FluentTableBuilder_Create() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentCreate.docx");
             using (var document = WordDocument.Create(filePath)) {
                 document.AsFluent()
-                    .Table(t => t.AddTable(2, 2).Table!.Rows[1].Cells[1].AddParagraph("B"))
+                    .Table(t => t.Create(2, 2).Table!.Rows[1].Cells[1].AddParagraph("B"))
                     .End()
                     .Save(false);
             }
@@ -72,7 +72,7 @@ namespace OfficeIMO.Tests {
             using (var document = WordDocument.Create(filePath)) {
                 document.AsFluent()
                     .Table(t => t
-                        .AddTable(2, 3)
+                        .Create(2, 3)
                         .ForEachCell((r, c, cell) => cell.AddParagraph($"R{r}C{c}", true))
                         .Cell(1, 3, cell => cell.AddParagraph("Last", true))
                         .InsertRow(3, "A", "B", "C")
@@ -96,6 +96,23 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("ccffcc", table.Rows[0].Cells[1].ShadingFillColorHex);
                 Assert.True(table.Rows[0].Cells[0].HasHorizontalMerge);
                 Assert.True(table.Rows[0].Cells[0].HasVerticalMerge);
+            }
+        }
+
+        [Fact]
+        public void Test_FluentTableBuilder_PreferredWidthPoints() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentTableBuilderPoints.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Table(t => t.PreferredWidth(points: 100).Columns(2).Row("A", "B"))
+                    .End()
+                    .Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                var table = document.Tables[0];
+                Assert.Equal(2000, table.Width);
+                Assert.Equal(TableWidthUnitValues.Dxa, table.WidthType);
             }
         }
     }

--- a/OfficeIMO.Word/Fluent/TableBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TableBuilder.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Word.Fluent {
         private WordTable? _table;
         private int _columns;
         private int? _preferredWidthPct;
-        private int? _preferredWidthDxa;
+        private int? _preferredWidthPoints;
 
         internal TableBuilder(WordFluentDocument fluent) {
             _fluent = fluent;
@@ -33,16 +33,10 @@ namespace OfficeIMO.Word.Fluent {
         /// <param name="rows">Number of rows.</param>
         /// <param name="columns">Number of columns.</param>
         /// <returns>The current <see cref="TableBuilder"/>.</returns>
-        public TableBuilder AddTable(int rows, int columns) {
+        public TableBuilder Create(int rows, int columns) {
             _columns = columns;
             _table = _fluent.Document.AddTable(rows, columns);
-            if (_preferredWidthPct.HasValue) {
-                _table.WidthType = TableWidthUnitValues.Pct;
-                _table.Width = _preferredWidthPct.Value * 50;
-            } else if (_preferredWidthDxa.HasValue) {
-                _table.WidthType = TableWidthUnitValues.Dxa;
-                _table.Width = _preferredWidthDxa.Value;
-            }
+            ApplyPreferredWidth();
             return this;
         }
 
@@ -60,31 +54,39 @@ namespace OfficeIMO.Word.Fluent {
                     _columns = 1;
                 }
                 _table = _fluent.Document.AddTable(rows, _columns);
-                if (_preferredWidthPct.HasValue) {
-                    _table.WidthType = TableWidthUnitValues.Pct;
-                    _table.Width = _preferredWidthPct.Value * 50;
-                } else if (_preferredWidthDxa.HasValue) {
-                    _table.WidthType = TableWidthUnitValues.Dxa;
-                    _table.Width = _preferredWidthDxa.Value;
-                }
+                ApplyPreferredWidth();
+            }
+        }
+
+        private void ApplyPreferredWidth() {
+            if (_table == null) {
+                return;
+            }
+
+            if (_preferredWidthPct.HasValue) {
+                _table.WidthType = TableWidthUnitValues.Pct;
+                _table.Width = _preferredWidthPct.Value * 50;
+            } else if (_preferredWidthPoints.HasValue) {
+                _table.WidthType = TableWidthUnitValues.Dxa;
+                _table.Width = _preferredWidthPoints.Value * 20;
             }
         }
 
         /// <summary>
         /// Sets the preferred width of the table.
         /// </summary>
-        public TableBuilder PreferredWidth(int? Percent = null, int? Dxa = null) {
+        public TableBuilder PreferredWidth(int? percent = null, int? points = null) {
             if (_table != null) {
-                if (Percent.HasValue) {
+                if (percent.HasValue) {
                     _table.WidthType = TableWidthUnitValues.Pct;
-                    _table.Width = Percent.Value * 50;
-                } else if (Dxa.HasValue) {
+                    _table.Width = percent.Value * 50;
+                } else if (points.HasValue) {
                     _table.WidthType = TableWidthUnitValues.Dxa;
-                    _table.Width = Dxa.Value;
+                    _table.Width = points.Value * 20;
                 }
             } else {
-                _preferredWidthPct = Percent;
-                _preferredWidthDxa = Dxa;
+                _preferredWidthPct = percent;
+                _preferredWidthPoints = points;
             }
             return this;
         }


### PR DESCRIPTION
## Summary
- rename fluent TableBuilder.AddTable to Create
- allow TableBuilder.PreferredWidth to accept points and apply width during creation
- update examples and tests for new API

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a5d362656c832ea04e9ce6f3450baa