### PR TITLE
Ensure Excel freeze panes emit complete selections

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.cs
+++ b/OfficeIMO.Excel/ExcelSheet.cs
@@ -467,8 +467,23 @@ namespace OfficeIMO.Excel {
             WriteLock(() => {
                 Worksheet worksheet = _worksheetPart.Worksheet;
                 SheetViews sheetViews = worksheet.GetFirstChild<SheetViews>();
+
+                if (topRows == 0 && leftCols == 0) {
+                    if (sheetViews != null) {
+                        worksheet.RemoveChild(sheetViews);
+                    }
+                    worksheet.Save();
+                    return;
+                }
+
                 if (sheetViews == null) {
-                    sheetViews = worksheet.AppendChild(new SheetViews());
+                    sheetViews = new SheetViews();
+                    SheetData sheetData = worksheet.GetFirstChild<SheetData>();
+                    if (sheetData != null) {
+                        worksheet.InsertBefore(sheetViews, sheetData);
+                    } else {
+                        worksheet.PrependChild(sheetViews);
+                    }
                 }
 
                 SheetView sheetView = sheetViews.GetFirstChild<SheetView>();
@@ -480,57 +495,62 @@ namespace OfficeIMO.Excel {
                 sheetView.RemoveAllChildren<Pane>();
                 sheetView.RemoveAllChildren<Selection>();
 
-                if (topRows > 0 || leftCols > 0) {
-                    Pane pane = new Pane { State = PaneStateValues.Frozen };
-                    if (topRows > 0) {
-                        pane.HorizontalSplit = topRows;
-                    }
-                    if (leftCols > 0) {
-                        pane.VerticalSplit = leftCols;
-                    }
-
-                    pane.TopLeftCell = GetColumnName(leftCols + 1) + (topRows + 1).ToString(CultureInfo.InvariantCulture);
-
-                    if (topRows > 0 && leftCols > 0) {
-                        pane.ActivePane = PaneValues.BottomRight;
-                        sheetView.Append(pane);
-                        sheetView.Append(new Selection {
-                            Pane = PaneValues.TopRight,
-                            ActiveCell = pane.TopLeftCell,
-                            SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
-                        });
-                        sheetView.Append(new Selection {
-                            Pane = PaneValues.BottomLeft,
-                            ActiveCell = pane.TopLeftCell,
-                            SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
-                        });
-                        sheetView.Append(new Selection {
-                            Pane = PaneValues.BottomRight,
-                            ActiveCell = pane.TopLeftCell,
-                            SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
-                        });
-                    } else if (topRows > 0) {
-                        pane.ActivePane = PaneValues.BottomLeft;
-                        sheetView.Append(pane);
-                        sheetView.Append(new Selection {
-                            Pane = PaneValues.BottomLeft,
-                            ActiveCell = pane.TopLeftCell,
-                            SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
-                        });
-                    } else {
-                        pane.ActivePane = PaneValues.TopRight;
-                        sheetView.Append(pane);
-                        sheetView.Append(new Selection {
-                            Pane = PaneValues.TopRight,
-                            ActiveCell = pane.TopLeftCell,
-                            SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
-                        });
-                    }
+                Pane pane = new Pane { State = PaneStateValues.Frozen };
+                if (topRows > 0) {
+                    pane.HorizontalSplit = topRows;
                 }
+                if (leftCols > 0) {
+                    pane.VerticalSplit = leftCols;
+                }
+
+                pane.TopLeftCell = GetColumnName(leftCols + 1) + (topRows + 1).ToString(CultureInfo.InvariantCulture);
+
+                if (topRows > 0 && leftCols > 0) {
+                    pane.ActivePane = PaneValues.BottomRight;
+                    sheetView.Append(pane);
+                    sheetView.Append(new Selection {
+                        Pane = PaneValues.TopRight,
+                        ActiveCell = pane.TopLeftCell,
+                        SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
+                    });
+                    sheetView.Append(new Selection {
+                        Pane = PaneValues.BottomLeft,
+                        ActiveCell = pane.TopLeftCell,
+                        SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
+                    });
+                    sheetView.Append(new Selection {
+                        Pane = PaneValues.BottomRight,
+                        ActiveCell = pane.TopLeftCell,
+                        SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
+                    });
+                } else if (topRows > 0) {
+                    pane.ActivePane = PaneValues.BottomLeft;
+                    sheetView.Append(pane);
+                    sheetView.Append(new Selection {
+                        Pane = PaneValues.BottomLeft,
+                        ActiveCell = pane.TopLeftCell,
+                        SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
+                    });
+                } else {
+                    pane.ActivePane = PaneValues.TopRight;
+                    sheetView.Append(pane);
+                    sheetView.Append(new Selection {
+                        Pane = PaneValues.TopRight,
+                        ActiveCell = pane.TopLeftCell,
+                        SequenceOfReferences = new ListValue<StringValue> { InnerText = pane.TopLeftCell }
+                    });
+                }
+
+                sheetView.Append(new Selection {
+                    Pane = PaneValues.TopLeft,
+                    ActiveCell = "A1",
+                    SequenceOfReferences = new ListValue<StringValue> { InnerText = "A1" }
+                });
 
                 worksheet.Save();
             });
         }
+
 
         public void AddAutoFilter(string range, Dictionary<uint, IEnumerable<string>> filterCriteria = null) {
             if (string.IsNullOrEmpty(range)) {


### PR DESCRIPTION
## Summary
- Fix ExcelSheet.Freeze to insert SheetViews correctly, remove them on unfreeze, and generate Selection entries for all panes
- Add OpenXmlValidator-driven tests for single-axis and dual-axis freezes plus unfreeze cleanup

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Freeze --nologo`


------
https://chatgpt.com/codex/tasks/task_e_68a8700863c0832e806dd429471712da