### PR TITLE
Fix null reference warnings in PowerPoint and Visio modules

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointNotes.cs
+++ b/OfficeIMO.PowerPoint/PowerPointNotes.cs
@@ -73,7 +73,7 @@ namespace OfficeIMO.PowerPoint {
                 NotesSlide notesSlide = NotesSlide;
                 CommonSlideData common = notesSlide.CommonSlideData ??= new CommonSlideData(new ShapeTree());
                 ShapeTree tree = common.ShapeTree ??= new ShapeTree();
-                Shape shape = tree.GetFirstChild<Shape>();
+                Shape? shape = tree.GetFirstChild<Shape>();
                 if (shape == null) {
                     shape = new Shape(
                         new NonVisualShapeProperties(
@@ -87,7 +87,7 @@ namespace OfficeIMO.PowerPoint {
                     tree.AppendChild(shape);
                 }
 
-                A.Paragraph paragraph = shape.TextBody!.GetFirstChild<A.Paragraph>() ?? shape.TextBody.AppendChild(new A.Paragraph());
+                A.Paragraph paragraph = shape!.TextBody!.GetFirstChild<A.Paragraph>() ?? shape.TextBody.AppendChild(new A.Paragraph());
                 A.Run run = paragraph.GetFirstChild<A.Run>() ?? paragraph.AppendChild(new A.Run());
                 A.Text text = run.GetFirstChild<A.Text>() ?? run.AppendChild(new A.Text());
                 text.Text = value;

--- a/OfficeIMO.PowerPoint/PowerPointTextBox.cs
+++ b/OfficeIMO.PowerPoint/PowerPointTextBox.cs
@@ -35,7 +35,7 @@ namespace OfficeIMO.PowerPoint {
         public bool Bold {
             get {
                 A.Run? run = Runs.FirstOrDefault();
-                return run?.RunProperties?.Bold == true;
+                return run?.RunProperties?.Bold?.Value ?? false;
             }
             set {
                 foreach (A.Run run in Runs) {
@@ -51,7 +51,7 @@ namespace OfficeIMO.PowerPoint {
         public bool Italic {
             get {
                 A.Run? run = Runs.FirstOrDefault();
-                return run?.RunProperties?.Italic == true;
+                return run?.RunProperties?.Italic?.Value ?? false;
             }
             set {
                 foreach (A.Run run in Runs) {

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -123,7 +123,7 @@ namespace OfficeIMO.Visio {
                 foreach (XElement masterElement in mastersDoc.Root?.Elements(ns + "Master") ?? Enumerable.Empty<XElement>()) {
                     string masterId = masterElement.Attribute("ID")?.Value ?? string.Empty;
                     string masterNameU = masterElement.Attribute("NameU")?.Value ?? string.Empty;
-                    string? mRelId = masterElement.Element(ns + "Rel")?.Attribute(rNs + "id")?.Value;
+                    string mRelId = masterElement.Element(ns + "Rel")?.Attribute(rNs + "id")?.Value ?? string.Empty;
                     if (string.IsNullOrEmpty(mRelId)) {
                         continue;
                     }


### PR DESCRIPTION
## Summary
- guard PowerPoint notes slide creation against null elements
- avoid nullable bool conversions in PowerPoint text formatting
- ensure Visio master relationships use non-empty identifiers

## Testing
- `dotnet build OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj`
- `dotnet build OfficeIMO.Visio/OfficeIMO.Visio.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8949733c0832eb7bb0515a988b93e