### PR TITLE
Ensure PowerPoint default parts are saved

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -271,21 +271,25 @@ namespace OfficeIMO.PowerPoint {
                 new CommonSlideData(CreateShapeTree()),
                 new ColorMapOverride(new A.MasterColorMapping())
             );
+            layoutPart0.SlideLayout.Save();
 
             SlideLayoutPart layoutPart1 = slideMasterPart.AddNewPart<SlideLayoutPart>();
             layoutPart1.SlideLayout = new SlideLayout(
                 new CommonSlideData(CreateShapeTree()),
                 new ColorMapOverride(new A.MasterColorMapping())
             );
+            layoutPart1.SlideLayout.Save();
 
             slideMaster.SlideLayoutIdList = new SlideLayoutIdList(
                 new SlideLayoutId { Id = 1U, RelationshipId = slideMasterPart.GetIdOfPart(layoutPart0) },
                 new SlideLayoutId { Id = 2U, RelationshipId = slideMasterPart.GetIdOfPart(layoutPart1) }
             );
+            slideMaster.Save();
 
             // theme part is stored under ppt/theme and referenced from both presentation and slide master
             ThemePart themePart = _presentationPart.AddNewPart<ThemePart>();
             themePart.Theme = new A.Theme { Name = "Office Theme", ThemeElements = new A.ThemeElements() };
+            themePart.Theme.Save();
             slideMasterPart.AddPart(themePart);
 
             _presentationPart.Presentation.SlideMasterIdList = new SlideMasterIdList(
@@ -298,6 +302,7 @@ namespace OfficeIMO.PowerPoint {
                 new ColorMapOverride(new A.MasterColorMapping()),
                 new NotesStyle()
             );
+            notesMasterPart.NotesMaster.Save();
 
             NotesMasterId notesMasterId = new NotesMasterId();
             notesMasterId.SetAttribute(new OpenXmlAttribute(
@@ -307,7 +312,6 @@ namespace OfficeIMO.PowerPoint {
                 _presentationPart.GetIdOfPart(notesMasterPart)
             ));
             _presentationPart.Presentation.NotesMasterIdList = new NotesMasterIdList(notesMasterId);
-            notesMasterPart.NotesMaster.Save();
 
             _presentationPart.Presentation.SlideSize = new SlideSize {
                 Cx = 9144000,

--- a/OfficeIMO.Tests/PowerPoint.PackageIntegrity.cs
+++ b/OfficeIMO.Tests/PowerPoint.PackageIntegrity.cs
@@ -36,17 +36,37 @@ namespace OfficeIMO.Tests {
                 }
 
                 foreach (SlideMasterPart master in presentationPart.SlideMasterParts) {
+                    if (master.SlideMaster == null) {
+                        warnings.Add("Slide master missing root element.");
+                    }
+
                     if (!master.SlideLayoutParts.Any()) {
                         warnings.Add("Slide master missing slide layout part.");
                     }
 
+                    foreach (SlideLayoutPart layout in master.SlideLayoutParts) {
+                        if (layout.SlideLayout == null) {
+                            warnings.Add("Slide layout part missing root element.");
+                        }
+                    }
+
                     if (master.ThemePart == null) {
                         warnings.Add("Slide master missing theme part.");
+                    } else if (master.ThemePart.Theme == null) {
+                        warnings.Add("Theme part missing root element.");
                     }
                 }
 
                 if (presentationPart.ThemePart == null) {
                     warnings.Add("Presentation missing theme part.");
+                } else if (presentationPart.ThemePart.Theme == null) {
+                    warnings.Add("Presentation theme part missing root element.");
+                }
+
+                if (presentationPart.NotesMasterPart == null) {
+                    warnings.Add("Presentation missing notes master part.");
+                } else if (presentationPart.NotesMasterPart.NotesMaster == null) {
+                    warnings.Add("Notes master part missing root element.");
                 }
 
                 List<SlidePart> slideParts = presentationPart.SlideParts.ToList();


### PR DESCRIPTION
## Summary
- Save slide master, slide layouts, theme, and notes master parts before saving presentation
- Extend package integrity checks to verify notes master and root elements

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "PowerPointPackageIntegrity|PowerPointInitializeDefaults"`

------
https://chatgpt.com/codex/tasks/task_e_68a6333a6194832e952ac24bf5aa3872