### PR TITLE
Fix nullability warnings in HTML conversion

### DIFF
--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -11,7 +11,7 @@ namespace OfficeIMO.Word.Html {
         /// <summary>
         /// Optional font family applied to created runs during conversion.
         /// </summary>
-        public string FontFamily { get; set; }
+        public string? FontFamily { get; set; }
 
         /// <summary>
         /// Character inserted before inline quoted text. Defaults to left double quotation mark.
@@ -70,7 +70,7 @@ namespace OfficeIMO.Word.Html {
         public List<string> StylesheetContents { get; } = new List<string>();
 
         /// <summary>
-        /// When true, <pre> elements are rendered inside a single-cell table.
+        /// When true, <c>&lt;pre&gt;</c> elements are rendered inside a single-cell table.
         /// </summary>
         public bool RenderPreAsTable { get; set; }
 

--- a/OfficeIMO.Word.Html/Options/WordToHtmlOptions.cs
+++ b/OfficeIMO.Word.Html/Options/WordToHtmlOptions.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Word.Html {
         /// <summary>
         /// Optional font family applied to created runs during conversion.
         /// </summary>
-        public string FontFamily { get; set; }
+        public string? FontFamily { get; set; }
         
         /// <summary>
         /// When true, includes run font information as inline styles.


### PR DESCRIPTION
## Summary
- handle nullable HTML head/body elements and metadata values
- make font options nullable and document `<pre>` usage
- guard image and style processing against null references

## Testing
- `dotnet build OfficeIMO.Word.Html/OfficeIMO.Word.Html.csproj`
- `dotnet test` *(fails: FileNotFoundException in Excel.Test_OpeningExcel)*

------
https://chatgpt.com/codex/tasks/task_e_68adefae1fcc832ea1c953a8b11af860