### PR TITLE
Allow specifying page size on Visio page creation

### DIFF
--- a/OfficeIMO.Examples/Visio/BasicVisioDocument.cs
+++ b/OfficeIMO.Examples/Visio/BasicVisioDocument.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Examples.Visio {
             string filePath = Path.Combine(folderPath, "Basic Visio.vsdx");
 
             VisioDocument document = VisioDocument.Create(filePath);
-            VisioPage page = document.AddPage("Page-1");
+            VisioPage page = document.AddPage("Page-1", 8.5, 11);
             page.Shapes.Add(new VisioShape("1", 2, 2, 2, 1, "Rectangle") { 
                 NameU = "Rectangle",
                 FillColor = Color.LightBlue,

--- a/OfficeIMO.Examples/Visio/ComprehensiveColoredShapes.cs
+++ b/OfficeIMO.Examples/Visio/ComprehensiveColoredShapes.cs
@@ -14,8 +14,7 @@ namespace OfficeIMO.Examples.Visio {
 
             VisioDocument document = VisioDocument.Create(filePath);
             document.RequestRecalcOnOpen();
-            VisioPage page = document.AddPage("Colored Shapes");
-            page.Size(11, 8.5); // Standard landscape page
+            VisioPage page = document.AddPage("Colored Shapes", 11, 8.5);
 
             // Row 1: Basic colored rectangles
             var blueRect = new VisioShape("1", 1.5, 7, 1.5, 1, "Blue") {

--- a/OfficeIMO.Examples/Visio/ComprehensiveColoredShapes.cs
+++ b/OfficeIMO.Examples/Visio/ComprehensiveColoredShapes.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Examples.Visio {
 
             VisioDocument document = VisioDocument.Create(filePath);
             document.RequestRecalcOnOpen();
-            VisioPage page = document.AddPage("Colored Shapes", 11, 8.5);
+            VisioPage page = document.AddPage("Colored Shapes", 29.7, 21, VisioMeasurementUnit.Centimeters);
 
             // Row 1: Basic colored rectangles
             var blueRect = new VisioShape("1", 1.5, 7, 1.5, 1, "Blue") {

--- a/OfficeIMO.Examples/Visio/ConnectRectangles.cs
+++ b/OfficeIMO.Examples/Visio/ConnectRectangles.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Examples.Visio {
 
             VisioDocument document = VisioDocument.Create(filePath);
             document.RequestRecalcOnOpen();
-            VisioPage page = document.AddPage("Page-1");
+            VisioPage page = document.AddPage("Page-1", 8.5, 11);
             
             VisioShape start = new("1", 1, 1, 2, 1, "Start") { 
                 NameU = "Rectangle",

--- a/OfficeIMO.Examples/Visio/ConnectionPoints.cs
+++ b/OfficeIMO.Examples/Visio/ConnectionPoints.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Examples.Visio {
             string filePath = Path.Combine(folderPath, "Connection Points.vsdx");
 
             VisioDocument document = VisioDocument.Create(filePath);
-            VisioPage page = document.AddPage("Page-1");
+            VisioPage page = document.AddPage("Page-1", 8.5, 11);
 
             VisioShape left = new("1", 2, 2, 2, 2, "Left");
             left.ConnectionPoints.Add(new VisioConnectionPoint(2, 1, 1, 0));

--- a/OfficeIMO.Tests/Visio.AssetSamples.cs
+++ b/OfficeIMO.Tests/Visio.AssetSamples.cs
@@ -14,9 +14,7 @@ namespace OfficeIMO.Tests {
             string target = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
 
             VisioDocument document = VisioDocument.Create(target);
-            VisioPage page = document.AddPage("Page-1");
-            page.PageWidth = 8.26771653543307;
-            page.PageHeight = 11.69291338582677;
+            VisioPage page = document.AddPage("Page-1", 8.26771653543307, 11.69291338582677);
             page.ViewCenterX = 4.1233127451916;
             page.ViewCenterY = 5.8492688900245;
             document.Save();
@@ -34,9 +32,7 @@ namespace OfficeIMO.Tests {
             string target = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
 
             VisioDocument document = VisioDocument.Create(target);
-            VisioPage page = document.AddPage("Page-1");
-            page.PageWidth = 11.69291338582677;
-            page.PageHeight = 8.26771653543307;
+            VisioPage page = document.AddPage("Page-1", 11.69291338582677, 8.26771653543307);
             page.ViewCenterX = 5.8424184863857;
             page.ViewCenterY = 4.133858091015;
             page.Shapes.Add(new VisioShape("1") {

--- a/OfficeIMO.Tests/Visio.AssetSamples.cs
+++ b/OfficeIMO.Tests/Visio.AssetSamples.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Tests {
             string target = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
 
             VisioDocument document = VisioDocument.Create(target);
-            VisioPage page = document.AddPage("Page-1", 8.26771653543307, 11.69291338582677);
+            VisioPage page = document.AddPage("Page-1", 21, 29.7, VisioMeasurementUnit.Centimeters);
             page.ViewCenterX = 4.1233127451916;
             page.ViewCenterY = 5.8492688900245;
             document.Save();
@@ -32,7 +32,7 @@ namespace OfficeIMO.Tests {
             string target = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
 
             VisioDocument document = VisioDocument.Create(target);
-            VisioPage page = document.AddPage("Page-1", 11.69291338582677, 8.26771653543307);
+            VisioPage page = document.AddPage("Page-1", 29.7, 21, VisioMeasurementUnit.Centimeters);
             page.ViewCenterX = 5.8424184863857;
             page.ViewCenterY = 4.133858091015;
             page.Shapes.Add(new VisioShape("1") {

--- a/OfficeIMO.Tests/Visio.PageHelpers.cs
+++ b/OfficeIMO.Tests/Visio.PageHelpers.cs
@@ -9,12 +9,14 @@ namespace OfficeIMO.Tests {
         public void AddShapeAndConnectorPopulateCollections() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
             VisioDocument document = VisioDocument.Create(filePath);
-            VisioPage page = document.AddPage("Page-1");
+            VisioPage page = document.AddPage("Page-1", 8.5, 11);
             VisioMaster master = new("1", "Rectangle", new VisioShape("1"));
 
             VisioShape shape1 = page.AddShape("1", master, 1, 1, 1, 1, "Start");
             VisioShape shape2 = page.AddShape("2", master, 2, 1, 1, 1, "End");
 
+            Assert.Equal(8.5, page.Width);
+            Assert.Equal(11, page.Height);
             Assert.Equal(2, page.Shapes.Count);
             Assert.Contains(shape1, page.Shapes);
             Assert.Contains(shape2, page.Shapes);
@@ -31,8 +33,8 @@ namespace OfficeIMO.Tests {
         public void SizeAndGridHelpersSetProperties() {
             VisioPage page = new("Page-1");
             page.Size(10, 5).Grid(true, false);
-            Assert.Equal(10, page.PageWidth);
-            Assert.Equal(5, page.PageHeight);
+            Assert.Equal(10, page.Width);
+            Assert.Equal(5, page.Height);
             Assert.True(page.GridVisible);
             Assert.False(page.Snap);
         }

--- a/OfficeIMO.Tests/Visio.PageHelpers.cs
+++ b/OfficeIMO.Tests/Visio.PageHelpers.cs
@@ -38,5 +38,15 @@ namespace OfficeIMO.Tests {
             Assert.True(page.GridVisible);
             Assert.False(page.Snap);
         }
+
+        [Fact]
+        public void MetricUnitsConvertToInches() {
+            VisioDocument document = VisioDocument.Create(Path.GetTempFileName());
+            VisioPage page = document.AddPage("Metric", 21, 29.7, VisioMeasurementUnit.Centimeters);
+            Assert.Equal(21, Math.Round(page.WidthCentimeters, 2));
+            Assert.Equal(29.7, Math.Round(page.HeightCentimeters, 2));
+            Assert.Equal(8.27, Math.Round(page.Width, 2));
+            Assert.Equal(11.69, Math.Round(page.Height, 2));
+        }
     }
 }

--- a/OfficeIMO.Visio/Fluent/VisioFluentDocument.cs
+++ b/OfficeIMO.Visio/Fluent/VisioFluentDocument.cs
@@ -17,7 +17,15 @@ namespace OfficeIMO.Visio.Fluent {
         /// Adds a page and returns the fluent document for chaining.
         /// </summary>
         /// <param name="name">Name of the page.</param>
+        /// <param name="widthInches">Page width in inches.</param>
+        /// <param name="heightInches">Page height in inches.</param>
         /// <param name="page">The created page.</param>
+        public VisioFluentDocument AddPage(string name, double widthInches, double heightInches, out VisioPage page) {
+            page = _document.AddPage(name, widthInches, heightInches);
+            return this;
+        }
+
+        [System.Obsolete("Use AddPage with width and height parameters")]
         public VisioFluentDocument AddPage(string name, out VisioPage page) {
             page = _document.AddPage(name);
             return this;

--- a/OfficeIMO.Visio/Fluent/VisioFluentDocument.cs
+++ b/OfficeIMO.Visio/Fluent/VisioFluentDocument.cs
@@ -17,15 +17,22 @@ namespace OfficeIMO.Visio.Fluent {
         /// Adds a page and returns the fluent document for chaining.
         /// </summary>
         /// <param name="name">Name of the page.</param>
-        /// <param name="widthInches">Page width in inches.</param>
-        /// <param name="heightInches">Page height in inches.</param>
+        /// <param name="width">Page width.</param>
+        /// <param name="height">Page height.</param>
+        /// <param name="unit">Measurement unit for width and height.</param>
         /// <param name="page">The created page.</param>
-        public VisioFluentDocument AddPage(string name, double widthInches, double heightInches, out VisioPage page) {
-            page = _document.AddPage(name, widthInches, heightInches);
+        public VisioFluentDocument AddPage(string name, double width, double height, VisioMeasurementUnit unit, out VisioPage page) {
+            page = _document.AddPage(name, width, height, unit);
             return this;
         }
 
-        [System.Obsolete("Use AddPage with width and height parameters")]
+        [System.Obsolete("Use AddPage with width, height and unit parameters")]
+        public VisioFluentDocument AddPage(string name, double width, double height, out VisioPage page) {
+            page = _document.AddPage(name, width, height);
+            return this;
+        }
+
+        [System.Obsolete("Use AddPage with width, height and unit parameters")]
         public VisioFluentDocument AddPage(string name, out VisioPage page) {
             page = _document.AddPage(name);
             return this;

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -53,10 +53,6 @@ namespace OfficeIMO.Visio {
             return page;
         }
 
-        [Obsolete("Use AddPage with unit parameter")]
-        public VisioPage AddPage(string name, double widthInches, double heightInches, int? id = null) {
-            return AddPage(name, widthInches, heightInches, VisioMeasurementUnit.Inches, id);
-        }
 
         /// <summary>
         /// Requests Visio to relayout and reroute connectors when the document is opened.

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -41,9 +41,11 @@ namespace OfficeIMO.Visio {
         /// Adds a new page to the document.
         /// </summary>
         /// <param name="name">Name of the page.</param>
+        /// <param name="widthInches">Page width in inches.</param>
+        /// <param name="heightInches">Page height in inches.</param>
         /// <param name="id">Optional page identifier. If not specified, uses zero-based index.</param>
-        public VisioPage AddPage(string name, int? id = null) {
-            VisioPage page = new(name) { Id = id ?? _pages.Count };
+        public VisioPage AddPage(string name, double widthInches = 8.26771653543307, double heightInches = 11.69291338582677, int? id = null) {
+            VisioPage page = new(name, widthInches, heightInches) { Id = id ?? _pages.Count };
             _pages.Add(page);
             return page;
         }
@@ -125,7 +127,7 @@ namespace OfficeIMO.Visio {
             foreach (XElement pageRef in pagesDoc.Root?.Elements(ns + "Page") ?? Enumerable.Empty<XElement>()) {
                 string name = pageRef.Attribute("Name")?.Value ?? "Page";
                 int pageId = int.TryParse(pageRef.Attribute("ID")?.Value, out int tmp) ? tmp : document.Pages.Count;
-                VisioPage page = document.AddPage(name, pageId);
+                VisioPage page = document.AddPage(name, id: pageId);
                 page.NameU = pageRef.Attribute("NameU")?.Value ?? name;
                 page.ViewScale = ParseDouble(pageRef.Attribute("ViewScale")?.Value);
                 page.ViewCenterX = ParseDouble(pageRef.Attribute("ViewCenterX")?.Value);
@@ -785,9 +787,9 @@ namespace OfficeIMO.Visio {
                         if (formula != null) writer.WriteAttributeString("F", formula);
                         writer.WriteEndElement();
                     }
-                    bool useUnits = page.PageWidth != 8.26771653543307 || page.PageHeight != 11.69291338582677;
-                    WritePageCell("PageWidth", page.PageWidth, useUnits ? "MM" : null);
-                    WritePageCell("PageHeight", page.PageHeight, useUnits ? "MM" : null);
+                    bool useUnits = page.Width != 8.26771653543307 || page.Height != 11.69291338582677;
+                    WritePageCell("PageWidth", page.Width, useUnits ? "MM" : null);
+                    WritePageCell("PageHeight", page.Height, useUnits ? "MM" : null);
                     WritePageCell("ShdwOffsetX", 0.1181102362204724, useUnits ? "MM" : null);
                     WritePageCell("ShdwOffsetY", -0.1181102362204724, useUnits ? "MM" : null);
                     WritePageCell("PageScale", 0.03937007874015748, "MM");

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -41,13 +41,21 @@ namespace OfficeIMO.Visio {
         /// Adds a new page to the document.
         /// </summary>
         /// <param name="name">Name of the page.</param>
-        /// <param name="widthInches">Page width in inches.</param>
-        /// <param name="heightInches">Page height in inches.</param>
+        /// <param name="width">Page width.</param>
+        /// <param name="height">Page height.</param>
+        /// <param name="unit">Measurement unit for width and height.</param>
         /// <param name="id">Optional page identifier. If not specified, uses zero-based index.</param>
-        public VisioPage AddPage(string name, double widthInches = 8.26771653543307, double heightInches = 11.69291338582677, int? id = null) {
+        public VisioPage AddPage(string name, double width = 8.26771653543307, double height = 11.69291338582677, VisioMeasurementUnit unit = VisioMeasurementUnit.Inches, int? id = null) {
+            double widthInches = width.ToInches(unit);
+            double heightInches = height.ToInches(unit);
             VisioPage page = new(name, widthInches, heightInches) { Id = id ?? _pages.Count };
             _pages.Add(page);
             return page;
+        }
+
+        [Obsolete("Use AddPage with unit parameter")]
+        public VisioPage AddPage(string name, double widthInches, double heightInches, int? id = null) {
+            return AddPage(name, widthInches, heightInches, VisioMeasurementUnit.Inches, id);
         }
 
         /// <summary>

--- a/OfficeIMO.Visio/VisioMeasurementUnit.cs
+++ b/OfficeIMO.Visio/VisioMeasurementUnit.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace OfficeIMO.Visio {
+    /// <summary>
+    /// Supported measurement units for Visio pages.
+    /// </summary>
+    public enum VisioMeasurementUnit {
+        /// <summary>
+        /// Measurements expressed in inches.
+        /// </summary>
+        Inches,
+
+        /// <summary>
+        /// Measurements expressed in centimeters.
+        /// </summary>
+        Centimeters
+    }
+
+    internal static class VisioMeasurementUnitExtensions {
+        public static double ToInches(this double value, VisioMeasurementUnit unit) {
+            return unit switch {
+                VisioMeasurementUnit.Centimeters => value / 2.54,
+                _ => value
+            };
+        }
+
+        public static double FromInches(this double value, VisioMeasurementUnit unit) {
+            return unit switch {
+                VisioMeasurementUnit.Centimeters => value * 2.54,
+                _ => value
+            };
+        }
+    }
+}

--- a/OfficeIMO.Visio/VisioPage.cs
+++ b/OfficeIMO.Visio/VisioPage.cs
@@ -48,12 +48,22 @@ namespace OfficeIMO.Visio {
             }
         }
 
+        public double WidthCentimeters {
+            get => _width.FromInches(VisioMeasurementUnit.Centimeters);
+            set => Width = value.ToInches(VisioMeasurementUnit.Centimeters);
+        }
+
         public double Height {
             get => _height;
             set {
                 _height = value;
                 ViewCenterY = value / 2;
             }
+        }
+
+        public double HeightCentimeters {
+            get => _height.FromInches(VisioMeasurementUnit.Centimeters);
+            set => Height = value.ToInches(VisioMeasurementUnit.Centimeters);
         }
 
         [System.Obsolete("Use Width instead")]
@@ -88,9 +98,9 @@ namespace OfficeIMO.Visio {
         /// </summary>
         public IList<VisioConnector> Connectors => _connectors;
 
-        public VisioPage Size(double w, double h) {
-            Width = w;
-            Height = h;
+        public VisioPage Size(double w, double h, VisioMeasurementUnit unit = VisioMeasurementUnit.Inches) {
+            Width = w.ToInches(unit);
+            Height = h.ToInches(unit);
             return this;
         }
 

--- a/OfficeIMO.Visio/VisioPage.cs
+++ b/OfficeIMO.Visio/VisioPage.cs
@@ -7,17 +7,22 @@ namespace OfficeIMO.Visio {
     public class VisioPage {
         private readonly List<VisioShape> _shapes = new();
         private readonly List<VisioConnector> _connectors = new();
-        private double _pageWidth = 8.26771653543307; // A4 width in inches
-        private double _pageHeight = 11.69291338582677; // A4 height in inches
+        private double _width = 8.26771653543307; // A4 width in inches
+        private double _height = 11.69291338582677; // A4 height in inches
         private bool _gridVisible;
         private bool _snap = true;
 
-        public VisioPage(string name) {
+        public VisioPage(string name) : this(name, 8.26771653543307, 11.69291338582677) {
+        }
+
+        public VisioPage(string name, double widthInches, double heightInches) {
             Name = name;
             NameU = name;
+            _width = widthInches;
+            _height = heightInches;
             ViewScale = -1;
-            ViewCenterX = _pageWidth / 2;
-            ViewCenterY = _pageHeight / 2;
+            ViewCenterX = widthInches / 2;
+            ViewCenterY = heightInches / 2;
         }
 
         public int Id { get; internal set; }
@@ -35,20 +40,32 @@ namespace OfficeIMO.Visio {
 
         public double ViewCenterY { get; set; }
 
-        public double PageWidth {
-            get => _pageWidth;
+        public double Width {
+            get => _width;
             set {
-                _pageWidth = value;
+                _width = value;
                 ViewCenterX = value / 2;
             }
         }
 
-        public double PageHeight {
-            get => _pageHeight;
+        public double Height {
+            get => _height;
             set {
-                _pageHeight = value;
+                _height = value;
                 ViewCenterY = value / 2;
             }
+        }
+
+        [System.Obsolete("Use Width instead")]
+        public double PageWidth {
+            get => Width;
+            set => Width = value;
+        }
+
+        [System.Obsolete("Use Height instead")]
+        public double PageHeight {
+            get => Height;
+            set => Height = value;
         }
 
         public bool GridVisible {
@@ -72,8 +89,8 @@ namespace OfficeIMO.Visio {
         public IList<VisioConnector> Connectors => _connectors;
 
         public VisioPage Size(double w, double h) {
-            PageWidth = w;
-            PageHeight = h;
+            Width = w;
+            Height = h;
             return this;
         }
 


### PR DESCRIPTION
## Summary
- allow AddPage to accept width and height
- rename VisioPage PageWidth/PageHeight to Width/Height with obsolete aliases
- update tests and examples to set page size during creation

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a6df0092ac832ea5b85a1aadc4a0ca