### PR TITLE
Fix nullability warnings and add missing XML docs

### DIFF
--- a/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
+++ b/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
@@ -45,6 +45,9 @@ namespace OfficeIMO.PowerPoint.Fluent {
             return Slide(0, 0, configure);
         }
 
+        /// <summary>
+        /// Ends fluent configuration and returns the underlying presentation.
+        /// </summary>
         public PowerPointPresentation End() {
             return Presentation;
         }

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -114,13 +114,15 @@ namespace OfficeIMO.PowerPoint {
                     .Union(_presentationPart.ExternalRelationships.Select(r => r.Id))
                     .Union(_presentationPart.HyperlinkRelationships.Select(r => r.Id))
                     .Where(id => !string.IsNullOrEmpty(id))
+                    .Select(id => id!)
             );
             
             // Also check the slide IDs
             if (_presentationPart.Presentation.SlideIdList != null) {
                 foreach (SlideId existingSlideId in _presentationPart.Presentation.SlideIdList.Elements<SlideId>()) {
-                    if (!string.IsNullOrEmpty(existingSlideId.RelationshipId)) {
-                        existingRelationships.Add(existingSlideId.RelationshipId);
+                    string? relId = existingSlideId.RelationshipId;
+                    if (relId != null && relId.Length > 0) {
+                        existingRelationships.Add(relId);
                     }
                 }
             }
@@ -237,7 +239,7 @@ namespace OfficeIMO.PowerPoint {
             _slides.RemoveAt(index);
             slideId.Remove();
 
-            if (!string.IsNullOrEmpty(relId)) {
+            if (relId != null && relId.Length > 0) {
                 OpenXmlPart part = _presentationPart.GetPartById(relId);
                 _presentationPart.DeletePart(part);
             }

--- a/OfficeIMO.PowerPoint/PowerPointTextBox.cs
+++ b/OfficeIMO.PowerPoint/PowerPointTextBox.cs
@@ -35,7 +35,7 @@ namespace OfficeIMO.PowerPoint {
         public bool Bold {
             get {
                 A.Run? run = Runs.FirstOrDefault();
-                return run?.RunProperties?.Bold == true;
+                return run?.RunProperties?.Bold?.Value ?? false;
             }
             set {
                 foreach (A.Run run in Runs) {
@@ -51,7 +51,7 @@ namespace OfficeIMO.PowerPoint {
         public bool Italic {
             get {
                 A.Run? run = Runs.FirstOrDefault();
-                return run?.RunProperties?.Italic == true;
+                return run?.RunProperties?.Italic?.Value ?? false;
             }
             set {
                 foreach (A.Run run in Runs) {

--- a/OfficeIMO.Visio/Fluent/VisioFluentDocument.cs
+++ b/OfficeIMO.Visio/Fluent/VisioFluentDocument.cs
@@ -39,12 +39,26 @@ namespace OfficeIMO.Visio.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Adds a page with the specified width and height.
+        /// </summary>
+        /// <param name="name">Name of the page.</param>
+        /// <param name="width">Page width.</param>
+        /// <param name="height">Page height.</param>
+        /// <param name="page">The created page.</param>
+        /// <remarks>This overload is obsolete. Use <see cref="AddPage(string,double,double,VisioMeasurementUnit,out VisioPage)"/> instead.</remarks>
         [System.Obsolete("Use AddPage with width, height and unit parameters")]
         public VisioFluentDocument AddPage(string name, double width, double height, out VisioPage page) {
             page = _document.AddPage(name, width, height);
             return this;
         }
 
+        /// <summary>
+        /// Adds a page with default dimensions.
+        /// </summary>
+        /// <param name="name">Name of the page.</param>
+        /// <param name="page">The created page.</param>
+        /// <remarks>This overload is obsolete. Use <see cref="AddPage(string,double,double,VisioMeasurementUnit,out VisioPage)"/> instead.</remarks>
         [System.Obsolete("Use AddPage with width, height and unit parameters")]
         public VisioFluentDocument AddPage(string name, out VisioPage page) {
             page = _document.AddPage(name);

--- a/OfficeIMO.Visio/VisioConnectionPoint.cs
+++ b/OfficeIMO.Visio/VisioConnectionPoint.cs
@@ -3,6 +3,13 @@ namespace OfficeIMO.Visio {
     /// Represents a connection point on a Visio shape.
     /// </summary>
     public class VisioConnectionPoint {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisioConnectionPoint"/> class.
+        /// </summary>
+        /// <param name="x">X coordinate relative to the shape.</param>
+        /// <param name="y">Y coordinate relative to the shape.</param>
+        /// <param name="dirX">Directional X component.</param>
+        /// <param name="dirY">Directional Y component.</param>
         public VisioConnectionPoint(double x, double y, double dirX, double dirY) {
             X = x;
             Y = y;

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -124,7 +124,7 @@ namespace OfficeIMO.Visio {
                     string masterId = masterElement.Attribute("ID")?.Value ?? string.Empty;
                     string masterNameU = masterElement.Attribute("NameU")?.Value ?? string.Empty;
                     string? mRelId = masterElement.Element(ns + "Rel")?.Attribute(rNs + "id")?.Value;
-                    if (string.IsNullOrEmpty(mRelId)) {
+                    if (mRelId == null || mRelId.Length == 0) {
                         continue;
                     }
 
@@ -151,7 +151,7 @@ namespace OfficeIMO.Visio {
                 page.ViewCenterY = ParseDouble(pageRef.Attribute("ViewCenterY")?.Value);
 
                 string? relId = pageRef.Element(ns + "Rel")?.Attribute(rNs + "id")?.Value;
-                if (string.IsNullOrEmpty(relId)) {
+                if (relId == null || relId.Length == 0) {
                     continue;
                 }
 
@@ -172,7 +172,7 @@ namespace OfficeIMO.Visio {
 
                     VisioShape shape = ParseShape(shapeElement, ns);
                     string? masterIdAttr = shapeElement.Attribute("Master")?.Value;
-                    if (!string.IsNullOrEmpty(masterIdAttr) && masters.TryGetValue(masterIdAttr, out VisioMaster master)) {
+                    if (masterIdAttr != null && masters.TryGetValue(masterIdAttr, out VisioMaster master)) {
                         shape.Master = master;
                         if (shape.Width == 0 || shape.Height == 0) {
                             VisioShape masterShape = shape.Master.Shape;
@@ -416,7 +416,7 @@ namespace OfficeIMO.Visio {
                     string? key = row.Attribute("N")?.Value;
                     XElement? valueCell = row.Elements(ns + "Cell").FirstOrDefault(c => c.Attribute("N")?.Value == "Value");
                     string? value = valueCell?.Attribute("V")?.Value;
-                    if (!string.IsNullOrEmpty(key) && value != null) {
+                    if (key != null && key.Length > 0 && value != null) {
                         shape.Data[key] = value;
                     }
                 }
@@ -489,19 +489,20 @@ namespace OfficeIMO.Visio {
         }
 
         /// <summary>
-        /// Saves the document to a <c>.vsdx</c> package.
+        /// Saves the document to the originally specified file path.
         /// </summary>
-        /// <summary>
-        /// Saves the document to a file.
-        /// </summary>
-        /// <param name="filePath">Path to save the file.</param>
         public void Save() {
-            if (string.IsNullOrEmpty(_filePath)) {
+            string path = _filePath ?? throw new InvalidOperationException("File path is not set.");
+            if (path.Length == 0) {
                 throw new InvalidOperationException("File path is not set.");
             }
-            SaveInternal(_filePath);
+            SaveInternal(path);
         }
 
+        /// <summary>
+        /// Saves the document to the specified file path.
+        /// </summary>
+        /// <param name="filePath">Path to save the file.</param>
         public void Save(string filePath) {
             _filePath = filePath;
             SaveInternal(filePath);

--- a/OfficeIMO.Visio/VisioMaster.cs
+++ b/OfficeIMO.Visio/VisioMaster.cs
@@ -3,16 +3,31 @@ namespace OfficeIMO.Visio {
     /// Represents a Visio master.
     /// </summary>
     public class VisioMaster {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisioMaster"/> class.
+        /// </summary>
+        /// <param name="id">Master identifier.</param>
+        /// <param name="nameU">Universal master name.</param>
+        /// <param name="shape">Shape defining the master.</param>
         public VisioMaster(string id, string nameU, VisioShape shape) {
             Id = id;
             NameU = nameU;
             Shape = shape;
         }
 
+        /// <summary>
+        /// Gets the master identifier.
+        /// </summary>
         public string Id { get; }
 
+        /// <summary>
+        /// Gets the universal master name.
+        /// </summary>
         public string NameU { get; }
 
+        /// <summary>
+        /// Gets the shape associated with the master.
+        /// </summary>
         public VisioShape Shape { get; }
     }
 }

--- a/OfficeIMO.Visio/VisioPage.cs
+++ b/OfficeIMO.Visio/VisioPage.cs
@@ -12,9 +12,19 @@ namespace OfficeIMO.Visio {
         private bool _gridVisible;
         private bool _snap = true;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisioPage"/> class with default A4 dimensions.
+        /// </summary>
+        /// <param name="name">Page name.</param>
         public VisioPage(string name) : this(name, 8.26771653543307, 11.69291338582677) {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisioPage"/> class with specified dimensions in inches.
+        /// </summary>
+        /// <param name="name">Page name.</param>
+        /// <param name="widthInches">Page width in inches.</param>
+        /// <param name="heightInches">Page height in inches.</param>
         public VisioPage(string name, double widthInches, double heightInches) {
             Name = name;
             NameU = name;

--- a/OfficeIMO.Visio/VisioValidator.cs
+++ b/OfficeIMO.Visio/VisioValidator.cs
@@ -76,9 +76,13 @@ namespace OfficeIMO.Visio {
                 }
 
                 XElement? relChild = page.Element(v + "Rel");
-                string? rid = (string?)relChild?.Attribute(rel + "id");
-                if (relChild == null || string.IsNullOrWhiteSpace(rid) || !rid.StartsWith("rId")) {
+                if (relChild == null) {
                     issues.Add("Page must contain <Rel r:id=\"rId#\"> child (not an attribute).");
+                } else {
+                    string? rid = (string?)relChild.Attribute(rel + "id");
+                    if (string.IsNullOrWhiteSpace(rid) || !rid.StartsWith("rId", StringComparison.Ordinal)) {
+                        issues.Add("Page must contain <Rel r:id=\"rId#\"> child (not an attribute).");
+                    }
                 }
             }
 

--- a/OfficeIMO.Visio/VsdxPackageValidator.cs
+++ b/OfficeIMO.Visio/VsdxPackageValidator.cs
@@ -429,7 +429,7 @@ namespace OfficeIMO.Visio {
                    id == 0;
         }
 
-        private XDocument LoadXml(string path) {
+        private XDocument? LoadXml(string path) {
             try {
                 return XDocument.Load(path, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
             } catch {


### PR DESCRIPTION
## Summary
- add explicit null checks in VisioDocument and related validators
- improve PowerPoint null safety
- document public Visio and PowerPoint APIs

## Testing
- `dotnet build OfficeIMO.Visio/OfficeIMO.Visio.csproj -v minimal`
- `dotnet build OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68ab3331a850832e9cc4ac5b72710dc5