### PR TITLE
Refactor cell value coercion with shared helper

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -22,15 +22,11 @@ namespace OfficeIMO.Excel {
         // Core implementation: single source of truth (no locks here)
         private void CellValueCore(int row, int column, object value)
         {
-            var ssPlanner = new SharedStringPlanner();
-            var (cellValue, dataType) = CoerceForCell(value, ssPlanner);
-
-            var prepared = new[] { (Row: row, Col: column, Val: cellValue, Type: dataType) };
-            ssPlanner.ApplyAndFixup(prepared, _excelDocument);
+            var (cellValue, dataType) = CoerceForCell(value);
 
             var cell = GetCell(row, column);
-            cell.CellValue = prepared[0].Val;
-            cell.DataType = prepared[0].Type;
+            cell.CellValue = cellValue;
+            cell.DataType = dataType;
 
             // Automatically apply date format for DateTime values
             // Using Excel's built-in date format code 14 (invariant short date)
@@ -46,83 +42,19 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        // Core coercion logic shared between sequential and parallel operations
-        private static (CellValue cellValue, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues> dataType) CoerceForCellInternal(object value, SharedStringPlanner planner)
+        private (CellValue cellValue, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues> dataType) CoerceForCell(object value)
         {
-            switch (value)
+            var (cellValue, type) = CoerceValueHelper(value, s =>
             {
-                case null:
-                    return (new CellValue(string.Empty), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.String));
-                case string s:
-                    planner.Note(s);
-                    return (new CellValue(s), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString));
-                case double d:
-                    return (new CellValue(d.ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
-                case float f:
-                    return (new CellValue(Convert.ToDouble(f).ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
-                case decimal dec:
-                    return (new CellValue(dec.ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
-                case int i:
-                    return (new CellValue(((double)i).ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
-                case long l:
-                    return (new CellValue(((double)l).ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
-                case DateTime dt:
-                    return (new CellValue(dt.ToOADate().ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
-                case DateTimeOffset dto:
-                    return (new CellValue(dto.UtcDateTime.ToOADate().ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
-                case TimeSpan ts:
-                    return (new CellValue(ts.TotalDays.ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
-                case bool b:
-                    return (new CellValue(b ? "1" : "0"), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Boolean));
-                case uint ui:
-                    return (new CellValue(((double)ui).ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
-                case ulong ul:
-                    return (new CellValue(((double)ul).ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
-                case ushort us:
-                    return (new CellValue(((double)us).ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
-                case byte by:
-                    return (new CellValue(((double)by).ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
-                case sbyte sb:
-                    return (new CellValue(((double)sb).ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
-                case short sh:
-                    return (new CellValue(((double)sh).ToString(CultureInfo.InvariantCulture)), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.Number));
-                case Guid guid:
+                if (s.Length > 32767)
                 {
-                    string text = guid.ToString();
-                    planner.Note(text);
-                    return (new CellValue(text), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString));
+                    throw new ArgumentException("String exceeds Excel's limit of 32,767 characters", nameof(value));
                 }
-                case Enum e:
-                {
-                    string name = e.ToString();
-                    planner.Note(name);
-                    return (new CellValue(name), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString));
-                }
-                case char ch:
-                {
-                    string text = ch.ToString();
-                    planner.Note(text);
-                    return (new CellValue(text), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString));
-                }
-                case System.DBNull:
-                    return (new CellValue(string.Empty), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.String));
-                case Uri uri:
-                {
-                    string text = uri.ToString();
-                    planner.Note(text);
-                    return (new CellValue(text), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString));
-                }
-                default:
-                    string stringValue = value?.ToString() ?? string.Empty;
-                    planner.Note(stringValue);
-                    return (new CellValue(stringValue), new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString));
-            }
-        }
+                int idx = _excelDocument.GetSharedStringIndex(s);
+                return new CellValue(idx.ToString(CultureInfo.InvariantCulture));
+            });
 
-        // Compute-only coercion (no OpenXML mutations, strings queued via planner)
-        private (CellValue cellValue, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues> dataType) CoerceForCell(object value, SharedStringPlanner planner)
-        {
-            return CoerceForCellInternal(value, planner);
+            return (cellValue, new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(type));
         }
 
         /// <inheritdoc cref="CellValue(int,int,object)" />

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -93,7 +93,13 @@ namespace OfficeIMO.Excel
         /// </summary>
         private (CellValue cellValue, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues> dataType) CoerceForCellNoDom(object value, SharedStringPlanner planner)
         {
-            return CoerceForCellInternal(value, planner);
+            var (cellValue, type) = CoerceValueHelper(value, s =>
+            {
+                planner.Note(s);
+                return new CellValue(s);
+            });
+
+            return (cellValue, new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(type));
         }
 
         /// <summary>

--- a/OfficeIMO.Excel/ExcelSheet.CoerceValueHelper.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CoerceValueHelper.cs
@@ -1,0 +1,64 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
+using System;
+using System.Globalization;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        private static (CellValue cellValue, DocumentFormat.OpenXml.Spreadsheet.CellValues type) CoerceValueHelper(object value, Func<string, CellValue> handleSharedString) {
+            switch (value) {
+                case null:
+                    return (new CellValue(string.Empty), DocumentFormat.OpenXml.Spreadsheet.CellValues.String);
+                case string s:
+                    return (handleSharedString(s), DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString);
+                case double d:
+                    return (new CellValue(d.ToString(CultureInfo.InvariantCulture)), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number);
+                case float f:
+                    return (new CellValue(Convert.ToDouble(f).ToString(CultureInfo.InvariantCulture)), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number);
+                case decimal dec:
+                    return (new CellValue(dec.ToString(CultureInfo.InvariantCulture)), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number);
+                case int i:
+                    return (new CellValue(((double)i).ToString(CultureInfo.InvariantCulture)), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number);
+                case long l:
+                    return (new CellValue(((double)l).ToString(CultureInfo.InvariantCulture)), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number);
+                case uint ui:
+                    return (new CellValue(((double)ui).ToString(CultureInfo.InvariantCulture)), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number);
+                case ulong ul:
+                    return (new CellValue(((double)ul).ToString(CultureInfo.InvariantCulture)), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number);
+                case ushort us:
+                    return (new CellValue(((double)us).ToString(CultureInfo.InvariantCulture)), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number);
+                case byte b:
+                    return (new CellValue(((double)b).ToString(CultureInfo.InvariantCulture)), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number);
+                case sbyte sb:
+                    return (new CellValue(((double)sb).ToString(CultureInfo.InvariantCulture)), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number);
+                case short sh:
+                    return (new CellValue(((double)sh).ToString(CultureInfo.InvariantCulture)), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number);
+                case DateTime dt:
+                    return (new CellValue(dt.ToOADate().ToString(CultureInfo.InvariantCulture)), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number);
+                case DateTimeOffset dto:
+                    return (new CellValue(dto.UtcDateTime.ToOADate().ToString(CultureInfo.InvariantCulture)), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number);
+                case TimeSpan ts:
+                    return (new CellValue(ts.TotalDays.ToString(CultureInfo.InvariantCulture)), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number);
+                case bool bo:
+                    return (new CellValue(bo ? "1" : "0"), DocumentFormat.OpenXml.Spreadsheet.CellValues.Boolean);
+                case Guid guid:
+                    var gtext = guid.ToString();
+                    return (handleSharedString(gtext), DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString);
+                case Enum e:
+                    var name = e.ToString();
+                    return (handleSharedString(name), DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString);
+                case char ch:
+                    var ctext = ch.ToString();
+                    return (handleSharedString(ctext), DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString);
+                case System.DBNull:
+                    return (new CellValue(string.Empty), DocumentFormat.OpenXml.Spreadsheet.CellValues.String);
+                case Uri uri:
+                    var utext = uri.ToString();
+                    return (handleSharedString(utext), DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString);
+                default:
+                    var text = value?.ToString() ?? string.Empty;
+                    return (handleSharedString(text), DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add CoerceValueHelper to centralize object to CellValue conversion
- refactor CoerceForCell and CoerceForCellNoDom to reuse helper with DOM or planner delegates
- ensure long strings still trigger ArgumentException and existing tests pass

## Testing
- `dotnet build OfficeImo.sln`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter CellValue`


------
https://chatgpt.com/codex/tasks/task_e_68c6e97d2200832ea67cea198ed15077