### PR TITLE
feat(word): allow setting cell margins per table cell

### DIFF
--- a/OfficeIMO.Examples/Word/Tables/Tables.CellMargins.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.CellMargins.cs
@@ -1,0 +1,27 @@
+using OfficeIMO.Word;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Tables {
+        internal static void Example_TableCellMargins(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Table cell custom margins");
+            string filePath = Path.Combine(folderPath, "TableCellMargins.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(2, 2);
+                table.StyleDetails!.MarginDefaultRightWidth = 100;
+
+                var cell1 = table.Rows[0].Cells[1];
+                cell1.AddParagraph("Right margin 200 twips");
+                cell1.MarginRightWidth = 200;
+
+                var cell2 = table.Rows[1].Cells[0];
+                cell2.AddParagraph("Top margin 0.5 cm");
+                cell2.MarginTopCentimeters = 0.5;
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Tables.CellOptions.cs
+++ b/OfficeIMO.Tests/Word.Tables.CellOptions.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    /// <summary>
+    /// Tests cell-level options such as margins, wrapping, and fit text.
+    /// </summary>
+    public partial class Word {
+        /// <summary>
+        /// Verifies that individual table cell margins can be set and persisted.
+        /// </summary>
+        [Fact]
+        public void Test_TableCellMargins() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithCellMargins.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(2, 2);
+
+                // Set a default right margin for the table
+                table.StyleDetails!.MarginDefaultRightWidth = 100;
+
+                // Override margins for a specific cell
+                var cell = table.Rows[0].Cells[1];
+                cell.MarginRightWidth = 200;
+                cell.MarginTopCentimeters = 0.3;
+
+                // Verify values before saving
+                Assert.True(cell.MarginRightWidth == 200);
+                Assert.True(Math.Abs(cell.MarginTopCentimeters.GetValueOrDefault() - 0.3) < 0.01);
+                Assert.True(table.Rows[0].Cells[0].MarginRightWidth == null);
+
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithCellMargins.docx"))) {
+                var cell = document.Tables[0].Rows[0].Cells[1];
+                Assert.True(cell.MarginRightWidth == 200);
+                Assert.True(Math.Abs(cell.MarginTopCentimeters.GetValueOrDefault() - 0.3) < 0.01);
+                Assert.True(document.Tables[0].Rows[0].Cells[0].MarginRightWidth == null);
+                document.Save();
+            }
+        }
+
+        /// <summary>
+        /// Verifies WrapText and FitText persistence on table cells.
+        /// </summary>
+        [Fact]
+        public void Test_TableCellWrapAndFitText() {
+            string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithCellOptions.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(1, 2);
+
+                var cell1 = table.Rows[0].Cells[0];
+                cell1.WrapText = false;
+
+                var cell2 = table.Rows[0].Cells[1];
+                cell2.FitText = true;
+
+                Assert.False(cell1.WrapText);
+                Assert.True(cell2.FitText);
+
+                document.Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var cell1 = document.Tables[0].Rows[0].Cells[0];
+                var cell2 = document.Tables[0].Rows[0].Cells[1];
+
+                Assert.False(cell1.WrapText);
+                Assert.True(cell2.FitText);
+
+                document.Save();
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -283,6 +283,191 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Removes the <see cref="TableCellMargin"/> element if it has no child elements.
+        /// </summary>
+        private void CleanupTableCellMargin() {
+            if (_tableCellProperties?.TableCellMargin != null && !_tableCellProperties.TableCellMargin.Any()) {
+                _tableCellProperties.TableCellMargin.Remove();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the top margin in twips for the current cell.
+        /// </summary>
+        public Int16? MarginTopWidth {
+            get {
+                var width = _tableCellProperties?.TableCellMargin?.TopMargin?.Width;
+                if (width != null) {
+                    return Int16.Parse(width);
+                }
+                return null;
+            }
+            set {
+                AddTableCellProperties();
+                if (value != null) {
+                    _tableCellProperties!.TableCellMargin ??= new TableCellMargin();
+                    _tableCellProperties.TableCellMargin.TopMargin ??= new TopMargin();
+                    _tableCellProperties.TableCellMargin.TopMargin.Width = value.ToString();
+                    _tableCellProperties.TableCellMargin.TopMargin.Type = TableWidthUnitValues.Dxa;
+                } else {
+                    _tableCellProperties?.TableCellMargin?.TopMargin?.Remove();
+                    CleanupTableCellMargin();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the bottom margin in twips for the current cell.
+        /// </summary>
+        public Int16? MarginBottomWidth {
+            get {
+                var width = _tableCellProperties?.TableCellMargin?.BottomMargin?.Width;
+                if (width != null) {
+                    return Int16.Parse(width);
+                }
+                return null;
+            }
+            set {
+                AddTableCellProperties();
+                if (value != null) {
+                    _tableCellProperties!.TableCellMargin ??= new TableCellMargin();
+                    _tableCellProperties.TableCellMargin.BottomMargin ??= new BottomMargin();
+                    _tableCellProperties.TableCellMargin.BottomMargin.Width = value.ToString();
+                    _tableCellProperties.TableCellMargin.BottomMargin.Type = TableWidthUnitValues.Dxa;
+                } else {
+                    _tableCellProperties?.TableCellMargin?.BottomMargin?.Remove();
+                    CleanupTableCellMargin();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the left margin in twips for the current cell.
+        /// </summary>
+        public Int16? MarginLeftWidth {
+            get {
+                var width = _tableCellProperties?.TableCellMargin?.LeftMargin?.Width;
+                if (width != null) {
+                    return Int16.Parse(width);
+                }
+                return null;
+            }
+            set {
+                AddTableCellProperties();
+                if (value != null) {
+                    _tableCellProperties!.TableCellMargin ??= new TableCellMargin();
+                    _tableCellProperties.TableCellMargin.LeftMargin ??= new LeftMargin();
+                    _tableCellProperties.TableCellMargin.LeftMargin.Width = value.ToString();
+                    _tableCellProperties.TableCellMargin.LeftMargin.Type = TableWidthUnitValues.Dxa;
+                } else {
+                    _tableCellProperties?.TableCellMargin?.LeftMargin?.Remove();
+                    CleanupTableCellMargin();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the right margin in twips for the current cell.
+        /// </summary>
+        public Int16? MarginRightWidth {
+            get {
+                var width = _tableCellProperties?.TableCellMargin?.RightMargin?.Width;
+                if (width != null) {
+                    return Int16.Parse(width);
+                }
+                return null;
+            }
+            set {
+                AddTableCellProperties();
+                if (value != null) {
+                    _tableCellProperties!.TableCellMargin ??= new TableCellMargin();
+                    _tableCellProperties.TableCellMargin.RightMargin ??= new RightMargin();
+                    _tableCellProperties.TableCellMargin.RightMargin.Width = value.ToString();
+                    _tableCellProperties.TableCellMargin.RightMargin.Type = TableWidthUnitValues.Dxa;
+                } else {
+                    _tableCellProperties?.TableCellMargin?.RightMargin?.Remove();
+                    CleanupTableCellMargin();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the top margin in centimeters for the current cell.
+        /// </summary>
+        public double? MarginTopCentimeters {
+            get {
+                if (MarginTopWidth != null) {
+                    return Helpers.ConvertTwipsToCentimeters(MarginTopWidth.Value);
+                }
+                return null;
+            }
+            set {
+                if (value != null) {
+                    MarginTopWidth = (Int16)Helpers.ConvertCentimetersToTwips(value.Value);
+                } else {
+                    MarginTopWidth = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the bottom margin in centimeters for the current cell.
+        /// </summary>
+        public double? MarginBottomCentimeters {
+            get {
+                if (MarginBottomWidth != null) {
+                    return Helpers.ConvertTwipsToCentimeters(MarginBottomWidth.Value);
+                }
+                return null;
+            }
+            set {
+                if (value != null) {
+                    MarginBottomWidth = (Int16)Helpers.ConvertCentimetersToTwips(value.Value);
+                } else {
+                    MarginBottomWidth = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the left margin in centimeters for the current cell.
+        /// </summary>
+        public double? MarginLeftCentimeters {
+            get {
+                if (MarginLeftWidth != null) {
+                    return Helpers.ConvertTwipsToCentimeters(MarginLeftWidth.Value);
+                }
+                return null;
+            }
+            set {
+                if (value != null) {
+                    MarginLeftWidth = (Int16)Helpers.ConvertCentimetersToTwips(value.Value);
+                } else {
+                    MarginLeftWidth = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the right margin in centimeters for the current cell.
+        /// </summary>
+        public double? MarginRightCentimeters {
+            get {
+                if (MarginRightWidth != null) {
+                    return Helpers.ConvertTwipsToCentimeters(MarginRightWidth.Value);
+                }
+                return null;
+            }
+            set {
+                if (value != null) {
+                    MarginRightWidth = (Int16)Helpers.ConvertCentimetersToTwips(value.Value);
+                } else {
+                    MarginRightWidth = null;
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets or sets whether text wraps within the cell.
         /// </summary>
         public bool WrapText {


### PR DESCRIPTION
## Summary
- enable per-cell margin customization in Word table cells, including centimeter helpers
- add tests covering WrapText and FitText options alongside cell margins
- add example showing custom cell margins

## Testing
- `dotnet build`
- `dotnet test --no-build`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build --filter Test_TableCellWrapAndFitText`


------
https://chatgpt.com/codex/tasks/task_e_68a5dc0bd64c832eaed094df4b356474