### PR TITLE
Expose async AddFromUrlAsync while keeping sync wrapper

### DIFF
--- a/OfficeIMO.Tests/Word.Fluent.ImageBuilder.cs
+++ b/OfficeIMO.Tests/Word.Fluent.ImageBuilder.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO;
@@ -56,6 +57,21 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(80, document.Images[3].Width);
                 Assert.Equal(JustificationValues.Center, document.Paragraphs[3].ParagraphAlignment);
             }
+        }
+
+        [Fact]
+        public async Task Test_FluentImageBuilderAddFromUrlCancellation() {
+            string filePath = Path.Combine(_directoryWithFiles, "FluentImageBuilderCancelled.docx");
+
+            using var document = WordDocument.Create(filePath);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => {
+                await document.AsFluent().ImageAsync(async i => {
+                    await i.AddFromUrlAsync("https://example.com/image.jpg", cts.Token);
+                });
+            });
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- Restore synchronous `AddFromUrl` that wraps async implementation to keep fluent chaining
- Demonstrate both sync and async image loading examples
- Update tests to cover sync downloads and async cancellation

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FluentImageBuilder --verbosity minimal`
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68bb5336b56c832e8ac78afee3517702