### PR TITLE
fix: address initial build warnings

### DIFF
--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -27,7 +27,7 @@ namespace OfficeIMO.Excel {
                 try {
                     List<ExcelSheet> listExcel = new List<ExcelSheet>();
                     List<Sheet>? elements = null;
-                    if (_spreadSheetDocument.WorkbookPart.Workbook.Sheets != null) {
+                    if (_spreadSheetDocument.WorkbookPart!.Workbook!.Sheets != null) {
                         elements = _spreadSheetDocument.WorkbookPart.Workbook.Sheets.OfType<Sheet>().ToList();
                         foreach (Sheet s in elements) {
                             listExcel.Add(new ExcelSheet(this, _spreadSheetDocument, s));
@@ -40,7 +40,7 @@ namespace OfficeIMO.Excel {
                         id.Add(0);
                         if (elements != null) {
                             foreach (Sheet s in elements) {
-                                if (!id.Contains(s.SheetId)) {
+                                if (s.SheetId != null && !id.Contains(s.SheetId)) {
                                     id.Add(s.SheetId);
                                 }
                             }
@@ -59,14 +59,14 @@ namespace OfficeIMO.Excel {
         /// <summary>
         /// Underlying Open XML spreadsheet document instance.
         /// </summary>
-        public SpreadsheetDocument _spreadSheetDocument;
-        private WorkbookPart _workBookPart;
-        private SharedStringTablePart _sharedStringTablePart;
+        public SpreadsheetDocument _spreadSheetDocument = null!;
+        private WorkbookPart _workBookPart = null!;
+        private SharedStringTablePart _sharedStringTablePart = null!;
 
         /// <summary>
         /// Path to the file backing this document.
         /// </summary>
-        public string FilePath;
+        public string FilePath = string.Empty;
 
         /// <summary>
         /// FileOpenAccess of the document
@@ -187,10 +187,11 @@ namespace OfficeIMO.Excel {
         /// <returns>Loaded <see cref="ExcelDocument"/> instance.</returns>
         /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
         public static async Task<ExcelDocument> LoadAsync(string filePath, bool readOnly = false, bool autoSave = false) {
-            if (filePath != null) {
-                if (!File.Exists(filePath)) {
-                    throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
-                }
+            if (filePath == null) {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+            if (!File.Exists(filePath)) {
+                throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
             }
             using var fileStream = new FileStream(filePath, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite, readOnly ? FileShare.Read : FileShare.ReadWrite, 4096, FileOptions.Asynchronous);
             var memoryStream = new MemoryStream();

--- a/OfficeIMO.Excel/ExcelSheet.cs
+++ b/OfficeIMO.Excel/ExcelSheet.cs
@@ -31,10 +31,10 @@ namespace OfficeIMO.Excel {
                 _sheet.Name = value;
             }
         }
-        private readonly UInt32Value Id;
-        private readonly WorksheetPart _worksheetPart;
-        private readonly SpreadsheetDocument _spreadSheetDocument;
-        private readonly ExcelDocument _excelDocument;
+        private readonly UInt32Value Id = null!;
+        private readonly WorksheetPart _worksheetPart = null!;
+        private readonly SpreadsheetDocument _spreadSheetDocument = null!;
+        private readonly ExcelDocument _excelDocument = null!;
         private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
 
         /// <summary>
@@ -47,6 +47,7 @@ namespace OfficeIMO.Excel {
             _excelDocument = excelDocument;
             _sheet = sheet;
             _spreadSheetDocument = spreadSheetDocument;
+            Id = sheet.SheetId ?? new UInt32Value((uint)0);
 
             var list = _spreadSheetDocument.WorkbookPart.WorksheetParts.ToList();
             foreach (var worksheetPart in list) {
@@ -467,7 +468,7 @@ namespace OfficeIMO.Excel {
             });
         }
 
-        public void AddAutoFilter(string range, Dictionary<uint, IEnumerable<string>> filterCriteria = null) {
+        public void AddAutoFilter(string range, Dictionary<uint, IEnumerable<string>>? filterCriteria = null) {
             if (string.IsNullOrEmpty(range)) {
                 throw new ArgumentNullException(nameof(range));
             }
@@ -997,9 +998,12 @@ namespace OfficeIMO.Excel {
         /// <param name="row">The 1-based row index.</param>
         /// <param name="column">The 1-based column index.</param>
         /// <param name="value">The value to assign.</param>
-        public void CellValue(int row, int column, object value) {
+        public void CellValue(int row, int column, object? value) {
             WriteLock(() => {
                 switch (value) {
+                    case null:
+                        CellValue(row, column, string.Empty);
+                        break;
                     case string s:
                         CellValue(row, column, s);
                         break;
@@ -1049,11 +1053,7 @@ namespace OfficeIMO.Excel {
                         CellValue(row, column, (double)sh);
                         break;
                     default:
-                        if (value != null) {
-                            CellValue(row, column, value.ToString());
-                        } else {
-                            CellValue(row, column, string.Empty);
-                        }
+                        CellValue(row, column, value.ToString()!);
                         break;
                 }
             });

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -118,7 +118,7 @@ namespace OfficeIMO.PowerPoint {
             }
 
             SlideLayoutPart layoutPart = layouts[layoutIndex];
-            _ = slidePart.AddPart(layoutPart);
+            slidePart.AddPart(layoutPart, masterPart.GetIdOfPart(layoutPart));
 
             if (_presentationPart.Presentation.SlideIdList == null) {
                 _presentationPart.Presentation.SlideIdList = new SlideIdList();

--- a/OfficeIMO.PowerPoint/PowerPointSlide.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.cs
@@ -161,7 +161,7 @@ namespace OfficeIMO.PowerPoint {
                 _slidePart.DeletePart(relId);
             }
 
-            _slidePart.AddPart(layoutPart);
+            _slidePart.AddPart(layoutPart, masterPart.GetIdOfPart(layoutPart));
         }
 
         /// <summary>

--- a/OfficeIMO.Tests/Excel.LoadExceptions.cs
+++ b/OfficeIMO.Tests/Excel.LoadExceptions.cs
@@ -29,7 +29,7 @@ namespace OfficeIMO.Tests {
         [Fact]
         public async Task Test_LoadAsyncNullPath_ThrowsArgumentNullException() {
             var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => ExcelDocument.LoadAsync(null));
-            Assert.Equal("path", ex.ParamName);
+            Assert.Equal("filePath", ex.ParamName);
         }
     }
 }

--- a/OfficeIMO.Tests/OfficeIMO.Tests.csproj
+++ b/OfficeIMO.Tests/OfficeIMO.Tests.csproj
@@ -30,6 +30,12 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- Explicitly reference patched versions for vulnerable packages -->
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\\OfficeIMO.Word\\OfficeIMO.Word.csproj" />
         <ProjectReference Include="..\\OfficeIMO.Excel\\OfficeIMO.Excel.csproj" />
         <ProjectReference Include="..\\OfficeIMO.Word.Pdf\\OfficeIMO.Word.Pdf.csproj" />


### PR DESCRIPTION
## Summary
- reference patched System.Net.Http and System.Text.RegularExpressions packages to silence vulnerability warnings
- initialize Excel core fields and add null checks
- allow null values in ExcelSheet APIs

## Testing
- `dotnet clean`
- `dotnet build` *(fails: Build failed with 1410 warning(s))*

------
https://chatgpt.com/codex/tasks/task_e_68a75dfb0a58832eb2fe2b38b1143418