### PR TITLE
Protect Excel parallel writes with workbook write lock

### DIFF
--- a/OfficeIMO.Tests/Excel.CellValuesParallelMixed.cs
+++ b/OfficeIMO.Tests/Excel.CellValuesParallelMixed.cs
@@ -1,0 +1,51 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public async Task Test_CellValuesParallel_WithConcurrentCellValue() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesParallelMixed.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+
+                var col1 = Enumerable.Range(1, 500).Select(i => (i, 1, (object)$"R{i}C1"));
+
+                await Task.WhenAll(
+                    Task.Run(() => sheet.CellValuesParallel(col1)),
+                    Task.Run(() => {
+                        for (int i = 1; i <= 500; i++) {
+                            sheet.CellValue(i, 2, $"R{i}C2");
+                        }
+                    })
+                );
+
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                SharedStringTablePart shared = spreadsheet.WorkbookPart!.SharedStringTablePart!;
+
+                for (int row = 1; row <= 500; row++) {
+                    for (int col = 1; col <= 2; col++) {
+                        string expected = $"R{row}C{col}";
+                        string cellRef = $"{(char)('A' + col - 1)}{row}";
+                        Cell cell = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == cellRef);
+                        Assert.Equal(CellValues.SharedString, cell.DataType!.Value);
+                        int index = int.Parse(cell.CellValue!.Text);
+                        Assert.Equal(expected, shared.SharedStringTable!.ElementAt(index).InnerText);
+                    }
+                }
+
+                Assert.Equal(1000, shared.SharedStringTable!.Count());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- guard `CellValuesParallel` with `WriteLock` to keep workbook and shared string table stable during bulk updates
- allow `CellValue` calls to optionally skip locking when outer lock is held
- test parallel writes mixing `CellValuesParallel` and `CellValue`

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a844b7c2ac832e9a81eeb1d4646ce9