### PR TITLE
refactor: remove paragraph-level list and table builders

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.ParagraphFormatting.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.ParagraphFormatting.cs
@@ -21,8 +21,9 @@ namespace OfficeIMO.Examples.Word {
                         .LineSpacing(24)
                         .Indentation(left: 24, firstLine: 24)
                         .Style(WordParagraphStyles.Heading2))
-                    .Paragraph(p => p.Text("Bullet list item").AddList(WordListStyle.Bulleted))
-                    .Paragraph(p => p.Text("Table below").AddTableAfter(2, 2))
+                    .List(l => l.Bulleted().Item("Bullet list item"))
+                    .Paragraph(p => p.Text("Table below"))
+                    .Table(t => t.Create(2, 2))
                     .End()
                     .Save(false);
             }

--- a/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
@@ -46,24 +46,6 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
-        /// <summary>
-        /// Adds or modifies a list within the document context.
-        /// </summary>
-        /// <param name="action">Action that receives a <see cref="ListBuilder"/>.</param>
-        public ParagraphBuilder List(Action<ListBuilder> action) {
-            action(new ListBuilder(_fluent));
-            return this;
-        }
-
-        /// <summary>
-        /// Adds or modifies a table within the document context.
-        /// </summary>
-        /// <param name="action">Action that receives a <see cref="TableBuilder"/>.</param>
-        public ParagraphBuilder Table(Action<TableBuilder> action) {
-            action(new TableBuilder(_fluent));
-            return this;
-        }
-      
         public ParagraphBuilder Align(HorizontalAlignment alignment) {
             _paragraph.ParagraphAlignment = alignment switch {
                 HorizontalAlignment.Center => JustificationValues.Center,
@@ -113,21 +95,6 @@ namespace OfficeIMO.Word.Fluent {
         public ParagraphBuilder Style(string styleId) {
             _paragraph.SetStyleId(styleId);
             return this;
-        }
-
-        public ListBuilder AddList(WordListStyle style) {
-            var list = _paragraph.AddList(style);
-            return new ListBuilder(_fluent, list);
-        }
-
-        public TableBuilder AddTableAfter(int rows, int columns, WordTableStyle tableStyle = WordTableStyle.TableGrid) {
-            var table = _paragraph.AddTableAfter(rows, columns, tableStyle);
-            return new TableBuilder(_fluent, table);
-        }
-
-        public TableBuilder AddTableBefore(int rows, int columns, WordTableStyle tableStyle = WordTableStyle.TableGrid) {
-            var table = _paragraph.AddTableBefore(rows, columns, tableStyle);
-            return new TableBuilder(_fluent, table);
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove list and table methods from `ParagraphBuilder`
- call `List`/`Table` on `WordFluentDocument` in fluent paragraph example

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68a6e4af5cdc832e894a16363fbca137