### PR TITLE
Define default Visio styles and reference them in shapes

### DIFF
--- a/OfficeIMO.Examples/Visio/StyleSheets.cs
+++ b/OfficeIMO.Examples/Visio/StyleSheets.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using System.IO.Packaging;
+using System.Linq;
+using System.Xml.Linq;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    /// <summary>
+    /// Demonstrates style sheet definitions in a Visio document.
+    /// </summary>
+    public static class StyleSheets {
+        public static void Example_StyleSheets(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - StyleSheets");
+            string filePath = Path.Combine(folderPath, "StyleSheets.vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            VisioShape start = new("1", 1, 1, 2, 1, "Start");
+            VisioShape end = new("2", 4, 1, 2, 1, "End");
+            page.Shapes.Add(start);
+            page.Shapes.Add(end);
+            page.Connectors.Add(new VisioConnector(start, end));
+            document.Save(filePath);
+
+            using Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read);
+            PackagePart docPart = package.GetPart(new Uri("/visio/document.xml", UriKind.Relative));
+            XDocument docXml = XDocument.Load(docPart.GetStream());
+            XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
+            var styles = docXml.Root!.Element(ns + "StyleSheets")!
+                .Elements(ns + "StyleSheet")
+                .Select(e => $"{e.Attribute("ID")?.Value}: {e.Attribute("NameU")?.Value}");
+            foreach (string style in styles) {
+                Console.WriteLine($"Style {style}");
+            }
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.DocumentSettings.cs
+++ b/OfficeIMO.Tests/Visio.DocumentSettings.cs
@@ -19,8 +19,8 @@ namespace OfficeIMO.Tests {
             XDocument docXml = XDocument.Load(docPart.GetStream());
             XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
             XElement settings = docXml.Root!.Element(ns + "DocumentSettings")!;
-            Assert.Equal("3", settings.Attribute("DefaultLineStyle")?.Value);
-            Assert.Equal("3", settings.Attribute("DefaultFillStyle")?.Value);
+            Assert.Equal("1", settings.Attribute("DefaultLineStyle")?.Value);
+            Assert.Equal("1", settings.Attribute("DefaultFillStyle")?.Value);
         }
     }
 }

--- a/OfficeIMO.Tests/Visio.RectangleGeometry.cs
+++ b/OfficeIMO.Tests/Visio.RectangleGeometry.cs
@@ -21,9 +21,9 @@ namespace OfficeIMO.Tests {
             XDocument pageDoc = XDocument.Load(pagePart.GetStream());
             XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
             XElement shape = pageDoc.Root!.Element(ns + "Shapes")!.Element(ns + "Shape")!;
-            Assert.Equal("3", shape.Attribute("LineStyle")?.Value);
-            Assert.Equal("3", shape.Attribute("FillStyle")?.Value);
-            Assert.Equal("3", shape.Attribute("TextStyle")?.Value);
+            Assert.Equal("1", shape.Attribute("LineStyle")?.Value);
+            Assert.Equal("1", shape.Attribute("FillStyle")?.Value);
+            Assert.Equal("1", shape.Attribute("TextStyle")?.Value);
             XElement geom = shape.Element(ns + "Geom")!;
             var lines = geom.Elements(ns + "LineTo").ToList();
             Assert.Equal(4, lines.Count);

--- a/OfficeIMO.Tests/Visio.StyleSheets.cs
+++ b/OfficeIMO.Tests/Visio.StyleSheets.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.IO.Packaging;
+using System.Linq;
+using System.Xml.Linq;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioStyleSheets {
+        [Fact]
+        public void DocumentDefinesAndReferencesStyles() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = new();
+            VisioPage page = document.AddPage("Page-1");
+            VisioShape start = new("1", 1, 1, 2, 1, "Start");
+            VisioShape end = new("2", 4, 1, 2, 1, "End");
+            page.Shapes.Add(start);
+            page.Shapes.Add(end);
+            page.Connectors.Add(new VisioConnector(start, end));
+            document.Save(filePath);
+
+            using Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read);
+            PackagePart docPart = package.GetPart(new Uri("/visio/document.xml", UriKind.Relative));
+            XDocument docXml = XDocument.Load(docPart.GetStream());
+            XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
+            XElement styleSheets = docXml.Root!.Element(ns + "StyleSheets")!;
+
+            XElement normal = styleSheets.Elements(ns + "StyleSheet").First(e => e.Attribute("ID")?.Value == "1");
+            Assert.Equal("Normal", normal.Attribute("NameU")?.Value);
+            Assert.Equal("1", normal.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "LinePattern").Attribute("V")?.Value);
+            Assert.Equal("RGB(0,0,0)", normal.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "LineColor").Attribute("V")?.Value);
+            Assert.Equal("1", normal.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "FillPattern").Attribute("V")?.Value);
+            Assert.Equal("RGB(255,255,255)", normal.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "FillForegnd").Attribute("V")?.Value);
+
+            XElement connectorStyle = styleSheets.Elements(ns + "StyleSheet").First(e => e.Attribute("ID")?.Value == "2");
+            Assert.Equal("1", connectorStyle.Attribute("BasedOn")?.Value);
+            Assert.Equal("0", connectorStyle.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "EndArrow").Attribute("V")?.Value);
+
+            PackagePart pagePart = package.GetPart(new Uri("/visio/pages/page1.xml", UriKind.Relative));
+            XDocument pageXml = XDocument.Load(pagePart.GetStream());
+            XElement shapesRoot = pageXml.Root!.Element(ns + "Shapes")!;
+            XElement shapeXml = shapesRoot.Elements(ns + "Shape").First(e => e.Attribute("ID")?.Value == "1");
+            Assert.Equal("1", shapeXml.Attribute("LineStyle")?.Value);
+            Assert.Equal("1", shapeXml.Attribute("FillStyle")?.Value);
+            Assert.Equal("1", shapeXml.Attribute("TextStyle")?.Value);
+            XElement connectorXml = shapesRoot.Elements(ns + "Shape").First(e => e.Attribute("NameU")?.Value == "Connector");
+            Assert.Equal("2", connectorXml.Attribute("LineStyle")?.Value);
+            Assert.Equal("2", connectorXml.Attribute("FillStyle")?.Value);
+            Assert.Equal("2", connectorXml.Attribute("TextStyle")?.Value);
+        }
+    }
+}

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -334,9 +334,9 @@ namespace OfficeIMO.Visio {
             XNamespace ns = VisioNamespace;
             XElement settings = new(ns + "DocumentSettings",
                 new XAttribute("TopPage", 0),
-                new XAttribute("DefaultTextStyle", 3),
-                new XAttribute("DefaultLineStyle", 3),
-                new XAttribute("DefaultFillStyle", 3),
+                new XAttribute("DefaultTextStyle", 1),
+                new XAttribute("DefaultLineStyle", 1),
+                new XAttribute("DefaultFillStyle", 1),
                 new XAttribute("DefaultGuideStyle", 4),
                 new XElement(ns + "GlueSettings", 9),
                 new XElement(ns + "SnapSettings", 295),
@@ -350,13 +350,34 @@ namespace OfficeIMO.Visio {
             if (requestRecalcOnOpen) {
                 settings.Add(new XElement(ns + "RelayoutAndRerouteUponOpen", 1));
             }
+            XElement styleSheets = new(ns + "StyleSheets",
+                new XElement(ns + "StyleSheet",
+                    new XAttribute("ID", 1),
+                    new XAttribute("Name", "Normal"),
+                    new XAttribute("NameU", "Normal"),
+                    new XAttribute("LineStyle", 0),
+                    new XAttribute("FillStyle", 0),
+                    new XAttribute("TextStyle", 0),
+                    new XElement(ns + "Cell", new XAttribute("N", "LinePattern"), new XAttribute("V", 1)),
+                    new XElement(ns + "Cell", new XAttribute("N", "LineColor"), new XAttribute("V", "RGB(0,0,0)")),
+                    new XElement(ns + "Cell", new XAttribute("N", "FillPattern"), new XAttribute("V", 1)),
+                    new XElement(ns + "Cell", new XAttribute("N", "FillForegnd"), new XAttribute("V", "RGB(255,255,255)"))),
+                new XElement(ns + "StyleSheet",
+                    new XAttribute("ID", 2),
+                    new XAttribute("Name", "Connector"),
+                    new XAttribute("NameU", "Connector"),
+                    new XAttribute("BasedOn", 1),
+                    new XAttribute("LineStyle", 0),
+                    new XAttribute("FillStyle", 0),
+                    new XAttribute("TextStyle", 0),
+                    new XElement(ns + "Cell", new XAttribute("N", "EndArrow"), new XAttribute("V", 0))));
 
             return new XDocument(
                 new XElement(ns + "VisioDocument",
                     settings,
                     new XElement(ns + "Colors"),
                     new XElement(ns + "FaceNames"),
-                    new XElement(ns + "StyleSheets")));
+                    styleSheets));
         }
 
         /// <summary>
@@ -601,9 +622,9 @@ namespace OfficeIMO.Visio {
                             writer.WriteAttributeString("Name", masterShapeName);
                             writer.WriteAttributeString("NameU", master.NameU);
                             writer.WriteAttributeString("Type", "Shape");
-                            writer.WriteAttributeString("LineStyle", "3");
-                            writer.WriteAttributeString("FillStyle", "3");
-                            writer.WriteAttributeString("TextStyle", "3");
+                            writer.WriteAttributeString("LineStyle", "1");
+                            writer.WriteAttributeString("FillStyle", "1");
+                            writer.WriteAttributeString("TextStyle", "1");
                             WriteXForm(writer, s, masterWidth, masterHeight);
                             // Always specify line weight so that shapes are visible
                             WriteCell(writer, "LineWeight", s.LineWeight);
@@ -785,6 +806,9 @@ namespace OfficeIMO.Visio {
                             writer.WriteAttributeString("Name", shapeName);
                             writer.WriteAttributeString("NameU", shape.NameU ?? shape.Master?.NameU ?? shapeName);
                             writer.WriteAttributeString("Type", "Shape");
+                            writer.WriteAttributeString("LineStyle", "1");
+                            writer.WriteAttributeString("FillStyle", "1");
+                            writer.WriteAttributeString("TextStyle", "1");
                             if (shape.Master != null) {
                                 writer.WriteAttributeString("Master", shape.Master.Id);
                                 double width = shape.Width;
@@ -820,9 +844,6 @@ namespace OfficeIMO.Visio {
                                 WriteDataSection(writer, shape.Data);
                                 WriteTextElement(writer, shape.Text);
                             } else {
-                                writer.WriteAttributeString("LineStyle", "3");
-                                writer.WriteAttributeString("FillStyle", "3");
-                                writer.WriteAttributeString("TextStyle", "3");
                                 double width = shape.Width > 0 ? shape.Width : 1;
                                 double height = shape.Height > 0 ? shape.Height : 1;
                                 shape.Width = width;
@@ -877,9 +898,9 @@ namespace OfficeIMO.Visio {
                               writer.WriteAttributeString("Name", "Connector");
                               writer.WriteAttributeString("NameU", "Connector");
                               writer.WriteAttributeString("Type", "Shape");
-                              writer.WriteAttributeString("LineStyle", "3");
-                              writer.WriteAttributeString("FillStyle", "3");
-                              writer.WriteAttributeString("TextStyle", "3");
+                              writer.WriteAttributeString("LineStyle", "2");
+                              writer.WriteAttributeString("FillStyle", "2");
+                              writer.WriteAttributeString("TextStyle", "2");
                               WriteCell(writer, "LineWeight", 0.0138889);
                               WriteCell(writer, "LinePattern", 1);
                               WriteCellValue(writer, "LineColor", "RGB(0,0,0)");


### PR DESCRIPTION
## Summary
- populate document with Normal and Connector styles
- apply Normal to shapes and Connector to connector shapes
- add tests and example demonstrating style sheet usage

## Testing
- `dotnet test OfficeImo.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a60f977b5c832e84a51e42378a0a77