### PR TITLE
Fix initial test warnings

### DIFF
--- a/OfficeIMO.Tests/Excel.CellAndRange.cs
+++ b/OfficeIMO.Tests/Excel.CellAndRange.cs
@@ -13,8 +13,8 @@ namespace OfficeIMO.Tests {
             var cell = worksheetPart.Worksheet.Descendants<Cell>().First(c => c.CellReference != null && c.CellReference.Value == cellReference);
             var value = cell.CellValue?.Text ?? string.Empty;
             if (cell.DataType != null && cell.DataType.Value == CellValues.SharedString) {
-                var table = document.WorkbookPart.SharedStringTablePart.SharedStringTable;
-                if (int.TryParse(value, out int id)) {
+                var table = document.WorkbookPart?.SharedStringTablePart?.SharedStringTable;
+                if (table != null && int.TryParse(value, out int id)) {
                     return table.ChildElements[id].InnerText;
                 }
             }
@@ -30,7 +30,10 @@ namespace OfficeIMO.Tests {
             }
 
             using (ExcelDocument document = ExcelDocument.Load(filePath)) {
-                var sheetPart = document._spreadSheetDocument.WorkbookPart.WorksheetParts.First();
+                Assert.NotNull(document._spreadSheetDocument);
+                var workbookPart = document._spreadSheetDocument.WorkbookPart;
+                Assert.NotNull(workbookPart);
+                var sheetPart = workbookPart.WorksheetParts.First();
                 Assert.Equal("Hello", GetCellValue(document._spreadSheetDocument, sheetPart, "C2"));
             }
 
@@ -60,7 +63,10 @@ namespace OfficeIMO.Tests {
             }
 
             using (ExcelDocument document = ExcelDocument.Load(filePath)) {
-                var sheetPart = document._spreadSheetDocument.WorkbookPart.WorksheetParts.First();
+                Assert.NotNull(document._spreadSheetDocument);
+                var workbookPart = document._spreadSheetDocument.WorkbookPart;
+                Assert.NotNull(workbookPart);
+                var sheetPart = workbookPart.WorksheetParts.First();
                 Assert.Equal("A", GetCellValue(document._spreadSheetDocument, sheetPart, "A1"));
                 Assert.Equal("D", GetCellValue(document._spreadSheetDocument, sheetPart, "B2"));
             }

--- a/OfficeIMO.Tests/Excel.Fluent.cs
+++ b/OfficeIMO.Tests/Excel.Fluent.cs
@@ -15,8 +15,8 @@ namespace OfficeIMO.Tests {
             var cell = worksheetPart.Worksheet.Descendants<Cell>().First(c => c.CellReference != null && c.CellReference.Value == cellReference);
             var value = cell.CellValue?.Text ?? string.Empty;
             if (cell.DataType != null && cell.DataType.Value == CellValues.SharedString) {
-                var table = document.WorkbookPart.SharedStringTablePart.SharedStringTable;
-                if (int.TryParse(value, out int id)) {
+                var table = document.WorkbookPart?.SharedStringTablePart?.SharedStringTable;
+                if (table != null && int.TryParse(value, out int id)) {
                     return table.ChildElements[id].InnerText;
                 }
             }
@@ -41,7 +41,10 @@ namespace OfficeIMO.Tests {
 
             using (ExcelDocument document = ExcelDocument.Load(filePath)) {
                 Assert.Single(document.Sheets);
-                var sheetPart = document._spreadSheetDocument.WorkbookPart.WorksheetParts.First();
+                Assert.NotNull(document._spreadSheetDocument);
+                var workbookPart = document._spreadSheetDocument.WorkbookPart;
+                Assert.NotNull(workbookPart);
+                var sheetPart = workbookPart.WorksheetParts.First();
                 Assert.Equal("Name", GetCellValue(document._spreadSheetDocument, sheetPart, "A1"));
                 Assert.Equal("93", GetCellValue(document._spreadSheetDocument, sheetPart, "B2"));
                 Assert.True(sheetPart.TableDefinitionParts.Any());
@@ -66,7 +69,10 @@ namespace OfficeIMO.Tests {
             }
 
             using (ExcelDocument document = ExcelDocument.Load(filePath)) {
-                var sheetPart = document._spreadSheetDocument.WorkbookPart.WorksheetParts.First();
+                Assert.NotNull(document._spreadSheetDocument);
+                var workbookPart = document._spreadSheetDocument.WorkbookPart;
+                Assert.NotNull(workbookPart);
+                var sheetPart = workbookPart.WorksheetParts.First();
                 Assert.Equal("Sheet", GetCellValue(document._spreadSheetDocument, sheetPart, "B2"));
                 Assert.Equal("Row", GetCellValue(document._spreadSheetDocument, sheetPart, "C1"));
                 Assert.Equal("Column", GetCellValue(document._spreadSheetDocument, sheetPart, "D2"));
@@ -92,14 +98,19 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                var workbookPart = spreadsheet.WorkbookPart;
+                Assert.NotNull(workbookPart);
+                WorksheetPart wsPart = workbookPart.WorksheetParts.First();
                 var columns = wsPart.Worksheet.GetFirstChild<Columns>();
                 Assert.NotNull(columns);
-                var col1 = columns.Elements<Column>().First(c => c.Min == 1 && c.Max == 1);
-                var col2 = columns.Elements<Column>().First(c => c.Min == 2 && c.Max == 2);
-                Assert.Equal(25D, col1.Width!.Value);
-                Assert.True(col1.Hidden!.Value);
-                Assert.Equal(30D, col2.Width!.Value);
+                var col1 = columns.Elements<Column>().First(c => c.Min != null && c.Min.Value == 1 && c.Max != null && c.Max.Value == 1);
+                var col2 = columns.Elements<Column>().First(c => c.Min != null && c.Min.Value == 2 && c.Max != null && c.Max.Value == 2);
+                Assert.NotNull(col1.Width);
+                Assert.Equal(25D, col1.Width.Value);
+                Assert.NotNull(col1.Hidden);
+                Assert.True(col1.Hidden.Value);
+                Assert.NotNull(col2.Width);
+                Assert.Equal(30D, col2.Width.Value);
                 Assert.False(col2.Hidden?.Value ?? false);
             }
 

--- a/OfficeIMO.Tests/Excel.PowerShellRoundTrip.cs
+++ b/OfficeIMO.Tests/Excel.PowerShellRoundTrip.cs
@@ -45,14 +45,14 @@ namespace OfficeIMO.Tests
             using (var doc = ExcelDocument.Load(path))
             {
                 var s = doc.Sheets[0];
-                foreach (var row in rows)
-                {
-                    string name = Convert.ToString(row["Name"]);
-                    int value = 0;
-                    if (row.TryGetValue("Value", out var val) && val != null)
+                    foreach (var row in rows)
                     {
-                        try { value = Convert.ToInt32(val); } catch { }
-                    }
+                        string name = Convert.ToString(row["Name"]) ?? string.Empty;
+                        int value = 0;
+                        if (row.TryGetValue("Value", out var val) && val != null)
+                        {
+                            try { value = Convert.ToInt32(val); } catch { }
+                        }
 
                     if (string.Equals(name, "Alpha", StringComparison.OrdinalIgnoreCase) && value == 10)
                     {

--- a/OfficeIMO.Tests/Excel.RangeBuilder.cs
+++ b/OfficeIMO.Tests/Excel.RangeBuilder.cs
@@ -13,8 +13,8 @@ namespace OfficeIMO.Tests {
             var cell = worksheetPart.Worksheet.Descendants<Cell>().First(c => c.CellReference != null && c.CellReference.Value == cellReference);
             var value = cell.CellValue?.Text ?? string.Empty;
             if (cell.DataType != null && cell.DataType.Value == CellValues.SharedString) {
-                var table = document.WorkbookPart.SharedStringTablePart.SharedStringTable;
-                if (int.TryParse(value, out int id)) {
+                var table = document.WorkbookPart?.SharedStringTablePart?.SharedStringTable;
+                if (table != null && int.TryParse(value, out int id)) {
                     return table.ChildElements[id].InnerText;
                 }
             }
@@ -32,7 +32,10 @@ namespace OfficeIMO.Tests {
             }
 
             using (ExcelDocument document = ExcelDocument.Load(filePath)) {
-                var sheetPart = document._spreadSheetDocument.WorkbookPart.WorksheetParts.First();
+                Assert.NotNull(document._spreadSheetDocument);
+                var workbookPart = document._spreadSheetDocument.WorkbookPart;
+                Assert.NotNull(workbookPart);
+                var sheetPart = workbookPart.WorksheetParts.First();
                 Assert.Equal("A", GetCellValue(document._spreadSheetDocument, sheetPart, "A1"));
                 Assert.Equal("D", GetCellValue(document._spreadSheetDocument, sheetPart, "B2"));
             }
@@ -50,7 +53,10 @@ namespace OfficeIMO.Tests {
             }
 
             using (ExcelDocument document = ExcelDocument.Load(filePath)) {
-                var sheetPart = document._spreadSheetDocument.WorkbookPart.WorksheetParts.First();
+                Assert.NotNull(document._spreadSheetDocument);
+                var workbookPart = document._spreadSheetDocument.WorkbookPart;
+                Assert.NotNull(workbookPart);
+                var sheetPart = workbookPart.WorksheetParts.First();
                 Assert.Equal("X", GetCellValue(document._spreadSheetDocument, sheetPart, "B2"));
             }
 
@@ -71,14 +77,24 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                var wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                var workbookPart = spreadsheet.WorkbookPart;
+                Assert.NotNull(workbookPart);
+                var wsPart = workbookPart.WorksheetParts.First();
                 var cell = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == "A1");
                 Assert.NotNull(cell.StyleIndex);
-                uint styleIndex = cell.StyleIndex!.Value;
-                var styles = spreadsheet.WorkbookPart.WorkbookStylesPart.Stylesheet;
+                uint styleIndex = cell.StyleIndex.Value;
+                var stylesPart = workbookPart.WorkbookStylesPart;
+                Assert.NotNull(stylesPart);
+                var styles = stylesPart.Stylesheet;
+                Assert.NotNull(styles);
+                Assert.NotNull(styles.CellFormats);
                 var cellFormat = (CellFormat)styles.CellFormats.ElementAt((int)styleIndex);
-                var nfId = cellFormat.NumberFormatId!.Value;
-                var numberingFormat = styles.NumberingFormats.Elements<NumberingFormat>().First(n => n.NumberFormatId.Value == nfId);
+                Assert.NotNull(cellFormat.NumberFormatId);
+                var nfId = cellFormat.NumberFormatId.Value;
+                var numberingFormats = styles.NumberingFormats;
+                Assert.NotNull(numberingFormats);
+                var numberingFormat = numberingFormats.Elements<NumberingFormat>().First(n => n.NumberFormatId != null && n.NumberFormatId.Value == nfId);
+                Assert.NotNull(numberingFormat.FormatCode);
                 Assert.Equal("0.00", numberingFormat.FormatCode.Value);
             }
 
@@ -99,7 +115,10 @@ namespace OfficeIMO.Tests {
             }
 
             using (ExcelDocument document = ExcelDocument.Load(filePath)) {
-                var sheetPart = document._spreadSheetDocument.WorkbookPart.WorksheetParts.First();
+                Assert.NotNull(document._spreadSheetDocument);
+                var workbookPart = document._spreadSheetDocument.WorkbookPart;
+                Assert.NotNull(workbookPart);
+                var sheetPart = workbookPart.WorksheetParts.First();
                 Assert.Equal(string.Empty, GetCellValue(document._spreadSheetDocument, sheetPart, "A1"));
                 Assert.Equal(string.Empty, GetCellValue(document._spreadSheetDocument, sheetPart, "B2"));
             }

--- a/OfficeIMO.Tests/Excel.RowsFromObjectsTests.cs
+++ b/OfficeIMO.Tests/Excel.RowsFromObjectsTests.cs
@@ -15,8 +15,8 @@ namespace OfficeIMO.Tests {
             var cell = worksheetPart.Worksheet.Descendants<Cell>().First(c => c.CellReference != null && c.CellReference.Value == cellReference);
             var value = cell.CellValue?.Text ?? string.Empty;
             if (cell.DataType != null && cell.DataType.Value == CellValues.SharedString) {
-                var table = document.WorkbookPart.SharedStringTablePart.SharedStringTable;
-                if (int.TryParse(value, out int id)) {
+                var table = document.WorkbookPart?.SharedStringTablePart?.SharedStringTable;
+                if (table != null && int.TryParse(value, out int id)) {
                     return table.ChildElements[id].InnerText;
                 }
             }
@@ -53,7 +53,9 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = SpreadsheetDocument.Open(filePath, false)) {
-                var wsPart = document.WorkbookPart.WorksheetParts.First();
+                var workbookPart = document.WorkbookPart;
+                Assert.NotNull(workbookPart);
+                var wsPart = workbookPart.WorksheetParts.First();
                 Assert.Equal("Name", GetCellValue(document, wsPart, "A1"));
                 Assert.Equal("Age", GetCellValue(document, wsPart, "B1"));
                 Assert.Equal("Address.City", GetCellValue(document, wsPart, "C1"));
@@ -91,7 +93,9 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = SpreadsheetDocument.Open(filePath, false)) {
-                var wsPart = document.WorkbookPart.WorksheetParts.First();
+                var workbookPart = document.WorkbookPart;
+                Assert.NotNull(workbookPart);
+                var wsPart = workbookPart.WorksheetParts.First();
                 Assert.Equal("N/A", GetCellValue(document, wsPart, "C3"));
                 Assert.Equal("", GetCellValue(document, wsPart, "D2"));
                 Assert.Equal("30y", GetCellValue(document, wsPart, "B2"));
@@ -120,11 +124,14 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = SpreadsheetDocument.Open(filePath, false)) {
-                var wsPart = document.WorkbookPart.WorksheetParts.First();
+                var workbookPart = document.WorkbookPart;
+                Assert.NotNull(workbookPart);
+                var wsPart = workbookPart.WorksheetParts.First();
                 // two rows for tags -> name repeats twice
                 Assert.Equal("Alice", GetCellValue(document, wsPart, "A2"));
                 Assert.Equal("Alice", GetCellValue(document, wsPart, "A3"));
                 var table = wsPart.TableDefinitionParts.First();
+                Assert.NotNull(table.Table);
                 Assert.Equal("People", table.Table.DisplayName.Value);
                 Assert.Equal("TableStyleMedium9", table.Table.TableStyleInfo?.Name?.Value);
             }


### PR DESCRIPTION
## Summary
- guard shared string lookups in helper methods to avoid null dereferences
- add workbook/worksheet part null checks across Excel tests
- ensure column metadata and PowerShell round-trip values are validated before use

## Testing
- `dotnet build OfficeIMO.Tests/OfficeIMO.Tests.csproj`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Debug -f net8.0 --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68adef7042f8832ea08e7204403d2100