### PR TITLE
Fix nullability warnings in Word content controls

### DIFF
--- a/OfficeIMO.Word/WordCustomProperty.cs
+++ b/OfficeIMO.Word/WordCustomProperty.cs
@@ -20,7 +20,7 @@ namespace OfficeIMO.Word {
         /// Gets or sets the raw value of the custom property.
         /// </summary>
         /// <remarks>The actual type is defined by <see cref="PropertyType"/>.</remarks>
-        public object Value;
+        public object Value { get; set; } = string.Empty;
         /// <summary>
         /// Gets or sets the kind of custom property.
         /// </summary>

--- a/OfficeIMO.Word/WordDatePicker.cs
+++ b/OfficeIMO.Word/WordDatePicker.cs
@@ -14,9 +14,9 @@ namespace OfficeIMO.Word {
         internal readonly SdtRun _sdtRun;
 
         internal WordDatePicker(WordDocument document, Paragraph paragraph, SdtRun sdtRun) {
-            _document = document;
-            _paragraph = paragraph;
-            _sdtRun = sdtRun;
+            _document = document ?? throw new ArgumentNullException(nameof(document));
+            _paragraph = paragraph ?? throw new ArgumentNullException(nameof(paragraph));
+            _sdtRun = sdtRun ?? throw new ArgumentNullException(nameof(sdtRun));
         }
 
         /// <summary>
@@ -31,10 +31,11 @@ namespace OfficeIMO.Word {
                 return null;
             }
             set {
-                var dp = _sdtRun.SdtProperties.Elements<SdtContentDate>().FirstOrDefault();
+                var properties = EnsureProperties();
+                var dp = properties.Elements<SdtContentDate>().FirstOrDefault();
                 if (dp == null) {
                     dp = new SdtContentDate();
-                    _sdtRun.SdtProperties.Append(dp);
+                    properties.Append(dp);
                 }
                 dp.FullDate = value.HasValue ? new DateTimeValue(value.Value) : null;
             }
@@ -43,9 +44,9 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the alias associated with this date picker control.
         /// </summary>
-        public string Alias {
+        public string? Alias {
             get {
-                var sdtAlias = _sdtRun.SdtProperties.OfType<SdtAlias>().FirstOrDefault();
+                var sdtAlias = _sdtRun.SdtProperties?.OfType<SdtAlias>().FirstOrDefault();
                 return sdtAlias?.Val;
             }
         }
@@ -53,16 +54,17 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the tag value for this date picker control.
         /// </summary>
-        public string Tag {
+        public string? Tag {
             get {
-                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                var tag = _sdtRun.SdtProperties?.OfType<Tag>().FirstOrDefault();
                 return tag?.Val;
             }
             set {
-                var tag = _sdtRun.SdtProperties.OfType<Tag>().FirstOrDefault();
+                var properties = EnsureProperties();
+                var tag = properties.OfType<Tag>().FirstOrDefault();
                 if (tag == null) {
                     tag = new Tag();
-                    _sdtRun.SdtProperties.Append(tag);
+                    properties.Append(tag);
                 }
                 tag.Val = value;
             }
@@ -73,6 +75,16 @@ namespace OfficeIMO.Word {
         /// </summary>
         public void Remove() {
             _sdtRun.Remove();
+        }
+
+        private SdtProperties EnsureProperties() {
+            var properties = _sdtRun.SdtProperties;
+            if (properties == null) {
+                properties = new SdtProperties();
+                _sdtRun.SdtProperties = properties;
+            }
+
+            return properties;
         }
     }
 }

--- a/OfficeIMO.Word/WordDocumentVariables.cs
+++ b/OfficeIMO.Word/WordDocumentVariables.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Word {
     public class WordDocumentVariables {
         private readonly WordprocessingDocument _wordprocessingDocument;
         private readonly WordDocument _document;
-        private DocumentVariables _variables;
+        private DocumentVariables? _variables;
 
         /// <summary>
         /// Initializes a new instance of <see cref="WordDocumentVariables"/> and loads or creates document variables.
@@ -20,8 +20,8 @@ namespace OfficeIMO.Word {
         /// <param name="document">Parent document.</param>
         /// <param name="create">When set to <c>true</c> variables are written to the document.</param>
         public WordDocumentVariables(WordDocument document, bool? create = null) {
-            _document = document;
-            _wordprocessingDocument = document._wordprocessingDocument;
+            _document = document ?? throw new ArgumentNullException(nameof(document));
+            _wordprocessingDocument = document._wordprocessingDocument ?? throw new ArgumentNullException(nameof(document._wordprocessingDocument));
 
             if (create == true) {
                 CreateDocumentVariables();
@@ -31,28 +31,45 @@ namespace OfficeIMO.Word {
         }
 
         private void LoadDocumentVariables() {
-            var settingsPart = _wordprocessingDocument.MainDocumentPart.DocumentSettingsPart;
-            if (settingsPart?.Settings != null) {
-                _variables = settingsPart.Settings.GetFirstChild<DocumentVariables>();
-                if (_variables != null) {
-                    foreach (var variable in _variables.Elements<DocumentVariable>()) {
-                        _document.DocumentVariables[variable.Name] = variable.Val;
-                    }
+            var mainDocumentPart = _wordprocessingDocument.MainDocumentPart;
+            if (mainDocumentPart == null) {
+                return;
+            }
+
+            var settingsPart = mainDocumentPart.DocumentSettingsPart;
+            var settings = settingsPart?.Settings;
+            if (settings == null) {
+                return;
+            }
+
+            _variables = settings.GetFirstChild<DocumentVariables>();
+            if (_variables == null) {
+                return;
+            }
+
+            foreach (var variable in _variables.Elements<DocumentVariable>()) {
+                var name = variable.Name?.Value;
+                if (string.IsNullOrEmpty(name)) {
+                    continue;
                 }
+
+                var value = variable.Val?.Value ?? string.Empty;
+                _document.DocumentVariables[name] = value;
             }
         }
 
         private void CreateDocumentVariables() {
-            var settingsPart = _wordprocessingDocument.MainDocumentPart.DocumentSettingsPart;
+            var mainDocumentPart = _wordprocessingDocument.MainDocumentPart ?? throw new InvalidOperationException("Main document part is missing.");
+            var settingsPart = mainDocumentPart.DocumentSettingsPart;
             if (settingsPart == null) {
                 if (_document.FileOpenAccess == FileAccess.Read) {
                     throw new ArgumentException("Document is read only!");
                 }
-                settingsPart = _wordprocessingDocument.MainDocumentPart.AddNewPart<DocumentSettingsPart>();
+                settingsPart = mainDocumentPart.AddNewPart<DocumentSettingsPart>();
                 settingsPart.Settings = new Settings();
             }
 
-            var settings = settingsPart.Settings;
+            var settings = settingsPart.Settings ??= new Settings();
             _variables = settings.GetFirstChild<DocumentVariables>();
 
             if (_document.DocumentVariables.Count == 0) {
@@ -67,7 +84,10 @@ namespace OfficeIMO.Word {
 
             // remove variables not present in the dictionary
             var toRemove = _variables.Elements<DocumentVariable>()
-                .Where(v => !_document.DocumentVariables.ContainsKey(v.Name))
+                .Where(v => {
+                    var name = v.Name?.Value;
+                    return string.IsNullOrEmpty(name) || !_document.DocumentVariables.ContainsKey(name);
+                })
                 .ToList();
             foreach (var variable in toRemove) {
                 variable.Remove();
@@ -75,7 +95,7 @@ namespace OfficeIMO.Word {
 
             foreach (var pair in _document.DocumentVariables) {
                 var existing = _variables.Elements<DocumentVariable>()
-                    .FirstOrDefault(v => v.Name == pair.Key);
+                    .FirstOrDefault(v => string.Equals(v.Name?.Value, pair.Key, StringComparison.Ordinal));
                 if (existing != null) {
                     existing.Val = pair.Value;
                 } else {


### PR DESCRIPTION
## Summary
- initialize custom property values to avoid null field warnings
- guard WordDatePicker and WordDropDownList against missing structured document tag properties
- harden document variable import/export logic against absent settings parts and missing names

## Testing
- dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68ca692dfe6c832eafb361aeb176da0e