### PR TITLE
feat: expand Excel fluent builders

### DIFF
--- a/OfficeIMO.Examples/Excel/Fluent/Fluent.Cells.cs
+++ b/OfficeIMO.Examples/Excel/Fluent/Fluent.Cells.cs
@@ -1,0 +1,22 @@
+using System;
+using System.IO;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Fluent;
+
+namespace OfficeIMO.Examples.Excel {
+    internal static partial class FluentWorkbook {
+        public static void Example_FluentCells(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - Fluent cell helpers");
+            string filePath = Path.Combine(folderPath, "FluentCells.xlsx");
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Sheet("Data", s => s
+                        .Cell("B2", "Direct")
+                        .Row(r => r.Cell("C", "Row builder"))
+                        .Range("A1:C3", r => r.Cell(3, 3, "Range cell")))
+                    .End()
+                    .Save(openExcel);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/Fluent/ColumnBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/ColumnBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using OfficeIMO.Excel;
 namespace OfficeIMO.Excel.Fluent {
     public class ColumnBuilder {
@@ -5,6 +6,7 @@ namespace OfficeIMO.Excel.Fluent {
         private readonly int _columnIndex;
 
         internal ColumnBuilder(ExcelSheet sheet, int columnIndex) {
+            if (columnIndex < 1) throw new ArgumentOutOfRangeException(nameof(columnIndex));
             _sheet = sheet;
             _columnIndex = columnIndex;
         }
@@ -21,6 +23,12 @@ namespace OfficeIMO.Excel.Fluent {
 
         public ColumnBuilder Hidden(bool hidden) {
             _sheet.SetColumnHidden(_columnIndex, hidden);
+            return this;
+        }
+
+        public ColumnBuilder Cell(int row, object? value = null, string? formula = null, string? numberFormat = null) {
+            if (row < 1) throw new ArgumentOutOfRangeException(nameof(row));
+            _sheet.Cell(row, _columnIndex, value, formula, numberFormat);
             return this;
         }
     }

--- a/OfficeIMO.Excel/Fluent/ColumnCollectionBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/ColumnCollectionBuilder.cs
@@ -9,6 +9,7 @@ namespace OfficeIMO.Excel.Fluent {
         }
 
         public ColumnCollectionBuilder Col(int index, Action<ColumnBuilder> action) {
+            if (index < 1) throw new ArgumentOutOfRangeException(nameof(index));
             var builder = new ColumnBuilder(_sheet, index);
             action(builder);
             return this;

--- a/OfficeIMO.Excel/Fluent/RangeBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/RangeBuilder.cs
@@ -58,6 +58,17 @@ namespace OfficeIMO.Excel.Fluent {
             }
             return this;
         }
+
+        public RangeBuilder Cell(int rowOffset, int columnOffset, object? value = null, string? formula = null, string? numberFormat = null) {
+            if (rowOffset < 1) throw new ArgumentOutOfRangeException(nameof(rowOffset));
+            if (columnOffset < 1) throw new ArgumentOutOfRangeException(nameof(columnOffset));
+            int row = _fromRow + rowOffset - 1;
+            int col = _fromCol + columnOffset - 1;
+            if (row > _toRow) throw new ArgumentOutOfRangeException(nameof(rowOffset));
+            if (col > _toCol) throw new ArgumentOutOfRangeException(nameof(columnOffset));
+            _sheet.Cell(row, col, value, formula, numberFormat);
+            return this;
+        }
     }
 }
 

--- a/OfficeIMO.Excel/Fluent/RowBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/RowBuilder.cs
@@ -12,8 +12,15 @@ namespace OfficeIMO.Excel.Fluent {
         }
 
         public RowBuilder Cell(int column, object? value = null, string? formula = null, string? numberFormat = null) {
+            if (column < 1) throw new ArgumentOutOfRangeException(nameof(column));
             _sheet.Cell(_rowIndex, column, value, formula, numberFormat);
             return this;
+        }
+
+        public RowBuilder Cell(string columnReference, object? value = null, string? formula = null, string? numberFormat = null) {
+            if (string.IsNullOrWhiteSpace(columnReference)) throw new ArgumentNullException(nameof(columnReference));
+            int column = ColumnLetterToIndex(columnReference);
+            return Cell(column, value, formula, numberFormat);
         }
 
         public RowBuilder Values(params object?[] values) {
@@ -21,6 +28,15 @@ namespace OfficeIMO.Excel.Fluent {
                 _sheet.CellValue(_rowIndex, i + 1, values[i]);
             }
             return this;
+        }
+
+        private static int ColumnLetterToIndex(string column) {
+            int result = 0;
+            foreach (char c in column.ToUpperInvariant()) {
+                if (c < 'A' || c > 'Z') throw new ArgumentException("Invalid column reference", nameof(column));
+                result = result * 26 + (c - 'A' + 1);
+            }
+            return result;
         }
     }
 }

--- a/OfficeIMO.Excel/Fluent/SheetBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/SheetBuilder.cs
@@ -102,6 +102,14 @@ namespace OfficeIMO.Excel.Fluent {
             return this;
         }
 
+        public SheetBuilder Cell(string reference, object? value = null, string? formula = null, string? numberFormat = null) {
+            if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
+            if (string.IsNullOrWhiteSpace(reference)) throw new ArgumentNullException(nameof(reference));
+            var (row, column) = ParseCellReference(reference);
+            Sheet.Cell(row, column, value, formula, numberFormat);
+            return this;
+        }
+
         public SheetBuilder Range(int fromRow, int fromCol, int toRow, int toCol, object[,]? values = null) {
             if (Sheet == null) throw new InvalidOperationException("Sheet not initialized");
             if (fromRow < 1) throw new ArgumentOutOfRangeException(nameof(fromRow));

--- a/OfficeIMO.Tests/Excel.Fluent.cs
+++ b/OfficeIMO.Tests/Excel.Fluent.cs
@@ -51,6 +51,32 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void CanSetCellsWithVariousBuilders() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Sheet("Data", s => s
+                        .Cell("B2", "Sheet")
+                        .Row(r => r.Cell("C", "Row"))
+                        .Columns(c => c.Col(4, col => col.Cell(2, "Column")))
+                        .Range("A1:D4", r => r.Cell(4, 4, "Range")))
+                    .End()
+                    .Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                var sheetPart = document._spreadSheetDocument.WorkbookPart.WorksheetParts.First();
+                Assert.Equal("Sheet", GetCellValue(document._spreadSheetDocument, sheetPart, "B2"));
+                Assert.Equal("Row", GetCellValue(document._spreadSheetDocument, sheetPart, "C1"));
+                Assert.Equal("Column", GetCellValue(document._spreadSheetDocument, sheetPart, "D2"));
+                Assert.Equal("Range", GetCellValue(document._spreadSheetDocument, sheetPart, "D4"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void CanChangeColumnWidthAndHiddenState() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
 

--- a/OfficeIMO.Tests/Excel.RangeBuilder.cs
+++ b/OfficeIMO.Tests/Excel.RangeBuilder.cs
@@ -41,6 +41,23 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void RangeBuilderSetsSingleCell() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AsFluent().Sheet("Data", s => s.Range("A1:C3", r => r.Cell(2, 2, "X")));
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                var sheetPart = document._spreadSheetDocument.WorkbookPart.WorksheetParts.First();
+                Assert.Equal("X", GetCellValue(document._spreadSheetDocument, sheetPart, "B2"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void RangeBuilderAppliesNumberFormat() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             object[,] values = { { 1.2, 3.4 }, { 5.6, 7.8 } };


### PR DESCRIPTION
## Summary
- add A1-style cell addressing to SheetBuilder
- allow row, column and range builders to set cells with 1-based indexing
- demonstrate new fluent cell helpers with example and tests

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~ExcelFluentWorkbookTests.CanSetCellsWithVariousBuilders|FullyQualifiedName~ExcelRangeBuilderTests.RangeBuilderSetsSingleCell"`
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a71d249de0832eaf174260b85877e3