### PR TITLE
Fix nullable reference warnings across Word components

### DIFF
--- a/OfficeIMO.Word/WordChart.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordChart.PrivateMethods.cs
@@ -143,7 +143,7 @@ namespace OfficeIMO.Word {
         private Chart CreatePieChart(Chart chart) {
             PieChart pieChart1 = new PieChart();
             pieChart1.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
-            chart.PlotArea.Append(pieChart1);
+            chart.PlotArea!.Append(pieChart1);
             return chart;
         }
 
@@ -154,9 +154,9 @@ namespace OfficeIMO.Word {
             BarChart barChart1 = CreateBarChart(catId, valId);
             CategoryAxis categoryAxis1 = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
             ValueAxis valueAxis1 = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
-            chart.PlotArea.Append(barChart1);
-            chart.PlotArea.Append(categoryAxis1);
-            chart.PlotArea.Append(valueAxis1);
+            chart.PlotArea!.Append(barChart1);
+            chart.PlotArea!.Append(categoryAxis1);
+            chart.PlotArea!.Append(valueAxis1);
 
             return chart;
         }
@@ -229,7 +229,7 @@ namespace OfficeIMO.Word {
                     if (catAxis != null) {
                         _chart.PlotArea.InsertBefore(barChart, catAxis);
                     } else {
-                        _chart.PlotArea.Append(barChart);
+                        _chart.PlotArea!.Append(barChart);
                     }
                 } else {
                     _chart = GenerateChartBar(_chart);
@@ -267,7 +267,7 @@ namespace OfficeIMO.Word {
                     if (catAxis != null) {
                         _chart.PlotArea.InsertBefore(lineChart, catAxis);
                     } else {
-                        _chart.PlotArea.Append(lineChart);
+                        _chart.PlotArea!.Append(lineChart);
                     }
                 } else {
                     _chart = GenerateLineChart(_chart);
@@ -338,9 +338,9 @@ namespace OfficeIMO.Word {
             CategoryAxis categoryAxis1 = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
             ValueAxis valueAxis1 = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
             //chart.PlotArea.Append(layout1);
-            chart.PlotArea.Append(lineChart1);
-            chart.PlotArea.Append(categoryAxis1);
-            chart.PlotArea.Append(valueAxis1);
+            chart.PlotArea!.Append(lineChart1);
+            chart.PlotArea!.Append(categoryAxis1);
+            chart.PlotArea!.Append(valueAxis1);
             return chart;
         }
         private LineChartSeries AddLineChartSeries<T>(UInt32Value index, string series, SixLabors.ImageSharp.Color color, List<string> categories, List<T> data) {
@@ -409,9 +409,9 @@ namespace OfficeIMO.Word {
             ValueAxis valueAxis1 = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
 
             //chart.PlotArea.Append(layout1);
-            chart.PlotArea.Append(areaChart);
-            chart.PlotArea.Append(categoryAxis1);
-            chart.PlotArea.Append(valueAxis1);
+            chart.PlotArea!.Append(areaChart);
+            chart.PlotArea!.Append(categoryAxis1);
+            chart.PlotArea!.Append(valueAxis1);
 
 
             return chart;
@@ -523,9 +523,9 @@ namespace OfficeIMO.Word {
             ValueAxis xAxis = AddValueAxisInternal(xId, yId, AxisPositionValues.Bottom);
             ValueAxis yAxis = AddValueAxisInternal(yId, xId, AxisPositionValues.Left);
 
-            chart.PlotArea.Append(scatter);
-            chart.PlotArea.Append(xAxis);
-            chart.PlotArea.Append(yAxis);
+            chart.PlotArea!.Append(scatter);
+            chart.PlotArea!.Append(xAxis);
+            chart.PlotArea!.Append(yAxis);
 
             return chart;
         }
@@ -596,9 +596,9 @@ namespace OfficeIMO.Word {
             CategoryAxis catAxis = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
             ValueAxis valAxis = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
 
-            chart.PlotArea.Append(radarChart);
-            chart.PlotArea.Append(catAxis);
-            chart.PlotArea.Append(valAxis);
+            chart.PlotArea!.Append(radarChart);
+            chart.PlotArea!.Append(catAxis);
+            chart.PlotArea!.Append(valAxis);
             return chart;
         }
 
@@ -656,9 +656,9 @@ namespace OfficeIMO.Word {
             CategoryAxis catAxis = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
             ValueAxis valAxis = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
 
-            chart.PlotArea.Append(chart3d);
-            chart.PlotArea.Append(catAxis);
-            chart.PlotArea.Append(valAxis);
+            chart.PlotArea!.Append(chart3d);
+            chart.PlotArea!.Append(catAxis);
+            chart.PlotArea!.Append(valAxis);
             return chart;
         }
 
@@ -732,10 +732,10 @@ namespace OfficeIMO.Word {
             ValueAxis valAxis = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
             SeriesAxis seriesAxis = AddSeriesAxisInternal(seriesId, catId, AxisPositionValues.Right);
 
-            chart.PlotArea.Append(chart3d);
-            chart.PlotArea.Append(catAxis);
-            chart.PlotArea.Append(valAxis);
-            chart.PlotArea.Append(seriesAxis);
+            chart.PlotArea!.Append(chart3d);
+            chart.PlotArea!.Append(catAxis);
+            chart.PlotArea!.Append(valAxis);
+            chart.PlotArea!.Append(seriesAxis);
             return chart;
         }
 
@@ -777,7 +777,7 @@ namespace OfficeIMO.Word {
 
         private Chart GeneratePie3DChart(Chart chart) {
             Pie3DChart pie3d = CreatePie3DChart();
-            chart.PlotArea.Append(pie3d);
+            chart.PlotArea!.Append(pie3d);
             return chart;
         }
 
@@ -813,9 +813,9 @@ namespace OfficeIMO.Word {
             CategoryAxis catAxis = AddCategoryAxisInternal(catId, valId, AxisPositionValues.Bottom);
             ValueAxis valAxis = AddValueAxisInternal(valId, catId, AxisPositionValues.Left);
 
-            chart.PlotArea.Append(area3d);
-            chart.PlotArea.Append(catAxis);
-            chart.PlotArea.Append(valAxis);
+            chart.PlotArea!.Append(area3d);
+            chart.PlotArea!.Append(catAxis);
+            chart.PlotArea!.Append(valAxis);
 
             return chart;
         }

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -621,15 +621,15 @@ namespace OfficeIMO.Word {
         public int? Rotation {
             get {
                 if (_Image.Inline != null) {
-                    var picture = _Image.Inline.Graphic.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
-                    if (picture.ShapeProperties.Transform2D.Rotation != null) {
+                    var picture = _Image.Inline.Graphic?.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
+                    if (picture?.ShapeProperties?.Transform2D?.Rotation != null) {
                         return picture.ShapeProperties.Transform2D.Rotation / 10000;
                     }
                 } else if (_Image.Anchor != null) {
                     var anchorGraphic = _Image.Anchor.OfType<Graphic>().FirstOrDefault();
-                    if (anchorGraphic != null && anchorGraphic.GraphicData != null) {
+                    if (anchorGraphic?.GraphicData != null) {
                         var picture = anchorGraphic.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
-                        if (picture.ShapeProperties.Transform2D.Rotation != null) {
+                        if (picture?.ShapeProperties?.Transform2D?.Rotation != null) {
                             return picture.ShapeProperties.Transform2D.Rotation / 10000;
                         }
                     }
@@ -639,20 +639,40 @@ namespace OfficeIMO.Word {
             }
             set {
                 if (_Image.Inline != null) {
-                    var picture = _Image.Inline.Graphic.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
-                    if (value == null) {
-                        picture.ShapeProperties.Transform2D.Rotation = null;
-                    } else {
-                        picture.ShapeProperties.Transform2D.Rotation = value.Value * 10000;
+                    var picture = _Image.Inline.Graphic?.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
+                    if (picture != null) {
+                        var shape = picture.ShapeProperties;
+                        if (shape == null) {
+                            shape = new ShapeProperties();
+                            picture.ShapeProperties = shape;
+                        }
+
+                        var transform = shape.Transform2D;
+                        if (transform == null) {
+                            transform = new A.Transform2D();
+                            shape.Transform2D = transform;
+                        }
+
+                        transform.Rotation = value == null ? null : value.Value * 10000;
                     }
                 } else if (_Image.Anchor != null) {
                     var anchorGraphic = _Image.Anchor.OfType<Graphic>().FirstOrDefault();
-                    if (anchorGraphic != null && anchorGraphic.GraphicData != null) {
+                    if (anchorGraphic?.GraphicData != null) {
                         var picture = anchorGraphic.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
-                        if (value == null) {
-                            picture.ShapeProperties.Transform2D.Rotation = null;
-                        } else {
-                            picture.ShapeProperties.Transform2D.Rotation = value.Value * 10000;
+                        if (picture != null) {
+                            var shape = picture.ShapeProperties;
+                            if (shape == null) {
+                                shape = new ShapeProperties();
+                                picture.ShapeProperties = shape;
+                            }
+
+                            var transform = shape.Transform2D;
+                            if (transform == null) {
+                                transform = new A.Transform2D();
+                                shape.Transform2D = transform;
+                            }
+
+                            transform.Rotation = value == null ? null : value.Value * 10000;
                         }
                     }
                 }
@@ -661,12 +681,12 @@ namespace OfficeIMO.Word {
 
         private DocumentFormat.OpenXml.Drawing.Pictures.Picture? GetPicture() {
             if (_Image.Inline != null) {
-                return _Image.Inline.Graphic.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
+                return _Image.Inline.Graphic?.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
             }
 
             if (_Image.Anchor != null) {
                 var anchorGraphic = _Image.Anchor.OfType<Graphic>().FirstOrDefault();
-                if (anchorGraphic != null && anchorGraphic.GraphicData != null) {
+                if (anchorGraphic?.GraphicData != null) {
                     return anchorGraphic.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
                 }
             }
@@ -676,9 +696,11 @@ namespace OfficeIMO.Word {
 
         private void SetPicture(Pic.Picture picture) {
             if (_Image.Inline != null) {
-                var graphicData = _Image.Inline.Graphic.GraphicData;
-                graphicData.RemoveAllChildren<Pic.Picture>();
-                graphicData.AppendChild(picture);
+                var graphicData = _Image.Inline.Graphic?.GraphicData;
+                if (graphicData != null) {
+                    graphicData.RemoveAllChildren<Pic.Picture>();
+                    graphicData.AppendChild(picture);
+                }
             } else if (_Image.Anchor != null) {
                 var anchorGraphic = _Image.Anchor.OfType<Graphic>().FirstOrDefault();
                 if (anchorGraphic?.GraphicData != null) {
@@ -694,18 +716,23 @@ namespace OfficeIMO.Word {
         public int? CropTop {
             get {
                 var picture = GetPicture();
-                return picture?.BlipFill?.SourceRectangle?.Top;
+                return (int?)picture?.BlipFill?.SourceRectangle?.Top;
             }
             set {
                 _cropTop = value;
                 var picture = GetPicture();
                 if (picture == null) return;
 
-                if (picture.BlipFill.SourceRectangle == null && value != null) {
-                    picture.BlipFill.SourceRectangle = new SourceRectangle();
+                if (picture.BlipFill?.SourceRectangle == null && value != null) {
+                    if (picture.BlipFill == null) {
+                        picture.BlipFill = new Pic.BlipFill();
+                    }
+                    if (picture.BlipFill.SourceRectangle == null) {
+                        picture.BlipFill.SourceRectangle = new A.SourceRectangle();
+                    }
                 }
 
-                if (picture.BlipFill.SourceRectangle != null) {
+                if (picture.BlipFill != null && picture.BlipFill.SourceRectangle != null) {
                     picture.BlipFill.SourceRectangle.Top = value;
                     if (value == null &&
                         picture.BlipFill.SourceRectangle.Left == null &&
@@ -723,18 +750,23 @@ namespace OfficeIMO.Word {
         public int? CropBottom {
             get {
                 var picture = GetPicture();
-                return picture?.BlipFill?.SourceRectangle?.Bottom;
+                return (int?)picture?.BlipFill?.SourceRectangle?.Bottom;
             }
             set {
                 _cropBottom = value;
                 var picture = GetPicture();
                 if (picture == null) return;
 
-                if (picture.BlipFill.SourceRectangle == null && value != null) {
-                    picture.BlipFill.SourceRectangle = new SourceRectangle();
+                if (picture.BlipFill?.SourceRectangle == null && value != null) {
+                    if (picture.BlipFill == null) {
+                        picture.BlipFill = new Pic.BlipFill();
+                    }
+                    if (picture.BlipFill.SourceRectangle == null) {
+                        picture.BlipFill.SourceRectangle = new A.SourceRectangle();
+                    }
                 }
 
-                if (picture.BlipFill.SourceRectangle != null) {
+                if (picture.BlipFill != null && picture.BlipFill.SourceRectangle != null) {
                     picture.BlipFill.SourceRectangle.Bottom = value;
                     if (value == null &&
                         picture.BlipFill.SourceRectangle.Left == null &&
@@ -752,18 +784,23 @@ namespace OfficeIMO.Word {
         public int? CropLeft {
             get {
                 var picture = GetPicture();
-                return picture?.BlipFill?.SourceRectangle?.Left;
+                return (int?)picture?.BlipFill?.SourceRectangle?.Left;
             }
             set {
                 _cropLeft = value;
                 var picture = GetPicture();
                 if (picture == null) return;
 
-                if (picture.BlipFill.SourceRectangle == null && value != null) {
-                    picture.BlipFill.SourceRectangle = new SourceRectangle();
+                if (picture.BlipFill?.SourceRectangle == null && value != null) {
+                    if (picture.BlipFill == null) {
+                        picture.BlipFill = new Pic.BlipFill();
+                    }
+                    if (picture.BlipFill.SourceRectangle == null) {
+                        picture.BlipFill.SourceRectangle = new A.SourceRectangle();
+                    }
                 }
 
-                if (picture.BlipFill.SourceRectangle != null) {
+                if (picture.BlipFill != null && picture.BlipFill.SourceRectangle != null) {
                     picture.BlipFill.SourceRectangle.Left = value;
                     if (value == null &&
                         picture.BlipFill.SourceRectangle.Top == null &&
@@ -781,18 +818,23 @@ namespace OfficeIMO.Word {
         public int? CropRight {
             get {
                 var picture = GetPicture();
-                return picture?.BlipFill?.SourceRectangle?.Right;
+                return (int?)picture?.BlipFill?.SourceRectangle?.Right;
             }
             set {
                 _cropRight = value;
                 var picture = GetPicture();
                 if (picture == null) return;
 
-                if (picture.BlipFill.SourceRectangle == null && value != null) {
-                    picture.BlipFill.SourceRectangle = new SourceRectangle();
+                if (picture.BlipFill?.SourceRectangle == null && value != null) {
+                    if (picture.BlipFill == null) {
+                        picture.BlipFill = new Pic.BlipFill();
+                    }
+                    if (picture.BlipFill.SourceRectangle == null) {
+                        picture.BlipFill.SourceRectangle = new A.SourceRectangle();
+                    }
                 }
 
-                if (picture.BlipFill.SourceRectangle != null) {
+                if (picture.BlipFill != null && picture.BlipFill.SourceRectangle != null) {
                     picture.BlipFill.SourceRectangle.Right = value;
                     if (value == null &&
                         picture.BlipFill.SourceRectangle.Top == null &&

--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -155,7 +155,7 @@ namespace OfficeIMO.Word {
         /// <remarks>The source list is removed after its items are transferred.</remarks>
         public void Merge(WordList documentList) {
             foreach (var item in documentList.ListItems.ToList()) {
-                var numberingProperties = item._paragraphProperties.NumberingProperties;
+                var numberingProperties = item._paragraphProperties?.NumberingProperties;
                 if (numberingProperties != null && numberingProperties.NumberingId != null) {
                     numberingProperties.NumberingId.Val = this._numberId;
                 }

--- a/OfficeIMO.Word/WordSection.cs
+++ b/OfficeIMO.Word/WordSection.cs
@@ -211,7 +211,9 @@ namespace OfficeIMO.Word {
                 List<WordBreak> list = new List<WordBreak>();
                 var paragraphs = Paragraphs.Where(p => p.IsPageBreak).ToList();
                 foreach (var paragraph in paragraphs) {
-                    list.Add(paragraph.PageBreak);
+                    if (paragraph.PageBreak != null) {
+                        list.Add(paragraph.PageBreak);
+                    }
                 }
                 return list;
             }
@@ -225,7 +227,9 @@ namespace OfficeIMO.Word {
                 List<WordChart> list = new List<WordChart>();
                 var paragraphs = Paragraphs.Where(p => p.IsChart).ToList();
                 foreach (var paragraph in paragraphs) {
-                    list.Add(paragraph.Chart);
+                    if (paragraph.Chart != null) {
+                        list.Add(paragraph.Chart);
+                    }
                 }
                 return list;
             }
@@ -239,7 +243,9 @@ namespace OfficeIMO.Word {
                 List<WordBreak> list = new List<WordBreak>();
                 var paragraphs = Paragraphs.Where(p => p.IsBreak).ToList();
                 foreach (var paragraph in paragraphs) {
-                    list.Add(paragraph.Break);
+                    if (paragraph.Break != null) {
+                        list.Add(paragraph.Break);
+                    }
                 }
                 return list;
             }
@@ -253,7 +259,9 @@ namespace OfficeIMO.Word {
                 List<WordImage> list = new List<WordImage>();
                 var paragraphs = Paragraphs.Where(p => p.IsImage).ToList();
                 foreach (var paragraph in paragraphs) {
-                    list.Add(paragraph.Image);
+                    if (paragraph.Image != null) {
+                        list.Add(paragraph.Image);
+                    }
                 }
                 return list;
             }
@@ -267,7 +275,9 @@ namespace OfficeIMO.Word {
                 List<WordEmbeddedObject> list = new List<WordEmbeddedObject>();
                 var paragraphs = Paragraphs.Where(p => p.IsEmbeddedObject).ToList();
                 foreach (var paragraph in paragraphs) {
-                    list.Add(paragraph.EmbeddedObject);
+                    if (paragraph.EmbeddedObject != null) {
+                        list.Add(paragraph.EmbeddedObject);
+                    }
                 }
                 return list;
             }
@@ -280,7 +290,9 @@ namespace OfficeIMO.Word {
                 List<WordBookmark> list = new List<WordBookmark>();
                 var paragraphs = Paragraphs.Where(p => p.IsBookmark).ToList();
                 foreach (var paragraph in paragraphs) {
-                    list.Add(paragraph.Bookmark);
+                    if (paragraph.Bookmark != null) {
+                        list.Add(paragraph.Bookmark);
+                    }
                 }
                 return list;
             }
@@ -294,7 +306,9 @@ namespace OfficeIMO.Word {
                 List<WordField> list = new List<WordField>();
                 var paragraphs = Paragraphs.Where(p => p.IsField).ToList();
                 foreach (var paragraph in paragraphs) {
-                    list.Add(paragraph.Field);
+                    if (paragraph.Field != null) {
+                        list.Add(paragraph.Field);
+                    }
                 }
                 return list;
             }
@@ -308,7 +322,9 @@ namespace OfficeIMO.Word {
                 List<WordEndNote> list = new List<WordEndNote>();
                 var paragraphs = Paragraphs.Where(p => p.IsEndNote).ToList();
                 foreach (var paragraph in paragraphs) {
-                    list.Add(paragraph.EndNote);
+                    if (paragraph.EndNote != null) {
+                        list.Add(paragraph.EndNote);
+                    }
                 }
                 return list;
             }
@@ -322,7 +338,9 @@ namespace OfficeIMO.Word {
                 List<WordFootNote> list = new List<WordFootNote>();
                 var paragraphs = Paragraphs.Where(p => p.IsFootNote).ToList();
                 foreach (var paragraph in paragraphs) {
-                    list.Add(paragraph.FootNote);
+                    if (paragraph.FootNote != null) {
+                        list.Add(paragraph.FootNote);
+                    }
                 }
                 return list;
             }
@@ -336,12 +354,14 @@ namespace OfficeIMO.Word {
                 List<WordHyperLink> list = new List<WordHyperLink>();
                 var paragraphs = Paragraphs.Where(p => p.IsHyperLink).ToList();
                 foreach (var paragraph in paragraphs) {
-                    list.Add(paragraph.Hyperlink);
+                    if (paragraph.Hyperlink != null) {
+                        list.Add(paragraph.Hyperlink);
+                    }
                 }
 
                 foreach (var table in this.Tables) {
                     foreach (var paragraph in table.Paragraphs) {
-                        if (paragraph.IsHyperLink) {
+                        if (paragraph.IsHyperLink && paragraph.Hyperlink != null) {
                             list.Add(paragraph.Hyperlink);
                         }
                     }
@@ -358,7 +378,9 @@ namespace OfficeIMO.Word {
                 List<WordTabChar> list = new List<WordTabChar>();
                 var paragraphs = Paragraphs.Where(p => p.IsTab).ToList();
                 foreach (var paragraph in paragraphs) {
-                    list.Add(paragraph.Tab);
+                    if (paragraph.Tab != null) {
+                        list.Add(paragraph.Tab);
+                    }
                 }
                 return list;
             }
@@ -373,7 +395,9 @@ namespace OfficeIMO.Word {
                 List<WordTextBox> list = new List<WordTextBox>();
                 var paragraphs = Paragraphs.Where(p => p.IsTextBox).ToList();
                 foreach (var paragraph in paragraphs) {
-                    list.Add(paragraph.TextBox);
+                    if (paragraph.TextBox != null) {
+                        list.Add(paragraph.TextBox);
+                    }
                 }
                 return list;
             }
@@ -388,7 +412,9 @@ namespace OfficeIMO.Word {
                 List<WordShape> list = new List<WordShape>();
                 var paragraphs = ParagraphsShapes;
                 foreach (var paragraph in paragraphs) {
-                    list.Add(paragraph.Shape);
+                    if (paragraph.Shape != null) {
+                        list.Add(paragraph.Shape);
+                    }
                 }
                 return list;
             }
@@ -403,7 +429,9 @@ namespace OfficeIMO.Word {
                 List<WordSmartArt> list = new List<WordSmartArt>();
                 var paragraphs = ParagraphsSmartArts;
                 foreach (var paragraph in paragraphs) {
-                    list.Add(paragraph.SmartArt);
+                    if (paragraph.SmartArt != null) {
+                        list.Add(paragraph.SmartArt);
+                    }
                 }
                 return list;
             }

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -298,7 +298,7 @@ namespace OfficeIMO.Word {
             get {
                 var width = _tableCellProperties?.TableCellMargin?.TopMargin?.Width;
                 if (width != null) {
-                    return Int16.Parse(width);
+                    return short.Parse(width!);
                 }
                 return null;
             }
@@ -323,7 +323,7 @@ namespace OfficeIMO.Word {
             get {
                 var width = _tableCellProperties?.TableCellMargin?.BottomMargin?.Width;
                 if (width != null) {
-                    return Int16.Parse(width);
+                    return short.Parse(width!);
                 }
                 return null;
             }
@@ -348,7 +348,7 @@ namespace OfficeIMO.Word {
             get {
                 var width = _tableCellProperties?.TableCellMargin?.LeftMargin?.Width;
                 if (width != null) {
-                    return Int16.Parse(width);
+                    return short.Parse(width!);
                 }
                 return null;
             }
@@ -373,7 +373,7 @@ namespace OfficeIMO.Word {
             get {
                 var width = _tableCellProperties?.TableCellMargin?.RightMargin?.Width;
                 if (width != null) {
-                    return Int16.Parse(width);
+                    return short.Parse(width!);
                 }
                 return null;
             }

--- a/OfficeIMO.Word/WordTablePosition.cs
+++ b/OfficeIMO.Word/WordTablePosition.cs
@@ -241,7 +241,7 @@ namespace OfficeIMO.Word {
         public TableOverlapValues? TableOverlap {
             get {
                 if (_tableProperties != null && _tableProperties.TableOverlap != null)
-                    return _tableProperties.TableOverlap.Val;
+                    return _tableProperties.TableOverlap.Val != null ? _tableProperties.TableOverlap.Val.Value : (TableOverlapValues?)null;
 
                 return null;
             }

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Word {
         private readonly WordDocument _document;
         private readonly WordParagraph _wordParagraph;
         private readonly WordHeaderFooter? _headerFooter;
-        private Run _run => _wordParagraph._run;
+        private Run _run => _wordParagraph._run!;
         private V.TextBox? _vmlTextBox;
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace OfficeIMO.Word {
         public WordTextBox(WordDocument wordDocument, string text, WrapTextImage wrapTextImage) {
             var paragraph = new WordParagraph(wordDocument, true, true);
             wordDocument.AddParagraph(paragraph);
-            paragraph._run.Append(new RunProperties());
+            paragraph._run!.Append(new RunProperties());
             AddAlternateContent(wordDocument, paragraph, text, wrapTextImage);
 
             _document = wordDocument;
@@ -57,7 +57,7 @@ namespace OfficeIMO.Word {
             _headerFooter = wordHeaderFooter;
 
             var paragraph = wordHeaderFooter.AddParagraph(newRun: true);
-            paragraph._run.Append(new RunProperties());
+            paragraph._run!.Append(new RunProperties());
             AddAlternateContent(wordDocument, paragraph, text, wrapTextImage);
 
             _wordParagraph = paragraph;
@@ -73,7 +73,7 @@ namespace OfficeIMO.Word {
         public WordTextBox(WordDocument wordDocument, WordParagraph paragraph, string text, WrapTextImage wrapTextImage) {
             _document = wordDocument;
 
-            paragraph._run.Append(new RunProperties());
+            paragraph._run!.Append(new RunProperties());
             AddAlternateContent(wordDocument, paragraph, text, wrapTextImage);
 
             _wordParagraph = paragraph;


### PR DESCRIPTION
## Summary
- guard paragraph-derived collections against null additions
- ensure image rotation and cropping handle missing OpenXML elements
- assert optional fields when merging lists and setting table overlap

## Testing
- `dotnet build -c Release`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68af4035c504832eb5e94ba464f29a68