### PR TITLE
feat(word): add table sizing and cell styling helpers

### DIFF
--- a/OfficeIMO.Examples/Word/Fluent/Fluent.TableCustomWidthAndShading.cs
+++ b/OfficeIMO.Examples/Word/Fluent/Fluent.TableCustomWidthAndShading.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class FluentDocument {
+        internal static void Example_FluentTableCustomWidthAndShading(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Fluent table with custom widths and shading");
+            string filePath = Path.Combine(folderPath, "FluentTableCustomWidthAndShading.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Table(t => t
+                        .Columns(2)
+                        .Row("Red", "Blue")
+                        .ColumnWidth(1, 72)
+                        .ColumnWidth(2, 144)
+                        .RowHeight(1, 36)
+                        .CellStyle(1, 1, cell => {
+                            cell.Paragraphs[0].ParagraphAlignment = JustificationValues.Center;
+                            cell.ShadingFillColorHex = "ff0000";
+                            cell.Borders.LeftStyle = BorderValues.Single;
+                            cell.Borders.RightStyle = BorderValues.Single;
+                            cell.Borders.TopStyle = BorderValues.Single;
+                            cell.Borders.BottomStyle = BorderValues.Single;
+                        })
+                        .CellStyle(1, 2, cell => {
+                            cell.Paragraphs[0].ParagraphAlignment = JustificationValues.Center;
+                            cell.ShadingFillColorHex = "0000ff";
+                            cell.Borders.LeftStyle = BorderValues.Single;
+                            cell.Borders.RightStyle = BorderValues.Single;
+                            cell.Borders.TopStyle = BorderValues.Single;
+                            cell.Borders.BottomStyle = BorderValues.Single;
+                        }))
+                    .End()
+                    .Save(false);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}
+

--- a/OfficeIMO.Examples/Word/Tables/Tables.CustomWidthAndShading.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.CustomWidthAndShading.cs
@@ -1,0 +1,31 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using System;
+using System.IO;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Tables {
+        internal static void Example_TableCustomWidthAndShading(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Table with custom column widths and shading");
+            string filePath = Path.Combine(folderPath, "TableCustomWidthAndShading.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(2, 2);
+
+                table.ColumnWidth = new List<int> { 1440, 2880 };
+                table.ColumnWidthType = TableWidthUnitValues.Dxa;
+
+                var cell1 = table.Rows[0].Cells[0];
+                cell1.AddParagraph("Red");
+                cell1.ShadingFillColorHex = "ff0000";
+
+                var cell2 = table.Rows[0].Cells[1];
+                cell2.AddParagraph("Blue");
+                cell2.ShadingFillColorHex = "0000ff";
+
+                document.Save(openWord);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.TableBuilder.cs
@@ -117,6 +117,42 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_FluentTableBuilder_ColumnWidthRowHeightAndCellStyle() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentTableBuilderSizeStyle.docx");
+            using (var document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Table(t => t
+                        .Create(2, 2)
+                        .ColumnWidth(1, 72)
+                        .ColumnWidth(2, 144)
+                        .RowHeight(1, 36)
+                        .RowHeight(2, 72)
+                        .CellStyle(1, 1, cell => {
+                            cell.Paragraphs[0].ParagraphAlignment = JustificationValues.Center;
+                            cell.VerticalAlignment = TableVerticalAlignmentValues.Center;
+                            cell.ShadingFillColorHex = "ffcc00";
+                            cell.Borders.LeftStyle = BorderValues.Single;
+                        }))
+                    .End()
+                    .Save(false);
+            }
+
+            using (var document = WordDocument.Load(filePath)) {
+                var table = document.Tables[0];
+                Assert.Equal(1440, table.Rows[0].Cells[0].Width);
+                Assert.Equal(TableWidthUnitValues.Dxa, table.Rows[0].Cells[0].WidthType);
+                Assert.Equal(2880, table.Rows[0].Cells[1].Width);
+                Assert.Equal(720, table.Rows[0].Height);
+                Assert.Equal(1440, table.Rows[1].Height);
+                var cell = table.Rows[0].Cells[0];
+                Assert.Equal("ffcc00", cell.ShadingFillColorHex);
+                Assert.Equal(TableVerticalAlignmentValues.Center, cell.VerticalAlignment);
+                Assert.Equal(JustificationValues.Center, cell.Paragraphs[0].ParagraphAlignment);
+                Assert.Equal(BorderValues.Single, cell.Borders.LeftStyle);
+            }
+        }
+
+        [Fact]
         public void TableBuilderCellEnforces1BasedIndexing() {
             string filePath = Path.Combine(_directoryWithFiles, "FluentTableBuilderInvalidCell.docx");
             using (var document = WordDocument.Create(filePath)) {

--- a/OfficeIMO.Word/Fluent/TableBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TableBuilder.cs
@@ -329,6 +329,41 @@ namespace OfficeIMO.Word.Fluent {
         }
 
         /// <summary>
+        /// Sets the width for the specified column in points.
+        /// </summary>
+        public TableBuilder ColumnWidth(int columnIndex, double widthPoints) {
+            if (_table != null && columnIndex >= 1) {
+                int width = (int)Math.Round(widthPoints * 20);
+                foreach (var row in _table.Rows) {
+                    if (columnIndex <= row.CellsCount) {
+                        var cell = row.Cells[columnIndex - 1];
+                        cell.Width = width;
+                        cell.WidthType = TableWidthUnitValues.Dxa;
+                    }
+                }
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the height for the specified row in points.
+        /// </summary>
+        public TableBuilder RowHeight(int rowIndex, double heightPoints) {
+            if (_table != null && rowIndex >= 1 && rowIndex <= _table.Rows.Count) {
+                int height = (int)Math.Round(heightPoints * 20);
+                _table.Rows[rowIndex - 1].Height = height;
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Applies an action to style a specific cell using 1-based coordinates.
+        /// </summary>
+        public TableBuilder CellStyle(int row, int column, Action<WordTableCell> action) {
+            return Cell(row, column, action);
+        }
+
+        /// <summary>
         /// Applies an action to a specified row.
         /// </summary>
         public TableBuilder RowStyle(int index, Action<WordTableRow> action) {


### PR DESCRIPTION
## Summary
- add ColumnWidth, RowHeight, and CellStyle helpers to table builder
- cover table sizing and styling with new unit tests
- demonstrate custom widths and shading in examples, including fluent usage

## Testing
- `dotnet format OfficeIMO.Examples/OfficeIMO.Examples.csproj --include Word/Fluent/Fluent.TableCustomWidthAndShading.cs`
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj -c Release`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b8767c8908832e9b89e2b28945c9a6