### PR TITLE
Fix nullability warnings in tests

### DIFF
--- a/OfficeIMO.Tests/Word.Properties.cs
+++ b/OfficeIMO.Tests/Word.Properties.cs
@@ -209,17 +209,21 @@ namespace OfficeIMO.Tests {
                 p1.Text = "Chapter1";
                 p1.SetStyleId(WordParagraphStyles.Heading1.ToString());
                 var p2 = document.AddParagraph("Chatper2").SetStyle(WordParagraphStyles.Heading1);
-                var style1= p1.Style.Value;
-                var style2= p2.Style.Value;
+                Assert.NotNull(p1.Style);
+                Assert.NotNull(p2.Style);
+                var style1 = p1.Style!.Value;
+                var style2 = p2.Style!.Value;
                 Assert.True(style1 == style2);
-                document.Save(tempFile);    
+                document.Save(tempFile);
                
             }
             using (WordDocument document = WordDocument.Load(tempFile)) {
                 var p3 = document.Paragraphs[0];
                 var p4 = document.Paragraphs[1];
-                var style3 = p3.Style.Value;
-                var style4 = p4.Style.Value;
+                Assert.NotNull(p3.Style);
+                Assert.NotNull(p4.Style);
+                var style3 = p3.Style!.Value;
+                var style4 = p4.Style!.Value;
                 Assert.True(style3 == style4);
             }
         }

--- a/OfficeIMO.Tests/Word.Revisions.cs
+++ b/OfficeIMO.Tests/Word.Revisions.cs
@@ -23,13 +23,16 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Contains(document._document.Body.Descendants<InsertedRun>(), run => run.InnerText == "Added");
-                Assert.Contains(document._document.Body.Descendants<DeletedRun>(), run => run.InnerText == "Removed");
+                Assert.NotNull(document._document);
+                var body = document._document!.Body;
+                Assert.NotNull(body);
+                Assert.Contains(body!.Descendants<InsertedRun>(), run => run.InnerText == "Added");
+                Assert.Contains(body.Descendants<DeletedRun>(), run => run.InnerText == "Removed");
 
                 document.AcceptRevisions();
 
-                Assert.DoesNotContain(document._document.Body.Descendants<InsertedRun>(), run => run.InnerText == "Added");
-                Assert.DoesNotContain(document._document.Body.Descendants<DeletedRun>(), run => run.InnerText == "Removed");
+                Assert.DoesNotContain(body.Descendants<InsertedRun>(), run => run.InnerText == "Added");
+                Assert.DoesNotContain(body.Descendants<DeletedRun>(), run => run.InnerText == "Removed");
                 Assert.Contains(document.Paragraphs, p => p.Text == "Before");
                 Assert.Contains(document.Paragraphs, p => p.Text == "Added");
             }
@@ -49,8 +52,11 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 document.RejectRevisions();
-                Assert.DoesNotContain(document._document.Body.Descendants<InsertedRun>(), run => run.InnerText == "Added");
-                Assert.DoesNotContain(document._document.Body.Descendants<DeletedRun>(), run => run.InnerText == "Removed");
+                Assert.NotNull(document._document);
+                var body = document._document!.Body;
+                Assert.NotNull(body);
+                Assert.DoesNotContain(body!.Descendants<InsertedRun>(), run => run.InnerText == "Added");
+                Assert.DoesNotContain(body.Descendants<DeletedRun>(), run => run.InnerText == "Removed");
                 Assert.Contains(document.Paragraphs, p => p.Text == "Removed");
             }
         }
@@ -86,19 +92,22 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(filePath)) {
                 document.ConvertRevisionsToMarkup();
 
-                Assert.DoesNotContain(document._document.Body.Descendants<InsertedRun>(), r => r.InnerText == "Added");
-                Assert.DoesNotContain(document._document.Body.Descendants<DeletedRun>(), r => r.InnerText == "Removed");
+                Assert.NotNull(document._document);
+                var body = document._document!.Body;
+                Assert.NotNull(body);
+                Assert.DoesNotContain(body!.Descendants<InsertedRun>(), r => r.InnerText == "Added");
+                Assert.DoesNotContain(body.Descendants<DeletedRun>(), r => r.InnerText == "Removed");
 
-                var insertedRun = document._document.Body.Descendants<Run>().FirstOrDefault(r => r.InnerText == "Added");
+                var insertedRun = body.Descendants<Run>().FirstOrDefault(r => r.InnerText == "Added");
                 Assert.NotNull(insertedRun);
-                Assert.NotNull(insertedRun.RunProperties);
-                Assert.NotNull(insertedRun.RunProperties.Underline);
+                Assert.NotNull(insertedRun!.RunProperties);
+                Assert.NotNull(insertedRun.RunProperties!.Underline);
                 Assert.Equal("0000FF", insertedRun.RunProperties.Color?.Val);
 
-                var deletedRun = document._document.Body.Descendants<Run>().FirstOrDefault(r => r.InnerText == "Removed");
+                var deletedRun = body.Descendants<Run>().FirstOrDefault(r => r.InnerText == "Removed");
                 Assert.NotNull(deletedRun);
-                Assert.NotNull(deletedRun.RunProperties);
-                Assert.NotNull(deletedRun.RunProperties.Strike);
+                Assert.NotNull(deletedRun!.RunProperties);
+                Assert.NotNull(deletedRun.RunProperties!.Strike);
                 Assert.Equal("FF0000", deletedRun.RunProperties.Color?.Val);
             }
         }

--- a/OfficeIMO.Tests/Word.ShapeTextBoxRecognition.cs
+++ b/OfficeIMO.Tests/Word.ShapeTextBoxRecognition.cs
@@ -22,11 +22,11 @@ namespace OfficeIMO.Tests {
             using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
                 var mainPart = wDoc.MainDocumentPart;
                 Assert.NotNull(mainPart);
-                var document = mainPart.Document;
+                var document = mainPart!.Document;
                 Assert.NotNull(document);
-                var body = document.Body;
+                var body = document!.Body;
                 Assert.NotNull(body);
-                var oval = body.Descendants<V.Oval>().First();
+                var oval = body!.Descendants<V.Oval>().First();
                 var textBox = new V.TextBox();
                 textBox.Append(new TextBoxContent(new Paragraph(new Run(new Text("Text")))));
                 oval.Append(textBox);
@@ -48,11 +48,11 @@ namespace OfficeIMO.Tests {
             using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
                 var mainPart = wDoc.MainDocumentPart;
                 Assert.NotNull(mainPart);
-                var document = mainPart.Document;
+                var document = mainPart!.Document;
                 Assert.NotNull(document);
-                var body = document.Body;
+                var body = document!.Body;
                 Assert.NotNull(body);
-                var run = body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
+                var run = body!.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
                 var drawing = run.Descendants<Drawing>().First();
                 drawing.Remove();
                 var choice = new AlternateContentChoice() { Requires = "wps" };
@@ -78,11 +78,11 @@ namespace OfficeIMO.Tests {
             using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
                 var mainPart = wDoc.MainDocumentPart;
                 Assert.NotNull(mainPart);
-                var document = mainPart.Document;
+                var document = mainPart!.Document;
                 Assert.NotNull(document);
-                var body = document.Body;
+                var body = document!.Body;
                 Assert.NotNull(body);
-                var run = body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
+                var run = body!.Descendants<Run>().First(r => r.Descendants<Drawing>().Any());
                 var drawing = run.Descendants<Drawing>().First();
                 var fallbackDrawing = (Drawing)drawing.CloneNode(true);
                 drawing.Remove();
@@ -113,11 +113,11 @@ namespace OfficeIMO.Tests {
             using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
                 var mainPart = wDoc.MainDocumentPart;
                 Assert.NotNull(mainPart);
-                var document = mainPart.Document;
+                var document = mainPart!.Document;
                 Assert.NotNull(document);
-                var body = document.Body;
+                var body = document!.Body;
                 Assert.NotNull(body);
-                var shapeRun = body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any() && !r.Descendants<Wps.TextBoxInfo2>().Any());
+                var shapeRun = body!.Descendants<Run>().First(r => r.Descendants<Drawing>().Any() && !r.Descendants<Wps.TextBoxInfo2>().Any());
                 var textBoxRun = body.Descendants<Run>().First(r => r.Descendants<Wps.TextBoxInfo2>().Any());
                 var shapeDrawing = shapeRun.Descendants<Drawing>().First();
                 var textBoxDrawing = textBoxRun.Descendants<Drawing>().First();
@@ -154,11 +154,11 @@ namespace OfficeIMO.Tests {
             using (WordprocessingDocument wDoc = WordprocessingDocument.Open(filePath, true)) {
                 var mainPart = wDoc.MainDocumentPart;
                 Assert.NotNull(mainPart);
-                var document = mainPart.Document;
+                var document = mainPart!.Document;
                 Assert.NotNull(document);
-                var body = document.Body;
+                var body = document!.Body;
                 Assert.NotNull(body);
-                var shapeRun = body.Descendants<Run>().First(r => r.Descendants<Drawing>().Any() && !r.Descendants<Wps.TextBoxInfo2>().Any());
+                var shapeRun = body!.Descendants<Run>().First(r => r.Descendants<Drawing>().Any() && !r.Descendants<Wps.TextBoxInfo2>().Any());
                 var textBoxRun = body.Descendants<Run>().First(r => r.Descendants<Wps.TextBoxInfo2>().Any());
                 var shapeDrawing = (Drawing)shapeRun.Descendants<Drawing>().First().CloneNode(true);
                 var textBoxDrawing = (Drawing)textBoxRun.Descendants<Drawing>().First().CloneNode(true);
@@ -179,7 +179,7 @@ namespace OfficeIMO.Tests {
 
                 var parent = shapeRun.Parent;
                 Assert.NotNull(parent);
-                parent.InsertBefore(run, shapeRun);
+                parent!.InsertBefore(run, shapeRun);
                 shapeRun.Remove();
                 textBoxRun.Remove();
 

--- a/OfficeIMO.Tests/Word.Shapes.cs
+++ b/OfficeIMO.Tests/Word.Shapes.cs
@@ -48,7 +48,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs[0].IsShape);
                 var loadedShape = document.Paragraphs[0].Shape;
                 Assert.NotNull(loadedShape);
-                Assert.Equal("Rectangle", loadedShape.Title);
+                Assert.Equal("Rectangle", loadedShape!.Title);
                 Assert.Equal("My rectangle", loadedShape.Description);
                 Assert.False(loadedShape.Hidden!.Value);
                 Assert.True(loadedShape.Stroked!.Value);
@@ -77,7 +77,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs[0].IsShape);
                 var loadedShape = document.Paragraphs[0].Shape;
                 Assert.NotNull(loadedShape);
-                Assert.Equal(Color.Lime.ToHexColor(), loadedShape.FillColorHex);
+                Assert.Equal(Color.Lime.ToHexColor(), loadedShape!.FillColorHex);
                 Assert.Equal(Color.Black.ToHexColor(), loadedShape.StrokeColorHex);
             }
         }
@@ -98,7 +98,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs[0].IsShape);
                 var loadedShape = document.Paragraphs[0].Shape;
                 Assert.NotNull(loadedShape);
-                Assert.Equal(Color.Aqua.ToHexColor(), loadedShape.FillColorHex);
+                Assert.Equal(Color.Aqua.ToHexColor(), loadedShape!.FillColorHex);
                 Assert.Equal(Color.Red.ToHexColor(), loadedShape.StrokeColorHex);
             }
         }
@@ -151,9 +151,12 @@ namespace OfficeIMO.Tests {
                 var section = document.Sections[0];
                 Assert.Equal(3, document.Shapes.Count);
                 Assert.Equal(3, section.Shapes.Count);
-                Assert.True(section.Header.Default.Paragraphs[0].IsShape);
-                Assert.True(section.Header.Default.Paragraphs[1].IsShape);
-                Assert.True(section.Header.Default.Paragraphs[2].IsShape);
+                Assert.NotNull(section.Header);
+                Assert.NotNull(section.Header!.Default);
+                var headerDefault = section.Header.Default!;
+                Assert.True(headerDefault.Paragraphs[0].IsShape);
+                Assert.True(headerDefault.Paragraphs[1].IsShape);
+                Assert.True(headerDefault.Paragraphs[2].IsShape);
             }
         }
 
@@ -172,7 +175,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs[0].IsShape);
                 var loadedShape = document.Paragraphs[0].Shape;
                 Assert.NotNull(loadedShape);
-                Assert.InRange(loadedShape.ArcSize!.Value, 0.29, 0.31);
+                Assert.InRange(loadedShape!.ArcSize!.Value, 0.29, 0.31);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.ShapesAdvanced.cs
+++ b/OfficeIMO.Tests/Word.ShapesAdvanced.cs
@@ -24,7 +24,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs[0].IsShape);
                 var shape = document.Paragraphs[0].Shape;
                 Assert.NotNull(shape);
-                Assert.Equal(40d, shape.Width, 1);
+                Assert.Equal(40d, shape!.Width, 1);
                 Assert.Equal(20d, shape.Height, 1);
             }
         }

--- a/OfficeIMO.Tests/Word.TablesBorders.cs
+++ b/OfficeIMO.Tests/Word.TablesBorders.cs
@@ -124,8 +124,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftColor == Color.Aqua);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize!.Value == 16);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace!.Value == 1U);
+                Assert.Equal(16U, wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize?.Value);
+                Assert.Equal(1U, wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace?.Value);
 
 
 
@@ -145,8 +145,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSize!.Value == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSpace!.Value == 5U);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.LeftSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.LeftSpace?.Value);
 
 
 
@@ -162,8 +162,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightStyle == BorderValues.Double);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSize!.Value == 4);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSpace!.Value == 5U);
+                Assert.Equal(4U, wordTable.Rows[1].Cells[1].Borders.RightSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.RightSpace?.Value);
 
 
 
@@ -177,8 +177,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopStyle == BorderValues.CirclesRectangles);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSize!.Value == 6);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSpace!.Value == 5U);
+                Assert.Equal(6U, wordTable.Rows[1].Cells[1].Borders.TopSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.TopSpace?.Value);
 
 
 
@@ -260,8 +260,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSize!.Value == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSpace!.Value == 5U);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.LeftSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.LeftSpace?.Value);
 
 
 
@@ -277,8 +277,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightStyle == BorderValues.Double);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSize!.Value == 4);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSpace!.Value == 5U);
+                Assert.Equal(4U, wordTable.Rows[1].Cells[1].Borders.RightSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.RightSpace?.Value);
 
 
 
@@ -292,8 +292,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopStyle == BorderValues.CirclesRectangles);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSize!.Value == 6);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSpace!.Value == 5U);
+                Assert.Equal(6U, wordTable.Rows[1].Cells[1].Borders.TopSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.TopSpace?.Value);
 
 
 
@@ -306,8 +306,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomStyle == BorderValues.Safari);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomColor == Color.Cyan);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSize!.Value == 8);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSpace!.Value == 5U);
+                Assert.Equal(8U, wordTable.Rows[1].Cells[1].Borders.BottomSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.BottomSpace?.Value);
 
                 wordTable.Rows[1].Cells[1].Borders.StartStyle = BorderValues.DashSmallGap;
                 wordTable.Rows[1].Cells[1].Borders.StartColorHex = SixLabors.ImageSharp.Color.Orange.ToHexColor();
@@ -318,8 +318,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.StartStyle == BorderValues.DashSmallGap);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.StartColor == Color.Yellow);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSize!.Value == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSpace!.Value == 10U);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.StartSize?.Value);
+                Assert.Equal(10U, wordTable.Rows[1].Cells[1].Borders.StartSpace?.Value);
 
                 wordTable.Rows[1].Cells[1].Borders.EndStyle = BorderValues.Dotted;
                 wordTable.Rows[1].Cells[1].Borders.EndColorHex = SixLabors.ImageSharp.Color.OrangeRed.ToHexColor();
@@ -330,7 +330,7 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.EndStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.EndColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSize!.Value == 24);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.EndSize?.Value);
                 Assert.Null(wordTable.Rows[1].Cells[1].Borders.EndSpace);
 
 
@@ -343,8 +343,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize!.Value == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace!.Value == 5U);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace?.Value);
 
 
                 wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle = BorderValues.Dotted;
@@ -356,8 +356,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftColor == Color.Aqua);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize!.Value == 16);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace!.Value == 1U);
+                Assert.Equal(16U, wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize?.Value);
+                Assert.Equal(1U, wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace?.Value);
 
                 wordTable.Rows[1].Cells[1].Borders.InsideVerticalStyle = BorderValues.DecoBlocks;
                 wordTable.Rows[1].Cells[1].Borders.InsideVerticalColorHex = SixLabors.ImageSharp.Color.YellowGreen.ToHexColor();
@@ -403,8 +403,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSize!.Value == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSpace!.Value == 5U);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.LeftSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.LeftSpace?.Value);
 
 
 
@@ -420,8 +420,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightStyle == BorderValues.Double);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSize!.Value == 4);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSpace!.Value == 5U);
+                Assert.Equal(4U, wordTable.Rows[1].Cells[1].Borders.RightSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.RightSpace?.Value);
 
 
 
@@ -435,8 +435,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopStyle == BorderValues.CirclesRectangles);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSize!.Value == 6);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSpace!.Value == 5U);
+                Assert.Equal(6U, wordTable.Rows[1].Cells[1].Borders.TopSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.TopSpace?.Value);
 
 
 
@@ -449,8 +449,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomStyle == BorderValues.Safari);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomColor == Color.Cyan);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSize!.Value == 8);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSpace!.Value == 5U);
+                Assert.Equal(8U, wordTable.Rows[1].Cells[1].Borders.BottomSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.BottomSpace?.Value);
 
                 wordTable.Rows[1].Cells[1].Borders.StartStyle = BorderValues.DashSmallGap;
                 wordTable.Rows[1].Cells[1].Borders.StartColorHex = SixLabors.ImageSharp.Color.Orange.ToHexColor();
@@ -461,8 +461,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.StartStyle == BorderValues.DashSmallGap);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.StartColor == Color.Yellow);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSize!.Value == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSpace!.Value == 10U);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.StartSize?.Value);
+                Assert.Equal(10U, wordTable.Rows[1].Cells[1].Borders.StartSpace?.Value);
 
                 wordTable.Rows[1].Cells[1].Borders.EndStyle = BorderValues.Dotted;
                 wordTable.Rows[1].Cells[1].Borders.EndColorHex = SixLabors.ImageSharp.Color.OrangeRed.ToHexColor();
@@ -473,7 +473,7 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.EndStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.EndColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSize!.Value == 24);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.EndSize?.Value);
                 Assert.Null(wordTable.Rows[1].Cells[1].Borders.EndSpace);
 
 
@@ -486,8 +486,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize!.Value == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace!.Value == 5U);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace?.Value);
 
 
                 wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle = BorderValues.Dotted;
@@ -499,8 +499,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftColor == Color.Aqua);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize!.Value == 16);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace!.Value == 1U);
+                Assert.Equal(16U, wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize?.Value);
+                Assert.Equal(1U, wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace?.Value);
 
                 document.Save();
             }
@@ -517,8 +517,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSize!.Value == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.LeftSpace!.Value == 5U);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.LeftSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.LeftSpace?.Value);
 
 
 
@@ -534,8 +534,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightStyle == BorderValues.Double);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.RightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSize!.Value == 4);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.RightSpace!.Value == 5U);
+                Assert.Equal(4U, wordTable.Rows[1].Cells[1].Borders.RightSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.RightSpace?.Value);
 
 
 
@@ -549,8 +549,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopStyle == BorderValues.CirclesRectangles);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSize!.Value == 6);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopSpace!.Value == 5U);
+                Assert.Equal(6U, wordTable.Rows[1].Cells[1].Borders.TopSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.TopSpace?.Value);
 
 
 
@@ -563,8 +563,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomStyle == BorderValues.Safari);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomColor == Color.Cyan);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSize!.Value == 8);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.BottomSpace!.Value == 5U);
+                Assert.Equal(8U, wordTable.Rows[1].Cells[1].Borders.BottomSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.BottomSpace?.Value);
 
                 wordTable.Rows[1].Cells[1].Borders.StartStyle = BorderValues.DashSmallGap;
                 wordTable.Rows[1].Cells[1].Borders.StartColorHex = SixLabors.ImageSharp.Color.Orange.ToHexColor();
@@ -575,8 +575,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.StartStyle == BorderValues.DashSmallGap);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.StartColor == Color.Yellow);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSize!.Value == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.StartSpace!.Value == 10U);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.StartSize?.Value);
+                Assert.Equal(10U, wordTable.Rows[1].Cells[1].Borders.StartSpace?.Value);
 
                 wordTable.Rows[1].Cells[1].Borders.EndStyle = BorderValues.Dotted;
                 wordTable.Rows[1].Cells[1].Borders.EndColorHex = SixLabors.ImageSharp.Color.OrangeRed.ToHexColor();
@@ -587,7 +587,7 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.EndStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.EndColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.EndSize!.Value == 24);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.EndSize?.Value);
                 Assert.Null(wordTable.Rows[1].Cells[1].Borders.EndSpace);
 
 
@@ -600,8 +600,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightColor == Color.Gold);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize!.Value == 24);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace!.Value == 5U);
+                Assert.Equal(24U, wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSize?.Value);
+                Assert.Equal(5U, wordTable.Rows[1].Cells[1].Borders.TopLeftToBottomRightSpace?.Value);
 
 
                 wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle = BorderValues.Dotted;
@@ -613,8 +613,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftStyle == BorderValues.Dotted);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftColor == Color.Aqua);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize!.Value == 16);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace!.Value == 1U);
+                Assert.Equal(16U, wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSize?.Value);
+                Assert.Equal(1U, wordTable.Rows[1].Cells[1].Borders.TopRightToBottomLeftSpace?.Value);
 
 
                 wordTable.Rows[1].Cells[1].Borders.InsideVerticalStyle = BorderValues.DecoBlocks;
@@ -626,8 +626,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideVerticalStyle == BorderValues.DecoBlocks);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideVerticalColor == Color.DarkSlateBlue);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideVerticalSize!.Value == 15);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideVerticalSpace!.Value == 3U);
+                Assert.Equal(15U, wordTable.Rows[1].Cells[1].Borders.InsideVerticalSize?.Value);
+                Assert.Equal(3U, wordTable.Rows[1].Cells[1].Borders.InsideVerticalSpace?.Value);
 
                 wordTable.Rows[1].Cells[1].Borders.InsideHorizontalStyle = BorderValues.DecoBlocks;
                 wordTable.Rows[1].Cells[1].Borders.InsideHorizontalColorHex = SixLabors.ImageSharp.Color.YellowGreen.ToHexColor();
@@ -638,8 +638,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideHorizontalStyle == BorderValues.DecoBlocks);
                 Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideHorizontalColor == Color.DarkSlateBlue);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideHorizontalSize!.Value == 15);
-                Assert.True(wordTable.Rows[1].Cells[1].Borders.InsideHorizontalSpace!.Value == 3U);
+                Assert.Equal(15U, wordTable.Rows[1].Cells[1].Borders.InsideHorizontalSize?.Value);
+                Assert.Equal(3U, wordTable.Rows[1].Cells[1].Borders.InsideHorizontalSpace?.Value);
 
                 document.Save();
             }


### PR DESCRIPTION
## Summary
- ensure style checks in SetStyleId tests
- guard document bodies in revision-related tests
- assert shape presence before property access in shape tests
- validate optional border values with `Assert.Equal`

## Testing
- `dotnet build`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68aa31c119b8832e89df8bf513039ded