### PR TITLE
Ensure default PowerPoint parts are saved

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -334,15 +334,19 @@ namespace OfficeIMO.PowerPoint {
 
             ExtendedFilePropertiesPart appPart = _document.AddExtendedFilePropertiesPart();
             appPart.Properties = new Ap.Properties(new Ap.Application { Text = "Microsoft Office PowerPoint" });
+            appPart.Properties.Save();
 
             PresentationPropertiesPart presPropsPart = _presentationPart.AddNewPart<PresentationPropertiesPart>();
             presPropsPart.PresentationProperties = new PresentationProperties();
+            presPropsPart.PresentationProperties.Save();
 
             ViewPropertiesPart viewPropsPart = _presentationPart.AddNewPart<ViewPropertiesPart>();
             viewPropsPart.ViewProperties = new ViewProperties();
+            viewPropsPart.ViewProperties.Save();
 
             TableStylesPart tableStylesPart = _presentationPart.AddNewPart<TableStylesPart>();
             tableStylesPart.TableStyleList = new A.TableStyleList { Default = "{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}" };
+            tableStylesPart.TableStyleList.Save();
 
             _presentationPart.Presentation.Save();
         }

--- a/OfficeIMO.Tests/PowerPoint.InitializeDefaults.cs
+++ b/OfficeIMO.Tests/PowerPoint.InitializeDefaults.cs
@@ -28,6 +28,11 @@ namespace OfficeIMO.Tests {
                 ThemePart theme = part.ThemePart!;
                 Assert.Same(theme, master.ThemePart);
                 Assert.Single(part.Presentation.SlideIdList!.Elements<SlideId>());
+
+                Assert.NotNull(document.ExtendedFilePropertiesPart?.Properties);
+                Assert.NotNull(part.PresentationPropertiesPart?.PresentationProperties);
+                Assert.NotNull(part.ViewPropertiesPart?.ViewProperties);
+                Assert.NotNull(part.TableStylesPart?.TableStyleList);
             }
 
             using (FileStream fs = File.OpenRead(filePath))

--- a/OfficeIMO.Tests/PowerPoint.PackageIntegrity.cs
+++ b/OfficeIMO.Tests/PowerPoint.PackageIntegrity.cs
@@ -69,6 +69,26 @@ namespace OfficeIMO.Tests {
                     warnings.Add("Notes master part missing root element.");
                 }
 
+                ExtendedFilePropertiesPart? appPart = document.ExtendedFilePropertiesPart;
+                if (appPart?.Properties == null) {
+                    warnings.Add("Presentation app part missing root element.");
+                }
+
+                PresentationPropertiesPart? presPropsPart = presentationPart.PresentationPropertiesPart;
+                if (presPropsPart?.PresentationProperties == null) {
+                    warnings.Add("Presentation properties part missing root element.");
+                }
+
+                ViewPropertiesPart? viewPropsPart = presentationPart.ViewPropertiesPart;
+                if (viewPropsPart?.ViewProperties == null) {
+                    warnings.Add("View properties part missing root element.");
+                }
+
+                TableStylesPart? tableStylesPart = presentationPart.TableStylesPart;
+                if (tableStylesPart?.TableStyleList == null) {
+                    warnings.Add("Table styles part missing root element.");
+                }
+
                 List<SlidePart> slideParts = presentationPart.SlideParts.ToList();
                 if (slideParts.Count == 0) {
                     warnings.Add("Presentation missing slide parts.");


### PR DESCRIPTION
## Summary
- persist root elements for default PowerPoint parts
- validate default PowerPoint parts are saved during initialization
- extend package integrity checks for additional PowerPoint parts

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter PowerPointInitializeDefaults`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter PowerPointPackageIntegrity`


------
https://chatgpt.com/codex/tasks/task_e_68a70a2810a0832e96eec86ea03f3cba