### PR TITLE
Add freeze panes support to SheetBuilder

### DIFF
--- a/OfficeIMO.Examples/Excel/Fluent/Fluent.Example.cs
+++ b/OfficeIMO.Examples/Excel/Fluent/Fluent.Example.cs
@@ -19,6 +19,7 @@ namespace OfficeIMO.Examples.Excel {
                         .AutoFilter("A1:B3")
                         .ConditionalColorScale("B2:B3", Color.Red, Color.Green)
                         .ConditionalDataBar("B2:B3", Color.Blue)
+                        .Freeze(topRows: 1, leftCols: 1)
                         .AutoFit(columns: true, rows: true))
                     .End()
                     .Save(openExcel);

--- a/OfficeIMO.Examples/Excel/Freeze.cs
+++ b/OfficeIMO.Examples/Excel/Freeze.cs
@@ -1,0 +1,25 @@
+using System;
+using OfficeIMO.Excel;
+
+namespace OfficeIMO.Examples.Excel {
+    /// <summary>
+    /// Demonstrates freezing top rows and left columns.
+    /// </summary>
+    public static class Freeze {
+        public static void Example(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - Freeze panes");
+            string filePath = System.IO.Path.Combine(folderPath, "Freeze.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Header1");
+                sheet.CellValue(1, 2, "Header2");
+                sheet.CellValue(2, 1, "Value1");
+                sheet.CellValue(2, 2, "Value2");
+                sheet.Freeze(topRows: 1, leftCols: 1);
+                document.Save(openExcel);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -34,6 +34,8 @@ namespace OfficeIMO.Examples {
             OfficeIMO.Examples.Excel.AddTable.Example(folderPath, false);
             // Excel/AutoFilter
             OfficeIMO.Examples.Excel.AutoFilter.Example(folderPath, false);
+            // Excel/Freeze
+            OfficeIMO.Examples.Excel.Freeze.Example(folderPath, false);
             // Excel/ConditionalFormatting
             OfficeIMO.Examples.Excel.ConditionalFormatting.Example(folderPath, false);
             // Excel/ConcurrentWrites

--- a/OfficeIMO.Excel/Fluent/SheetBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/SheetBuilder.cs
@@ -169,6 +169,17 @@ namespace OfficeIMO.Excel.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Freezes the specified number of rows and columns on the current sheet.
+        /// </summary>
+        /// <param name="topRows">Number of rows at the top to freeze.</param>
+        /// <param name="leftCols">Number of columns on the left to freeze.</param>
+        public SheetBuilder Freeze(int topRows = 0, int leftCols = 0) {
+            if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
+            Sheet.Freeze(topRows, leftCols);
+            return this;
+        }
+
         public SheetBuilder AutoFit(bool columns, bool rows) {
             if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
             if (columns) {

--- a/OfficeIMO.Tests/Excel.Freeze.cs
+++ b/OfficeIMO.Tests/Excel.Freeze.cs
@@ -1,0 +1,57 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    /// <summary>
+    /// Tests for freezing rows and columns.
+    /// </summary>
+    public partial class Excel {
+        [Fact]
+        public void Test_FreezeTopRows() {
+            string filePath = Path.Combine(_directoryWithFiles, "FreezeTopRows.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Sheet("Data", s => s.Freeze(topRows: 1))
+                    .End()
+                    .Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                Pane pane = wsPart.Worksheet.GetFirstChild<SheetViews>()?.GetFirstChild<SheetView>()?.GetFirstChild<Pane>();
+                Assert.NotNull(pane);
+                Assert.Equal(1D, pane!.HorizontalSplit?.Value);
+                Assert.Null(pane.VerticalSplit);
+                Assert.Equal(PaneValues.BottomLeft, pane.ActivePane?.Value);
+                Assert.Equal("A2", pane.TopLeftCell?.Value);
+            }
+        }
+
+        [Fact]
+        public void Test_FreezeLeftColumns() {
+            string filePath = Path.Combine(_directoryWithFiles, "FreezeLeftColumns.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Sheet("Data", s => s.Freeze(leftCols: 2))
+                    .End()
+                    .Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                Pane pane = wsPart.Worksheet.GetFirstChild<SheetViews>()?.GetFirstChild<SheetView>()?.GetFirstChild<Pane>();
+                Assert.NotNull(pane);
+                Assert.Equal(2D, pane!.VerticalSplit?.Value);
+                Assert.Null(pane.HorizontalSplit);
+                Assert.Equal(PaneValues.TopRight, pane.ActivePane?.Value);
+                Assert.Equal("C1", pane.TopLeftCell?.Value);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Freeze method to Excel sheet and fluent SheetBuilder
- document and demonstrate freezing top rows and left columns
- cover freeze panes with unit tests

## Testing
- `dotnet build -c Release`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --no-build --filter Freeze`


------
https://chatgpt.com/codex/tasks/task_e_68a6e4bf2b14832e8b8d52aaffe97b04