### PR TITLE
Account for cell styles in Excel AutoFit

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.cs
+++ b/OfficeIMO.Excel/ExcelSheet.cs
@@ -218,6 +218,36 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        private SixLabors.Fonts.Font GetCellFont(Cell cell) {
+            var defaultFont = GetDefaultFont();
+            if (cell.StyleIndex == null) return defaultFont;
+
+            var stylesPart = _spreadSheetDocument.WorkbookPart.WorkbookStylesPart;
+            var stylesheet = stylesPart?.Stylesheet;
+            var fonts = stylesheet?.Fonts;
+            var cellFormats = stylesheet?.CellFormats;
+            if (fonts == null || cellFormats == null) return defaultFont;
+
+            var cellFormat = cellFormats.Elements<CellFormat>().ElementAtOrDefault((int)cell.StyleIndex.Value);
+            if (cellFormat?.FontId == null) return defaultFont;
+
+            var fontElement = fonts.Elements<DocumentFormat.OpenXml.Spreadsheet.Font>().ElementAtOrDefault((int)cellFormat.FontId.Value);
+            if (fontElement == null) return defaultFont;
+
+            var fontName = fontElement.GetFirstChild<FontName>()?.Val?.Value;
+            var fontSize = fontElement.GetFirstChild<FontSize>()?.Val?.Value ?? defaultFont.Size;
+            bool bold = fontElement.GetFirstChild<Bold>() != null;
+
+            try {
+                if (!string.IsNullOrEmpty(fontName)) {
+                    return SystemFonts.CreateFont(fontName, (float)fontSize, bold ? FontStyle.Bold : FontStyle.Regular);
+                }
+                return defaultFont.Family.CreateFont((float)fontSize, bold ? FontStyle.Bold : FontStyle.Regular);
+            } catch (FontFamilyNotFoundException) {
+                return defaultFont.Family.CreateFont((float)fontSize, bold ? FontStyle.Bold : FontStyle.Regular);
+            }
+        }
+
         /// <summary>
         /// Automatically fits all columns based on their content.
         /// </summary>
@@ -291,46 +321,48 @@ namespace OfficeIMO.Excel {
         }
 
         public void AutoFitColumn(int columnIndex) {
-            var worksheet = _worksheetPart.Worksheet;
-            SheetData sheetData = worksheet.GetFirstChild<SheetData>();
-            if (sheetData == null) return;
+            WriteLock(() => {
+                var worksheet = _worksheetPart.Worksheet;
+                SheetData sheetData = worksheet.GetFirstChild<SheetData>();
+                if (sheetData == null) return;
 
-            var columns = worksheet.GetFirstChild<Columns>();
-            if (columns == null) {
-                columns = worksheet.InsertAt(new Columns(), 0);
-            }
-
-            var font = GetDefaultFont();
-            var options = new TextOptions(font);
-            float zeroWidth = TextMeasurer.MeasureSize("0", options).Width;
-            double width = 0;
-
-            foreach (var row in sheetData.Elements<Row>()) {
-                var cell = row.Elements<Cell>()
-                    .FirstOrDefault(c => c.CellReference != null && GetColumnIndex(c.CellReference.Value) == columnIndex);
-                if (cell == null) continue;
-                string text = GetCellText(cell);
-                if (string.IsNullOrWhiteSpace(text)) continue;
-                var size = TextMeasurer.MeasureSize(text, options);
-                double cellWidth = size.Width / zeroWidth + 1;
-                if (cellWidth > width) width = cellWidth;
-            }
-
-            Column column = columns.Elements<Column>()
-                .FirstOrDefault(c => c.Min != null && c.Max != null && c.Min.Value <= (uint)columnIndex && c.Max.Value >= (uint)columnIndex);
-            if (width > 0) {
-                if (column == null) {
-                    column = new Column { Min = (uint)columnIndex, Max = (uint)columnIndex };
-                    columns.Append(column);
+                var columns = worksheet.GetFirstChild<Columns>();
+                if (columns == null) {
+                    columns = worksheet.InsertAt(new Columns(), 0);
                 }
-                column.Width = width;
-                column.CustomWidth = true;
-                column.BestFit = true;
-            } else if (column != null) {
-                column.Remove();
-            }
 
-            worksheet.Save();
+                double width = 0;
+
+                foreach (var row in sheetData.Elements<Row>()) {
+                    var cell = row.Elements<Cell>()
+                        .FirstOrDefault(c => c.CellReference != null && GetColumnIndex(c.CellReference.Value) == columnIndex);
+                    if (cell == null) continue;
+                    string text = GetCellText(cell);
+                    if (string.IsNullOrWhiteSpace(text)) continue;
+                    var font = GetCellFont(cell);
+                    var options = new TextOptions(font);
+                    float zeroWidth = TextMeasurer.MeasureSize("0", options).Width;
+                    var size = TextMeasurer.MeasureSize(text, options);
+                    double cellWidth = zeroWidth == 0 ? 0 : size.Width / zeroWidth + 1;
+                    if (cellWidth > width) width = cellWidth;
+                }
+
+                Column column = columns.Elements<Column>()
+                    .FirstOrDefault(c => c.Min != null && c.Max != null && c.Min.Value <= (uint)columnIndex && c.Max.Value >= (uint)columnIndex);
+                if (width > 0) {
+                    if (column == null) {
+                        column = new Column { Min = (uint)columnIndex, Max = (uint)columnIndex };
+                        columns.Append(column);
+                    }
+                    column.Width = width;
+                    column.CustomWidth = true;
+                    column.BestFit = true;
+                } else if (column != null) {
+                    column.Remove();
+                }
+
+                worksheet.Save();
+            });
         }
 
         public void SetColumnWidth(int columnIndex, double width) {
@@ -371,46 +403,45 @@ namespace OfficeIMO.Excel {
         }
 
         public void AutoFitRow(int rowIndex) {
-            var worksheet = _worksheetPart.Worksheet;
-            SheetData sheetData = worksheet.GetFirstChild<SheetData>();
-            if (sheetData == null) return;
+            WriteLock(() => {
+                var worksheet = _worksheetPart.Worksheet;
+                SheetData sheetData = worksheet.GetFirstChild<SheetData>();
+                if (sheetData == null) return;
 
-            var font = GetDefaultFont();
-            var options = new TextOptions(font);
+                Row row = sheetData.Elements<Row>().FirstOrDefault(r => r.RowIndex == (uint)rowIndex);
+                if (row == null) return;
 
-            double defaultHeight = 15;
-            double ToPoints(double height) {
-                return height * 72.0 / options.Dpi;
-            }
+                const double defaultHeight = 15;
+                const double pointsPerInch = 72.0;
 
-            Row row = sheetData.Elements<Row>().FirstOrDefault(r => r.RowIndex == (uint)rowIndex);
-            if (row == null) return;
-
-            double maxHeight = 0;
-            foreach (var cell in row.Elements<Cell>()) {
-                string text = GetCellText(cell);
-                if (string.IsNullOrWhiteSpace(text)) continue;
-                var lines = text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
-                double lineHeight = lines.Max(line => ToPoints(TextMeasurer.MeasureSize(line, options).Height));
-                double cellHeight = lineHeight * lines.Length;
-                if (cellHeight > maxHeight) maxHeight = cellHeight;
-            }
-
-            if (maxHeight > 0) {
-                row.Height = maxHeight + 2;
-                row.CustomHeight = true;
-                var sheetFormat = worksheet.GetFirstChild<SheetFormatProperties>();
-                if (sheetFormat == null) {
-                    sheetFormat = worksheet.InsertAt(new SheetFormatProperties(), 0);
+                double maxHeight = 0;
+                foreach (var cell in row.Elements<Cell>()) {
+                    string text = GetCellText(cell);
+                    if (string.IsNullOrWhiteSpace(text)) continue;
+                    var font = GetCellFont(cell);
+                    var options = new TextOptions(font);
+                    var lines = text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+                    double lineHeight = lines.Max(line => TextMeasurer.MeasureSize(line, options).Height * pointsPerInch / options.Dpi);
+                    double cellHeight = lineHeight * lines.Length;
+                    if (cellHeight > maxHeight) maxHeight = cellHeight;
                 }
-                sheetFormat.DefaultRowHeight = defaultHeight;
-                sheetFormat.CustomHeight = true;
-            } else {
-                row.Height = null;
-                row.CustomHeight = null;
-            }
 
-            worksheet.Save();
+                if (maxHeight > 0) {
+                    row.Height = maxHeight + 2;
+                    row.CustomHeight = true;
+                    var sheetFormat = worksheet.GetFirstChild<SheetFormatProperties>();
+                    if (sheetFormat == null) {
+                        sheetFormat = worksheet.InsertAt(new SheetFormatProperties(), 0);
+                    }
+                    sheetFormat.DefaultRowHeight = defaultHeight;
+                    sheetFormat.CustomHeight = true;
+                } else {
+                    row.Height = null;
+                    row.CustomHeight = null;
+                }
+
+                worksheet.Save();
+            });
         }
 
         /// <summary>

--- a/OfficeIMO.Tests/Excel.AutoFit.cs
+++ b/OfficeIMO.Tests/Excel.AutoFit.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
+using SixLabors.Fonts;
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -170,6 +171,71 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AutoFit_MixedFonts() {
+            string filePath = Path.Combine(_directoryWithFiles, "AutoFit.MixedFonts.xlsx");
+
+            static uint AddFontStyle(SpreadsheetDocument doc, string name, double size) {
+                var stylesPart = doc.WorkbookPart.WorkbookStylesPart ?? doc.WorkbookPart.AddNewPart<WorkbookStylesPart>();
+                if (stylesPart.Stylesheet == null) {
+                    stylesPart.Stylesheet = new Stylesheet(new Fonts(new DocumentFormat.OpenXml.Spreadsheet.Font()), new Fills(new Fill()), new Borders(new Border()), new CellFormats(new CellFormat()));
+                    stylesPart.Stylesheet.Fonts.Count = 1;
+                    stylesPart.Stylesheet.Fills.Count = 1;
+                    stylesPart.Stylesheet.Borders.Count = 1;
+                    stylesPart.Stylesheet.CellFormats.Count = 1;
+                }
+                var ss = stylesPart.Stylesheet;
+                ss.Fonts.Append(new DocumentFormat.OpenXml.Spreadsheet.Font(new FontName { Val = name }, new FontSize { Val = size }));
+                ss.Fonts.Count = (uint)ss.Fonts.ChildElements.Count;
+                ss.CellFormats.Append(new CellFormat { FontId = ss.Fonts.Count - 1, ApplyFont = true });
+                ss.CellFormats.Count = (uint)ss.CellFormats.ChildElements.Count;
+                stylesPart.Stylesheet.Save();
+                return ss.CellFormats.Count - 1;
+            }
+
+            static void SetCellStyle(SpreadsheetDocument doc, string cellRef, uint styleIndex) {
+                var wsPart = doc.WorkbookPart.WorksheetParts.First();
+                var cell = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == cellRef);
+                cell.StyleIndex = styleIndex;
+                wsPart.Worksheet.Save();
+            }
+
+            var families = SystemFonts.Collection.Families.ToList();
+            string fontName = families.Count > 1 ? families[1].Name : families[0].Name;
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Small");
+                sheet.CellValue(2, 1, "Large text");
+                sheet.CellValue(3, 1, "Short");
+                sheet.CellValue(3, 2, "Tall\nText");
+
+                uint style = AddFontStyle(document._spreadSheetDocument, fontName, 20);
+                SetCellStyle(document._spreadSheetDocument, "A2", style);
+                SetCellStyle(document._spreadSheetDocument, "B3", style);
+
+                sheet.AutoFitColumn(1);
+                sheet.AutoFitRow(3);
+                document.Save();
+            }
+
+            var font = SystemFonts.CreateFont(fontName, 20);
+            var options = new TextOptions(font);
+            float zero = TextMeasurer.MeasureSize("0", options).Width;
+            double expectedWidth = TextMeasurer.MeasureSize("Large text", options).Width / zero + 1;
+            double lineHeight = TextMeasurer.MeasureSize("Tall", options).Height * 72.0 / options.Dpi;
+            double expectedHeight = lineHeight * 2 + 2;
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                var column = wsPart.Worksheet.GetFirstChild<Columns>()!.Elements<Column>().First(c => c.Min == 1 && c.Max == 1);
+                Assert.InRange(column.Width!.Value, expectedWidth - 1, expectedWidth + 1);
+
+                var row = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex == 3);
+                Assert.InRange(row.Height!.Value, expectedHeight - 1, expectedHeight + 1);
+            }
+        }
+
+        [Fact]
         public async Task Test_AutoFitConcurrentOperations_AreThreadSafe() {
             string filePath = Path.Combine(_directoryWithFiles, "AutoFit.ConcurrentOperations.xlsx");
             using (var document = ExcelDocument.Create(filePath)) {
@@ -201,6 +267,36 @@ namespace OfficeIMO.Tests {
                 Assert.NotNull(sheetFormat);
                 Assert.True(sheetFormat.CustomHeight);
                 Assert.True(sheetFormat.DefaultRowHeight > 0);
+            }
+        }
+
+        [Fact]
+        public async Task Test_AutoFitColumnRowConcurrentCalls_AreThreadSafe() {
+            string filePath = Path.Combine(_directoryWithFiles, "AutoFit.ConcurrentSingle.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Long piece of text");
+                sheet.CellValue(2, 1, "Line1\nLine2");
+
+                var tasks = Enumerable.Range(0, 10)
+                    .SelectMany(_ => new[] {
+                        Task.Run(() => sheet.AutoFitColumn(1)),
+                        Task.Run(() => sheet.AutoFitRow(2))
+                    })
+                    .ToArray();
+                await Task.WhenAll(tasks);
+
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                var column = wsPart.Worksheet.GetFirstChild<Columns>()!.Elements<Column>().First(c => c.Min == 1 && c.Max == 1);
+                Assert.True(column.Width.HasValue && column.Width.Value > 0);
+
+                var row = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex == 2);
+                Assert.True(row.CustomHeight?.Value ?? false);
+                Assert.True(row.Height.HasValue && row.Height.Value > 0);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Wrap AutoFitColumn/AutoFitRow in write lock and compute sizes per cell font
- Remove pixel-to-point helper and use direct conversion based on TextMeasurer output
- Respect cell-specific fonts and add coverage for mixed fonts and concurrent calls

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a7870fac1c832e95e5535a4ebfb7a1