### PR TITLE
Fix PowerPoint notes master wiring and add validator tests

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/CreateValidPresentationPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/CreateValidPresentationPowerPoint.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.Examples.PowerPoint {
+    /// <summary>
+    /// Demonstrates creating a valid presentation and validating its structure.
+    /// </summary>
+    public static class CreateValidPresentationPowerPoint {
+        public static void Example_PowerPointCreateValidPresentation(string folderPath, bool openPowerPoint) {
+            Console.WriteLine("[*] PowerPoint - Create valid presentation");
+            string filePath = Path.Combine(folderPath, "ValidPresentation.pptx");
+
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+            presentation.AddSlide();
+            presentation.Save();
+
+            using PresentationDocument document = PresentationDocument.Open(filePath, false);
+            List<string> warnings = PptxValidator.GetWarnings(document);
+            Console.WriteLine(warnings.Count == 0
+                ? "Validator reports no issues." : string.Join(Environment.NewLine, warnings));
+        }
+
+        private static class PptxValidator {
+            public static List<string> GetWarnings(PresentationDocument doc) {
+                PresentationPart pPart = doc.PresentationPart!;
+                Presentation pres = pPart.Presentation!;
+                List<string> warnings = new();
+
+                if (pres.SlideMasterIdList == null || !pres.SlideMasterIdList.Elements<SlideMasterId>().Any()) {
+                    warnings.Add("Missing or empty <p:sldMasterIdLst> (no master attached)");
+                }
+
+                if (pres.SlideIdList == null || !pres.SlideIdList.Elements<SlideId>().Any()) {
+                    warnings.Add("Missing or empty <p:sldIdLst> (no slides registered)");
+                }
+
+                HashSet<uint> seenIds = new();
+                foreach (SlideId sldId in pres.SlideIdList?.Elements<SlideId>() ?? Enumerable.Empty<SlideId>()) {
+                    if (!seenIds.Add(sldId.Id!.Value)) {
+                        warnings.Add($"Duplicate <p:sldId/@Id> {sldId.Id.Value} (must be unique).");
+                    }
+
+                    if (pPart.GetReferenceRelationship(sldId.RelationshipId!) == null) {
+                        warnings.Add($"Presentation rel '{sldId.RelationshipId}' not found for a slide.");
+                    }
+                }
+
+                foreach (SlideMasterPart master in pPart.SlideMasterParts) {
+                    if (!master.SlideLayoutParts.Any()) {
+                        warnings.Add("SlideMasterPart has no SlideLayoutPart (need at least one).");
+                    }
+
+                    if (master.ThemePart == null) {
+                        warnings.Add("SlideMasterPart has no ThemePart (PowerPoint will generate/repair one).");
+                    }
+
+                    HashSet<string> layoutIds = master.SlideMaster!.SlideLayoutIdList!
+                        .Elements<SlideLayoutId>().Select(x => x.RelationshipId!.Value!).ToHashSet();
+                    HashSet<string> actualLayoutRelIds = master.SlideLayoutParts
+                        .Select(l => master.GetIdOfPart(l)).ToHashSet();
+
+                    if (!layoutIds.SetEquals(actualLayoutRelIds)) {
+                        warnings.Add("slideMaster layout id list doesn’t match its rels (broken master→layout links).");
+                    }
+                }
+
+                foreach (SlidePart slide in pPart.SlideParts) {
+                    if (slide.SlideLayoutPart == null) {
+                        warnings.Add("SlidePart without a slideLayout relationship.");
+                    }
+                }
+
+                if (pres.SlideSize == null) {
+                    warnings.Add("Missing <p:sldSz> (slide size).");
+                }
+
+                if (pres.NotesSize == null) {
+                    warnings.Add("Missing <p:notesSz> (notes size).");
+                }
+
+                return warnings;
+            }
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -1,5 +1,6 @@
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
+using DocumentFormat.OpenXml;
 using OfficeIMO.PowerPoint.Fluent;
 using A = DocumentFormat.OpenXml.Drawing;
 using Ap = DocumentFormat.OpenXml.ExtendedProperties;
@@ -298,9 +299,9 @@ namespace OfficeIMO.PowerPoint {
                 new NotesStyle()
             );
 
-            _presentationPart.Presentation.NotesMasterIdList = new NotesMasterIdList(new NotesMasterId {
-                Id = _presentationPart.GetIdOfPart(notesMasterPart)
-            });
+            NotesMasterId notesMasterId = new();
+            notesMasterId.SetAttribute(new OpenXmlAttribute("r", "id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships", _presentationPart.GetIdOfPart(notesMasterPart)));
+            _presentationPart.Presentation.NotesMasterIdList = new NotesMasterIdList(notesMasterId);
 
             _presentationPart.Presentation.SlideSize = new SlideSize {
                 Cx = 9144000,

--- a/OfficeIMO.Tests/PowerPoint.PackageIntegrity.cs
+++ b/OfficeIMO.Tests/PowerPoint.PackageIntegrity.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointPackageIntegrity {
+        [Fact]
+        public void GraphIsIntact() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                presentation.AddSlide();
+                presentation.Save();
+            }
+
+            using PresentationDocument document = PresentationDocument.Open(filePath, false);
+            List<string> warnings = PptxDoctor.GetWarnings(document);
+            Assert.Empty(warnings);
+            File.Delete(filePath);
+        }
+    }
+
+    internal static class PptxDoctor {
+        internal static List<string> GetWarnings(PresentationDocument doc) {
+            PresentationPart pPart = doc.PresentationPart!;
+            Presentation pres = pPart.Presentation!;
+            List<string> warnings = new();
+
+            if (pres.SlideMasterIdList == null || !pres.SlideMasterIdList.Elements<SlideMasterId>().Any()) {
+                warnings.Add("Missing or empty <p:sldMasterIdLst> (no master attached)");
+            }
+
+            if (pres.SlideIdList == null || !pres.SlideIdList.Elements<SlideId>().Any()) {
+                warnings.Add("Missing or empty <p:sldIdLst> (no slides registered)");
+            }
+
+            HashSet<uint> seenIds = new();
+            foreach (SlideId sldId in pres.SlideIdList?.Elements<SlideId>() ?? Enumerable.Empty<SlideId>()) {
+                if (!seenIds.Add(sldId.Id!.Value)) {
+                    warnings.Add($"Duplicate <p:sldId/@Id> {sldId.Id.Value} (must be unique).");
+                }
+
+                if (pPart.GetReferenceRelationship(sldId.RelationshipId!) == null) {
+                    warnings.Add($"Presentation rel '{sldId.RelationshipId}' not found for a slide.");
+                }
+            }
+
+            foreach (SlideMasterPart master in pPart.SlideMasterParts) {
+                if (!master.SlideLayoutParts.Any()) {
+                    warnings.Add("SlideMasterPart has no SlideLayoutPart (need at least one).");
+                }
+
+                if (master.ThemePart == null) {
+                    warnings.Add("SlideMasterPart has no ThemePart (PowerPoint will generate/repair one).");
+                }
+
+                HashSet<string> layoutIds = master.SlideMaster!.SlideLayoutIdList!
+                    .Elements<SlideLayoutId>().Select(x => x.RelationshipId!).ToHashSet();
+                HashSet<string> actualLayoutRelIds = master
+                    .GetRelationshipsByType("http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout")
+                    .Select(r => r.Id).ToHashSet();
+
+                if (!layoutIds.SetEquals(actualLayoutRelIds)) {
+                    warnings.Add("slideMaster layout id list doesn’t match its rels (broken master→layout links).");
+                }
+            }
+
+            foreach (SlidePart slide in pPart.SlideParts) {
+                bool hasLayoutRel = slide
+                    .GetRelationshipsByType("http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout")
+                    .Any();
+                if (!hasLayoutRel) {
+                    warnings.Add("SlidePart without a slideLayout relationship.");
+                }
+
+                if (slide.Slide?.CommonSlideData?.ShapeTree == null) {
+                    warnings.Add("Slide is missing <p:cSld>/<p:spTree> (minimal content).");
+                }
+            }
+
+            if (pres.SlideSize == null) {
+                warnings.Add("Missing <p:sldSz> (slide size).");
+            }
+
+            if (pres.NotesSize == null) {
+                warnings.Add("Missing <p:notesSz> (notes size).");
+            }
+
+            return warnings;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- wire notes master with proper relationship id to avoid PowerPoint repair
- add validator-based regression test ensuring slide graph integrity
- provide example demonstrating creation and validation of a presentation

## Testing
- `dotnet test`
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a5f64ab57c832ea3687c439b489bd2