### PR TITLE
Fix invisible Visio shapes by adding geometry style cells

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -29,6 +29,7 @@ namespace OfficeIMO.Examples {
             OfficeIMO.Examples.Visio.ThemeAndWindows.Example_ThemeAndWindows(folderPath, false);
             OfficeIMO.Examples.Visio.AllNamedShapesHaveMasters.Run();
             OfficeIMO.Examples.Visio.MasterShapes.Run();
+            OfficeIMO.Examples.Visio.RectangleStyles.Example_RectangleStyles(folderPath, false);
 
             // Excel/BasicExcelFunctionality
             OfficeIMO.Examples.Excel.BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);

--- a/OfficeIMO.Examples/Visio/RectangleStyles.cs
+++ b/OfficeIMO.Examples/Visio/RectangleStyles.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    /// <summary>
+    /// Demonstrates creating a rectangle with explicit styles so it remains visible.
+    /// </summary>
+    public static class RectangleStyles {
+        public static void Example_RectangleStyles(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Rectangle with styles");
+            string filePath = Path.Combine(folderPath, "Rectangle Styles.vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            page.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "Rect"));
+            document.Save(filePath);
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.RectangleGeometry.cs
+++ b/OfficeIMO.Tests/Visio.RectangleGeometry.cs
@@ -21,6 +21,9 @@ namespace OfficeIMO.Tests {
             XDocument pageDoc = XDocument.Load(pagePart.GetStream());
             XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
             XElement shape = pageDoc.Root!.Element(ns + "Shapes")!.Element(ns + "Shape")!;
+            Assert.Equal("3", shape.Attribute("LineStyle")?.Value);
+            Assert.Equal("3", shape.Attribute("FillStyle")?.Value);
+            Assert.Equal("3", shape.Attribute("TextStyle")?.Value);
             XElement geom = shape.Element(ns + "Geom")!;
             var lines = geom.Elements(ns + "LineTo").ToList();
             Assert.Equal(4, lines.Count);

--- a/OfficeIMO.Tests/Visio.RectangleGeometry.cs
+++ b/OfficeIMO.Tests/Visio.RectangleGeometry.cs
@@ -21,7 +21,8 @@ namespace OfficeIMO.Tests {
             XDocument pageDoc = XDocument.Load(pagePart.GetStream());
             XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
             XElement shape = pageDoc.Root!.Element(ns + "Shapes")!.Element(ns + "Shape")!;
-            var lines = shape.Element(ns + "Geom")!.Elements(ns + "LineTo").ToList();
+            XElement geom = shape.Element(ns + "Geom")!;
+            var lines = geom.Elements(ns + "LineTo").ToList();
             Assert.Equal(4, lines.Count);
             Assert.Equal("2", lines[0].Attribute("X")!.Value);
             Assert.Equal("0", lines[0].Attribute("Y")!.Value);
@@ -31,6 +32,13 @@ namespace OfficeIMO.Tests {
             Assert.Equal("1", lines[2].Attribute("Y")!.Value);
             Assert.Equal("0", lines[3].Attribute("X")!.Value);
             Assert.Equal("0", lines[3].Attribute("Y")!.Value);
+
+            var noFill = geom.Elements(ns + "Cell").FirstOrDefault(e => e.Attribute("N")?.Value == "NoFill");
+            Assert.NotNull(noFill);
+            Assert.Equal("0", noFill!.Attribute("V")!.Value);
+            var noLine = geom.Elements(ns + "Cell").FirstOrDefault(e => e.Attribute("N")?.Value == "NoLine");
+            Assert.NotNull(noLine);
+            Assert.Equal("0", noLine!.Attribute("V")!.Value);
         }
 
     }

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -594,6 +594,9 @@ namespace OfficeIMO.Visio {
                             writer.WriteAttributeString("Name", masterShapeName);
                             writer.WriteAttributeString("NameU", master.NameU);
                             writer.WriteAttributeString("Type", "Shape");
+                            writer.WriteAttributeString("LineStyle", "3");
+                            writer.WriteAttributeString("FillStyle", "3");
+                            writer.WriteAttributeString("TextStyle", "3");
                             WriteXForm(writer, s, masterWidth, masterHeight);
                             // Always specify line weight so that shapes are visible
                             WriteCell(writer, "LineWeight", s.LineWeight);
@@ -802,6 +805,9 @@ namespace OfficeIMO.Visio {
                                 WriteDataSection(writer, shape.Data);
                                 WriteTextElement(writer, shape.Text);
                             } else {
+                                writer.WriteAttributeString("LineStyle", "3");
+                                writer.WriteAttributeString("FillStyle", "3");
+                                writer.WriteAttributeString("TextStyle", "3");
                                 double width = shape.Width > 0 ? shape.Width : 1;
                                 double height = shape.Height > 0 ? shape.Height : 1;
                                 shape.Width = width;
@@ -847,12 +853,16 @@ namespace OfficeIMO.Visio {
                                 endY = (top + bottom) / 2;
                             }
 
-                            writer.WriteStartElement("Shape", ns);
-                            writer.WriteAttributeString("ID", connector.Id);
-                            writer.WriteAttributeString("Name", "Connector");
-                            writer.WriteAttributeString("NameU", "Connector");
-                            writer.WriteAttributeString("Type", "Shape");
-                            writer.WriteStartElement("Geom", ns);
+                              writer.WriteStartElement("Shape", ns);
+                              writer.WriteAttributeString("ID", connector.Id);
+                              writer.WriteAttributeString("Name", "Connector");
+                              writer.WriteAttributeString("NameU", "Connector");
+                              writer.WriteAttributeString("Type", "Shape");
+                              writer.WriteAttributeString("LineStyle", "3");
+                              writer.WriteAttributeString("FillStyle", "3");
+                              writer.WriteAttributeString("TextStyle", "3");
+                              WriteCell(writer, "LineWeight", 0.0138889);
+                              writer.WriteStartElement("Geom", ns);
                             writer.WriteStartElement("MoveTo", ns);
                             writer.WriteAttributeString("X", ToVisioString(startX));
                             writer.WriteAttributeString("Y", ToVisioString(startY));

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -447,6 +447,26 @@ namespace OfficeIMO.Visio {
 
                 void WriteRectangleGeometry(XmlWriter writer, double width, double height) {
                     writer.WriteStartElement("Geom", ns);
+                    writer.WriteStartElement("Cell", ns);
+                    writer.WriteAttributeString("N", "NoFill");
+                    writer.WriteAttributeString("V", "0");
+                    writer.WriteEndElement();
+                    writer.WriteStartElement("Cell", ns);
+                    writer.WriteAttributeString("N", "NoLine");
+                    writer.WriteAttributeString("V", "0");
+                    writer.WriteEndElement();
+                    writer.WriteStartElement("Cell", ns);
+                    writer.WriteAttributeString("N", "NoShow");
+                    writer.WriteAttributeString("V", "0");
+                    writer.WriteEndElement();
+                    writer.WriteStartElement("Cell", ns);
+                    writer.WriteAttributeString("N", "NoSnap");
+                    writer.WriteAttributeString("V", "0");
+                    writer.WriteEndElement();
+                    writer.WriteStartElement("Cell", ns);
+                    writer.WriteAttributeString("N", "NoQuickDrag");
+                    writer.WriteAttributeString("V", "0");
+                    writer.WriteEndElement();
                     writer.WriteStartElement("MoveTo", ns);
                     writer.WriteAttributeString("X", ToVisioString(0));
                     writer.WriteAttributeString("Y", ToVisioString(0));


### PR DESCRIPTION
## Summary
- ensure rectangle geometry writes NoFill and NoLine cells so shapes are visible
- cover rectangle geometry with visibility test

## Testing
- `dotnet test --no-build --filter VisioRectangleGeometry`


------
https://chatgpt.com/codex/tasks/task_e_68a5f9d33570832eba27a6df7e0f1717