### PR TITLE
Remove justified alignment from API

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.ParagraphFormatting.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.ParagraphFormatting.cs
@@ -15,7 +15,7 @@ namespace OfficeIMO.Examples.Word {
                     .Paragraph(p => p.Text("Centered paragraph").Align(HorizontalAlignment.Center))
                     .Paragraph(p => p.Text("Right aligned paragraph").Align(HorizontalAlignment.Right))
                     .Paragraph(p => p.Text("Justified heading with spacing and indentation")
-                        .Align(HorizontalAlignment.Justified)
+                        .Justify()
                         .SpacingBefore(12)
                         .SpacingAfter(12)
                         .LineSpacing(24)

--- a/OfficeIMO.Tests/Word.Fluent.ImageBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ImageBuilder.cs
@@ -36,7 +36,7 @@ namespace OfficeIMO.Tests {
                         i.Add(stream, "stream.jpg").Size(60, 60).Align(HorizontalAlignment.Right);
                     })
                     .Image(i => i.Add(bytes, "bytes.jpg").Size(70, 70).Align(HorizontalAlignment.Left))
-                    .Image(i => i.AddFromUrl($"http://localhost:{port}/").Size(80, 80).Align(HorizontalAlignment.Justified))
+                    .Image(i => i.AddFromUrl($"http://localhost:{port}/").Size(80, 80).Align(HorizontalAlignment.Center))
                     .End();
                 document.Save(false);
             }
@@ -54,7 +54,7 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(70, document.Images[2].Width);
                 Assert.Equal(JustificationValues.Left, document.Paragraphs[2].ParagraphAlignment);
                 Assert.Equal(80, document.Images[3].Width);
-                Assert.Equal(JustificationValues.Both, document.Paragraphs[3].ParagraphAlignment);
+                Assert.Equal(JustificationValues.Center, document.Paragraphs[3].ParagraphAlignment);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.Fluent.ParagraphBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ParagraphBuilder.cs
@@ -61,5 +61,21 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(JustificationValues.Right, document.Paragraphs.Last().ParagraphAlignment);
             }
         }
+
+        [Fact]
+        public void Test_FluentParagraphBuilderJustify() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentParagraphBuilderJustify.docx");
+
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Paragraph(p => p.Text("Justified").Justify())
+                    .End()
+                    .Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(JustificationValues.Both, document.Paragraphs.Last().ParagraphAlignment);
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/Enums/HorizontalAlignment.cs
+++ b/OfficeIMO.Word/Enums/HorizontalAlignment.cs
@@ -5,7 +5,6 @@ namespace OfficeIMO {
     public enum HorizontalAlignment {
         Left,
         Center,
-        Right,
-        Justified
+        Right
     }
 }

--- a/OfficeIMO.Word/Fluent/ImageBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ImageBuilder.cs
@@ -90,7 +90,6 @@ namespace OfficeIMO.Word.Fluent {
             var justification = alignment switch {
                 HorizontalAlignment.Center => JustificationValues.Center,
                 HorizontalAlignment.Right => JustificationValues.Right,
-                HorizontalAlignment.Justified => JustificationValues.Both,
                 _ => JustificationValues.Left,
             };
             _paragraph?.SetAlignment(justification);

--- a/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
@@ -68,9 +68,13 @@ namespace OfficeIMO.Word.Fluent {
             _paragraph.ParagraphAlignment = alignment switch {
                 HorizontalAlignment.Center => JustificationValues.Center,
                 HorizontalAlignment.Right => JustificationValues.Right,
-                HorizontalAlignment.Justified => JustificationValues.Both,
                 _ => JustificationValues.Left,
             };
+            return this;
+        }
+
+        public ParagraphBuilder Justify() {
+            _paragraph.ParagraphAlignment = JustificationValues.Both;
             return this;
         }
 


### PR DESCRIPTION
## Summary
- remove `Justified` value from `HorizontalAlignment`
- add `ParagraphBuilder.Justify()` and limit `Align` to Left/Center/Right
- drop justification option for `ImageBuilder.Align`
- update examples and tests for new API

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a6e49081f0832ebbb68ef792b53664