### PR TITLE
Add Excel workbook validation helper

### DIFF
--- a/OfficeIMO.Examples/Excel/ValidateDocument.cs
+++ b/OfficeIMO.Examples/Excel/ValidateDocument.cs
@@ -1,0 +1,24 @@
+using System;
+using OfficeIMO.Excel;
+
+namespace OfficeIMO.Examples.Excel {
+    /// <summary>
+    /// Demonstrates validating a spreadsheet document.
+    /// </summary>
+    public static class ValidateDocument {
+        public static void Example(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - Validate document");
+            string filePath = System.IO.Path.Combine(folderPath, "ValidateDocument.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Test");
+
+                Console.WriteLine(document.DocumentIsValid);
+                Console.WriteLine(document.DocumentValidationErrors);
+                document.Save(openExcel);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -50,6 +50,8 @@ namespace OfficeIMO.Examples {
             OfficeIMO.Examples.Excel.CellValues.Example(folderPath, false);
             // Excel/CellValuesParallel
             OfficeIMO.Examples.Excel.CellValuesParallel.Example(folderPath, false);
+            // Excel/ValidateDocument
+            OfficeIMO.Examples.Excel.ValidateDocument.Example(folderPath, false);
             // Excel/Fluent
             OfficeIMO.Examples.Excel.FluentWorkbook.Example_FluentWorkbook(folderPath, false);
             OfficeIMO.Examples.Excel.FluentWorkbook.Example_RangeBuilder(folderPath, false);

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using DocumentFormat.OpenXml.Validation;
 
 namespace OfficeIMO.Excel {
     /// <summary>
@@ -73,6 +74,42 @@ namespace OfficeIMO.Excel {
         /// FileOpenAccess of the document
         /// </summary>
         public FileAccess FileOpenAccess => _spreadSheetDocument.FileOpenAccess;
+
+        /// <summary>
+        /// Indicates whether the document is valid.
+        /// </summary>
+        public bool DocumentIsValid {
+            get {
+                if (DocumentValidationErrors.Count > 0) {
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Gets the list of validation errors for the document.
+        /// </summary>
+        public List<ValidationErrorInfo> DocumentValidationErrors {
+            get {
+                return ValidateDocument();
+            }
+        }
+
+        /// <summary>
+        /// Validates the document using the specified file format version.
+        /// </summary>
+        /// <param name="fileFormatVersions">File format version to validate against.</param>
+        /// <returns>List of validation errors.</returns>
+        public List<ValidationErrorInfo> ValidateDocument(FileFormatVersions fileFormatVersions = FileFormatVersions.Microsoft365) {
+            List<ValidationErrorInfo> listErrors = new List<ValidationErrorInfo>();
+            OpenXmlValidator validator = new OpenXmlValidator(fileFormatVersions);
+            foreach (ValidationErrorInfo error in validator.Validate(_spreadSheetDocument)) {
+                listErrors.Add(error);
+            }
+            return listErrors;
+        }
 
         internal SharedStringTablePart SharedStringTablePart {
             get {

--- a/OfficeIMO.Tests/Excel.CellValues.Additional.cs
+++ b/OfficeIMO.Tests/Excel.CellValues.Additional.cs
@@ -44,7 +44,12 @@ namespace OfficeIMO.Tests {
                 document.Save();
             }
 
-            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+            SpreadsheetDocument spreadsheet = null!;
+            Exception? ex = Record.Exception(() => spreadsheet = SpreadsheetDocument.Open(filePath, false));
+            Assert.Null(ex);
+            using (spreadsheet) {
+                ValidateSpreadsheetDocument(filePath, spreadsheet);
+
                 WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
                 var cells = wsPart.Worksheet.Descendants<Cell>().ToList();
                 SharedStringTablePart shared = spreadsheet.WorkbookPart.SharedStringTablePart;

--- a/OfficeIMO.Tests/Excel.CellValues.cs
+++ b/OfficeIMO.Tests/Excel.CellValues.cs
@@ -28,7 +28,12 @@ namespace OfficeIMO.Tests {
                 document.Save();
             }
 
-            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+            SpreadsheetDocument spreadsheet = null!;
+            Exception? ex = Record.Exception(() => spreadsheet = SpreadsheetDocument.Open(filePath, false));
+            Assert.Null(ex);
+            using (spreadsheet) {
+                  ValidateSpreadsheetDocument(filePath, spreadsheet);
+
                   WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                   var cells = wsPart.Worksheet.Descendants<Cell>().ToList();
                   SharedStringTablePart shared = spreadsheet.WorkbookPart!.SharedStringTablePart!;

--- a/OfficeIMO.Tests/Excel.CellValuesParallel.cs
+++ b/OfficeIMO.Tests/Excel.CellValuesParallel.cs
@@ -30,7 +30,12 @@ namespace OfficeIMO.Tests {
                 document.Save();
             }
 
-            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+            SpreadsheetDocument spreadsheet = null!;
+            Exception? ex = Record.Exception(() => spreadsheet = SpreadsheetDocument.Open(filePath, false));
+            Assert.Null(ex);
+            using (spreadsheet) {
+                ValidateSpreadsheetDocument(filePath, spreadsheet);
+
                 WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 SharedStringTablePart shared = spreadsheet.WorkbookPart!.SharedStringTablePart!;
 

--- a/OfficeIMO.Tests/Excel.CellValuesParallelMixed.cs
+++ b/OfficeIMO.Tests/Excel.CellValuesParallelMixed.cs
@@ -29,7 +29,12 @@ namespace OfficeIMO.Tests {
                 document.Save();
             }
 
-            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+            SpreadsheetDocument spreadsheet = null!;
+            Exception? ex = Record.Exception(() => spreadsheet = SpreadsheetDocument.Open(filePath, false));
+            Assert.Null(ex);
+            using (spreadsheet) {
+                ValidateSpreadsheetDocument(filePath, spreadsheet);
+
                 WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 SharedStringTablePart shared = spreadsheet.WorkbookPart!.SharedStringTablePart!;
 

--- a/OfficeIMO.Tests/Excel.ConcurrentWrites.cs
+++ b/OfficeIMO.Tests/Excel.ConcurrentWrites.cs
@@ -23,7 +23,12 @@ namespace OfficeIMO.Tests {
                 document.Save();
             }
 
-            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+            SpreadsheetDocument spreadsheet = null!;
+            Exception? ex = Record.Exception(() => spreadsheet = SpreadsheetDocument.Open(filePath, false));
+            Assert.Null(ex);
+            using (spreadsheet) {
+                ValidateSpreadsheetDocument(filePath, spreadsheet);
+
                 WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 SharedStringTablePart shared = spreadsheet.WorkbookPart!.SharedStringTablePart!;
                 for (int i = 1; i <= 1000; i++) {

--- a/OfficeIMO.Tests/Excel.SaveOpen.cs
+++ b/OfficeIMO.Tests/Excel.SaveOpen.cs
@@ -27,7 +27,11 @@ namespace OfficeIMO.Tests {
                 document.Save();
             }
 
-            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+            SpreadsheetDocument spreadsheet = null!;
+            Exception? ex = Record.Exception(() => spreadsheet = SpreadsheetDocument.Open(filePath, false));
+            Assert.Null(ex);
+            using (spreadsheet) {
+                ValidateSpreadsheetDocument(filePath, spreadsheet);
                 Assert.Equal(2, spreadsheet.WorkbookPart.Workbook.Sheets.OfType<Sheet>().Count());
             }
         }

--- a/OfficeIMO.Tests/Excel.SpreadsheetDocumentValidation.cs
+++ b/OfficeIMO.Tests/Excel.SpreadsheetDocumentValidation.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using System.IO.Packaging;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        private static void ValidateSpreadsheetDocument(string filePath, SpreadsheetDocument spreadsheet) {
+            Assert.NotNull(spreadsheet.WorkbookPart);
+            Assert.True(spreadsheet.WorkbookPart!.WorksheetParts.Any());
+
+            using Package package = Package.Open(filePath, FileMode.Open, FileAccess.Read);
+            foreach (PackagePart part in package.GetParts().Where(p => p.ContentType == "application/xml")) {
+                using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
+                XDocument.Load(stream);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.ValidateDocument.cs
+++ b/OfficeIMO.Tests/Excel.ValidateDocument.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_ValidateDocument() {
+            string filePath = Path.Combine(_directoryWithFiles, "ValidateDocument.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Test");
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var errors = document.ValidateDocument();
+                Assert.True(errors.Count == 0, Excel.FormatValidationErrors(errors));
+                Assert.True(document.DocumentIsValid);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Excel.cs
+++ b/OfficeIMO.Tests/Excel.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Validation;
 
 namespace OfficeIMO.Tests {
     /// <summary>
@@ -20,6 +21,16 @@ namespace OfficeIMO.Tests {
             //_directoryDocuments = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "Tests", "TempDocuments");
             _directoryWithFiles = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TempDocuments1");
             Word.Setup(_directoryWithFiles);
+        }
+
+        internal static string FormatValidationErrors(IEnumerable<ValidationErrorInfo> errors) {
+            return string.Join(Environment.NewLine + Environment.NewLine,
+                errors.Select(error =>
+                    $"Description: {error.Description}\n" +
+                    $"Id: {error.Id}\n" +
+                    $"ErrorType: {error.ErrorType}\n" +
+                    $"Part: {error.Part?.Uri}\n" +
+                    $"Path: {error.Path?.XPath}"));
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose `ValidateDocument` API on `ExcelDocument` with `DocumentIsValid` and `DocumentValidationErrors`
- add sample demonstrating validation usage
- cover validation helper with unit test

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Test_ValidateDocument -nologo`


------
https://chatgpt.com/codex/tasks/task_e_68a853ffefec832eb8d2ec93c0a4ec36