### PR TITLE
Refine PowerPoint slide relationship handling

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -120,8 +120,8 @@ namespace OfficeIMO.PowerPoint {
             // Also check the slide IDs
             if (_presentationPart.Presentation.SlideIdList != null) {
                 foreach (SlideId existingSlideId in _presentationPart.Presentation.SlideIdList.Elements<SlideId>()) {
-                    if (!string.IsNullOrEmpty(existingSlideId.RelationshipId)) {
-                        existingRelationships.Add(existingSlideId.RelationshipId!);
+                    if (existingSlideId.RelationshipId is { Value: { Length: > 0 } relId }) {
+                        existingRelationships.Add(relId);
                     }
                 }
             }
@@ -233,13 +233,13 @@ namespace OfficeIMO.PowerPoint {
             }
 
             SlideId slideId = slideIdList.Elements<SlideId>().ElementAt(index);
-            string? relId = slideId.RelationshipId;
+            StringValue? relIdValue = slideId.RelationshipId;
 
             _slides.RemoveAt(index);
             slideId.Remove();
 
-            if (!string.IsNullOrEmpty(relId)) {
-                OpenXmlPart part = _presentationPart.GetPartById(relId!);
+            if (relIdValue is { Value: { Length: > 0 } relId }) {
+                OpenXmlPart part = _presentationPart.GetPartById(relId);
                 _presentationPart.DeletePart(part);
             }
 


### PR DESCRIPTION
## Summary
- guard slide relationship IDs when collecting existing IDs
- validate slide IDs before removing related parts

## Testing
- `dotnet build OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj -v m`
- `dotnet build OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj -p:TargetFrameworks=net472 -v m`
- `dotnet build OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj -p:TargetFrameworks=net9.0 -v m`
- `dotnet test OfficeImo.sln -p:TargetFramework=net9.0 --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68b74fdad4d4832eb9de0a4c6bcd29b9