### PR TITLE
Add InfoBuilder support for document property metadata

### DIFF
--- a/OfficeIMO.Examples/Word/DocumentProperties/DocumentProperties.Fluent.cs
+++ b/OfficeIMO.Examples/Word/DocumentProperties/DocumentProperties.Fluent.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class DocumentProperties {
+        public static void Example_FluentDocumentProperties(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with fluent document properties");
+
+            string filePath = Path.Combine(folderPath, "Fluent Document Properties.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Info(i => i.Title("Title")
+                        .Author("Author")
+                        .Subject("Subject")
+                        .Keywords("k1, k2")
+                        .Comments("Some comments")
+                        .Category("Category")
+                        .Company("Evotec")
+                        .Manager("Manager1")
+                        .LastModifiedBy("John")
+                        .Revision("1.0"))
+                    .Paragraph(p => p.Text("Test"));
+
+                document.Save(openWord);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Word.Fluent.InfoBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.InfoBuilder.cs
@@ -15,6 +15,11 @@ namespace OfficeIMO.Tests {
                         .Subject("Subject")
                         .Keywords("k1, k2")
                         .Comments("Some comments")
+                        .Category("Cat")
+                        .Company("Evotec")
+                        .Manager("Manager1")
+                        .LastModifiedBy("John")
+                        .Revision("1.0")
                         .Custom("Custom1", "Value1"))
                     .Paragraph(p => p.Text("Test"));
                 document.Save(false);
@@ -26,6 +31,11 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Subject", document.BuiltinDocumentProperties.Subject);
                 Assert.Equal("k1, k2", document.BuiltinDocumentProperties.Keywords);
                 Assert.Equal("Some comments", document.BuiltinDocumentProperties.Description);
+                Assert.Equal("Cat", document.BuiltinDocumentProperties.Category);
+                Assert.Equal("Evotec", document.ApplicationProperties.Company);
+                Assert.Equal("Manager1", document.ApplicationProperties.Manager?.Text);
+                Assert.Equal("John", document.BuiltinDocumentProperties.LastModifiedBy);
+                Assert.Equal("1.0", document.BuiltinDocumentProperties.Revision);
                 Assert.True(document.CustomDocumentProperties.ContainsKey("Custom1"));
                 Assert.Equal("Value1", document.CustomDocumentProperties["Custom1"].Value);
             }

--- a/OfficeIMO.Word/Fluent/InfoBuilder.cs
+++ b/OfficeIMO.Word/Fluent/InfoBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using DocumentFormat.OpenXml.ExtendedProperties;
 
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
@@ -53,6 +54,51 @@ namespace OfficeIMO.Word.Fluent {
         /// <param name="comments">Comments text.</param>
         public InfoBuilder Comments(string comments) {
             _fluent.Document.BuiltinDocumentProperties.Description = comments;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the document category.
+        /// </summary>
+        /// <param name="category">Category text.</param>
+        public InfoBuilder Category(string category) {
+            _fluent.Document.BuiltinDocumentProperties.Category = category;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the company name.
+        /// </summary>
+        /// <param name="company">Company name.</param>
+        public InfoBuilder Company(string company) {
+            _fluent.Document.ApplicationProperties.Company = company;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the manager name.
+        /// </summary>
+        /// <param name="manager">Manager name.</param>
+        public InfoBuilder Manager(string manager) {
+            _fluent.Document.ApplicationProperties.Manager = new Manager { Text = manager };
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the user who last modified the document.
+        /// </summary>
+        /// <param name="lastModifiedBy">Last modified by.</param>
+        public InfoBuilder LastModifiedBy(string lastModifiedBy) {
+            _fluent.Document.BuiltinDocumentProperties.LastModifiedBy = lastModifiedBy;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the document revision.
+        /// </summary>
+        /// <param name="revision">Revision value.</param>
+        public InfoBuilder Revision(string revision) {
+            _fluent.Document.BuiltinDocumentProperties.Revision = revision;
             return this;
         }
 


### PR DESCRIPTION
## Summary
- extend fluent InfoBuilder with Category, Company, Manager, LastModifiedBy, and Revision helpers
- document new property helpers with example under Word/DocumentProperties
- test fluent property setters persist values to saved documents

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Test_FluentInfoBuilderProperties --logger "console;verbosity=minimal"`


------
https://chatgpt.com/codex/tasks/task_e_68b87066ca74832eb99cdeaf9568dcf2