### PR TITLE
Fix nullability warnings in Word controls

### DIFF
--- a/OfficeIMO.Word/WordBookmark.cs
+++ b/OfficeIMO.Word/WordBookmark.cs
@@ -1,6 +1,7 @@
 using DocumentFormat.OpenXml.Wordprocessing;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace OfficeIMO.Word {
@@ -12,9 +13,10 @@ namespace OfficeIMO.Word {
         private Paragraph _paragraph;
         private BookmarkStart _bookmarkStart;
 
-        private BookmarkEnd _bookmarkEnd {
+        private BookmarkEnd? _bookmarkEnd {
             get {
-                var listElements = _document._wordprocessingDocument.MainDocumentPart.Document.Body.ChildElements.OfType<Paragraph>();
+                var listElements = _document._wordprocessingDocument.MainDocumentPart?.Document?.Body?
+                    .ChildElements.OfType<Paragraph>() ?? Enumerable.Empty<Paragraph>();
                 foreach (Paragraph paragraph in listElements) {
                     var listBookmarkEnds = paragraph.ChildElements.OfType<BookmarkEnd>();
                     foreach (var bookmarkEnd in listBookmarkEnds) {
@@ -31,7 +33,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the bookmark name.
         /// </summary>
-        public string Name {
+        public string? Name {
             get => _bookmarkStart.Name;
             set => _bookmarkStart.Name = value;
         }
@@ -40,7 +42,7 @@ namespace OfficeIMO.Word {
         /// Gets or sets the bookmark identifier.
         /// </summary>
         public int Id {
-            get => int.Parse(_bookmarkStart.Id);
+            get => int.TryParse(_bookmarkStart.Id, out var id) ? id : 0;
             set => _bookmarkStart.Id = value.ToString();
         }
 
@@ -60,7 +62,7 @@ namespace OfficeIMO.Word {
         /// Removes the bookmark from the document.
         /// </summary>
         public void Remove() {
-            this._bookmarkEnd.Remove();
+            this._bookmarkEnd?.Remove();
             this._bookmarkStart.Remove();
         }
 

--- a/OfficeIMO.Word/WordComboBox.cs
+++ b/OfficeIMO.Word/WordComboBox.cs
@@ -23,9 +23,11 @@ namespace OfficeIMO.Word {
         /// </summary>
         public IReadOnlyList<string> Items {
             get {
-                var combo = _sdtRun.SdtProperties?.Elements<SdtContentComboBox>().FirstOrDefault();
+                var combo = _sdtRun.SdtProperties?.Elements<SdtContentComboBox>()?.FirstOrDefault();
                 if (combo != null) {
-                    return combo.Elements<ListItem>().Select(li => li.DisplayText?.Value ?? li.Value?.Value).ToList();
+                    return combo.Elements<ListItem>()
+                        .Select(li => li.DisplayText?.Value ?? li.Value?.Value ?? string.Empty)
+                        .ToList();
                 }
                 return new List<string>();
             }
@@ -34,16 +36,17 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the tag value for this combo box control.
         /// </summary>
-        public string Tag {
+        public string? Tag {
             get {
-                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                var tag = _sdtRun.SdtProperties?.OfType<Tag>()?.FirstOrDefault();
                 return tag?.Val;
             }
             set {
-                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                var properties = _sdtRun.SdtProperties ?? (_sdtRun.SdtProperties = new SdtProperties());
+                var tag = properties.OfType<Tag>().FirstOrDefault();
                 if (tag == null) {
                     tag = new Tag();
-                    _sdtRun.SdtProperties.Append(tag);
+                    properties.Append(tag);
                 }
                 tag.Val = value;
             }
@@ -52,9 +55,9 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the alias associated with this combo box control.
         /// </summary>
-        public string Alias {
+        public string? Alias {
             get {
-                var sdtAlias = _sdtRun.SdtProperties.OfType<SdtAlias>().FirstOrDefault();
+                var sdtAlias = _sdtRun.SdtProperties?.OfType<SdtAlias>()?.FirstOrDefault();
                 return sdtAlias?.Val;
             }
         }


### PR DESCRIPTION
## Summary
- improve null-safety for bookmark lookup and tagging
- handle absent ComboBox metadata without null warnings

## Testing
- `dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a895209f8c832e8431c03947abb629