### PR TITLE
Improve null-safety in Word list helpers

### DIFF
--- a/OfficeIMO.Word/WordImageLocation.cs
+++ b/OfficeIMO.Word/WordImageLocation.cs
@@ -8,12 +8,12 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the <see cref="ImagePart"/> associated with the image.
         /// </summary>
-        public ImagePart ImagePart { get; set; }
+        public ImagePart ImagePart { get; set; } = null!;
 
         /// <summary>
         /// Gets or sets the relationship identifier linking to the image part.
         /// </summary>
-        public string RelationshipId { get; set; }
+        public string RelationshipId { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the width of the image in pixels.
@@ -28,6 +28,6 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets or sets the descriptive name of the image.
         /// </summary>
-        public string ImageName { get; set; }
+        public string ImageName { get; set; } = string.Empty;
     }
 }

--- a/OfficeIMO.Word/WordLine.cs
+++ b/OfficeIMO.Word/WordLine.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Word {
         internal WordDocument _document;
         internal WordParagraph _wordParagraph;
         internal Run _run;
-        internal V.Line _line;
+        internal V.Line _line = null!;
 
         internal WordLine(WordDocument document, WordParagraph paragraph, double startXPt, double startYPt, double endXPt, double endYPt, string color = "#000000", double strokeWeightPt = 1) {
             _document = document;
@@ -39,7 +39,8 @@ namespace OfficeIMO.Word {
             _document = document;
             _wordParagraph = new WordParagraph(document, paragraph, run);
             _run = run;
-            _line = run.Descendants<V.Line>().FirstOrDefault();
+            _line = run.Descendants<V.Line>().FirstOrDefault()
+                ?? throw new ArgumentException("The provided run does not contain a VML line.", nameof(run));
         }
 
         /// <summary>

--- a/OfficeIMO.Word/WordListLevel.cs
+++ b/OfficeIMO.Word/WordListLevel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word {
@@ -135,24 +136,79 @@ public enum WordListLevelKind {
         /// </summary>
         /// <param name="level">The underlying Open XML list level element.</param>
         public WordListLevel(Level level) {
-            _level = level;
+            _level = level ?? throw new ArgumentNullException(nameof(level));
         }
 
         /// <summary>
         /// Gets or sets the underlying Open XML list level element that backs
         /// this instance.
         /// </summary>
-        public Level _level { get; set; }
+        public Level _level { get; set; } = null!;
+
+        private StartNumberingValue GetStartNumberingValueElement() {
+            var element = _level.Descendants<StartNumberingValue>().FirstOrDefault();
+            if (element == null) {
+                element = new StartNumberingValue { Val = 1 };
+                _level.Append(element);
+            } else if (!element.Val.HasValue) {
+                element.Val = 1;
+            }
+
+            return element;
+        }
+
+        private Indentation GetIndentationElement() {
+            var indentation = _level.Descendants<Indentation>().FirstOrDefault();
+            if (indentation != null) {
+                return indentation;
+            }
+
+            var paragraphProperties = _level.GetFirstChild<PreviousParagraphProperties>();
+            if (paragraphProperties == null) {
+                paragraphProperties = new PreviousParagraphProperties();
+                _level.Append(paragraphProperties);
+            }
+
+            indentation = new Indentation { Left = "0", Hanging = "0" };
+            paragraphProperties.Append(indentation);
+            return indentation;
+        }
+
+        private LevelText GetLevelTextElement() {
+            var levelText = _level.GetFirstChild<LevelText>();
+            if (levelText == null) {
+                levelText = new LevelText { Val = string.Empty };
+                _level.Append(levelText);
+            } else if (levelText.Val == null) {
+                levelText.Val = string.Empty;
+            }
+
+            return levelText;
+        }
+
+        private LevelJustification GetLevelJustificationElement() {
+            var justification = _level.GetFirstChild<LevelJustification>();
+            if (justification == null) {
+                justification = new LevelJustification { Val = LevelJustificationValues.Left };
+                _level.Append(justification);
+            } else if (!justification.Val.HasValue) {
+                justification.Val = LevelJustificationValues.Left;
+            }
+
+            return justification;
+        }
 
         /// <summary>
         /// Gets or sets the start numbering value.
         /// </summary>
         public int StartNumberingValue {
             get {
-                return _level.Descendants<StartNumberingValue>().First().Val;
+                var element = GetStartNumberingValueElement();
+                return element.Val?.Value ?? 0;
             }
             set {
-                _level.Descendants<StartNumberingValue>().First().Val = value;
+                var element = GetStartNumberingValueElement();
+                element.Val = value;
             }
         }
 
@@ -171,10 +227,12 @@ public enum WordListLevelKind {
         /// </summary>
         public int IndentationLeft {
             get {
-                return int.Parse(_level.Descendants<Indentation>().First().Left);
+                var indentation = GetIndentationElement();
+                return int.TryParse(indentation.Left, out int value) ? value : 0;
             }
             set {
-                _level.Descendants<Indentation>().First().Left = value.ToString();
+                var indentation = GetIndentationElement();
+                indentation.Left = value.ToString();
             }
         }
 
@@ -191,10 +249,12 @@ public enum WordListLevelKind {
         /// </summary>
         public int IndentationHanging {
             get {
-                return int.Parse(_level.Descendants<Indentation>().First().Hanging);
+                var indentation = GetIndentationElement();
+                return int.TryParse(indentation.Hanging, out int value) ? value : 0;
             }
             set {
-                _level.Descendants<Indentation>().First().Hanging = value.ToString();
+                var indentation = GetIndentationElement();
+                indentation.Hanging = value.ToString();
             }
         }
 
@@ -211,10 +271,12 @@ public enum WordListLevelKind {
         /// </summary>
         public string LevelText {
             get {
-                return _level.Descendants<LevelText>().First().Val;
+                var element = GetLevelTextElement();
+                return element.Val?.Value ?? string.Empty;
             }
             set {
-                _level.Descendants<LevelText>().First().Val = value;
+                var element = GetLevelTextElement();
+                element.Val = value ?? string.Empty;
             }
         }
 
@@ -223,10 +285,12 @@ public enum WordListLevelKind {
         /// </summary>
         public LevelJustificationValues LevelJustification {
             get {
-                return _level.Descendants<LevelJustification>().First().Val;
+                var element = GetLevelJustificationElement();
+                return element.Val?.Value ?? LevelJustificationValues.Left;
             }
             set {
-                _level.Descendants<LevelJustification>().First().Val = value;
+                var element = GetLevelJustificationElement();
+                element.Val = value;
             }
         }
 

--- a/OfficeIMO.Word/WordListNumbering.cs
+++ b/OfficeIMO.Word/WordListNumbering.cs
@@ -37,7 +37,13 @@ namespace OfficeIMO.Word {
         /// Gets the abstract numbering identifier.
         /// </summary>
         public int AbstractNumberId {
-            get { return (int)_abstractNum.AbstractNumberId.Value; }
+            get {
+                var abstractNumberId = _abstractNum.AbstractNumberId?.Value;
+                if (!abstractNumberId.HasValue) {
+                    throw new InvalidOperationException("Abstract numbering identifier is missing.");
+                }
+                return abstractNumberId.Value;
+            }
         }
 
         /// <summary>
@@ -49,12 +55,12 @@ namespace OfficeIMO.Word {
         private int GetNextLevelIndex {
             get {
                 var currentLevels = _abstractNum.Descendants<Level>();
-                if (currentLevels.Count() == 0) {
+                if (!currentLevels.Any()) {
                     return 0;
                 }
                 var lastLevel = currentLevels.Last();
-                var nextLevel = lastLevel.LevelIndex + 1;
-                return nextLevel;
+                var lastIndex = lastLevel.LevelIndex?.Value ?? -1;
+                return lastIndex + 1;
             }
         }
 
@@ -77,19 +83,16 @@ namespace OfficeIMO.Word {
                 throw new ArgumentNullException(nameof(document));
             }
 
-            var mainPart = document._wordprocessingDocument.MainDocumentPart;
+            var mainPart = document._wordprocessingDocument.MainDocumentPart
+                ?? throw new InvalidOperationException("The document does not contain a main document part.");
             var numberingPart = mainPart.NumberingDefinitionsPart ?? mainPart.AddNewPart<NumberingDefinitionsPart>();
-            if (numberingPart.Numbering == null) {
-                numberingPart.Numbering = new Numbering();
-            }
-
-            var numbering = numberingPart.Numbering;
+            var numbering = numberingPart.Numbering ??= new Numbering();
             var newId = numbering.Elements<AbstractNum>()
-                .Select(a => (int)a.AbstractNumberId.Value)
-                .DefaultIfEmpty(0)
+                .Select(a => a.AbstractNumberId?.Value ?? -1)
+                .DefaultIfEmpty(-1)
                 .Max() + 1;
 
-            var abstractNum = new AbstractNum { AbstractNumberId = newId };
+            var abstractNum = new AbstractNum { AbstractNumberId = new Int32Value(newId) };
             numbering.Append(abstractNum);
             numberingPart.Numbering.Save(numberingPart);
             return new WordListNumbering(abstractNum);
@@ -106,8 +109,14 @@ namespace OfficeIMO.Word {
                 throw new ArgumentNullException(nameof(document));
             }
 
-            var numbering = document._wordprocessingDocument.MainDocumentPart?.NumberingDefinitionsPart?.Numbering;
-            var abstractNum = numbering?.Elements<AbstractNum>().FirstOrDefault(a => a.AbstractNumberId.Value == abstractNumberId);
+            var mainPart = document._wordprocessingDocument.MainDocumentPart;
+            var numbering = mainPart?.NumberingDefinitionsPart?.Numbering;
+            if (numbering == null) {
+                return null;
+            }
+
+            var abstractNum = numbering.Elements<AbstractNum>()
+                .FirstOrDefault(a => a.AbstractNumberId?.Value == abstractNumberId);
             return abstractNum != null ? new WordListNumbering(abstractNum) : null;
         }
 
@@ -119,9 +128,16 @@ namespace OfficeIMO.Word {
         /// <param name="wordListLevel">The word list level.</param>
         private void UpdateLevelText(WordListLevel wordListLevel) {
             // Replace the placeholder in LevelText with the LevelIndex + 1
-            string levelText = wordListLevel._level.LevelText.Val;
-            levelText = levelText.Replace("%CurrentLevel", "%" + (wordListLevel._level.LevelIndex + 1));
-            wordListLevel._level.LevelText.Val = new StringValue(levelText);
+            if (wordListLevel == null) throw new ArgumentNullException(nameof(wordListLevel));
+
+            var level = wordListLevel._level ?? throw new InvalidOperationException("The list level is not initialized.");
+            var levelTextElement = level.GetFirstChild<LevelText>()
+                ?? throw new InvalidOperationException("Level text element is missing.");
+            var levelText = levelTextElement.Val?.Value ?? string.Empty;
+            var levelIndex = level.LevelIndex?.Value ?? 0;
+
+            levelText = levelText.Replace("%CurrentLevel", "%" + (levelIndex + 1));
+            levelTextElement.Val = new StringValue(levelText);
         }
 
         /// <summary>
@@ -131,6 +147,8 @@ namespace OfficeIMO.Word {
         public void AddLevel(WordListLevel wordListLevel) {
             // before adding new level, we need to find the last level index and increment it by 1
             // once we have LevelIndex we need to set it to the level
+            if (wordListLevel == null) throw new ArgumentNullException(nameof(wordListLevel));
+
             wordListLevel._level.LevelIndex = GetNextLevelIndex;
             // Update the LevelText to match the new LevelIndex
             UpdateLevelText(wordListLevel);
@@ -144,6 +162,8 @@ namespace OfficeIMO.Word {
         /// <param name="level">The level.</param>
         public void AddLevel(Level level) {
             // before adding new level, we need to find the last level index and increment it by 1
+            if (level == null) throw new ArgumentNullException(nameof(level));
+
             level.LevelIndex = GetNextLevelIndex;
             // add the level to the abstractNum
             _abstractNum.Append(level);


### PR DESCRIPTION
## Summary
- initialize `WordImageLocation` metadata with safe defaults to silence nullable warnings
- ensure VML line retrieval validates input when recreating `WordLine`
- add comprehensive null checks and element helpers across list numbering APIs and traversal utilities

## Testing
- dotnet build OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68ca7aa67b0c832eab231aacb17fe39d