### PR TITLE
Add null checks for list conversion and style tests

### DIFF
--- a/OfficeIMO.Tests/Word.ListConversion.cs
+++ b/OfficeIMO.Tests/Word.ListConversion.cs
@@ -22,9 +22,12 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = WordDocument.Load(filePath)) {
+                var paragraph = document.Paragraphs.FirstOrDefault();
+                Assert.NotNull(paragraph);
                 var list = document.Lists.First();
                 Assert.Equal(new[] { "One", "Two" }, list.ListItems.Select(i => i.Text).ToArray());
-                Assert.Equal(NumberFormatValues.Decimal, list.Numbering.Levels.First()._level.NumberingFormat.Val.Value);
+                Assert.NotNull(list.Numbering);
+                Assert.Equal(NumberFormatValues.Decimal, list.Numbering!.Levels.First()._level.NumberingFormat.Val.Value);
                 Assert.Equal(indent, list.Numbering.Levels.First().IndentationLeft);
             }
         }
@@ -45,9 +48,12 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = WordDocument.Load(filePath)) {
+                var paragraph = document.Paragraphs.FirstOrDefault();
+                Assert.NotNull(paragraph);
                 var list = document.Lists.First();
                 Assert.Equal(new[] { "One", "Two" }, list.ListItems.Select(i => i.Text).ToArray());
-                Assert.Equal(NumberFormatValues.Bullet, list.Numbering.Levels.First()._level.NumberingFormat.Val.Value);
+                Assert.NotNull(list.Numbering);
+                Assert.Equal(NumberFormatValues.Bullet, list.Numbering!.Levels.First()._level.NumberingFormat.Val.Value);
                 Assert.Equal(indent, list.Numbering.Levels.First().IndentationLeft);
             }
         }

--- a/OfficeIMO.Tests/Word.ParagraphCustomStyles.cs
+++ b/OfficeIMO.Tests/Word.ParagraphCustomStyles.cs
@@ -35,12 +35,15 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void Test_OverrideBuiltInParagraphStyle() {
             var original = WordParagraphStyle.GetStyleDefinition(WordParagraphStyles.Normal);
+            Assert.NotNull(original);
             var custom = new Style { Type = StyleValues.Paragraph, StyleId = "Normal" };
             WordParagraphStyle.OverrideBuiltInStyle(WordParagraphStyles.Normal, custom);
 
-            Assert.Equal(custom, WordParagraphStyle.GetStyleDefinition(WordParagraphStyles.Normal));
+            var retrieved = WordParagraphStyle.GetStyleDefinition(WordParagraphStyles.Normal);
+            Assert.NotNull(retrieved);
+            Assert.Equal(custom, retrieved);
 
-            WordParagraphStyle.OverrideBuiltInStyle(WordParagraphStyles.Normal, original);
+            WordParagraphStyle.OverrideBuiltInStyle(WordParagraphStyles.Normal, original!);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- ensure list conversion tests verify paragraph retrieval and numbering presence
- validate style definitions before overriding built-in paragraph styles

## Testing
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68aa9f120f88832eba48caeccd1de58f