### PR TITLE
Enable fluent slide builder chaining

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/FluentPowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/FluentPowerPoint.cs
@@ -14,12 +14,12 @@ namespace OfficeIMO.Examples.PowerPoint {
 
             using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
                 presentation.AsFluent()
-                    .Slide(s => s
-                        .Layout(0, 0)
+                    .Slide(0, 0)
                         .Title("Fluent Presentation")
                         .TextBox("Hello from fluent API")
                         .Bullets("First", "Second")
-                        .Notes("Example notes"))
+                        .Notes("Example notes")
+                        .End()
                     .Slide(s => s.Title("Second Slide"))
                     .End()
                     .Save();

--- a/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
+++ b/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
@@ -16,22 +16,29 @@ namespace OfficeIMO.PowerPoint.Fluent {
         internal PowerPointPresentation Presentation { get; }
 
         /// <summary>
+        ///     Adds and returns a builder for a new slide.
+        /// </summary>
+        /// <param name="masterIndex">Index of the slide master.</param>
+        /// <param name="layoutIndex">Index of the slide layout.</param>
+        public PowerPointSlideBuilder Slide(int masterIndex = 0, int layoutIndex = 0) {
+            PowerPointSlide slide = Presentation.AddSlide(masterIndex, layoutIndex);
+            return new PowerPointSlideBuilder(this, slide);
+        }
+
+        /// <summary>
         ///     Adds and optionally configures a new slide to the presentation.
         /// </summary>
         /// <param name="masterIndex">Index of the slide master.</param>
         /// <param name="layoutIndex">Index of the slide layout.</param>
-        /// <param name="configure">Optional action used to configure the slide via a <see cref="PowerPointSlideBuilder"/>.</param>
-        public PowerPointFluentPresentation Slide(int masterIndex = 0, int layoutIndex = 0, Action<PowerPointSlideBuilder> configure = null) {
-            PowerPointSlide slide = Presentation.AddSlide(masterIndex, layoutIndex);
-            if (configure != null) {
-                PowerPointSlideBuilder builder = new PowerPointSlideBuilder(slide);
-                configure(builder);
-            }
+        /// <param name="configure">Action used to configure the slide.</param>
+        public PowerPointFluentPresentation Slide(int masterIndex, int layoutIndex, Action<PowerPointSlideBuilder> configure) {
+            PowerPointSlideBuilder builder = Slide(masterIndex, layoutIndex);
+            configure?.Invoke(builder);
             return this;
         }
 
         /// <summary>
-        ///     Adds and configures a new slide using a builder action.
+        ///     Adds and configures a new slide using a builder action with default master and layout indexes.
         /// </summary>
         /// <param name="configure">Action used to configure the slide.</param>
         public PowerPointFluentPresentation Slide(Action<PowerPointSlideBuilder> configure) {

--- a/OfficeIMO.PowerPoint/Fluent/PowerPointSlideBuilder.cs
+++ b/OfficeIMO.PowerPoint/Fluent/PowerPointSlideBuilder.cs
@@ -3,9 +3,11 @@ namespace OfficeIMO.PowerPoint.Fluent {
     ///     Builder for slide content.
     /// </summary>
     public class PowerPointSlideBuilder {
+        private readonly PowerPointFluentPresentation _presentation;
         private readonly PowerPointSlide _slide;
 
-        internal PowerPointSlideBuilder(PowerPointSlide slide) {
+        internal PowerPointSlideBuilder(PowerPointFluentPresentation presentation, PowerPointSlide slide) {
+            _presentation = presentation;
             _slide = slide;
         }
 
@@ -67,6 +69,13 @@ namespace OfficeIMO.PowerPoint.Fluent {
         public PowerPointSlideBuilder Notes(string text) {
             _slide.Notes.Text = text;
             return this;
+        }
+
+        /// <summary>
+        ///     Ends slide configuration and returns to the presentation builder.
+        /// </summary>
+        public PowerPointFluentPresentation End() {
+            return _presentation;
         }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.Fluent.cs
+++ b/OfficeIMO.Tests/PowerPoint.Fluent.cs
@@ -14,14 +14,14 @@ namespace OfficeIMO.Tests {
 
             using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
                 presentation.AsFluent()
-                    .Slide(s => s
-                        .Layout(0, 1)
+                    .Slide(0, 1)
                         .Title("Fluent Title")
                         .TextBox("Hello")
                         .Bullets("One", "Two")
                         .Image(imagePath)
                         .Table(2, 2)
-                        .Notes("Notes text"))
+                        .Notes("Notes text")
+                        .End()
                     .Slide(s => s.Title("Second Slide"))
                     .End()
                     .Save();


### PR DESCRIPTION
## Summary
- allow creating slides via `Slide()` builder methods
- support returning to presentation builder with `SlideBuilder.End()`
- add example and tests for fluent slide chaining

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a71d2a82e0832eb64dfe036796874a