### PR TITLE
Ensure SectionBuilder adds content to active section

### DIFF
--- a/OfficeIMO.Tests/Word.Fluent.SectionBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.SectionBuilder.cs
@@ -35,5 +35,28 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("ff00ff", document.Background.Color);
             }
         }
+
+        [Fact]
+        public void Test_FluentSectionBuilderContentAssignments() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentSectionBuilderContent.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AsFluent()
+                    .Paragraph(p => p.Text("Section1"))
+                    .Section(s => s.New()
+                        .Paragraph(p => p.Text("Section2"))
+                        .Table(t => t.Row("cell")))
+                    .End()
+                    .Save(false);
+            }
+
+            using (WordDocument document = WordDocument.Load(filePath)) {
+                Assert.Equal(2, document.Sections.Count);
+                Assert.Single(document.Sections[0].Paragraphs);
+                Assert.Empty(document.Sections[0].Tables);
+                Assert.Single(document.Sections[1].Paragraphs);
+                Assert.Single(document.Sections[1].Tables);
+                Assert.Equal("Section2", document.Sections[1].Paragraphs[0].Text);
+            }
+        }
     }
 }

--- a/OfficeIMO.Word/Fluent/SectionBuilder.cs
+++ b/OfficeIMO.Word/Fluent/SectionBuilder.cs
@@ -137,7 +137,7 @@ namespace OfficeIMO.Word.Fluent {
         /// </summary>
         /// <param name="action">Configuration action for the paragraph.</param>
         public SectionBuilder Paragraph(Action<ParagraphBuilder> action) {
-            var paragraph = _fluent.Document.AddParagraph();
+            var paragraph = _section != null ? _section.AddParagraph() : _fluent.Document.AddParagraph();
             action(new ParagraphBuilder(_fluent, paragraph));
             return this;
         }
@@ -147,7 +147,12 @@ namespace OfficeIMO.Word.Fluent {
         /// </summary>
         /// <param name="action">Configuration action for the table.</param>
         public SectionBuilder Table(Action<TableBuilder> action) {
-            action(new TableBuilder(_fluent));
+            if (_section != null) {
+                var table = _section.AddTable(1, 1);
+                action(new TableBuilder(_fluent, table));
+            } else {
+                action(new TableBuilder(_fluent));
+            }
             return this;
         }
     }

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -65,6 +65,19 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Adds a table to the section.
+        /// </summary>
+        /// <param name="rows">Number of rows.</param>
+        /// <param name="columns">Number of columns.</param>
+        /// <param name="tableStyle">Table style to apply.</param>
+        public WordTable AddTable(int rows, int columns, WordTableStyle tableStyle = WordTableStyle.TableGrid) {
+            var anchor = AddParagraph();
+            var table = anchor.AddTableAfter(rows, columns, tableStyle);
+            anchor.Remove();
+            return table;
+        }
+
+        /// <summary>
         /// Adds a watermark to the section.
         /// </summary>
         /// <param name="watermarkStyle">Watermark style.</param>


### PR DESCRIPTION
## Summary
- ensure SectionBuilder uses active section for Paragraph additions
- route SectionBuilder tables through section
- verify SectionBuilder attaches content to correct section

## Testing
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68bb5315196c832eb8123f906765df11