### PR TITLE
Ensure examples run relative to executable directory

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -10,8 +10,10 @@ namespace OfficeIMO.Examples {
         }
 
         static void Main(string[] args) {
-            string templatesPath = Path.Combine(Directory.GetCurrentDirectory(), "Templates");
-            string folderPath = Path.Combine(Directory.GetCurrentDirectory(), "Documents");
+            string baseFolder = Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory);
+            Directory.SetCurrentDirectory(baseFolder);
+            string templatesPath = Path.Combine(baseFolder, "Templates");
+            string folderPath = Path.Combine(baseFolder, "Documents");
             Setup(folderPath);
 
             // Visio - Core Examples

--- a/OfficeIMO.Tests/OfficeIMO.Tests.csproj
+++ b/OfficeIMO.Tests/OfficeIMO.Tests.csproj
@@ -38,7 +38,6 @@
         <ProjectReference Include="..\\OfficeIMO.Visio\\OfficeIMO.Visio.csproj" />
         <ProjectReference Include="..\\OfficeIMO.PowerPoint\\OfficeIMO.PowerPoint.csproj" />
     </ItemGroup>
-
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
         <Reference Include="System.IO.Compression" />
     </ItemGroup>


### PR DESCRIPTION
## Summary
- Inline current-directory setup so examples resolve templates and output paths next to the executable
- Drop ExampleHelper class

## Testing
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj`
- `dotnet build OfficeIMO.Tests/OfficeIMO.Tests.csproj`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68a76d4bd25c832ea6b5ddb86c044a84