### PR TITLE
Add crop and rotate to fluent image builder

### DIFF
--- a/OfficeIMO.Examples/Word/Images/Images.FluentCropAndRotate.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.FluentCropAndRotate.cs
@@ -1,0 +1,23 @@
+using System;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Images {
+        internal static void Example_ImageFluentCropAndRotate(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with cropped and rotated image using fluent API");
+            string filePath = System.IO.Path.Combine(folderPath, "ImageFluentCropRotate.docx");
+            string imagePaths = System.IO.Path.Combine(System.IO.Directory.GetCurrentDirectory(), "Images");
+
+            using var document = WordDocument.Create(filePath);
+            document.AsFluent()
+                .Image(i => i.Add(System.IO.Path.Combine(imagePaths, "Kulek.jpg"))
+                    .Size(200, 200)
+                    .Crop(1, 1, 1, 1)
+                    .Rotate(45))
+                .End();
+            document.Save(openWord);
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Word.Fluent.ImageBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ImageBuilder.cs
@@ -79,5 +79,42 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs[0].IsHyperLink);
             }
         }
+
+        [Fact]
+        public void Test_FluentImageCrop() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentImageCrop.docx");
+            string imagePath = Path.Combine(_directoryWithImages, "Kulek.jpg");
+
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Image(i => i.Add(imagePath).Crop(1, 2, 3, 4))
+                    .End();
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(1, document.Images[0].CropLeftCentimeters);
+                Assert.Equal(2, document.Images[0].CropTopCentimeters);
+                Assert.Equal(3, document.Images[0].CropRightCentimeters);
+                Assert.Equal(4, document.Images[0].CropBottomCentimeters);
+            }
+        }
+
+        [Fact]
+        public void Test_FluentImageRotate() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentImageRotate.docx");
+            string imagePath = Path.Combine(_directoryWithImages, "Kulek.jpg");
+
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Image(i => i.Add(imagePath).Rotate(45))
+                    .End();
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(45, document.Images[0].Rotation);
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/Fluent/ImageBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ImageBuilder.cs
@@ -113,6 +113,34 @@ namespace OfficeIMO.Word.Fluent {
         }
 
         /// <summary>
+        /// Crops the image by the specified amounts in centimeters.
+        /// </summary>
+        /// <param name="left">Amount to crop from the left.</param>
+        /// <param name="top">Amount to crop from the top.</param>
+        /// <param name="right">Amount to crop from the right.</param>
+        /// <param name="bottom">Amount to crop from the bottom.</param>
+        public ImageBuilder Crop(double left, double top, double right, double bottom) {
+            if (_image != null) {
+                _image.CropLeftCentimeters = left;
+                _image.CropTopCentimeters = top;
+                _image.CropRightCentimeters = right;
+                _image.CropBottomCentimeters = bottom;
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Rotates the image by the specified number of degrees.
+        /// </summary>
+        /// <param name="degrees">Rotation angle in degrees.</param>
+        public ImageBuilder Rotate(double degrees) {
+            if (_image != null) {
+                _image.Rotation = (int)Math.Round(degrees);
+            }
+            return this;
+        }
+
+        /// <summary>
         /// Applies a wrapping style to the image.
         /// </summary>
         /// <param name="wrapImage">Wrapping option.</param>


### PR DESCRIPTION
## Summary
- add Crop and Rotate methods to ImageBuilder
- test crop and rotate persistence
- demonstrate fluent cropping and rotation

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b8768430d4832ea5e23fc8edc8d7ab