### PR TITLE
Initialize default PowerPoint parts and add tests

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/InitializeDefaultsPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/InitializeDefaultsPowerPoint.cs
@@ -1,0 +1,19 @@
+using System;
+using System.IO;
+using OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.Examples.PowerPoint {
+    /// <summary>
+    /// Demonstrates creation of a presentation with default parts and a single slide.
+    /// </summary>
+    public static class InitializeDefaultsPowerPoint {
+        public static void Example_PowerPointInitializeDefaults(string folderPath, bool openPowerPoint) {
+            Console.WriteLine("[*] PowerPoint - Initialize defaults presentation");
+            string filePath = Path.Combine(folderPath, "InitializeDefaults.pptx");
+
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+            presentation.AddSlide();
+            presentation.Save();
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -265,14 +265,21 @@ namespace OfficeIMO.PowerPoint {
             );
             slideMasterPart.SlideMaster = slideMaster;
 
-            SlideLayoutPart layoutPart = slideMasterPart.AddNewPart<SlideLayoutPart>();
-            layoutPart.SlideLayout = new SlideLayout(
+            SlideLayoutPart layoutPart0 = slideMasterPart.AddNewPart<SlideLayoutPart>();
+            layoutPart0.SlideLayout = new SlideLayout(
+                new CommonSlideData(CreateShapeTree()),
+                new ColorMapOverride(new A.MasterColorMapping())
+            );
+
+            SlideLayoutPart layoutPart1 = slideMasterPart.AddNewPart<SlideLayoutPart>();
+            layoutPart1.SlideLayout = new SlideLayout(
                 new CommonSlideData(CreateShapeTree()),
                 new ColorMapOverride(new A.MasterColorMapping())
             );
 
             slideMaster.SlideLayoutIdList = new SlideLayoutIdList(
-                new SlideLayoutId { Id = 1U, RelationshipId = slideMasterPart.GetIdOfPart(layoutPart) }
+                new SlideLayoutId { Id = 1U, RelationshipId = slideMasterPart.GetIdOfPart(layoutPart0) },
+                new SlideLayoutId { Id = 2U, RelationshipId = slideMasterPart.GetIdOfPart(layoutPart1) }
             );
 
             // theme part is stored under ppt/theme and referenced from both presentation and slide master

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -117,7 +117,7 @@ namespace OfficeIMO.PowerPoint {
             }
 
             SlideLayoutPart layoutPart = layouts[layoutIndex];
-            slidePart.AddPart(layoutPart);
+            _ = slidePart.AddPart(layoutPart);
 
             if (_presentationPart.Presentation.SlideIdList == null) {
                 _presentationPart.Presentation.SlideIdList = new SlideIdList();
@@ -265,21 +265,14 @@ namespace OfficeIMO.PowerPoint {
             );
             slideMasterPart.SlideMaster = slideMaster;
 
-            SlideLayoutPart slideLayoutPart1 = slideMasterPart.AddNewPart<SlideLayoutPart>();
-            slideLayoutPart1.SlideLayout = new SlideLayout(
-                new CommonSlideData(CreateShapeTree()),
-                new ColorMapOverride(new A.MasterColorMapping())
-            );
-
-            SlideLayoutPart slideLayoutPart2 = slideMasterPart.AddNewPart<SlideLayoutPart>();
-            slideLayoutPart2.SlideLayout = new SlideLayout(
+            SlideLayoutPart layoutPart = slideMasterPart.AddNewPart<SlideLayoutPart>();
+            layoutPart.SlideLayout = new SlideLayout(
                 new CommonSlideData(CreateShapeTree()),
                 new ColorMapOverride(new A.MasterColorMapping())
             );
 
             slideMaster.SlideLayoutIdList = new SlideLayoutIdList(
-                new SlideLayoutId { Id = 2147483649U, RelationshipId = slideMasterPart.GetIdOfPart(slideLayoutPart1) },
-                new SlideLayoutId { Id = 2147483650U, RelationshipId = slideMasterPart.GetIdOfPart(slideLayoutPart2) }
+                new SlideLayoutId { Id = 1U, RelationshipId = slideMasterPart.GetIdOfPart(layoutPart) }
             );
 
             // theme part is stored under ppt/theme and referenced from both presentation and slide master
@@ -287,9 +280,9 @@ namespace OfficeIMO.PowerPoint {
             themePart.Theme = new A.Theme { Name = "Office Theme", ThemeElements = new A.ThemeElements() };
             slideMasterPart.AddPart(themePart);
 
-            _presentationPart.Presentation.SlideMasterIdList = new SlideMasterIdList(new SlideMasterId {
-                Id = 2147483648U, RelationshipId = _presentationPart.GetIdOfPart(slideMasterPart)
-            });
+            _presentationPart.Presentation.SlideMasterIdList = new SlideMasterIdList(
+                new SlideMasterId { Id = 1U, RelationshipId = _presentationPart.GetIdOfPart(slideMasterPart) }
+            );
 
             NotesMasterPart notesMasterPart = _presentationPart.AddNewPart<NotesMasterPart>();
             notesMasterPart.NotesMaster = new NotesMaster(

--- a/OfficeIMO.Tests/PowerPoint.InitializeDefaults.cs
+++ b/OfficeIMO.Tests/PowerPoint.InitializeDefaults.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointInitializeDefaults {
+        [Fact]
+        public void DefaultPartsAndContentTypesAreCreated() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                presentation.AddSlide();
+                presentation.Save();
+            }
+
+            using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                PresentationPart part = document.PresentationPart!;
+                Assert.NotNull(part.Presentation.SlideSize);
+                Assert.NotNull(part.Presentation.NotesSize);
+                SlideMasterPart master = part.SlideMasterParts.First();
+                Assert.NotEmpty(master.SlideLayoutParts);
+                ThemePart theme = part.ThemePart!;
+                Assert.Same(theme, master.ThemePart);
+                Assert.Single(part.Presentation.SlideIdList!.Elements<SlideId>());
+            }
+
+            using (FileStream fs = File.OpenRead(filePath))
+            using (ZipArchive zip = new ZipArchive(fs, ZipArchiveMode.Read)) {
+                ZipArchiveEntry entry = zip.GetEntry("[Content_Types].xml")!;
+                using Stream s = entry.Open();
+                XDocument xml = XDocument.Load(s);
+                XNamespace ns = "http://schemas.openxmlformats.org/package/2006/content-types";
+
+                bool HasOverride(string type) => xml.Descendants(ns + "Override")
+                    .Any(o => (string?)o.Attribute("ContentType") == type);
+
+                const string pres = "application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml";
+                bool presentationDefined = HasOverride(pres) ||
+                    xml.Descendants(ns + "Default").Any(d => (string?)d.Attribute("ContentType") == pres);
+                Assert.True(presentationDefined);
+                Assert.True(HasOverride("application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"));
+                Assert.True(HasOverride("application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"));
+                Assert.True(HasOverride("application/vnd.openxmlformats-officedocument.presentationml.slide+xml"));
+                Assert.True(HasOverride("application/vnd.openxmlformats-officedocument.theme+xml"));
+                Assert.True(HasOverride("application/vnd.openxmlformats-officedocument.presentationml.tableStyles+xml"));
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure presentation initialization creates slide master, layout and theme parts with proper IDs
- link new slides to layouts and register slide IDs
- add example and test verifying content types and default parts

## Testing
- `dotnet test OfficeIMO.Tests --filter "PowerPointInitializeDefaults"`

------
https://chatgpt.com/codex/tasks/task_e_68a5f717abc0832eabd18817a09ed7f3