### PR TITLE
Write connector endpoints

### DIFF
--- a/OfficeIMO.Tests/Visio.ShapeAndConnectorStyles.cs
+++ b/OfficeIMO.Tests/Visio.ShapeAndConnectorStyles.cs
@@ -41,6 +41,10 @@ namespace OfficeIMO.Tests {
             Assert.Equal("RGB(255,255,255)", connectorXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "FillForegnd").Attribute("V")?.Value);
             Assert.Equal("1", connectorXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "OneD").Attribute("V")?.Value);
             Assert.Equal("13", connectorXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "EndArrow").Attribute("V")?.Value);
+            Assert.Equal("2", connectorXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "BeginX").Attribute("V")?.Value);
+            Assert.Equal("1", connectorXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "BeginY").Attribute("V")?.Value);
+            Assert.Equal("3", connectorXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "EndX").Attribute("V")?.Value);
+            Assert.Equal("1", connectorXml.Elements(ns + "Cell").First(c => c.Attribute("N")?.Value == "EndY").Attribute("V")?.Value);
 
             var badCells = pageXml.Descendants(ns + "Cell")
                 .Where(c => (c.Attribute("N")?.Value == "NoLine" || c.Attribute("N")?.Value == "NoFill") && c.Attribute("V")?.Value == "1");

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -473,6 +473,20 @@ namespace OfficeIMO.Visio {
                     WriteCell(writer, "Angle", shape.Angle);
                 }
 
+                void WriteXForm1D(XmlWriter writer, double beginX, double beginY, double endX, double endY) {
+                    writer.WriteStartElement("XForm1D", ns);
+                    writer.WriteElementString("BeginX", ns, ToVisioString(beginX));
+                    writer.WriteElementString("BeginY", ns, ToVisioString(beginY));
+                    writer.WriteElementString("EndX", ns, ToVisioString(endX));
+                    writer.WriteElementString("EndY", ns, ToVisioString(endY));
+                    writer.WriteEndElement();
+
+                    WriteCell(writer, "BeginX", beginX);
+                    WriteCell(writer, "BeginY", beginY);
+                    WriteCell(writer, "EndX", endX);
+                    WriteCell(writer, "EndY", endY);
+                }
+
                 void WriteRectangleGeometry(XmlWriter writer, double width, double height) {
                     writer.WriteStartElement("Geom", ns);
                     writer.WriteStartElement("Cell", ns);
@@ -901,6 +915,7 @@ namespace OfficeIMO.Visio {
                               writer.WriteAttributeString("LineStyle", "2");
                               writer.WriteAttributeString("FillStyle", "2");
                               writer.WriteAttributeString("TextStyle", "2");
+                              WriteXForm1D(writer, startX, startY, endX, endY);
                               WriteCell(writer, "LineWeight", 0.0138889);
                               WriteCell(writer, "LinePattern", 1);
                               WriteCellValue(writer, "LineColor", "RGB(0,0,0)");


### PR DESCRIPTION
## Summary
- group 1-D connector coordinates via new `WriteXForm1D`
- emit Begin/End cell values for connectors
- test connector output for begin/end coordinates

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a61796df08832e929d159b3d513288