### PR TITLE
fix: resolve initial word project warnings

### DIFF
--- a/OfficeIMO.Word/BuiltinDocumentProperties.cs
+++ b/OfficeIMO.Word/BuiltinDocumentProperties.cs
@@ -6,8 +6,8 @@ namespace OfficeIMO.Word {
     /// Provides access to the built-in document properties such as title, creator and keywords.
     /// </summary>
     public class BuiltinDocumentProperties {
-        private WordprocessingDocument _wordprocessingDocument;
-        private WordDocument _document;
+        private readonly WordprocessingDocument _wordprocessingDocument;
+        private readonly WordDocument _document;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BuiltinDocumentProperties"/> class
@@ -23,7 +23,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the creator of the document.
         /// </summary>
-        public string Creator {
+        public string? Creator {
             get {
                 return _wordprocessingDocument.PackageProperties.Creator;
             }
@@ -34,7 +34,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the title of the document.
         /// </summary>
-        public string Title {
+        public string? Title {
             get {
                 return _wordprocessingDocument.PackageProperties.Title;
             }
@@ -45,7 +45,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the document description.
         /// </summary>
-        public string Description {
+        public string? Description {
             get {
                 return _wordprocessingDocument.PackageProperties.Description;
             }
@@ -56,7 +56,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the category of the document.
         /// </summary>
-        public string Category {
+        public string? Category {
             get {
                 return _wordprocessingDocument.PackageProperties.Category;
             }
@@ -67,7 +67,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// A delimited set of keywords (tags) to support searching and indexing the Package and content.
         /// </summary>
-        public string Keywords {
+        public string? Keywords {
             get {
                 return _wordprocessingDocument.PackageProperties.Keywords;
             }
@@ -78,7 +78,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the document subject.
         /// </summary>
-        public string Subject {
+        public string? Subject {
             get {
                 return _wordprocessingDocument.PackageProperties.Subject;
             }
@@ -89,7 +89,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the document revision number.
         /// </summary>
-        public string Revision {
+        public string? Revision {
             get {
                 return _wordprocessingDocument.PackageProperties.Revision;
             }
@@ -100,7 +100,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the last user who modified the document.
         /// </summary>
-        public string LastModifiedBy {
+        public string? LastModifiedBy {
             get {
                 return _wordprocessingDocument.PackageProperties.LastModifiedBy;
             }
@@ -111,7 +111,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the document version.
         /// </summary>
-        public string Version {
+        public string? Version {
             get {
                 return _wordprocessingDocument.PackageProperties.Version;
             }

--- a/OfficeIMO.Word/ColorNameResolver.cs
+++ b/OfficeIMO.Word/ColorNameResolver.cs
@@ -13,8 +13,7 @@ namespace OfficeIMO.Word {
         static ColorNameResolver() {
             // Use reflection to get all named colors from the Color structure
             foreach (var prop in typeof(Color).GetFields(BindingFlags.Static | BindingFlags.Public)) {
-                if (prop.FieldType == typeof(Color)) {
-                    Color color = (Color)prop.GetValue(null);
+                if (prop.FieldType == typeof(Color) && prop.GetValue(null) is Color color) {
                     colorNameMap[color] = prop.Name;
                 }
             }
@@ -27,7 +26,7 @@ namespace OfficeIMO.Word {
         /// <param name="color">The color to resolve.</param>
         /// <returns>The color name or RGBA string.</returns>
         public static string GetColorName(Color color) {
-            if (colorNameMap.TryGetValue(color, out string colorName)) {
+            if (colorNameMap.TryGetValue(color, out var colorName)) {
                 return colorName;
             }
 

--- a/OfficeIMO.Word/Converters/ConversionException.cs
+++ b/OfficeIMO.Word/Converters/ConversionException.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Runtime.Serialization;
 
 namespace OfficeIMO.Word {
     /// <summary>
     /// Represents errors that occur during document conversion processes.
     /// </summary>
-    [Serializable]
     public class ConversionException : Exception {
         /// <summary>
         /// Initializes a new instance of the <see cref="ConversionException"/> class.
@@ -28,13 +26,6 @@ namespace OfficeIMO.Word {
         public ConversionException(string message, Exception innerException) : base(message, innerException) {
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ConversionException"/> class with serialized data.
-        /// </summary>
-        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data.</param>
-        /// <param name="context">The contextual information about the source or destination.</param>
-        protected ConversionException(SerializationInfo info, StreamingContext context) : base(info, context) {
-        }
     }
 }
 

--- a/OfficeIMO.Word/Converters/DocumentTraversal.cs
+++ b/OfficeIMO.Word/Converters/DocumentTraversal.cs
@@ -67,10 +67,11 @@ namespace OfficeIMO.Word {
 
             int? numberId = paragraph._listNumberId;
             var list = numberId.HasValue ? paragraph._document?.Lists.FirstOrDefault(l => l._numberId == numberId) : null;
-            var wordLevel = list?.Numbering.Levels.FirstOrDefault(l => l._level.LevelIndex == level);
+            var wordLevel = list?.Numbering.Levels.FirstOrDefault(l => l._level.LevelIndex?.Value == level);
             if (wordLevel != null) {
-                start = wordLevel.StartNumberingValue;
-                numberFormat = wordLevel._level.NumberingFormat?.Val;
+                var startVal = wordLevel._level.StartNumberingValue?.Val;
+                start = startVal?.Value ?? 1;
+                numberFormat = wordLevel._level.NumberingFormat?.Val?.Value;
                 levelText = wordLevel.LevelText;
             }
 

--- a/OfficeIMO.Word/ExtensionsHeadersAndFooters.cs
+++ b/OfficeIMO.Word/ExtensionsHeadersAndFooters.cs
@@ -85,6 +85,7 @@ namespace OfficeIMO.Word {
 
             var header = new Header();
             header.Save(headerPart);
+            var headerElement = headerPart.Header ?? throw new InvalidOperationException("Header element is missing.");
 
             if (headerPart != null) {
                 var id = document._wordprocessingDocument.MainDocumentPart!.GetIdOfPart(headerPart);
@@ -99,15 +100,13 @@ namespace OfficeIMO.Word {
                 }
             }
 
+            var headers = section.Header ?? throw new InvalidOperationException("Headers collection is missing.");
             if (headerFooterValue == HeaderFooterValues.Default) {
-                //  section._headerDefault = headerPart.Header;
-                section.Header.Default = new WordHeader(document, HeaderFooterValues.Default, headerPart.Header, section);
+                headers.Default = new WordHeader(document, HeaderFooterValues.Default, headerElement, section);
             } else if (headerFooterValue == HeaderFooterValues.First) {
-                //  section._headerFirst = headerPart.Header;
-                section.Header.First = new WordHeader(document, HeaderFooterValues.First, headerPart.Header, section);
+                headers.First = new WordHeader(document, HeaderFooterValues.First, headerElement, section);
             } else {
-                // section._headerEven = headerPart.Header;
-                section.Header.Even = new WordHeader(document, HeaderFooterValues.Even, headerPart.Header, section);
+                headers.Even = new WordHeader(document, HeaderFooterValues.Even, headerElement, section);
             }
         }
 
@@ -130,6 +129,7 @@ namespace OfficeIMO.Word {
 
             var footer = new Footer();
             footer.Save(footerPart);
+            var footerElement = footerPart.Footer ?? throw new InvalidOperationException("Footer element is missing.");
 
             if (footerPart != null) {
                 var id = document._wordprocessingDocument.MainDocumentPart!.GetIdOfPart(footerPart);
@@ -142,15 +142,13 @@ namespace OfficeIMO.Word {
                 }
             }
 
+            var footers = section.Footer ?? throw new InvalidOperationException("Footers collection is missing.");
             if (headerFooterValue == HeaderFooterValues.Default) {
-                //section._footerDefault = footerPart.Footer;
-                section.Footer.Default = new WordFooter(document, HeaderFooterValues.Default, footerPart.Footer, section);
+                footers.Default = new WordFooter(document, HeaderFooterValues.Default, footerElement, section);
             } else if (headerFooterValue == HeaderFooterValues.First) {
-                //section._footerFirst = footerPart.Footer;
-                section.Footer.First = new WordFooter(document, HeaderFooterValues.First, footerPart.Footer, section);
+                footers.First = new WordFooter(document, HeaderFooterValues.First, footerElement, section);
             } else {
-                //section._footerEven = footerPart.Footer;
-                section.Footer.Even = new WordFooter(document, HeaderFooterValues.Even, footerPart.Footer, section);
+                footers.Even = new WordFooter(document, HeaderFooterValues.Even, footerElement, section);
             }
         }
 

--- a/OfficeIMO.Word/FieldCodes/AskField.cs
+++ b/OfficeIMO.Word/FieldCodes/AskField.cs
@@ -9,17 +9,17 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Bookmark to assign the value to.
         /// </summary>
-        public string Bookmark { get; set; }
+        public string? Bookmark { get; set; }
 
         /// <summary>
         /// Prompt displayed to the user.
         /// </summary>
-        public string Prompt { get; set; }
+        public string? Prompt { get; set; }
 
         /// <summary>
         /// Default response for the prompt. Added using the \d switch.
         /// </summary>
-        public string DefaultResponse { get; set; }
+        public string? DefaultResponse { get; set; }
 
         /// <summary>
         /// Indicates whether the prompt should appear only once. Added using the \o switch.

--- a/OfficeIMO.Word/FieldCodes/AuthorField.cs
+++ b/OfficeIMO.Word/FieldCodes/AuthorField.cs
@@ -8,7 +8,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Optional author name to insert instead of the document property.
         /// </summary>
-        public string Author { get; set; }
+        public string? Author { get; set; }
 
         internal override WordFieldType FieldType => WordFieldType.Author;
 

--- a/OfficeIMO.Word/FieldCodes/CitationField.cs
+++ b/OfficeIMO.Word/FieldCodes/CitationField.cs
@@ -9,7 +9,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Tag of the source to cite.
         /// </summary>
-        public string SourceTag { get; set; }
+        public string? SourceTag { get; set; }
 
         internal override WordFieldType FieldType => WordFieldType.Citation;
 

--- a/OfficeIMO.Word/FieldCodes/RefField.cs
+++ b/OfficeIMO.Word/FieldCodes/RefField.cs
@@ -8,7 +8,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Bookmark to reference.
         /// </summary>
-        public string Bookmark { get; set; }
+        public string? Bookmark { get; set; }
 
         /// <summary>
         /// When true, inserts a hyperlink to the bookmark (\\h switch).

--- a/OfficeIMO.Word/FieldCodes/SetField.cs
+++ b/OfficeIMO.Word/FieldCodes/SetField.cs
@@ -8,12 +8,12 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Name of the bookmark or variable to set.
         /// </summary>
-        public string Bookmark { get; set; }
+        public string? Bookmark { get; set; }
 
         /// <summary>
         /// Value to assign to the bookmark.
         /// </summary>
-        public string Value { get; set; }
+        public string? Value { get; set; }
 
         internal override WordFieldType FieldType => WordFieldType.Set;
 

--- a/OfficeIMO.Word/Fluent/FootersBuilder.cs
+++ b/OfficeIMO.Word/Fluent/FootersBuilder.cs
@@ -29,39 +29,54 @@ namespace OfficeIMO.Word.Fluent {
             if (footer == null) {
                 WordHeadersAndFooters.AddFooterReference(document, section, type);
                 if (type == HeaderFooterValues.First) {
-                    footer = document.Footer.First;
+                    footer = document.Footer!.First;
                 } else if (type == HeaderFooterValues.Even) {
-                    footer = document.Footer.Even;
+                    footer = document.Footer!.Even;
                 } else {
-                    footer = document.Footer.Default;
+                    footer = document.Footer!.Default;
                 }
             }
 
             return footer;
         }
 
+        /// <summary>
+        /// Adds content to the default footer.
+        /// </summary>
         public FootersBuilder Default(Action<FooterContentBuilder> action) {
             var footer = GetOrCreate(HeaderFooterValues.Default);
             action(new FooterContentBuilder(_fluent, footer));
             return this;
         }
 
+        /// <summary>
+        /// Adds content to the first-page footer.
+        /// </summary>
         public FootersBuilder First(Action<FooterContentBuilder> action) {
             var footer = GetOrCreate(HeaderFooterValues.First);
             action(new FooterContentBuilder(_fluent, footer));
             return this;
         }
 
+        /// <summary>
+        /// Adds content to the even-page footer.
+        /// </summary>
         public FootersBuilder Even(Action<FooterContentBuilder> action) {
             var footer = GetOrCreate(HeaderFooterValues.Even);
             action(new FooterContentBuilder(_fluent, footer));
             return this;
         }
 
+        /// <summary>
+        /// Adds content to the odd-page footer.
+        /// </summary>
         public FootersBuilder Odd(Action<FooterContentBuilder> action) {
             return Default(action);
         }
 
+        /// <summary>
+        /// Adds a new footer containing the specified text.
+        /// </summary>
         public FootersBuilder AddFooter(string text) {
             return Default(f => f.Paragraph(text));
         }
@@ -79,23 +94,35 @@ namespace OfficeIMO.Word.Fluent {
             _footer = footer;
         }
 
+        /// <summary>
+        /// Adds a paragraph with the specified text.
+        /// </summary>
         public FooterContentBuilder Paragraph(string text) {
             _footer.AddParagraph(text);
             return this;
         }
 
+        /// <summary>
+        /// Adds a paragraph configured using the supplied action.
+        /// </summary>
         public FooterContentBuilder Paragraph(Action<ParagraphBuilder> action) {
             var paragraph = _footer.AddParagraph();
             action(new ParagraphBuilder(_fluent, paragraph));
             return this;
         }
 
+        /// <summary>
+        /// Adds an image to the footer.
+        /// </summary>
         public FooterContentBuilder Image(string path, double? width = null, double? height = null, WrapTextImage wrapImage = WrapTextImage.InLineWithText, string description = "") {
             var paragraph = _footer.AddParagraph();
             paragraph.AddImage(path, width, height, wrapImage, description);
             return this;
         }
 
+        /// <summary>
+        /// Adds a table to the footer.
+        /// </summary>
         public FooterContentBuilder Table(int rows, int columns, WordTableStyle tableStyle = WordTableStyle.TableGrid, Action<WordTable>? configure = null) {
             var table = _footer.AddTable(rows, columns, tableStyle);
             configure?.Invoke(table);

--- a/OfficeIMO.Word/Fluent/HeadersBuilder.cs
+++ b/OfficeIMO.Word/Fluent/HeadersBuilder.cs
@@ -29,39 +29,54 @@ namespace OfficeIMO.Word.Fluent {
             if (header == null) {
                 WordHeadersAndFooters.AddHeaderReference(document, section, type);
                 if (type == HeaderFooterValues.First) {
-                    header = document.Header.First;
+                    header = document.Header!.First;
                 } else if (type == HeaderFooterValues.Even) {
-                    header = document.Header.Even;
+                    header = document.Header!.Even;
                 } else {
-                    header = document.Header.Default;
+                    header = document.Header!.Default;
                 }
             }
 
             return header;
         }
 
+        /// <summary>
+        /// Adds content to the default header.
+        /// </summary>
         public HeadersBuilder Default(Action<HeaderContentBuilder> action) {
             var header = GetOrCreate(HeaderFooterValues.Default);
             action(new HeaderContentBuilder(_fluent, header));
             return this;
         }
 
+        /// <summary>
+        /// Adds content to the first-page header.
+        /// </summary>
         public HeadersBuilder First(Action<HeaderContentBuilder> action) {
             var header = GetOrCreate(HeaderFooterValues.First);
             action(new HeaderContentBuilder(_fluent, header));
             return this;
         }
 
+        /// <summary>
+        /// Adds content to the even-page header.
+        /// </summary>
         public HeadersBuilder Even(Action<HeaderContentBuilder> action) {
             var header = GetOrCreate(HeaderFooterValues.Even);
             action(new HeaderContentBuilder(_fluent, header));
             return this;
         }
 
+        /// <summary>
+        /// Adds content to the odd-page header.
+        /// </summary>
         public HeadersBuilder Odd(Action<HeaderContentBuilder> action) {
             return Default(action);
         }
 
+        /// <summary>
+        /// Adds a new header containing the specified text.
+        /// </summary>
         public HeadersBuilder AddHeader(string text) {
             return Default(h => h.Paragraph(text));
         }
@@ -79,22 +94,34 @@ namespace OfficeIMO.Word.Fluent {
             _header = header;
         }
 
+        /// <summary>
+        /// Adds a paragraph with the specified text.
+        /// </summary>
         public HeaderContentBuilder Paragraph(string text) {
             _header.AddParagraph(text);
             return this;
         }
 
+        /// <summary>
+        /// Adds a paragraph configured using the supplied action.
+        /// </summary>
         public HeaderContentBuilder Paragraph(Action<ParagraphBuilder> action) {
             var paragraph = _header.AddParagraph();
             action(new ParagraphBuilder(_fluent, paragraph));
             return this;
         }
 
+        /// <summary>
+        /// Adds an image to the header.
+        /// </summary>
         public HeaderContentBuilder Image(string path, double? width = null, double? height = null, WrapTextImage wrapImage = WrapTextImage.InLineWithText, string description = "") {
             var paragraph = _header.AddParagraph();
             paragraph.AddImage(path, width, height, wrapImage, description);
             return this;
         }
+        /// <summary>
+        /// Adds a table to the header.
+        /// </summary>
         public HeaderContentBuilder Table(int rows, int columns, WordTableStyle tableStyle = WordTableStyle.TableGrid, Action<WordTable>? configure = null) {
             var table = _header.AddTable(rows, columns, tableStyle);
             configure?.Invoke(table);

--- a/OfficeIMO.Word/Helpers.Cloners.cs
+++ b/OfficeIMO.Word/Helpers.Cloners.cs
@@ -73,9 +73,9 @@ public static partial class Helpers {
     /// </summary>
     /// <param name="source">The source stream.</param>
     /// <param name="target">The target stream.</param>
-    public static void CopyStream(Stream source, Stream target) {
+    public static void CopyStream(Stream? source, Stream target) {
         if (source != null) {
-            MemoryStream mstream = source as MemoryStream;
+            MemoryStream? mstream = source as MemoryStream;
             if (mstream != null) {
                 mstream.WriteTo(target);
             } else {

--- a/OfficeIMO.Word/Helpers.cs
+++ b/OfficeIMO.Word/Helpers.cs
@@ -45,7 +45,7 @@ namespace OfficeIMO.Word {
         /// Normalizes color input which may be a hex value or a named color.
         /// Returns a lowercase hex string without '#'.
         /// </summary>
-        internal static string NormalizeColor(string color) {
+        internal static string? NormalizeColor(string? color) {
             if (string.IsNullOrEmpty(color)) {
                 return null;
             }
@@ -117,7 +117,7 @@ namespace OfficeIMO.Word {
             return IsFileLocked(new FileInfo(fileName));
         }
 
-        internal static ImageCharacteristics GetImageCharacteristics(Stream imageStream, string fileName = null) {
+        internal static ImageCharacteristics GetImageCharacteristics(Stream imageStream, string? fileName = null) {
             try {
                 using var img = SixLabors.ImageSharp.Image.Load(imageStream, out var imageFormat);
                 imageStream.Position = 0;
@@ -134,7 +134,7 @@ namespace OfficeIMO.Word {
                         try {
                             using var reader = new StreamReader(imageStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
                             var svg = System.Xml.Linq.XDocument.Load(reader);
-                            var root = svg.Root;
+                            var root = svg.Root ?? throw new InvalidOperationException("SVG document has no root element.");
                             double width = 0;
                             double height = 0;
                             var wAttr = root.Attribute("width");

--- a/OfficeIMO.Word/WordComment.PublicMethods.cs
+++ b/OfficeIMO.Word/WordComment.PublicMethods.cs
@@ -20,7 +20,7 @@ namespace OfficeIMO.Word {
         /// <param name="comment">Comment text.</param>
         /// <param name="parent">Optional parent comment when creating a reply.</param>
         /// <returns>The newly created <see cref="WordComment"/>.</returns>
-        public static WordComment Create(WordDocument document, string author, string initials, string comment, WordComment parent = null) {
+        public static WordComment Create(WordDocument document, string author, string initials, string comment, WordComment? parent = null) {
             var comments = GetCommentsPart(document);
             var commentsEx = GetCommentsExPart(document);
             // Compose a new Comment and add it to the Comments part.

--- a/OfficeIMO.Word/WordDocument.Fonts.cs
+++ b/OfficeIMO.Word/WordDocument.Fonts.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Word {
             if (string.IsNullOrEmpty(fontPath)) throw new ArgumentNullException(nameof(fontPath));
             if (!File.Exists(fontPath)) throw new FileNotFoundException($"Font file '{fontPath}' doesn't exist.", fontPath);
 
-            var mainPart = _wordprocessingDocument.MainDocumentPart;
+            var mainPart = _wordprocessingDocument?.MainDocumentPart ?? throw new InvalidOperationException("Main document part is missing.");
             var fontTablePart = mainPart.FontTablePart ?? mainPart.AddNewPart<FontTablePart>();
             fontTablePart.Fonts ??= new Fonts();
 
@@ -25,7 +25,7 @@ namespace OfficeIMO.Word {
             }
             var relId = fontTablePart.GetIdOfPart(fontPart);
 
-            var font = fontTablePart.Fonts.Elements<Font>().FirstOrDefault(f => string.Equals(f.Name.Value, fontName, StringComparison.OrdinalIgnoreCase));
+            var font = fontTablePart.Fonts.Elements<Font>().FirstOrDefault(f => string.Equals(f.Name?.Value, fontName, StringComparison.OrdinalIgnoreCase));
             if (font == null) {
                 font = new Font { Name = fontName };
                 fontTablePart.Fonts.Append(font);
@@ -40,11 +40,11 @@ namespace OfficeIMO.Word {
         /// <param name="fontPath">Path to a TrueType/OpenType font file.</param>
         /// <param name="styleId">Style identifier to register.</param>
         /// <param name="styleName">Optional friendly name for the style.</param>
-        public void EmbedFont(string fontPath, string styleId, string styleName = null) {
+        public void EmbedFont(string fontPath, string styleId, string? styleName = null) {
             EmbedFont(fontPath);
             var fontName = Path.GetFileNameWithoutExtension(fontPath);
             WordParagraphStyle.RegisterFontStyle(styleId, fontName, styleName);
-            var stylePart = _wordprocessingDocument.MainDocumentPart.StyleDefinitionsPart;
+            var stylePart = _wordprocessingDocument?.MainDocumentPart?.StyleDefinitionsPart;
             if (stylePart != null) {
                 AddStyleDefinitions(stylePart, overrideExisting: false);
             }

--- a/OfficeIMO.Word/WordEmbeddedObjectOptions.cs
+++ b/OfficeIMO.Word/WordEmbeddedObjectOptions.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the path to the icon used when <see cref="DisplayAsIcon"/> is <c>true</c>.
         /// </summary>
-        public string IconPath { get; set; }
+        public string? IconPath { get; set; }
 
         /// <summary>
         /// Gets or sets the width of the embedded object when displayed as an icon.
@@ -32,7 +32,7 @@ namespace OfficeIMO.Word {
         /// <param name="width">Optional icon width in points.</param>
         /// <param name="height">Optional icon height in points.</param>
         /// <returns>A configured <see cref="WordEmbeddedObjectOptions"/> instance.</returns>
-        public static WordEmbeddedObjectOptions Icon(string iconPath = null, double? width = null, double? height = null) {
+        public static WordEmbeddedObjectOptions Icon(string? iconPath = null, double? width = null, double? height = null) {
             return new WordEmbeddedObjectOptions {
                 DisplayAsIcon = true,
                 IconPath = iconPath,

--- a/OfficeIMO.Word/WordField.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordField.PrivateMethods.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Word {
     /// Holds private helpers for field processing.
     /// </summary>
     public partial class WordField {
-        private static SimpleField AddSimpleField(WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, string customFormat = null, List<String> parameters = null) {
+        private static SimpleField AddSimpleField(WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, string? customFormat = null, List<string>? parameters = null) {
             SimpleField simpleField1 = new SimpleField() { Instruction = GenerateField(wordFieldType, wordFieldFormat, customFormat, parameters) };
 
             Run run1 = new Run();
@@ -31,7 +31,7 @@ namespace OfficeIMO.Word {
         }
 
 
-        private static Run AddAdvancedField(WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, string customFormat = null, List<String> parameters = null) {
+        private static Run AddAdvancedField(WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, string? customFormat = null, List<string>? parameters = null) {
             Run run = new Run();
 
             RunProperties runProperties = new RunProperties();
@@ -47,7 +47,7 @@ namespace OfficeIMO.Word {
             return run;
         }
 
-        private static string GenerateField(WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, string customFormat = null, List<String> parameters = null) {
+        private static string GenerateField(WordFieldType wordFieldType, WordFieldFormat? wordFieldFormat = null, string? customFormat = null, List<string>? parameters = null) {
             var fieldType = " " + wordFieldType.ToString().ToUpper() + " ";
             var fieldFormat = string.Empty;
             if (wordFieldFormat != null) {

--- a/OfficeIMO.Word/WordTabStop.cs
+++ b/OfficeIMO.Word/WordTabStop.cs
@@ -11,21 +11,22 @@ namespace OfficeIMO.Word {
 
         private Tabs _tabs {
             get {
-                if (_paragraph._paragraphProperties.Tabs == null) {
-                    _paragraph._paragraphProperties.Append(new Tabs());
+                var paragraphProperties = _paragraph._paragraphProperties;
+                if (paragraphProperties.Tabs == null) {
+                    paragraphProperties.Append(new Tabs());
                 }
-                return _paragraph._paragraphProperties.Tabs;
+                return paragraphProperties.Tabs!;
             }
         }
 
-        private TabStop _tabStop { get; set; }
+        private TabStop _tabStop { get; set; } = new TabStop();
 
         /// <summary>
         /// Gets or sets the alignment type for the tab stop.
         /// </summary>
         public TabStopValues Alignment {
             get {
-                return _tabStop.Val;
+                return _tabStop.Val ?? TabStopValues.Left;
             }
             set {
                 _tabStop.Val = value;
@@ -37,7 +38,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public TabStopLeaderCharValues Leader {
             get {
-                return _tabStop.Leader;
+                return _tabStop.Leader ?? TabStopLeaderCharValues.None;
             }
             set {
                 _tabStop.Leader = value;
@@ -49,7 +50,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int Position {
             get {
-                return (int)_tabStop.Position;
+                return (int)(_tabStop.Position ?? 0);
             }
             set {
                 _tabStop.Position = value;
@@ -96,7 +97,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="other">The tab stop to compare with the current instance.</param>
         /// <returns><c>true</c> if the tab stops have the same alignment, leader and position; otherwise, <c>false</c>.</returns>
-        public bool Equals(WordTabStop other) {
+        public bool Equals(WordTabStop? other) {
             if (other is null) return false;
             return Alignment == other.Alignment && Leader == other.Leader && Position == other.Position;
         }
@@ -106,7 +107,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="obj">The object to compare with the current instance.</param>
         /// <returns><c>true</c> if the objects are equal; otherwise, <c>false</c>.</returns>
-        public override bool Equals(object obj) {
+        public override bool Equals(object? obj) {
             return obj is WordTabStop other && Equals(other);
         }
 

--- a/OfficeIMO.Word/WordWrapTextImage.cs
+++ b/OfficeIMO.Word/WordWrapTextImage.cs
@@ -112,6 +112,9 @@ namespace OfficeIMO.Word {
         /// <param name="wrapImage">The desired wrapping option.</param>
         public static void SetWrapTextImage(DocumentFormat.OpenXml.Wordprocessing.Drawing drawing, Anchor anchor, Inline inline, WrapTextImage? wrapImage) {
             var currentWrap = GetWrapTextImage(anchor, inline);
+            if (wrapImage == null) {
+                throw new ArgumentNullException(nameof(wrapImage));
+            }
             if (currentWrap == wrapImage) {
                 // nothing to do
                 return;


### PR DESCRIPTION
## Summary
- address nullable reference warnings across initial Word files
- improve header/footer setup and builder documentation
- ensure font embedding and field helpers handle null values safely

## Testing
- `dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj -warnaserror:false --no-incremental`

------
https://chatgpt.com/codex/tasks/task_e_68a75e2192dc832eaf7dfff71d0ec741