### PR TITLE
Fix nullable and documentation warnings

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -120,7 +120,7 @@ namespace OfficeIMO.PowerPoint {
             if (_presentationPart.Presentation.SlideIdList != null) {
                 foreach (SlideId existingSlideId in _presentationPart.Presentation.SlideIdList.Elements<SlideId>()) {
                     if (!string.IsNullOrEmpty(existingSlideId.RelationshipId)) {
-                        existingRelationships.Add(existingSlideId.RelationshipId);
+                        existingRelationships.Add(existingSlideId.RelationshipId!);
                     }
                 }
             }
@@ -238,7 +238,7 @@ namespace OfficeIMO.PowerPoint {
             slideId.Remove();
 
             if (!string.IsNullOrEmpty(relId)) {
-                OpenXmlPart part = _presentationPart.GetPartById(relId);
+                OpenXmlPart part = _presentationPart.GetPartById(relId!);
                 _presentationPart.DeletePart(part);
             }
 

--- a/OfficeIMO.PowerPoint/PowerPointTextBox.cs
+++ b/OfficeIMO.PowerPoint/PowerPointTextBox.cs
@@ -35,7 +35,7 @@ namespace OfficeIMO.PowerPoint {
         public bool Bold {
             get {
                 A.Run? run = Runs.FirstOrDefault();
-                return run?.RunProperties?.Bold == true;
+                return run?.RunProperties?.Bold?.Value ?? false;
             }
             set {
                 foreach (A.Run run in Runs) {
@@ -51,7 +51,7 @@ namespace OfficeIMO.PowerPoint {
         public bool Italic {
             get {
                 A.Run? run = Runs.FirstOrDefault();
-                return run?.RunProperties?.Italic == true;
+                return run?.RunProperties?.Italic?.Value ?? false;
             }
             set {
                 foreach (A.Run run in Runs) {

--- a/OfficeIMO.Visio/Fluent/VisioFluentDocument.cs
+++ b/OfficeIMO.Visio/Fluent/VisioFluentDocument.cs
@@ -39,12 +39,24 @@ namespace OfficeIMO.Visio.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Adds a page using default measurement unit.
+        /// </summary>
+        /// <param name="name">Name of the page.</param>
+        /// <param name="width">Page width.</param>
+        /// <param name="height">Page height.</param>
+        /// <param name="page">The created page.</param>
         [System.Obsolete("Use AddPage with width, height and unit parameters")]
         public VisioFluentDocument AddPage(string name, double width, double height, out VisioPage page) {
             page = _document.AddPage(name, width, height);
             return this;
         }
 
+        /// <summary>
+        /// Adds a page with default size.
+        /// </summary>
+        /// <param name="name">Name of the page.</param>
+        /// <param name="page">The created page.</param>
         [System.Obsolete("Use AddPage with width, height and unit parameters")]
         public VisioFluentDocument AddPage(string name, out VisioPage page) {
             page = _document.AddPage(name);

--- a/OfficeIMO.Visio/VisioConnectionPoint.cs
+++ b/OfficeIMO.Visio/VisioConnectionPoint.cs
@@ -3,6 +3,13 @@ namespace OfficeIMO.Visio {
     /// Represents a connection point on a Visio shape.
     /// </summary>
     public class VisioConnectionPoint {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisioConnectionPoint"/> class.
+        /// </summary>
+        /// <param name="x">X coordinate relative to the shape.</param>
+        /// <param name="y">Y coordinate relative to the shape.</param>
+        /// <param name="dirX">Directional X component.</param>
+        /// <param name="dirY">Directional Y component.</param>
         public VisioConnectionPoint(double x, double y, double dirX, double dirY) {
             X = x;
             Y = y;

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -417,7 +417,7 @@ namespace OfficeIMO.Visio {
                     XElement? valueCell = row.Elements(ns + "Cell").FirstOrDefault(c => c.Attribute("N")?.Value == "Value");
                     string? value = valueCell?.Attribute("V")?.Value;
                     if (!string.IsNullOrEmpty(key) && value != null) {
-                        shape.Data[key] = value;
+                        shape.Data[key!] = value;
                     }
                 }
             }
@@ -489,20 +489,21 @@ namespace OfficeIMO.Visio {
         }
 
         /// <summary>
-        /// Saves the document to a <c>.vsdx</c> package.
+        /// Saves the document to the file previously specified when opening or saving.
         /// </summary>
+        public void Save() {
+            string filePath = _filePath ?? throw new InvalidOperationException("File path is not set.");
+            SaveInternal(filePath);
+        }
+
         /// <summary>
         /// Saves the document to a file.
         /// </summary>
-        /// <param name="filePath">Path to save the file.</param>
-        public void Save() {
-            if (string.IsNullOrEmpty(_filePath)) {
-                throw new InvalidOperationException("File path is not set.");
-            }
-            SaveInternal(_filePath);
-        }
-
+        /// <param name="filePath">Path where the file should be saved.</param>
         public void Save(string filePath) {
+            if (filePath == null) {
+                throw new ArgumentNullException(nameof(filePath));
+            }
             _filePath = filePath;
             SaveInternal(filePath);
         }

--- a/OfficeIMO.Visio/VisioMaster.cs
+++ b/OfficeIMO.Visio/VisioMaster.cs
@@ -3,16 +3,31 @@ namespace OfficeIMO.Visio {
     /// Represents a Visio master.
     /// </summary>
     public class VisioMaster {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisioMaster"/> class.
+        /// </summary>
+        /// <param name="id">Identifier of the master.</param>
+        /// <param name="nameU">Universal name of the master.</param>
+        /// <param name="shape">The shape associated with the master.</param>
         public VisioMaster(string id, string nameU, VisioShape shape) {
             Id = id;
             NameU = nameU;
             Shape = shape;
         }
 
+        /// <summary>
+        /// Identifier of the master.
+        /// </summary>
         public string Id { get; }
 
+        /// <summary>
+        /// Universal name of the master.
+        /// </summary>
         public string NameU { get; }
 
+        /// <summary>
+        /// Shape that defines the master.
+        /// </summary>
         public VisioShape Shape { get; }
     }
 }

--- a/OfficeIMO.Visio/VisioShape.cs
+++ b/OfficeIMO.Visio/VisioShape.cs
@@ -44,16 +44,34 @@ namespace OfficeIMO.Visio {
 
         public double Width { get; set; }
 
+        /// <summary>
+        /// Height of the shape.
+        /// </summary>
         public double Height { get; set; }
 
+        /// <summary>
+        /// Thickness of the shape's outline.
+        /// </summary>
         public double LineWeight { get; set; }
 
+        /// <summary>
+        /// Local X coordinate of the pin (anchor) point.
+        /// </summary>
         public double LocPinX { get; set; }
 
+        /// <summary>
+        /// Local Y coordinate of the pin (anchor) point.
+        /// </summary>
         public double LocPinY { get; set; }
 
+        /// <summary>
+        /// Rotation angle in radians.
+        /// </summary>
         public double Angle { get; set; }
 
+        /// <summary>
+        /// Text displayed by the shape.
+        /// </summary>
         public string? Text { get; set; }
         
         /// <summary>
@@ -76,8 +94,14 @@ namespace OfficeIMO.Visio {
         /// </summary>
         public int FillPattern { get; set; }
 
+        /// <summary>
+        /// Connection points associated with the shape.
+        /// </summary>
         public IList<VisioConnectionPoint> ConnectionPoints { get; } = new List<VisioConnectionPoint>();
 
+        /// <summary>
+        /// Custom data stored on the shape.
+        /// </summary>
         public Dictionary<string, string> Data { get; } = new();
 
         /// <summary>

--- a/OfficeIMO.Visio/VisioTheme.cs
+++ b/OfficeIMO.Visio/VisioTheme.cs
@@ -3,6 +3,9 @@ namespace OfficeIMO.Visio {
     /// Represents a Visio theme.
     /// </summary>
     public class VisioTheme {
+        /// <summary>
+        /// Name of the theme.
+        /// </summary>
         public string? Name { get; set; }
     }
 }

--- a/OfficeIMO.Visio/VisioValidator.cs
+++ b/OfficeIMO.Visio/VisioValidator.cs
@@ -7,6 +7,9 @@ using System.Linq;
 using System.Xml.Linq;
 
 namespace OfficeIMO.Visio {
+    /// <summary>
+    /// Validates the structure of Visio <c>.vsdx</c> packages.
+    /// </summary>
     public static class VisioValidator {
         private static readonly XNamespace ct = "http://schemas.openxmlformats.org/package/2006/content-types";
         private static readonly XNamespace rel = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
@@ -21,6 +24,10 @@ namespace OfficeIMO.Visio {
         private const string CT_Pages = "application/vnd.ms-visio.pages+xml";
         private const string CT_Page = "application/vnd.ms-visio.page+xml";
 
+        /// <summary>
+        /// Validates the specified Visio file and returns a list of issues.
+        /// </summary>
+        /// <param name="vsdxPath">Path to the <c>.vsdx</c> file.</param>
         public static IReadOnlyList<string> Validate(string vsdxPath) {
             List<string> issues = new();
             using Package pkg = Package.Open(vsdxPath, FileMode.Open, FileAccess.Read, FileShare.Read);

--- a/OfficeIMO.Visio/VsdxPackageValidator.cs
+++ b/OfficeIMO.Visio/VsdxPackageValidator.cs
@@ -8,6 +8,9 @@ using System.Xml;
 using System.Xml.Linq;
 
 namespace OfficeIMO.Visio {
+    /// <summary>
+    /// Validates and optionally fixes Visio <c>.vsdx</c> packages.
+    /// </summary>
     public class VsdxPackageValidator {
         private static readonly XNamespace nsCore = "http://schemas.microsoft.com/office/visio/2011/1/core";
         private static readonly XNamespace nsPkgRel = "http://schemas.openxmlformats.org/package/2006/relationships";
@@ -27,10 +30,25 @@ namespace OfficeIMO.Visio {
         private readonly List<string> _warnings = new();
         private readonly List<string> _fixes = new();
 
+        /// <summary>
+        /// List of validation errors.
+        /// </summary>
         public IReadOnlyList<string> Errors => _errors.AsReadOnly();
+
+        /// <summary>
+        /// List of validation warnings.
+        /// </summary>
         public IReadOnlyList<string> Warnings => _warnings.AsReadOnly();
+
+        /// <summary>
+        /// List of fixes applied when repairing a package.
+        /// </summary>
         public IReadOnlyList<string> Fixes => _fixes.AsReadOnly();
 
+        /// <summary>
+        /// Validates the specified <c>.vsdx</c> file.
+        /// </summary>
+        /// <param name="inputPath">Path to the file to validate.</param>
         public bool ValidateFile(string inputPath) {
             _errors.Clear();
             _warnings.Clear();
@@ -50,6 +68,11 @@ namespace OfficeIMO.Visio {
             }
         }
 
+        /// <summary>
+        /// Validates and fixes the specified file, writing the result to <paramref name="outputPath"/>.
+        /// </summary>
+        /// <param name="inputPath">Path to the file to fix.</param>
+        /// <param name="outputPath">Path to save the fixed file.</param>
         public bool FixFile(string inputPath, string outputPath) {
             _errors.Clear();
             _warnings.Clear();


### PR DESCRIPTION
## Summary
- add XML comments for Visio API surface
- guard against nullable values in VisioDocument save logic
- ensure PowerPoint text formatting checks handle nullable runs
- verify slide operations handle nullable relationship IDs

## Testing
- `dotnet build -warnaserror /nologo`

------
https://chatgpt.com/codex/tasks/task_e_68ab3354adb0832e835ddd1c680af5d2