### PR TITLE
Fix Excel and Markdown build warnings

### DIFF
--- a/OfficeIMO.Examples/Excel/ReadPresetsAndHelpers.cs
+++ b/OfficeIMO.Examples/Excel/ReadPresetsAndHelpers.cs
@@ -16,7 +16,7 @@ namespace OfficeIMO.Examples.Excel
             public decimal Amount { get; set; }
             public DateTime Date { get; set; }
             public int Qty { get; set; }
-            public string Note { get; set; }
+            public string Note { get; set; } = string.Empty;
         }
 
         public static void Example(string folderPath, bool openExcel)

--- a/OfficeIMO.Examples/Excel/ReadWithConverters.cs
+++ b/OfficeIMO.Examples/Excel/ReadWithConverters.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Examples.Excel
             public decimal Amount { get; set; }
             public DateTime Date { get; set; }
             public int Qty { get; set; }
-            public string Note { get; set; }
+            public string Note { get; set; } = string.Empty;
         }
 
         public static void Example(string folderPath, bool openExcel)

--- a/OfficeIMO.Excel/Fluent/ColumnSizingOptions.cs
+++ b/OfficeIMO.Excel/Fluent/ColumnSizingOptions.cs
@@ -7,18 +7,54 @@ namespace OfficeIMO.Excel.Fluent {
     /// Widths use Excel's character-based units (approx. number of '0' glyphs).
     /// </summary>
     public sealed class ColumnSizingOptions {
+        /// <summary>
+        /// Width in characters used for headers registered in <see cref="ShortHeaders"/>.
+        /// </summary>
         public double ShortWidth { get; set; } = 16;     // Status/Alg/Hash
+
+        /// <summary>
+        /// Width in characters used for headers registered in <see cref="NumericHeaders"/>.
+        /// </summary>
         public double NumericWidth { get; set; } = 10;   // Depth/Count/Days
+
+        /// <summary>
+        /// Width in characters used for headers registered in <see cref="MediumHeaders"/>.
+        /// </summary>
         public double MediumWidth { get; set; } = 28;    // Provider/Target/Reason
+
+        /// <summary>
+        /// Width in characters used for headers registered in <see cref="LongHeaders"/>.
+        /// </summary>
         public double LongWidth { get; set; } = 56;      // Evidence/Record/URL/Summary
 
+        /// <summary>
+        /// Case-insensitive set of header names that should use <see cref="ShortWidth"/>.
+        /// </summary>
         public HashSet<string> ShortHeaders { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Case-insensitive set of header names that should use <see cref="NumericWidth"/>.
+        /// </summary>
         public HashSet<string> NumericHeaders { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Case-insensitive set of header names that should use <see cref="MediumWidth"/>.
+        /// </summary>
         public HashSet<string> MediumHeaders { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Case-insensitive set of header names that should use <see cref="LongWidth"/>.
+        /// </summary>
         public HashSet<string> LongHeaders { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Case-insensitive set of header names that should be wrapped regardless of width.
+        /// </summary>
         public HashSet<string> WrapHeaders { get; } = new(StringComparer.OrdinalIgnoreCase);
 
-        // Explicit overrides
+        /// <summary>
+        /// Explicit column width overrides keyed by header name. Values are Excel character widths.
+        /// </summary>
         public Dictionary<string, double> WidthByHeader { get; } = new(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
@@ -43,14 +43,16 @@ namespace OfficeIMO.Word.Markdown {
 
             // Parse using OfficeIMO.Markdown reader.
             var omd = Omd.MarkdownReader.Parse(markdown);
+            var blocks = omd.Blocks;
             // Build footnote definitions map for this document
-            _currentFootnotes = omd.Blocks is not null
-                ? omd.Blocks
+            _currentFootnotes = blocks is not null
+                ? blocks
                     .OfType<Omd.FootnoteDefinitionBlock>()
                     .GroupBy(f => f.Label)
                     .ToDictionary(g => g.Key, g => g.Last().Text)
                 : null;
-            foreach (var block in omd.Blocks) {
+
+            foreach (var block in blocks ?? Array.Empty<Omd.IMarkdownBlock>()) {
                 cancellationToken.ThrowIfCancellationRequested();
                 ProcessBlockOmd(block, document, options, quoteDepth: 0);
             }


### PR DESCRIPTION
## Summary
- add XML documentation to `ColumnSizingOptions` so Excel builds without missing comment warnings
- initialize the `Note` property in Excel reading examples to satisfy nullable analysis
- guard the markdown-to-word converter against null block collections when iterating

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68c86f8d7c80832e81034863a79d1697