### PR TITLE
Escape special characters in Markdown conversion

### DIFF
--- a/OfficeIMO.Examples/Converters/Markdown/Markdown.EscapeCharacters.cs
+++ b/OfficeIMO.Examples/Converters/Markdown/Markdown.EscapeCharacters.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Markdown;
+
+namespace OfficeIMO.Examples.Markdown {
+    internal static partial class Markdown {
+        public static void Example_MarkdownEscapeCharacters(string folderPath, bool openWord) {
+            string filePath = Path.Combine(folderPath, "MarkdownEscapeCharacters.docx");
+
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Characters: * _ [ ] ( ) # + - . ! \\ >");
+            doc.Save(filePath);
+
+            string markdown = doc.ToMarkdown(new WordToMarkdownOptions());
+            Console.WriteLine(markdown);
+
+            if (openWord) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Markdown.EscapeCharacters.cs
+++ b/OfficeIMO.Tests/Markdown.EscapeCharacters.cs
@@ -1,0 +1,30 @@
+using OfficeIMO.Word;
+using OfficeIMO.Word.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Markdown {
+        [Fact]
+        public void WordToMarkdown_EscapesSpecialCharacters() {
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Characters: * _ [ ] ( ) # + - . ! \\ >");
+
+            string md = doc.ToMarkdown(new WordToMarkdownOptions());
+
+            Assert.Contains("\\*", md);
+            Assert.Contains("\\_", md);
+            Assert.Contains("\\[", md);
+            Assert.Contains("\\]", md);
+            Assert.Contains("\\(", md);
+            Assert.Contains("\\)", md);
+            Assert.Contains("\\#", md);
+            Assert.Contains("\\+", md);
+            Assert.Contains("\\-", md);
+            Assert.Contains("\\.", md);
+            Assert.Contains("\\!", md);
+            Assert.Contains("\\\\", md);
+            Assert.Contains("\\>", md);
+        }
+    }
+}
+

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Paragraphs.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Paragraphs.cs
@@ -63,9 +63,15 @@ namespace OfficeIMO.Word.Markdown.Converters {
                     continue;
                 }
 
+                bool code = !string.IsNullOrEmpty(codeFont) && string.Equals(run.FontFamily, codeFont, StringComparison.OrdinalIgnoreCase);
+
                 string? text = run.Text;
                 if (string.IsNullOrEmpty(text)) {
                     continue;
+                }
+
+                if (!code) {
+                    text = EscapeMarkdown(text);
                 }
 
                 if (run.Bold && run.Italic) {
@@ -88,7 +94,6 @@ namespace OfficeIMO.Word.Markdown.Converters {
                     text = $"=={text}==";
                 }
 
-                bool code = !string.IsNullOrEmpty(codeFont) && string.Equals(run.FontFamily, codeFont, StringComparison.OrdinalIgnoreCase);
                 if (code) {
                     text = $"`{text}`";
                 }
@@ -158,6 +163,17 @@ namespace OfficeIMO.Word.Markdown.Converters {
                 string base64 = System.Convert.ToBase64String(bytes);
                 return $"![{alt}](data:{mime};base64,{base64})";
             }
+        }
+
+        private static string EscapeMarkdown(string text) {
+            var sb = new StringBuilder(text.Length * 2);
+            foreach (char c in text) {
+                if (c == '\\' || c == '`' || c == '*' || c == '_' || c == '{' || c == '}' || c == '[' || c == ']' || c == '(' || c == ')' || c == '#' || c == '+' || c == '-' || c == '.' || c == '!' || c == '>') {
+                    sb.Append('\\');
+                }
+                sb.Append(c);
+            }
+            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
## Summary
- escape Markdown control characters in Word-to-Markdown conversion
- add example demonstrating special character escaping
- add unit test for escaping behavior

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "WordToMarkdown_EscapesSpecialCharacters"`
- `dotnet build OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b16d300b54832e86107da49a1f6807