### PR TITLE
Fix Excel Save reopening to release file locks

### DIFF
--- a/OfficeIMO.Tests/Excel.SaveOpen.cs
+++ b/OfficeIMO.Tests/Excel.SaveOpen.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_Save_OpensWithoutSharingViolation() {
+            string filePath = Path.Combine(_directoryWithFiles, "SaveOpen.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Test");
+
+                try {
+                    document.Save(true);
+                } catch {
+                    // Opening the file may fail on systems without associated application
+                }
+
+                using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) {
+                }
+
+                document.AddWorkSheet("Second");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                Assert.Equal(2, spreadsheet.WorkbookPart.Workbook.Sheets.OfType<Sheet>().Count());
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure `ExcelDocument.Save` flushes to disk and reopens from memory before launching Excel
- add regression test verifying save-and-open releases file lock and document remains usable

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Test_Save_OpensWithoutSharingViolation`


------
https://chatgpt.com/codex/tasks/task_e_68a786f93dc0832e967c5b02091121c8