### PR TITLE
fix: ensure watermark color uses hex

### DIFF
--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Sample4.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Sample4.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Watermark {
+        /// <summary>
+        /// Demonstrates how to apply a watermark using a hex color value.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the file.</param>
+        /// <param name="openWord">Whether to open the document after creation.</param>
+        public static void Watermark_Sample4(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with Watermark hex color");
+            string filePath = Path.Combine(folderPath, "Basic Document with Watermark Hex Color.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Section 0");
+                document.AddHeadersAndFooters();
+                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "HexColor");
+                watermark.ColorHex = "00ff00";
+                document.Save(openWord);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Sample5.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Sample5.cs
@@ -1,0 +1,52 @@
+using OfficeIMO.Word;
+using SixLabors.ImageSharp;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Watermark {
+        /// <summary>
+        /// Demonstrates applying watermarks with SixLabors colors and hex values across multiple sections.
+        /// </summary>
+        /// <param name="folderPath">Destination folder for the file.</param>
+        /// <param name="openWord">Whether to open the document after creation.</param>
+        public static void Watermark_Sample5(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with mixed watermark color inputs");
+            string filePath = Path.Combine(folderPath, "Watermark Multiple Colors.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                // Section 0 - SixLabors Color.Red
+                document.Sections[0].SetMargins(WordMargin.Normal);
+                var watermark = document.Sections[0].AddWatermark(WordWatermarkStyle.Text, "Red");
+                watermark.Color = Color.Red;
+                Console.WriteLine($"Section 0 hex: {watermark.ColorHex}");
+
+                // Section 1 - SixLabors Color.Green
+                document.AddSection();
+                document.Sections[1].SetMargins(WordMargin.Normal);
+                watermark = document.Sections[1].AddWatermark(WordWatermarkStyle.Text, "Green");
+                watermark.Color = Color.Green;
+                Console.WriteLine($"Section 1 hex: {watermark.ColorHex}");
+
+                // Section 2 - SixLabors Color.Blue
+                document.AddSection();
+                document.Sections[2].SetMargins(WordMargin.Normal);
+                watermark = document.Sections[2].AddWatermark(WordWatermarkStyle.Text, "Blue");
+                watermark.Color = Color.Blue;
+                Console.WriteLine($"Section 2 hex: {watermark.ColorHex}");
+
+                // Section 3 - Hex without '#'
+                document.AddSection();
+                document.Sections[3].SetMargins(WordMargin.Moderate);
+                watermark = document.Sections[3].AddWatermark(WordWatermarkStyle.Text, "Magenta");
+                watermark.ColorHex = "ff00ff";
+
+                // Section 4 - Hex with '#'
+                document.AddSection();
+                document.Sections[4].SetMargins(WordMargin.Moderate);
+                watermark = document.Sections[4].AddWatermark(WordWatermarkStyle.Text, "Cyan");
+                watermark.ColorHex = "#00ffff";
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Watermark.cs
+++ b/OfficeIMO.Tests/Word.Watermark.cs
@@ -377,5 +377,15 @@ namespace OfficeIMO.Tests {
                 Assert.Throws<ArgumentException>(() => watermark.ColorHex = "notacolor");
             }
         }
+
+        [Fact]
+        public void Test_WatermarkEmptyColorThrows() {
+            string filePath = Path.Combine(_directoryWithFiles, "Test_WatermarkEmptyColorThrows.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddHeadersAndFooters();
+                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Invalid");
+                Assert.Throws<ArgumentException>(() => watermark.ColorHex = "");
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Word.Watermark.cs
+++ b/OfficeIMO.Tests/Word.Watermark.cs
@@ -338,6 +338,12 @@ namespace OfficeIMO.Tests {
                 var cyan = document.Sections[4].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Cyan");
                 cyan.ColorHex = "#00ffff";
 
+                // Named color string
+                document.AddSection();
+                document.Sections[5].AddHeadersAndFooters();
+                var yellow = document.Sections[5].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Yellow");
+                yellow.ColorHex = "yellow";
+
                 document.Save();
             }
 
@@ -356,6 +362,19 @@ namespace OfficeIMO.Tests {
 
                 Assert.Equal("00ffff", document.Sections[4].Header.Default.Watermarks[0].ColorHex);
                 Assert.Equal(Color.Cyan, document.Sections[4].Header.Default.Watermarks[0].Color);
+
+                Assert.Equal("ffff00", document.Sections[5].Header.Default.Watermarks[0].ColorHex);
+                Assert.Equal(Color.Yellow, document.Sections[5].Header.Default.Watermarks[0].Color);
+            }
+        }
+
+        [Fact]
+        public void Test_WatermarkInvalidColorThrows() {
+            string filePath = Path.Combine(_directoryWithFiles, "Test_WatermarkInvalidColorThrows.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddHeadersAndFooters();
+                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Invalid");
+                Assert.Throws<ArgumentException>(() => watermark.ColorHex = "notacolor");
             }
         }
     }

--- a/OfficeIMO.Word/WordWatermark.cs
+++ b/OfficeIMO.Word/WordWatermark.cs
@@ -1,20 +1,20 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Vml;
+using DocumentFormat.OpenXml.Wordprocessing;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using DocumentFormat.OpenXml.Wordprocessing;
-using DocumentFormat.OpenXml;
-using V = DocumentFormat.OpenXml.Vml;
+using Color = SixLabors.ImageSharp.Color;
 using Ovml = DocumentFormat.OpenXml.Vml.Office;
 using Paragraph = DocumentFormat.OpenXml.Wordprocessing.Paragraph;
 using ParagraphProperties = DocumentFormat.OpenXml.Wordprocessing.ParagraphProperties;
 using Picture = DocumentFormat.OpenXml.Wordprocessing.Picture;
 using Run = DocumentFormat.OpenXml.Wordprocessing.Run;
 using RunProperties = DocumentFormat.OpenXml.Wordprocessing.RunProperties;
+using V = DocumentFormat.OpenXml.Vml;
 using Wvml = DocumentFormat.OpenXml.Vml.Wordprocessing;
-using DocumentFormat.OpenXml.Vml;
-using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Word {
     /// <summary>
@@ -421,16 +421,26 @@ namespace OfficeIMO.Word {
             get {
                 var shape = _shape;
                 if (shape?.FillColor?.Value != null) {
-                    return shape.FillColor.Value;
+                    var color = shape.FillColor.Value;
+                    return color.StartsWith("#", StringComparison.Ordinal) ? color.Substring(1) : color;
                 }
                 return "";
             }
             set {
                 var shape = _shape;
-                if (shape?.FillColor != null) {
-                    shape.FillColor.Value = value;
+                if (shape?.FillColor != null && value != null) {
+                    var trimmed = value.StartsWith("#", StringComparison.Ordinal) ? value.Substring(1) : value;
+                    if (IsHexColor(trimmed)) {
+                        shape.FillColor.Value = "#" + trimmed.ToLowerInvariant();
+                    } else {
+                        shape.FillColor.Value = value;
+                    }
                 }
             }
+        }
+
+        private static bool IsHexColor(string value) {
+            return value.Length == 6 && value.All(Uri.IsHexDigit);
         }
 
         private Shape? _shape {

--- a/OfficeIMO.Word/WordWatermark.cs
+++ b/OfficeIMO.Word/WordWatermark.cs
@@ -442,11 +442,24 @@ namespace OfficeIMO.Word {
             }
 
             var trimmed = value.StartsWith("#", StringComparison.Ordinal) ? value.Substring(1) : value;
+
             if (TryValidateHexColor(trimmed, out _)) {
-                return trimmed.ToLowerInvariant();
+                for (int i = 0; i < trimmed.Length; i++) {
+                    char c = trimmed[i];
+                    if (c >= 'A' && c <= 'F') {
+                        return trimmed.ToLowerInvariant();
+                    }
+                }
+
+                return trimmed;
             }
 
-            if (SixLabors.ImageSharp.Color.TryParse(value, out var named) || SixLabors.ImageSharp.Color.TryParse("#" + value, out named)) {
+            if (SixLabors.ImageSharp.Color.TryParse(value, out var named)) {
+                return named.ToHexColor();
+            }
+
+            if (!value.StartsWith("#", StringComparison.Ordinal) &&
+                SixLabors.ImageSharp.Color.TryParse("#" + value, out named)) {
                 return named.ToHexColor();
             }
 

--- a/OfficeIMO.Word/WordWatermark.cs
+++ b/OfficeIMO.Word/WordWatermark.cs
@@ -437,20 +437,20 @@ namespace OfficeIMO.Word {
         }
 
         private static string NormalizeColorValue(string value) {
+            if (string.IsNullOrWhiteSpace(value)) {
+                throw new ArgumentException("Color value cannot be null or empty.", nameof(value));
+            }
+
             var trimmed = value.StartsWith("#", StringComparison.Ordinal) ? value.Substring(1) : value;
-            if (TryValidateHexColor(trimmed, out string? _)) {
-                return trimmed.Equals(trimmed.ToLowerInvariant(), StringComparison.Ordinal) ? trimmed : trimmed.ToLowerInvariant();
+            if (TryValidateHexColor(trimmed, out _)) {
+                return trimmed.ToLowerInvariant();
             }
 
             if (SixLabors.ImageSharp.Color.TryParse(value, out var named) || SixLabors.ImageSharp.Color.TryParse("#" + value, out named)) {
                 return named.ToHexColor();
             }
 
-            if (!TryValidateHexColor(trimmed, out var error)) {
-                throw new ArgumentException(error, nameof(value));
-            }
-
-            throw new ArgumentException($"Invalid color value: {value}", nameof(value));
+            throw new ArgumentException($"Invalid color value: {value}. Must be a valid hex color (6 characters) or named color.", nameof(value));
         }
 
         private static bool TryValidateHexColor(string value, out string? error) {


### PR DESCRIPTION
## Summary
- ensure watermark fill colors include `#` prefix and validate hex values
- cover watermark colors with regression tests for hex and SixLabors inputs
- document watermark color usage examples including hex values and SixLabors colors

## Testing
- `dotnet build`
- `dotnet test`
- `dotnet format OfficeIMO.Examples/OfficeIMO.Examples.csproj --include OfficeIMO.Examples/Word/Watermark/Watermark.Sample5.cs` *(fails: Required references did not load for OfficeIMO.Examples or referenced project. Run `dotnet restore` prior to formatting.)*
- `dotnet format OfficeIMO.Tests/OfficeIMO.Tests.csproj --include OfficeIMO.Tests/Word.Watermark.cs` *(fails: Required references did not load for OfficeIMO.Tests or referenced project. Run `dotnet restore` prior to formatting.)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8a1e4808832e9b857a5d5c804206