### PR TITLE
Fix nullable warnings in PowerPoint project

### DIFF
--- a/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
+++ b/OfficeIMO.PowerPoint/Fluent/PowerPointFluentPresentation.cs
@@ -45,6 +45,9 @@ namespace OfficeIMO.PowerPoint.Fluent {
             return Slide(0, 0, configure);
         }
 
+        /// <summary>
+        ///     Completes fluent configuration and returns the underlying presentation.
+        /// </summary>
         public PowerPointPresentation End() {
             return Presentation;
         }

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -114,13 +114,14 @@ namespace OfficeIMO.PowerPoint {
                     .Union(_presentationPart.ExternalRelationships.Select(r => r.Id))
                     .Union(_presentationPart.HyperlinkRelationships.Select(r => r.Id))
                     .Where(id => !string.IsNullOrEmpty(id))
+                    .Select(id => id!)
             );
             
             // Also check the slide IDs
             if (_presentationPart.Presentation.SlideIdList != null) {
                 foreach (SlideId existingSlideId in _presentationPart.Presentation.SlideIdList.Elements<SlideId>()) {
                     if (!string.IsNullOrEmpty(existingSlideId.RelationshipId)) {
-                        existingRelationships.Add(existingSlideId.RelationshipId);
+                        existingRelationships.Add(existingSlideId.RelationshipId!);
                     }
                 }
             }
@@ -238,7 +239,7 @@ namespace OfficeIMO.PowerPoint {
             slideId.Remove();
 
             if (!string.IsNullOrEmpty(relId)) {
-                OpenXmlPart part = _presentationPart.GetPartById(relId);
+                OpenXmlPart part = _presentationPart.GetPartById(relId!);
                 _presentationPart.DeletePart(part);
             }
 

--- a/OfficeIMO.PowerPoint/PowerPointTextBox.cs
+++ b/OfficeIMO.PowerPoint/PowerPointTextBox.cs
@@ -35,7 +35,7 @@ namespace OfficeIMO.PowerPoint {
         public bool Bold {
             get {
                 A.Run? run = Runs.FirstOrDefault();
-                return run?.RunProperties?.Bold?.Value ?? false;
+                return run?.RunProperties?.Bold?.Value == true;
             }
             set {
                 foreach (A.Run run in Runs) {
@@ -51,7 +51,7 @@ namespace OfficeIMO.PowerPoint {
         public bool Italic {
             get {
                 A.Run? run = Runs.FirstOrDefault();
-                return run?.RunProperties?.Italic?.Value ?? false;
+                return run?.RunProperties?.Italic?.Value == true;
             }
             set {
                 foreach (A.Run run in Runs) {


### PR DESCRIPTION
## Summary
- ensure slide relationship lookups handle null IDs
- guard text formatting accessors against nulls
- document fluent End() method

## Testing
- `dotnet build OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj`
- `dotnet build OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj -p:TargetFrameworks=net9.0`
- `dotnet build OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj -p:TargetFrameworks=net472`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68adefb81f20832ea1911af36efa7182