### PR TITLE
Throw ArgumentOutOfRangeException for invalid cell indices

### DIFF
--- a/OfficeIMO.Excel/Fluent/SheetBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/SheetBuilder.cs
@@ -96,18 +96,18 @@ namespace OfficeIMO.Excel.Fluent {
 
         public SheetBuilder Cell(int row, int column, object? value = null, string? formula = null, string? numberFormat = null) {
             if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
-            if (row <= 0) throw new ArgumentOutOfRangeException(nameof(row));
-            if (column <= 0) throw new ArgumentOutOfRangeException(nameof(column));
+            if (row < 1) throw new ArgumentOutOfRangeException(nameof(row));
+            if (column < 1) throw new ArgumentOutOfRangeException(nameof(column));
             Sheet.Cell(row, column, value, formula, numberFormat);
             return this;
         }
 
         public SheetBuilder Range(int fromRow, int fromCol, int toRow, int toCol, object[,]? values = null) {
             if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
-            if (fromRow <= 0) throw new ArgumentOutOfRangeException(nameof(fromRow));
-            if (fromCol <= 0) throw new ArgumentOutOfRangeException(nameof(fromCol));
-            if (toRow <= 0) throw new ArgumentOutOfRangeException(nameof(toRow));
-            if (toCol <= 0) throw new ArgumentOutOfRangeException(nameof(toCol));
+            if (fromRow < 1) throw new ArgumentOutOfRangeException(nameof(fromRow));
+            if (fromCol < 1) throw new ArgumentOutOfRangeException(nameof(fromCol));
+            if (toRow < 1) throw new ArgumentOutOfRangeException(nameof(toRow));
+            if (toCol < 1) throw new ArgumentOutOfRangeException(nameof(toCol));
             if (toRow < fromRow) throw new ArgumentOutOfRangeException(nameof(toRow));
             if (toCol < fromCol) throw new ArgumentOutOfRangeException(nameof(toCol));
 

--- a/OfficeIMO.Tests/Excel.CellAndRange.cs
+++ b/OfficeIMO.Tests/Excel.CellAndRange.cs
@@ -42,6 +42,7 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using (ExcelDocument document = ExcelDocument.Create(filePath)) {
                 Assert.Throws<ArgumentOutOfRangeException>(() => document.AsFluent().Sheet("Data", s => s.Cell(0, 1, "X")));
+                Assert.Throws<ArgumentOutOfRangeException>(() => document.AsFluent().Sheet("Data", s => s.Cell(1, 0, "X")));
             }
             File.Delete(filePath);
         }
@@ -72,6 +73,7 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using (ExcelDocument document = ExcelDocument.Create(filePath)) {
                 Assert.Throws<ArgumentOutOfRangeException>(() => document.AsFluent().Sheet("Data", s => s.Range(0, 1, 1, 1, null)));
+                Assert.Throws<ArgumentOutOfRangeException>(() => document.AsFluent().Sheet("Data", s => s.Range(1, 0, 1, 1, null)));
             }
             File.Delete(filePath);
         }

--- a/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
@@ -115,6 +115,15 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(TableWidthUnitValues.Dxa, table.WidthType);
             }
         }
+
+        [Fact]
+        public void TableBuilderCellEnforces1BasedIndexing() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentTableBuilderInvalidCell.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                Assert.Throws<ArgumentOutOfRangeException>(() => document.AsFluent().Table(t => t.Cell(0, 1, _ => { })));
+                Assert.Throws<ArgumentOutOfRangeException>(() => document.AsFluent().Table(t => t.Cell(1, 0, _ => { })));
+            }
+        }
     }
 }
 

--- a/OfficeIMO.Word/Fluent/TableBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TableBuilder.cs
@@ -183,6 +183,9 @@ namespace OfficeIMO.Word.Fluent {
         /// Performs an action on the specified cell using 1-based row and column indices.
         /// </summary>
         public TableBuilder Cell(int row, int column, Action<WordTableCell> action) {
+            if (row < 1) throw new ArgumentOutOfRangeException(nameof(row));
+            if (column < 1) throw new ArgumentOutOfRangeException(nameof(column));
+
             EnsureTable(row);
             if (_table == null) {
                 return this;


### PR DESCRIPTION
## Summary
- Validate SheetBuilder.Cell and Range to reject rows/columns < 1
- Guard TableBuilder.Cell with 1-based indexing
- Test 1-based indexing for Excel and Word fluent APIs

## Testing
- `dotnet build -c Release`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --filter FullyQualifiedName~ExcelCellAndRangeTests.CellEnforces1BasedIndexing`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --filter FullyQualifiedName~ExcelCellAndRangeTests.RangeEnforces1BasedIndexing`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --filter FullyQualifiedName~Word.TableBuilderCellEnforces1BasedIndexing`


------
https://chatgpt.com/codex/tasks/task_e_68a6e4a03978832eb7e1a6a42e5ade3f