### PR TITLE
Fix null reference warnings in tests

### DIFF
--- a/OfficeIMO.Tests/Word.Charts.cs
+++ b/OfficeIMO.Tests/Word.Charts.cs
@@ -351,27 +351,29 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var part = document._wordprocessingDocument.MainDocumentPart.ChartParts.First();
-                var chart = part.ChartSpace.GetFirstChild<Chart>();
-                var catAxis = chart.PlotArea.GetFirstChild<CategoryAxis>();
-                var valAxis = chart.PlotArea.GetFirstChild<ValueAxis>();
+                var part = document._wordprocessingDocument!.MainDocumentPart!.ChartParts.First();
+                var chart = part.ChartSpace.GetFirstChild<Chart>()!;
+                var catAxis = chart.PlotArea!.GetFirstChild<CategoryAxis>()!;
+                var valAxis = chart.PlotArea!.GetFirstChild<ValueAxis>()!;
 
-                var catTitle = catAxis.GetFirstChild<Title>();
-                var valTitle = valAxis.GetFirstChild<Title>();
+                var catTitle = catAxis.GetFirstChild<Title>()!;
+                var valTitle = valAxis.GetFirstChild<Title>()!;
 
                 var catProps = catTitle.Descendants<DocumentFormat.OpenXml.Drawing.DefaultRunProperties>().First();
                 var valProps = valTitle.Descendants<DocumentFormat.OpenXml.Drawing.DefaultRunProperties>().First();
 
-                Assert.Equal(1400, (int)catProps.FontSize.Value);
-                Assert.Equal("Arial", catProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.LatinFont>().Typeface);
-                var catColor = catProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.SolidFill>()
-                    .GetFirstChild<DocumentFormat.OpenXml.Drawing.RgbColorModelHex>().Val;
+                Assert.NotNull(catProps.FontSize);
+                Assert.Equal(1400, (int)catProps.FontSize!.Value!);
+                Assert.Equal("Arial", catProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.LatinFont>()!.Typeface);
+                var catColor = catProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.SolidFill>()!
+                    .GetFirstChild<DocumentFormat.OpenXml.Drawing.RgbColorModelHex>()!.Val!;
                 Assert.Equal(Color.Red.ToHexColor(), catColor);
 
-                Assert.Equal(1400, (int)valProps.FontSize.Value);
-                Assert.Equal("Arial", valProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.LatinFont>().Typeface);
-                var valColor = valProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.SolidFill>()
-                    .GetFirstChild<DocumentFormat.OpenXml.Drawing.RgbColorModelHex>().Val;
+                Assert.NotNull(valProps.FontSize);
+                Assert.Equal(1400, (int)valProps.FontSize!.Value!);
+                Assert.Equal("Arial", valProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.LatinFont>()!.Typeface);
+                var valColor = valProps.GetFirstChild<DocumentFormat.OpenXml.Drawing.SolidFill>()!
+                    .GetFirstChild<DocumentFormat.OpenXml.Drawing.RgbColorModelHex>()!.Val!;
                 Assert.Equal(Color.Red.ToHexColor(), valColor);
 
                 var validation = document.ValidateDocument();
@@ -395,17 +397,17 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.Single(document.Charts);
-                var part = document._wordprocessingDocument.MainDocumentPart.ChartParts.First();
-                var c = part.ChartSpace.GetFirstChild<Chart>();
-                var bar = c.PlotArea.GetFirstChild<BarChart>();
-                var line = c.PlotArea.GetFirstChild<LineChart>();
+                var part = document._wordprocessingDocument!.MainDocumentPart!.ChartParts.First();
+                var c = part.ChartSpace.GetFirstChild<Chart>()!;
+                var bar = c.PlotArea!.GetFirstChild<BarChart>();
+                var line = c.PlotArea!.GetFirstChild<LineChart>();
                 Assert.NotNull(bar);
                 Assert.NotNull(line);
-                var barIds = bar.Elements<AxisId>().Select(a => a.Val.Value).ToList();
-                var lineIds = line.Elements<AxisId>().Select(a => a.Val.Value).ToList();
+                var barIds = bar!.Elements<AxisId>().Select(a => a.Val!.Value!).ToList();
+                var lineIds = line!.Elements<AxisId>().Select(a => a.Val!.Value!).ToList();
                 Assert.Equal(barIds, lineIds);
-                var seriesIdx = bar.Elements<BarChartSeries>().Select(s => s.Index.Val.Value)
-                    .Concat(line.Elements<LineChartSeries>().Select(s => s.Index.Val.Value))
+                var seriesIdx = bar.Elements<BarChartSeries>().Select(s => s.Index!.Val!.Value!)
+                    .Concat(line.Elements<LineChartSeries>().Select(s => s.Index!.Val!.Value!))
                     .ToList();
                 Assert.Equal(seriesIdx.Count, seriesIdx.Distinct().Count());
 

--- a/OfficeIMO.Tests/Word.CheckBox.cs
+++ b/OfficeIMO.Tests/Word.CheckBox.cs
@@ -33,7 +33,9 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.False(document.GetCheckBoxByTag("AgreeTag").IsChecked);
+                var checkBox = document.GetCheckBoxByTag("AgreeTag");
+                Assert.NotNull(checkBox);
+                Assert.False(checkBox!.IsChecked);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.CleanupOptions.cs
+++ b/OfficeIMO.Tests/Word.CleanupOptions.cs
@@ -73,7 +73,9 @@ namespace OfficeIMO.Tests {
                 run.SetBold(false);
                 Assert.NotNull(run._run.RunProperties);
                 document.CleanupDocument();
-                Assert.Null(run._paragraph.Elements<Run>().First().RunProperties);
+                Assert.NotNull(run._paragraph);
+                var firstRun = run._paragraph!.Elements<Run>().First();
+                Assert.Null(firstRun.RunProperties);
                 document.Save(false);
             }
         }

--- a/OfficeIMO.Tests/Word.ContentControlsAdvanced.cs
+++ b/OfficeIMO.Tests/Word.ContentControlsAdvanced.cs
@@ -38,9 +38,11 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 var aliasControl = document.GetStructuredDocumentTagByAlias("Alias2");
-                Assert.Equal("Changed", aliasControl.Text);
+                Assert.NotNull(aliasControl);
+                Assert.Equal("Changed", aliasControl!.Text);
                 var tagControl = document.GetStructuredDocumentTagByTag("Tag3");
-                Assert.Equal("Modified", tagControl.Text);
+                Assert.NotNull(tagControl);
+                Assert.Equal("Modified", tagControl!.Text);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.EmbeddedDocuments.cs
+++ b/OfficeIMO.Tests/Word.EmbeddedDocuments.cs
@@ -121,7 +121,7 @@ public partial class Word {
             Assert.True(document.EmbeddedDocuments[3].ContentType == "application/rtf");
             Assert.True(document.EmbeddedDocuments[4].ContentType == "application/rtf");
 
-            var list1 = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            var list1 = document._document!.MainDocumentPart!.AlternativeFormatImportParts;
             Assert.True(list1.Count() == 5);
 
             // lets delete last 3 embedded documents 
@@ -135,7 +135,7 @@ public partial class Word {
             Assert.True(document.Sections[0].EmbeddedDocuments.Count == 2);
             Assert.True(document.Sections[1].EmbeddedDocuments.Count == 0);
 
-            var list2 = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            var list2 = document._document!.MainDocumentPart!.AlternativeFormatImportParts;
             Assert.True(list2.Count() == 2);
 
 
@@ -218,8 +218,8 @@ public partial class Word {
             document.AddEmbeddedDocument(rtfFilePath);
             document.AddEmbeddedDocument(rtfFilePath);
 
-            var ids = document._wordprocessingDocument.MainDocumentPart.AlternativeFormatImportParts
-                .Select(p => document._wordprocessingDocument.MainDocumentPart.GetIdOfPart(p))
+            var ids = document._wordprocessingDocument!.MainDocumentPart!.AlternativeFormatImportParts
+                .Select(p => document._wordprocessingDocument!.MainDocumentPart!.GetIdOfPart(p))
                 .ToList();
 
             Assert.Equal(ids.Count, ids.Distinct().Count());
@@ -228,8 +228,8 @@ public partial class Word {
         }
 
         using (var document = WordDocument.Load(filePath)) {
-            var ids = document._wordprocessingDocument.MainDocumentPart.AlternativeFormatImportParts
-                .Select(p => document._wordprocessingDocument.MainDocumentPart.GetIdOfPart(p))
+            var ids = document._wordprocessingDocument!.MainDocumentPart!.AlternativeFormatImportParts
+                .Select(p => document._wordprocessingDocument!.MainDocumentPart!.GetIdOfPart(p))
                 .ToList();
 
             Assert.Equal(ids.Count, ids.Distinct().Count());
@@ -267,7 +267,7 @@ public partial class Word {
 
             Assert.True(document.EmbeddedDocuments.Count == 2);
 
-            var listBefore = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            var listBefore = document._document!.MainDocumentPart!.AlternativeFormatImportParts;
             Assert.True(listBefore.Count() == 2);
 
             document.EmbeddedDocuments[0].Remove();
@@ -275,7 +275,7 @@ public partial class Word {
             Assert.True(document.EmbeddedDocuments.Count == 1);
             Assert.True(document.EmbeddedDocuments[0].ContentType == "text/html");
 
-            var listAfter = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            var listAfter = document._document!.MainDocumentPart!.AlternativeFormatImportParts;
             Assert.True(listAfter.Count() == 1);
 
             document.Save(false);
@@ -285,7 +285,7 @@ public partial class Word {
             Assert.True(document.EmbeddedDocuments.Count == 1);
             Assert.True(document.EmbeddedDocuments[0].ContentType == "text/html");
 
-            var listAfter = document._document.MainDocumentPart.AlternativeFormatImportParts;
+            var listAfter = document._document!.MainDocumentPart!.AlternativeFormatImportParts;
             Assert.True(listAfter.Count() == 1);
         }
     }

--- a/OfficeIMO.Tests/Word.Fields.cs
+++ b/OfficeIMO.Tests/Word.Fields.cs
@@ -26,17 +26,17 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Sections[1].Fields.Count == 0);
                 Assert.True(document.Sections[1].HyperLinks.Count == 0);
 
-                Assert.True(document.ParagraphsHyperLinks[0].Hyperlink.IsEmail == false);
-                Assert.True(document.ParagraphsHyperLinks[1].Hyperlink.IsEmail == true);
-                Assert.True(document.ParagraphsHyperLinks[1].Hyperlink.EmailAddress == "przemyslaw.klys@test.pl");
+                Assert.True(document.ParagraphsHyperLinks[0].Hyperlink!.IsEmail == false);
+                Assert.True(document.ParagraphsHyperLinks[1].Hyperlink!.IsEmail == true);
+                Assert.True(document.ParagraphsHyperLinks[1].Hyperlink!.EmailAddress == "przemyslaw.klys@test.pl");
 
-                Assert.True(document.Sections[0].ParagraphsFields[0].Field.Text == "Przemysław Kłys");
-                Assert.True(document.Sections[0].ParagraphsFields[1].Field.Text == "FieldsAndSections.docx");
-                Assert.True(document.Sections[0].ParagraphsFields[2].Field.Text == "1");
+                Assert.True(document.Sections[0].ParagraphsFields[0].Field!.Text == "Przemysław Kłys");
+                Assert.True(document.Sections[0].ParagraphsFields[1].Field!.Text == "FieldsAndSections.docx");
+                Assert.True(document.Sections[0].ParagraphsFields[2].Field!.Text == "1");
 
-                Assert.True(document.Sections[0].ParagraphsFields[0].Field.Field == @" AUTHOR  \* Caps  \* MERGEFORMAT ");
-                Assert.True(document.Sections[0].ParagraphsFields[1].Field.Field == @" FILENAME   \* MERGEFORMAT ");
-                Assert.True(document.Sections[0].ParagraphsFields[2].Field.Field == @" PAGE  \* Arabic  \* MERGEFORMAT ");
+                Assert.True(document.Sections[0].ParagraphsFields[0].Field!.Field == @" AUTHOR  \* Caps  \* MERGEFORMAT ");
+                Assert.True(document.Sections[0].ParagraphsFields[1].Field!.Field == @" FILENAME   \* MERGEFORMAT ");
+                Assert.True(document.Sections[0].ParagraphsFields[2].Field!.Field == @" PAGE  \* Arabic  \* MERGEFORMAT ");
 
 
                 Assert.Equal(new[] { WordFieldFormat.Caps, WordFieldFormat.Mergeformat }, document.Fields[0].FieldFormat);
@@ -97,17 +97,17 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Sections[1].Fields.Count == 0);
                 Assert.True(document.Sections[1].HyperLinks.Count == 0);
 
-                Assert.True(document.ParagraphsHyperLinks[0].Hyperlink.IsEmail == false);
-                Assert.True(document.ParagraphsHyperLinks[1].Hyperlink.IsEmail == true);
-                Assert.True(document.ParagraphsHyperLinks[1].Hyperlink.EmailAddress == "przemyslaw.klys@test.pl");
+                Assert.True(document.ParagraphsHyperLinks[0].Hyperlink!.IsEmail == false);
+                Assert.True(document.ParagraphsHyperLinks[1].Hyperlink!.IsEmail == true);
+                Assert.True(document.ParagraphsHyperLinks[1].Hyperlink!.EmailAddress == "przemyslaw.klys@test.pl");
 
-                Assert.True(document.Sections[0].ParagraphsFields[0].Field.Text == "Przemysław Kłys");
-                Assert.True(document.Sections[0].ParagraphsFields[1].Field.Text == "FieldsAndSections.docx");
-                Assert.True(document.Sections[0].ParagraphsFields[2].Field.Text == "1");
+                Assert.True(document.Sections[0].ParagraphsFields[0].Field!.Text == "Przemysław Kłys");
+                Assert.True(document.Sections[0].ParagraphsFields[1].Field!.Text == "FieldsAndSections.docx");
+                Assert.True(document.Sections[0].ParagraphsFields[2].Field!.Text == "1");
 
-                Assert.True(document.Sections[0].ParagraphsFields[0].Field.Field == @" AUTHOR  \* Caps  \* MERGEFORMAT ");
-                Assert.True(document.Sections[0].ParagraphsFields[1].Field.Field == @" FILENAME   \* MERGEFORMAT ");
-                Assert.True(document.Sections[0].ParagraphsFields[2].Field.Field == @" PAGE  \* Arabic  \* MERGEFORMAT ");
+                Assert.True(document.Sections[0].ParagraphsFields[0].Field!.Field == @" AUTHOR  \* Caps  \* MERGEFORMAT ");
+                Assert.True(document.Sections[0].ParagraphsFields[1].Field!.Field == @" FILENAME   \* MERGEFORMAT ");
+                Assert.True(document.Sections[0].ParagraphsFields[2].Field!.Field == @" PAGE  \* Arabic  \* MERGEFORMAT ");
 
                 document.Fields[0].UpdateField = true;
                 document.Fields[1].UpdateField = true;
@@ -170,14 +170,16 @@ namespace OfficeIMO.Tests {
                 var fieldTypes = (WordFieldType[])Enum.GetValues(typeof(WordFieldType));
                 foreach (var fieldType in fieldTypes) {
                     var paragraph = document.AddParagraph("field Type " + fieldType.ToString() + ": ").AddField(fieldType);
-                    Assert.True(paragraph.Field.FieldType == fieldType, "FieldType matches");
+                    Assert.NotNull(paragraph.Field);
+                    Assert.True(paragraph.Field!.FieldType == fieldType, "FieldType matches");
                 }
 
                 Assert.True(document.Paragraphs.Count == 6 + fieldTypes.Length * 2);
 
                 foreach (var fieldType in fieldTypes) {
                     var paragraph = document.AddParagraph("field Type " + fieldType.ToString() + ": ").AddField(fieldType, null, advanced: true);
-                    Assert.True(paragraph.Field.FieldType == fieldType, "FieldType matches");
+                    Assert.NotNull(paragraph.Field);
+                    Assert.True(paragraph.Field!.FieldType == fieldType, "FieldType matches");
                 }
 
                 Assert.True(document.Paragraphs.Count == 6 + fieldTypes.Length * 4);
@@ -191,8 +193,9 @@ namespace OfficeIMO.Tests {
                 foreach (var fieldType in fieldTypes) {
                     foreach (var fieldTypeFormat in fieldTypesFormats) {
                         var paragraph = document.AddParagraph("field Type " + fieldType.ToString() + ": ").AddField(fieldType, fieldTypeFormat);
-                        Assert.True(paragraph.Field.FieldType == fieldType, "FieldType matches");
-                        Assert.Contains(fieldTypeFormat, paragraph.Field.FieldFormat);
+                        Assert.NotNull(paragraph.Field);
+                        Assert.True(paragraph.Field!.FieldType == fieldType, "FieldType matches");
+                        Assert.Contains(fieldTypeFormat, paragraph.Field!.FieldFormat);
                     }
                 }
 
@@ -298,7 +301,8 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "CustomFormattedField.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var paragraph = document.AddParagraph("Time: ").AddField(WordFieldType.Time, customFormat: "dd/MM/yyyy HH:mm");
-                Assert.Equal(" TIME  \\@ \"dd/MM/yyyy HH:mm\" \\* MERGEFORMAT ", paragraph.Field.Field);
+                Assert.NotNull(paragraph.Field);
+                Assert.Equal(" TIME  \\@ \"dd/MM/yyyy HH:mm\" \\* MERGEFORMAT ", paragraph.Field!.Field);
                 document.Save(false);
             }
 


### PR DESCRIPTION
## Summary
- guard chart axis and properties against nulls in `Word.Charts` tests
- ensure checkbox lookups are non-null before assertions
- add paragraph null checks for cleanup and content control tests
- assert underlying document parts exist when handling embedded documents
- treat hyperlink and field references as non-null in field tests

## Testing
- `dotnet build --no-restore -v minimal`
- `dotnet test --no-build --no-restore OfficeIMO.Tests/OfficeIMO.Tests.csproj` *(failed: terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9b8efc28832ebd5be88a62c48c66