### PR TITLE
Ensure notes master override is validated

### DIFF
--- a/OfficeIMO.Tests/PowerPoint.InitializeDefaults.cs
+++ b/OfficeIMO.Tests/PowerPoint.InitializeDefaults.cs
@@ -48,6 +48,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(HasOverride("application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"));
                 Assert.True(HasOverride("application/vnd.openxmlformats-officedocument.presentationml.slide+xml"));
                 Assert.True(HasOverride("application/vnd.openxmlformats-officedocument.theme+xml"));
+                Assert.True(HasOverride("application/vnd.openxmlformats-officedocument.presentationml.notesMaster+xml"));
                 Assert.True(HasOverride("application/vnd.openxmlformats-officedocument.presentationml.tableStyles+xml"));
             }
 


### PR DESCRIPTION
## Summary
- check that PPTX default notes master part registers a content type override

## Testing
- `dotnet build -v:m --nologo`
- `dotnet test --no-build --filter PowerPointInitializeDefaults`


------
https://chatgpt.com/codex/tasks/task_e_68a6b92e47a8832e8fdf15853f9c0bb9