### PR TITLE
Ensure default styles for Visio shapes and connectors

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -30,6 +30,7 @@ namespace OfficeIMO.Examples {
             OfficeIMO.Examples.Visio.AllNamedShapesHaveMasters.Run();
             OfficeIMO.Examples.Visio.MasterShapes.Run();
             OfficeIMO.Examples.Visio.RectangleStyles.Example_RectangleStyles(folderPath, false);
+            OfficeIMO.Examples.Visio.ConnectorStyles.Example_ConnectorStyles(folderPath, false);
 
             // Excel/BasicExcelFunctionality
             OfficeIMO.Examples.Excel.BasicExcelFunctionality.BasicExcel_Example1(folderPath, false);

--- a/OfficeIMO.Examples/Visio/ConnectorStyles.cs
+++ b/OfficeIMO.Examples/Visio/ConnectorStyles.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    /// <summary>
+    /// Demonstrates a connector with explicit styles.
+    /// </summary>
+    public static class ConnectorStyles {
+        public static void Example_ConnectorStyles(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Connector with styles");
+            string filePath = Path.Combine(folderPath, "Connector Styles.vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            VisioShape start = new("1", 1, 1, 2, 1, "Start") { NameU = "Rectangle" };
+            VisioShape end = new("2", 4, 1, 2, 1, "End") { NameU = "Rectangle" };
+            page.Shapes.Add(start);
+            page.Shapes.Add(end);
+            page.Connectors.Add(new VisioConnector(start, end) { EndArrow = 13 });
+            document.Save(filePath);
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.ShapeAndConnectorStyles.cs
+++ b/OfficeIMO.Tests/Visio.ShapeAndConnectorStyles.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.IO.Packaging;
+using System.Linq;
+using System.Xml.Linq;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioShapeAndConnectorStyles {
+        [Fact]
+        public void ShapesAndConnectorsHaveDefaultStyles() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            VisioShape start = new("1", 1, 1, 2, 1, "Start");
+            VisioShape end = new("2", 4, 1, 2, 1, "End");
+            page.Shapes.Add(start);
+            page.Shapes.Add(end);
+            VisioConnector connector = new(start, end) { EndArrow = 13 };
+            page.Connectors.Add(connector);
+            document.Save(filePath);
+
+            using Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read);
+            XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
+            PackagePart pagePart = package.GetPart(new Uri("/visio/pages/page1.xml", UriKind.Relative));
+            XDocument pageXml = XDocument.Load(pagePart.GetStream());
+            XElement shapesRoot = pageXml.Root!.Element(ns + "Shapes")!;
+
+            XElement shapeXml = shapesRoot.Elements(ns + "Shape").First(e => e.Attribute("ID")?.Value == "1");
+            Assert.Equal("1", shapeXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "LinePattern").Attribute("V")?.Value);
+            Assert.Equal("RGB(0,0,0)", shapeXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "LineColor").Attribute("V")?.Value);
+            Assert.Equal("1", shapeXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "FillPattern").Attribute("V")?.Value);
+            Assert.Equal("RGB(255,255,255)", shapeXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "FillForegnd").Attribute("V")?.Value);
+
+            XElement connectorXml = shapesRoot.Elements(ns + "Shape").First(e => e.Attribute("ID")?.Value == connector.Id);
+            Assert.Equal("1", connectorXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "LinePattern").Attribute("V")?.Value);
+            Assert.Equal("RGB(0,0,0)", connectorXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "LineColor").Attribute("V")?.Value);
+            Assert.Equal("1", connectorXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "FillPattern").Attribute("V")?.Value);
+            Assert.Equal("RGB(255,255,255)", connectorXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "FillForegnd").Attribute("V")?.Value);
+            Assert.Equal("1", connectorXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "OneD").Attribute("V")?.Value);
+            Assert.Equal("13", connectorXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "EndArrow").Attribute("V")?.Value);
+
+            var badCells = pageXml.Descendants(ns + "Cell")
+                .Where(c => (c.Attribute("N")?.Value == "NoLine" || c.Attribute("N")?.Value == "NoFill") && c.Attribute("V")?.Value == "1");
+            Assert.Empty(badCells);
+        }
+    }
+}

--- a/OfficeIMO.Visio/VisioConnector.cs
+++ b/OfficeIMO.Visio/VisioConnector.cs
@@ -58,6 +58,11 @@ namespace OfficeIMO.Visio {
         /// </summary>
         public ConnectorKind Kind { get; set; } = ConnectorKind.Straight;
 
+        /// <summary>
+        /// Gets or sets the end arrow style.
+        /// </summary>
+        public int? EndArrow { get; set; }
+
         private static string GetNextId(VisioShape from, VisioShape to) {
             int fromId = int.TryParse(from.Id, out int fi) ? fi : 0;
             int toId = int.TryParse(to.Id, out int ti) ? ti : 0;

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -424,6 +424,13 @@ namespace OfficeIMO.Visio {
                     writer.WriteEndElement();
                 }
 
+                void WriteCellValue(XmlWriter writer, string name, string value) {
+                    writer.WriteStartElement("Cell", ns);
+                    writer.WriteAttributeString("N", name);
+                    writer.WriteAttributeString("V", value);
+                    writer.WriteEndElement();
+                }
+
                 void WriteXForm(XmlWriter writer, VisioShape shape, double width, double height) {
                     writer.WriteStartElement("XForm", ns);
                     writer.WriteElementString("PinX", ns, ToVisioString(shape.PinX));
@@ -600,6 +607,10 @@ namespace OfficeIMO.Visio {
                             WriteXForm(writer, s, masterWidth, masterHeight);
                             // Always specify line weight so that shapes are visible
                             WriteCell(writer, "LineWeight", s.LineWeight);
+                            WriteCell(writer, "LinePattern", 1);
+                            WriteCellValue(writer, "LineColor", "RGB(0,0,0)");
+                            WriteCell(writer, "FillPattern", 1);
+                            WriteCellValue(writer, "FillForegnd", "RGB(255,255,255)");
                             WriteRectangleGeometry(writer, masterWidth, masterHeight);
                             WriteConnectionSection(writer, s.ConnectionPoints);
                             WriteDataSection(writer, s.Data);
@@ -801,6 +812,10 @@ namespace OfficeIMO.Visio {
                                 WriteXForm(writer, shape, width, height);
                                 // Always include line weight to avoid invisible shapes
                                 WriteCell(writer, "LineWeight", shape.LineWeight);
+                                WriteCell(writer, "LinePattern", 1);
+                                WriteCellValue(writer, "LineColor", "RGB(0,0,0)");
+                                WriteCell(writer, "FillPattern", 1);
+                                WriteCellValue(writer, "FillForegnd", "RGB(255,255,255)");
                                 WriteConnectionSection(writer, shape.ConnectionPoints);
                                 WriteDataSection(writer, shape.Data);
                                 WriteTextElement(writer, shape.Text);
@@ -821,6 +836,10 @@ namespace OfficeIMO.Visio {
                                 WriteXForm(writer, shape, width, height);
                                 // Always include line weight to avoid invisible shapes
                                 WriteCell(writer, "LineWeight", shape.LineWeight);
+                                WriteCell(writer, "LinePattern", 1);
+                                WriteCellValue(writer, "LineColor", "RGB(0,0,0)");
+                                WriteCell(writer, "FillPattern", 1);
+                                WriteCellValue(writer, "FillForegnd", "RGB(255,255,255)");
                                 WriteRectangleGeometry(writer, width, height);
                                 WriteConnectionSection(writer, shape.ConnectionPoints);
                                 WriteDataSection(writer, shape.Data);
@@ -862,6 +881,14 @@ namespace OfficeIMO.Visio {
                               writer.WriteAttributeString("FillStyle", "3");
                               writer.WriteAttributeString("TextStyle", "3");
                               WriteCell(writer, "LineWeight", 0.0138889);
+                              WriteCell(writer, "LinePattern", 1);
+                              WriteCellValue(writer, "LineColor", "RGB(0,0,0)");
+                              WriteCell(writer, "FillPattern", 1);
+                              WriteCellValue(writer, "FillForegnd", "RGB(255,255,255)");
+                              WriteCell(writer, "OneD", 1);
+                              if (connector.EndArrow.HasValue) {
+                                  WriteCell(writer, "EndArrow", connector.EndArrow.Value);
+                              }
                               writer.WriteStartElement("Geom", ns);
                             writer.WriteStartElement("MoveTo", ns);
                             writer.WriteAttributeString("X", ToVisioString(startX));


### PR DESCRIPTION
## Summary
- add overload to write string-valued Visio cells and apply default line and fill styles to shapes
- include line and fill styles, OneD, and optional EndArrow when writing connectors
- add example and tests covering styled connectors and ensuring geometry doesn't disable line or fill

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a608c271ac832eac71fabffb4ef7d1