### PR TITLE
Fix nullable reference warnings in tests

### DIFF
--- a/OfficeIMO.Tests/Excel.ConditionalFormatting.cs
+++ b/OfficeIMO.Tests/Excel.ConditionalFormatting.cs
@@ -21,13 +21,14 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                ConditionalFormatting cf = wsPart.Worksheet.Elements<ConditionalFormatting>().FirstOrDefault();
+                var workbookPart = spreadsheet.WorkbookPart!;
+                WorksheetPart wsPart = workbookPart.WorksheetParts.First();
+                ConditionalFormatting? cf = wsPart.Worksheet.Elements<ConditionalFormatting>().FirstOrDefault();
                 Assert.NotNull(cf);
-                Assert.Equal("A1:A2", cf.SequenceOfReferences.InnerText);
+                Assert.Equal("A1:A2", cf!.SequenceOfReferences!.InnerText);
                 ConditionalFormattingRule rule = cf.Elements<ConditionalFormattingRule>().First();
-                Assert.Equal(ConditionalFormatValues.CellIs, rule.Type.Value);
-                Assert.Equal(ConditionalFormattingOperatorValues.GreaterThan, rule.Operator.Value);
+                Assert.Equal(ConditionalFormatValues.CellIs, rule.Type!.Value);
+                Assert.Equal(ConditionalFormattingOperatorValues.GreaterThan, rule.Operator!.Value);
                 Assert.Equal("10", rule.Elements<Formula>().First().Text);
             }
         }
@@ -45,16 +46,17 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                ConditionalFormatting cf = wsPart.Worksheet.Elements<ConditionalFormatting>().FirstOrDefault();
+                var workbookPart = spreadsheet.WorkbookPart!;
+                WorksheetPart wsPart = workbookPart.WorksheetParts.First();
+                ConditionalFormatting? cf = wsPart.Worksheet.Elements<ConditionalFormatting>().FirstOrDefault();
                 Assert.NotNull(cf);
-                ConditionalFormattingRule rule = cf.Elements<ConditionalFormattingRule>().First();
-                Assert.Equal(ConditionalFormatValues.ColorScale, rule.Type.Value);
-                ColorScale colorScale = rule.GetFirstChild<ColorScale>();
+                ConditionalFormattingRule rule = cf!.Elements<ConditionalFormattingRule>().First();
+                Assert.Equal(ConditionalFormatValues.ColorScale, rule.Type!.Value);
+                ColorScale? colorScale = rule.GetFirstChild<ColorScale>();
                 Assert.NotNull(colorScale);
-                var colors = colorScale.Elements<DocumentFormat.OpenXml.Spreadsheet.Color>().ToList();
-                Assert.Equal("FFFF0000", colors[0].Rgb.Value);
-                Assert.Equal("FF00FF00", colors[1].Rgb.Value);
+                var colors = colorScale!.Elements<DocumentFormat.OpenXml.Spreadsheet.Color>().ToList();
+                Assert.Equal("FFFF0000", colors[0].Rgb!.Value);
+                Assert.Equal("FF00FF00", colors[1].Rgb!.Value);
             }
         }
 
@@ -71,15 +73,16 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                ConditionalFormatting cf = wsPart.Worksheet.Elements<ConditionalFormatting>().FirstOrDefault();
+                var workbookPart = spreadsheet.WorkbookPart!;
+                WorksheetPart wsPart = workbookPart.WorksheetParts.First();
+                ConditionalFormatting? cf = wsPart.Worksheet.Elements<ConditionalFormatting>().FirstOrDefault();
                 Assert.NotNull(cf);
-                ConditionalFormattingRule rule = cf.Elements<ConditionalFormattingRule>().First();
-                Assert.Equal(ConditionalFormatValues.DataBar, rule.Type.Value);
-                DataBar dataBar = rule.GetFirstChild<DataBar>();
+                ConditionalFormattingRule rule = cf!.Elements<ConditionalFormattingRule>().First();
+                Assert.Equal(ConditionalFormatValues.DataBar, rule.Type!.Value);
+                DataBar? dataBar = rule.GetFirstChild<DataBar>();
                 Assert.NotNull(dataBar);
-                var color = dataBar.Elements<DocumentFormat.OpenXml.Spreadsheet.Color>().First();
-                Assert.Equal("FF0000FF", color.Rgb.Value);
+                var color = dataBar!.Elements<DocumentFormat.OpenXml.Spreadsheet.Color>().First();
+                Assert.Equal("FF0000FF", color.Rgb!.Value);
             }
         }
 
@@ -102,11 +105,12 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                var workbookPart = spreadsheet.WorkbookPart!;
+                WorksheetPart wsPart = workbookPart.WorksheetParts.First();
                 var formats = wsPart.Worksheet.Elements<ConditionalFormatting>().ToList();
-                Assert.Contains(formats, cf => cf.Elements<ConditionalFormattingRule>().Any(r => r.Type == ConditionalFormatValues.CellIs));
-                Assert.Contains(formats, cf => cf.Elements<ConditionalFormattingRule>().Any(r => r.Type == ConditionalFormatValues.ColorScale));
-                Assert.Contains(formats, cf => cf.Elements<ConditionalFormattingRule>().Any(r => r.Type == ConditionalFormatValues.DataBar));
+                Assert.Contains(formats, cf => cf.Elements<ConditionalFormattingRule>().Any(r => r.Type?.Value == ConditionalFormatValues.CellIs));
+                Assert.Contains(formats, cf => cf.Elements<ConditionalFormattingRule>().Any(r => r.Type?.Value == ConditionalFormatValues.ColorScale));
+                Assert.Contains(formats, cf => cf.Elements<ConditionalFormattingRule>().Any(r => r.Type?.Value == ConditionalFormatValues.DataBar));
             }
         }
     }

--- a/OfficeIMO.Tests/Excel.Freeze.cs
+++ b/OfficeIMO.Tests/Excel.Freeze.cs
@@ -24,9 +24,10 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                SheetView sheetView = wsPart.Worksheet.GetFirstChild<SheetViews>()?.GetFirstChild<SheetView>();
-                Pane pane = sheetView?.GetFirstChild<Pane>();
+                var workbookPart = spreadsheet.WorkbookPart!;
+                WorksheetPart wsPart = workbookPart.WorksheetParts.First();
+                SheetView? sheetView = wsPart.Worksheet.GetFirstChild<SheetViews>()?.GetFirstChild<SheetView>();
+                Pane? pane = sheetView?.GetFirstChild<Pane>();
                 Assert.NotNull(pane);
                 Assert.Equal(PaneValues.BottomLeft, pane!.ActivePane?.Value);
                 Assert.Equal("A2", pane.TopLeftCell?.Value);
@@ -57,9 +58,10 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                SheetView sheetView = wsPart.Worksheet.GetFirstChild<SheetViews>()?.GetFirstChild<SheetView>();
-                Pane pane = sheetView?.GetFirstChild<Pane>();
+                var workbookPart = spreadsheet.WorkbookPart!;
+                WorksheetPart wsPart = workbookPart.WorksheetParts.First();
+                SheetView? sheetView = wsPart.Worksheet.GetFirstChild<SheetViews>()?.GetFirstChild<SheetView>();
+                Pane? pane = sheetView?.GetFirstChild<Pane>();
                 Assert.NotNull(pane);
                 Assert.Equal(PaneValues.TopRight, pane!.ActivePane?.Value);
                 Assert.Equal("C1", pane.TopLeftCell?.Value);
@@ -90,9 +92,10 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
-                SheetView sheetView = wsPart.Worksheet.GetFirstChild<SheetViews>()?.GetFirstChild<SheetView>();
-                Pane pane = sheetView?.GetFirstChild<Pane>();
+                var workbookPart = spreadsheet.WorkbookPart!;
+                WorksheetPart wsPart = workbookPart.WorksheetParts.First();
+                SheetView? sheetView = wsPart.Worksheet.GetFirstChild<SheetViews>()?.GetFirstChild<SheetView>();
+                Pane? pane = sheetView?.GetFirstChild<Pane>();
                 Assert.NotNull(pane);
                 Assert.Equal(1D, pane!.HorizontalSplit?.Value);
                 Assert.Equal(1D, pane.VerticalSplit?.Value);
@@ -132,7 +135,8 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                var workbookPart = spreadsheet.WorkbookPart!;
+                WorksheetPart wsPart = workbookPart.WorksheetParts.First();
                 Assert.Null(wsPart.Worksheet.GetFirstChild<SheetViews>());
 
                 OpenXmlValidator validator = new OpenXmlValidator(FileFormatVersions.Microsoft365);

--- a/OfficeIMO.Tests/Excel.SaveOpen.cs
+++ b/OfficeIMO.Tests/Excel.SaveOpen.cs
@@ -33,7 +33,10 @@ namespace OfficeIMO.Tests {
             Assert.Null(ex);
             using (spreadsheet) {
                 ValidateSpreadsheetDocument(filePath, spreadsheet);
-                Assert.Equal(2, spreadsheet.WorkbookPart.Workbook.Sheets.OfType<Sheet>().Count());
+                Assert.NotNull(spreadsheet.WorkbookPart);
+                Assert.NotNull(spreadsheet.WorkbookPart!.Workbook);
+                Assert.NotNull(spreadsheet.WorkbookPart!.Workbook!.Sheets);
+                Assert.Equal(2, spreadsheet.WorkbookPart!.Workbook!.Sheets!.OfType<Sheet>().Count());
             }
         }
     }

--- a/OfficeIMO.Tests/Word.Bookmarks.cs
+++ b/OfficeIMO.Tests/Word.Bookmarks.cs
@@ -47,9 +47,9 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Bookmarks[2].Name == "Middle0");
                 Assert.True(document.Bookmarks[3].Name == "EndOfDocument");
 
-                Assert.True(bookmark.Bookmark.Name == "Start");
+                Assert.True(bookmark.Bookmark!.Name == "Start");
 
-                Assert.True(bookmark1.Bookmark.Name == "Middle0");
+                Assert.True(bookmark1.Bookmark!.Name == "Middle0");
                 document.Save(false);
             }
 
@@ -73,16 +73,16 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Bookmarks[3].Name == "EndOfDocument");
                 Assert.True(document.Bookmarks[4].Name == "EndofEnds");
 
-                Assert.True(document.ParagraphsBookmarks[0].Bookmark.Name == "Start");
-                Assert.True(document.ParagraphsBookmarks[1].Bookmark.Name == "Middle1");
-                Assert.True(document.ParagraphsBookmarks[2].Bookmark.Name == "Middle0");
-                Assert.True(document.ParagraphsBookmarks[3].Bookmark.Name == "EndOfDocument");
-                Assert.True(document.ParagraphsBookmarks[4].Bookmark.Name == "EndofEnds");
+                Assert.True(document.ParagraphsBookmarks[0].Bookmark!.Name == "Start");
+                Assert.True(document.ParagraphsBookmarks[1].Bookmark!.Name == "Middle1");
+                Assert.True(document.ParagraphsBookmarks[2].Bookmark!.Name == "Middle0");
+                Assert.True(document.ParagraphsBookmarks[3].Bookmark!.Name == "EndOfDocument");
+                Assert.True(document.ParagraphsBookmarks[4].Bookmark!.Name == "EndofEnds");
 
                 Assert.True(document.Bookmarks.Count == 5);
                 Assert.True(document.Paragraphs.Count == 16);
 
-                document.ParagraphsBookmarks[2].Bookmark.Name = "Middle6";
+                document.ParagraphsBookmarks[2].Bookmark!.Name = "Middle6";
                 document.Bookmarks[1].Name = "MiddleDocument";
 
                 document.Save(false);
@@ -92,11 +92,11 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.True(document.Bookmarks.Count == 5);
                 Assert.True(document.Paragraphs.Count == 16);
-                Assert.True(document.ParagraphsBookmarks[0].Bookmark.Name == "Start");
-                Assert.True(document.ParagraphsBookmarks[1].Bookmark.Name == "MiddleDocument");
-                Assert.True(document.ParagraphsBookmarks[2].Bookmark.Name == "Middle6");
-                Assert.True(document.ParagraphsBookmarks[3].Bookmark.Name == "EndOfDocument");
-                Assert.True(document.ParagraphsBookmarks[4].Bookmark.Name == "EndofEnds");
+                Assert.True(document.ParagraphsBookmarks[0].Bookmark!.Name == "Start");
+                Assert.True(document.ParagraphsBookmarks[1].Bookmark!.Name == "MiddleDocument");
+                Assert.True(document.ParagraphsBookmarks[2].Bookmark!.Name == "Middle6");
+                Assert.True(document.ParagraphsBookmarks[3].Bookmark!.Name == "EndOfDocument");
+                Assert.True(document.ParagraphsBookmarks[4].Bookmark!.Name == "EndofEnds");
 
                 document.AddBookmark("Add bookmark straight to document. This shouldn't throw");
 

--- a/OfficeIMO.Tests/Word.CleanupOptions.cs
+++ b/OfficeIMO.Tests/Word.CleanupOptions.cs
@@ -71,7 +71,8 @@ namespace OfficeIMO.Tests {
                 WordParagraph run = document.AddParagraph().AddText("Test");
                 run.SetBold();
                 run.SetBold(false);
-                Assert.NotNull(run._run.RunProperties);
+                Assert.NotNull(run._run);
+                Assert.NotNull(run._run!.RunProperties);
                 document.CleanupDocument();
                 Assert.NotNull(run._paragraph);
                 var firstRun = run._paragraph!.Elements<Run>().First();

--- a/OfficeIMO.Tests/Word.Fluent.ParagraphBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ParagraphBuilder.cs
@@ -12,8 +12,9 @@ namespace OfficeIMO.Tests {
     public partial class Word {
         private static void RemoveCustomStyle(string styleId) {
             var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static);
-            var dict = (IDictionary<string, Style>)field!.GetValue(null);
-            dict.Remove(styleId);
+            var dict = (IDictionary<string, Style>?)field!.GetValue(null);
+            Assert.NotNull(dict);
+            dict!.Remove(styleId);
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Word.FontEmbedding.cs
+++ b/OfficeIMO.Tests/Word.FontEmbedding.cs
@@ -19,9 +19,9 @@ namespace OfficeIMO.Tests {
             }
 
             using var word = WordprocessingDocument.Open(filePath, false);
-            var fontTablePart = word.MainDocumentPart.FontTablePart;
+            var fontTablePart = word.MainDocumentPart?.FontTablePart;
             Assert.NotNull(fontTablePart);
-            Assert.True(fontTablePart.FontParts.Any());
+            Assert.True(fontTablePart!.FontParts.Any());
             File.Delete(fontPath);
         }
 
@@ -37,8 +37,11 @@ namespace OfficeIMO.Tests {
             }
 
             using var word = WordprocessingDocument.Open(filePath, false);
-            var styles = word.MainDocumentPart.StyleDefinitionsPart!.Styles;
-            Assert.NotNull(styles.Elements<Style>().FirstOrDefault(s => s.StyleId == "DejaVuStyle"));
+            var stylePart = word.MainDocumentPart?.StyleDefinitionsPart;
+            Assert.NotNull(stylePart);
+            var styles = stylePart!.Styles;
+            Assert.NotNull(styles);
+            Assert.NotNull(styles!.Elements<Style>().FirstOrDefault(s => s.StyleId == "DejaVuStyle"));
             File.Delete(fontPath);
         }
     }

--- a/OfficeIMO.Tests/Word.FootnoteEndnoteProperties.cs
+++ b/OfficeIMO.Tests/Word.FootnoteEndnoteProperties.cs
@@ -27,15 +27,20 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Equal(NumberFormatValues.LowerRoman, document.Sections[0].FootnoteProperties.NumberingFormat.Val.Value);
-                Assert.Equal(FootnotePositionValues.PageBottom, document.Sections[0].FootnoteProperties.FootnotePosition.Val.Value);
-                Assert.Equal(RestartNumberValues.EachSection, document.Sections[0].FootnoteProperties.NumberingRestart.Val.Value);
-                Assert.Equal(5, document.Sections[0].FootnoteProperties.NumberingStart.Val.Value);
+                var section = document.Sections[0];
+                var footProps = section.FootnoteProperties;
+                Assert.NotNull(footProps);
+                Assert.Equal(NumberFormatValues.LowerRoman, footProps!.NumberingFormat!.Val!.Value);
+                Assert.Equal(FootnotePositionValues.PageBottom, footProps.FootnotePosition!.Val!.Value);
+                Assert.Equal(RestartNumberValues.EachSection, footProps.NumberingRestart!.Val!.Value);
+                Assert.Equal(5, footProps.NumberingStart!.Val!.Value);
 
-                Assert.Equal(NumberFormatValues.Decimal, document.Sections[0].EndnoteProperties.NumberingFormat.Val.Value);
-                Assert.Equal(EndnotePositionValues.SectionEnd, document.Sections[0].EndnoteProperties.EndnotePosition.Val.Value);
-                Assert.Equal(RestartNumberValues.EachSection, document.Sections[0].EndnoteProperties.NumberingRestart.Val.Value);
-                Assert.Equal(5, document.Sections[0].EndnoteProperties.NumberingStart.Val.Value);
+                var endProps = section.EndnoteProperties;
+                Assert.NotNull(endProps);
+                Assert.Equal(NumberFormatValues.Decimal, endProps!.NumberingFormat!.Val!.Value);
+                Assert.Equal(EndnotePositionValues.SectionEnd, endProps.EndnotePosition!.Val!.Value);
+                Assert.Equal(RestartNumberValues.EachSection, endProps.NumberingRestart!.Val!.Value);
+                Assert.Equal(5, endProps.NumberingStart!.Val!.Value);
             }
         }
     }


### PR DESCRIPTION
## Summary
- add null checks and assertions across Word bookmark and Excel tests
- ensure WorksheetPart and Word sections are validated before use
- harden helper methods for font embedding and paragraph builder

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68b59334d854832eacb8bf1a56c210cf