### PR TITLE
fix: resolve nullable warnings in tests

### DIFF
--- a/OfficeIMO.Tests/Excel.Tables.cs
+++ b/OfficeIMO.Tests/Excel.Tables.cs
@@ -21,11 +21,11 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 TableDefinitionPart tablePart = wsPart.TableDefinitionParts.First();
-                Assert.Equal("A1:B2", tablePart.Table.Reference.Value);
+                Assert.Equal("A1:B2", tablePart.Table.Reference!.Value);
                 Assert.Equal("MyTable", tablePart.Table.Name);
-                Assert.Equal("TableStyleMedium9", tablePart.Table.TableStyleInfo.Name.Value);
+                Assert.Equal("TableStyleMedium9", tablePart.Table.TableStyleInfo!.Name!.Value);
             }
         }
 
@@ -41,7 +41,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 var cells = wsPart.Worksheet.Descendants<DocumentFormat.OpenXml.Spreadsheet.Cell>();
                 Assert.Contains(cells, c => c.CellReference == "A2");
                 Assert.Contains(cells, c => c.CellReference == "B2");
@@ -71,7 +71,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 Assert.Equal(5, wsPart.TableDefinitionParts.Count());
             }
         }
@@ -95,9 +95,9 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 Assert.Single(wsPart.TableDefinitionParts);
-                Assert.Equal("A1:B3", wsPart.TableDefinitionParts.First().Table.Reference.Value);
+                  Assert.Equal("A1:B3", wsPart.TableDefinitionParts.First().Table.Reference!.Value);
             }
         }
     }

--- a/OfficeIMO.Tests/Html.TableBorderCollapse.cs
+++ b/OfficeIMO.Tests/Html.TableBorderCollapse.cs
@@ -11,7 +11,7 @@ namespace OfficeIMO.Tests {
             string html = "<table style=\"border-collapse:collapse;border:2px solid #ff0000\"><tr><td>A1</td><td>B1</td></tr></table>";
             using var doc = html.LoadFromHtml(new HtmlToWordOptions());
             var table = doc.Tables[0];
-            var insideH = table.StyleDetails.GetBorderProperties(WordTableBorderSide.InsideHorizontal);
+            var insideH = table.StyleDetails!.GetBorderProperties(WordTableBorderSide.InsideHorizontal);
             Assert.Equal(BorderValues.Single, insideH.Style);
             Assert.Equal((UInt32Value)12U, insideH.Size);
             Assert.Equal("ff0000", insideH.ColorHex);
@@ -24,7 +24,7 @@ namespace OfficeIMO.Tests {
             string html = "<table style=\"border-collapse:separate;border:2px solid #ff0000\"><tr><td>A1</td><td>B1</td></tr></table>";
             using var doc = html.LoadFromHtml(new HtmlToWordOptions());
             var table = doc.Tables[0];
-            var insideH = table.StyleDetails.GetBorderProperties(WordTableBorderSide.InsideHorizontal);
+            var insideH = table.StyleDetails!.GetBorderProperties(WordTableBorderSide.InsideHorizontal);
             Assert.Null(insideH.Style);
             var cell = table.Rows[0].Cells[0];
             Assert.Equal(BorderValues.Single, cell.Borders.TopStyle);

--- a/OfficeIMO.Tests/Html.TableBordersAttribute.cs
+++ b/OfficeIMO.Tests/Html.TableBordersAttribute.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Tests {
             using WordDocument doc = html.LoadFromHtml();
             var table = doc.Tables[0];
 
-            var (style, size, colorHex) = table.StyleDetails.GetBorderProperties(WordTableBorderSide.Top);
+            var (style, size, colorHex) = table.StyleDetails!.GetBorderProperties(WordTableBorderSide.Top);
             Assert.Equal(BorderValues.Single, style);
             Assert.Equal((UInt32Value)12U, size);
             Assert.Equal("000000", colorHex);

--- a/OfficeIMO.Tests/Html.TableStyles.cs
+++ b/OfficeIMO.Tests/Html.TableStyles.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Tests {
             string html = "<table style=\"border:2px solid #ff0000\"><tr style=\"background-color:#00ff00\"><td style=\"border:1px dashed #0000ff\">Cell</td></tr></table>";
             var doc = html.LoadFromHtml(new HtmlToWordOptions());
             var table = doc.Tables[0];
-            var (style, size, colorHex) = table.StyleDetails.GetBorderProperties(WordTableBorderSide.Top);
+            var (style, size, colorHex) = table.StyleDetails!.GetBorderProperties(WordTableBorderSide.Top);
             Assert.Equal(BorderValues.Single, style);
             Assert.Equal((UInt32Value)12U, size);
             Assert.Equal("ff0000", colorHex);

--- a/OfficeIMO.Tests/Word.Borders.cs
+++ b/OfficeIMO.Tests/Word.Borders.cs
@@ -35,8 +35,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(document.Sections[0].Borders.LeftStyle == BorderValues.BabyPacifier);
                 Assert.True(document.Sections[0].Borders.LeftColor.ToHexColor() == SixLabors.ImageSharp.Color.Aqua.ToHexColor());
-                Assert.True(document.Sections[0].Borders.LeftSpace == 10);
-                Assert.True(document.Sections[0].Borders.LeftSize == 24);
+                Assert.Equal(10U, document.Sections[0].Borders.LeftSpace!.Value);
+                Assert.Equal(24U, document.Sections[0].Borders.LeftSize!.Value);
 
                 Assert.True(document.Sections[0].Borders.RightStyle == BorderValues.BirdsFlight);
                 Assert.True(document.Sections[0].Borders.RightColor.ToHexColor() == SixLabors.ImageSharp.Color.Red.ToHexColor());
@@ -50,8 +50,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(document.Sections[0].Borders.BottomStyle == BorderValues.Thick);
                 Assert.True(document.Sections[0].Borders.BottomColor.ToHexColor() == SixLabors.ImageSharp.Color.Blue.ToHexColor());
-                Assert.True(document.Sections[0].Borders.BottomSpace == 15);
-                Assert.True(document.Sections[0].Borders.BottomSize == 18);
+                Assert.Equal(15U, document.Sections[0].Borders.BottomSpace!.Value);
+                Assert.Equal(18U, document.Sections[0].Borders.BottomSize!.Value);
 
 
                 document.AddSection();
@@ -77,8 +77,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(document.Sections[0].Borders.LeftStyle == BorderValues.BabyPacifier);
                 Assert.True(document.Sections[0].Borders.LeftColor.ToHexColor() == SixLabors.ImageSharp.Color.Aqua.ToHexColor());
-                Assert.True(document.Sections[0].Borders.LeftSpace == 10);
-                Assert.True(document.Sections[0].Borders.LeftSize == 24);
+                Assert.Equal(10U, document.Sections[0].Borders.LeftSpace!.Value);
+                Assert.Equal(24U, document.Sections[0].Borders.LeftSize!.Value);
 
                 Assert.True(document.Sections[0].Borders.RightStyle == BorderValues.BirdsFlight);
                 Assert.True(document.Sections[0].Borders.RightColor.ToHexColor() == SixLabors.ImageSharp.Color.Red.ToHexColor());
@@ -92,8 +92,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(document.Sections[0].Borders.BottomStyle == BorderValues.Thick);
                 Assert.True(document.Sections[0].Borders.BottomColor.ToHexColor() == SixLabors.ImageSharp.Color.Blue.ToHexColor());
-                Assert.True(document.Sections[0].Borders.BottomSpace == 15);
-                Assert.True(document.Sections[0].Borders.BottomSize == 18);
+                Assert.Equal(15U, document.Sections[0].Borders.BottomSpace!.Value);
+                Assert.Equal(18U, document.Sections[0].Borders.BottomSize!.Value);
 
 
                 Assert.True(document.Sections[1].Borders.LeftStyle == BorderValues.BabyRattle);
@@ -133,8 +133,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(document.Sections[0].Borders.LeftStyle == BorderValues.BabyPacifier);
                 Assert.True(document.Sections[0].Borders.LeftColor.ToHexColor() == SixLabors.ImageSharp.Color.Aqua.ToHexColor());
-                Assert.True(document.Sections[0].Borders.LeftSpace == 10);
-                Assert.True(document.Sections[0].Borders.LeftSize == 24);
+                Assert.Equal(10U, document.Sections[0].Borders.LeftSpace!.Value);
+                Assert.Equal(24U, document.Sections[0].Borders.LeftSize!.Value);
 
                 Assert.True(document.Sections[0].Borders.RightStyle == BorderValues.BirdsFlight);
                 Assert.True(document.Sections[0].Borders.RightColor.ToHexColor() == SixLabors.ImageSharp.Color.Red.ToHexColor());
@@ -148,8 +148,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(document.Sections[0].Borders.BottomStyle == BorderValues.Thick);
                 Assert.True(document.Sections[0].Borders.BottomColor.ToHexColor() == SixLabors.ImageSharp.Color.Blue.ToHexColor());
-                Assert.True(document.Sections[0].Borders.BottomSpace == 15);
-                Assert.True(document.Sections[0].Borders.BottomSize == 18);
+                Assert.Equal(15U, document.Sections[0].Borders.BottomSpace!.Value);
+                Assert.Equal(18U, document.Sections[0].Borders.BottomSize!.Value);
 
 
                 Assert.True(document.Sections[1].Borders.LeftStyle == BorderValues.BabyRattle);

--- a/OfficeIMO.Tests/Word.Breaks.cs
+++ b/OfficeIMO.Tests/Word.Breaks.cs
@@ -128,7 +128,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs[0].Color == SixLabors.ImageSharp.Color.Blue);
                 Assert.True(document.Paragraphs[1].Color == null);
                 Assert.True(document.Paragraphs[2].IsBreak == true);
-                Assert.True(document.Paragraphs[2].Break.BreakType == BreakValues.TextWrapping);
+                  Assert.True(document.Paragraphs[2].Break!.BreakType == BreakValues.TextWrapping);
                 Assert.True(document.Sections.Count == 1);
                 Assert.True(document.Sections[0].Paragraphs.Count == 8);
 


### PR DESCRIPTION
## Summary
- ensure Word border tests access nullable properties safely
- guard HTML table style lookups against null
- assert Excel table metadata and worksheet parts with null-forgiving operators
- avoid null dereference in break assertions

## Testing
- `dotnet build OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68a8950b55c4832e96f6908a1ba62460