### PR TITLE
Set ActiveCell and Sqref in frozen pane selections

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.cs
+++ b/OfficeIMO.Excel/ExcelSheet.cs
@@ -485,17 +485,37 @@ namespace OfficeIMO.Excel {
                     if (topRows > 0 && leftCols > 0) {
                         pane.ActivePane = PaneValues.BottomRight;
                         sheetView.Append(pane);
-                        sheetView.Append(new Selection { Pane = PaneValues.TopRight });
-                        sheetView.Append(new Selection { Pane = PaneValues.BottomLeft });
-                        sheetView.Append(new Selection { Pane = PaneValues.BottomRight });
+                        sheetView.Append(new Selection {
+                            Pane = PaneValues.TopRight,
+                            ActiveCell = pane.TopLeftCell,
+                            SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
+                        });
+                        sheetView.Append(new Selection {
+                            Pane = PaneValues.BottomLeft,
+                            ActiveCell = pane.TopLeftCell,
+                            SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
+                        });
+                        sheetView.Append(new Selection {
+                            Pane = PaneValues.BottomRight,
+                            ActiveCell = pane.TopLeftCell,
+                            SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
+                        });
                     } else if (topRows > 0) {
                         pane.ActivePane = PaneValues.BottomLeft;
                         sheetView.Append(pane);
-                        sheetView.Append(new Selection { Pane = PaneValues.BottomLeft });
+                        sheetView.Append(new Selection {
+                            Pane = PaneValues.BottomLeft,
+                            ActiveCell = pane.TopLeftCell,
+                            SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
+                        });
                     } else {
                         pane.ActivePane = PaneValues.TopRight;
                         sheetView.Append(pane);
-                        sheetView.Append(new Selection { Pane = PaneValues.TopRight });
+                        sheetView.Append(new Selection {
+                            Pane = PaneValues.TopRight,
+                            ActiveCell = pane.TopLeftCell,
+                            SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
+                        });
                     }
                 }
 

--- a/OfficeIMO.Tests/Excel.Freeze.cs
+++ b/OfficeIMO.Tests/Excel.Freeze.cs
@@ -23,12 +23,19 @@ namespace OfficeIMO.Tests {
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
                 WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                Pane pane = wsPart.Worksheet.GetFirstChild<SheetViews>()?.GetFirstChild<SheetView>()?.GetFirstChild<Pane>();
+                SheetView sheetView = wsPart.Worksheet.GetFirstChild<SheetViews>()?.GetFirstChild<SheetView>();
+                Pane pane = sheetView?.GetFirstChild<Pane>();
                 Assert.NotNull(pane);
                 Assert.Equal(1D, pane!.HorizontalSplit?.Value);
                 Assert.Null(pane.VerticalSplit);
                 Assert.Equal(PaneValues.BottomLeft, pane.ActivePane?.Value);
                 Assert.Equal("A2", pane.TopLeftCell?.Value);
+
+                Selection selection = sheetView!.GetFirstChild<Selection>();
+                Assert.NotNull(selection);
+                Assert.Equal(PaneValues.BottomLeft, selection!.Pane?.Value);
+                Assert.Equal("A2", selection.ActiveCell?.Value);
+                Assert.Equal("A2", selection.SequenceOfReferences?.InnerText);
             }
         }
 
@@ -44,12 +51,48 @@ namespace OfficeIMO.Tests {
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
                 WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                Pane pane = wsPart.Worksheet.GetFirstChild<SheetViews>()?.GetFirstChild<SheetView>()?.GetFirstChild<Pane>();
+                SheetView sheetView = wsPart.Worksheet.GetFirstChild<SheetViews>()?.GetFirstChild<SheetView>();
+                Pane pane = sheetView?.GetFirstChild<Pane>();
                 Assert.NotNull(pane);
                 Assert.Equal(2D, pane!.VerticalSplit?.Value);
                 Assert.Null(pane.HorizontalSplit);
                 Assert.Equal(PaneValues.TopRight, pane.ActivePane?.Value);
                 Assert.Equal("C1", pane.TopLeftCell?.Value);
+
+                Selection selection = sheetView!.GetFirstChild<Selection>();
+                Assert.NotNull(selection);
+                Assert.Equal(PaneValues.TopRight, selection!.Pane?.Value);
+                Assert.Equal("C1", selection.ActiveCell?.Value);
+                Assert.Equal("C1", selection.SequenceOfReferences?.InnerText);
+            }
+        }
+
+        [Fact]
+        public void Test_FreezeTopRowsAndLeftColumns() {
+            string filePath = Path.Combine(_directoryWithFiles, "FreezeTopRowsAndLeftColumns.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Sheet("Data", s => s.Freeze(topRows: 1, leftCols: 1))
+                    .End()
+                    .Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                SheetView sheetView = wsPart.Worksheet.GetFirstChild<SheetViews>()?.GetFirstChild<SheetView>();
+                Pane pane = sheetView?.GetFirstChild<Pane>();
+                Assert.NotNull(pane);
+                Assert.Equal(1D, pane!.HorizontalSplit?.Value);
+                Assert.Equal(1D, pane.VerticalSplit?.Value);
+                Assert.Equal(PaneValues.BottomRight, pane.ActivePane?.Value);
+                Assert.Equal("B2", pane.TopLeftCell?.Value);
+
+                Selection[] selections = sheetView!.Elements<Selection>().ToArray();
+                Assert.Equal(3, selections.Length);
+                foreach (Selection selection in selections) {
+                    Assert.Equal(pane.TopLeftCell?.Value, selection.ActiveCell?.Value);
+                    Assert.Equal(pane.TopLeftCell?.Value, selection.SequenceOfReferences?.InnerText);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure Freeze sets ActiveCell and Sqref for pane selections
- verify frozen panes through new unit tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a844ac35e4832e9bde88471d292d93