### PR TITLE
Fix Excel used range header mapping

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.EnsureOrder.cs
+++ b/OfficeIMO.Excel/ExcelSheet.EnsureOrder.cs
@@ -91,6 +91,9 @@ namespace OfficeIMO.Excel
                 foreach (var element in kv.Value)
                     worksheet.AppendChild(element);
             }
+
+            // Persist any structural changes
+            worksheet.Save();
         }
     }
 }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
@@ -170,7 +170,7 @@ namespace OfficeIMO.Excel.Read
 
                 foreach (var cell in row.Elements<Cell>())
                 {
-                    var (cIndex, _) = A1.ParseCellRef(cell.CellReference?.Value ?? string.Empty);
+                    var (_, cIndex) = A1.ParseCellRef(cell.CellReference?.Value ?? string.Empty);
                     if (cIndex < c1 || cIndex > c2) continue;
 
                     var raw = new CellRaw


### PR DESCRIPTION
## Summary
- ensure column indices are parsed correctly when reading used ranges
- save worksheet parts when reordering to persist changes

## Testing
- `dotnet test OfficeImo.sln --configuration Release --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68aaa9da50f4832e83ef0f7955f1d910