### PR TITLE
Fix null reference warnings in test suite

### DIFF
--- a/OfficeIMO.Tests/Excel.LoadExceptions.cs
+++ b/OfficeIMO.Tests/Excel.LoadExceptions.cs
@@ -15,7 +15,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void Test_LoadNullPath_ThrowsArgumentNullException() {
-            var ex = Assert.Throws<ArgumentNullException>(() => ExcelDocument.Load(null));
+            var ex = Assert.Throws<ArgumentNullException>(() => ExcelDocument.Load(null!));
             Assert.Equal("filePath", ex.ParamName);
         }
 
@@ -28,7 +28,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public async Task Test_LoadAsyncNullPath_ThrowsArgumentNullException() {
-            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => ExcelDocument.LoadAsync(null));
+            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => ExcelDocument.LoadAsync(null!));
             Assert.Equal("path", ex.ParamName);
         }
     }

--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -84,17 +84,25 @@ namespace OfficeIMO.Tests {
             var doc = html.LoadFromHtml(new HtmlToWordOptions());
             Assert.Collection(doc.Images, _ => { }, _ => { });
             Assert.Equal(doc.Images[0].RelationshipId, doc.Images[1].RelationshipId);
-            Assert.Single(doc._wordprocessingDocument.MainDocumentPart.ImageParts);
+            var wordDoc = doc._wordprocessingDocument;
+            Assert.NotNull(wordDoc);
+            var mainPart = wordDoc.MainDocumentPart;
+            Assert.NotNull(mainPart);
+            Assert.Single(mainPart.ImageParts);
         }
 
         [Fact]
         public void DuplicateImageFileSrcSharesPart() {
             var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
-            string html = $"<p><img src=\"{path}\"/><img src=\"{path}\"/></p>"; 
+            string html = $"<p><img src=\"{path}\"/><img src=\"{path}\"/></p>";
             var doc = html.LoadFromHtml(new HtmlToWordOptions());
             Assert.Equal(2, doc.Images.Count);
             Assert.Equal(doc.Images[0].RelationshipId, doc.Images[1].RelationshipId);
-            Assert.Single(doc._wordprocessingDocument.MainDocumentPart.ImageParts);
+            var wordDoc = doc._wordprocessingDocument;
+            Assert.NotNull(wordDoc);
+            var mainPart = wordDoc.MainDocumentPart;
+            Assert.NotNull(mainPart);
+            Assert.Single(mainPart.ImageParts);
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.CustomFonts.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.CustomFonts.cs
@@ -32,7 +32,7 @@ namespace OfficeIMO.Tests {
                 byte[] pdf = document.SaveAsPdf(options);
                 using (PdfDocument pdfDoc = PdfDocument.Open(new MemoryStream(pdf))) {
                     var fonts = pdfDoc.GetPage(1).Letters.Select(l => l.FontName).Distinct();
-                    Assert.Contains(fonts, f => f.Contains(expectedFont));
+                    Assert.Contains(fonts, f => f != null && f.Contains(expectedFont));
                 }
             }
         }
@@ -60,7 +60,7 @@ namespace OfficeIMO.Tests {
                 byte[] pdf = document.SaveAsPdf(options);
                 using (PdfDocument pdfDoc = PdfDocument.Open(new MemoryStream(pdf))) {
                     var fonts = pdfDoc.GetPage(1).Letters.Select(l => l.FontName).Distinct();
-                    Assert.Contains(fonts, f => f.Contains(expectedFont));
+                    Assert.Contains(fonts, f => f != null && f.Contains(expectedFont));
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add explicit null checks in HTML image tests
- use null-forgiving operator in Excel load exception tests
- guard PDF font assertions against null values

## Testing
- `dotnet build OfficeIMO.Tests/OfficeIMO.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8949f3a00832eb393563877f52d5e