### PR TITLE
Resolve initial warnings in OfficeIMO.Tests

### DIFF
--- a/OfficeIMO.Tests/Excel.AutoFit.cs
+++ b/OfficeIMO.Tests/Excel.AutoFit.cs
@@ -36,7 +36,8 @@ namespace OfficeIMO.Tests {
 
                 var sheetFormat = wsPart.Worksheet.GetFirstChild<SheetFormatProperties>();
                 Assert.NotNull(sheetFormat);
-                Assert.True(sheetFormat!.DefaultRowHeight > 0);
+                Assert.NotNull(sheetFormat!.DefaultRowHeight);
+                Assert.True(sheetFormat.DefaultRowHeight.Value > 0);
 
                 var row1 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex != null && r.RowIndex.Value == 1);
 
@@ -208,25 +209,25 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "AutoFit.MixedFonts.xlsx");
 
             static uint AddFontStyle(SpreadsheetDocument doc, string name, double size) {
-                var stylesPart = doc.WorkbookPart.WorkbookStylesPart ?? doc.WorkbookPart.AddNewPart<WorkbookStylesPart>();
+                var stylesPart = doc.WorkbookPart!.WorkbookStylesPart ?? doc.WorkbookPart!.AddNewPart<WorkbookStylesPart>();
                 if (stylesPart.Stylesheet == null) {
                     stylesPart.Stylesheet = new Stylesheet(new Fonts(new DocumentFormat.OpenXml.Spreadsheet.Font()), new Fills(new Fill()), new Borders(new Border()), new CellFormats(new CellFormat()));
-                    stylesPart.Stylesheet.Fonts.Count = 1;
-                    stylesPart.Stylesheet.Fills.Count = 1;
-                    stylesPart.Stylesheet.Borders.Count = 1;
-                    stylesPart.Stylesheet.CellFormats.Count = 1;
+                    stylesPart.Stylesheet.Fonts!.Count = 1;
+                    stylesPart.Stylesheet.Fills!.Count = 1;
+                    stylesPart.Stylesheet.Borders!.Count = 1;
+                    stylesPart.Stylesheet.CellFormats!.Count = 1;
                 }
-                var ss = stylesPart.Stylesheet;
-                ss.Fonts.Append(new DocumentFormat.OpenXml.Spreadsheet.Font(new FontName { Val = name }, new FontSize { Val = size }));
+                var ss = stylesPart.Stylesheet!;
+                ss.Fonts!.Append(new DocumentFormat.OpenXml.Spreadsheet.Font(new FontName { Val = name }, new FontSize { Val = size }));
                 ss.Fonts.Count = (uint)ss.Fonts.ChildElements.Count;
-                ss.CellFormats.Append(new CellFormat { FontId = ss.Fonts.Count - 1, ApplyFont = true });
+                ss.CellFormats!.Append(new CellFormat { FontId = ss.Fonts.Count - 1, ApplyFont = true });
                 ss.CellFormats.Count = (uint)ss.CellFormats.ChildElements.Count;
-                stylesPart.Stylesheet.Save();
+                stylesPart.Stylesheet!.Save();
                 return ss.CellFormats.Count - 1;
             }
 
             static void SetCellStyle(SpreadsheetDocument doc, string cellRef, uint styleIndex) {
-                var wsPart = doc.WorkbookPart.WorksheetParts.First();
+                var wsPart = doc.WorkbookPart!.WorksheetParts.First();
                 var cell = wsPart.Worksheet.Descendants<Cell>().First(c => c.CellReference == cellRef);
                 cell.StyleIndex = styleIndex;
                 wsPart.Worksheet.Save();
@@ -294,7 +295,8 @@ namespace OfficeIMO.Tests {
 
                 var sheetFormat = wsPart.Worksheet.GetFirstChild<SheetFormatProperties>();
                 Assert.NotNull(sheetFormat);
-                Assert.True(sheetFormat!.DefaultRowHeight > 0);
+                Assert.NotNull(sheetFormat!.DefaultRowHeight);
+                Assert.True(sheetFormat.DefaultRowHeight.Value > 0);
             }
         }
 
@@ -325,7 +327,7 @@ namespace OfficeIMO.Tests {
 
                 var row = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex != null && r.RowIndex.Value == 2);
                 Assert.True(row.CustomHeight?.Value ?? false);
-                Assert.True(row.Height.HasValue && row.Height.Value > 0);
+                Assert.True(row.Height != null && row.Height.Value > 0);
             }
         }
     }

--- a/OfficeIMO.Tests/Excel.CellValues.Additional.cs
+++ b/OfficeIMO.Tests/Excel.CellValues.Additional.cs
@@ -50,48 +50,48 @@ namespace OfficeIMO.Tests {
             using (spreadsheet) {
                 ValidateSpreadsheetDocument(filePath, spreadsheet);
 
-                WorksheetPart wsPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 var cells = wsPart.Worksheet.Descendants<Cell>().ToList();
-                SharedStringTablePart shared = spreadsheet.WorkbookPart.SharedStringTablePart;
+                SharedStringTablePart shared = spreadsheet.WorkbookPart!.SharedStringTablePart!;
 
                 Cell cellDto = cells.First(c => c.CellReference == "A1");
-                Assert.Equal(dateOffset.UtcDateTime.ToOADate().ToString(CultureInfo.InvariantCulture), cellDto.CellValue.Text);
+                Assert.Equal(dateOffset.UtcDateTime.ToOADate().ToString(CultureInfo.InvariantCulture), cellDto.CellValue!.Text);
 
                 Cell cellTs = cells.First(c => c.CellReference == "A2");
-                Assert.Equal(time.TotalDays.ToString(CultureInfo.InvariantCulture), cellTs.CellValue.Text);
+                Assert.Equal(time.TotalDays.ToString(CultureInfo.InvariantCulture), cellTs.CellValue!.Text);
 
                 Cell cellUint = cells.First(c => c.CellReference == "A3");
-                Assert.Equal(ui.ToString(CultureInfo.InvariantCulture), cellUint.CellValue.Text);
+                Assert.Equal(ui.ToString(CultureInfo.InvariantCulture), cellUint.CellValue!.Text);
 
                 Cell cellUlong = cells.First(c => c.CellReference == "A4");
-                Assert.Equal(((double)ul).ToString(CultureInfo.InvariantCulture), cellUlong.CellValue.Text);
+                Assert.Equal(((double)ul).ToString(CultureInfo.InvariantCulture), cellUlong.CellValue!.Text);
 
                 Cell cellUshort = cells.First(c => c.CellReference == "A5");
-                Assert.Equal(us.ToString(CultureInfo.InvariantCulture), cellUshort.CellValue.Text);
+                Assert.Equal(us.ToString(CultureInfo.InvariantCulture), cellUshort.CellValue!.Text);
 
                 Cell cellByte = cells.First(c => c.CellReference == "A6");
-                Assert.Equal(by.ToString(CultureInfo.InvariantCulture), cellByte.CellValue.Text);
+                Assert.Equal(by.ToString(CultureInfo.InvariantCulture), cellByte.CellValue!.Text);
 
                 Cell cellNullableInt = cells.First(c => c.CellReference == "A7");
-                Assert.Equal(nullableInt.Value.ToString(CultureInfo.InvariantCulture), cellNullableInt.CellValue.Text);
+                Assert.Equal(nullableInt.Value.ToString(CultureInfo.InvariantCulture), cellNullableInt.CellValue!.Text);
 
                 Cell cellNullableNull = cells.First(c => c.CellReference == "A8");
-                Assert.Equal(CellValues.SharedString, cellNullableNull.DataType.Value);
-                Assert.Equal("0", cellNullableNull.CellValue.Text);
+                Assert.Equal(CellValues.SharedString, cellNullableNull.DataType!.Value);
+                Assert.Equal("0", cellNullableNull.CellValue!.Text);
                 Assert.NotNull(shared);
-                Assert.Equal(string.Empty, shared.SharedStringTable.ElementAt(0).InnerText);
+                Assert.Equal(string.Empty, shared!.SharedStringTable!.ElementAt(0).InnerText);
 
                 Cell cellNullableDto = cells.First(c => c.CellReference == "A9");
-                Assert.Equal(nullableDto.Value.UtcDateTime.ToOADate().ToString(CultureInfo.InvariantCulture), cellNullableDto.CellValue.Text);
+                Assert.Equal(nullableDto.Value.UtcDateTime.ToOADate().ToString(CultureInfo.InvariantCulture), cellNullableDto.CellValue!.Text);
 
                 Cell cellNullableTs = cells.First(c => c.CellReference == "A10");
-                Assert.Equal(nullableTs.Value.TotalDays.ToString(CultureInfo.InvariantCulture), cellNullableTs.CellValue.Text);
+                Assert.Equal(nullableTs.Value.TotalDays.ToString(CultureInfo.InvariantCulture), cellNullableTs.CellValue!.Text);
 
-                var styles = spreadsheet.WorkbookPart.WorkbookStylesPart.Stylesheet;
-                var numberingFormats = styles.NumberingFormats.Elements<NumberingFormat>().ToList();
-                Assert.Contains(numberingFormats, n => n.FormatCode.Value == "yyyy-mm-dd hh:mm");
-                Assert.Contains(numberingFormats, n => n.FormatCode.Value == "hh:mm:ss");
-                Assert.Contains(numberingFormats, n => n.FormatCode.Value == "000000");
+                var styles = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+                var numberingFormats = styles.NumberingFormats!.Elements<NumberingFormat>().ToList();
+                Assert.Contains(numberingFormats, n => n.FormatCode != null && n.FormatCode.Value == "yyyy-mm-dd hh:mm");
+                Assert.Contains(numberingFormats, n => n.FormatCode != null && n.FormatCode.Value == "hh:mm:ss");
+                Assert.Contains(numberingFormats, n => n.FormatCode != null && n.FormatCode.Value == "000000");
             }
         }
     }

--- a/OfficeIMO.Tests/Excel.CellValues.cs
+++ b/OfficeIMO.Tests/Excel.CellValues.cs
@@ -34,11 +34,11 @@ namespace OfficeIMO.Tests {
             using (spreadsheet) {
                   ValidateSpreadsheetDocument(filePath, spreadsheet);
 
-                  WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
-                  var cells = wsPart.Worksheet.Descendants<Cell>().ToList();
-                  SharedStringTablePart shared = spreadsheet.WorkbookPart!.SharedStringTablePart!;
-                  Assert.NotNull(shared);
-                  Assert.Equal("Hello", shared.SharedStringTable!.ElementAt(0).InnerText);
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                var cells = wsPart.Worksheet.Descendants<Cell>().ToList();
+                SharedStringTablePart shared = spreadsheet.WorkbookPart!.SharedStringTablePart!;
+                Assert.NotNull(shared);
+                Assert.Equal("Hello", shared.SharedStringTable!.ElementAt(0).InnerText);
 
                 Cell cellString = cells.First(c => c.CellReference == "A1");
                   Assert.Equal(CellValues.SharedString, cellString.DataType!.Value);
@@ -70,9 +70,9 @@ namespace OfficeIMO.Tests {
                   Assert.NotNull(cellCombined.CellFormula);
                   Assert.Equal("A2+1", cellCombined.CellFormula!.Text);
                   Assert.NotNull(cellCombined.StyleIndex);
-                  var styles = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet;
-                  var formats = styles.NumberingFormats.Elements<NumberingFormat>().ToList();
-                  Assert.Contains(formats, n => n.FormatCode != null && n.FormatCode.Value == "0.00");
+                var styles = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+                var formats = styles.NumberingFormats!.Elements<NumberingFormat>().ToList();
+                Assert.Contains(formats, n => n.FormatCode != null && n.FormatCode.Value == "0.00");
             }
         }
     }

--- a/OfficeIMO.Tests/Html.Abbreviations.cs
+++ b/OfficeIMO.Tests/Html.Abbreviations.cs
@@ -11,9 +11,10 @@ namespace OfficeIMO.Tests {
             using var doc = html.LoadFromHtml();
             Assert.True(doc.Paragraphs.Count >= 1);
             Assert.Equal("text", doc.Paragraphs[0].Text);
-            Assert.NotNull(doc.FootNotes);
-            Assert.Single(doc.FootNotes);
-            Assert.Equal("desc", doc.FootNotes![0].Paragraphs[1].Text);
+            var footNotes = doc.FootNotes;
+            Assert.NotNull(footNotes);
+            Assert.Single(footNotes!);
+            Assert.Equal("desc", footNotes![0].Paragraphs![1].Text);
 
             string roundTrip = doc.ToHtml(new WordToHtmlOptions { ExportFootnotes = true });
             Assert.Contains("<abbr", roundTrip, StringComparison.OrdinalIgnoreCase);

--- a/OfficeIMO.Tests/Html.BlockquoteCitations.cs
+++ b/OfficeIMO.Tests/Html.BlockquoteCitations.cs
@@ -11,9 +11,10 @@ namespace OfficeIMO.Tests {
 
             Assert.Equal("First", doc.Paragraphs[0].Text);
             Assert.Contains(doc.Paragraphs, p => p.Text == "Second");
-            Assert.NotNull(doc.FootNotes);
-            Assert.Single(doc.FootNotes);
-            Assert.Equal("https://example.com", doc.FootNotes![0].Paragraphs[1].Text);
+            var footNotes = doc.FootNotes;
+            Assert.NotNull(footNotes);
+            Assert.Single(footNotes!);
+            Assert.Equal("https://example.com", footNotes![0].Paragraphs![1].Text);
         }
     }
 }

--- a/OfficeIMO.Tests/Html.Footnotes.cs
+++ b/OfficeIMO.Tests/Html.Footnotes.cs
@@ -17,11 +17,12 @@ namespace OfficeIMO.Tests {
 
             using var roundTrip = html.LoadFromHtml();
 
-            Assert.NotNull(roundTrip.FootNotes);
-            Assert.True(roundTrip.FootNotes!.Count >= 1);
-            var footnote = roundTrip.FootNotes[0];
-            Assert.NotNull(footnote);
-            Assert.Equal("footnote text", footnote.Paragraphs[1].Text);
+            var footNotes = roundTrip.FootNotes;
+            Assert.NotNull(footNotes);
+            Assert.True(footNotes!.Count >= 1);
+            var footnote = footNotes![0];
+            Assert.True(footnote.Paragraphs!.Count > 1);
+            Assert.Equal("footnote text", footnote.Paragraphs![1].Text);
 
             string html2 = roundTrip.ToHtml(new WordToHtmlOptions { ExportFootnotes = true });
             Assert.Contains("footnote text", html2, StringComparison.OrdinalIgnoreCase);

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Tests;
 public partial class Html {
     private static void RemoveCustomStyle(string styleId) {
         var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static);
-        var dict = (IDictionary<string, Style>)field!.GetValue(null);
+        var dict = (IDictionary<string, Style>)field!.GetValue(null)!;
         dict.Remove(styleId);
     }
     [Fact]
@@ -176,7 +176,7 @@ public partial class Html {
         ms.Position = 0;
         using WordprocessingDocument docx = WordprocessingDocument.Open(ms, false);
         Paragraph p = docx.MainDocumentPart!.Document.Body!.Elements<Paragraph>().First();
-        string styleId = p.ParagraphProperties?.ParagraphStyleId?.Val;
+        string? styleId = p.ParagraphProperties?.ParagraphStyleId?.Val;
         Assert.Equal(WordParagraphStyles.Heading1.ToString(), styleId);
     }
 
@@ -275,8 +275,10 @@ public partial class Html {
 
         var doc = html.LoadFromHtml(new HtmlToWordOptions());
 
-        Assert.Equal(5, doc.Lists[0].Numbering.Levels[0].StartNumberingValue);
-        Assert.Equal(NumberFormatValues.LowerLetter, doc.Lists[0].Numbering.Levels[0]._level.NumberingFormat.Val.Value);
+        var list = doc.Lists[0];
+        Assert.NotNull(list.Numbering);
+        Assert.Equal(5, list.Numbering!.Levels[0].StartNumberingValue);
+        Assert.Equal(NumberFormatValues.LowerLetter, list.Numbering.Levels[0]._level.NumberingFormat!.Val!.Value);
     }
 
     [Fact]
@@ -285,7 +287,9 @@ public partial class Html {
 
         var doc = html.LoadFromHtml(new HtmlToWordOptions());
 
-        Assert.Equal("o", doc.Lists[0].Numbering.Levels[0]._level.LevelText.Val);
+        var list = doc.Lists[0];
+        Assert.NotNull(list.Numbering);
+        Assert.Equal("o", list.Numbering!.Levels[0]._level.LevelText!.Val);
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Markdown.Footnotes.cs
+++ b/OfficeIMO.Tests/Markdown.Footnotes.cs
@@ -7,9 +7,10 @@ namespace OfficeIMO.Tests {
         public void MarkdownToWord_Footnotes() {
             string md = "Text with footnote[^1].\n\n[^1]: Footnote text";
             using var doc = md.LoadFromMarkdown();
-            Assert.NotNull(doc.FootNotes);
-            Assert.Single(doc.FootNotes);
-            Assert.Equal("Footnote text", doc.FootNotes![0].Paragraphs[1].Text);
+            var footNotes = doc.FootNotes;
+            Assert.NotNull(footNotes);
+            Assert.Single(footNotes!);
+            Assert.Equal("Footnote text", footNotes![0].Paragraphs![1].Text);
         }
     }
 }

--- a/OfficeIMO.Tests/Visio.PackageCreation.cs
+++ b/OfficeIMO.Tests/Visio.PackageCreation.cs
@@ -97,9 +97,9 @@ namespace OfficeIMO.Tests {
 
             using (FileStream zipStream = File.OpenRead(filePath))
             using (ZipArchive archive = new(zipStream, ZipArchiveMode.Read)) {
-                ZipArchiveEntry entry = archive.GetEntry("[Content_Types].xml");
-                Assert.NotNull(entry);
-                using Stream entryStream = entry.Open();
+            ZipArchiveEntry? entry = archive.GetEntry("[Content_Types].xml");
+            Assert.NotNull(entry);
+            using Stream entryStream = entry!.Open();
                 XDocument contentTypes = XDocument.Load(entryStream);
                 XNamespace ct = "http://schemas.openxmlformats.org/package/2006/content-types";
                 Assert.NotNull(contentTypes.Root?.Elements(ct + "Default").FirstOrDefault(e => e.Attribute("Extension")?.Value == "xml" && e.Attribute("ContentType")?.Value == "application/xml"));
@@ -113,12 +113,12 @@ namespace OfficeIMO.Tests {
                 Assert.NotNull(contentTypes.Root?.Elements(ct + "Override").FirstOrDefault(e => e.Attribute("PartName")?.Value == "/docProps/thumbnail.emf" && e.Attribute("ContentType")?.Value == "image/x-emf"));
                 Assert.NotNull(contentTypes.Root?.Elements(ct + "Override").FirstOrDefault(e => e.Attribute("PartName")?.Value == "/visio/windows.xml" && e.Attribute("ContentType")?.Value == "application/vnd.ms-visio.windows+xml"));
 
-                XElement shape = pageDoc.Root?.Element(ns + "Shapes")?.Element(ns + "Shape");
-                Assert.Equal("1", shape?.Attribute("ID")?.Value);
-                Assert.NotNull(shape?.Attribute("Name"));
-                Assert.NotNull(shape?.Attribute("NameU"));
-                Assert.Equal("Shape", shape?.Attribute("Type")?.Value);
-                Assert.Equal("Rectangle", shape?.Element(ns + "Text")?.Value);
+            XElement? shape = pageDoc.Root?.Element(ns + "Shapes")?.Element(ns + "Shape");
+            Assert.Equal("1", shape?.Attribute("ID")?.Value);
+            Assert.NotNull(shape?.Attribute("Name"));
+            Assert.NotNull(shape?.Attribute("NameU"));
+            Assert.Equal("Shape", shape?.Attribute("Type")?.Value);
+            Assert.Equal("Rectangle", shape?.Element(ns + "Text")?.Value);
             }
 
             var issues = VisioValidator.Validate(filePath);

--- a/OfficeIMO.Tests/Word.AddCustomBulletList.cs
+++ b/OfficeIMO.Tests/Word.AddCustomBulletList.cs
@@ -25,12 +25,12 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("■", list.Numbering.Levels[3].LevelText);
                 Assert.Equal("●", list.Numbering.Levels[4].LevelText);
 
-                var level1Props = list.Numbering.Levels[0]._level.NumberingSymbolRunProperties;
+                var level1Props = list.Numbering.Levels[0]._level.NumberingSymbolRunProperties!;
                 Assert.Equal("Courier New", level1Props.GetFirstChild<RunFonts>()?.Ascii);
                 Assert.Equal("ff0000", level1Props.GetFirstChild<Color>()?.Val);
                 Assert.Equal("28", level1Props.GetFirstChild<FontSize>()?.Val);
 
-                var level5Props = list.Numbering.Levels[4]._level.NumberingSymbolRunProperties;
+                var level5Props = list.Numbering.Levels[4]._level.NumberingSymbolRunProperties!;
                 Assert.Equal("Arial", level5Props.GetFirstChild<RunFonts>()?.Ascii);
                 Assert.Equal("00ff00", level5Props.GetFirstChild<Color>()?.Val);
                 Assert.Equal("20", level5Props.GetFirstChild<FontSize>()?.Val);
@@ -51,7 +51,7 @@ namespace OfficeIMO.Tests {
                 Assert.Single(list.Numbering.Levels);
                 Assert.Equal("◆", list.Numbering.Levels[0].LevelText);
 
-                var props = list.Numbering.Levels[0]._level.NumberingSymbolRunProperties;
+                var props = list.Numbering.Levels[0]._level.NumberingSymbolRunProperties!;
                 Assert.Equal("Wingdings", props.GetFirstChild<RunFonts>()?.Ascii);
                 Assert.Equal("0000ff", props.GetFirstChild<Color>()?.Val);
                 Assert.Equal("24", props.GetFirstChild<FontSize>()?.Val);

--- a/OfficeIMO.Tests/Word.ListConversion.cs
+++ b/OfficeIMO.Tests/Word.ListConversion.cs
@@ -16,7 +16,7 @@ namespace OfficeIMO.Tests {
                 list.AddItem("Two");
                 indent = list.Numbering.Levels.First().IndentationLeft;
                 list.ConvertToNumbered();
-                Assert.Equal(NumberFormatValues.Decimal, list.Numbering.Levels.First()._level.NumberingFormat.Val.Value);
+                Assert.Equal(NumberFormatValues.Decimal, list.Numbering!.Levels.First()._level.NumberingFormat!.Val!.Value);
                 Assert.Equal(indent, list.Numbering.Levels.First().IndentationLeft);
                 document.Save(false);
             }
@@ -27,7 +27,7 @@ namespace OfficeIMO.Tests {
                 var list = document.Lists.First();
                 Assert.Equal(new[] { "One", "Two" }, list.ListItems.Select(i => i.Text).ToArray());
                 Assert.NotNull(list.Numbering);
-                Assert.Equal(NumberFormatValues.Decimal, list.Numbering!.Levels.First()._level.NumberingFormat.Val.Value);
+                Assert.Equal(NumberFormatValues.Decimal, list.Numbering!.Levels.First()._level.NumberingFormat!.Val!.Value);
                 Assert.Equal(indent, list.Numbering.Levels.First().IndentationLeft);
             }
         }
@@ -42,7 +42,7 @@ namespace OfficeIMO.Tests {
                 list.AddItem("Two");
                 indent = list.Numbering.Levels.First().IndentationLeft;
                 list.ConvertToBulleted();
-                Assert.Equal(NumberFormatValues.Bullet, list.Numbering.Levels.First()._level.NumberingFormat.Val.Value);
+                Assert.Equal(NumberFormatValues.Bullet, list.Numbering.Levels.First()._level.NumberingFormat!.Val!.Value);
                 Assert.Equal(indent, list.Numbering.Levels.First().IndentationLeft);
                 document.Save(false);
             }
@@ -53,7 +53,7 @@ namespace OfficeIMO.Tests {
                 var list = document.Lists.First();
                 Assert.Equal(new[] { "One", "Two" }, list.ListItems.Select(i => i.Text).ToArray());
                 Assert.NotNull(list.Numbering);
-                Assert.Equal(NumberFormatValues.Bullet, list.Numbering!.Levels.First()._level.NumberingFormat.Val.Value);
+                Assert.Equal(NumberFormatValues.Bullet, list.Numbering!.Levels.First()._level.NumberingFormat!.Val!.Value);
                 Assert.Equal(indent, list.Numbering.Levels.First().IndentationLeft);
             }
         }

--- a/OfficeIMO.Tests/Word.ParagraphCustomStyles.cs
+++ b/OfficeIMO.Tests/Word.ParagraphCustomStyles.cs
@@ -28,7 +28,7 @@ namespace OfficeIMO.Tests {
             }
 
             var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static);
-            var dict = (IDictionary<string, Style>)field.GetValue(null)!;
+            var dict = (IDictionary<string, Style>)field!.GetValue(null)!;
             dict.Clear();
         }
 
@@ -76,7 +76,7 @@ namespace OfficeIMO.Tests {
 
             // cleanup
             var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static);
-            var dict = (IDictionary<string, Style>)field.GetValue(null)!;
+            var dict = (IDictionary<string, Style>)field!.GetValue(null)!;
             dict.Clear();
         }
 
@@ -104,7 +104,7 @@ namespace OfficeIMO.Tests {
 
             // cleanup
             var field = typeof(WordParagraphStyle).GetField("_customStyles", BindingFlags.NonPublic | BindingFlags.Static);
-            var dict = (IDictionary<string, Style>)field.GetValue(null)!;
+            var dict = (IDictionary<string, Style>)field!.GetValue(null)!;
             dict.Clear();
         }
     }


### PR DESCRIPTION
## Summary
- address nullability warnings across test suite
- validate Excel cell structures before use and ensure list numbering safe
- harden footnote tests against null collections

## Testing
- `dotnet build OfficeIMO.Tests/OfficeIMO.Tests.csproj`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68b74fcc566c832eb302ddf2e5c534be