### PR TITLE
Add DateOnly and TimeOnly support for Excel cell values

### DIFF
--- a/OfficeIMO.Examples/Excel/CellValues.cs
+++ b/OfficeIMO.Examples/Excel/CellValues.cs
@@ -38,6 +38,14 @@ namespace OfficeIMO.Examples.Excel {
                 sheet.CellFormula(9, 2, "SUM(B2)");
                 sheet.CellValue(10, 1, "Combined");
                 sheet.Cell(10, 2, 1.23, "B2+1", "0.00");
+#if NET6_0_OR_GREATER
+                sheet.CellValue(11, 1, "DateOnly");
+                sheet.CellValue(11, 2, DateOnly.FromDateTime(DateTime.Today));
+                sheet.FormatCell(11, 2, "yyyy-mm-dd");
+                sheet.CellValue(12, 1, "TimeOnly");
+                sheet.CellValue(12, 2, new TimeOnly(1, 2, 3));
+                sheet.FormatCell(12, 2, "hh:mm:ss");
+#endif
 
                 document.Save(openExcel);
             }

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -66,6 +66,12 @@ namespace OfficeIMO.Excel {
                     return (new CellValue(dt.ToOADate().ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
                 case DateTimeOffset dto:
                     return (new CellValue(dto.UtcDateTime.ToOADate().ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
+#if NET6_0_OR_GREATER
+                case DateOnly dateOnly:
+                    return (new CellValue(dateOnly.ToDateTime(TimeOnly.MinValue).ToOADate().ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
+                case TimeOnly timeOnly:
+                    return (new CellValue(timeOnly.ToTimeSpan().TotalDays.ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
+#endif
                 case TimeSpan ts:
                     return (new CellValue(ts.TotalDays.ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
                 case bool b:

--- a/OfficeIMO.Tests/Excel.CellValues.Additional.cs
+++ b/OfficeIMO.Tests/Excel.CellValues.Additional.cs
@@ -14,6 +14,10 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "CellValuesAdditional.xlsx");
             var dateOffset = new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero);
             var time = new TimeSpan(1, 2, 3, 4);
+#if NET6_0_OR_GREATER
+            var dateOnly = new DateOnly(2024, 1, 2);
+            var timeOnly = new TimeOnly(3, 4, 5);
+#endif
             uint ui = 123u;
             ulong ul = 1234567890UL;
             ushort us = 32100;
@@ -41,6 +45,12 @@ namespace OfficeIMO.Tests {
                 sheet.FormatCell(9, 1, "yyyy-mm-dd hh:mm");
                 sheet.CellValue(10, 1, nullableTs);
                 sheet.FormatCell(10, 1, "hh:mm:ss");
+#if NET6_0_OR_GREATER
+                sheet.CellValue(11, 1, dateOnly);
+                sheet.FormatCell(11, 1, "yyyy-mm-dd");
+                sheet.CellValue(12, 1, timeOnly);
+                sheet.FormatCell(12, 1, "hh:mm:ss");
+#endif
                 document.Save();
             }
 
@@ -86,12 +96,22 @@ namespace OfficeIMO.Tests {
 
                 Cell cellNullableTs = cells.First(c => c.CellReference == "A10");
                 Assert.Equal(nullableTs.Value.TotalDays.ToString(CultureInfo.InvariantCulture), cellNullableTs.CellValue!.Text);
+#if NET6_0_OR_GREATER
+                Cell cellDateOnly = cells.First(c => c.CellReference == "A11");
+                Assert.Equal(dateOnly.ToDateTime(TimeOnly.MinValue).ToOADate().ToString(CultureInfo.InvariantCulture), cellDateOnly.CellValue!.Text);
+
+                Cell cellTimeOnly = cells.First(c => c.CellReference == "A12");
+                Assert.Equal(timeOnly.ToTimeSpan().TotalDays.ToString(CultureInfo.InvariantCulture), cellTimeOnly.CellValue!.Text);
+#endif
 
                 var styles = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
                 var numberingFormats = styles.NumberingFormats!.Elements<NumberingFormat>().ToList();
                 Assert.Contains(numberingFormats, n => n.FormatCode != null && n.FormatCode.Value == "yyyy-mm-dd hh:mm");
                 Assert.Contains(numberingFormats, n => n.FormatCode != null && n.FormatCode.Value == "hh:mm:ss");
                 Assert.Contains(numberingFormats, n => n.FormatCode != null && n.FormatCode.Value == "000000");
+#if NET6_0_OR_GREATER
+                Assert.Contains(numberingFormats, n => n.FormatCode != null && n.FormatCode.Value == "yyyy-mm-dd");
+#endif
             }
         }
     }


### PR DESCRIPTION
## Summary
- handle `DateOnly` and `TimeOnly` in cell value coercion using OA-date numeric representation
- test `DateOnly` and `TimeOnly` cell values and formatting

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Test_CellValues_AdditionalTypes`


------
https://chatgpt.com/codex/tasks/task_e_68c310f89414832e950750a7e9e5fa95