### PR TITLE
Add paragraph border and shading support

### DIFF
--- a/OfficeIMO.Examples/Word/Paragraphs/Paragraph_FluentBordersAndShading.cs
+++ b/OfficeIMO.Examples/Word/Paragraphs/Paragraph_FluentBordersAndShading.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+using Color = SixLabors.ImageSharp.Color;
+
+namespace OfficeIMO.Examples.Word;
+
+internal static partial class Paragraphs {
+
+    internal static void Example_Word_Fluent_Paragraph_BordersAndShading(string folderPath, bool openWord) {
+        Console.WriteLine("[*] Creating document with fluent bordered and shaded paragraph");
+        string filePath = Path.Combine(folderPath, "Fluent_Paragraph_BordersAndShading.docx");
+
+        using (var document = WordDocument.Create(filePath)) {
+            document.AsFluent()
+                .Paragraph(p => p
+                    .Text("Border and shading")
+                    .Border(b => {
+                        b.LeftStyle = BorderValues.Thick;
+                        b.LeftColor = Color.Red;
+                        b.LeftSize = 24;
+                    })
+                    .Shading(Color.LightGray))
+                .End()
+                .Save(false);
+        }
+        Helpers.Open(filePath, openWord);
+    }
+}

--- a/OfficeIMO.Examples/Word/Paragraphs/Paragraphs.BordersAndShading.cs
+++ b/OfficeIMO.Examples/Word/Paragraphs/Paragraphs.BordersAndShading.cs
@@ -1,0 +1,25 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Color = SixLabors.ImageSharp.Color;
+
+namespace OfficeIMO.Examples.Word;
+
+internal static partial class Paragraphs {
+
+    internal static void Example_BordersAndShading(string folderPath, bool openWord) {
+        Console.WriteLine("[*] Creating document with bordered and shaded paragraphs");
+        string filePath = System.IO.Path.Combine(folderPath, "Paragraphs with borders and shading.docx");
+        using (WordDocument document = WordDocument.Create(filePath)) {
+            var bordered = document.AddParagraph("Bordered paragraph");
+            bordered.Borders.LeftStyle = BorderValues.Thick;
+            bordered.Borders.LeftColor = Color.Red;
+            bordered.Borders.LeftSize = 24;
+
+            var shaded = document.AddParagraph("Shaded paragraph");
+            shaded.ShadingFillColor = Color.LightGray;
+
+            document.Save(openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Fluent.ParagraphBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ParagraphBuilder.cs
@@ -7,6 +7,7 @@ using OfficeIMO;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Fluent;
 using Xunit;
+using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Tests {
     public partial class Word {
@@ -76,6 +77,32 @@ namespace OfficeIMO.Tests {
 
             using (var document = WordDocument.Load(filePath)) {
                 Assert.Equal(JustificationValues.Both, document.Paragraphs.Last().ParagraphAlignment);
+            }
+        }
+
+        [Fact]
+        public void Test_FluentParagraphBuilderBorderAndShading() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentParagraphBuilderBorderShading.docx");
+
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Paragraph(p => p.Text("Border and shading")
+                        .Border(b => {
+                            b.LeftStyle = BorderValues.Thick;
+                            b.LeftColor = Color.Blue;
+                            b.LeftSize = 24;
+                        })
+                        .Shading(Color.LightGray))
+                    .End()
+                    .Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                var paragraph = document.Paragraphs[0];
+                Assert.Equal(BorderValues.Thick, paragraph.Borders.LeftStyle);
+                Assert.Equal(Color.Blue.ToHexColor(), paragraph.Borders.LeftColor!.Value.ToHexColor());
+                Assert.Equal(24U, paragraph.Borders.LeftSize!.Value);
+                Assert.Equal(Color.LightGray.ToHexColor(), paragraph.ShadingFillColorHex);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.ParagraphBordersAndShading.cs
+++ b/OfficeIMO.Tests/Word.ParagraphBordersAndShading.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+using Color = SixLabors.ImageSharp.Color;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_ParagraphBordersAndShading() {
+            string filePath = Path.Combine(_directoryWithFiles, "ParagraphBordersAndShading.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                var paragraph = document.AddParagraph("Border and shading");
+                paragraph.Borders.LeftStyle = BorderValues.Thick;
+                paragraph.Borders.LeftColor = Color.Red;
+                paragraph.Borders.LeftSize = 24;
+                paragraph.ShadingFillColor = Color.LightGray;
+                document.Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                var paragraph = document.Paragraphs[0];
+                Assert.Equal(BorderValues.Thick, paragraph.Borders.LeftStyle);
+                Assert.Equal(Color.Red.ToHexColor(), paragraph.Borders.LeftColor!.Value.ToHexColor());
+                Assert.Equal(24U, paragraph.Borders.LeftSize!.Value);
+                Assert.Equal(Color.LightGray.ToHexColor(), paragraph.ShadingFillColorHex);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
+++ b/OfficeIMO.Word/Fluent/ParagraphBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO;
 using OfficeIMO.Word;
+using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Word.Fluent {
     /// <summary>
@@ -146,6 +147,24 @@ namespace OfficeIMO.Word.Fluent {
                 _paragraph.IndentationAfterPoints = right.Value;
             }
 
+            return this;
+        }
+
+        /// <summary>
+        /// Configures borders for the paragraph.
+        /// </summary>
+        /// <param name="configure">Callback to configure individual border settings.</param>
+        public ParagraphBuilder Border(Action<WordParagraphBorders> configure) {
+            configure(_paragraph.Borders);
+            return this;
+        }
+
+        /// <summary>
+        /// Applies shading to the paragraph.
+        /// </summary>
+        /// <param name="color">Fill color.</param>
+        public ParagraphBuilder Shading(Color color) {
+            _paragraph.ShadingFillColor = color;
             return this;
         }
 

--- a/OfficeIMO.Word/WordParagraph.Shading.cs
+++ b/OfficeIMO.Word/WordParagraph.Shading.cs
@@ -1,0 +1,63 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using Color = SixLabors.ImageSharp.Color;
+
+namespace OfficeIMO.Word {
+    public partial class WordParagraph {
+        /// <summary>
+        /// Get or set the paragraph shading fill color using hexadecimal value.
+        /// </summary>
+        public string ShadingFillColorHex {
+            get {
+                var fill = _paragraphProperties?.Shading?.Fill?.Value;
+                return fill != null ? fill.ToLowerInvariant() : string.Empty;
+            }
+            set {
+                var props = _paragraph.ParagraphProperties ??= new ParagraphProperties();
+                if (value != string.Empty) {
+                    var color = value.Replace("#", string.Empty).ToLowerInvariant();
+                    props.Shading ??= new Shading();
+                    props.Shading.Fill = color;
+                    props.Shading.Val ??= ShadingPatternValues.Clear;
+                } else {
+                    props.Shading?.Remove();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get or set the paragraph shading fill color.
+        /// </summary>
+        public Color? ShadingFillColor {
+            get {
+                if (ShadingFillColorHex != string.Empty) {
+                    return Helpers.ParseColor(ShadingFillColorHex);
+                }
+
+                return null;
+            }
+            set {
+                if (value != null) {
+                    ShadingFillColorHex = value.Value.ToHexColor();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get or set the paragraph shading pattern.
+        /// </summary>
+        public ShadingPatternValues? ShadingPattern {
+            get {
+                return _paragraphProperties?.Shading?.Val?.Value;
+            }
+            set {
+                var props = _paragraph.ParagraphProperties ??= new ParagraphProperties();
+                if (value != null) {
+                    props.Shading ??= new Shading();
+                    props.Shading.Val = value.Value;
+                } else {
+                    props.Shading?.Remove();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow fluent paragraph builder to configure borders and shading
- add shading utilities to `WordParagraph`
- document bordered and shaded paragraphs example and tests
- add fluent example for bordered and shaded paragraphs

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --no-build --filter "Test_ParagraphBordersAndShading|Test_FluentParagraphBuilderBorderAndShading"`


------
https://chatgpt.com/codex/tasks/task_e_68b876898430832e801a7162e1f8cc5c