### PR TITLE
Fix nullability warnings in test suite

### DIFF
--- a/OfficeIMO.Tests/Word.ShapeTextBoxRecognition.cs
+++ b/OfficeIMO.Tests/Word.ShapeTextBoxRecognition.cs
@@ -20,11 +20,17 @@ namespace OfficeIMO.Tests {
                 doc.Save(false);
             }
             using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
-                var oval = wDoc.MainDocumentPart.Document.Body.Descendants<V.Oval>().First();
+                var mainPart = wDoc.MainDocumentPart;
+                Assert.NotNull(mainPart);
+                var document = mainPart.Document;
+                Assert.NotNull(document);
+                var body = document.Body;
+                Assert.NotNull(body);
+                var oval = body.Descendants<V.Oval>().First();
                 var textBox = new V.TextBox();
                 textBox.Append(new TextBoxContent(new Paragraph(new Run(new Text("Text")))));
                 oval.Append(textBox);
-                wDoc.MainDocumentPart.Document.Save();
+                document.Save();
             }
             using (WordDocument doc = WordDocument.Load(filePath)) {
                 Assert.Empty(doc.Shapes);
@@ -40,7 +46,13 @@ namespace OfficeIMO.Tests {
                 doc.Save(false);
             }
             using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
-                var run = wDoc.MainDocumentPart.Document.Body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
+                var mainPart = wDoc.MainDocumentPart;
+                Assert.NotNull(mainPart);
+                var document = mainPart.Document;
+                Assert.NotNull(document);
+                var body = document.Body;
+                Assert.NotNull(body);
+                var run = body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
                 var drawing = run.Descendants<Drawing>().First();
                 drawing.Remove();
                 var choice = new AlternateContentChoice() { Requires = "wps" };
@@ -48,7 +60,7 @@ namespace OfficeIMO.Tests {
                 var alt = new AlternateContent();
                 alt.Append(choice);
                 run.Append(alt);
-                wDoc.MainDocumentPart.Document.Save();
+                document.Save();
             }
             using (WordDocument doc = WordDocument.Load(filePath)) {
                 Assert.Single(doc.Shapes);
@@ -64,7 +76,13 @@ namespace OfficeIMO.Tests {
                 doc.Save(false);
             }
             using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
-                var run = wDoc.MainDocumentPart.Document.Body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
+                var mainPart = wDoc.MainDocumentPart;
+                Assert.NotNull(mainPart);
+                var document = mainPart.Document;
+                Assert.NotNull(document);
+                var body = document.Body;
+                Assert.NotNull(body);
+                var run = body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
                 var drawing = run.Descendants<Drawing>().First();
                 var fallbackDrawing = (Drawing)drawing.CloneNode(true);
                 drawing.Remove();
@@ -76,7 +94,7 @@ namespace OfficeIMO.Tests {
                 alt.Append(choice);
                 alt.Append(fallback);
                 run.Append(alt);
-                wDoc.MainDocumentPart.Document.Save();
+                document.Save();
             }
             using (WordDocument doc = WordDocument.Load(filePath)) {
                 Assert.Single(doc.Shapes);
@@ -93,7 +111,12 @@ namespace OfficeIMO.Tests {
                 doc.Save(false);
             }
             using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
-                var body = wDoc.MainDocumentPart.Document.Body;
+                var mainPart = wDoc.MainDocumentPart;
+                Assert.NotNull(mainPart);
+                var document = mainPart.Document;
+                Assert.NotNull(document);
+                var body = document.Body;
+                Assert.NotNull(body);
                 var shapeRun = body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any() && !r.Descendants<Wps.TextBoxInfo2>().Any());
                 var textBoxRun = body.Descendants<Run>().First(r => r.Descendants<Wps.TextBoxInfo2>().Any());
                 var shapeDrawing = shapeRun.Descendants<Drawing>().First();
@@ -108,7 +131,6 @@ namespace OfficeIMO.Tests {
                 alt.Append(fallback);
                 shapeRun.Append(alt);
                 textBoxRun.Remove();
-                var document = wDoc.MainDocumentPart.Document;
                 if (document.LookupNamespace("wps") == null) {
                     document.AddNamespaceDeclaration("wps", "http://schemas.microsoft.com/office/word/2010/wordprocessingShape");
                 }
@@ -130,7 +152,12 @@ namespace OfficeIMO.Tests {
                 doc.Save(false);
             }
             using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
-                var body = wDoc.MainDocumentPart.Document.Body;
+                var mainPart = wDoc.MainDocumentPart;
+                Assert.NotNull(mainPart);
+                var document = mainPart.Document;
+                Assert.NotNull(document);
+                var body = document.Body;
+                Assert.NotNull(body);
                 var shapeRun = body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any() && !r.Descendants<Wps.TextBoxInfo2>().Any());
                 var textBoxRun = body.Descendants<Run>().First(r => r.Descendants<Wps.TextBoxInfo2>().Any());
                 var shapeDrawing = (Drawing)shapeRun.Descendants<Drawing>().First().CloneNode(true);
@@ -150,11 +177,12 @@ namespace OfficeIMO.Tests {
                 run.Append(shapeAc);
                 run.Append(textBoxAc);
 
-                shapeRun.Parent.InsertBefore(run, shapeRun);
+                var parent = shapeRun.Parent;
+                Assert.NotNull(parent);
+                parent.InsertBefore(run, shapeRun);
                 shapeRun.Remove();
                 textBoxRun.Remove();
 
-                var document = wDoc.MainDocumentPart.Document;
                 if (document.LookupNamespace("wps") == null) {
                     document.AddNamespaceDeclaration("wps", "http://schemas.microsoft.com/office/word/2010/wordprocessingShape");
                 }

--- a/OfficeIMO.Tests/Word.Shapes.cs
+++ b/OfficeIMO.Tests/Word.Shapes.cs
@@ -46,17 +46,19 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreateDocumentWithShapes.docx"))) {
                 Assert.True(document.Paragraphs[0].IsShape);
-                Assert.Equal("Rectangle", document.Paragraphs[0].Shape.Title);
-                Assert.Equal("My rectangle", document.Paragraphs[0].Shape.Description);
-                Assert.False(document.Paragraphs[0].Shape.Hidden!.Value);
-                Assert.True(document.Paragraphs[0].Shape.Stroked!.Value);
-                Assert.Equal(Color.Blue.ToHexColor(), document.Paragraphs[0].Shape.StrokeColorHex);
-                Assert.Equal(2d, document.Paragraphs[0].Shape.StrokeWeight!.Value, 1);
-                Assert.Equal(120d, document.Paragraphs[0].Shape.Width, 1);
-                Assert.Equal(60d, document.Paragraphs[0].Shape.Height, 1);
-                Assert.Equal(10d, document.Paragraphs[0].Shape.Left!.Value, 1);
-                Assert.Equal(20d, document.Paragraphs[0].Shape.Top!.Value, 1);
-                Assert.Equal(45d, document.Paragraphs[0].Shape.Rotation!.Value, 1);
+                var loadedShape = document.Paragraphs[0].Shape;
+                Assert.NotNull(loadedShape);
+                Assert.Equal("Rectangle", loadedShape.Title);
+                Assert.Equal("My rectangle", loadedShape.Description);
+                Assert.False(loadedShape.Hidden!.Value);
+                Assert.True(loadedShape.Stroked!.Value);
+                Assert.Equal(Color.Blue.ToHexColor(), loadedShape.StrokeColorHex);
+                Assert.Equal(2d, loadedShape.StrokeWeight!.Value, 1);
+                Assert.Equal(120d, loadedShape.Width, 1);
+                Assert.Equal(60d, loadedShape.Height, 1);
+                Assert.Equal(10d, loadedShape.Left!.Value, 1);
+                Assert.Equal(20d, loadedShape.Top!.Value, 1);
+                Assert.Equal(45d, loadedShape.Rotation!.Value, 1);
             }
         }
 
@@ -73,8 +75,10 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.True(document.Paragraphs[0].IsShape);
-                Assert.Equal(Color.Lime.ToHexColor(), document.Paragraphs[0].Shape.FillColorHex);
-                Assert.Equal(Color.Black.ToHexColor(), document.Paragraphs[0].Shape.StrokeColorHex);
+                var loadedShape = document.Paragraphs[0].Shape;
+                Assert.NotNull(loadedShape);
+                Assert.Equal(Color.Lime.ToHexColor(), loadedShape.FillColorHex);
+                Assert.Equal(Color.Black.ToHexColor(), loadedShape.StrokeColorHex);
             }
         }
 
@@ -92,8 +96,10 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.True(document.Paragraphs[0].IsShape);
-                Assert.Equal(Color.Aqua.ToHexColor(), document.Paragraphs[0].Shape.FillColorHex);
-                Assert.Equal(Color.Red.ToHexColor(), document.Paragraphs[0].Shape.StrokeColorHex);
+                var loadedShape = document.Paragraphs[0].Shape;
+                Assert.NotNull(loadedShape);
+                Assert.Equal(Color.Aqua.ToHexColor(), loadedShape.FillColorHex);
+                Assert.Equal(Color.Red.ToHexColor(), loadedShape.StrokeColorHex);
             }
         }
 
@@ -164,7 +170,9 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.True(document.Paragraphs[0].IsShape);
-                Assert.InRange(document.Paragraphs[0].Shape.ArcSize!.Value, 0.29, 0.31);
+                var loadedShape = document.Paragraphs[0].Shape;
+                Assert.NotNull(loadedShape);
+                Assert.InRange(loadedShape.ArcSize!.Value, 0.29, 0.31);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.ShapesAdvanced.cs
+++ b/OfficeIMO.Tests/Word.ShapesAdvanced.cs
@@ -22,8 +22,10 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.True(document.Paragraphs[0].IsShape);
-                Assert.Equal(40d, document.Paragraphs[0].Shape.Width, 1);
-                Assert.Equal(20d, document.Paragraphs[0].Shape.Height, 1);
+                var shape = document.Paragraphs[0].Shape;
+                Assert.NotNull(shape);
+                Assert.Equal(40d, shape.Width, 1);
+                Assert.Equal(20d, shape.Height, 1);
             }
         }
         [Fact]

--- a/OfficeIMO.Tests/Word.TablesBorders.cs
+++ b/OfficeIMO.Tests/Word.TablesBorders.cs
@@ -124,8 +124,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftColor == Color.Aqua);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize == 16);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace == 1U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize!.Value == 16);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace!.Value == 1U);
 
 
 
@@ -145,8 +145,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSize!.Value == 24);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSpace!.Value == 5U);
 
 
 
@@ -162,8 +162,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightStyle == BorderValues.Double);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSize == 4);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSize!.Value == 4);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSpace!.Value == 5U);
 
 
 
@@ -177,8 +177,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopStyle == BorderValues.CirclesRectangles);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSize == 6);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSize!.Value == 6);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSpace!.Value == 5U);
 
 
 
@@ -260,8 +260,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSize!.Value == 24);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSpace!.Value == 5U);
 
 
 
@@ -277,8 +277,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightStyle == BorderValues.Double);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSize == 4);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSize!.Value == 4);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSpace!.Value == 5U);
 
 
 
@@ -292,8 +292,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopStyle == BorderValues.CirclesRectangles);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSize == 6);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSize!.Value == 6);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSpace!.Value == 5U);
 
 
 
@@ -306,8 +306,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomStyle == BorderValues.Safari);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomColor == Color.Cyan);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSize == 8);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSize!.Value == 8);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSpace!.Value == 5U);
 
                 wordTable.Rows[1].Cells[1].Borders.StartStyle = BorderValues.DashSmallGap;
                 wordTable.Rows[1].Cells[1].Borders.StartColorHex = SixLabors.ImageSharp.Color.Orange.ToHexColor();
@@ -318,8 +318,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.StartStyle == BorderValues.DashSmallGap);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.StartColor == Color.Yellow);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSpace == 10U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSize!.Value == 24);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSpace!.Value == 10U);
 
                 wordTable.Rows[1].Cells[1].Borders.EndStyle = BorderValues.Dotted;
                 wordTable.Rows[1].Cells[1].Borders.EndColorHex = SixLabors.ImageSharp.Color.OrangeRed.ToHexColor();
@@ -330,8 +330,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.EndStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.EndColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSpace == null);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSize!.Value == 24);
+                Assert.Null(wordTable.Rows[1].Cells[1].Borders.EndSpace);
 
 
                 wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle = BorderValues.Dotted;
@@ -343,8 +343,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize!.Value == 24);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace!.Value == 5U);
 
 
                 wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle = BorderValues.Dotted;
@@ -356,8 +356,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftColor == Color.Aqua);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize == 16);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace == 1U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize!.Value == 16);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace!.Value == 1U);
 
                 wordTable.Rows[1].Cells[1].Borders.InsideVerticalStyle = BorderValues.DecoBlocks;
                 wordTable.Rows[1].Cells[1].Borders.InsideVerticalColorHex = SixLabors.ImageSharp.Color.YellowGreen.ToHexColor();
@@ -403,8 +403,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSize!.Value == 24);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSpace!.Value == 5U);
 
 
 
@@ -420,8 +420,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightStyle == BorderValues.Double);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSize == 4);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSize!.Value == 4);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSpace!.Value == 5U);
 
 
 
@@ -435,8 +435,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopStyle == BorderValues.CirclesRectangles);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSize == 6);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSize!.Value == 6);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSpace!.Value == 5U);
 
 
 
@@ -449,8 +449,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomStyle == BorderValues.Safari);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomColor == Color.Cyan);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSize == 8);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSize!.Value == 8);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSpace!.Value == 5U);
 
                 wordTable.Rows[1].Cells[1].Borders.StartStyle = BorderValues.DashSmallGap;
                 wordTable.Rows[1].Cells[1].Borders.StartColorHex = SixLabors.ImageSharp.Color.Orange.ToHexColor();
@@ -461,8 +461,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.StartStyle == BorderValues.DashSmallGap);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.StartColor == Color.Yellow);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSpace == 10U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSize!.Value == 24);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSpace!.Value == 10U);
 
                 wordTable.Rows[1].Cells[1].Borders.EndStyle = BorderValues.Dotted;
                 wordTable.Rows[1].Cells[1].Borders.EndColorHex = SixLabors.ImageSharp.Color.OrangeRed.ToHexColor();
@@ -473,8 +473,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.EndStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.EndColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSpace == null);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSize!.Value == 24);
+                Assert.Null(wordTable.Rows[1].Cells[1].Borders.EndSpace);
 
 
                 wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle = BorderValues.Dotted;
@@ -486,8 +486,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize!.Value == 24);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace!.Value == 5U);
 
 
                 wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle = BorderValues.Dotted;
@@ -499,8 +499,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftColor == Color.Aqua);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize == 16);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace == 1U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize!.Value == 16);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace!.Value == 1U);
 
                 document.Save();
             }
@@ -517,8 +517,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSize!.Value == 24);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSpace!.Value == 5U);
 
 
 
@@ -534,8 +534,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightStyle == BorderValues.Double);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSize == 4);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSize!.Value == 4);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSpace!.Value == 5U);
 
 
 
@@ -549,8 +549,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopStyle == BorderValues.CirclesRectangles);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSize == 6);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSize!.Value == 6);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSpace!.Value == 5U);
 
 
 
@@ -563,8 +563,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomStyle == BorderValues.Safari);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomColor == Color.Cyan);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSize == 8);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSize!.Value == 8);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSpace!.Value == 5U);
 
                 wordTable.Rows[1].Cells[1].Borders.StartStyle = BorderValues.DashSmallGap;
                 wordTable.Rows[1].Cells[1].Borders.StartColorHex = SixLabors.ImageSharp.Color.Orange.ToHexColor();
@@ -575,8 +575,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.StartStyle == BorderValues.DashSmallGap);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.StartColor == Color.Yellow);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSpace == 10U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSize!.Value == 24);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSpace!.Value == 10U);
 
                 wordTable.Rows[1].Cells[1].Borders.EndStyle = BorderValues.Dotted;
                 wordTable.Rows[1].Cells[1].Borders.EndColorHex = SixLabors.ImageSharp.Color.OrangeRed.ToHexColor();
@@ -587,8 +587,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.EndStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.EndColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSpace == null);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSize!.Value == 24);
+                Assert.Null(wordTable.Rows[1].Cells[1].Borders.EndSpace);
 
 
                 wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle = BorderValues.Dotted;
@@ -600,8 +600,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace == 5U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize!.Value == 24);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace!.Value == 5U);
 
 
                 wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle = BorderValues.Dotted;
@@ -613,8 +613,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftColor == Color.Aqua);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize == 16);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace == 1U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize!.Value == 16);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace!.Value == 1U);
 
 
                 wordTable.Rows[1].Cells[1].Borders.InsideVerticalStyle = BorderValues.DecoBlocks;
@@ -626,8 +626,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideVerticalStyle == BorderValues.DecoBlocks);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideVerticalColor == Color.DarkSlateBlue);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideVerticalSize == 15);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideVerticalSpace == 3U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideVerticalSize!.Value == 15);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideVerticalSpace!.Value == 3U);
 
                 wordTable.Rows[1].Cells[1].Borders.InsideHorizontalStyle = BorderValues.DecoBlocks;
                 wordTable.Rows[1].Cells[1].Borders.InsideHorizontalColorHex = SixLabors.ImageSharp.Color.YellowGreen.ToHexColor();
@@ -638,8 +638,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideHorizontalStyle == BorderValues.DecoBlocks);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideHorizontalColor == Color.DarkSlateBlue);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideHorizontalSize == 15);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideHorizontalSpace == 3U);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideHorizontalSize!.Value == 15);
+                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideHorizontalSpace!.Value == 3U);
 
                 document.Save();
             }


### PR DESCRIPTION
## Summary
- guard shape access in tests with explicit null checks
- compare table border sizes and spaces using value properties
- ensure shape recognition tests validate OpenXML parts before usage

## Testing
- `dotnet test`
- `dotnet build OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68aa2ab1b0d0832ea55d078667280606