### PR TITLE
Add fluent RangeBuilder for Excel ranges

### DIFF
--- a/OfficeIMO.Examples/Excel/Fluent/Fluent.RangeBuilder.cs
+++ b/OfficeIMO.Examples/Excel/Fluent/Fluent.RangeBuilder.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Fluent;
+
+namespace OfficeIMO.Examples.Excel {
+    internal static partial class FluentWorkbook {
+        public static void Example_RangeBuilder(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - Using RangeBuilder");
+            string filePath = Path.Combine(folderPath, "FluentRangeBuilder.xlsx");
+            object[,] values = { { "A", "B" }, { "C", "D" } };
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Sheet("Data", s => s.Range("A1:B2", r => {
+                        r.Set(values);
+                        r.NumberFormat("@");
+                    }))
+                    .End()
+                    .Save(openExcel);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -48,6 +48,7 @@ namespace OfficeIMO.Examples {
             OfficeIMO.Examples.Excel.CellValuesParallel.Example(folderPath, false);
             // Excel/Fluent
             OfficeIMO.Examples.Excel.FluentWorkbook.Example_FluentWorkbook(folderPath, false);
+            OfficeIMO.Examples.Excel.FluentWorkbook.Example_RangeBuilder(folderPath, false);
             // PowerPoint
             OfficeIMO.Examples.PowerPoint.BasicPowerPointDocument.Example_BasicPowerPoint(folderPath, false);
             OfficeIMO.Examples.PowerPoint.AdvancedPowerPoint.Example_AdvancedPowerPoint(folderPath, false);

--- a/OfficeIMO.Excel/Fluent/RangeBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/RangeBuilder.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using OfficeIMO.Excel;
+
+namespace OfficeIMO.Excel.Fluent {
+    public class RangeBuilder {
+        private readonly ExcelSheet _sheet;
+        private readonly int _fromRow;
+        private readonly int _fromCol;
+        private readonly int _toRow;
+        private readonly int _toCol;
+
+        internal RangeBuilder(ExcelSheet sheet, int fromRow, int fromCol, int toRow, int toCol) {
+            _sheet = sheet;
+            _fromRow = fromRow;
+            _fromCol = fromCol;
+            _toRow = toRow;
+            _toCol = toCol;
+        }
+
+        public RangeBuilder NumberFormat(string numberFormat) {
+            for (int r = _fromRow; r <= _toRow; r++) {
+                for (int c = _fromCol; c <= _toCol; c++) {
+                    _sheet.FormatCell(r, c, numberFormat);
+                }
+            }
+            return this;
+        }
+
+        public RangeBuilder Style(Action<StyleBuilder> action) {
+            var builder = new StyleBuilder(_sheet);
+            action(builder);
+            return this;
+        }
+
+        public RangeBuilder Set(object[,] values) {
+            int rows = _toRow - _fromRow + 1;
+            int cols = _toCol - _fromCol + 1;
+            if (values.GetLength(0) != rows || values.GetLength(1) != cols) {
+                throw new ArgumentException("Values array dimensions must match the range.", nameof(values));
+            }
+
+            var cells = new List<(int Row, int Column, object Value)>();
+            for (int r = 0; r < rows; r++) {
+                for (int c = 0; c < cols; c++) {
+                    cells.Add((_fromRow + r, _fromCol + c, values[r, c]));
+                }
+            }
+            _sheet.CellValuesParallel(cells);
+            return this;
+        }
+
+        public RangeBuilder Clear() {
+            for (int r = _fromRow; r <= _toRow; r++) {
+                for (int c = _fromCol; c <= _toCol; c++) {
+                    _sheet.CellValue(r, c, string.Empty);
+                }
+            }
+            return this;
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Excel.RangeBuilder.cs
+++ b/OfficeIMO.Tests/Excel.RangeBuilder.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class ExcelRangeBuilderTests {
+        private static string GetCellValue(SpreadsheetDocument document, WorksheetPart worksheetPart, string cellReference) {
+            var cell = worksheetPart.Worksheet.Descendants<Cell>().First(c => c.CellReference != null && c.CellReference.Value == cellReference);
+            var value = cell.CellValue?.Text ?? string.Empty;
+            if (cell.DataType != null && cell.DataType.Value == CellValues.SharedString) {
+                var table = document.WorkbookPart.SharedStringTablePart.SharedStringTable;
+                if (int.TryParse(value, out int id)) {
+                    return table.ChildElements[id].InnerText;
+                }
+            }
+            return value;
+        }
+
+        [Fact]
+        public void RangeBuilderSetsValues() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            object[,] values = { { "A", "B" }, { "C", "D" } };
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AsFluent().Sheet("Data", s => s.Range("A1:B2", r => r.Set(values)));
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                var sheetPart = document._spreadSheetDocument.WorkbookPart.WorksheetParts.First();
+                Assert.Equal("A", GetCellValue(document._spreadSheetDocument, sheetPart, "A1"));
+                Assert.Equal("D", GetCellValue(document._spreadSheetDocument, sheetPart, "B2"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void RangeBuilderAppliesNumberFormat() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            object[,] values = { { 1.2, 3.4 }, { 5.6, 7.8 } };
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AsFluent().Sheet("Data", s => s.Range("A1:B2", r => {
+                    r.Set(values);
+                    r.NumberFormat("0.00");
+                }));
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                var cell = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "A1");
+                Assert.NotNull(cell.StyleIndex);
+                uint styleIndex = cell.StyleIndex!.Value;
+                var styles = spreadsheet.WorkbookPart.WorkbookStylesPart.Stylesheet;
+                var cellFormat = (CellFormat)styles.CellFormats.ElementAt((int)styleIndex);
+                var nfId = cellFormat.NumberFormatId!.Value;
+                var numberingFormat = styles.NumberingFormats.Elements<NumberingFormat>().First(n => n.NumberFormatId.Value == nfId);
+                Assert.Equal("0.00", numberingFormat.FormatCode.Value);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void RangeBuilderCanClearValues() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            object[,] values = { { "A", "B" }, { "C", "D" } };
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AsFluent().Sheet("Data", s => s.Range("A1:B2", r => {
+                    r.Set(values);
+                    r.Clear();
+                }));
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                var sheetPart = document._spreadSheetDocument.WorkbookPart.WorksheetParts.First();
+                Assert.Equal(string.Empty, GetCellValue(document._spreadSheetDocument, sheetPart, "A1"));
+                Assert.Equal(string.Empty, GetCellValue(document._spreadSheetDocument, sheetPart, "B2"));
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add RangeBuilder to format, set, and clear cell ranges
- allow SheetBuilder to parse string references into RangeBuilder
- cover RangeBuilder value, formatting, and clearing in unit tests

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter RangeBuilder`


------
https://chatgpt.com/codex/tasks/task_e_68a6f58d6114832e8357bf3eb8112deb