### PR TITLE
Fix notes master relationship

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/NotesMasterPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/NotesMasterPowerPoint.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.Examples.PowerPoint {
+    /// <summary>
+    /// Demonstrates that notes masters are referenced correctly when creating a presentation.
+    /// </summary>
+    public static class NotesMasterPowerPoint {
+        public static void Example_PowerPointNotesMaster(string folderPath, bool openPowerPoint) {
+            Console.WriteLine("[*] PowerPoint - Notes master");
+            string filePath = Path.Combine(folderPath, "NotesMaster.pptx");
+
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+            PowerPointSlide slide = presentation.AddSlide();
+            slide.Notes.Text = "Example notes";
+            presentation.Save();
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -1,5 +1,6 @@
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
+using DocumentFormat.OpenXml;
 using OfficeIMO.PowerPoint.Fluent;
 using A = DocumentFormat.OpenXml.Drawing;
 using Ap = DocumentFormat.OpenXml.ExtendedProperties;
@@ -298,9 +299,15 @@ namespace OfficeIMO.PowerPoint {
                 new NotesStyle()
             );
 
-            _presentationPart.Presentation.NotesMasterIdList = new NotesMasterIdList(new NotesMasterId {
-                Id = _presentationPart.GetIdOfPart(notesMasterPart)
-            });
+            NotesMasterId notesMasterId = new NotesMasterId();
+            notesMasterId.SetAttribute(new OpenXmlAttribute(
+                "r",
+                "id",
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+                _presentationPart.GetIdOfPart(notesMasterPart)
+            ));
+            _presentationPart.Presentation.NotesMasterIdList = new NotesMasterIdList(notesMasterId);
+            notesMasterPart.NotesMaster.Save();
 
             _presentationPart.Presentation.SlideSize = new SlideSize {
                 Cx = 9144000,

--- a/OfficeIMO.Tests/PowerPoint.NotesMaster.cs
+++ b/OfficeIMO.Tests/PowerPoint.NotesMaster.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using DocumentFormat.OpenXml;
+using System.Linq;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointNotesMaster {
+        [Fact]
+        public void NotesMasterUsesRelationshipId() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                presentation.AddSlide();
+                presentation.Save();
+            }
+
+            using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                PresentationPart presentationPart = document.PresentationPart!;
+                NotesMasterPart notesMasterPart = presentationPart.NotesMasterPart!;
+                NotesMasterIdList? list = presentationPart.Presentation.NotesMasterIdList;
+                Assert.NotNull(list);
+                NotesMasterId notesMasterId = list!.GetFirstChild<NotesMasterId>()!;
+                OpenXmlAttribute attr = notesMasterId.GetAttributes().First(a =>
+                    a.LocalName == "id" &&
+                    a.NamespaceUri == "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                );
+                Assert.False(string.IsNullOrEmpty(attr.Value));
+                Assert.True(notesMasterId.GetAttributes().All(a => a.LocalName != "id" || a.NamespaceUri != string.Empty));
+                Assert.Equal(attr.Value, presentationPart.GetIdOfPart(notesMasterPart));
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- fix NotesMasterId to use r:id relationship and save the notes master part
- add unit test validating notes master relationship
- include example demonstrating notes master handling

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a624f45c1c832eb67b4225c699830e