### PR TITLE
Add fluent section orientation and background configuration

### DIFF
--- a/OfficeIMO.Examples/Word/Sections/Sections_Fluent_OrientationBackground.cs
+++ b/OfficeIMO.Examples/Word/Sections/Sections_Fluent_OrientationBackground.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal partial class Sections {
+
+        internal static void Example_Word_Fluent_Sections_OrientationBackground(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with section orientation and background color via fluent API");
+            string filePath = Path.Combine(folderPath, "Fluent_Sections_OrientationBackground.docx");
+
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Section(s => s
+                        .New()
+                            .Orientation(PageOrientationValues.Landscape)
+                            .Background("FFD700")
+                            .Paragraph(p => p.Text("Landscape section with background")))
+                    .End()
+                    .Save(false);
+            }
+
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Fluent.SectionBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.SectionBuilder.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_FluentSectionBuilderOrientation() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentSectionBuilderOrientation.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Section(s => s.New().Orientation(PageOrientationValues.Landscape))
+                    .End()
+                    .Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal(PageOrientationValues.Landscape, document.Sections[1].PageSettings.Orientation);
+            }
+        }
+
+        [Fact]
+        public void Test_FluentSectionBuilderBackground() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentSectionBuilderBackground.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Section(s => s.New().Background("FF00FF"))
+                    .End()
+                    .Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal("ff00ff", document.Background.Color);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/SectionBuilder.cs
+++ b/OfficeIMO.Word/Fluent/SectionBuilder.cs
@@ -107,6 +107,32 @@ namespace OfficeIMO.Word.Fluent {
         }
 
         /// <summary>
+        /// Sets the page orientation for the section.
+        /// </summary>
+        /// <param name="orientation">Orientation value.</param>
+        public SectionBuilder Orientation(PageOrientationValues orientation) {
+            if (_section == null) {
+                throw new InvalidOperationException("No section available to configure. Call New() before setting orientation.");
+            }
+
+            _section.PageSettings.Orientation = orientation;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the document background color using a hex value.
+        /// </summary>
+        /// <param name="hex">Hex color value.</param>
+        public SectionBuilder Background(string hex) {
+            if (_section == null) {
+                throw new InvalidOperationException("No section available to configure. Call New() before setting background.");
+            }
+
+            _section._document.Background.SetColorHex(hex);
+            return this;
+        }
+
+        /// <summary>
         /// Adds a paragraph to the section.
         /// </summary>
         /// <param name="action">Configuration action for the paragraph.</param>


### PR DESCRIPTION
## Summary
- add Orientation(PageOrientationValues) and Background(hex) to SectionBuilder
- cover landscape orientation and background color with new tests
- demonstrate section orientation and background in examples

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b870605124832ebfeb9715f17ae6de