### PR TITLE
Resolve initial warnings in OfficeIMO.Visio

### DIFF
--- a/OfficeIMO.Visio/Fluent/VisioFluentDocument.cs
+++ b/OfficeIMO.Visio/Fluent/VisioFluentDocument.cs
@@ -39,12 +39,24 @@ namespace OfficeIMO.Visio.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Adds a page with the specified dimensions.
+        /// </summary>
+        /// <param name="name">Name of the page.</param>
+        /// <param name="width">Page width.</param>
+        /// <param name="height">Page height.</param>
+        /// <param name="page">The created page.</param>
         [System.Obsolete("Use AddPage with width, height and unit parameters")]
         public VisioFluentDocument AddPage(string name, double width, double height, out VisioPage page) {
             page = _document.AddPage(name, width, height);
             return this;
         }
 
+        /// <summary>
+        /// Adds a page with default dimensions.
+        /// </summary>
+        /// <param name="name">Name of the page.</param>
+        /// <param name="page">The created page.</param>
         [System.Obsolete("Use AddPage with width, height and unit parameters")]
         public VisioFluentDocument AddPage(string name, out VisioPage page) {
             page = _document.AddPage(name);

--- a/OfficeIMO.Visio/VisioConnectionPoint.cs
+++ b/OfficeIMO.Visio/VisioConnectionPoint.cs
@@ -3,6 +3,13 @@ namespace OfficeIMO.Visio {
     /// Represents a connection point on a Visio shape.
     /// </summary>
     public class VisioConnectionPoint {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisioConnectionPoint"/> class.
+        /// </summary>
+        /// <param name="x">X coordinate relative to the shape.</param>
+        /// <param name="y">Y coordinate relative to the shape.</param>
+        /// <param name="dirX">Directional X component.</param>
+        /// <param name="dirY">Directional Y component.</param>
         public VisioConnectionPoint(double x, double y, double dirX, double dirY) {
             X = x;
             Y = y;

--- a/OfficeIMO.Visio/VisioMaster.cs
+++ b/OfficeIMO.Visio/VisioMaster.cs
@@ -3,16 +3,31 @@ namespace OfficeIMO.Visio {
     /// Represents a Visio master.
     /// </summary>
     public class VisioMaster {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisioMaster"/> class.
+        /// </summary>
+        /// <param name="id">Identifier of the master.</param>
+        /// <param name="nameU">Universal name of the master.</param>
+        /// <param name="shape">Associated master shape.</param>
         public VisioMaster(string id, string nameU, VisioShape shape) {
             Id = id;
             NameU = nameU;
             Shape = shape;
         }
 
+        /// <summary>
+        /// Master identifier.
+        /// </summary>
         public string Id { get; }
 
+        /// <summary>
+        /// Universal name of the master.
+        /// </summary>
         public string NameU { get; }
 
+        /// <summary>
+        /// Shape that defines the master.
+        /// </summary>
         public VisioShape Shape { get; }
     }
 }

--- a/OfficeIMO.Visio/VisioTheme.cs
+++ b/OfficeIMO.Visio/VisioTheme.cs
@@ -3,6 +3,9 @@ namespace OfficeIMO.Visio {
     /// Represents a Visio theme.
     /// </summary>
     public class VisioTheme {
+        /// <summary>
+        /// Name of the theme.
+        /// </summary>
         public string? Name { get; set; }
     }
 }

--- a/OfficeIMO.Visio/VisioValidator.cs
+++ b/OfficeIMO.Visio/VisioValidator.cs
@@ -87,7 +87,9 @@ namespace OfficeIMO.Visio {
                 string? rid = relChild?.Attribute(rel + "id")?.Value;
                 if (relChild == null) {
                     issues.Add("Page must contain <Rel r:id=\"rId#\"> child (not an attribute).");
-                } else if (string.IsNullOrWhiteSpace(rid) || !rid.StartsWith("rId", StringComparison.Ordinal)) {
+                } else if (rid == null || string.IsNullOrWhiteSpace(rid)) {
+                    issues.Add("Page must contain <Rel r:id=\"rId#\"> child (not an attribute).");
+                } else if (!rid.StartsWith("rId", StringComparison.Ordinal)) {
                     issues.Add("Page must contain <Rel r:id=\"rId#\"> child (not an attribute).");
                 }
             }

--- a/OfficeIMO.Visio/VsdxPackageValidator.cs
+++ b/OfficeIMO.Visio/VsdxPackageValidator.cs
@@ -229,7 +229,7 @@ namespace OfficeIMO.Visio {
             }
 
             var docRel = doc.Root.Elements(nsPkgRel + "Relationship")
-                .FirstOrDefault(r => (string)r.Attribute("Type") == RT_Document);
+                .FirstOrDefault(r => (string?)r.Attribute("Type") == RT_Document);
 
             if (docRel == null) {
                 _errors.Add("No root relationship to visio/document.xml");
@@ -478,19 +478,19 @@ namespace OfficeIMO.Visio {
         }
 
         private bool HasDefault(XDocument doc, string ext, string contentType) {
-            return doc.Root.Elements(nsCT + "Default").Any(e =>
+            return doc.Root?.Elements(nsCT + "Default").Any(e =>
                 (string?)e.Attribute("Extension") == ext &&
-                (string?)e.Attribute("ContentType") == contentType);
+                (string?)e.Attribute("ContentType") == contentType) ?? false;
         }
 
         private bool HasOverride(XDocument doc, string partName, string contentType) {
-            return doc.Root.Elements(nsCT + "Override").Any(e =>
+            return doc.Root?.Elements(nsCT + "Override").Any(e =>
                 (string?)e.Attribute("PartName") == partName &&
-                (string?)e.Attribute("ContentType") == contentType);
+                (string?)e.Attribute("ContentType") == contentType) ?? false;
         }
 
         private void AddDefault(XDocument doc, string ext, string contentType) {
-            if (!HasDefault(doc, ext, contentType)) {
+            if (doc.Root != null && !HasDefault(doc, ext, contentType)) {
                 doc.Root.Add(new XElement(nsCT + "Default",
                     new XAttribute("Extension", ext),
                     new XAttribute("ContentType", contentType)));
@@ -498,7 +498,7 @@ namespace OfficeIMO.Visio {
         }
 
         private void AddOverride(XDocument doc, string partName, string contentType) {
-            if (!HasOverride(doc, partName, contentType)) {
+            if (doc.Root != null && !HasOverride(doc, partName, contentType)) {
                 doc.Root.Add(new XElement(nsCT + "Override",
                     new XAttribute("PartName", partName),
                     new XAttribute("ContentType", contentType)));


### PR DESCRIPTION
## Summary
- eliminate nullability warnings and guard dictionary access in Visio document handling
- add XML comments and ensure safe XML processing
- document connection and master classes

## Testing
- `dotnet build OfficeIMO.Visio/OfficeIMO.Visio.csproj`
- `dotnet build OfficeIMO.Visio/OfficeIMO.Visio.csproj -p:TargetFrameworks=netstandard2.0`
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68adef68c864832e87b6f8c59e3e57a8