### PR TITLE
Fix initial OfficeIMO.Excel warnings

### DIFF
--- a/OfficeIMO.Excel/Enums/ExcelNumberPreset.cs
+++ b/OfficeIMO.Excel/Enums/ExcelNumberPreset.cs
@@ -3,20 +3,32 @@ namespace OfficeIMO.Excel
     /// <summary>
     /// Common number format presets for convenience. For full control, use a custom format string.
     /// </summary>
-    public enum ExcelNumberPreset
-    {
-        General,
-        Integer,
-        Decimal,
-        Percent,
-        Currency,
-        Scientific,
-        DateShort,
-        DateLong,
-        Time,
-        DateTime,
-        DurationHours,
-        Text
-    }
+        public enum ExcelNumberPreset
+        {
+            /// <summary>General format with no specific pattern.</summary>
+            General,
+            /// <summary>Whole number with thousands separators.</summary>
+            Integer,
+            /// <summary>Decimal number with configurable fraction digits.</summary>
+            Decimal,
+            /// <summary>Percentage format.</summary>
+            Percent,
+            /// <summary>Currency format using culture-specific symbol.</summary>
+            Currency,
+            /// <summary>Scientific notation.</summary>
+            Scientific,
+            /// <summary>Short date format (yyyy-mm-dd).</summary>
+            DateShort,
+            /// <summary>Long date/time format (yyyy-mm-dd hh:mm).</summary>
+            DateLong,
+            /// <summary>Time format (h:mm:ss).</summary>
+            Time,
+            /// <summary>Date and time format (yyyy-mm-dd hh:mm:ss).</summary>
+            DateTime,
+            /// <summary>Duration in hours format ([h]:mm:ss).</summary>
+            DurationHours,
+            /// <summary>Text format.</summary>
+            Text
+        }
 }
 

--- a/OfficeIMO.Excel/ExcelDocument.Fluent.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Fluent.cs
@@ -2,6 +2,9 @@ using OfficeIMO.Excel.Fluent;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
+        /// <summary>
+        /// Returns a fluent API wrapper for this document.
+        /// </summary>
         public ExcelFluentWorkbook AsFluent() {
             return new ExcelFluentWorkbook(this);
         }

--- a/OfficeIMO.Excel/ExcelDocument.ReadBridge.cs
+++ b/OfficeIMO.Excel/ExcelDocument.ReadBridge.cs
@@ -37,7 +37,7 @@ namespace OfficeIMO.Excel
         /// <summary>
         /// Tries to get a worksheet by name.
         /// </summary>
-        public bool TryGetSheet(string name, out ExcelSheet sheet)
+        public bool TryGetSheet(string name, out ExcelSheet? sheet)
         {
             sheet = Sheets.FirstOrDefault(s => string.Equals(s.Name, name, StringComparison.Ordinal));
             return sheet != null;

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -76,7 +76,6 @@ namespace OfficeIMO.Excel {
         /// Path to the file backing this document.
         /// </summary>
         public string FilePath = string.Empty;
-        private bool _isMemory;
 
         /// <summary>
         /// FileOpenAccess of the document
@@ -375,7 +374,6 @@ namespace OfficeIMO.Excel {
             _spreadSheetDocument = SpreadsheetDocument.Open(mem, true);
             _workBookPart = _spreadSheetDocument.WorkbookPart ?? throw new InvalidOperationException("WorkbookPart is null");
             _sharedStringTablePart = null;
-            _isMemory = true;
 
             if (openExcel) {
                 Helpers.Open(path, true);
@@ -468,15 +466,18 @@ namespace OfficeIMO.Excel {
             return SaveAsync("", openExcel, cancellationToken);
         }
 
+        private bool _disposed;
+
         /// <summary>
         /// Releases resources used by the document.
         /// </summary>
-        private bool _disposed;
-
         public void Dispose() {
             DisposeAsync().GetAwaiter().GetResult();
         }
 
+        /// <summary>
+        /// Asynchronously releases resources used by the document.
+        /// </summary>
         public async ValueTask DisposeAsync() {
             if (_disposed) {
                 return;

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -552,12 +552,6 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
-        /// Sets the value of a cell.
-        /// </summary>
-        /// <param name="row">The 1-based row index.</param>
-        /// <param name="column">The 1-based column index.</param>
-        /// <param name="value">The value to assign.</param>
-        /// <summary>
         /// Sets the specified value into a cell, inferring the data type.
         /// </summary>
         /// <param name="row">The 1-based row index.</param>

--- a/OfficeIMO.Excel/ExcelSheet.ColumnsRows.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ColumnsRows.cs
@@ -629,6 +629,10 @@ namespace OfficeIMO.Excel {
 
         
 
+        /// <summary>
+        /// Auto-fits the width of the specified column based on its contents.
+        /// </summary>
+        /// <param name="columnIndex">1-based column index.</param>
         public void AutoFitColumn(int columnIndex) {
             WriteLockConditional(() => {
                 var width = CalculateColumnWidth(columnIndex);
@@ -686,6 +690,11 @@ namespace OfficeIMO.Excel {
 
         }
 
+        /// <summary>
+        /// Sets the width of the specified column.
+        /// </summary>
+        /// <param name="columnIndex">1-based column index.</param>
+        /// <param name="width">The column width.</param>
         public void SetColumnWidth(int columnIndex, double width) {
             WriteLock(() => {
                 var worksheet = _worksheetPart.Worksheet;
@@ -705,6 +714,11 @@ namespace OfficeIMO.Excel {
             });
         }
 
+        /// <summary>
+        /// Hides or shows the specified column.
+        /// </summary>
+        /// <param name="columnIndex">1-based column index.</param>
+        /// <param name="hidden">True to hide the column; false to show it.</param>
         public void SetColumnHidden(int columnIndex, bool hidden) {
             WriteLock(() => {
                 var worksheet = _worksheetPart.Worksheet;
@@ -723,6 +737,10 @@ namespace OfficeIMO.Excel {
             });
         }
 
+        /// <summary>
+        /// Auto-fits the height of the specified row based on its contents.
+        /// </summary>
+        /// <param name="rowIndex">1-based row index.</param>
         public void AutoFitRow(int rowIndex) {
             WriteLockConditional(() => {
                 var height = CalculateRowHeight(rowIndex);

--- a/OfficeIMO.Excel/ExcelSheet.ConditionalFormatting.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ConditionalFormatting.cs
@@ -18,6 +18,13 @@ using SixLaborsColor = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
+        /// <summary>
+        /// Adds a conditional formatting rule to the specified range.
+        /// </summary>
+        /// <param name="range">A1-style range to apply the rule to.</param>
+        /// <param name="operator">Comparison operator for the rule.</param>
+        /// <param name="formula1">Primary formula or value.</param>
+        /// <param name="formula2">Optional secondary formula or value.</param>
         public void AddConditionalRule(string range, ConditionalFormattingOperatorValues @operator, string formula1, string? formula2 = null) {
             if (string.IsNullOrEmpty(range)) {
                 throw new ArgumentNullException(nameof(range));
@@ -74,10 +81,22 @@ namespace OfficeIMO.Excel {
             return "FF" + color.ToHexColor();
         }
 
+        /// <summary>
+        /// Adds a two-color scale conditional format to a range.
+        /// </summary>
+        /// <param name="range">A1-style range to format.</param>
+        /// <param name="startColor">Starting color of the scale.</param>
+        /// <param name="endColor">Ending color of the scale.</param>
         public void AddConditionalColorScale(string range, SixLaborsColor startColor, SixLaborsColor endColor) {
             AddConditionalColorScale(range, ConvertColor(startColor), ConvertColor(endColor));
         }
 
+        /// <summary>
+        /// Adds a two-color scale conditional format to a range using hex colors.
+        /// </summary>
+        /// <param name="range">A1-style range to format.</param>
+        /// <param name="startColor">Starting color in hex (e.g. FF0000).</param>
+        /// <param name="endColor">Ending color in hex.</param>
         public void AddConditionalColorScale(string range, string startColor, string endColor) {
             if (string.IsNullOrEmpty(range)) {
                 throw new ArgumentNullException(nameof(range));
@@ -131,10 +150,20 @@ namespace OfficeIMO.Excel {
             });
         }
 
+        /// <summary>
+        /// Adds a data bar conditional format to a range.
+        /// </summary>
+        /// <param name="range">A1-style range to format.</param>
+        /// <param name="color">Bar color.</param>
         public void AddConditionalDataBar(string range, SixLaborsColor color) {
             AddConditionalDataBar(range, ConvertColor(color));
         }
 
+        /// <summary>
+        /// Adds a data bar conditional format to a range using a hex color.
+        /// </summary>
+        /// <param name="range">A1-style range to format.</param>
+        /// <param name="color">Bar color in hex (e.g. FF0000).</param>
         public void AddConditionalDataBar(string range, string color) {
             if (string.IsNullOrEmpty(range)) {
                 throw new ArgumentNullException(nameof(range));

--- a/OfficeIMO.Excel/ExcelSheet.Core.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Core.cs
@@ -58,10 +58,17 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public NoLockContext BeginNoLock() => new();
 
+        /// <summary>
+        /// Represents a scope where worksheet operations bypass locking.
+        /// </summary>
         public sealed class NoLockContext : IDisposable
         {
             private readonly IDisposable _scope;
             internal NoLockContext() => _scope = Locking.EnterNoLockScope();
+
+            /// <summary>
+            /// Ends the no-lock scope and restores normal locking behavior.
+            /// </summary>
             public void Dispose() => _scope.Dispose();
         }
 
@@ -413,6 +420,9 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        /// <summary>
+        /// Releases resources held by this worksheet.
+        /// </summary>
         public void Dispose() {
             // No local lock to dispose anymore - using document's lock
         }

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.cs
@@ -97,7 +97,9 @@ namespace OfficeIMO.Excel
                     {
                         var (r, c, obj, fmt) = cells[i];
                         var (val, type) = CoerceForCellNoDom(obj, ssPlanner);
-                        if (type?.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString && val?.Text is string raw)
+                        val ??= new CellValue(string.Empty);
+                        type ??= new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.String);
+                        if (type.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString && val.Text is string raw)
                         {
                             if (raw.Contains("\n") || raw.Contains("\r"))
                                 wrapFlags[i] = true;

--- a/OfficeIMO.Excel/ExcelSheet.Headers.StyleBuilder.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.StyleBuilder.cs
@@ -27,27 +27,64 @@ namespace OfficeIMO.Excel
             return this;
         }
 
+        /// <summary>
+        /// Applies a numeric format with optional decimal places.
+        /// </summary>
+        /// <param name="decimals">Number of decimal places.</param>
         public ColumnStyleByHeaderBuilder Number(int decimals = 0)
             => ApplyFormat(ExcelNumberFormats.Get(ExcelNumberPreset.Decimal, decimals));
 
+        /// <summary>
+        /// Applies an integer number format.
+        /// </summary>
         public ColumnStyleByHeaderBuilder Integer() => ApplyFormat(ExcelNumberFormats.Get(ExcelNumberPreset.Integer));
 
+        /// <summary>
+        /// Applies a percentage format.
+        /// </summary>
+        /// <param name="decimals">Number of decimal places.</param>
         public ColumnStyleByHeaderBuilder Percent(int decimals = 0)
             => ApplyFormat(ExcelNumberFormats.Get(ExcelNumberPreset.Percent, decimals));
 
+        /// <summary>
+        /// Applies a currency format using the specified culture.
+        /// </summary>
+        /// <param name="decimals">Number of decimal places.</param>
+        /// <param name="culture">Culture for currency symbol.</param>
         public ColumnStyleByHeaderBuilder Currency(int decimals = 2, CultureInfo? culture = null)
             => ApplyFormat(ExcelNumberFormats.Get(ExcelNumberPreset.Currency, decimals, culture));
 
+        /// <summary>
+        /// Applies a date format using the provided pattern.
+        /// </summary>
+        /// <param name="pattern">Date format pattern.</param>
         public ColumnStyleByHeaderBuilder Date(string pattern = "yyyy-mm-dd") => ApplyFormat(pattern);
 
+        /// <summary>
+        /// Applies a date and time format using the provided pattern.
+        /// </summary>
+        /// <param name="pattern">DateTime format pattern.</param>
         public ColumnStyleByHeaderBuilder DateTime(string pattern = "yyyy-mm-dd hh:mm:ss") => ApplyFormat(pattern);
 
+        /// <summary>
+        /// Applies a time format.
+        /// </summary>
         public ColumnStyleByHeaderBuilder Time() => ApplyFormat(ExcelNumberFormats.Get(ExcelNumberPreset.Time));
 
+        /// <summary>
+        /// Applies a duration format in hours.
+        /// </summary>
         public ColumnStyleByHeaderBuilder DurationHours() => ApplyFormat(ExcelNumberFormats.Get(ExcelNumberPreset.DurationHours));
 
+        /// <summary>
+        /// Applies a text format.
+        /// </summary>
         public ColumnStyleByHeaderBuilder Text() => ApplyFormat(ExcelNumberFormats.Get(ExcelNumberPreset.Text));
 
+        /// <summary>
+        /// Applies a custom number format string.
+        /// </summary>
+        /// <param name="format">Number format pattern.</param>
         public ColumnStyleByHeaderBuilder NumberFormat(string format) => ApplyFormat(format);
 
         public ColumnStyleByHeaderBuilder Bold()

--- a/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.cs
@@ -18,6 +18,13 @@ using SixLaborsColor = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
+        /// <summary>
+        /// Inserts objects into the worksheet by flattening their properties into columns.
+        /// </summary>
+        /// <typeparam name="T">Type of objects being inserted.</typeparam>
+        /// <param name="items">Collection of objects to insert.</param>
+        /// <param name="includeHeaders">Whether to include column headers.</param>
+        /// <param name="startRow">1-based starting row.</param>
         public void InsertObjects<T>(IEnumerable<T> items, bool includeHeaders = true, int startRow = 1) {
             if (items == null) {
                 throw new ArgumentNullException(nameof(items));

--- a/OfficeIMO.Excel/ExcelSheet.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Tables.cs
@@ -90,7 +90,7 @@ namespace OfficeIMO.Excel {
                 Worksheet worksheet = _worksheetPart.Worksheet;
 
                 // Remove any existing worksheet AutoFilter
-                AutoFilter existing = worksheet.Elements<AutoFilter>().FirstOrDefault();
+                AutoFilter? existing = worksheet.Elements<AutoFilter>().FirstOrDefault();
                 if (existing != null) {
                     worksheet.RemoveChild(existing);
                 }
@@ -266,19 +266,18 @@ namespace OfficeIMO.Excel {
                 
                 // SMART AUTOFILTER HANDLING
                 // Check if there's already a worksheet-level AutoFilter on this range
-                AutoFilter existingWorksheetAutoFilter = _worksheetPart.Worksheet.Elements<AutoFilter>().FirstOrDefault();
-                bool hasExistingFilter = existingWorksheetAutoFilter != null && existingWorksheetAutoFilter.Reference?.Value == range;
-                
+                AutoFilter? existingWorksheetAutoFilter = _worksheetPart.Worksheet.Elements<AutoFilter>().FirstOrDefault();
+                bool hasExistingFilter = existingWorksheetAutoFilter?.Reference?.Value == range;
+
                 if (includeAutoFilter) {
                     // User wants AutoFilter on the table
-                    if (hasExistingFilter) {
+                    if (hasExistingFilter && existingWorksheetAutoFilter != null) {
                         // MIGRATE: Move the existing worksheet AutoFilter to the table (preserving filter criteria)
-                        // First clone the existing AutoFilter to preserve any filter criteria
                         var tableAutoFilter = (AutoFilter)existingWorksheetAutoFilter.CloneNode(true);
-                        
+
                         // Remove from worksheet to avoid conflicts
                         _worksheetPart.Worksheet.RemoveChild(existingWorksheetAutoFilter);
-                        
+
                         // Add to table
                         table.Append(tableAutoFilter);
                     } else {
@@ -287,7 +286,7 @@ namespace OfficeIMO.Excel {
                     }
                 } else {
                     // User doesn't want AutoFilter on the table
-                    if (hasExistingFilter) {
+                    if (hasExistingFilter && existingWorksheetAutoFilter != null) {
                         // REMOVE: Excel doesn't allow worksheet AutoFilter and table on same range
                         // We must remove the worksheet AutoFilter to avoid conflicts
                         _worksheetPart.Worksheet.RemoveChild(existingWorksheetAutoFilter);

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Stream.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Stream.cs
@@ -64,13 +64,13 @@ namespace OfficeIMO.Excel.Read
 
             for (int i = 0; i < chunkIndex; i++)
             {
-                RangeChunk readyChunk;
+                RangeChunk? readyChunk;
                 while (!results.TryRemove(nextToYield, out readyChunk))
                 {
                     Thread.SpinWait(200);
                     Thread.Yield();
                 }
-                yield return readyChunk;
+                yield return readyChunk!;
                 nextToYield++;
             }
 

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.cs
@@ -86,10 +86,12 @@ namespace OfficeIMO.Excel.Read
 
         private object? ConvertCell(Cell cell)
         {
+            var cellRef = cell.CellReference?.Value;
+            var coords = cellRef != null ? A1.ParseCellRef(cellRef) : (Row: 0, Col: 0);
             var raw = new CellRaw
             {
-                Row = (int)(cell.CellReference != null ? A1.ParseCellRef(cell.CellReference.Value).Row : 0),
-                Col = (int)(cell.CellReference != null ? A1.ParseCellRef(cell.CellReference.Value).Col : 0),
+                Row = coords.Row,
+                Col = coords.Col,
                 TypeHint = cell.DataType?.Value,
                 StyleIndex = cell.StyleIndex?.Value,
                 HasFormula = cell.CellFormula is not null,


### PR DESCRIPTION
## Summary
- improve null-safety for sheet access, cell parsing, and data preparation
- add missing XML documentation across Excel helpers
- tidy column and row utilities

## Testing
- `dotnet build OfficeIMO.Excel/OfficeIMO.Excel.csproj`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b74fd29dac832eb0a32eb83f7f3845