### PR TITLE
fix: resolve initial run property nullability warnings

### DIFF
--- a/OfficeIMO.Word/WordParagraph.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PrivateMethods.cs
@@ -52,7 +52,7 @@ namespace OfficeIMO.Word {
             return this._run;
         }
 
-        internal Run VerifyRun(Paragraph paragraph, Run run) {
+        internal Run VerifyRun(Paragraph paragraph, Run? run) {
             if (run == null) {
                 run = new Run();
                 paragraph.Append(run);
@@ -61,7 +61,7 @@ namespace OfficeIMO.Word {
             return run;
         }
 
-        internal Run VerifyRun(Hyperlink hyperlink, Run run) {
+        internal Run VerifyRun(Hyperlink hyperlink, Run? run) {
             if (run == null) {
                 run = new Run();
                 hyperlink.Append(run);
@@ -70,7 +70,7 @@ namespace OfficeIMO.Word {
             return run;
         }
 
-        private RunProperties VerifyRunProperties(Hyperlink hyperlink, Run run, RunProperties runProperties) {
+        private RunProperties VerifyRunProperties(Hyperlink hyperlink, Run? run, RunProperties? runProperties) {
             VerifyRun(hyperlink, run);
             if (run != null) {
                 if (runProperties == null) {
@@ -80,10 +80,11 @@ namespace OfficeIMO.Word {
                     } else {
                         run.Append(new RunProperties());
                     }
+                    runProperties = run.RunProperties;
                 }
             }
 
-            return runProperties;
+            return runProperties!;
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool Bold {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink && Hyperlink != null ? Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Bold != null) {
                     return true;
                 } else {
@@ -22,12 +22,12 @@ namespace OfficeIMO.Word {
             }
             set {
                 RunProperties runProperties;
-                if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                if (IsHyperLink && Hyperlink != null) {
+                    VerifyRunProperties(Hyperlink._hyperlink, Hyperlink._run, Hyperlink._runProperties);
+                    runProperties = Hyperlink._runProperties!;
                 } else {
                     VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = _runProperties!;
                 }
                 if (value == true) {
                     runProperties.Bold = new Bold();
@@ -49,7 +49,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool Italic {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink && Hyperlink != null ? Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Italic != null) {
                     return true;
                 } else {
@@ -58,12 +58,12 @@ namespace OfficeIMO.Word {
             }
             set {
                 RunProperties runProperties;
-                if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                if (IsHyperLink && Hyperlink != null) {
+                    VerifyRunProperties(Hyperlink._hyperlink, Hyperlink._run, Hyperlink._runProperties);
+                    runProperties = Hyperlink._runProperties!;
                 } else {
                     VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = _runProperties!;
                 }
                 if (value != true) {
                     runProperties.Italic = null;
@@ -78,7 +78,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public UnderlineValues? Underline {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink && Hyperlink != null ? Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Underline != null) {
                     return runProperties.Underline.Val?.Value;
                 }
@@ -86,12 +86,12 @@ namespace OfficeIMO.Word {
             }
             set {
                 RunProperties runProperties;
-                if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                if (IsHyperLink && Hyperlink != null) {
+                    VerifyRunProperties(Hyperlink._hyperlink, Hyperlink._run, Hyperlink._runProperties);
+                    runProperties = Hyperlink._runProperties!;
                 } else {
                     VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = _runProperties!;
                 }
                 if (value != null) {
                     if (runProperties.Underline == null) {
@@ -110,7 +110,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool DoNotCheckSpellingOrGrammar {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink && Hyperlink != null ? Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.NoProof != null) {
                     return true;
                 } else {
@@ -119,12 +119,12 @@ namespace OfficeIMO.Word {
             }
             set {
                 RunProperties runProperties;
-                if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                if (IsHyperLink && Hyperlink != null) {
+                    VerifyRunProperties(Hyperlink._hyperlink, Hyperlink._run, Hyperlink._runProperties);
+                    runProperties = Hyperlink._runProperties!;
                 } else {
                     VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = _runProperties!;
                 }
                 if (value != true) {
                     if (runProperties.NoProof != null) runProperties.NoProof.Remove();
@@ -139,7 +139,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? Spacing {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink && Hyperlink != null ? Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Spacing != null) {
                     return runProperties.Spacing.Val?.Value;
                 }
@@ -147,12 +147,12 @@ namespace OfficeIMO.Word {
             }
             set {
                 RunProperties runProperties;
-                if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                if (IsHyperLink && Hyperlink != null) {
+                    VerifyRunProperties(Hyperlink._hyperlink, Hyperlink._run, Hyperlink._runProperties);
+                    runProperties = Hyperlink._runProperties!;
                 } else {
                     VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = _runProperties!;
                 }
                 if (value != null) {
                     Spacing spacing = new Spacing();
@@ -169,7 +169,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool Strike {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink && Hyperlink != null ? Hyperlink._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Strike != null) {
                     return true;
                 } else {
@@ -178,12 +178,12 @@ namespace OfficeIMO.Word {
             }
             set {
                 RunProperties runProperties;
-                if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                if (IsHyperLink && Hyperlink != null) {
+                    VerifyRunProperties(Hyperlink._hyperlink, Hyperlink._run, Hyperlink._runProperties);
+                    runProperties = Hyperlink._runProperties!;
                 } else {
                     VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = _runProperties!;
                 }
                 if (value != true) {
                     if (runProperties.Strike != null) runProperties.Strike.Remove();


### PR DESCRIPTION
## Summary
- guard hyperlink run properties against null
- update helper methods to accept nullable run inputs

## Testing
- `dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj -t:Rebuild`
- `dotnet format OfficeIMO.Word/OfficeIMO.Word.csproj --no-restore` *(fails: Required references did not load)*

------
https://chatgpt.com/codex/tasks/task_e_68a89535e378832eb15c9a5763c826ea