### PR TITLE
Scope Microsoft.Bcl.AsyncInterfaces reference to legacy frameworks

### DIFF
--- a/OfficeIMO.Excel/OfficeIMO.Excel.csproj
+++ b/OfficeIMO.Excel/OfficeIMO.Excel.csproj
@@ -37,6 +37,9 @@
         <PackageReference Include="DocumentFormat.OpenXml" Version="[3.3.0,4.0.0)" />
         <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
         <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net48'">
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     </ItemGroup>
 

--- a/OfficeIMO.Visio/OfficeIMO.Visio.csproj
+++ b/OfficeIMO.Visio/OfficeIMO.Visio.csproj
@@ -58,8 +58,11 @@
     <ItemGroup>
         <PackageReference Include="DocumentFormat.OpenXml" Version="[3.3.0,4.0.0)" />
         <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="System.IO.Packaging" Version="8.0.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">


### PR DESCRIPTION
## Summary
- limit Microsoft.Bcl.AsyncInterfaces package reference to legacy target frameworks
- avoid including async interfaces package on .NET 8/9 builds

## Testing
- `dotnet build`
- `dotnet build OfficeIMO.Excel/OfficeIMO.Excel.csproj -f net472` *(fails: The reference assemblies for .NETFramework,Version=v4.7.2 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f78ab20c832eaf9f72ba19475afb