### PR TITLE
Fix nullable warnings in WordParagraph RunProperties

### DIFF
--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -135,7 +135,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? Spacing {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Spacing != null) {
                     return runProperties.Spacing.Val?.Value;
                 }
@@ -144,11 +144,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 if (value != null) {
                     Spacing spacing = new Spacing();
@@ -165,7 +164,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool Strike {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Strike != null) {
                     return true;
                 } else {
@@ -175,11 +174,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 if (value != true) {
                     if (runProperties.Strike != null) runProperties.Strike.Remove();
@@ -194,7 +192,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool DoubleStrike {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.DoubleStrike != null) {
                     return true;
                 } else {
@@ -204,11 +202,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 if (value != true) {
                     if (runProperties.DoubleStrike != null) runProperties.DoubleStrike.Remove();
@@ -222,7 +219,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? FontSize {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.FontSize != null) {
                     var val = runProperties.FontSize.Val;
                     if (!string.IsNullOrEmpty(val) && int.TryParse(val, out var fontSizeInHalfPoint)) {
@@ -234,11 +231,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 if (value != null) {
                     FontSize fontSize = new FontSize();
@@ -272,7 +268,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string ColorHex {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Color != null) {
                     return runProperties.Color.Val?.Value ?? "";
                 }
@@ -281,11 +277,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 if (value != "") {
                     var color = new DocumentFormat.OpenXml.Wordprocessing.Color();
@@ -302,7 +297,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public ThemeColorValues? ThemeColor {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Color != null && runProperties.Color.ThemeColor != null) {
                     return runProperties.Color.ThemeColor?.Value;
                 }
@@ -311,11 +306,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 if (value != null) {
                     var color = new DocumentFormat.OpenXml.Wordprocessing.Color {
@@ -335,7 +329,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public HighlightColorValues? Highlight {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Highlight != null) {
                     return runProperties.Highlight.Val?.Value;
                 }
@@ -344,11 +338,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 var highlight = new Highlight {
                     Val = value
@@ -362,7 +355,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public CapsStyle CapsStyle {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.Caps != null) {
                     return CapsStyle.Caps;
                 } else if (runProperties != null && runProperties.SmallCaps != null) {
@@ -374,11 +367,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 if (value == CapsStyle.None) {
                     runProperties.Caps = null;
@@ -403,7 +395,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? FontFamily {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.RunFonts != null) {
                     return runProperties.RunFonts.Ascii;
                 }
@@ -412,11 +404,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
 
                 if (runProperties.RunFonts == null) {
@@ -441,7 +432,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? FontFamilyHighAnsi {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.RunFonts != null) {
                     return runProperties.RunFonts.HighAnsi;
                 }
@@ -450,11 +441,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 if (runProperties.RunFonts == null) {
                     runProperties.RunFonts = new RunFonts { };
@@ -473,7 +463,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? FontFamilyEastAsia {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.RunFonts != null) {
                     return runProperties.RunFonts.EastAsia;
                 }
@@ -482,11 +472,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 if (runProperties.RunFonts == null) {
                     runProperties.RunFonts = new RunFonts { };
@@ -505,7 +494,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? FontFamilyComplexScript {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.RunFonts != null) {
                     return runProperties.RunFonts.ComplexScript;
                 }
@@ -514,11 +503,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
                 if (runProperties.RunFonts == null) {
                     runProperties.RunFonts = new RunFonts { };
@@ -537,7 +525,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         public WordCharacterStyles? CharacterStyle {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 if (runProperties != null && runProperties.RunStyle != null) {
                     var styleId = runProperties.RunStyle.Val;
                     if (!string.IsNullOrEmpty(styleId)) {
@@ -549,11 +537,10 @@ namespace OfficeIMO.Word {
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
 
                 if (value == null) {
@@ -570,17 +557,16 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? CharacterStyleId {
             get {
-                var runProperties = IsHyperLink ? this.Hyperlink._runProperties : _runProperties;
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
                 return runProperties?.RunStyle?.Val;
             }
             set {
                 RunProperties runProperties;
                 if (IsHyperLink) {
-                    VerifyRunProperties(this.Hyperlink._hyperlink, this.Hyperlink._run, this.Hyperlink._runProperties);
-                    runProperties = this.Hyperlink._runProperties;
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
                 } else {
-                    VerifyRunProperties();
-                    runProperties = _runProperties;
+                    runProperties = VerifyRunProperties();
                 }
 
                 if (string.IsNullOrEmpty(value)) {


### PR DESCRIPTION
## Summary
- eliminate nullable warnings in `WordParagraph.RunProperties`
- ensure run property setters verify hyperlink context before access

## Testing
- `dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj -c Release`
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68af40207930832eaba8e7fb0d7c22db