### PR TITLE
feat: add fluent list numbering customization

### DIFF
--- a/OfficeIMO.Examples/Word/Lists/Lists.CustomNumberingFluent.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.CustomNumberingFluent.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Lists {
+        internal static void Example_CustomNumberingFluent(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with custom numbering using fluent API");
+            string filePath = Path.Combine(folderPath, "DocumentCustomNumberingFluent.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .List(l => l.Numbered().NumberFormat(NumberFormatValues.UpperRoman)
+                                     .Item("First")
+                                     .Item("Second"))
+                    .List(l => l.Bulleted().BulletCharacter("\u2192")
+                                     .Item("Step 1")
+                                     .Item("Step 2"))
+                    .End()
+                    .Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Fluent.ListBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ListBuilder.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
 using Xunit;
@@ -41,6 +42,32 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(0, bulleted.ListItems[1].ListItemLevel);
                 Assert.Equal(1, bulleted.ListItems[2].ListItemLevel);
                 Assert.Equal(0, bulleted.ListItems[3].ListItemLevel);
+            }
+        }
+
+        [Fact]
+        public void Test_FluentListBuilder_CustomFormats() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentListBuilderFormats.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .List(l => l.Numbered().NumberFormat(NumberFormatValues.LowerRoman)
+                                     .Item("first")
+                                     .Item("second"))
+                    .List(l => l.Bulleted().BulletCharacter("\u2736")
+                                     .Item("alpha")
+                                     .Item("beta"))
+                    .End()
+                    .Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                Assert.Equal(2, document.Lists.Count);
+
+                var roman = document.Lists[0];
+                Assert.Equal(NumberFormatValues.LowerRoman, roman.Numbering.Levels[0]._level.NumberingFormat.Val!.Value);
+
+                var custom = document.Lists[1];
+                Assert.Equal("\u2736", custom.Numbering.Levels[0].LevelText);
             }
         }
     }

--- a/OfficeIMO.Word/Fluent/ListBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ListBuilder.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Word.Fluent {
@@ -40,11 +41,40 @@ namespace OfficeIMO.Word.Fluent {
         }
 
         /// <summary>
+        /// Sets the numbering format for the current list level.
+        /// </summary>
+        /// <param name="format">Number format to apply.</param>
+        public ListBuilder NumberFormat(NumberFormatValues format) {
+            if (_list != null) {
+                var levels = _list.Numbering.Levels;
+                if (_level < levels.Count) {
+                    levels[_level]._level.NumberingFormat = new NumberingFormat { Val = format };
+                }
+            }
+            return this;
+        }
+
+        /// <summary>
         /// Sets the starting number for the list.
         /// </summary>
         /// <param name="start">Starting number.</param>
         public ListBuilder StartAt(int start) {
             _list?.Numbering.Levels[0].SetStartNumberingValue(start);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a custom bullet character for the current list level.
+        /// </summary>
+        /// <param name="character">Bullet character to use.</param>
+        public ListBuilder BulletCharacter(string character) {
+            if (_list != null) {
+                var levels = _list.Numbering.Levels;
+                if (_level < levels.Count) {
+                    levels[_level].LevelText = character;
+                    levels[_level]._level.NumberingFormat = new NumberingFormat { Val = NumberFormatValues.Bullet };
+                }
+            }
             return this;
         }
 


### PR DESCRIPTION
## Summary
- allow specifying number format and bullet character in `ListBuilder`
- test custom roman numerals and bullet glyphs
- add example demonstrating fluent custom numbering

## Testing
- `dotnet build`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build --filter FullyQualifiedName~FluentListBuilder`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build -f net9.0 --filter FullyQualifiedName~FluentListBuilder`


------
https://chatgpt.com/codex/tasks/task_e_68b876810eb8832eaf9cf0dfad4aa312