### PR TITLE
Support Visio document title and author metadata

### DIFF
--- a/OfficeIMO.Examples/Visio/BasicVisioDocument.cs
+++ b/OfficeIMO.Examples/Visio/BasicVisioDocument.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using OfficeIMO.Visio;
+using OfficeIMO.Visio.Fluent;
 using SixLabors.ImageSharp;
 
 namespace OfficeIMO.Examples.Visio {
@@ -13,8 +14,11 @@ namespace OfficeIMO.Examples.Visio {
             string filePath = Path.Combine(folderPath, "Basic Visio.vsdx");
 
             VisioDocument document = VisioDocument.Create(filePath);
-            VisioPage page = document.AddPage("Page-1", 8.5, 11);
-            page.Shapes.Add(new VisioShape("1", 2, 2, 2, 1, "Rectangle") { 
+            document.AsFluent()
+                .Info(info => info.Title("Basic Visio").Author("OfficeIMO"))
+                .AddPage("Page-1", 8.5, 11, VisioMeasurementUnit.Inches, out VisioPage page)
+                .End();
+            page.Shapes.Add(new VisioShape("1", 2, 2, 2, 1, "Rectangle") {
                 NameU = "Rectangle",
                 FillColor = Color.LightBlue,
                 LineColor = Color.DarkBlue,

--- a/OfficeIMO.Tests/Visio.Metadata.cs
+++ b/OfficeIMO.Tests/Visio.Metadata.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+using OfficeIMO.Visio.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioMetadataTests {
+        [Fact]
+        public void TitleAndAuthorRoundTrip() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+            VisioDocument document = VisioDocument.Create(filePath);
+            document.Title = "My Diagram";
+            document.Author = "John Doe";
+            document.AddPage("Page1");
+            document.Save();
+
+            VisioDocument loaded = VisioDocument.Load(filePath);
+            Assert.Equal("My Diagram", loaded.Title);
+            Assert.Equal("John Doe", loaded.Author);
+        }
+
+        [Fact]
+        public void FluentInfoSetsMetadata() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+            VisioDocument document = VisioDocument.Create(filePath);
+            document.AsFluent()
+                .Info(info => info.Title("Fluent Diagram").Author("Jane Doe"))
+                .End();
+            document.AddPage("Page1");
+            document.Save();
+
+            VisioDocument loaded = VisioDocument.Load(filePath);
+            Assert.Equal("Fluent Diagram", loaded.Title);
+            Assert.Equal("Jane Doe", loaded.Author);
+        }
+    }
+}
+

--- a/OfficeIMO.Visio/Fluent/InfoBuilder.cs
+++ b/OfficeIMO.Visio/Fluent/InfoBuilder.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace OfficeIMO.Visio.Fluent {
+    /// <summary>
+    /// Builder for document information properties.
+    /// </summary>
+    public class InfoBuilder {
+        private readonly VisioFluentDocument _fluent;
+
+        internal InfoBuilder(VisioFluentDocument fluent) {
+            _fluent = fluent;
+        }
+
+        /// <summary>
+        /// Sets the document title.
+        /// </summary>
+        /// <param name="title">Title to assign.</param>
+        public InfoBuilder Title(string title) {
+            _fluent.Document.Title = title;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the document author.
+        /// </summary>
+        /// <param name="author">Author name.</param>
+        public InfoBuilder Author(string author) {
+            _fluent.Document.Author = author;
+            return this;
+        }
+    }
+}
+

--- a/OfficeIMO.Visio/Fluent/VisioFluentDocument.cs
+++ b/OfficeIMO.Visio/Fluent/VisioFluentDocument.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace OfficeIMO.Visio.Fluent {
     /// <summary>
     /// Provides a fluent wrapper for <see cref="VisioDocument"/> allowing chained configuration.
@@ -5,12 +7,23 @@ namespace OfficeIMO.Visio.Fluent {
     public class VisioFluentDocument {
         private readonly VisioDocument _document;
 
+        internal VisioDocument Document => _document;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="VisioFluentDocument"/> class.
         /// </summary>
         /// <param name="document">The underlying <see cref="VisioDocument"/>.</param>
         public VisioFluentDocument(VisioDocument document) {
             _document = document;
+        }
+
+        /// <summary>
+        /// Provides fluent access to document information.
+        /// </summary>
+        /// <param name="action">Action that receives an <see cref="InfoBuilder"/>.</param>
+        public VisioFluentDocument Info(Action<InfoBuilder> action) {
+            action(new InfoBuilder(this));
+            return this;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add Title and Author properties to VisioDocument
- expose Info builder in Visio fluent API for setting document metadata
- demonstrate and test metadata round-trip

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a703063208832e931ba541bdc826f4