### PR TITLE
Add validation support for PowerPoint presentations

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/ValidateDocument.cs
+++ b/OfficeIMO.Examples/PowerPoint/ValidateDocument.cs
@@ -1,0 +1,25 @@
+using System;
+using OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.Examples.PowerPoint {
+    /// <summary>
+    /// Demonstrates validating a PowerPoint presentation.
+    /// </summary>
+    public static class ValidateDocument {
+        public static void Example(string folderPath, bool openPowerPoint) {
+            Console.WriteLine("[*] PowerPoint - Validate document");
+            string filePath = System.IO.Path.Combine(folderPath, "ValidateDocument.pptx");
+
+            using (var presentation = PowerPointPresentation.Create(filePath)) {
+                Console.WriteLine(presentation.DocumentIsValid);
+                Console.WriteLine(presentation.DocumentValidationErrors);
+                presentation.Save();
+            }
+
+            if (openPowerPoint) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Examples/PowerPoint/ValidateDocument.cs
+++ b/OfficeIMO.Examples/PowerPoint/ValidateDocument.cs
@@ -12,7 +12,9 @@ namespace OfficeIMO.Examples.PowerPoint {
 
             using (var presentation = PowerPointPresentation.Create(filePath)) {
                 Console.WriteLine(presentation.DocumentIsValid);
-                Console.WriteLine(presentation.DocumentValidationErrors);
+                foreach (var error in presentation.DocumentValidationErrors) {
+                    Console.WriteLine($"Validation Error: {error.Description}");
+                }
                 presentation.Save();
             }
 

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -65,6 +65,7 @@ namespace OfficeIMO.Examples {
             OfficeIMO.Examples.PowerPoint.TextFormattingPowerPoint.Example_TextFormattingPowerPoint(folderPath, false);
             OfficeIMO.Examples.PowerPoint.ThemeAndLayoutPowerPoint.Example_PowerPointThemeAndLayout(folderPath, false);
             OfficeIMO.Examples.PowerPoint.UpdatePicturePowerPoint.Example_PowerPointUpdatePicture(folderPath, false);
+            OfficeIMO.Examples.PowerPoint.ValidateDocument.Example(folderPath, false);
             OfficeIMO.Examples.PowerPoint.TestLazyInit.Example_TestLazyInit(folderPath, false);
             return;
             // Html/Html

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -317,6 +317,16 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         /// <param name="fileFormatVersions">File format version to validate against.</param>
         /// <returns>List of validation errors.</returns>
+        /// <example>
+        /// <code>
+        /// using (var presentation = PowerPointPresentation.Create("test.pptx")) {
+        ///     var errors = presentation.ValidateDocument();
+        ///     if (errors.Count > 0) {
+        ///         // Handle validation errors
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
         public List<ValidationErrorInfo> ValidateDocument(FileFormatVersions fileFormatVersions = FileFormatVersions.Microsoft365) {
             List<ValidationErrorInfo> listErrors = new List<ValidationErrorInfo>();
             OpenXmlValidator validator = new OpenXmlValidator(fileFormatVersions);

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Validation;
 using OfficeIMO.PowerPoint.Fluent;
 using A = DocumentFormat.OpenXml.Drawing;
 using Ap = DocumentFormat.OpenXml.ExtendedProperties;
@@ -287,6 +288,43 @@ namespace OfficeIMO.PowerPoint {
             }
 
             _presentationPart.Presentation.Save();
+        }
+
+        /// <summary>
+        ///     Indicates whether the presentation passes Open XML validation.
+        /// </summary>
+        public bool DocumentIsValid {
+            get {
+                if (DocumentValidationErrors.Count > 0) {
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+        /// <summary>
+        ///     Gets the list of validation errors for the presentation.
+        /// </summary>
+        public List<ValidationErrorInfo> DocumentValidationErrors {
+            get {
+                return ValidateDocument();
+            }
+        }
+
+        /// <summary>
+        ///     Validates the presentation using the specified file format version.
+        /// </summary>
+        /// <param name="fileFormatVersions">File format version to validate against.</param>
+        /// <returns>List of validation errors.</returns>
+        public List<ValidationErrorInfo> ValidateDocument(FileFormatVersions fileFormatVersions = FileFormatVersions.Microsoft365) {
+            List<ValidationErrorInfo> listErrors = new List<ValidationErrorInfo>();
+            OpenXmlValidator validator = new OpenXmlValidator(fileFormatVersions);
+            foreach (ValidationErrorInfo error in validator.Validate(_document)) {
+                listErrors.Add(error);
+            }
+
+            return listErrors;
         }
 
         /// <summary>

--- a/OfficeIMO.Tests/PowerPoint.ValidateDocument.cs
+++ b/OfficeIMO.Tests/PowerPoint.ValidateDocument.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using DocumentFormat.OpenXml.Validation;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointValidateDocument {
+        [Fact]
+        public void Test_ValidateDocument() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            using (var presentation = PowerPointPresentation.Create(filePath)) {
+                var errors = presentation.ValidateDocument();
+                Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+                Assert.True(presentation.DocumentIsValid);
+                presentation.Save();
+            }
+
+            using (var presentation = PowerPointPresentation.Open(filePath)) {
+                var errors = presentation.ValidateDocument();
+                Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+                Assert.True(presentation.DocumentIsValid);
+            }
+
+            File.Delete(filePath);
+        }
+
+        private static string FormatValidationErrors(IEnumerable<ValidationErrorInfo> errors) {
+            return string.Join(Environment.NewLine + Environment.NewLine,
+                errors.Select(error =>
+                    $"Description: {error.Description}\n" +
+                    $"Id: {error.Id}\n" +
+                    $"ErrorType: {error.ErrorType}\n" +
+                    $"Part: {error.Part?.Uri}\n" +
+                    $"Path: {error.Path?.XPath}"));
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add OpenXML validation helpers to PowerPointPresentation
- add example and program entry for validating presentations
- test PowerPoint presentation validation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a875d6e114832ebd0775319518c2d5