### PR TITLE
Add connector arrowheads and labels

### DIFF
--- a/OfficeIMO.Examples/Visio/ComprehensiveColoredShapes.cs
+++ b/OfficeIMO.Examples/Visio/ComprehensiveColoredShapes.cs
@@ -150,7 +150,7 @@ namespace OfficeIMO.Examples.Visio {
                 LineColor = Color.Blue,
                 LineWeight = 0.02,
                 LinePattern = 1,
-                EndArrow = 1 // Arrow at end
+                EndArrow = EndArrow.Arrow
             };
             page.Connectors.Add(connector1);
 
@@ -158,7 +158,7 @@ namespace OfficeIMO.Examples.Visio {
                 LineColor = Color.Green,
                 LineWeight = 0.02,
                 LinePattern = 1,
-                EndArrow = 1 // Arrow at end
+                EndArrow = EndArrow.Arrow
             };
             page.Connectors.Add(connector2);
 

--- a/OfficeIMO.Examples/Visio/ConnectRectangles.cs
+++ b/OfficeIMO.Examples/Visio/ConnectRectangles.cs
@@ -36,7 +36,10 @@ namespace OfficeIMO.Examples.Visio {
             var connector = new VisioConnector(start, end) {
                 LineColor = Color.Blue,
                 LineWeight = 0.02,
-                EndArrow = 1 // Add arrow at the end
+                Kind = ConnectorKind.RightAngle,
+                BeginArrow = EndArrow.Arrow,
+                EndArrow = EndArrow.Triangle,
+                Label = "Start to End"
             };
             page.Connectors.Add(connector);
             

--- a/OfficeIMO.Tests/Visio.ConnectorArrows.cs
+++ b/OfficeIMO.Tests/Visio.ConnectorArrows.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioConnectorArrows {
+        [Fact]
+        public void ConnectorRoundTripsKindArrowsAndLabel() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = VisioDocument.Create(filePath);
+            VisioPage page = document.AddPage("Page-1");
+            VisioShape start = new("1", 1, 1, 1, 1, "Start");
+            VisioShape end = new("2", 3, 2, 1, 1, "End");
+            page.Shapes.Add(start);
+            page.Shapes.Add(end);
+
+            VisioConnector connector = new VisioConnector(start, end) {
+                Kind = ConnectorKind.RightAngle,
+                BeginArrow = EndArrow.Arrow,
+                EndArrow = EndArrow.Triangle,
+                Label = "A to B"
+            };
+            page.Connectors.Add(connector);
+            document.Save();
+
+            VisioDocument loaded = VisioDocument.Load(filePath);
+            VisioConnector loadedConnector = loaded.Pages[0].Connectors[0];
+
+            Assert.Equal(ConnectorKind.RightAngle, loadedConnector.Kind);
+            Assert.Equal(EndArrow.Arrow, loadedConnector.BeginArrow);
+            Assert.Equal(EndArrow.Triangle, loadedConnector.EndArrow);
+            Assert.Equal("A to B", loadedConnector.Label);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.ShapeAndConnectorStyles.cs
+++ b/OfficeIMO.Tests/Visio.ShapeAndConnectorStyles.cs
@@ -18,7 +18,7 @@ namespace OfficeIMO.Tests {
             VisioShape end = new("2", 4, 1, 2, 1, "End");
             page.Shapes.Add(start);
             page.Shapes.Add(end);
-            VisioConnector connector = new(start, end) { EndArrow = 13 };
+            VisioConnector connector = new(start, end) { EndArrow = EndArrow.Triangle };
             page.Connectors.Add(connector);
             document.Save();
 

--- a/OfficeIMO.Visio/EndArrow.cs
+++ b/OfficeIMO.Visio/EndArrow.cs
@@ -1,0 +1,13 @@
+namespace OfficeIMO.Visio {
+    /// <summary>
+    /// Specifies arrowhead styles for connector ends.
+    /// </summary>
+    public enum EndArrow {
+        /// <summary>No arrowhead.</summary>
+        None = 0,
+        /// <summary>Simple arrowhead.</summary>
+        Arrow = 1,
+        /// <summary>Triangle arrowhead.</summary>
+        Triangle = 13
+    }
+}

--- a/OfficeIMO.Visio/VisioConnector.cs
+++ b/OfficeIMO.Visio/VisioConnector.cs
@@ -60,12 +60,22 @@ namespace OfficeIMO.Visio {
         /// <summary>
         /// Gets or sets the kind of connector.
         /// </summary>
-        public ConnectorKind Kind { get; set; } = ConnectorKind.Straight;
+        public ConnectorKind Kind { get; set; } = ConnectorKind.Dynamic;
 
         /// <summary>
-        /// Gets or sets the end arrow style.
+        /// Gets or sets the arrow style at the beginning of the connector.
         /// </summary>
-        public int? EndArrow { get; set; }
+        public EndArrow? BeginArrow { get; set; }
+
+        /// <summary>
+        /// Gets or sets the arrow style at the end of the connector.
+        /// </summary>
+        public EndArrow? EndArrow { get; set; }
+
+        /// <summary>
+        /// Optional label displayed alongside the connector.
+        /// </summary>
+        public string? Label { get; set; }
         
         /// <summary>
         /// Line color of the connector.


### PR DESCRIPTION
## Summary
- support begin/end arrowheads and labels on connectors
- emit connector geometry based on ConnectorKind and arrowhead settings
- load connector kind, arrowheads, and labels from Visio documents

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a70a5678f4832e8095f296cbe8cb7a