### PR TITLE
fix: handle null shape when adding notes

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointNotes.cs
+++ b/OfficeIMO.PowerPoint/PowerPointNotes.cs
@@ -73,8 +73,8 @@ namespace OfficeIMO.PowerPoint {
                 NotesSlide notesSlide = NotesSlide;
                 CommonSlideData common = notesSlide.CommonSlideData ??= new CommonSlideData(new ShapeTree());
                 ShapeTree tree = common.ShapeTree ??= new ShapeTree();
-                Shape shape = tree.GetFirstChild<Shape>();
-                if (shape == null) {
+                Shape? shape = tree.GetFirstChild<Shape>();
+                if (shape is null) {
                     shape = new Shape(
                         new NonVisualShapeProperties(
                             new NonVisualDrawingProperties { Id = 1U, Name = "Notes Placeholder" },


### PR DESCRIPTION
## Summary
- ensure NotesSlide uses nullable shape when retrieving

## Testing
- `dotnet build OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a894c9ea68832ebd340e927cf0ac28