### PR TITLE
Allow HorizontalAlignment in ImageBuilder

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.BlockLevel.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.BlockLevel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;

--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.FromUrl.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.FromUrl.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;

--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.FromUrlAsync.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.FromUrlAsync.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;

--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.Mixed.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.Mixed.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;

--- a/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.Multiple.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Images/Fluent.Images.Multiple.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;

--- a/OfficeIMO.Tests/Word.Fluent.ImageBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ImageBuilder.cs
@@ -33,10 +33,10 @@ namespace OfficeIMO.Tests {
                     .Image(i => i.Add(imagePath).Size(50, 50).Wrap(WrapTextImage.Square).Align(HorizontalAlignment.Center))
                     .Image(i => {
                         using var stream = File.OpenRead(imagePath);
-                        i.Add(stream, "stream.jpg").Size(60, 60);
+                        i.Add(stream, "stream.jpg").Size(60, 60).Align(HorizontalAlignment.Right);
                     })
-                    .Image(i => i.Add(bytes, "bytes.jpg").Size(70, 70))
-                    .Image(i => i.AddFromUrl($"http://localhost:{port}/").Size(80, 80))
+                    .Image(i => i.Add(bytes, "bytes.jpg").Size(70, 70).Align(HorizontalAlignment.Left))
+                    .Image(i => i.AddFromUrl($"http://localhost:{port}/").Size(80, 80).Align(HorizontalAlignment.Justified))
                     .End();
                 document.Save(false);
             }
@@ -50,8 +50,11 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(WrapTextImage.Square, document.Images[0].WrapText);
                 Assert.Equal(JustificationValues.Center, document.Paragraphs[0].ParagraphAlignment);
                 Assert.Equal(60, document.Images[1].Width);
+                Assert.Equal(JustificationValues.Right, document.Paragraphs[1].ParagraphAlignment);
                 Assert.Equal(70, document.Images[2].Width);
+                Assert.Equal(JustificationValues.Left, document.Paragraphs[2].ParagraphAlignment);
                 Assert.Equal(80, document.Images[3].Width);
+                Assert.Equal(JustificationValues.Both, document.Paragraphs[3].ParagraphAlignment);
             }
         }
     }

--- a/OfficeIMO.Word/Fluent/ImageBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ImageBuilder.cs
@@ -82,6 +82,10 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Sets horizontal alignment for the image's paragraph.
+        /// </summary>
+        /// <param name="alignment">Desired horizontal alignment.</param>
         public ImageBuilder Align(HorizontalAlignment alignment) {
             var justification = alignment switch {
                 HorizontalAlignment.Center => JustificationValues.Center,


### PR DESCRIPTION
## Summary
- map HorizontalAlignment to JustificationValues in ImageBuilder
- extend fluent image tests for alignment cases
- clean image examples to remove old DocumentFormat alignment imports

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fcee972c832ea781d3ec7ab956dc