### PR TITLE
Fix nullable warnings in test files

### DIFF
--- a/OfficeIMO.Tests/Word.Hyperlinks.InvalidInputs.cs
+++ b/OfficeIMO.Tests/Word.Hyperlinks.InvalidInputs.cs
@@ -8,10 +8,10 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void Test_AddHyperLink_InvalidTextThrows() {
             using var document = WordDocument.Create();
-            Assert.Throws<ArgumentException>(() => document.AddHyperLink(null, new Uri("https://example.com")));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink(null!, new Uri("https://example.com")));
             Assert.Throws<ArgumentException>(() => document.AddHyperLink(string.Empty, new Uri("https://example.com")));
             Assert.Throws<ArgumentException>(() => document.AddHyperLink(" ", new Uri("https://example.com")));
-            Assert.Throws<ArgumentException>(() => document.AddHyperLink(null, "Bookmark"));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink(null!, "Bookmark"));
             Assert.Throws<ArgumentException>(() => document.AddHyperLink(string.Empty, "Bookmark"));
             Assert.Throws<ArgumentException>(() => document.AddHyperLink(" ", "Bookmark"));
         }
@@ -19,8 +19,8 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void Test_AddHyperLink_InvalidUriOrAnchorThrows() {
             using var document = WordDocument.Create();
-            Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", (Uri)null));
-            Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", (string)null));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", (Uri)null!));
+            Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", (string)null!));
             Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", string.Empty));
             Assert.Throws<ArgumentException>(() => document.AddHyperLink("Test", " "));
         }

--- a/OfficeIMO.Tests/Word.ImageCoordinates.cs
+++ b/OfficeIMO.Tests/Word.ImageCoordinates.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Tests {
             var paragraph = document.AddParagraph();
             paragraph.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 50, 50);
 
-            var loc = paragraph.Image.Location;
+            var loc = paragraph.Image!.Location;
             Assert.Equal(0, loc.X);
             Assert.Equal(0, loc.Y);
 
@@ -28,16 +28,17 @@ namespace OfficeIMO.Tests {
             var paragraph = document.AddParagraph();
             paragraph.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 50, 50, WrapTextImage.Square);
             int offset = 914400;
-            paragraph.Image.horizontalPosition = new HorizontalPosition() {
+            var image = paragraph.Image!;
+            image.horizontalPosition = new HorizontalPosition() {
                 RelativeFrom = HorizontalRelativePositionValues.Page,
                 PositionOffset = new PositionOffset { Text = offset.ToString() }
             };
-            paragraph.Image.verticalPosition = new VerticalPosition() {
+            image.verticalPosition = new VerticalPosition() {
                 RelativeFrom = VerticalRelativePositionValues.Page,
                 PositionOffset = new PositionOffset { Text = offset.ToString() }
             };
 
-            var loc = paragraph.Image.Location;
+            var loc = image.Location;
             Assert.Equal(offset, loc.X);
             Assert.Equal(offset, loc.Y);
 


### PR DESCRIPTION
## Summary
- silence nullability warnings in image coordinate tests
- suppress null argument warnings in hyperlink validation tests

## Testing
- `dotnet build OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a894fcd2c8832e8f5337bdd02d0b5a