### PR TITLE
Validate table range overlaps and persist table definitions

### DIFF
--- a/OfficeIMO.Examples/Excel/AddTableOverlapping.cs
+++ b/OfficeIMO.Examples/Excel/AddTableOverlapping.cs
@@ -1,0 +1,34 @@
+using System;
+using OfficeIMO.Excel;
+
+namespace OfficeIMO.Examples.Excel {
+    /// <summary>
+    /// Demonstrates detection of overlapping table ranges.
+    /// </summary>
+    public static class AddTableOverlapping {
+        public static void Example(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - Add table overlapping range");
+            string filePath = System.IO.Path.Combine(folderPath, "Add Table Overlapping.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Value");
+                sheet.CellValue(2, 1, "A");
+                sheet.CellValue(2, 2, 10d);
+                sheet.CellValue(3, 1, "B");
+                sheet.CellValue(3, 2, 20d);
+                sheet.AddTable("A1:B3", true, "Table1", TableStyle.TableStyleMedium9);
+
+                try {
+                    sheet.AddTable("B2:C4", true, "Table2", TableStyle.TableStyleMedium9);
+                } catch (InvalidOperationException ex) {
+                    Console.WriteLine($"Expected error: {ex.Message}");
+                }
+
+                document.Save(openExcel);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Excel/ExcelSheet.cs
+++ b/OfficeIMO.Excel/ExcelSheet.cs
@@ -163,6 +163,11 @@ namespace OfficeIMO.Excel {
             return columnIndex;
         }
 
+        private static int GetRowIndex(string cellReference) {
+            var digits = new string(cellReference.Where(char.IsDigit).ToArray());
+            return int.Parse(digits, CultureInfo.InvariantCulture);
+        }
+
         private string GetCellText(Cell cell) {
             if (cell.CellValue == null) return string.Empty;
             string value = cell.CellValue.InnerText;
@@ -516,11 +521,35 @@ namespace OfficeIMO.Excel {
 
                 int startColumnIndex = GetColumnIndex(startRef);
                 int endColumnIndex = GetColumnIndex(endRef);
+                int startRowIndex = GetRowIndex(startRef);
+                int endRowIndex = GetRowIndex(endRef);
 
                 uint columnsCount = (uint)(endColumnIndex - startColumnIndex + 1);
 
-                var tableDefinitionPart = _worksheetPart.AddNewPart<TableDefinitionPart>();
+                foreach (var existingPart in _worksheetPart.TableDefinitionParts) {
+                    var existingRange = existingPart.Table?.Reference?.Value;
+                    if (string.IsNullOrEmpty(existingRange)) continue;
+                    var existingCells = existingRange.Split(':');
+                    if (existingCells.Length != 2) continue;
+                    string existingStartRef = existingCells[0];
+                    string existingEndRef = existingCells[1];
+
+                    int existingStartColumn = GetColumnIndex(existingStartRef);
+                    int existingEndColumn = GetColumnIndex(existingEndRef);
+                    int existingStartRow = GetRowIndex(existingStartRef);
+                    int existingEndRow = GetRowIndex(existingEndRef);
+
+                    bool overlaps = startColumnIndex <= existingEndColumn &&
+                                    endColumnIndex >= existingStartColumn &&
+                                    startRowIndex <= existingEndRow &&
+                                    endRowIndex >= existingStartRow;
+                    if (overlaps) {
+                        throw new InvalidOperationException("The specified range overlaps with an existing table.");
+                    }
+                }
+
                 uint tableId = (uint)(_worksheetPart.TableDefinitionParts.Count() + 1);
+                var tableDefinitionPart = _worksheetPart.AddNewPart<TableDefinitionPart>();
 
                 if (string.IsNullOrEmpty(name)) {
                     name = $"Table{tableId}";
@@ -550,6 +579,7 @@ namespace OfficeIMO.Excel {
                 });
 
                 tableDefinitionPart.Table = table;
+                tableDefinitionPart.Table.Save();
 
                 var tableParts = _worksheetPart.Worksheet.Elements<TableParts>().FirstOrDefault();
                 if (tableParts == null) {


### PR DESCRIPTION
## Summary
- fix off-by-one table IDs by computing before adding new part
- persist table definitions by saving table parts
- prevent overlapping tables and add example and tests

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter AddTable`

------
https://chatgpt.com/codex/tasks/task_e_68a7870753b0832e890914fbe3d816b8