### PR TITLE
Fix nullability warnings in PDF renderer

### DIFF
--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
@@ -70,8 +70,8 @@ namespace OfficeIMO.Word.Pdf {
                 return container;
             }
 
-            if (paragraph.Bookmark != null) {
-                container = container.Section(paragraph.Bookmark.Name);
+            if (!string.IsNullOrEmpty(paragraph.Bookmark?.Name)) {
+                container = container.Section(paragraph.Bookmark!.Name);
             }
 
             if (paragraph.IsHyperLink && paragraph.Hyperlink != null) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Tables.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Tables.cs
@@ -54,7 +54,8 @@ namespace OfficeIMO.Word.Pdf {
 
             WordTableCellBorder borders = cell.Borders;
 
-            List<string> colors = new() {
+            List<string?> colors = new()
+            {
                 borders.TopColorHex,
                 borders.BottomColorHex,
                 borders.LeftColorHex,
@@ -62,7 +63,7 @@ namespace OfficeIMO.Word.Pdf {
             };
             colors.RemoveAll(string.IsNullOrEmpty);
             if (colors.Count > 0 && colors.Distinct(StringComparer.OrdinalIgnoreCase).Count() == 1) {
-                container = container.BorderColor("#" + colors[0]);
+                container = container.BorderColor("#" + colors[0]!);
             }
 
             if (HasBorder(borders.TopStyle)) {
@@ -83,6 +84,6 @@ namespace OfficeIMO.Word.Pdf {
 
         private static bool HasBorder(W.BorderValues? style) => style != null && style != W.BorderValues.Nil && style != W.BorderValues.None;
 
-        private static float GetBorderWidth(UInt32Value size) => size != null ? size.Value / 8f : 1f;
+        private static float GetBorderWidth(UInt32Value? size) => size != null ? size.Value / 8f : 1f;
     }
 }


### PR DESCRIPTION
## Summary
- guard bookmark sections against null names
- handle nullable table border colors and sizes in PDF rendering

## Testing
- `dotnet build OfficeIMO.Word.Pdf/OfficeIMO.Word.Pdf.csproj -v m`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FullyQualifiedName~Pdf`


------
https://chatgpt.com/codex/tasks/task_e_68adef9a06d0832e842d0211ae8396bb