### PR TITLE
Add run-level text effects and fluent helpers

### DIFF
--- a/OfficeIMO.Examples/Word/Text/Text.RunFormatting.cs
+++ b/OfficeIMO.Examples/Word/Text/Text.RunFormatting.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Fluent;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class TextExamples {
+        internal static void Example_RunFormatting(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Creating document with run-level formatting");
+            string filePath = Path.Combine(folderPath, "TextRunFormatting.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Paragraph(p => p
+                        .Text("Outline ", t => t.Outline())
+                        .Text("Shadow ", t => t.Shadow())
+                        .Text("Emboss ", t => t.Emboss())
+                        .Text("SmallCaps ", t => t.SmallCaps())
+                        .Text("Combined", t => t.Outline().Shadow().Emboss().SmallCaps()))
+                    .End()
+                    .Save(false);
+            }
+            Helpers.Open(filePath, openWord);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Fluent.TextBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.TextBuilder.cs
@@ -46,14 +46,18 @@ namespace OfficeIMO.Tests {
                         .Text(" Highlight", t => t.Highlight(HighlightColorValues.Yellow))
                         .Text(" Sub", t => t.SubScript())
                         .Text(" Super", t => t.SuperScript())
-                        .Text(" Caps", t => t.CapsStyle(CapsStyle.Caps)))
+                        .Text(" Caps", t => t.CapsStyle(CapsStyle.Caps))
+                        .Text(" Outline", t => t.Outline())
+                        .Text(" Shadow", t => t.Shadow())
+                        .Text(" Emboss", t => t.Emboss())
+                        .Text(" SmallCaps", t => t.SmallCaps()))
                     .End()
                     .Save(false);
             }
 
             using (var document = WordDocument.Load(filePath)) {
                 var runs = document.Paragraphs[0].GetRuns().ToList();
-                Assert.Equal(9, runs.Count);
+                Assert.Equal(13, runs.Count);
                 Assert.Equal(UnderlineValues.Double, runs[0].Underline);
                 Assert.True(runs[1].Strike);
                 Assert.True(runs[2].DoubleStrike);
@@ -63,6 +67,10 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(VerticalPositionValues.Subscript, runs[6].VerticalTextAlignment);
                 Assert.Equal(VerticalPositionValues.Superscript, runs[7].VerticalTextAlignment);
                 Assert.Equal(CapsStyle.Caps, runs[8].CapsStyle);
+                Assert.True(runs[9].Outline);
+                Assert.True(runs[10].Shadow);
+                Assert.True(runs[11].Emboss);
+                Assert.Equal(CapsStyle.SmallCaps, runs[12].CapsStyle);
             }
         }
     }

--- a/OfficeIMO.Word/Fluent/TextBuilder.cs
+++ b/OfficeIMO.Word/Fluent/TextBuilder.cs
@@ -123,5 +123,37 @@ namespace OfficeIMO.Word.Fluent {
             _paragraph?.SetCapsStyle(capsStyle);
             return this;
         }
+
+        /// <summary>
+        /// Applies outline formatting to the current run.
+        /// </summary>
+        public TextBuilder Outline() {
+            _paragraph?.SetOutline();
+            return this;
+        }
+
+        /// <summary>
+        /// Applies shadow formatting to the current run.
+        /// </summary>
+        public TextBuilder Shadow() {
+            _paragraph?.SetShadow();
+            return this;
+        }
+
+        /// <summary>
+        /// Applies emboss formatting to the current run.
+        /// </summary>
+        public TextBuilder Emboss() {
+            _paragraph?.SetEmboss();
+            return this;
+        }
+
+        /// <summary>
+        /// Applies small caps formatting to the current run.
+        /// </summary>
+        public TextBuilder SmallCaps() {
+            _paragraph?.SetSmallCaps();
+            return this;
+        }
     }
 }

--- a/OfficeIMO.Word/WordParagraph.RunProperties.cs
+++ b/OfficeIMO.Word/WordParagraph.RunProperties.cs
@@ -214,6 +214,79 @@ namespace OfficeIMO.Word {
                 }
             }
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the run text is outlined.
+        /// </summary>
+        public bool Outline {
+            get {
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
+                return runProperties != null && runProperties.Outline != null;
+            }
+            set {
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
+                } else {
+                    runProperties = VerifyRunProperties();
+                }
+                if (value != true) {
+                    if (runProperties.Outline != null) runProperties.Outline.Remove();
+                } else {
+                    runProperties.Outline = new Outline();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the run has a shadow effect.
+        /// </summary>
+        public bool Shadow {
+            get {
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
+                return runProperties != null && runProperties.Shadow != null;
+            }
+            set {
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
+                } else {
+                    runProperties = VerifyRunProperties();
+                }
+                if (value != true) {
+                    if (runProperties.Shadow != null) runProperties.Shadow.Remove();
+                } else {
+                    runProperties.Shadow = new Shadow();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the run is embossed.
+        /// </summary>
+        public bool Emboss {
+            get {
+                var runProperties = IsHyperLink ? this.Hyperlink?._runProperties : _runProperties;
+                return runProperties != null && runProperties.Emboss != null;
+            }
+            set {
+                RunProperties runProperties;
+                if (IsHyperLink) {
+                    var hyperlink = this.Hyperlink!;
+                    runProperties = VerifyRunProperties(hyperlink._hyperlink!, hyperlink._run!, hyperlink._runProperties);
+                } else {
+                    runProperties = VerifyRunProperties();
+                }
+                if (value != true) {
+                    if (runProperties.Emboss != null) runProperties.Emboss.Remove();
+                } else {
+                    runProperties.Emboss = new Emboss();
+                }
+            }
+        }
+
         /// <summary>
         /// Gets or sets the font size in points.
         /// </summary>

--- a/OfficeIMO.Word/WordParagraph.RunPropertiesMethods.cs
+++ b/OfficeIMO.Word/WordParagraph.RunPropertiesMethods.cs
@@ -59,6 +59,46 @@ namespace OfficeIMO.Word {
             this.DoubleStrike = isDoubleStrike;
             return this;
         }
+
+        /// <summary>
+        /// Enables or disables outline effect on the text.
+        /// </summary>
+        /// <param name="isOutline">Whether the text should be outlined.</param>
+        /// <returns>The current paragraph instance.</returns>
+        public WordParagraph SetOutline(bool isOutline = true) {
+            this.Outline = isOutline;
+            return this;
+        }
+
+        /// <summary>
+        /// Enables or disables shadow effect on the text.
+        /// </summary>
+        /// <param name="isShadow">Whether the text should have a shadow.</param>
+        /// <returns>The current paragraph instance.</returns>
+        public WordParagraph SetShadow(bool isShadow = true) {
+            this.Shadow = isShadow;
+            return this;
+        }
+
+        /// <summary>
+        /// Enables or disables emboss effect on the text.
+        /// </summary>
+        /// <param name="isEmboss">Whether the text should be embossed.</param>
+        /// <returns>The current paragraph instance.</returns>
+        public WordParagraph SetEmboss(bool isEmboss = true) {
+            this.Emboss = isEmboss;
+            return this;
+        }
+
+        /// <summary>
+        /// Enables or disables small caps formatting on the text.
+        /// </summary>
+        /// <param name="isSmallCaps">Whether the text should use small caps.</param>
+        /// <returns>The current paragraph instance.</returns>
+        public WordParagraph SetSmallCaps(bool isSmallCaps = true) {
+            this.CapsStyle = isSmallCaps ? CapsStyle.SmallCaps : CapsStyle.None;
+            return this;
+        }
         /// <summary>
         /// Sets the font size for the text.
         /// </summary>


### PR DESCRIPTION
## Summary
- add fluent `Outline`, `Shadow`, `Emboss`, and `SmallCaps` text helpers
- implement underlying run property setters for outline, shadow, emboss, and small caps
- demonstrate and test new run-level formatting options

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b89af732c4832e9f4c2dea27a8f556