### PR TITLE
Fix initial warnings in Excel library

### DIFF
--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -40,10 +40,11 @@ namespace OfficeIMO.Excel {
                 return Locking.ExecuteWrite(EnsureLock(), () => {
                     List<ExcelSheet> listExcel = new List<ExcelSheet>();
                     List<Sheet>? elements = null;
-                    if (_spreadSheetDocument.WorkbookPart.Workbook.Sheets != null) {
-                        elements = _spreadSheetDocument.WorkbookPart.Workbook.Sheets.OfType<Sheet>().ToList();
+                    var sheets = _spreadSheetDocument?.WorkbookPart?.Workbook.Sheets;
+                    if (sheets != null) {
+                        elements = sheets.OfType<Sheet>().ToList();
                         foreach (Sheet s in elements) {
-                            listExcel.Add(new ExcelSheet(this, _spreadSheetDocument, s));
+                            listExcel.Add(new ExcelSheet(this, _spreadSheetDocument!, s));
                         }
                     }
 
@@ -52,8 +53,9 @@ namespace OfficeIMO.Excel {
                     id.Add(0);
                     if (elements != null) {
                         foreach (Sheet s in elements) {
-                            if (!id.Contains(s.SheetId)) {
-                                id.Add(s.SheetId);
+                            var sheetId = s.SheetId;
+                            if (sheetId != null && !id.Contains(sheetId)) {
+                                id.Add(sheetId);
                             }
                         }
                     }
@@ -66,14 +68,14 @@ namespace OfficeIMO.Excel {
         /// <summary>
         /// Underlying Open XML spreadsheet document instance.
         /// </summary>
-        public SpreadsheetDocument _spreadSheetDocument;
-        private WorkbookPart _workBookPart;
-        private SharedStringTablePart _sharedStringTablePart;
+        public SpreadsheetDocument _spreadSheetDocument = null!;
+        private WorkbookPart _workBookPart = null!;
+        private SharedStringTablePart? _sharedStringTablePart;
 
         /// <summary>
         /// Path to the file backing this document.
         /// </summary>
-        public string FilePath;
+        public string FilePath = string.Empty;
         private bool _isMemory;
 
         /// <summary>
@@ -235,7 +237,7 @@ namespace OfficeIMO.Excel {
             document._spreadSheetDocument = spreadSheetDocument;
 
             //// Add a WorkbookPart to the document.
-            document._workBookPart = document._spreadSheetDocument.WorkbookPart;
+            document._workBookPart = spreadSheetDocument.WorkbookPart ?? throw new InvalidOperationException("WorkbookPart is null");
 
             return document;
         }
@@ -249,10 +251,11 @@ namespace OfficeIMO.Excel {
         /// <returns>Loaded <see cref="ExcelDocument"/> instance.</returns>
         /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
         public static async Task<ExcelDocument> LoadAsync(string filePath, bool readOnly = false, bool autoSave = false) {
-            if (filePath != null) {
-                if (!File.Exists(filePath)) {
-                    throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
-                }
+            if (filePath == null) {
+                throw new ArgumentNullException("path");
+            }
+            if (!File.Exists(filePath)) {
+                throw new FileNotFoundException($"File '{filePath}' doesn't exist.", filePath);
             }
             using var fileStream = new FileStream(filePath, FileMode.Open, readOnly ? FileAccess.Read : FileAccess.ReadWrite, readOnly ? FileShare.Read : FileShare.ReadWrite, 4096, FileOptions.Asynchronous);
             var memoryStream = new MemoryStream();
@@ -268,7 +271,7 @@ namespace OfficeIMO.Excel {
             ExcelDocument document = new ExcelDocument {
                 FilePath = filePath,
                 _spreadSheetDocument = spreadSheetDocument,
-                _workBookPart = spreadSheetDocument.WorkbookPart
+                _workBookPart = spreadSheetDocument.WorkbookPart ?? throw new InvalidOperationException("WorkbookPart is null")
             };
 
             return document;
@@ -370,7 +373,7 @@ namespace OfficeIMO.Excel {
             snapshot.CopyTo(mem);
             mem.Position = 0;
             _spreadSheetDocument = SpreadsheetDocument.Open(mem, true);
-            _workBookPart = _spreadSheetDocument.WorkbookPart;
+            _workBookPart = _spreadSheetDocument.WorkbookPart ?? throw new InvalidOperationException("WorkbookPart is null");
             _sharedStringTablePart = null;
             _isMemory = true;
 
@@ -439,7 +442,7 @@ namespace OfficeIMO.Excel {
                     await fs.FlushAsync(cancellationToken);
                 }
                 FilePath = target;
-            } catch (Exception) when (true) {
+            } catch (Exception) {
                 throw;
             }
 
@@ -489,7 +492,7 @@ namespace OfficeIMO.Excel {
                 } catch {
                     // ignored
                 }
-                this._spreadSheetDocument = null;
+                this._spreadSheetDocument = null!;
             }
 
             _lock?.Dispose();

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -237,10 +237,11 @@ namespace OfficeIMO.Excel {
 
         private void ApplyWrapText(Cell cell)
         {
-            WorkbookStylesPart stylesPart = _excelDocument._spreadSheetDocument.WorkbookPart.WorkbookStylesPart;
+            var workbookPart = _excelDocument._spreadSheetDocument.WorkbookPart ?? throw new InvalidOperationException("WorkbookPart is null");
+            WorkbookStylesPart? stylesPart = workbookPart.WorkbookStylesPart;
             if (stylesPart == null)
             {
-                stylesPart = _excelDocument._spreadSheetDocument.WorkbookPart.AddNewPart<WorkbookStylesPart>();
+                stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
             }
 
             Stylesheet stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
@@ -315,9 +316,10 @@ namespace OfficeIMO.Excel {
 
         private void ApplyFontBold(Cell cell, bool bold)
         {
-            var stylesPart = _excelDocument._spreadSheetDocument.WorkbookPart.WorkbookStylesPart;
+            var workbookPart = _excelDocument._spreadSheetDocument.WorkbookPart ?? throw new InvalidOperationException("WorkbookPart is null");
+            var stylesPart = workbookPart.WorkbookStylesPart;
             if (stylesPart == null)
-                stylesPart = _excelDocument._spreadSheetDocument.WorkbookPart.AddNewPart<WorkbookStylesPart>();
+                stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
 
             var stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
             stylesheet.Fonts ??= new Fonts(new DocumentFormat.OpenXml.Spreadsheet.Font());
@@ -386,9 +388,10 @@ namespace OfficeIMO.Excel {
 
         private void ApplyBackground(Cell cell, string hexColor)
         {
-            var stylesPart = _excelDocument._spreadSheetDocument.WorkbookPart.WorkbookStylesPart;
+            var workbookPart = _excelDocument._spreadSheetDocument.WorkbookPart ?? throw new InvalidOperationException("WorkbookPart is null");
+            var stylesPart = workbookPart.WorkbookStylesPart;
             if (stylesPart == null)
-                stylesPart = _excelDocument._spreadSheetDocument.WorkbookPart.AddNewPart<WorkbookStylesPart>();
+                stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
 
             var stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
             stylesheet.Fills ??= new Fills(new Fill(new PatternFill { PatternType = PatternValues.None }));
@@ -439,9 +442,10 @@ namespace OfficeIMO.Excel {
         private void ApplyBuiltInNumberFormat(int row, int column, uint builtInFormatId) {
             Cell cell = GetCell(row, column);
 
-            WorkbookStylesPart stylesPart = _excelDocument._spreadSheetDocument.WorkbookPart.WorkbookStylesPart;
+            var workbookPart = _excelDocument._spreadSheetDocument.WorkbookPart ?? throw new InvalidOperationException("WorkbookPart is null");
+            WorkbookStylesPart? stylesPart = workbookPart.WorkbookStylesPart;
             if (stylesPart == null) {
-                stylesPart = _excelDocument._spreadSheetDocument.WorkbookPart.AddNewPart<WorkbookStylesPart>();
+                stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
             }
 
             Stylesheet stylesheet = stylesPart.Stylesheet ??= new Stylesheet();

--- a/OfficeIMO.Excel/ExcelSheet.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Tables.cs
@@ -31,7 +31,7 @@ namespace OfficeIMO.Excel {
         /// Order doesn't matter - whether you add Table then AutoFilter or AutoFilter then Table, 
         /// the final result will be a table with AutoFilter enabled.
         /// </remarks>
-        public void AddAutoFilter(string range, Dictionary<uint, IEnumerable<string>> filterCriteria = null) {
+        public void AddAutoFilter(string range, Dictionary<uint, IEnumerable<string>>? filterCriteria = null) {
             if (string.IsNullOrEmpty(range)) {
                 throw new ArgumentNullException(nameof(range));
             }

--- a/OfficeIMO.Excel/Read/Edit/CellEdit.cs
+++ b/OfficeIMO.Excel/Read/Edit/CellEdit.cs
@@ -60,7 +60,7 @@ namespace OfficeIMO.Excel.Read.Edit
             if (dest.IsAssignableFrom(v.GetType())) return (T)v;
             try
             {
-                if (dest == typeof(string)) return (T)(object)Convert.ToString(v);
+                if (dest == typeof(string)) return (T)(object)(Convert.ToString(v) ?? string.Empty);
                 if (dest == typeof(int)) return (T)(object)Convert.ToInt32(v);
                 if (dest == typeof(long)) return (T)(object)Convert.ToInt64(v);
                 if (dest == typeof(double)) return (T)(object)Convert.ToDouble(v);

--- a/OfficeIMO.Excel/StylePlanner.cs
+++ b/OfficeIMO.Excel/StylePlanner.cs
@@ -32,10 +32,11 @@ namespace OfficeIMO.Excel
                 return;
             }
 
-            WorkbookStylesPart stylesPart = doc._spreadSheetDocument.WorkbookPart.WorkbookStylesPart;
+            var workbookPart = doc._spreadSheetDocument.WorkbookPart ?? throw new InvalidOperationException("WorkbookPart is null");
+            WorkbookStylesPart? stylesPart = workbookPart.WorkbookStylesPart;
             if (stylesPart == null)
             {
-                stylesPart = doc._spreadSheetDocument.WorkbookPart.AddNewPart<WorkbookStylesPart>();
+                stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
             }
 
             Stylesheet stylesheet = stylesPart.Stylesheet ??= new Stylesheet();


### PR DESCRIPTION
## Summary
- improve nullable handling across ExcelDocument
- ensure AutoFilter accepts optional criteria
- guard workbook style access in cell styling helpers

## Testing
- `dotnet build OfficeIMO.Excel/OfficeIMO.Excel.csproj`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68adef6c84a0832eba9044488e34c60b