### PR TITLE
Add XML documentation for public APIs

### DIFF
--- a/OfficeIMO.Word/Enums/HorizontalAlignment.cs
+++ b/OfficeIMO.Word/Enums/HorizontalAlignment.cs
@@ -3,8 +3,17 @@ namespace OfficeIMO {
     /// Represents horizontal alignment options.
     /// </summary>
     public enum HorizontalAlignment {
+        /// <summary>
+        /// Align content to the left.
+        /// </summary>
         Left,
+        /// <summary>
+        /// Align content to the center.
+        /// </summary>
         Center,
+        /// <summary>
+        /// Align content to the right.
+        /// </summary>
         Right
     }
 }

--- a/OfficeIMO.Word/Enums/VerticalAlignment.cs
+++ b/OfficeIMO.Word/Enums/VerticalAlignment.cs
@@ -3,8 +3,17 @@ namespace OfficeIMO {
     /// Represents vertical alignment options.
     /// </summary>
     public enum VerticalAlignment {
+        /// <summary>
+        /// Align content to the top.
+        /// </summary>
         Top,
+        /// <summary>
+        /// Align content to the center.
+        /// </summary>
         Center,
+        /// <summary>
+        /// Align content to the bottom.
+        /// </summary>
         Bottom
     }
 }

--- a/OfficeIMO.Word/Fluent/ImageBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ImageBuilder.cs
@@ -21,8 +21,15 @@ namespace OfficeIMO.Word.Fluent {
             _fluent = fluent;
         }
 
+        /// <summary>
+        /// Gets the image created by the most recent operation.
+        /// </summary>
         public WordImage? Image => _image;
 
+        /// <summary>
+        /// Adds an image from a file path.
+        /// </summary>
+        /// <param name="path">Path to the image file.</param>
         public ImageBuilder Add(string path) {
             var paragraph = _fluent.Document.AddParagraph();
             paragraph.AddImage(path);
@@ -31,6 +38,11 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Adds an image from a stream.
+        /// </summary>
+        /// <param name="stream">Stream containing image data.</param>
+        /// <param name="fileName">File name of the image.</param>
         public ImageBuilder Add(Stream stream, string fileName) {
             var paragraph = _fluent.Document.AddParagraph();
             paragraph.AddImage(stream, fileName, null, null);
@@ -39,11 +51,20 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Adds an image from a byte array.
+        /// </summary>
+        /// <param name="bytes">Image bytes.</param>
+        /// <param name="fileName">File name of the image.</param>
         public ImageBuilder Add(byte[] bytes, string fileName) {
             using var ms = new MemoryStream(bytes);
             return Add(ms, fileName);
         }
 
+        /// <summary>
+        /// Downloads and adds an image from a URL.
+        /// </summary>
+        /// <param name="url">Image URL.</param>
         public ImageBuilder AddFromUrl(string url) {
             using HttpClient client = new HttpClient();
             var data = client.GetByteArrayAsync(url).GetAwaiter().GetResult();
@@ -51,6 +72,11 @@ namespace OfficeIMO.Word.Fluent {
             return Add(data, fileName);
         }
 
+        /// <summary>
+        /// Asynchronously downloads and adds an image from a URL.
+        /// </summary>
+        /// <param name="url">Image URL.</param>
+        /// <returns>The current <see cref="ImageBuilder"/>.</returns>
         public async Task<ImageBuilder> AddFromUrlAsync(string url) {
             using HttpClient client = new HttpClient();
             var data = await client.GetByteArrayAsync(url);
@@ -58,6 +84,11 @@ namespace OfficeIMO.Word.Fluent {
             return Add(data, fileName);
         }
 
+        /// <summary>
+        /// Sets the size of the image in pixels.
+        /// </summary>
+        /// <param name="width">Image width in pixels.</param>
+        /// <param name="height">Optional image height in pixels.</param>
         public ImageBuilder Size(double width, double? height = null) {
             if (_image != null) {
                 _image.Width = width;
@@ -68,6 +99,10 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Sets the maximum allowed width of the image.
+        /// </summary>
+        /// <param name="width">Maximum width in pixels.</param>
         public ImageBuilder MaxWidth(double width) {
             if (_image != null) {
                 if (_image.Width == null || _image.Width > width) {
@@ -77,6 +112,10 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Applies a wrapping style to the image.
+        /// </summary>
+        /// <param name="wrapImage">Wrapping option.</param>
         public ImageBuilder Wrap(WrapTextImage wrapImage) {
             if (_image != null) {
                 _image.WrapText = wrapImage;

--- a/OfficeIMO.Word/Fluent/PageSetupBuilder.cs
+++ b/OfficeIMO.Word/Fluent/PageSetupBuilder.cs
@@ -12,26 +12,46 @@ namespace OfficeIMO.Word.Fluent {
             _fluent = fluent;
         }
 
+        /// <summary>
+        /// Sets the page orientation.
+        /// </summary>
+        /// <param name="orientation">Orientation value.</param>
         public PageSetupBuilder Orientation(PageOrientationValues orientation) {
             _fluent.Document.PageOrientation = orientation;
             return this;
         }
 
+        /// <summary>
+        /// Sets the page size.
+        /// </summary>
+        /// <param name="pageSize">Page size definition.</param>
         public PageSetupBuilder Size(WordPageSize pageSize) {
             _fluent.Document.PageSettings.PageSize = pageSize;
             return this;
         }
 
+        /// <summary>
+        /// Sets page margins for the first section.
+        /// </summary>
+        /// <param name="margin">Margin values.</param>
         public PageSetupBuilder Margins(WordMargin margin) {
             _fluent.Document.Sections[0].SetMargins(margin);
             return this;
         }
 
+        /// <summary>
+        /// Configures whether the first page uses a different header and footer.
+        /// </summary>
+        /// <param name="value">True to enable different first page.</param>
         public PageSetupBuilder DifferentFirstPage(bool value = true) {
             _fluent.Document.DifferentFirstPage = value;
             return this;
         }
 
+        /// <summary>
+        /// Configures whether odd and even pages have different headers and footers.
+        /// </summary>
+        /// <param name="value">True to enable different headers and footers.</param>
         public PageSetupBuilder DifferentOddAndEvenPages(bool value = true) {
             _fluent.Document.DifferentOddAndEvenPages = value;
             return this;

--- a/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
@@ -16,36 +16,73 @@ namespace OfficeIMO.Word.Fluent {
             _paragraph = paragraph;
         }
 
+        /// <summary>
+        /// Gets the underlying paragraph.
+        /// </summary>
         public WordParagraph Paragraph => _paragraph;
 
+        /// <summary>
+        /// Adds a text run to the paragraph.
+        /// </summary>
+        /// <param name="text">Text to add.</param>
+        /// <param name="configure">Optional configuration for the run.</param>
         public ParagraphBuilder Text(string text, Action<TextBuilder>? configure = null) {
             var run = _paragraph.AddText(text);
             configure?.Invoke(new TextBuilder(run));
             return this;
         }
 
+        /// <summary>
+        /// Adds a text run to the paragraph.
+        /// </summary>
+        /// <param name="text">Text to add.</param>
+        /// <param name="configure">Optional configuration for the run.</param>
         public ParagraphBuilder Run(string text, Action<TextBuilder>? configure = null) => Text(text, configure);
 
+        /// <summary>
+        /// Inserts an inline image into the paragraph.
+        /// </summary>
+        /// <param name="path">Path to the image file.</param>
+        /// <param name="widthPx">Optional width in pixels.</param>
+        /// <param name="heightPx">Optional height in pixels.</param>
+        /// <param name="alt">Alternative text.</param>
         public ParagraphBuilder InlineImage(string path, double? widthPx = null, double? heightPx = null, string alt = "") {
             _paragraph.AddImage(path, widthPx, heightPx, WrapTextImage.InLineWithText, alt);
             return this;
         }
 
+        /// <summary>
+        /// Adds a hyperlink to the paragraph.
+        /// </summary>
+        /// <param name="url">Destination URL.</param>
+        /// <param name="text">Optional text to display.</param>
+        /// <param name="style">True to apply hyperlink style.</param>
         public ParagraphBuilder Link(string url, string? text = null, bool style = false) {
             _paragraph.AddHyperLink(text ?? url, new Uri(url), style);
             return this;
         }
 
+        /// <summary>
+        /// Inserts a break into the paragraph.
+        /// </summary>
+        /// <param name="breakType">Optional break type.</param>
         public ParagraphBuilder Break(BreakValues? breakType = null) {
             _paragraph.AddBreak(breakType);
             return this;
         }
 
+        /// <summary>
+        /// Inserts a tab character.
+        /// </summary>
         public ParagraphBuilder Tab() {
             _paragraph.AddTab();
             return this;
         }
 
+        /// <summary>
+        /// Sets the paragraph alignment.
+        /// </summary>
+        /// <param name="alignment">Desired alignment.</param>
         public ParagraphBuilder Align(HorizontalAlignment alignment) {
             _paragraph.ParagraphAlignment = alignment switch {
                 HorizontalAlignment.Center => JustificationValues.Center,
@@ -55,26 +92,47 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Applies justified alignment to the paragraph.
+        /// </summary>
         public ParagraphBuilder Justify() {
             _paragraph.ParagraphAlignment = JustificationValues.Both;
             return this;
         }
 
+        /// <summary>
+        /// Sets spacing before the paragraph.
+        /// </summary>
+        /// <param name="points">Spacing in points.</param>
         public ParagraphBuilder SpacingBefore(double points) {
             _paragraph.LineSpacingBeforePoints = points;
             return this;
         }
 
+        /// <summary>
+        /// Sets spacing after the paragraph.
+        /// </summary>
+        /// <param name="points">Spacing in points.</param>
         public ParagraphBuilder SpacingAfter(double points) {
             _paragraph.LineSpacingAfterPoints = points;
             return this;
         }
 
+        /// <summary>
+        /// Sets line spacing for the paragraph.
+        /// </summary>
+        /// <param name="points">Spacing in points.</param>
         public ParagraphBuilder LineSpacing(double points) {
             _paragraph.LineSpacingPoints = points;
             return this;
         }
 
+        /// <summary>
+        /// Sets indentation values for the paragraph.
+        /// </summary>
+        /// <param name="left">Left indentation in points.</param>
+        /// <param name="firstLine">First-line indentation in points.</param>
+        /// <param name="right">Right indentation in points.</param>
         public ParagraphBuilder Indentation(double? left = null, double? firstLine = null, double? right = null) {
             if (left != null) {
                 _paragraph.IndentationBeforePoints = left.Value;
@@ -91,11 +149,19 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Applies a built-in style to the paragraph.
+        /// </summary>
+        /// <param name="style">Built-in style.</param>
         public ParagraphBuilder Style(WordParagraphStyles style) {
             _paragraph.SetStyle(style);
             return this;
         }
 
+        /// <summary>
+        /// Applies a style by its identifier.
+        /// </summary>
+        /// <param name="styleId">Style identifier.</param>
         public ParagraphBuilder Style(string styleId) {
             _paragraph.SetStyleId(styleId);
             return this;

--- a/OfficeIMO.Word/Fluent/RunBuilder.cs
+++ b/OfficeIMO.Word/Fluent/RunBuilder.cs
@@ -11,6 +11,9 @@ namespace OfficeIMO.Word.Fluent {
             _run = run;
         }
 
+        /// <summary>
+        /// Gets the underlying run.
+        /// </summary>
         public WordParagraph Run => _run;
     }
 }

--- a/OfficeIMO.Word/Fluent/SectionBuilder.cs
+++ b/OfficeIMO.Word/Fluent/SectionBuilder.cs
@@ -19,17 +19,31 @@ namespace OfficeIMO.Word.Fluent {
             _section = section;
         }
 
+        /// <summary>
+        /// Gets the section being configured.
+        /// </summary>
         public WordSection? Section => _section;
 
+        /// <summary>
+        /// Starts a new section on the next page.
+        /// </summary>
         public SectionBuilder New() {
             return New(SectionMarkValues.NextPage);
         }
 
+        /// <summary>
+        /// Starts a new section using the specified break type.
+        /// </summary>
+        /// <param name="breakType">Section break type.</param>
         public SectionBuilder New(SectionMarkValues breakType) {
             var section = _fluent.Document.AddSection(breakType);
             return new SectionBuilder(_fluent, section);
         }
 
+        /// <summary>
+        /// Enables page numbering for the section.
+        /// </summary>
+        /// <param name="restart">Restart numbering at 1.</param>
         public SectionBuilder PageNumbering(bool restart = false) {
             if (_section == null) {
                 throw new InvalidOperationException("No section available to configure.");
@@ -39,6 +53,11 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Enables page numbering with a specific number format.
+        /// </summary>
+        /// <param name="format">Number format.</param>
+        /// <param name="restart">Restart numbering at 1.</param>
         public SectionBuilder PageNumbering(NumberFormatValues format, bool restart = false) {
             if (_section == null) {
                 throw new InvalidOperationException("No section available to configure.");
@@ -48,6 +67,10 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Sets the number of columns for the section.
+        /// </summary>
+        /// <param name="count">Column count.</param>
         public SectionBuilder Columns(int count) {
             if (_section == null) {
                 throw new InvalidOperationException("No section available to configure.");
@@ -57,6 +80,10 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Sets the margins for the section.
+        /// </summary>
+        /// <param name="margins">Margin values.</param>
         public SectionBuilder Margins(WordMargin margins) {
             if (_section == null) {
                 throw new InvalidOperationException("No section available to configure.");
@@ -66,6 +93,10 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Sets the page size for the section.
+        /// </summary>
+        /// <param name="pageSize">Page size definition.</param>
         public SectionBuilder Size(WordPageSize pageSize) {
             if (_section == null) {
                 throw new InvalidOperationException("No section available to configure.");
@@ -75,12 +106,20 @@ namespace OfficeIMO.Word.Fluent {
             return this;
         }
 
+        /// <summary>
+        /// Adds a paragraph to the section.
+        /// </summary>
+        /// <param name="action">Configuration action for the paragraph.</param>
         public SectionBuilder Paragraph(Action<ParagraphBuilder> action) {
             var paragraph = _fluent.Document.AddParagraph();
             action(new ParagraphBuilder(_fluent, paragraph));
             return this;
         }
 
+        /// <summary>
+        /// Adds a table to the section.
+        /// </summary>
+        /// <param name="action">Configuration action for the table.</param>
         public SectionBuilder Table(Action<TableBuilder> action) {
             action(new TableBuilder(_fluent));
             return this;

--- a/OfficeIMO.Word/Fluent/TableBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TableBuilder.cs
@@ -25,6 +25,9 @@ namespace OfficeIMO.Word.Fluent {
             _columns = table.Rows.Count > 0 ? table.Rows[0].Cells.Count : 0;
         }
 
+        /// <summary>
+        /// Gets the table being built.
+        /// </summary>
         public WordTable? Table => _table;
 
         /// <summary>

--- a/OfficeIMO.Word/Fluent/TextBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TextBuilder.cs
@@ -11,18 +11,31 @@ namespace OfficeIMO.Word.Fluent {
             _paragraph = paragraph;
         }
 
+        /// <summary>
+        /// Gets the paragraph associated with this builder.
+        /// </summary>
         public WordParagraph? Paragraph => _paragraph;
 
+        /// <summary>
+        /// Applies bold formatting to the current run.
+        /// </summary>
         public TextBuilder BoldOn() {
             _paragraph?.SetBold();
             return this;
         }
 
+        /// <summary>
+        /// Applies italic formatting to the current run.
+        /// </summary>
         public TextBuilder ItalicOn() {
             _paragraph?.SetItalic();
             return this;
         }
 
+        /// <summary>
+        /// Sets the text color using a hexadecimal value.
+        /// </summary>
+        /// <param name="hex">Color in hexadecimal format.</param>
         public TextBuilder Color(string hex) {
             if (hex.StartsWith("#")) {
                 hex = hex.Substring(1);

--- a/OfficeIMO.Word/WordDocument.SectionHelpers.cs
+++ b/OfficeIMO.Word/WordDocument.SectionHelpers.cs
@@ -18,6 +18,10 @@ namespace OfficeIMO.Word {
             if (type == HeaderFooterValues.Even) return headers.Even;
             return headers.Default;
         }
+        /// <summary>
+        /// Returns the default header for a specific section index.
+        /// </summary>
+        /// <param name="sectionIndex">Index of the section or -1 for the last section.</param>
         public WordHeader GetHeaderForSection(int sectionIndex = -1) => GetHeaderForSection(sectionIndex, HeaderFooterValues.Default);
 
         /// <summary>
@@ -32,6 +36,10 @@ namespace OfficeIMO.Word {
             if (type == HeaderFooterValues.Even) return footers.Even;
             return footers.Default;
         }
+        /// <summary>
+        /// Returns the default footer for a specific section index.
+        /// </summary>
+        /// <param name="sectionIndex">Index of the section or -1 for the last section.</param>
         public WordFooter GetFooterForSection(int sectionIndex = -1) => GetFooterForSection(sectionIndex, HeaderFooterValues.Default);
     }
 }

--- a/OfficeIMO.Word/WordSection.Helpers.cs
+++ b/OfficeIMO.Word/WordSection.Helpers.cs
@@ -13,6 +13,9 @@ namespace OfficeIMO.Word {
             if (type == HeaderFooterValues.Even) return this.Header.Even;
             return this.Header.Default;
         }
+        /// <summary>
+        /// Returns the default section header.
+        /// </summary>
         public WordHeader GetHeader() => GetHeader(HeaderFooterValues.Default);
 
         /// <summary>
@@ -23,6 +26,9 @@ namespace OfficeIMO.Word {
             if (type == HeaderFooterValues.Even) return this.Footer.Even;
             return this.Footer.Default;
         }
+        /// <summary>
+        /// Returns the default section footer.
+        /// </summary>
         public WordFooter GetFooter() => GetFooter(HeaderFooterValues.Default);
 
         /// <summary>
@@ -36,6 +42,11 @@ namespace OfficeIMO.Word {
             }
             return string.IsNullOrEmpty(text) ? header.AddParagraph("") : header.AddParagraph(text);
         }
+        /// <summary>
+        /// Adds a paragraph to the default section header.
+        /// </summary>
+        /// <param name="text">Paragraph text.</param>
+        /// <param name="removeExistingParagraphs">True to clear existing paragraphs.</param>
         public WordParagraph AddHeaderParagraph(string text = "", bool removeExistingParagraphs = false) =>
             AddHeaderParagraph(text, HeaderFooterValues.Default, removeExistingParagraphs);
 
@@ -49,6 +60,11 @@ namespace OfficeIMO.Word {
             }
             return string.IsNullOrEmpty(text) ? footer.AddParagraph("") : footer.AddParagraph(text);
         }
+        /// <summary>
+        /// Adds a paragraph to the default section footer.
+        /// </summary>
+        /// <param name="text">Paragraph text.</param>
+        /// <param name="removeExistingParagraphs">True to clear existing paragraphs.</param>
         public WordParagraph AddFooterParagraph(string text = "", bool removeExistingParagraphs = false) =>
             AddFooterParagraph(text, HeaderFooterValues.Default, removeExistingParagraphs);
     }


### PR DESCRIPTION
## Summary
- document fluent image operations
- describe page setup and paragraph builder methods
- add XML comments for section helpers and alignment enums

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68af3fdfd418832eb4094e07cc86551a