### PR TITLE
fix: handle null references in Word operations

### DIFF
--- a/OfficeIMO.Word/WordCoverPage.cs
+++ b/OfficeIMO.Word/WordCoverPage.cs
@@ -4,7 +4,7 @@ namespace OfficeIMO.Word {
     /// <summary>
     /// Built-in cover page templates available for Word documents.
     /// </summary>
-public enum CoverPageTemplate {
+    public enum CoverPageTemplate {
         /// <summary>
         /// The "Austin" built-in template.
         /// </summary>
@@ -88,7 +88,9 @@ public enum CoverPageTemplate {
         public WordCoverPage(WordDocument wordDocument, CoverPageTemplate coverPageTemplate) {
             _document = wordDocument;
             _sdtBlock = GetStyle(coverPageTemplate);
-            this._document._wordprocessingDocument.MainDocumentPart.Document.Body.Append(_sdtBlock);
+            var body = _document._wordprocessingDocument?.MainDocumentPart?.Document?.Body
+                ?? throw new InvalidOperationException("Document body is missing.");
+            body.Append(_sdtBlock);
         }
 
         private SdtBlock GetStyle(CoverPageTemplate template) {

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -1,14 +1,14 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.IO;
-using System.Net.Http;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Drawing.Charts;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using SixLabors.ImageSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
 
 namespace OfficeIMO.Word {
     /// <summary>
@@ -165,7 +165,7 @@ namespace OfficeIMO.Word {
 
             var paragraph = AddParagraph();
             paragraph.AddImage(ms, fileName, width, height);
-            return paragraph.Image;
+            return paragraph.Image ?? throw new InvalidOperationException("Image was not added to the paragraph.");
         }
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace OfficeIMO.Word {
         public WordImage AddImageVml(string filePathImage, double? width = null, double? height = null) {
             var paragraph = AddParagraph();
             paragraph.AddImageVml(filePathImage, width, height);
-            return paragraph.Image;
+            return paragraph.Image ?? throw new InvalidOperationException("Image was not added to the paragraph.");
         }
 
         /// <summary>
@@ -985,11 +985,11 @@ namespace OfficeIMO.Word {
             if (foundList?.Count > 0) {
                 count += foundList.Count;
                 foreach (var ts in foundList) {
-                      if (!IsSegmentValid(paragraphs, ts))
-                          continue;
-                      if (ts.BeginIndex == ts.EndIndex) {
-                          var p = paragraphs[ts.BeginIndex];
-                          if (p is not null) {
+                    if (!IsSegmentValid(paragraphs, ts))
+                        continue;
+                    if (ts.BeginIndex == ts.EndIndex) {
+                        var p = paragraphs[ts.BeginIndex];
+                        if (p is not null) {
                             if (replace) {
                                 int replaceCount = 0;
                                 p.Text = p.Text.FindAndReplace(oldText, newText, stringComparison, ref replaceCount);
@@ -1002,7 +1002,7 @@ namespace OfficeIMO.Word {
                         if (replace) {
                             var beginPara = paragraphs[ts.BeginIndex];
                             var endPara = paragraphs[ts.EndIndex];
-                              if (beginPara is not null && endPara is not null) {
+                            if (beginPara is not null && endPara is not null) {
                                 beginPara.Text = beginPara.Text.Replace(beginPara.Text.Substring(ts.BeginChar), newText);
                                 endPara.Text = endPara.Text.Replace(endPara.Text.Substring(0, ts.EndChar + 1), "");
                                 if (!foundParagraphs.Any(fp => ReferenceEquals(fp._paragraph, beginPara._paragraph))) {


### PR DESCRIPTION
## Summary
- ensure image helpers never return null
- guard cover page creation against missing document body
- add null checks throughout revision handling to avoid dereferences

## Testing
- `dotnet build`
- `dotnet test --no-build` *(fails: Test_LoadingWordWithFootNotesAndEndNotes)*

------
https://chatgpt.com/codex/tasks/task_e_68af3ff6c388832ea5a5727e17f29f3e