### PR TITLE
Fix nullable reference warnings in tests

### DIFF
--- a/OfficeIMO.Tests/Excel.AutoFilter.cs
+++ b/OfficeIMO.Tests/Excel.AutoFilter.cs
@@ -35,16 +35,18 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                AutoFilter autoFilter = wsPart.Worksheet.Elements<AutoFilter>().FirstOrDefault();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                AutoFilter? autoFilter = wsPart.Worksheet.Elements<AutoFilter>().FirstOrDefault();
                 Assert.NotNull(autoFilter);
-                Assert.Equal("A1:B3", autoFilter.Reference.Value);
-                FilterColumn filterColumn = autoFilter.Elements<FilterColumn>().FirstOrDefault();
+                Assert.NotNull(autoFilter!.Reference);
+                Assert.Equal("A1:B3", autoFilter.Reference!.Value);
+                FilterColumn? filterColumn = autoFilter.Elements<FilterColumn>().FirstOrDefault();
                 Assert.NotNull(filterColumn);
-                Filters filters = filterColumn.GetFirstChild<Filters>();
+                Filters? filters = filterColumn!.GetFirstChild<Filters>();
                 Assert.NotNull(filters);
-                Filter filter = filters.Elements<Filter>().First();
-                Assert.Equal("A", filter.Val.Value);
+                Filter filter = filters!.Elements<Filter>().First();
+                Assert.NotNull(filter.Val);
+                Assert.Equal("A", filter.Val!.Value);
             }
         }
 
@@ -68,10 +70,11 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                AutoFilter autoFilter = wsPart.Worksheet.Elements<AutoFilter>().FirstOrDefault();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                AutoFilter? autoFilter = wsPart.Worksheet.Elements<AutoFilter>().FirstOrDefault();
                 Assert.NotNull(autoFilter);
-                Assert.Equal("A1:B3", autoFilter.Reference.Value);
+                Assert.NotNull(autoFilter!.Reference);
+                Assert.Equal("A1:B3", autoFilter.Reference!.Value);
             }
         }
     }

--- a/OfficeIMO.Tests/Excel.AutoFit.cs
+++ b/OfficeIMO.Tests/Excel.AutoFit.cs
@@ -27,20 +27,23 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 var columns = wsPart.Worksheet.GetFirstChild<Columns>();
                 Assert.NotNull(columns);
-                var column = columns.Elements<Column>().First();
-                Assert.True(column.Width.HasValue && column.Width.Value > 0);
+                var column = columns!.Elements<Column>().First();
+                Assert.NotNull(column.Width);
+                Assert.True(column.Width!.Value > 0);
 
                 var sheetFormat = wsPart.Worksheet.GetFirstChild<SheetFormatProperties>();
-                Assert.True(sheetFormat?.DefaultRowHeight > 0);
+                Assert.NotNull(sheetFormat);
+                Assert.True(sheetFormat!.DefaultRowHeight > 0);
 
-                var row1 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex == 1);
+                var row1 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex != null && r.RowIndex.Value == 1);
 
-                var row3 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex == 3);
+                var row3 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex != null && r.RowIndex.Value == 3);
                 Assert.True(row3.CustomHeight?.Value ?? false);
-                Assert.True(row3.Height.HasValue && row3.Height.Value > 0);
+                Assert.NotNull(row3.Height);
+                Assert.True(row3.Height!.Value > 0);
             }
         }
 
@@ -56,8 +59,8 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                var row2 = wsPart.Worksheet.Descendants<Row>().FirstOrDefault(r => r.RowIndex == 2);
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                var row2 = wsPart.Worksheet.Descendants<Row>().FirstOrDefault(r => r.RowIndex != null && r.RowIndex.Value == 2);
                 Assert.NotNull(row2);
                 Assert.False(row2!.CustomHeight?.Value ?? false);
                 Assert.False(row2.Height?.HasValue ?? false);
@@ -82,8 +85,8 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                var row1 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex == 1);
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                var row1 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex != null && r.RowIndex.Value == 1);
                 Assert.False(row1.CustomHeight?.Value ?? false);
                 Assert.False(row1.Height?.HasValue ?? false);
             }
@@ -107,9 +110,9 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 var columns = wsPart.Worksheet.GetFirstChild<Columns>();
-                Assert.True(columns == null || !columns.Elements<Column>().Any(c => c.Min == 1 && c.Max == 1));
+                Assert.True(columns == null || !columns.Elements<Column>().Any(c => c.Min != null && c.Max != null && c.Min.Value == 1 && c.Max.Value == 1));
             }
         }
 
@@ -125,15 +128,15 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 var columns = wsPart.Worksheet.GetFirstChild<Columns>();
                 Assert.NotNull(columns);
-                var column1 = columns.Elements<Column>().FirstOrDefault(c => c.Min == 1 && c.Max == 1);
+                var column1 = columns!.Elements<Column>().FirstOrDefault(c => c.Min != null && c.Max != null && c.Min.Value == 1 && c.Max.Value == 1);
                 Assert.NotNull(column1);
                 Assert.True(column1!.BestFit?.Value ?? false);
                 Assert.True(column1.Width?.Value > 0);
 
-                var column2 = columns.Elements<Column>().FirstOrDefault(c => c.Min == 2 && c.Max == 2);
+                var column2 = columns.Elements<Column>().FirstOrDefault(c => c.Min != null && c.Max != null && c.Min.Value == 2 && c.Max.Value == 2);
                 Assert.Null(column2);
             }
         }
@@ -149,7 +152,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 var worksheet = wsPart.Worksheet;
                 var columns = worksheet.GetFirstChild<Columns>() ?? worksheet.InsertAt(new Columns(), 0);
                 columns.RemoveAllChildren();
@@ -164,11 +167,11 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 var cols = wsPart.Worksheet.GetFirstChild<Columns>()!.Elements<Column>().ToList();
                 Assert.Equal(new uint[] { 1, 2 }, cols.Select(c => c.Min!.Value).ToArray());
-                var column1 = cols.First(c => c.Min == 1 && c.Max == 1);
-                var column2 = cols.First(c => c.Min == 2 && c.Max == 2);
+                var column1 = cols.First(c => c.Min != null && c.Max != null && c.Min.Value == 1 && c.Max.Value == 1);
+                var column2 = cols.First(c => c.Min != null && c.Max != null && c.Min.Value == 2 && c.Max.Value == 2);
                 Assert.True(column1.Width!.Value > column2.Width!.Value);
                 Assert.Equal(10.0, column2.Width!.Value);
 
@@ -189,12 +192,12 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                var row1 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex == 1);
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                var row1 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex != null && r.RowIndex.Value == 1);
                 Assert.True(row1.CustomHeight?.Value ?? false);
                 Assert.True(row1.Height?.Value > 0);
 
-                var row2 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex == 2);
+                var row2 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex != null && r.RowIndex.Value == 2);
                 Assert.False(row2.CustomHeight?.Value ?? false);
                 Assert.False(row2.Height?.HasValue ?? false);
             }
@@ -256,11 +259,11 @@ namespace OfficeIMO.Tests {
             double expectedHeight = lineHeight * 2 + 2;
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                var column = wsPart.Worksheet.GetFirstChild<Columns>()!.Elements<Column>().First(c => c.Min == 1 && c.Max == 1);
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                var column = wsPart.Worksheet.GetFirstChild<Columns>()!.Elements<Column>().First(c => c.Min != null && c.Max != null && c.Min.Value == 1 && c.Max.Value == 1);
                 Assert.True(column.Width!.Value >= expectedWidth - 1);
 
-                var row = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex == 3);
+                var row = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex != null && r.RowIndex.Value == 3);
                 Assert.True(row.Height!.Value > 0);
             }
         }
@@ -281,15 +284,17 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 var columns = wsPart.Worksheet.GetFirstChild<Columns>();
                 Assert.NotNull(columns);
-                var column = columns.Elements<Column>().First();
+                var column = columns!.Elements<Column>().First();
                 Assert.True(column.BestFit?.Value ?? false);
-                Assert.True(column.Width.HasValue && column.Width.Value > 0);
+                Assert.NotNull(column.Width);
+                Assert.True(column.Width!.Value > 0);
 
                 var sheetFormat = wsPart.Worksheet.GetFirstChild<SheetFormatProperties>();
-                Assert.True(sheetFormat?.DefaultRowHeight > 0);
+                Assert.NotNull(sheetFormat);
+                Assert.True(sheetFormat!.DefaultRowHeight > 0);
             }
         }
 
@@ -313,11 +318,12 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                var column = wsPart.Worksheet.GetFirstChild<Columns>()!.Elements<Column>().First(c => c.Min == 1 && c.Max == 1);
-                Assert.True(column.Width.HasValue && column.Width.Value > 0);
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                var column = wsPart.Worksheet.GetFirstChild<Columns>()!.Elements<Column>().First(c => c.Min != null && c.Max != null && c.Min.Value == 1 && c.Max.Value == 1);
+                Assert.NotNull(column.Width);
+                Assert.True(column.Width!.Value > 0);
 
-                var row = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex == 2);
+                var row = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex != null && r.RowIndex.Value == 2);
                 Assert.True(row.CustomHeight?.Value ?? false);
                 Assert.True(row.Height.HasValue && row.Height.Value > 0);
             }

--- a/OfficeIMO.Tests/Excel.Fluent.cs
+++ b/OfficeIMO.Tests/Excel.Fluent.cs
@@ -140,23 +140,24 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                AutoFilter autoFilter = wsPart.Worksheet.Elements<AutoFilter>().FirstOrDefault();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                AutoFilter? autoFilter = wsPart.Worksheet.Elements<AutoFilter>().FirstOrDefault();
                 Assert.NotNull(autoFilter);
-                Assert.Equal("A1:B3", autoFilter.Reference.Value);
+                Assert.NotNull(autoFilter!.Reference);
+                Assert.Equal("A1:B3", autoFilter.Reference!.Value);
 
-                var rules = wsPart.Worksheet.Elements<ConditionalFormatting>()
-                    .SelectMany(cf => cf.Elements<ConditionalFormattingRule>())
-                    .ToList();
-                Assert.Contains(rules, r => r.Type == ConditionalFormatValues.ColorScale);
-                Assert.Contains(rules, r => r.Type == ConditionalFormatValues.DataBar);
+                  var rules = wsPart.Worksheet.Elements<ConditionalFormatting>()
+                      .SelectMany(cf => cf.Elements<ConditionalFormattingRule>())
+                      .ToList();
+                  Assert.Contains(rules, r => r.Type?.Value == ConditionalFormatValues.ColorScale);
+                  Assert.Contains(rules, r => r.Type?.Value == ConditionalFormatValues.DataBar);
 
-                var column = wsPart.Worksheet.GetFirstChild<Columns>()?.Elements<Column>().FirstOrDefault();
-                Assert.True(column?.BestFit?.Value ?? false);
+                  var column = wsPart.Worksheet.GetFirstChild<Columns>()?.Elements<Column>().FirstOrDefault();
+                  Assert.True(column?.BestFit?.Value ?? false);
 
-                var row = wsPart.Worksheet.Descendants<Row>().FirstOrDefault(r => r.RowIndex == 1);
-                Assert.False(row?.CustomHeight?.Value ?? false);
-            }
+                  var row = wsPart.Worksheet.Descendants<Row>().FirstOrDefault(r => r.RowIndex != null && r.RowIndex.Value == 1);
+                  Assert.False(row?.CustomHeight?.Value ?? false);
+              }
 
             File.Delete(filePath);
         }

--- a/OfficeIMO.Tests/Excel.RowsFromObjectsTests.cs
+++ b/OfficeIMO.Tests/Excel.RowsFromObjectsTests.cs
@@ -132,7 +132,8 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Alice", GetCellValue(document, wsPart, "A3"));
                 var table = wsPart.TableDefinitionParts.First();
                 Assert.NotNull(table.Table);
-                Assert.Equal("People", table.Table.DisplayName.Value);
+                Assert.NotNull(table.Table!.DisplayName);
+                Assert.Equal("People", table.Table.DisplayName!.Value);
                 Assert.Equal("TableStyleMedium9", table.Table.TableStyleInfo?.Name?.Value);
             }
 

--- a/OfficeIMO.Tests/Html.Abbreviations.cs
+++ b/OfficeIMO.Tests/Html.Abbreviations.cs
@@ -11,8 +11,9 @@ namespace OfficeIMO.Tests {
             using var doc = html.LoadFromHtml();
             Assert.True(doc.Paragraphs.Count >= 1);
             Assert.Equal("text", doc.Paragraphs[0].Text);
+            Assert.NotNull(doc.FootNotes);
             Assert.Single(doc.FootNotes);
-            Assert.Equal("desc", doc.FootNotes[0].Paragraphs[1].Text);
+            Assert.Equal("desc", doc.FootNotes![0].Paragraphs[1].Text);
 
             string roundTrip = doc.ToHtml(new WordToHtmlOptions { ExportFootnotes = true });
             Assert.Contains("<abbr", roundTrip, StringComparison.OrdinalIgnoreCase);

--- a/OfficeIMO.Tests/Html.BlockquoteCitations.cs
+++ b/OfficeIMO.Tests/Html.BlockquoteCitations.cs
@@ -11,8 +11,9 @@ namespace OfficeIMO.Tests {
 
             Assert.Equal("First", doc.Paragraphs[0].Text);
             Assert.Contains(doc.Paragraphs, p => p.Text == "Second");
+            Assert.NotNull(doc.FootNotes);
             Assert.Single(doc.FootNotes);
-            Assert.Equal("https://example.com", doc.FootNotes[0].Paragraphs[1].Text);
+            Assert.Equal("https://example.com", doc.FootNotes![0].Paragraphs[1].Text);
         }
     }
 }

--- a/OfficeIMO.Tests/Html.Footnotes.cs
+++ b/OfficeIMO.Tests/Html.Footnotes.cs
@@ -17,8 +17,11 @@ namespace OfficeIMO.Tests {
 
             using var roundTrip = html.LoadFromHtml();
 
-            Assert.True(roundTrip.FootNotes.Count >= 1);
-            Assert.Equal("footnote text", roundTrip.FootNotes[0].Paragraphs[1].Text);
+            Assert.NotNull(roundTrip.FootNotes);
+            Assert.True(roundTrip.FootNotes!.Count >= 1);
+            var footnote = roundTrip.FootNotes[0];
+            Assert.NotNull(footnote);
+            Assert.Equal("footnote text", footnote.Paragraphs[1].Text);
 
             string html2 = roundTrip.ToHtml(new WordToHtmlOptions { ExportFootnotes = true });
             Assert.Contains("footnote text", html2, StringComparison.OrdinalIgnoreCase);

--- a/OfficeIMO.Tests/Html.WordToHtml.cs
+++ b/OfficeIMO.Tests/Html.WordToHtml.cs
@@ -74,7 +74,8 @@ namespace OfficeIMO.Tests {
             var paragraph = doc.AddParagraph();
             paragraph.AddImage(assetPath, 40, 40, description: "Company logo");
 
-            Assert.Equal("Company logo", paragraph.Image.Description);
+            Assert.NotNull(paragraph.Image);
+            Assert.Equal("Company logo", paragraph.Image!.Description);
 
             string html = doc.ToHtml();
 
@@ -129,7 +130,7 @@ namespace OfficeIMO.Tests {
         public void Test_WordToHtml_BulletType() {
             using var doc = WordDocument.Create();
             var list = doc.AddList(WordListStyle.Bulleted);
-            list.Numbering.Levels[0]._level.LevelText.Val = "o";
+            list.Numbering.Levels[0]._level.LevelText!.Val = "o";
             list.AddItem("One");
             list.AddItem("Two");
 
@@ -142,7 +143,7 @@ namespace OfficeIMO.Tests {
         public void Test_WordToHtml_LowerLetter() {
             using var doc = WordDocument.Create();
             var list = doc.AddList(WordListStyle.ArticleSections);
-            list.Numbering.Levels[0]._level.NumberingFormat.Val = NumberFormatValues.LowerLetter;
+            list.Numbering.Levels[0]._level.NumberingFormat!.Val = NumberFormatValues.LowerLetter;
             list.AddItem("alpha");
             list.AddItem("beta");
 
@@ -156,7 +157,7 @@ namespace OfficeIMO.Tests {
         public void Test_WordToHtml_DecimalLeadingZero() {
             using var doc = WordDocument.Create();
             var list = doc.AddList(WordListStyle.ArticleSections);
-            list.Numbering.Levels[0]._level.NumberingFormat.Val = NumberFormatValues.DecimalZero;
+            list.Numbering.Levels[0]._level.NumberingFormat!.Val = NumberFormatValues.DecimalZero;
             list.Numbering.Levels[0].SetStartNumberingValue(3);
             list.AddItem("three");
             list.AddItem("four");

--- a/OfficeIMO.Tests/Markdown.Footnotes.cs
+++ b/OfficeIMO.Tests/Markdown.Footnotes.cs
@@ -7,8 +7,9 @@ namespace OfficeIMO.Tests {
         public void MarkdownToWord_Footnotes() {
             string md = "Text with footnote[^1].\n\n[^1]: Footnote text";
             using var doc = md.LoadFromMarkdown();
+            Assert.NotNull(doc.FootNotes);
             Assert.Single(doc.FootNotes);
-            Assert.Equal("Footnote text", doc.FootNotes[0].Paragraphs[1].Text);
+            Assert.Equal("Footnote text", doc.FootNotes![0].Paragraphs[1].Text);
         }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.RepairTest.cs
+++ b/OfficeIMO.Tests/PowerPoint.RepairTest.cs
@@ -56,11 +56,11 @@ namespace OfficeIMO.Tests {
                 foreach (var slidePart in document.PresentationPart.SlideParts) {
                     var shapeTree = slidePart.Slide.CommonSlideData?.ShapeTree;
                     if (shapeTree != null) {
-                        var ids = shapeTree.Descendants<NonVisualDrawingProperties>()
-                            .Select(dp => dp.Id?.Value)
-                            .Where(id => id.HasValue)
-                            .Select(id => id.Value)
-                            .ToList();
+                      var ids = shapeTree.Descendants<NonVisualDrawingProperties>()
+                          .Select(dp => dp.Id?.Value)
+                          .Where(id => id.HasValue)
+                          .Select(id => id!.Value)
+                          .ToList();
                         
                         // Verify all IDs are unique
                         Assert.Equal(ids.Count, ids.Distinct().Count());
@@ -72,12 +72,12 @@ namespace OfficeIMO.Tests {
                 Assert.NotNull(slideIdList);
                 
                 foreach (SlideId slideId in slideIdList.Elements<SlideId>()) {
-                    Assert.NotNull(slideId.RelationshipId);
-                    Assert.NotNull(slideId.Id);
-                    Assert.True(slideId.Id.Value >= 256);
-                    
-                    // Verify the relationship exists
-                    var part = document.PresentationPart.GetPartById(slideId.RelationshipId);
+                      Assert.NotNull(slideId.RelationshipId);
+                      Assert.NotNull(slideId.Id);
+                      Assert.True(slideId.Id!.Value >= 256);
+
+                      // Verify the relationship exists
+                      var part = document.PresentationPart.GetPartById(slideId.RelationshipId!);
                     Assert.NotNull(part);
                     Assert.IsType<SlidePart>(part);
                 }

--- a/OfficeIMO.Tests/PowerPoint.TextFormatting.cs
+++ b/OfficeIMO.Tests/PowerPoint.TextFormatting.cs
@@ -30,16 +30,16 @@ namespace OfficeIMO.Tests {
                 SlidePart slidePart = document.PresentationPart!.SlideParts.First();
                 Shape shape = slidePart.Slide.Descendants<Shape>().First();
                 var paragraphs = shape.TextBody!.Elements<A.Paragraph>().ToList();
-                foreach (var paragraph in paragraphs) {
-                    A.Run run = paragraph.GetFirstChild<A.Run>()!;
-                    A.RunProperties rp = run.RunProperties!;
-                    Assert.True(rp.Bold == true);
-                    Assert.True(rp.Italic == true);
-                    Assert.Equal(2400, rp.FontSize!.Value);
-                    Assert.Equal("Arial", rp.GetFirstChild<A.LatinFont>()?.Typeface);
-                    Assert.Equal("FF0000", rp.GetFirstChild<A.SolidFill>()?.RgbColorModelHex?.Val);
+                    foreach (var paragraph in paragraphs) {
+                        A.Run run = paragraph.GetFirstChild<A.Run>()!;
+                        A.RunProperties rp = run.RunProperties!;
+                        Assert.True(rp.Bold?.Value ?? false);
+                        Assert.True(rp.Italic?.Value ?? false);
+                        Assert.Equal(2400, rp.FontSize!.Value);
+                        Assert.Equal("Arial", rp.GetFirstChild<A.LatinFont>()?.Typeface);
+                        Assert.Equal("FF0000", rp.GetFirstChild<A.SolidFill>()?.RgbColorModelHex?.Val);
+                    }
                 }
-            }
 
             File.Delete(filePath);
         }

--- a/OfficeIMO.Tests/Visio.Connectors.cs
+++ b/OfficeIMO.Tests/Visio.Connectors.cs
@@ -34,12 +34,13 @@ namespace OfficeIMO.Tests {
 
             PackagePart pagePart = package.GetPart(new Uri("/visio/pages/page1.xml", UriKind.Relative));
             XDocument pageXml = XDocument.Load(pagePart.GetStream());
-            XElement connectorShape = pageXml.Root?
+            XElement? connectorShape = pageXml.Root?
                 .Element(ns + "Shapes")?
                 .Elements(ns + "Shape")
-                .First(e => e.Attribute("ID")?.Value == connector.Id);
+                .FirstOrDefault(e => e.Attribute("ID")?.Value == connector.Id);
+            Assert.NotNull(connectorShape);
 
-            XElement[] segments = connectorShape.Element(ns + "Geom")?.Elements().ToArray() ?? Array.Empty<XElement>();
+            XElement[] segments = connectorShape!.Element(ns + "Geom")?.Elements().ToArray() ?? Array.Empty<XElement>();
             Assert.Empty(segments);
 
             XElement connects = pageXml.Root?.Element(ns + "Connects") ?? new XElement("none");

--- a/OfficeIMO.Tests/Visio.Fluent.cs
+++ b/OfficeIMO.Tests/Visio.Fluent.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Tests {
             VisioDocument document = VisioDocument.Create(filePath);
 
             VisioDocument result = document.AsFluent()
-                .AddPage("Page1", out VisioPage page)
+                .AddPage("Page1", 8.5, 11, VisioMeasurementUnit.Inches, out VisioPage page)
                 .End();
 
             Assert.Same(document, result);

--- a/OfficeIMO.Tests/Visio.ShapeBounds.cs
+++ b/OfficeIMO.Tests/Visio.ShapeBounds.cs
@@ -36,12 +36,13 @@ namespace OfficeIMO.Tests {
             XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
             PackagePart pagePart = package.GetPart(new Uri("/visio/pages/page1.xml", UriKind.Relative));
             XDocument pageXml = XDocument.Load(pagePart.GetStream());
-            XElement connectorShape = pageXml.Root?
+            XElement? connectorShape = pageXml.Root?
                 .Element(ns + "Shapes")?
                 .Elements(ns + "Shape")
-                .First(e => e.Attribute("ID")?.Value == connector.Id);
+                .FirstOrDefault(e => e.Attribute("ID")?.Value == connector.Id);
+            Assert.NotNull(connectorShape);
 
-            XElement[] segments = connectorShape.Element(ns + "Geom")?.Elements().ToArray() ?? Array.Empty<XElement>();
+            XElement[] segments = connectorShape!.Element(ns + "Geom")?.Elements().ToArray() ?? Array.Empty<XElement>();
             Assert.Empty(segments);
         }
     }

--- a/OfficeIMO.Tests/Word.Watermark.cs
+++ b/OfficeIMO.Tests/Word.Watermark.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using Xunit;
 using Color = SixLabors.ImageSharp.Color;
 using V = DocumentFormat.OpenXml.Vml;
-using DocumentFormat.OpenXml.Packaging;
 
 namespace OfficeIMO.Tests {
     public partial class Word {


### PR DESCRIPTION
## Summary
- guard against null footnote collections in HTML and Markdown tests
- add null checks in Excel, PowerPoint, and Visio tests to satisfy nullable analysis
- replace obsolete Visio AddPage overload and remove duplicate using directive

## Testing
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68b59358fae8832eb86b4f22d725066d