### PR TITLE
Add fluent text formatting helpers and examples

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.TextBuilder.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.TextBuilder.cs
@@ -1,7 +1,8 @@
-using System;
-using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
+using System;
+using System.IO;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class FluentDocument {
@@ -11,7 +12,14 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AsFluent()
                     .Paragraph(p => p.Text("Hello")
-                        .Text(" World", t => t.BoldOn().ItalicOn().Color("#ff0000")))
+                        .Text(" World", t => t.BoldOn().ItalicOn().Color("#ff0000"))
+                        .Text(" Formatting", t => t
+                            .Underline(UnderlineValues.Single)
+                            .Highlight(HighlightColorValues.Yellow)
+                            .FontSize(18)
+                            .FontFamily("Arial")
+                            .CapsStyle(CapsStyle.SmallCaps)
+                            .Strike()))
                     .End()
                     .Save(false);
             }

--- a/OfficeIMO.Tests/Word.Fluent.TextBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.TextBuilder.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
 using System.Linq;
@@ -28,6 +29,40 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("ff0000", runs[1].ColorHex);
                 Assert.Equal("!", runs[2].Text);
                 Assert.True(runs[2].Bold);
+            }
+        }
+
+        [Fact]
+        public void Test_FluentTextBuilderAdditionalFormatting() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentTextBuilderAdvanced.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Paragraph(p => p
+                        .Text("Underline", t => t.Underline(UnderlineValues.Double))
+                        .Text(" Strike", t => t.Strike())
+                        .Text(" DoubleStrike", t => t.DoubleStrike())
+                        .Text(" FontSize", t => t.FontSize(20))
+                        .Text(" FontFamily", t => t.FontFamily("Arial"))
+                        .Text(" Highlight", t => t.Highlight(HighlightColorValues.Yellow))
+                        .Text(" Sub", t => t.SubScript())
+                        .Text(" Super", t => t.SuperScript())
+                        .Text(" Caps", t => t.CapsStyle(CapsStyle.Caps)))
+                    .End()
+                    .Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                var runs = document.Paragraphs[0].GetRuns().ToList();
+                Assert.Equal(9, runs.Count);
+                Assert.Equal(UnderlineValues.Double, runs[0].Underline);
+                Assert.True(runs[1].Strike);
+                Assert.True(runs[2].DoubleStrike);
+                Assert.Equal(20, runs[3].FontSize);
+                Assert.Equal("Arial", runs[4].FontFamily);
+                Assert.Equal(HighlightColorValues.Yellow, runs[5].Highlight);
+                Assert.Equal(VerticalPositionValues.Subscript, runs[6].VerticalTextAlignment);
+                Assert.Equal(VerticalPositionValues.Superscript, runs[7].VerticalTextAlignment);
+                Assert.Equal(CapsStyle.Caps, runs[8].CapsStyle);
             }
         }
     }

--- a/OfficeIMO.Word/Fluent/TextBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TextBuilder.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Word.Fluent {
@@ -41,6 +42,85 @@ namespace OfficeIMO.Word.Fluent {
                 hex = hex.Substring(1);
             }
             _paragraph?.SetColorHex("#" + hex);
+            return this;
+        }
+
+        /// <summary>
+        /// Applies underline formatting to the current run.
+        /// </summary>
+        /// <param name="underline">Underline style.</param>
+        public TextBuilder Underline(UnderlineValues underline) {
+            _paragraph?.SetUnderline(underline);
+            return this;
+        }
+
+        /// <summary>
+        /// Applies single strikethrough formatting to the current run.
+        /// </summary>
+        /// <param name="isStrike">Whether to apply strikethrough.</param>
+        public TextBuilder Strike(bool isStrike = true) {
+            _paragraph?.SetStrike(isStrike);
+            return this;
+        }
+
+        /// <summary>
+        /// Applies double strikethrough formatting to the current run.
+        /// </summary>
+        /// <param name="isDoubleStrike">Whether to apply double strikethrough.</param>
+        public TextBuilder DoubleStrike(bool isDoubleStrike = true) {
+            _paragraph?.SetDoubleStrike(isDoubleStrike);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the font size for the current run.
+        /// </summary>
+        /// <param name="fontSize">Font size in points.</param>
+        public TextBuilder FontSize(int fontSize) {
+            _paragraph?.SetFontSize(fontSize);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the font family for the current run.
+        /// </summary>
+        /// <param name="fontFamily">Font family name.</param>
+        public TextBuilder FontFamily(string fontFamily) {
+            _paragraph?.SetFontFamily(fontFamily);
+            return this;
+        }
+
+        /// <summary>
+        /// Applies a highlight color to the current run.
+        /// </summary>
+        /// <param name="highlight">Highlight color.</param>
+        public TextBuilder Highlight(HighlightColorValues highlight) {
+            _paragraph?.SetHighlight(highlight);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the text as subscript.
+        /// </summary>
+        public TextBuilder SubScript() {
+            _paragraph?.SetSubScript();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the text as superscript.
+        /// </summary>
+        public TextBuilder SuperScript() {
+            _paragraph?.SetSuperScript();
+            return this;
+        }
+
+        /// <summary>
+        /// Applies capitalization style to the current run.
+        /// </summary>
+        /// <param name="capsStyle">Capitalization style.</param>
+        public TextBuilder CapsStyle(CapsStyle capsStyle) {
+            _paragraph?.SetCapsStyle(capsStyle);
             return this;
         }
     }


### PR DESCRIPTION
## Summary
- extend `TextBuilder` with chainable formatting helpers for underline, strike, double-strike, font size, font family, highlight, sub/superscript and caps style
- exercise new formatting options with unit tests
- demonstrate combined text styling in fluent examples

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Test_FluentTextBuilder`
- `dotnet format OfficeIMO.Word/OfficeIMO.Word.csproj --no-restore --include OfficeIMO.Word/Fluent/TextBuilder.cs` *(fails: Required references did not load)*

------
https://chatgpt.com/codex/tasks/task_e_68b870343904832ebf6a30753a43711b