### PR TITLE
Fix nullability warnings in word table utilities

### DIFF
--- a/OfficeIMO.Word/WordTabStop.cs
+++ b/OfficeIMO.Word/WordTabStop.cs
@@ -12,6 +12,10 @@ namespace OfficeIMO.Word {
         private Tabs _tabs {
             get {
                 var paragraphProperties = _paragraph._paragraphProperties;
+                if (paragraphProperties == null) {
+                    paragraphProperties = new ParagraphProperties();
+                    _paragraph._paragraph.ParagraphProperties = paragraphProperties;
+                }
                 if (paragraphProperties.Tabs == null) {
                     paragraphProperties.Append(new Tabs());
                 }

--- a/OfficeIMO.Word/WordTableRow.cs
+++ b/OfficeIMO.Word/WordTableRow.cs
@@ -46,7 +46,7 @@ namespace OfficeIMO.Word {
             get {
                 if (_tableRow.TableRowProperties != null) {
                     var rowHeight = _tableRow.TableRowProperties.OfType<TableRowHeight>().FirstOrDefault();
-                    if (rowHeight != null) {
+                    if (rowHeight?.Val != null) {
                         return (int)rowHeight.Val.Value;
                     }
                 }
@@ -55,15 +55,16 @@ namespace OfficeIMO.Word {
             set {
                 if (value != null) {
                     AddTableRowProperties();
-                    var tableRowHeight = _tableRow.TableRowProperties.OfType<TableRowHeight>().FirstOrDefault();
+                    var tableRowProperties = _tableRow.TableRowProperties!;
+                    var tableRowHeight = tableRowProperties.OfType<TableRowHeight>().FirstOrDefault();
                     if (tableRowHeight == null) {
                         tableRowHeight = new TableRowHeight();
-                        _tableRow.TableRowProperties.InsertAt(tableRowHeight, 0);
+                        tableRowProperties.InsertAt(tableRowHeight, 0);
                     }
                     tableRowHeight.Val = (uint)value;
                     tableRowHeight.HeightType = HeightRuleValues.Exact;
                 } else {
-                    var tableRowHeight = _tableRow.TableRowProperties.OfType<TableRowHeight>().FirstOrDefault();
+                    var tableRowHeight = _tableRow.TableRowProperties?.OfType<TableRowHeight>().FirstOrDefault();
                     if (tableRowHeight != null) {
                         tableRowHeight.Remove();
                     }
@@ -99,9 +100,10 @@ namespace OfficeIMO.Word {
                     }
                 } else {
                     AddTableRowProperties();
-                    var cantSplit = _tableRow.TableRowProperties.OfType<CantSplit>().FirstOrDefault();
+                    var tableRowProperties = _tableRow.TableRowProperties!;
+                    var cantSplit = tableRowProperties.OfType<CantSplit>().FirstOrDefault();
                     if (cantSplit == null) {
-                        _tableRow.TableRowProperties.InsertAt(new CantSplit(), 0);
+                        tableRowProperties.InsertAt(new CantSplit(), 0);
                     }
                 }
             }
@@ -123,14 +125,15 @@ namespace OfficeIMO.Word {
             }
             set {
                 AddTableRowProperties();
-                var rowHeader = _tableRow.TableRowProperties.OfType<TableHeader>().FirstOrDefault();
+                var tableRowProperties = _tableRow.TableRowProperties!;
+                var rowHeader = tableRowProperties.OfType<TableHeader>().FirstOrDefault();
                 if (rowHeader != null) {
                     if (value == false) {
                         rowHeader.Remove();
                     }
                 } else {
                     // Add table header
-                    _tableRow.TableRowProperties.InsertAt(new TableHeader(), 0);
+                    tableRowProperties.InsertAt(new TableHeader(), 0);
 
                 }
             }


### PR DESCRIPTION
## Summary
- ensure paragraph properties are initialized before accessing tabs
- guard table row properties to avoid null dereferences

## Testing
- `dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj`
- `dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj -p:TargetFramework=net9.0` *(fails: Assets file ... doesn't have a target for 'net9.0')*
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build` *(terminated: long runtime with many skipped tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a89e553760832e99724a97da7c5309