### PR TITLE
Fix watermark color normalization to avoid double hash

### DIFF
--- a/OfficeIMO.Tests/Word.Watermark.cs
+++ b/OfficeIMO.Tests/Word.Watermark.cs
@@ -307,6 +307,23 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_WatermarkColorSupportsUppercaseHexWithHash() {
+            string filePath = Path.Combine(_directoryWithFiles, "Test_WatermarkColorSupportsUppercaseHexWithHash.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddHeadersAndFooters();
+                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Upper");
+                watermark.ColorHex = "#FF00FF";
+                document.Save();
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                var watermark = document.Watermarks[0];
+                Assert.Equal("ff00ff", watermark.ColorHex);
+                Assert.Equal(Color.Magenta, watermark.Color);
+            }
+        }
+
+        [Fact]
         public void Test_WatermarkSupportsMultipleColorInputs() {
             string filePath = Path.Combine(_directoryWithFiles, "Test_WatermarkSupportsMultipleColorInputs.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {

--- a/OfficeIMO.Word/WordWatermark.cs
+++ b/OfficeIMO.Word/WordWatermark.cs
@@ -441,7 +441,8 @@ namespace OfficeIMO.Word {
                 throw new ArgumentException("Color value cannot be null or empty.", nameof(value));
             }
 
-            var trimmed = value.StartsWith("#", StringComparison.Ordinal) ? value.Substring(1) : value;
+            var startsWithHash = value.StartsWith("#", StringComparison.Ordinal);
+            var trimmed = startsWithHash ? value.Substring(1) : value;
 
             if (TryValidateHexColor(trimmed, out _)) {
                 for (int i = 0; i < trimmed.Length; i++) {
@@ -458,7 +459,7 @@ namespace OfficeIMO.Word {
                 return named.ToHexColor();
             }
 
-            if (!value.StartsWith("#", StringComparison.Ordinal) &&
+            if (!startsWithHash &&
                 SixLabors.ImageSharp.Color.TryParse("#" + value, out named)) {
                 return named.ToHexColor();
             }


### PR DESCRIPTION
## Summary
- prevent double `#` when normalizing watermark colors
- add regression test for uppercase hex values with hash

## Testing
- `dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj -f net472` *(fails: reference assemblies for .NETFramework v4.7.2 not found)*
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -p:TargetFrameworks=net8.0`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -p:TargetFrameworks=net9.0` *(fails: SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68adf42ba820832eb97c35182eaf55d3