### PR TITLE
fix: resolve initial batch of word warnings

### DIFF
--- a/OfficeIMO.Word/Helpers/ImageEmbedder.cs
+++ b/OfficeIMO.Word/Helpers/ImageEmbedder.cs
@@ -72,13 +72,15 @@ namespace OfficeIMO.Word {
                 return Convert.FromBase64String(base64Data);
             }
 
-            if (Uri.TryCreate(src, UriKind.Absolute, out Uri uri)) {
-                if (uri.Scheme == Uri.UriSchemeFile) {
-                    return File.ReadAllBytes(uri.LocalPath);
-                }
-                if (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps) {
-                    using HttpClient client = new HttpClient();
-                    return client.GetByteArrayAsync(uri).GetAwaiter().GetResult();
+            if (Uri.TryCreate(src, UriKind.Absolute, out var uri)) {
+                if (uri != null) {
+                    if (uri.Scheme == Uri.UriSchemeFile) {
+                        return File.ReadAllBytes(uri.LocalPath);
+                    }
+                    if (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps) {
+                        using HttpClient client = new HttpClient();
+                        return client.GetByteArrayAsync(uri).GetAwaiter().GetResult();
+                    }
                 }
             }
 

--- a/OfficeIMO.Word/ImageShapeStyle.cs
+++ b/OfficeIMO.Word/ImageShapeStyle.cs
@@ -9,25 +9,25 @@ namespace OfficeIMO.Word;
 /// </summary>
 public class ImageShapeStyle {
     /// <summary>Gets or sets the CSS position property.</summary>
-    public string Position { get; set; }
+    public string Position { get; set; } = string.Empty;
     /// <summary>Gets or sets the left margin.</summary>
-    public string MarginLeft { get; set; }
+    public string MarginLeft { get; set; } = string.Empty;
     /// <summary>Gets or sets the top margin.</summary>
-    public string MarginTop { get; set; }
+    public string MarginTop { get; set; } = string.Empty;
     /// <summary>Gets or sets the width.</summary>
-    public string Width { get; set; }
+    public string Width { get; set; } = string.Empty;
     /// <summary>Gets or sets the height.</summary>
-    public string Height { get; set; }
+    public string Height { get; set; } = string.Empty;
     /// <summary>Gets or sets the Z-index value.</summary>
-    public string ZIndex { get; set; }
+    public string ZIndex { get; set; } = string.Empty;
     /// <summary>Gets or sets the horizontal position mode.</summary>
-    public string MsoPositionHorizontal { get; set; }
+    public string MsoPositionHorizontal { get; set; } = string.Empty;
     /// <summary>Gets or sets the horizontal position relative to.</summary>
-    public string MsoPositionHorizontalRelative { get; set; }
+    public string MsoPositionHorizontalRelative { get; set; } = string.Empty;
     /// <summary>Gets or sets the vertical position mode.</summary>
-    public string MsoPositionVertical { get; set; }
+    public string MsoPositionVertical { get; set; } = string.Empty;
     /// <summary>Gets or sets the vertical position relative to.</summary>
-    public string MsoPositionVerticalRelative { get; set; }
+    public string MsoPositionVerticalRelative { get; set; } = string.Empty;
 
     /// <summary>
     /// Parses a semicolon delimited style string into an <see cref="ImageShapeStyle"/> instance.

--- a/OfficeIMO.Word/Orientation.cs
+++ b/OfficeIMO.Word/Orientation.cs
@@ -19,12 +19,13 @@ namespace OfficeIMO.Word {
                 bool documentChanged = false;
 
                 var docPart = document.MainDocumentPart;
+                if (docPart?.Document == null) return;
                 var sections = docPart.Document.Descendants<SectionProperties>();
 
                 foreach (SectionProperties sectPr in sections) {
                     bool pageOrientationChanged = false;
 
-                    PageSize pgSz = sectPr.Descendants<PageSize>().FirstOrDefault();
+                    PageSize? pgSz = sectPr.Descendants<PageSize>().FirstOrDefault();
                     if (pgSz != null) {
                         // No Orient property? Create it now. Otherwise, just
                         // set its value. Assume that the default orientation
@@ -57,8 +58,9 @@ namespace OfficeIMO.Word {
                             pgSz.Width = height;
                             pgSz.Height = width;
 
-                            PageMargin pgMar = sectPr.Descendants<PageMargin>().FirstOrDefault();
-                            if (pgMar != null) {
+                            PageMargin? pgMar = sectPr.Descendants<PageMargin>().FirstOrDefault();
+                            if (pgMar?.Top?.Value != null && pgMar.Bottom?.Value != null &&
+                                pgMar.Left?.Value != null && pgMar.Right?.Value != null) {
                                 // Rotate margins. Printer settings control how far you
                                 // rotate when switching to landscape mode. Not having those
                                 // settings, this code rotates 90 degrees. You could easily

--- a/OfficeIMO.Word/Security.cs
+++ b/OfficeIMO.Word/Security.cs
@@ -170,8 +170,10 @@ namespace OfficeIMO.Word {
             documentProtection.CryptographicSpinCount = uintVal;
             documentProtection.Hash = Convert.ToBase64String(generatedKey);
             documentProtection.Salt = Convert.ToBase64String(arrSalt);
-            wordDocument.MainDocumentPart.DocumentSettingsPart.Settings.AppendChild(documentProtection);
-            wordDocument.MainDocumentPart.DocumentSettingsPart.Settings.Save();
+            var settingsPart = wordDocument.MainDocumentPart?.DocumentSettingsPart;
+            if (settingsPart?.Settings == null) return;
+            settingsPart.Settings.AppendChild(documentProtection);
+            settingsPart.Settings.Save();
         }
 
         // Helper to generate legacy write protection hash

--- a/OfficeIMO.Word/Table/WordTableStyleDetails.cs
+++ b/OfficeIMO.Word/Table/WordTableStyleDetails.cs
@@ -22,8 +22,8 @@ public partial class WordTableStyleDetails {
     /// </summary>
     public Int16? MarginDefaultTopWidth {
         get {
-            if (_tableProperties != null && _tableProperties.TableCellMarginDefault?.TopMargin?.Width != null) {
-                return Int16.Parse(_tableProperties.TableCellMarginDefault.TopMargin.Width.Value);
+            if (_tableProperties != null && _tableProperties.TableCellMarginDefault?.TopMargin?.Width?.Value != null) {
+                return short.Parse(_tableProperties.TableCellMarginDefault.TopMargin.Width.Value);
             }
             return null;
         }
@@ -72,8 +72,8 @@ public partial class WordTableStyleDetails {
     /// </summary>
     public Int16? MarginDefaultBottomWidth {
         get {
-            if (_tableProperties?.TableCellMarginDefault?.BottomMargin?.Width != null) {
-                return Int16.Parse(_tableProperties.TableCellMarginDefault.BottomMargin.Width.Value);
+            if (_tableProperties?.TableCellMarginDefault?.BottomMargin?.Width?.Value != null) {
+                return short.Parse(_tableProperties.TableCellMarginDefault.BottomMargin.Width.Value);
             }
             return null;
         }
@@ -173,7 +173,7 @@ public partial class WordTableStyleDetails {
     public Int16? MarginDefaultRightWidth {
         get {
             if (_tableProperties?.TableCellMarginDefault?.TableCellRightMargin?.Width != null) {
-                return Int16.Parse(_tableProperties.TableCellMarginDefault.TableCellRightMargin.Width);
+                return (short)_tableProperties.TableCellMarginDefault.TableCellRightMargin.Width!;
             }
             return null;
         }
@@ -222,8 +222,8 @@ public partial class WordTableStyleDetails {
     /// </summary>
     public Int16? CellSpacing {
         get {
-            if (_tableProperties?.TableCellSpacing?.Width != null) {
-                return Int16.Parse(_tableProperties.TableCellSpacing.Width.Value);
+            if (_tableProperties?.TableCellSpacing?.Width?.Value != null) {
+                return short.Parse(_tableProperties.TableCellSpacing.Width.Value);
             }
             return null;
         }

--- a/OfficeIMO.Word/WordBibliography.cs
+++ b/OfficeIMO.Word/WordBibliography.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Word {
     internal class WordBibliography {
         private readonly WordDocument _document;
         private readonly WordprocessingDocument _wordDocument;
-        private CustomXmlPart _part;
+        private CustomXmlPart? _part;
 
         /// <summary>
         /// Initializes a new instance responsible for managing bibliography sources.
@@ -42,7 +42,7 @@ namespace OfficeIMO.Word {
             foreach (var source in sources.Elements<Source>()) {
                 var wrapper = new WordBibliographySource(source);
                 if (!string.IsNullOrEmpty(wrapper.Tag)) {
-                    _document.BibliographySources[wrapper.Tag] = wrapper;
+                    _document.BibliographySources[wrapper.Tag!] = wrapper;
                 }
             }
         }
@@ -61,7 +61,7 @@ namespace OfficeIMO.Word {
             }
 
             if (_document.BibliographySources.Count == 0) {
-                _wordDocument.MainDocumentPart.DeletePart(_part);
+                _wordDocument.MainDocumentPart.DeletePart(_part!);
                 _part = null;
                 return;
             }

--- a/OfficeIMO.Word/WordBibliographySource.cs
+++ b/OfficeIMO.Word/WordBibliographySource.cs
@@ -8,7 +8,7 @@ namespace OfficeIMO.Word {
     public class WordBibliographySource {
         internal Source Source { get; }
 
-        private string _tag;
+        private string? _tag;
 
         /// <summary>
         /// Initializes a new source with the given tag and type.
@@ -27,7 +27,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the tag used to reference the source in citation fields.
         /// </summary>
-        public string Tag {
+        public string? Tag {
             get => _tag;
             set {
                 _tag = value;
@@ -58,18 +58,18 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the title of the source.
         /// </summary>
-        public string Title {
+        public string? Title {
             get => Source.Title?.Text;
             set {
                 if (Source.Title == null) Source.Title = new Title();
-                Source.Title.Text = value;
+                Source.Title.Text = value ?? string.Empty;
             }
         }
 
         /// <summary>
         /// Gets or sets the corporate author of the source.
         /// </summary>
-        public string Author {
+        public string? Author {
             get => Source.AuthorList?.GetFirstChild<Author>()?.GetFirstChild<Corporate>()?.Text;
             set {
                 if (Source.AuthorList == null) Source.AuthorList = new AuthorList();
@@ -83,18 +83,18 @@ namespace OfficeIMO.Word {
                     corp = new Corporate();
                     author.Append(corp);
                 }
-                corp.Text = value;
+                corp.Text = value ?? string.Empty;
             }
         }
 
         /// <summary>
         /// Gets or sets the publication year of the source.
         /// </summary>
-        public string Year {
+        public string? Year {
             get => Source.Year?.Text;
             set {
                 if (Source.Year == null) Source.Year = new Year();
-                Source.Year.Text = value;
+                Source.Year.Text = value ?? string.Empty;
             }
         }
 

--- a/OfficeIMO.Word/WordBreak.cs
+++ b/OfficeIMO.Word/WordBreak.cs
@@ -25,7 +25,7 @@ namespace OfficeIMO.Word {
                         return null;
                     }
 
-                    return brake.Type;
+                    return brake.Type?.Value;
                 }
 
                 return null;

--- a/OfficeIMO.Word/WordCheckBox.cs
+++ b/OfficeIMO.Word/WordCheckBox.cs
@@ -28,7 +28,7 @@ namespace OfficeIMO.Word {
                 return ch != null && ch.Val != null && ch.Val.Value == W14.OnOffValues.One;
             }
             set {
-                var cb = _sdtRun.SdtProperties.Elements<W14.SdtContentCheckBox>().FirstOrDefault();
+                var cb = _sdtRun.SdtProperties?.Elements<W14.SdtContentCheckBox>().FirstOrDefault();
                 if (cb != null) {
                     var ch = cb.Elements<W14.Checked>().FirstOrDefault();
                     if (ch == null) {
@@ -43,9 +43,9 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the alias associated with this checkbox control.
         /// </summary>
-        public string Alias {
+        public string? Alias {
             get {
-                var sdtAlias = _sdtRun.SdtProperties.OfType<SdtAlias>().FirstOrDefault();
+                var sdtAlias = _sdtRun.SdtProperties?.OfType<SdtAlias>().FirstOrDefault();
                 return sdtAlias?.Val;
             }
         }
@@ -53,18 +53,20 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the tag value for this checkbox control.
         /// </summary>
-        public string Tag {
+        public string? Tag {
             get {
-                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                var tag = _sdtRun.SdtProperties?.OfType<Tag>().FirstOrDefault();
                 return tag?.Val;
             }
             set {
-                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                var tag = _sdtRun.SdtProperties?.OfType<Tag>().FirstOrDefault();
                 if (tag == null) {
                     tag = new Tag();
-                    _sdtRun.SdtProperties.Append(tag);
+                    _sdtRun.SdtProperties?.Append(tag);
                 }
-                tag.Val = value;
+                if (tag != null) {
+                    tag.Val = value;
+                }
             }
         }
 

--- a/OfficeIMO.Word/WordComment.PublicMethods.cs
+++ b/OfficeIMO.Word/WordComment.PublicMethods.cs
@@ -29,7 +29,7 @@ namespace OfficeIMO.Word {
                 Id = GetNewId(document),
                 Author = author,
                 Initials = initials,
-                Date = DateTime.Now
+                Date = System.DateTime.Now
             };
             cmt.AppendChild(p);
             comments.AppendChild(cmt);

--- a/OfficeIMO.Word/WordComment.cs
+++ b/OfficeIMO.Word/WordComment.cs
@@ -20,22 +20,22 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// ID of a comment
         /// </summary>
-        public string Id => _comment.Id;
+        public string? Id => _comment.Id;
 
         /// <summary>
         /// Identifier used to link threaded replies.
         /// </summary>
-        public string ParaId => _commentEx?.ParaId;
+        public string? ParaId => _commentEx?.ParaId;
 
         /// <summary>
         /// Identifier of parent comment if this comment is a reply.
         /// </summary>
-        public string ParentParaId => _commentEx?.ParaIdParent;
+        public string? ParentParaId => _commentEx?.ParaIdParent;
 
         /// <summary>
         /// Parent comment instance if available.
         /// </summary>
-        public WordComment ParentComment => _document.Comments.FirstOrDefault(c => c.ParaId == ParentParaId);
+        public WordComment? ParentComment => _document.Comments.FirstOrDefault(c => c.ParaId == ParentParaId);
 
         /// <summary>
         /// Replies for this comment.
@@ -45,7 +45,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Text content of a comment
         /// </summary>
-        public string Text {
+        public string? Text {
             get {
                 return _paragraph.Text;
             }
@@ -57,7 +57,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Initials of a person who created a comment
         /// </summary>
-        public string Initials {
+        public string? Initials {
             get {
                 return _comment.Initials;
             }
@@ -69,7 +69,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Full name of a person who created a comment
         /// </summary>
-        public string Author {
+        public string? Author {
             get {
                 return _comment.Author;
             }
@@ -81,8 +81,8 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// DateTime when the comment was created
         /// </summary>
-        public DateTime DateTime {
-            get => _comment.Date;
+        public DateTime? DateTime {
+            get => _comment.Date?.Value;
             set => _comment.Date = value;
         }
     }

--- a/OfficeIMO.Word/WordCustomProperties.cs
+++ b/OfficeIMO.Word/WordCustomProperties.cs
@@ -15,7 +15,7 @@ namespace OfficeIMO.Word {
     public class WordCustomProperties {
         private WordprocessingDocument _wordprocessingDocument;
         private WordDocument _document;
-        private Properties _customProperties;
+        private Properties? _customProperties;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WordCustomProperties"/> class.
@@ -39,9 +39,11 @@ namespace OfficeIMO.Word {
             var customProps = _wordprocessingDocument.CustomFilePropertiesPart;
             if (customProps != null) {
                 _customProperties = customProps.Properties;
-                foreach (CustomDocumentProperty property in _customProperties.CustomFilePropertiesPart.Properties) {
-                    WordCustomProperty wordCustomProperty = new WordCustomProperty(property);
-                    _document.CustomDocumentProperties.Add(property.Name, wordCustomProperty);
+                if (_customProperties?.CustomFilePropertiesPart?.Properties != null) {
+                    foreach (CustomDocumentProperty property in _customProperties.CustomFilePropertiesPart.Properties.OfType<CustomDocumentProperty>()) {
+                        WordCustomProperty wordCustomProperty = new WordCustomProperty(property);
+                        _document.CustomDocumentProperties.Add(property.Name!, wordCustomProperty);
+                    }
                 }
             }
         }
@@ -154,19 +156,19 @@ namespace OfficeIMO.Word {
 
         private void Add(string name, CustomDocumentProperty newProp) {
             if (_customProperties != null) {
-                // This will trigger an exception if the property's Name 
-                // property is null, but if that happens, the property is damaged, 
+                // This will trigger an exception if the property's Name
+                // property is null, but if that happens, the property is damaged,
                 // and probably should raise an exception.
-                var prop = _customProperties.Where(p => ((CustomDocumentProperty)p).Name.Value == name).FirstOrDefault();
+                var prop = _customProperties.Where(p => ((CustomDocumentProperty)p).Name?.Value == name).FirstOrDefault();
 
-                // Does the property exist? If so, get the return value, 
+                // Does the property exist? If so, get the return value,
                 // and then delete the property.
                 if (prop != null) {
                     prop.Remove();
                 }
 
-                // Append the new property, and 
-                // fix up all the property ID values. 
+                // Append the new property, and
+                // fix up all the property ID values.
                 // The PropertyId value must start at 2.
                 _customProperties.AppendChild(newProp);
                 int pid = 2;

--- a/OfficeIMO.Word/WordCustomProperty.cs
+++ b/OfficeIMO.Word/WordCustomProperty.cs
@@ -74,7 +74,7 @@ namespace OfficeIMO.Word {
         /// Gets the value as text when the property type is textual.
         /// </summary>
         /// <remarks>Returns <see langword="null"/> if the value does not contain text.</remarks>
-        public string Text {
+        public string? Text {
             get {
                 if ((Value) is string) {
                     return (string)Value;


### PR DESCRIPTION
## Summary
- initialize image style properties to satisfy nullability
- handle optional bibliography data and comment fields safely
- add null checks in orientation and security helpers

## Testing
- `dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b753c9614c832e90ec4338739f5ee3