### PR TITLE
Fix initial Word project warnings

### DIFF
--- a/OfficeIMO.Word/WordParagraph.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PrivateMethods.cs
@@ -70,15 +70,17 @@ namespace OfficeIMO.Word {
             return run;
         }
 
-        private RunProperties VerifyRunProperties(Hyperlink hyperlink, Run run, RunProperties runProperties) {
-            VerifyRun(hyperlink, run);
+        private RunProperties VerifyRunProperties(Hyperlink hyperlink, Run run, RunProperties? runProperties) {
+            run = VerifyRun(hyperlink, run);
             if (run != null) {
+                runProperties ??= run.GetFirstChild<RunProperties>();
                 if (runProperties == null) {
                     var text = run.ChildElements.OfType<Text>().FirstOrDefault();
+                    runProperties = new RunProperties();
                     if (text != null) {
-                        text.InsertBeforeSelf(new RunProperties());
+                        text.InsertBeforeSelf(runProperties);
                     } else {
-                        run.Append(new RunProperties());
+                        run.Append(runProperties);
                     }
                 }
             }
@@ -93,17 +95,19 @@ namespace OfficeIMO.Word {
         private RunProperties VerifyRunProperties() {
             VerifyRun();
             if (this._run != null) {
-                if (this._runProperties == null) {
+                _runProperties ??= _run.GetFirstChild<RunProperties>();
+                if (_runProperties == null) {
                     var text = _run.ChildElements.OfType<Text>().FirstOrDefault();
+                    _runProperties = new RunProperties();
                     if (text != null) {
-                        text.InsertBeforeSelf(new RunProperties());
+                        text.InsertBeforeSelf(_runProperties);
                     } else {
-                        this._run.Append(new RunProperties());
+                        this._run.Append(_runProperties);
                     }
                 }
             }
 
-            return this._runProperties;
+            return this._runProperties!;
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordParagraph.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.PrivateMethods.cs
@@ -73,19 +73,13 @@ namespace OfficeIMO.Word {
         private RunProperties VerifyRunProperties(Hyperlink hyperlink, Run run, RunProperties? runProperties) {
             run = VerifyRun(hyperlink, run);
             if (run != null) {
-                runProperties ??= run.GetFirstChild<RunProperties>();
+                runProperties = run.GetFirstChild<RunProperties>();
                 if (runProperties == null) {
-                    var text = run.ChildElements.OfType<Text>().FirstOrDefault();
-                    runProperties = new RunProperties();
-                    if (text != null) {
-                        text.InsertBeforeSelf(runProperties);
-                    } else {
-                        run.Append(runProperties);
-                    }
+                    runProperties = run.PrependChild(new RunProperties());
                 }
             }
 
-            return runProperties;
+            return runProperties!;
         }
 
         /// <summary>
@@ -94,20 +88,16 @@ namespace OfficeIMO.Word {
         /// <returns></returns>
         private RunProperties VerifyRunProperties() {
             VerifyRun();
-            if (this._run != null) {
-                _runProperties ??= _run.GetFirstChild<RunProperties>();
-                if (_runProperties == null) {
-                    var text = _run.ChildElements.OfType<Text>().FirstOrDefault();
-                    _runProperties = new RunProperties();
-                    if (text != null) {
-                        text.InsertBeforeSelf(_runProperties);
-                    } else {
-                        this._run.Append(_runProperties);
-                    }
-                }
+            if (_run == null) {
+                throw new InvalidOperationException("Run is not initialized.");
             }
 
-            return this._runProperties!;
+            var runProperties = _run.GetFirstChild<RunProperties>();
+            if (runProperties == null) {
+                runProperties = _run.PrependChild(new RunProperties());
+            }
+
+            return runProperties;
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool Bold {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Bold != null) {
                     return true;
                 } else {
@@ -23,11 +23,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 if (value == true) {
                     runProperties.Bold = new Bold();
@@ -49,7 +48,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool Italic {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Italic != null) {
                     return true;
                 } else {
@@ -59,11 +58,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 if (value != true) {
                     runProperties.Italic = null;
@@ -78,7 +76,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public UnderlineValues? Underline {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Underline != null) {
                     return runProperties.Underline.Val?.Value;
                 }
@@ -87,11 +85,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 if (value != null) {
                     if (runProperties.Underline == null) {
@@ -110,7 +107,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool DoNotCheckSpellingOrGrammar {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.NoProof != null) {
                     return true;
                 } else {
@@ -120,11 +117,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 if (value != true) {
                     if (runProperties.NoProof != null) runProperties.NoProof.Remove();

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -410,25 +410,35 @@ namespace OfficeIMO.Word {
             }
 
             foreach (var headerRef in _sectionProperties.Elements<HeaderReference>().ToList()) {
-                string id = headerRef.Id;
-                bool usedElsewhere = _document.Sections
-                    .Where(s => s != this)
-                    .Any(s => s._sectionProperties.Elements<HeaderReference>().Any(hr => hr.Id == id));
-                if (!usedElsewhere) {
-                    var part = (HeaderPart)_document._wordprocessingDocument.MainDocumentPart.GetPartById(id);
-                    _document._wordprocessingDocument.MainDocumentPart.DeletePart(part);
+                var id = headerRef.Id?.Value;
+                if (id != null) {
+                    bool usedElsewhere = _document.Sections
+                        .Where(s => s != this)
+                        .Any(s => s._sectionProperties.Elements<HeaderReference>().Any(hr => hr.Id == id));
+                    if (!usedElsewhere) {
+                        var mainDocumentPart = _document._wordprocessingDocument?.MainDocumentPart;
+                        var part = mainDocumentPart?.GetPartById(id) as HeaderPart;
+                        if (part != null) {
+                            mainDocumentPart.DeletePart(part);
+                        }
+                    }
                 }
                 headerRef.Remove();
             }
 
             foreach (var footerRef in _sectionProperties.Elements<FooterReference>().ToList()) {
-                string id = footerRef.Id;
-                bool usedElsewhere = _document.Sections
-                    .Where(s => s != this)
-                    .Any(s => s._sectionProperties.Elements<FooterReference>().Any(fr => fr.Id == id));
-                if (!usedElsewhere) {
-                    var part = (FooterPart)_document._wordprocessingDocument.MainDocumentPart.GetPartById(id);
-                    _document._wordprocessingDocument.MainDocumentPart.DeletePart(part);
+                var id = footerRef.Id?.Value;
+                if (id != null) {
+                    bool usedElsewhere = _document.Sections
+                        .Where(s => s != this)
+                        .Any(s => s._sectionProperties.Elements<FooterReference>().Any(fr => fr.Id == id));
+                    if (!usedElsewhere) {
+                        var mainDocumentPart = _document._wordprocessingDocument?.MainDocumentPart;
+                        var part = mainDocumentPart?.GetPartById(id) as FooterPart;
+                        if (part != null) {
+                            mainDocumentPart.DeletePart(part);
+                        }
+                    }
                 }
                 footerRef.Remove();
             }


### PR DESCRIPTION
## Summary
- guard against missing run properties and ensure they are created before use
- harden section cleanup by checking part IDs and part existence

## Testing
- `dotnet build OfficeImo.sln -v minimal`
- `dotnet test OfficeImo.sln -v minimal` *(fails: Cannot insert the OpenXmlElement "newChild" because it is part of a tree.)*

------
https://chatgpt.com/codex/tasks/task_e_68adef633c44832e8c0322c6f28cb268