### PR TITLE
Ensure table range cells exist before adding table

### DIFF
--- a/OfficeIMO.Examples/Excel/AddTableMissingCells.cs
+++ b/OfficeIMO.Examples/Excel/AddTableMissingCells.cs
@@ -1,0 +1,23 @@
+using System;
+using OfficeIMO.Excel;
+
+namespace OfficeIMO.Examples.Excel {
+    /// <summary>
+    /// Demonstrates adding a table when some cells in the range are missing.
+    /// </summary>
+    public static class AddTableMissingCells {
+        public static void Example(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - Add table with missing cells");
+            string filePath = System.IO.Path.Combine(folderPath, "Add Table Missing Cells.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Value");
+                // intentionally leave row 2 cells empty
+                sheet.AddTable("A1:B2", true, "MyTable", TableStyle.TableStyleMedium9);
+                document.Save(openExcel);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -34,6 +34,8 @@ namespace OfficeIMO.Examples {
             OfficeIMO.Examples.Excel.AutoFit.Example(folderPath, false);
             // Excel/AddTable
             OfficeIMO.Examples.Excel.AddTable.Example(folderPath, false);
+            // Excel/AddTableMissingCells
+            OfficeIMO.Examples.Excel.AddTableMissingCells.Example(folderPath, false);
             // Excel/AutoFilter
             OfficeIMO.Examples.Excel.AutoFilter.Example(folderPath, false);
             // Excel/Freeze

--- a/OfficeIMO.Excel/ExcelSheet.cs
+++ b/OfficeIMO.Excel/ExcelSheet.cs
@@ -536,6 +536,19 @@ namespace OfficeIMO.Excel {
             });
         }
 
+        /// <summary>
+        /// Adds an Excel table to the worksheet over the specified range.
+        /// </summary>
+        /// <param name="range">Cell range (e.g. "A1:B3") defining the table area.</param>
+        /// <param name="hasHeader">Indicates whether the first row is a header row.</param>
+        /// <param name="name">Name of the table. If empty, a default name is used.</param>
+        /// <param name="style">Table style to apply.</param>
+        /// <remarks>
+        /// All cells within <paramref name="range"/> must exist. Missing cells are automatically created with empty values.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="range"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="range"/> is not in a valid format.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the specified range overlaps with an existing table.</exception>
         public void AddTable(string range, bool hasHeader, string name, TableStyle style) {
             if (string.IsNullOrEmpty(range)) {
                 throw new ArgumentNullException(nameof(range));
@@ -576,6 +589,16 @@ namespace OfficeIMO.Excel {
                                     endRowIndex >= existingStartRow;
                     if (overlaps) {
                         throw new InvalidOperationException("The specified range overlaps with an existing table.");
+                    }
+                }
+
+                for (int row = startRowIndex; row <= endRowIndex; row++) {
+                    for (int column = startColumnIndex; column <= endColumnIndex; column++) {
+                        var cell = GetCell(row, column);
+                        if (cell.CellValue == null) {
+                            cell.CellValue = new CellValue(string.Empty);
+                            cell.DataType = CellValues.String;
+                        }
                     }
                 }
 

--- a/OfficeIMO.Tests/Excel.Tables.cs
+++ b/OfficeIMO.Tests/Excel.Tables.cs
@@ -30,6 +30,25 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AddTablePopulatesMissingCells() {
+            string filePath = Path.Combine(_directoryWithFiles, "Table.MissingCells.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Value");
+                sheet.AddTable("A1:B2", true, "MyTable", TableStyle.TableStyleMedium9);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                var cells = wsPart.Worksheet.Descendants<DocumentFormat.OpenXml.Spreadsheet.Cell>();
+                Assert.Contains(cells, c => c.CellReference == "A2");
+                Assert.Contains(cells, c => c.CellReference == "B2");
+            }
+        }
+
+        [Fact]
         public async Task Test_AddTableConcurrent() {
             string filePath = Path.Combine(_directoryWithFiles, "Table.Concurrent.xlsx");
             using (var document = ExcelDocument.Create(filePath)) {


### PR DESCRIPTION
## Summary
- enforce cell existence when adding tables and create empty cells if missing
- add example demonstrating table creation with missing cells
- test that table creation populates missing cells

## Testing
- `dotnet build --no-restore`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-restore --filter Test_AddTablePopulatesMissingCells`


------
https://chatgpt.com/codex/tasks/task_e_68a844cba468832e8c2a5990e4f3c584