### PR TITLE
Expand Word fluent API with read helpers

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.EndToEnd.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.EndToEnd.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class FluentDocument {
+        public static void Example_FluentEndToEnd(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating end-to-end fluent document");
+            string filePath = Path.Combine(folderPath, "FluentEndToEnd.docx");
+            string imagesPath = Path.Combine(Directory.GetCurrentDirectory(), "Images");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Info(i => i.Title("Quarterly Review").Author("OfficeIMO"))
+                    .PageSetup(ps => ps.Orientation(PageOrientationValues.Portrait)
+                                        .Size(WordPageSize.A4)
+                                        .Margins(WordMargin.Normal))
+                    .Paragraph(p => p.Text("Hello ").Text("World", t => t.BoldOn().Color("#ff0000")).Text("!"))
+                    .List(l => l.Numbered().Item("First").Item("Second"))
+                    .Table(t => t.Columns(3).PreferredWidth(percent: 100)
+                        .Header("Name", "Role", "Score")
+                        .Row("Alice", "Dev", 98)
+                        .Row("Bob", "Ops", 91)
+                        .Style(WordTableStyle.TableGrid)
+                        .Align(HorizontalAlignment.Center))
+                    .Image(i => i.Add(Path.Combine(imagesPath, "Kulek.jpg")).Size(100).Alt("Chart", "Quarterly chart"))
+                    .End()
+                    .Save(false);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Fluent.ImageBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ImageBuilder.cs
@@ -57,5 +57,27 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(JustificationValues.Center, document.Paragraphs[3].ParagraphAlignment);
             }
         }
+
+        [Fact]
+        public void Test_FluentImageAltAndLink() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentImageAltLink.docx");
+            string imagePath = Path.Combine(_directoryWithImages, "Kulek.jpg");
+
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Image(i => i.Add(imagePath).Alt("Title", "Desc").Link("https://example.com"))
+                    .End();
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                var hyperlink = document.Paragraphs[0].Hyperlink!;
+                var drawing = hyperlink._hyperlink.Descendants<DocumentFormat.OpenXml.Wordprocessing.Drawing>().First();
+                var image = new WordImage(document, drawing);
+                Assert.Equal("Desc", image.Description);
+                Assert.Equal("Title", image.Title);
+                Assert.True(document.Paragraphs[0].IsHyperLink);
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Word.Fluent.ReadApis.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ReadApis.cs
@@ -1,0 +1,33 @@
+using System.IO;
+using System.Linq;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_FluentReadApis() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentReadApis.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Section(s => s.New())
+                    .Paragraph(p => p.Text("Hello"))
+                    .Table(t => t.Columns(2).Row("A", "B"))
+                    .End();
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                int sectionCount = 0;
+                document.AsFluent().ForEachSection((i, s) => sectionCount++);
+                Assert.Equal(2, sectionCount);
+
+                Assert.True(document.AsFluent().Paragraphs().Any());
+                Assert.Single(document.AsFluent().Tables());
+                Assert.Equal(2, document.AsFluent().Sections().Count());
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/WordFluentDocument.cs
+++ b/OfficeIMO.Word/Fluent/WordFluentDocument.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using OfficeIMO.Word;
 
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
@@ -106,6 +107,38 @@ namespace OfficeIMO.Word.Fluent {
         public WordFluentDocument Footer(Action<FootersBuilder> action) {
             action(new FootersBuilder(this));
             return this;
+        }
+
+        /// <summary>
+        /// Executes an action for each section in the document.
+        /// </summary>
+        /// <param name="action">Action to execute for every section with its 1-based index.</param>
+        public WordFluentDocument ForEachSection(Action<int, WordSection> action) {
+            for (int i = 0; i < Document.Sections.Count; i++) {
+                action(i + 1, Document.Sections[i]);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Returns all sections in the document.
+        /// </summary>
+        public IEnumerable<WordSection> Sections() {
+            return Document.Sections;
+        }
+
+        /// <summary>
+        /// Returns all paragraphs in the document.
+        /// </summary>
+        public IEnumerable<WordParagraph> Paragraphs() {
+            return Document.Paragraphs;
+        }
+
+        /// <summary>
+        /// Returns all tables in the document.
+        /// </summary>
+        public IEnumerable<WordTable> Tables() {
+            return Document.Tables;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- expose section, paragraph, and table read helpers on Word fluent API
- support image alt text, behind-text, and hyperlink verbs
- add end-to-end fluent example and cover new verbs with tests

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a71d0bd750832e92fc24eefff100be