### PR TITLE
Add named range management

### DIFF
--- a/OfficeIMO.Examples/Excel/NamedRanges.cs
+++ b/OfficeIMO.Examples/Excel/NamedRanges.cs
@@ -15,6 +15,13 @@ namespace OfficeIMO.Examples.Excel {
                 document.SetNamedRange("GlobalRange", "'Data'!A1:A2", save: false);
                 sheet.SetNamedRange("LocalRange", "A1", save: false);
 
+                foreach (var pair in document.GetAllNamedRanges()) {
+                    Console.WriteLine($"Workbook named range {pair.Key}: {pair.Value}");
+                }
+                foreach (var pair in sheet.GetAllNamedRanges()) {
+                    Console.WriteLine($"Worksheet named range {pair.Key}: {pair.Value}");
+                }
+
                 document.Save(openExcel);
             }
         }

--- a/OfficeIMO.Examples/Excel/NamedRanges.cs
+++ b/OfficeIMO.Examples/Excel/NamedRanges.cs
@@ -12,8 +12,8 @@ namespace OfficeIMO.Examples.Excel {
                 sheet.CellValue(1, 1, "Value1");
                 sheet.CellValue(2, 1, "Value2");
 
-                document.SetNamedRange("GlobalRange", "'Data'!A1:A2");
-                sheet.SetNamedRange("LocalRange", "A1");
+                document.SetNamedRange("GlobalRange", "'Data'!A1:A2", save: false);
+                sheet.SetNamedRange("LocalRange", "A1", save: false);
 
                 document.Save(openExcel);
             }

--- a/OfficeIMO.Examples/Excel/NamedRanges.cs
+++ b/OfficeIMO.Examples/Excel/NamedRanges.cs
@@ -1,0 +1,23 @@
+using System;
+using OfficeIMO.Excel;
+
+namespace OfficeIMO.Examples.Excel {
+    public static class NamedRanges {
+        public static void Example(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - Named ranges");
+            string filePath = System.IO.Path.Combine(folderPath, "NamedRanges.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Value1");
+                sheet.CellValue(2, 1, "Value2");
+
+                document.SetNamedRange("GlobalRange", "'Data'!A1:A2");
+                sheet.SetNamedRange("LocalRange", "A1");
+
+                document.Save(openExcel);
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
+++ b/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Linq;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel.Read;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        public void SetNamedRange(string name, string range, ExcelSheet? scope = null) {
+            if (string.IsNullOrWhiteSpace(name)) {
+                throw new ArgumentException("Name cannot be null or empty.", nameof(name));
+            }
+            if (string.IsNullOrWhiteSpace(range)) {
+                throw new ArgumentException("Range cannot be null or empty.", nameof(range));
+            }
+
+            var workbook = _workBookPart.Workbook;
+            var definedNames = workbook.DefinedNames ??= new DefinedNames();
+
+            uint? sheetIndex = scope != null ? GetSheetIndex(scope) : null;
+
+            var existing = definedNames.Elements<DefinedName>().FirstOrDefault(d =>
+                d.Name == name && ((sheetIndex == null && d.LocalSheetId == null) ||
+                (sheetIndex != null && d.LocalSheetId != null && d.LocalSheetId.Value == sheetIndex)));
+
+            existing?.Remove();
+
+            string reference = scope != null ? $"'{scope.Name}'!{range}" : range;
+            reference = NormalizeRange(reference);
+
+            DefinedName dn = new DefinedName {
+                Name = name,
+                Text = reference
+            };
+            if (sheetIndex != null) {
+                dn.LocalSheetId = sheetIndex;
+            }
+            definedNames.Append(dn);
+            workbook.Save();
+        }
+
+        public string? GetNamedRange(string name, ExcelSheet? scope = null) {
+            var definedNames = _workBookPart.Workbook.DefinedNames;
+            if (definedNames == null) {
+                return null;
+            }
+
+            uint? sheetIndex = scope != null ? GetSheetIndex(scope) : null;
+
+            var dn = definedNames.Elements<DefinedName>().FirstOrDefault(d =>
+                d.Name == name && ((sheetIndex == null && d.LocalSheetId == null) ||
+                (sheetIndex != null && d.LocalSheetId != null && d.LocalSheetId.Value == sheetIndex)));
+
+            if (dn == null) {
+                return null;
+            }
+
+            if (scope != null) {
+                string text = dn.Text ?? string.Empty;
+                int idx = text.IndexOf('!');
+                if (idx >= 0 && idx < text.Length - 1) {
+                    return text.Substring(idx + 1);
+                }
+            }
+            return dn.Text;
+        }
+
+        public bool RemoveNamedRange(string name, ExcelSheet? scope = null) {
+            var definedNames = _workBookPart.Workbook.DefinedNames;
+            if (definedNames == null) {
+                return false;
+            }
+
+            uint? sheetIndex = scope != null ? GetSheetIndex(scope) : null;
+
+            var dn = definedNames.Elements<DefinedName>().FirstOrDefault(d =>
+                d.Name == name && ((sheetIndex == null && d.LocalSheetId == null) ||
+                (sheetIndex != null && d.LocalSheetId != null && d.LocalSheetId.Value == sheetIndex)));
+
+            if (dn == null) {
+                return false;
+            }
+
+            dn.Remove();
+            if (!definedNames.Elements<DefinedName>().Any()) {
+                _workBookPart.Workbook.DefinedNames = null;
+            }
+            _workBookPart.Workbook.Save();
+            return true;
+        }
+
+        private uint GetSheetIndex(ExcelSheet sheet) {
+            var sheets = _workBookPart.Workbook.Sheets?.OfType<Sheet>().ToList() ?? new();
+            for (int i = 0; i < sheets.Count; i++) {
+                if (sheets[i].Name == sheet.Name) {
+                    return (uint)i;
+                }
+            }
+            throw new ArgumentException("Worksheet not found in workbook.", nameof(sheet));
+        }
+
+        private static string NormalizeRange(string range) {
+            string? sheetPrefix = null;
+            string a1 = range;
+            int idx = range.IndexOf('!');
+            if (idx >= 0) {
+                sheetPrefix = range.Substring(0, idx + 1);
+                a1 = range.Substring(idx + 1);
+            }
+
+            int r1, c1, r2, c2;
+            try {
+                (r1, c1, r2, c2) = A1.ParseRange(a1);
+            } catch (ArgumentException) {
+                var cell = A1.ParseCellRef(a1);
+                if (cell.Row <= 0 || cell.Col <= 0) {
+                    throw;
+                }
+                r1 = r2 = cell.Row;
+                c1 = c2 = cell.Col;
+            }
+
+            string start = $"${A1.ColumnIndexToLetters(c1)}${r1}";
+            string end = $"${A1.ColumnIndexToLetters(c2)}${r2}";
+
+            string normalized = start;
+            if (start != end) {
+                normalized += ":" + end;
+            }
+            return sheetPrefix + normalized;
+        }
+    }
+}
+

--- a/OfficeIMO.Excel/ExcelSheet.NamedRanges.cs
+++ b/OfficeIMO.Excel/ExcelSheet.NamedRanges.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        public void SetNamedRange(string name, string range) {
+            _excelDocument.SetNamedRange(name, range, this);
+        }
+
+        public string? GetNamedRange(string name) {
+            return _excelDocument.GetNamedRange(name, this);
+        }
+
+        public bool RemoveNamedRange(string name) {
+            return _excelDocument.RemoveNamedRange(name, this);
+        }
+    }
+}
+

--- a/OfficeIMO.Excel/ExcelSheet.NamedRanges.cs
+++ b/OfficeIMO.Excel/ExcelSheet.NamedRanges.cs
@@ -1,15 +1,15 @@
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
-        public void SetNamedRange(string name, string range) {
-            _excelDocument.SetNamedRange(name, range, this);
+        public void SetNamedRange(string name, string range, bool save = true) {
+            _excelDocument.SetNamedRange(name, range, this, save);
         }
 
         public string? GetNamedRange(string name) {
             return _excelDocument.GetNamedRange(name, this);
         }
 
-        public bool RemoveNamedRange(string name) {
-            return _excelDocument.RemoveNamedRange(name, this);
+        public bool RemoveNamedRange(string name, bool save = true) {
+            return _excelDocument.RemoveNamedRange(name, this, save);
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.NamedRanges.cs
+++ b/OfficeIMO.Excel/ExcelSheet.NamedRanges.cs
@@ -8,6 +8,10 @@ namespace OfficeIMO.Excel {
             return _excelDocument.GetNamedRange(name, this);
         }
 
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> GetAllNamedRanges() {
+            return _excelDocument.GetAllNamedRanges(this);
+        }
+
         public bool RemoveNamedRange(string name, bool save = true) {
             return _excelDocument.RemoveNamedRange(name, this, save);
         }

--- a/OfficeIMO.Tests/Excel.NamedRanges.cs
+++ b/OfficeIMO.Tests/Excel.NamedRanges.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using System.Linq;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class ExcelNamedRangesTests {
+        [Fact]
+        public void CanCreateAndReadNamedRanges() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                document.SetNamedRange("GlobalRange", "'Data'!A1:A2");
+                sheet.SetNamedRange("LocalRange", "A1");
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                Assert.Equal("'Data'!$A$1:$A$2", document.GetNamedRange("GlobalRange"));
+                var sheet = document.Sheets.First(s => s.Name == "Data");
+                Assert.Equal("$A$1", sheet.GetNamedRange("LocalRange"));
+            }
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void CanDeleteNamedRange() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.SetNamedRange("TempRange", "A1:B2");
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var sheet = document.Sheets.First(s => s.Name == "Data");
+                Assert.True(sheet.RemoveNamedRange("TempRange"));
+                Assert.Null(sheet.GetNamedRange("TempRange"));
+                document.Save();
+            }
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void InvalidA1RangeThrows() {
+            using var document = ExcelDocument.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx"));
+            document.AddWorkSheet("Data");
+            Assert.Throws<ArgumentException>(() => document.SetNamedRange("Bad", "'Data'!A1:A"));
+        }
+    }
+}
+

--- a/OfficeIMO.Tests/Excel.NamedRanges.cs
+++ b/OfficeIMO.Tests/Excel.NamedRanges.cs
@@ -11,8 +11,8 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using (var document = ExcelDocument.Create(filePath)) {
                 var sheet = document.AddWorkSheet("Data");
-                document.SetNamedRange("GlobalRange", "'Data'!A1:A2");
-                sheet.SetNamedRange("LocalRange", "A1");
+                document.SetNamedRange("GlobalRange", "'Data'!A1:A2", save: false);
+                sheet.SetNamedRange("LocalRange", "A1", save: false);
                 document.Save();
             }
 
@@ -29,13 +29,13 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using (var document = ExcelDocument.Create(filePath)) {
                 var sheet = document.AddWorkSheet("Data");
-                sheet.SetNamedRange("TempRange", "A1:B2");
+                sheet.SetNamedRange("TempRange", "A1:B2", save: false);
                 document.Save();
             }
 
             using (var document = ExcelDocument.Load(filePath)) {
                 var sheet = document.Sheets.First(s => s.Name == "Data");
-                Assert.True(sheet.RemoveNamedRange("TempRange"));
+                Assert.True(sheet.RemoveNamedRange("TempRange", save: false));
                 Assert.Null(sheet.GetNamedRange("TempRange"));
                 document.Save();
             }

--- a/OfficeIMO.Tests/Excel.NamedRanges.cs
+++ b/OfficeIMO.Tests/Excel.NamedRanges.cs
@@ -48,6 +48,28 @@ namespace OfficeIMO.Tests {
             document.AddWorkSheet("Data");
             Assert.Throws<ArgumentException>(() => document.SetNamedRange("Bad", "'Data'!A1:A"));
         }
+
+        [Fact]
+        public void CanListNamedRanges() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                document.SetNamedRange("GlobalRange", "'Data'!A1:A2", save: false);
+                sheet.SetNamedRange("LocalRange", "A1:B2", save: false);
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var globals = document.GetAllNamedRanges();
+                Assert.Single(globals);
+                Assert.Equal("'Data'!$A$1:$A$2", globals["GlobalRange"]);
+                var sheet = document.Sheets.First(s => s.Name == "Data");
+                var locals = sheet.GetAllNamedRanges();
+                Assert.Single(locals);
+                Assert.Equal("$A$1:$B$2", locals["LocalRange"]);
+            }
+            File.Delete(filePath);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add APIs to create, retrieve, and delete named ranges on workbooks and worksheets
- normalize ranges and support optional scope
- include example and unit tests for named range operations

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bdbb0a4ff4832e9b5f9629367f3f05