### PR TITLE
Fix nullable warnings in samples, tests, and Markdown

### DIFF
--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.HeaderFooterImages.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.HeaderFooterImages.cs
@@ -13,8 +13,8 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Create(docPath)) {
                 document.AddHeadersAndFooters();
-                document.Header.Default.AddParagraph().AddImage(imagePath, 50, 50);
-                document.Footer.Default.AddParagraph().AddImage(imagePath, 300, 300);
+                document.Header!.Default.AddParagraph().AddImage(imagePath, 50, 50);
+                document.Footer!.Default.AddParagraph().AddImage(imagePath, 300, 300);
                 document.Save();
                 document.SaveAsPdf(pdfPath);
             }

--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdf.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdf.cs
@@ -22,11 +22,11 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Create(docPath)) {
                 document.AddHeadersAndFooters();
-                document.Header.Default.AddParagraph("Example Header");
-                WordTable headerTable = document.Header.Default.AddTable(1, 1);
+                document.Header!.Default.AddParagraph("Example Header");
+                WordTable headerTable = document.Header!.Default.AddTable(1, 1);
                 headerTable.Rows[0].Cells[0].Paragraphs[0].Text = "H1";
-                document.Footer.Default.AddParagraph("Example Footer");
-                WordTable footerTable = document.Footer.Default.AddTable(1, 1);
+                document.Footer!.Default.AddParagraph("Example Footer");
+                WordTable footerTable = document.Footer!.Default.AddTable(1, 1);
                 footerTable.Rows[0].Cells[0].Paragraphs[0].Text = "F1";
 
                 WordParagraph heading = document.AddParagraph("Sample Heading");

--- a/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.Create.cs
+++ b/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.Create.cs
@@ -92,7 +92,7 @@ namespace OfficeIMO.Examples.Word {
                 document.AddHeadersAndFooters();
 
                 // adding text to default header
-                document.Header.Default.AddParagraph("Text added to header - Default");
+                document.Header!.Default.AddParagraph("Text added to header - Default");
 
                 var section1 = document.AddSection();
                 section1.PageOrientation = PageOrientationValues.Portrait;
@@ -105,7 +105,7 @@ namespace OfficeIMO.Examples.Word {
                 document.CustomDocumentProperties.Add("IsTodayGreatDay", new WordCustomProperty(true));
 
                 // add page numbers
-                document.Footer.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
 
                 // add watermark
                 document.Sections[0].AddWatermark(WordWatermarkStyle.Text, "Draft");

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create05.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create05.cs
@@ -24,29 +24,29 @@ namespace OfficeIMO.Examples.Word {
 
                 Console.WriteLine("Images count: " + document.Images.Count);
 
-                document.Header.Default.AddParagraph().AddImage(filePathImage, 734, 92);
-                document.Header.Default.Paragraphs[0].SetFontFamily("Arial");
-                document.Header.Default.Paragraphs[0].SetFontSize(7).Bold = false;
+                document.Header!.Default.AddParagraph().AddImage(filePathImage, 734, 92);
+                document.Header!.Default.Paragraphs[0].SetFontFamily("Arial");
+                document.Header!.Default.Paragraphs[0].SetFontSize(7).Bold = false;
 
                 Console.WriteLine("Images Count: " + document.Images.Count);
-                Console.WriteLine("Images in Header Count: " + document.Header.Default.Images.Count);
+                Console.WriteLine("Images in Header Count: " + document.Header!.Default.Images.Count);
 
-                document.Footer.Default.AddParagraph();
-                document.Footer.Default.Paragraphs[0].SetFontFamily("Arial");
-                document.Footer.Default.Paragraphs[0].SetFontSize(7).Bold = false;
-                document.Footer.Default.Paragraphs[0].ParagraphAlignment = JustificationValues.Right;
-                document.Footer.Default.Paragraphs[0].Text = "SMA.5.doc 04/10/19";
-                document.Footer.Default.Paragraphs[0].LineSpacingAfter = 0;
-                document.Footer.Default.Paragraphs[0].LineSpacingBefore = 0;
-                document.Footer.Default.AddPageNumber(WordPageNumberStyle.PageNumberXofY);
+                document.Footer!.Default.AddParagraph();
+                document.Footer!.Default.Paragraphs[0].SetFontFamily("Arial");
+                document.Footer!.Default.Paragraphs[0].SetFontSize(7).Bold = false;
+                document.Footer!.Default.Paragraphs[0].ParagraphAlignment = JustificationValues.Right;
+                document.Footer!.Default.Paragraphs[0].Text = "SMA.5.doc 04/10/19";
+                document.Footer!.Default.Paragraphs[0].LineSpacingAfter = 0;
+                document.Footer!.Default.Paragraphs[0].LineSpacingBefore = 0;
+                document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PageNumberXofY);
 
-                document.Footer.Default.AddParagraph();
-                document.Footer.Default.Paragraphs[1].SetFontFamily("Arial");
-                document.Footer.Default.Paragraphs[1].SetFontSize(7).Bold = false;
-                document.Footer.Default.Paragraphs[1].ParagraphAlignment = JustificationValues.Center;
-                document.Footer.Default.Paragraphs[1].Text = "My address";
-                document.Footer.Default.Paragraphs[1].LineSpacingAfter = 0;
-                document.Footer.Default.Paragraphs[1].LineSpacingBefore = 0;
+                document.Footer!.Default.AddParagraph();
+                document.Footer!.Default.Paragraphs[1].SetFontFamily("Arial");
+                document.Footer!.Default.Paragraphs[1].SetFontSize(7).Bold = false;
+                document.Footer!.Default.Paragraphs[1].ParagraphAlignment = JustificationValues.Center;
+                document.Footer!.Default.Paragraphs[1].Text = "My address";
+                document.Footer!.Default.Paragraphs[1].LineSpacingAfter = 0;
+                document.Footer!.Default.Paragraphs[1].LineSpacingBefore = 0;
 
                 var par00 = document.AddParagraph("My text");
                 par00.ParagraphAlignment = JustificationValues.Left;

--- a/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample04.cs
+++ b/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample04.cs
@@ -17,15 +17,15 @@ internal static partial class CleanupDocuments {
         using (WordDocument document = WordDocument.Create(filePath)) {
             document.AddHeadersAndFooters();
 
-            var headerParagraph = document.Header.Default.AddParagraph("Header ");
+            var headerParagraph = document.Header!.Default.AddParagraph("Header ");
             headerParagraph.AddText("clutter ");
             headerParagraph.AddText("text");
-            document.Header.Default.AddParagraph();
+            document.Header!.Default.AddParagraph();
 
-            var footerParagraph = document.Footer.Default.AddParagraph("Footer ");
+            var footerParagraph = document.Footer!.Default.AddParagraph("Footer ");
             footerParagraph.AddText("clutter ");
             footerParagraph.AddText("text");
-            document.Footer.Default.AddParagraph();
+            document.Footer!.Default.AddParagraph();
 
             document.CleanupDocument();
             document.Save(openWord);

--- a/OfficeIMO.Examples/Word/CoverPages/CoverPages.Example1.cs
+++ b/OfficeIMO.Examples/Word/CoverPages/CoverPages.Example1.cs
@@ -17,10 +17,12 @@ namespace OfficeIMO.Examples.Word {
 
                 document.PageSettings.PageSize = WordPageSize.A4;
 
-                Console.WriteLine(document.PageSettings.Height.ToString());
-                Console.WriteLine(document.PageSettings.Width.ToString());
-                Console.WriteLine(document.PageSettings.Code.ToString());
-                Console.WriteLine(document.PageSettings.PageSize);
+                var pageSettings = document.PageSettings ?? throw new InvalidOperationException("Page settings are not initialized.");
+
+                Console.WriteLine(pageSettings.Height?.ToString() ?? "Height not set");
+                Console.WriteLine(pageSettings.Width?.ToString() ?? "Width not set");
+                Console.WriteLine(pageSettings.Code?.ToString() ?? "Code not set");
+                Console.WriteLine(pageSettings.PageSize?.ToString() ?? "Page size not set");
 
                 document.BuiltinDocumentProperties.Title = "Cover Page Templates";
                 document.BuiltinDocumentProperties.Subject = "How to use Cover Pages with TOC";

--- a/OfficeIMO.Examples/Word/EndToEnd/Word.EndToEnd.cs
+++ b/OfficeIMO.Examples/Word/EndToEnd/Word.EndToEnd.cs
@@ -18,8 +18,8 @@ namespace OfficeIMO.Examples.Word.EndToEnd {
             using (var doc = WordDocument.Create()) {
                 // Headers/Footers + page numbering
                 doc.AddHeadersAndFooters();
-                doc.Header.Default.AddParagraph("End-to-End Demo");
-                doc.Footer.Default.AddParagraph().AddPageNumber(includeTotalPages: true);
+                doc.Header!.Default.AddParagraph("End-to-End Demo");
+                doc.Footer!.Default.AddParagraph().AddPageNumber(includeTotalPages: true);
 
                 // TOC at top (updates on open)
                 new WordFluentDocument(doc).TocAtTop("Contents", minLevel: 1, maxLevel: 3, titleLevel: 2);

--- a/OfficeIMO.Examples/Word/Fields/Fields.CustomFormat.cs
+++ b/OfficeIMO.Examples/Word/Fields/Fields.CustomFormat.cs
@@ -26,7 +26,7 @@ namespace OfficeIMO.Examples.Word {
             string filePath = System.IO.Path.Combine(folderPath, "CustomFormattedHeaderDate.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                document.Header.Default.AddField(WordFieldType.Date, customFormat: "yyyy-MM-dd", advanced: true);
+                document.Header!.Default.AddField(WordFieldType.Date, customFormat: "yyyy-MM-dd", advanced: true);
                 document.AddParagraph("Body paragraph");
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/Fields/Fields02.cs
+++ b/OfficeIMO.Examples/Word/Fields/Fields02.cs
@@ -27,7 +27,7 @@ namespace OfficeIMO.Examples.Word {
                 document.AddField(WordFieldType.GreetingLine);
 
                 // added page number using dedicated way
-                var pageNumber = document.Header.Default.AddPageNumber(WordPageNumberStyle.Roman);
+                var pageNumber = document.Header!.Default.AddPageNumber(WordPageNumberStyle.Roman);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example1.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example1.cs
@@ -16,37 +16,37 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentOddAndEvenPages = true;
                 document.DifferentFirstPage = true;
 
-                document.Header.Default.AddParagraph().SetColor(Color.Red).SetText("Test Header");
+                document.Header!.Default.AddParagraph().SetColor(Color.Red).SetText("Test Header");
 
-                document.Footer.Default.AddParagraph().SetColor(Color.Blue).SetText("Test Footer");
+                document.Footer!.Default.AddParagraph().SetColor(Color.Blue).SetText("Test Footer");
 
-                Console.WriteLine("Header Default Count: " + document.Header.Default.Paragraphs.Count);
-                Console.WriteLine("Header Even Count: " + document.Header.Even.Paragraphs.Count);
-                Console.WriteLine("Header First Count: " + document.Header.First.Paragraphs.Count);
+                Console.WriteLine("Header Default Count: " + document.Header!.Default.Paragraphs.Count);
+                Console.WriteLine("Header Even Count: " + document.Header!.Even.Paragraphs.Count);
+                Console.WriteLine("Header First Count: " + document.Header!.First.Paragraphs.Count);
 
-                Console.WriteLine("Header text: " + document.Header.Default.Paragraphs[0].Text);
+                Console.WriteLine("Header text: " + document.Header!.Default.Paragraphs[0].Text);
 
-                Console.WriteLine("Footer Default Count: " + document.Footer.Default.Paragraphs.Count);
-                Console.WriteLine("Footer Even Count: " + document.Footer.Even.Paragraphs.Count);
-                Console.WriteLine("Footer First Count: " + document.Footer.First.Paragraphs.Count);
+                Console.WriteLine("Footer Default Count: " + document.Footer!.Default.Paragraphs.Count);
+                Console.WriteLine("Footer Even Count: " + document.Footer!.Even.Paragraphs.Count);
+                Console.WriteLine("Footer First Count: " + document.Footer!.First.Paragraphs.Count);
 
-                Console.WriteLine("Footer text: " + document.Footer.Default.Paragraphs[0].Text);
+                Console.WriteLine("Footer text: " + document.Footer!.Default.Paragraphs[0].Text);
 
                 document.Save();
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Console.WriteLine("Header Default Count: " + document.Header.Default.Paragraphs.Count);
-                Console.WriteLine("Header Even Count: " + document.Header.Even.Paragraphs.Count);
-                Console.WriteLine("Header First Count: " + document.Header.First.Paragraphs.Count);
+                Console.WriteLine("Header Default Count: " + document.Header!.Default.Paragraphs.Count);
+                Console.WriteLine("Header Even Count: " + document.Header!.Even.Paragraphs.Count);
+                Console.WriteLine("Header First Count: " + document.Header!.First.Paragraphs.Count);
 
-                Console.WriteLine("Header text: " + document.Header.Default.Paragraphs[0].Text);
+                Console.WriteLine("Header text: " + document.Header!.Default.Paragraphs[0].Text);
 
-                Console.WriteLine("Footer Default Count: " + document.Footer.Default.Paragraphs.Count);
-                Console.WriteLine("Footer Even Count: " + document.Footer.Even.Paragraphs.Count);
-                Console.WriteLine("Footer First Count: " + document.Footer.First.Paragraphs.Count);
+                Console.WriteLine("Footer Default Count: " + document.Footer!.Default.Paragraphs.Count);
+                Console.WriteLine("Footer Even Count: " + document.Footer!.Even.Paragraphs.Count);
+                Console.WriteLine("Footer First Count: " + document.Footer!.First.Paragraphs.Count);
 
-                Console.WriteLine("Footer text: " + document.Footer.Default.Paragraphs[0].Text);
+                Console.WriteLine("Footer text: " + document.Footer!.Default.Paragraphs[0].Text);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example2.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example2.cs
@@ -23,28 +23,28 @@ namespace OfficeIMO.Examples.Word {
                 document.AddHeadersAndFooters();
                 document.DifferentFirstPage = true;
                 //document.DifferentOddAndEvenPages = false;
-                //var paragraphInFooter = document.Footer.Default.InsertParagraph();
+                //var paragraphInFooter = document.Footer!.Default.InsertParagraph();
                 //paragraphInFooter.Text = "This is a test on odd pages (aka default if no options are set)";
 
-                var paragraphInHeader = document.Header.Default.AddParagraph();
+                var paragraphInHeader = document.Header!.Default.AddParagraph();
                 paragraphInHeader.Text = "Default Header / Section 0";
 
-                paragraphInHeader = document.Header.First.AddParagraph();
+                paragraphInHeader = document.Header!.First.AddParagraph();
                 paragraphInHeader.Text = "First Header / Section 0";
 
-                //var paragraphInFooterFirst = document.Footer.First.InsertParagraph();
+                //var paragraphInFooterFirst = document.Footer!.First.InsertParagraph();
                 //paragraphInFooterFirst.Text = "This is a test on first";
 
-                //var count = document.Footer.First.Paragraphs.Count;
+                //var count = document.Footer!.First.Paragraphs.Count;
 
-                //var paragraphInFooterOdd = document.Footer.Odd.InsertParagraph();
+                //var paragraphInFooterOdd = document.Footer!.Odd.InsertParagraph();
                 //paragraphInFooterOdd.Text = "This is a test odd";
 
 
-                //var paragraphHeader = document.Header.Odd.InsertParagraph();
+                //var paragraphHeader = document.Header!.Odd.InsertParagraph();
                 //paragraphHeader.Text = "Header - ODD";
 
-                //var paragraphInFooterEven = document.Footer.Even.InsertParagraph();
+                //var paragraphInFooterEven = document.Footer!.Even.InsertParagraph();
                 //paragraphInFooterEven.Text = "This is a test - Even";
 
 
@@ -84,17 +84,17 @@ namespace OfficeIMO.Examples.Word {
 
 
                 // Add header to section
-                //var paragraghInHeaderSection = section2.Header.First.InsertParagraph();
+                //var paragraghInHeaderSection = section2.Header!.First.InsertParagraph();
                 //paragraghInHeaderSection.Text = "Ok, work please?";
 
-                var paragraghInHeaderSection1 = section2.Header.Default.AddParagraph();
+                var paragraghInHeaderSection1 = section2.Header!.Default.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit? 1";
 
-                paragraghInHeaderSection1 = section2.Header.First.AddParagraph();
+                paragraghInHeaderSection1 = section2.Header!.First.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit 2?";
                 // paragraghInHeaderSection1.InsertText("ok?");
 
-                paragraghInHeaderSection1 = section2.Header.Even.AddParagraph();
+                paragraghInHeaderSection1 = section2.Header!.Even.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit? 3";
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 6");
@@ -120,7 +120,7 @@ namespace OfficeIMO.Examples.Word {
 
                 paragraph = document.AddPageBreak();
 
-                //paragraph = document.Footer.Odd.InsertParagraph();
+                //paragraph = document.Footer!.Odd.InsertParagraph();
                 //paragraph.Text = "Lets see";
 
                 // 2 section, 9 paragraphs + 7 pagebreaks = 15 paragraphs, 7 pagebreaks

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example3.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example3.cs
@@ -17,7 +17,7 @@ namespace OfficeIMO.Examples.Word {
 
                 document.Sections[0].PageOrientation = PageOrientationValues.Landscape;
 
-                var paragraphInHeader = document.Header.Default.AddParagraph();
+                var paragraphInHeader = document.Header!.Default.AddParagraph();
                 paragraphInHeader.Text = "Default Header / Section 0";
 
                 document.AddPageBreak();
@@ -29,7 +29,7 @@ namespace OfficeIMO.Examples.Word {
                 var section2 = document.AddSection();
                 section2.AddHeadersAndFooters();
 
-                var paragraghInHeaderSection1 = section2.Header.Default.AddParagraph();
+                var paragraghInHeaderSection1 = section2.Header!.Default.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit? 1";
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 2");
@@ -39,7 +39,7 @@ namespace OfficeIMO.Examples.Word {
                 var section3 = document.AddSection();
                 section3.AddHeadersAndFooters();
 
-                var paragraghInHeaderSection3 = section3.Header.Default.AddParagraph();
+                var paragraghInHeaderSection3 = section3.Header!.Default.AddParagraph();
                 paragraghInHeaderSection3.Text = "Weird shit? 2";
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 3");

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.ExampleNoSection.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.ExampleNoSection.cs
@@ -23,10 +23,10 @@ namespace OfficeIMO.Examples.Word {
                 paragraph.ParagraphAlignment = JustificationValues.Center;
                 paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
-                var paragraphInHeaderO = document.Header.Default.AddParagraph();
+                var paragraphInHeaderO = document.Header!.Default.AddParagraph();
                 paragraphInHeaderO.Text = "Odd Header / Section 0";
 
-                var paragraphInHeaderE = document.Header.Even.AddParagraph();
+                var paragraphInHeaderE = document.Header!.Even.AddParagraph();
                 paragraphInHeaderE.Text = "Even Header / Section 0";
 
                 document.AddPageBreak();

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Sections1.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Sections1.cs
@@ -23,56 +23,56 @@ namespace OfficeIMO.Examples.Word {
                 document.AddPageBreak();
 
                 document.AddHeadersAndFooters();
-                document.Sections[0].Header.Default.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header1");
+                document.Sections[0].Header!.Default.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header1");
 
-                var tableHeader = document.Sections[0].Header.Default.AddTable(3, 4);
+                var tableHeader = document.Sections[0].Header!.Default.AddTable(3, 4);
                 tableHeader.Rows[0].Cells[3].Paragraphs[0].Text = "This is sparta";
-                Console.WriteLine(document.Sections[0].Header.Default.Tables.Count);
+                Console.WriteLine(document.Sections[0].Header!.Default.Tables.Count);
 
-                document.Sections[0].Header.Default.AddHorizontalLine();
+                document.Sections[0].Header!.Default.AddHorizontalLine();
 
-                document.Sections[0].Header.Default.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
+                document.Sections[0].Header!.Default.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
 
-                document.Sections[0].Header.Default.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
+                document.Sections[0].Header!.Default.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
 
-                document.Sections[0].Header.Default.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
+                document.Sections[0].Header!.Default.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
 
 
-                document.Sections[0].Footer.Default.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header2");
+                document.Sections[0].Footer!.Default.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header2");
 
-                var tableFooter = document.Sections[0].Footer.Default.AddTable(2, 3);
+                var tableFooter = document.Sections[0].Footer!.Default.AddTable(2, 3);
                 tableFooter.Rows[0].Cells[2].Paragraphs[0].Text = "This is not sparta";
 
-                document.Sections[0].Footer.Default.AddHorizontalLine();
+                document.Sections[0].Footer!.Default.AddHorizontalLine();
 
-                document.Sections[0].Footer.Default.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
+                document.Sections[0].Footer!.Default.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
 
-                document.Sections[0].Footer.Default.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
+                document.Sections[0].Footer!.Default.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
 
-                document.Sections[0].Footer.Default.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
+                document.Sections[0].Footer!.Default.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
 
 
                 var section1 = document.AddSection();
                 section1.AddParagraph("Test Middle1 Section - 1");
                 section1.AddHeadersAndFooters();
-                section1.Header.Default.AddParagraph().AddText("Section 1 - Header");
-                section1.Footer.Default.AddParagraph().AddText("Section 1 - Footer");
+                section1.Header!.Default.AddParagraph().AddText("Section 1 - Header");
+                section1.Footer!.Default.AddParagraph().AddText("Section 1 - Footer");
 
                 var section2 = document.AddSection();
                 section2.AddParagraph("Test Middle2 Section - 1");
                 section2.AddHeadersAndFooters();
-                section2.Header.Default.AddParagraph().AddText("Section 2 - Header");
-                section2.Footer.Default.AddParagraph().AddText("Section 2 - Footer");
+                section2.Header!.Default.AddParagraph().AddText("Section 2 - Header");
+                section2.Footer!.Default.AddParagraph().AddText("Section 2 - Footer");
 
                 var section3 = document.AddSection();
                 section3.AddParagraph("Test Last Section - 1");
                 section3.AddHeadersAndFooters();
                 section3.DifferentOddAndEvenPages = true;
                 section3.DifferentFirstPage = true;
-                section3.Header.Default.AddParagraph().AddText("Section 3 - Header Odd/Default");
-                section3.Footer.Default.AddParagraph().AddText("Section 3 - Footer Odd/Default");
-                section3.Header.Even.AddParagraph().AddText("Section 3 - Header Even");
-                section3.Footer.Even.AddParagraph().AddText("Section 3 - Footer Even");
+                section3.Header!.Default.AddParagraph().AddText("Section 3 - Header Odd/Default");
+                section3.Footer!.Default.AddParagraph().AddText("Section 3 - Footer Odd/Default");
+                section3.Header!.Even.AddParagraph().AddText("Section 3 - Header Even");
+                section3.Footer!.Even.AddParagraph().AddText("Section 3 - Footer Even");
 
                 document.AddPageBreak();
                 section3.AddParagraph("Test Last Section - 2");

--- a/OfficeIMO.Examples/Word/HyperLinksAndFields/HyperLinks.FormattedAdvancedExample.cs
+++ b/OfficeIMO.Examples/Word/HyperLinksAndFields/HyperLinks.FormattedAdvancedExample.cs
@@ -24,12 +24,12 @@ namespace OfficeIMO.Examples.Word {
                 var yahoo = baseLink.InsertFormattedHyperlinkAfter("Yahoo", new Uri("https://yahoo.com"));
                 yahoo.CopyFormattingFrom(baseLink);
 
-                var headerPara = document.Header.Default.AddParagraph("Search with ");
+                var headerPara = document.Header!.Default.AddParagraph("Search with ");
                 var duck = headerPara.AddHyperLink("DuckDuckGo", new Uri("https://duckduckgo.com"), addStyle: true);
                 var duckLink = Guard.NotNull(duck.Hyperlink, "Expected DuckDuckGo hyperlink to be created.");
                 duckLink.InsertFormattedHyperlinkAfter("Startpage", new Uri("https://startpage.com"));
 
-                var footerPara = document.Footer.Default.AddParagraph("Code on ");
+                var footerPara = document.Footer!.Default.AddParagraph("Code on ");
                 var gitHub = footerPara.AddHyperLink("GitHub", new Uri("https://github.com"), addStyle: true);
                 var gitHubLink = Guard.NotNull(gitHub.Hyperlink, "Expected GitHub hyperlink to be created.");
                 gitHubLink.InsertFormattedHyperlinkBefore("GitLab", new Uri("https://gitlab.com"));

--- a/OfficeIMO.Examples/Word/Images/Images.HeadersFooters.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.HeadersFooters.cs
@@ -21,14 +21,14 @@ namespace OfficeIMO.Examples.Word {
                 document.AddHeadersAndFooters();
                 document.DifferentOddAndEvenPages = true;
 
-                var header = Guard.NotNull(document.Header.Default, "Default header must exist after enabling headers.");
+                var header = Guard.NotNull(document.Header!.Default, "Default header must exist after enabling headers.");
                 var paragraphHeader = header.AddParagraph("This is header");
 
                 // add image to header, directly to paragraph
                 header.AddParagraph().AddImage(filePathImage, 100, 100);
 
                 // add image to footer, directly to paragraph
-                var footer = Guard.NotNull(document.Footer.Default, "Default footer must exist after enabling headers.");
+                var footer = Guard.NotNull(document.Footer!.Default, "Default footer must exist after enabling headers.");
                 footer.AddParagraph().AddImage(filePathImage, 100, 100);
 
                 // add image to header, but to a table
@@ -93,7 +93,7 @@ namespace OfficeIMO.Examples.Word {
                 string fileToSave = System.IO.Path.Combine(imagePaths, "OutputPrzemyslawKlysAndKulkozaurr.jpg");
                 firstImage.SaveToFile(fileToSave);
 
-                var headerEven = Guard.NotNull(document.Header.Even, "Even header must exist after enabling different odd/even pages.");
+                var headerEven = Guard.NotNull(document.Header!.Even, "Even header must exist after enabling different odd/even pages.");
                 var paragraphHeaderEven = headerEven.AddParagraph("This adds another picture via Stream with 100x100 to Header Even");
                 const string fileNameImageEvotec = "EvotecLogo.png";
                 var filePathImageEvotec = System.IO.Path.Combine(imagePaths, fileNameImageEvotec);

--- a/OfficeIMO.Examples/Word/Images/Images.InTable.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.InTable.cs
@@ -20,7 +20,7 @@ namespace OfficeIMO.Examples.Word {
 
             document.AddHeadersAndFooters();
 
-            var tableInHeader = document.Header.Default.AddTable(2, 2);
+            var tableInHeader = document.Header!.Default.AddTable(2, 2);
             tableInHeader.Rows[0].Cells[0].Paragraphs[0].AddImage(System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg"), 200, 200);
 
             // not really nessessary to add new paragraph since one is already there by default

--- a/OfficeIMO.Examples/Word/Images/Images.Sample2.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.Sample2.cs
@@ -16,8 +16,8 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Load(System.IO.Path.Combine(documentPaths, "DocumentWithImagesWraps.docx"), true)) {
                 Console.WriteLine("+ Document paragraphs: " + document.Paragraphs.Count);
                 Console.WriteLine("+ Document images: " + document.Images.Count);
-                Console.WriteLine("+ Document images in header: " + document.Header.Default.Images.Count);
-                Console.WriteLine("+ Document images in footer: " + document.Footer.Default.Images.Count);
+                Console.WriteLine("+ Document images in header: " + document.Header!.Default.Images.Count);
+                Console.WriteLine("+ Document images in footer: " + document.Footer!.Default.Images.Count);
                 //document.Images[0].SaveToFile(System.IO.Path.Combine(outputPath, "random.jpg"));
 
                 Console.WriteLine("----");

--- a/OfficeIMO.Examples/Word/Lists/Lists.Create7.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.Create7.cs
@@ -130,20 +130,20 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddHeadersAndFooters();
 
-                var listInHeader = document.Header.Default.AddList(WordListStyle.Bulleted);
+                var listInHeader = document.Header!.Default.AddList(WordListStyle.Bulleted);
 
                 listInHeader.AddItem("Test Header 1");
 
-                document.Footer.Default.AddParagraph("Test Me Header");
+                document.Footer!.Default.AddParagraph("Test Me Header");
 
                 listInHeader.AddItem("Test Header 2");
 
 
-                var listInFooter = document.Footer.Default.AddList(WordListStyle.Numbered);
+                var listInFooter = document.Footer!.Default.AddList(WordListStyle.Numbered);
 
                 listInFooter.AddItem("Test Footer 1");
 
-                document.Footer.Default.AddParagraph("Test Me Footer");
+                document.Footer!.Default.AddParagraph("Test Me Footer");
 
                 listInFooter.AddItem("Test Footer 2");
 

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example1.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example1.cs
@@ -17,9 +17,9 @@ namespace OfficeIMO.Examples.Word {
                 document.Settings.UpdateFieldsOnOpen = true;
                 document.AddTableOfContent(tableOfContentStyle: TableOfContentStyle.Template2);
                 document.AddHeadersAndFooters();
-                var pageNumber = document.Header.Default.AddPageNumber(WordPageNumberStyle.Dots);
-                //var pageNumber = document.Footer.Default.AddPageNumber(WordPageNumberStyle.VerticalOutline2);
-                //var pageNumber = document.Footer.Default.AddPageNumber(WordPageNumberStyle.Dots);
+                var pageNumber = document.Header!.Default.AddPageNumber(WordPageNumberStyle.Dots);
+                //var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.VerticalOutline2);
+                //var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.Dots);
 
                 pageNumber.ParagraphAlignment = JustificationValues.Center;
 

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example2.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example2.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
-                var table = document.Footer.Default.AddTable(1, 2, WordTableStyle.TableGrid);
+                var table = document.Footer!.Default.AddTable(1, 2, WordTableStyle.TableGrid);
                 table.WidthType = TableWidthUnitValues.Pct;
                 // 5000 represents 100% when using Pct width
                 table.Width = 5000;

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example3.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example3.cs
@@ -11,7 +11,7 @@ namespace OfficeIMO.Examples.Word {
                 document.Sections[0].AddPageNumbering(2, NumberFormatValues.LowerRoman);
                 document.AddHeadersAndFooters();
 
-                var para = document.Footer.Default.AddParagraph();
+                var para = document.Footer!.Default.AddParagraph();
                 para.AddText("Page ");
                 para.AddPageNumber();
 

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example4.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example4.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
-                var para = document.Header.Default.AddParagraph();
+                var para = document.Header!.Default.AddParagraph();
                 para.ParagraphAlignment = JustificationValues.Center;
                 para.AddPageNumber();
 

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example5.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example5.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
-                var firstFooter = document.Footer.Default.AddParagraph();
+                var firstFooter = document.Footer!.Default.AddParagraph();
                 firstFooter.ParagraphAlignment = JustificationValues.Right;
                 firstFooter.AddText("Page ");
                 firstFooter.AddPageNumber(includeTotalPages: true, separator: " of ");
@@ -21,7 +21,7 @@ namespace OfficeIMO.Examples.Word {
                 section.AddPageNumbering(1);
                 section.AddParagraph("Section 2");
 
-                var secondFooter = document.Footer.Default.AddParagraph();
+                var secondFooter = document.Footer!.Default.AddParagraph();
                 secondFooter.ParagraphAlignment = JustificationValues.Right;
                 secondFooter.AddText("Page ");
                 secondFooter.AddPageNumber(includeTotalPages: true, separator: " of ");

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example6.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example6.cs
@@ -11,7 +11,7 @@ namespace OfficeIMO.Examples.Word {
                 document.Sections[0].AddPageNumbering(1, NumberFormatValues.UpperRoman);
                 document.AddHeadersAndFooters();
 
-                var para = document.Footer.Default.AddParagraph();
+                var para = document.Footer!.Default.AddParagraph();
                 para.ParagraphAlignment = JustificationValues.Right;
                 para.AddText("Page ");
                 para.AddPageNumber(includeTotalPages: true, format: WordFieldFormat.Roman, separator: " of ");

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example7.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example7.cs
@@ -9,7 +9,7 @@ namespace OfficeIMO.Examples.Word {
             string filePath = System.IO.Path.Combine(folderPath, "Document with PageNumbers7.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var pageNumber = document.Footer.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
                 pageNumber.AppendText(" of ");
                 pageNumber.Paragraph.AddField(WordFieldType.NumPages);
                 document.Save(openWord);

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example8.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example8.cs
@@ -15,7 +15,7 @@ namespace OfficeIMO.Examples.Word {
                 string filePath = System.IO.Path.Combine(folderPath, $"Document_PageNumbers_{safeFormat}.docx");
                 using (WordDocument document = WordDocument.Create(filePath)) {
                     document.AddHeadersAndFooters();
-                    var pageNumber = document.Footer.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                    var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
                     pageNumber.CustomFormat = format;
                     document.Save(openWord);
                 }

--- a/OfficeIMO.Examples/Word/Sections/Sections.Example6.cs
+++ b/OfficeIMO.Examples/Word/Sections/Sections.Example6.cs
@@ -23,9 +23,9 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentFirstPage = true;
                 document.DifferentOddAndEvenPages = true;
 
-                document.Sections[0].Header.Default.AddParagraph().SetText("Test Section 0 - Header");
-                document.Sections[0].Header.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Sections[0].Header.Even.AddParagraph().SetText("Test Section 0 - Even");
+                document.Sections[0].Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
+                document.Sections[0].Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
+                document.Sections[0].Header!.Even.AddParagraph().SetText("Test Section 0 - Even");
 
                 document.Sections[0].Paragraphs[0].AddComment("Przemysław Kłys", "PK", "This should be a comment");
 
@@ -48,26 +48,26 @@ namespace OfficeIMO.Examples.Word {
                 //Console.WriteLine("Section 2 - Text 1: " + document.Sections[2].Paragraphs[1].Text);
                 //Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Paragraphs[0].Text);
 
-                //Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Header.Default.Paragraphs[0].Text);
-                //Console.WriteLine("Section 1 - Text 0: " + document.Sections[1].Header.Default.Paragraphs[0].Text);
-                //Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Header.Default.Paragraphs[0].Text);
-                //Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Header.Default.Paragraphs[0].Text);
+                //Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Header!.Default.Paragraphs[0].Text);
+                //Console.WriteLine("Section 1 - Text 0: " + document.Sections[1].Header!.Default.Paragraphs[0].Text);
+                //Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Header!.Default.Paragraphs[0].Text);
+                //Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Header!.Default.Paragraphs[0].Text);
                 document.Save(false);
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 document.Sections[1].AddHeadersAndFooters();
-                document.Sections[1].Header.Default.AddParagraph().SetText("Test Section 1 - Header");
-                document.Sections[1].Footer.Default.AddParagraph().SetText("Test Section 1 - Header");
+                document.Sections[1].Header!.Default.AddParagraph().SetText("Test Section 1 - Header");
+                document.Sections[1].Footer!.Default.AddParagraph().SetText("Test Section 1 - Header");
 
                 document.Sections[1].DifferentFirstPage = true;
-                document.Sections[1].Header.First.AddParagraph().SetText("Test Section 1 - First Header");
-                document.Sections[1].Footer.First.AddParagraph().SetText("Test Section 1 - First Footer");
+                document.Sections[1].Header!.First.AddParagraph().SetText("Test Section 1 - First Header");
+                document.Sections[1].Footer!.First.AddParagraph().SetText("Test Section 1 - First Footer");
 
                 document.Sections[1].DifferentOddAndEvenPages = true;
 
-                document.Sections[1].Header.Even.AddParagraph().SetText("Test Section 1 - Even Header");
-                document.Sections[1].Footer.Even.AddParagraph().SetText("Test Section 1 - Even Footer");
+                document.Sections[1].Header!.Even.AddParagraph().SetText("Test Section 1 - Even Header");
+                document.Sections[1].Footer!.Even.AddParagraph().SetText("Test Section 1 - Even Footer");
 
                 document.Settings.ProtectionPassword = "ThisIsTest";
                 document.Settings.ProtectionType = DocumentProtectionValues.ReadOnly;

--- a/OfficeIMO.Examples/Word/Sections/Sections.Example7.cs
+++ b/OfficeIMO.Examples/Word/Sections/Sections.Example7.cs
@@ -19,9 +19,9 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentFirstPage = true;
                 document.DifferentOddAndEvenPages = true;
 
-                document.Sections[0].Header.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Sections[0].Header.Default.AddParagraph().SetText("Test Section 0 - Header");
-                document.Sections[0].Header.Even.AddParagraph().SetText("Test Section 0 - Even");
+                document.Sections[0].Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
+                document.Sections[0].Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
+                document.Sections[0].Header!.Even.AddParagraph().SetText("Test Section 0 - Even");
 
                 document.AddPageBreak();
 
@@ -39,9 +39,9 @@ namespace OfficeIMO.Examples.Word {
                 section1.PageOrientation = PageOrientationValues.Portrait;
                 section1.AddParagraph("Test Section1");
                 section1.AddHeadersAndFooters();
-                section1.Header.Default.AddParagraph().SetText("Test Section 1 - Header");
+                section1.Header!.Default.AddParagraph().SetText("Test Section 1 - Header");
                 section1.DifferentFirstPage = true;
-                section1.Header.First.AddParagraph().SetText("Test Section 1 - First Header");
+                section1.Header!.First.AddParagraph().SetText("Test Section 1 - First Header");
 
 
                 document.AddPageBreak();
@@ -60,7 +60,7 @@ namespace OfficeIMO.Examples.Word {
                 section2.AddParagraph("Test Section2");
                 section2.PageOrientation = PageOrientationValues.Landscape;
                 section2.AddHeadersAndFooters();
-                section2.Header.Default.AddParagraph().SetText("Test Section 2 - Header");
+                section2.Header!.Default.AddParagraph().SetText("Test Section 2 - Header");
 
                 document.AddParagraph("Test Section2 - Paragraph 1");
 
@@ -68,7 +68,7 @@ namespace OfficeIMO.Examples.Word {
                 var section3 = document.AddSection();
                 section3.AddParagraph("Test Section3");
                 section3.AddHeadersAndFooters();
-                section3.Header.Default.AddParagraph().SetText("Test Section 3 - Header");
+                section3.Header!.Default.AddParagraph().SetText("Test Section 3 - Header");
 
 
                 Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Paragraphs[0].Text);
@@ -77,10 +77,10 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine("Section 2 - Text 1: " + document.Sections[2].Paragraphs[1].Text);
                 Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Paragraphs[0].Text);
 
-                Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Header.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 1 - Text 0: " + document.Sections[1].Header.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Header.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Header.Default.Paragraphs[0].Text);
+                Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Header!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Section 1 - Text 0: " + document.Sections[1].Header!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Header!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Header!.Default.Paragraphs[0].Text);
                 document.Save(false);
             }
 
@@ -91,13 +91,13 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Paragraphs[0].Text);
                 Console.WriteLine("Section 2 - Text 1: " + document.Sections[2].Paragraphs[1].Text);
                 Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Paragraphs[0].Text);
-                Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Header.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 1 - Text 0: " + document.Sections[1].Header.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Header.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Header.Default.Paragraphs[0].Text);
+                Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Header!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Section 1 - Text 0: " + document.Sections[1].Header!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Header!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Header!.Default.Paragraphs[0].Text);
                 Console.WriteLine("-----");
-                document.Sections[1].Header.Default.AddParagraph().SetText("Test Section 1 - Header-Par1");
-                Console.WriteLine("Section 1 - Text 1: " + document.Sections[1].Header.Default.Paragraphs[1].Text);
+                document.Sections[1].Header!.Default.AddParagraph().SetText("Test Section 1 - Header-Par1");
+                Console.WriteLine("Section 1 - Text 1: " + document.Sections[1].Header!.Default.Paragraphs[1].Text);
                 document.Save(openWord);
             }
         }

--- a/OfficeIMO.Examples/Word/Shapes/Shapes.SectionAndHeader.cs
+++ b/OfficeIMO.Examples/Word/Shapes/Shapes.SectionAndHeader.cs
@@ -15,9 +15,9 @@ namespace OfficeIMO.Examples.Word {
                 section.AddShapeDrawing(ShapeType.Ellipse, 40, 40);
 
                 section.AddHeadersAndFooters();
-                section.Header.Default.AddShape(ShapeType.Rectangle, 30, 20, Color.Blue, Color.Black);
-                section.Header.Default.AddShape(ShapeType.RoundedRectangle, 25, 15, Color.Green, Color.Black, 1, arcSize: 0.3);
-                section.Header.Default.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
+                section.Header!.Default.AddShape(ShapeType.Rectangle, 30, 20, Color.Blue, Color.Black);
+                section.Header!.Default.AddShape(ShapeType.RoundedRectangle, 25, 15, Color.Green, Color.Black, 1, arcSize: 0.3);
+                section.Header!.Default.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Remove.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Remove.cs
@@ -18,9 +18,9 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentFirstPage = true;
                 document.DifferentOddAndEvenPages = true;
 
-                document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Default");
-                document.Sections[0].Header.First.AddWatermark(WordWatermarkStyle.Text, "First");
-                document.Sections[0].Header.Even.AddWatermark(WordWatermarkStyle.Text, "Even");
+                document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Default");
+                document.Sections[0].Header!.First.AddWatermark(WordWatermarkStyle.Text, "First");
+                document.Sections[0].Header!.Even.AddWatermark(WordWatermarkStyle.Text, "Even");
 
                 Console.WriteLine("Watermarks before: " + document.Watermarks.Count);
                 foreach (var watermark in document.Watermarks.ToList()) {

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Sample1.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Sample1.cs
@@ -20,7 +20,7 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddParagraph("Section 0");
                 document.AddHeadersAndFooters();
-                document.Sections[0].Header.Default.AddParagraph("Section 0 - In header");
+                document.Sections[0].Header!.Default.AddParagraph("Section 0 - In header");
                 document.Sections[0].SetMargins(WordMargin.Normal);
 
                 Console.WriteLine(document.Sections[0].Margins.Left.Value);
@@ -33,7 +33,7 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine(document.Sections[0].Margins.Type);
 
                 Console.WriteLine("----");
-                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Watermark");
+                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Watermark");
                 watermark.Color = Color.Red;
 
                 // ColorHex normally returns hex colors, but for watermark it returns string as the underlying value is in string name, not hex
@@ -62,16 +62,16 @@ namespace OfficeIMO.Examples.Word {
                 document.AddParagraph("Section 1");
 
                 document.Sections[1].AddHeadersAndFooters();
-                document.Sections[1].Header.Default.AddParagraph("Section 1 - In header");
+                document.Sections[1].Header!.Default.AddParagraph("Section 1 - In header");
                 document.Sections[1].Margins.Type = WordMargin.Narrow;
                 Console.WriteLine("----");
 
-                Console.WriteLine("Section 0 - Paragraphs Count: " + document.Sections[0].Header.Default.Paragraphs.Count);
-                Console.WriteLine("Section 1 - Paragraphs Count: " + document.Sections[1].Header.Default.Paragraphs.Count);
+                Console.WriteLine("Section 0 - Paragraphs Count: " + document.Sections[0].Header!.Default.Paragraphs.Count);
+                Console.WriteLine("Section 1 - Paragraphs Count: " + document.Sections[1].Header!.Default.Paragraphs.Count);
 
                 Console.WriteLine("----");
                 document.Sections[1].AddParagraph("Test");
-                document.Sections[1].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Draft");
+                document.Sections[1].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Draft");
 
                 Console.WriteLine(document.Sections[0].Margins.Left.Value);
                 Console.WriteLine(document.Sections[0].Margins.Right.Value);
@@ -86,17 +86,17 @@ namespace OfficeIMO.Examples.Word {
 
                 Console.WriteLine("----");
 
-                Console.WriteLine("Watermarks in default header: " + document.Header.Default.Watermarks.Count);
+                Console.WriteLine("Watermarks in default header: " + document.Header!.Default.Watermarks.Count);
 
-                Console.WriteLine("Watermarks in default footer: " + document.Footer.Default.Watermarks.Count);
+                Console.WriteLine("Watermarks in default footer: " + document.Footer!.Default.Watermarks.Count);
 
                 Console.WriteLine("Watermarks in section 0: " + document.Sections[0].Watermarks.Count);
-                Console.WriteLine("Watermarks in section 0 (header): " + document.Sections[0].Header.Default.Watermarks.Count);
-                Console.WriteLine("Paragraphs in section 0 (header): " + document.Sections[0].Header.Default.Paragraphs.Count);
+                Console.WriteLine("Watermarks in section 0 (header): " + document.Sections[0].Header!.Default.Watermarks.Count);
+                Console.WriteLine("Paragraphs in section 0 (header): " + document.Sections[0].Header!.Default.Paragraphs.Count);
 
                 Console.WriteLine("Watermarks in section 1: " + document.Sections[1].Watermarks.Count);
-                Console.WriteLine("Watermarks in section 1 (header): " + document.Sections[1].Header.Default.Watermarks.Count);
-                Console.WriteLine("Paragraphs in section 1 (header): " + document.Sections[1].Header.Default.Paragraphs.Count);
+                Console.WriteLine("Watermarks in section 1 (header): " + document.Sections[1].Header!.Default.Watermarks.Count);
+                Console.WriteLine("Paragraphs in section 1 (header): " + document.Sections[1].Header!.Default.Paragraphs.Count);
 
                 Console.WriteLine("Watermarks in document: " + document.Watermarks.Count);
 
@@ -105,17 +105,17 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 //Console.WriteLine("----");
-                //Console.WriteLine("Watermarks in default header: " + document.Header.Default.Watermarks.Count);
+                //Console.WriteLine("Watermarks in default header: " + document.Header!.Default.Watermarks.Count);
 
-                //Console.WriteLine("Watermarks in default footer: " + document.Footer.Default.Watermarks.Count);
+                //Console.WriteLine("Watermarks in default footer: " + document.Footer!.Default.Watermarks.Count);
 
                 //Console.WriteLine("Watermarks in section 0: " + document.Sections[0].Watermarks.Count);
-                //Console.WriteLine("Watermarks in section 0 (header): " + document.Sections[0].Header.Default.Watermarks.Count);
-                //Console.WriteLine("Paragraphs in section 0 (header): " + document.Sections[0].Header.Default.Paragraphs.Count);
+                //Console.WriteLine("Watermarks in section 0 (header): " + document.Sections[0].Header!.Default.Watermarks.Count);
+                //Console.WriteLine("Paragraphs in section 0 (header): " + document.Sections[0].Header!.Default.Paragraphs.Count);
 
                 //Console.WriteLine("Watermarks in section 1: " + document.Sections[1].Watermarks.Count);
 
-                //Console.WriteLine("Paragraphs in section 1 (header): " + document.Sections[1].Header.Default.Paragraphs.Count);
+                //Console.WriteLine("Paragraphs in section 1 (header): " + document.Sections[1].Header!.Default.Paragraphs.Count);
 
                 //Console.WriteLine("Watermarks in document: " + document.Watermarks.Count);
 

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Sample4.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Sample4.cs
@@ -19,7 +19,7 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddParagraph("Section 0");
                 document.AddHeadersAndFooters();
-                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "HexColor");
+                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "HexColor");
                 watermark.ColorHex = "00ff00";
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.SampleImage1.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.SampleImage1.cs
@@ -17,15 +17,15 @@ namespace OfficeIMO.Examples.Word {
                 document.AddHeadersAndFooters();
 
                 var imagePathToAdd = System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg");
-                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Image, imagePathToAdd);
+                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Image, imagePathToAdd);
 
                 //Console.WriteLine(watermark.Height);
                 //Console.WriteLine(watermark.Width);
 
                 //Console.WriteLine("Watermarks in document: " + document.Watermarks.Count);
                 //Console.WriteLine("Images in document: " + document.Images.Count);
-                //Console.WriteLine("Watermarks in header: " + document.Header.Default.Watermarks.Count);
-                //Console.WriteLine("Images in header: " + document.Header.Default.Images.Count);
+                //Console.WriteLine("Watermarks in header: " + document.Header!.Default.Watermarks.Count);
+                //Console.WriteLine("Images in header: " + document.Header!.Default.Images.Count);
 
                 document.Save(false);
             }
@@ -34,8 +34,8 @@ namespace OfficeIMO.Examples.Word {
 
                 //Console.WriteLine("Watermarks in document: " + document.Watermarks.Count);
                 //Console.WriteLine("Images in document: " + document.Images.Count);
-                //Console.WriteLine("Watermarks in header: " + document.Header.Default.Watermarks.Count);
-                //Console.WriteLine("Images in header: " + document.Header.Default.Images.Count);
+                //Console.WriteLine("Watermarks in header: " + document.Header!.Default.Watermarks.Count);
+                //Console.WriteLine("Images in header: " + document.Header!.Default.Images.Count);
                 document.Save(openWord);
             }
         }

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample3.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample3.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddHeadersAndFooters();
 
-                var textBox = document.Header.Default.AddTextBox("My textbox on the left");
+                var textBox = document.Header!.Default.AddTextBox("My textbox on the left");
 
                 textBox.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
                 // horizontal alignment overwrites the horizontal position offset so only one will work

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample4.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample4.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddHeadersAndFooters();
 
-                var textBox = document.Header.Default.AddTextBox("My textbox in header");
+                var textBox = document.Header!.Default.AddTextBox("My textbox in header");
 
                 Console.WriteLine("Textbox (header) wraptext: " + textBox.WrapText);
 

--- a/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
+++ b/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
@@ -352,7 +352,8 @@ internal static class HtmlRenderer {
         // Cache scoped base CSS (style preset + common extras) by (style|scopeSelector)
         string cacheKey = ((int)options.Style).ToString() + "|" + (options.CssScopeSelector ?? string.Empty);
         if (!_scopedBaseCssCache.TryGetValue(cacheKey, out var baseCss)) {
-            baseCss = ScopeCss(HtmlResources.GetStyleCss(options.Style) + HtmlResources.CommonExtraCss, options.CssScopeSelector);
+            string scopeSelector = options.CssScopeSelector ?? "article.markdown-body";
+            baseCss = ScopeCss(HtmlResources.GetStyleCss(options.Style) + HtmlResources.CommonExtraCss, scopeSelector);
             _scopedBaseCssCache[cacheKey] = baseCss;
         }
 

--- a/OfficeIMO.Tests/Excel.AutoFit.cs
+++ b/OfficeIMO.Tests/Excel.AutoFit.cs
@@ -194,10 +194,10 @@ namespace OfficeIMO.Tests {
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
                 WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 var column = wsPart.Worksheet.GetFirstChild<Columns>()?.Elements<Column>().FirstOrDefault(c => c.Min?.Value == 1 && c.Max?.Value == 1);
-                Assert.NotNull(column);
-                Assert.True(column!.Width.HasValue);
-                Assert.True(column.Width!.Value <= 255.0);
-                Assert.True(column.Width.Value >= 200.0); // ensure we actually expanded significantly
+                Column nonNullColumn = Assert.IsType<Column>(column);
+                Assert.True(nonNullColumn.Width!.HasValue);
+                Assert.True(nonNullColumn.Width.Value <= 255.0);
+                Assert.True(nonNullColumn.Width.Value >= 200.0); // ensure we actually expanded significantly
 
                 OpenXmlValidator validator = new();
                 var validationErrors = validator.Validate(spreadsheet);

--- a/OfficeIMO.Tests/Html.Async.cs
+++ b/OfficeIMO.Tests/Html.Async.cs
@@ -53,12 +53,12 @@ namespace OfficeIMO.Tests {
             string fragment = "<p>Header</p>";
             docSync.AddHtmlToHeader(fragment);
             await docAsync.AddHtmlToHeaderAsync(fragment);
-            Assert.Equal(docSync.Header.Default.Paragraphs[0].Text, docAsync.Header.Default.Paragraphs[0].Text);
+            Assert.Equal(docSync.Header!.Default.Paragraphs[0].Text, docAsync.Header!.Default.Paragraphs[0].Text);
 
             string footerFrag = "<p>Footer</p>";
             docSync.AddHtmlToFooter(footerFrag);
             await docAsync.AddHtmlToFooterAsync(footerFrag);
-            Assert.Equal(docSync.Footer.Default.Paragraphs[0].Text, docAsync.Footer.Default.Paragraphs[0].Text);
+            Assert.Equal(docSync.Footer!.Default.Paragraphs[0].Text, docAsync.Footer!.Default.Paragraphs[0].Text);
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Sections.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Sections.cs
@@ -13,14 +13,14 @@ public partial class Word {
 
         using (WordDocument document = WordDocument.Create(docPath)) {
             document.AddHeadersAndFooters();
-            document.Header.Default.AddParagraph("Header1");
-            document.Footer.Default.AddParagraph("Footer1");
+            document.Header!.Default.AddParagraph("Header1");
+            document.Footer!.Default.AddParagraph("Footer1");
             document.AddParagraph("Section1 Paragraph");
 
             WordSection section2 = document.AddSection();
             section2.AddHeadersAndFooters();
-            section2.Header.Default.AddParagraph("Header2");
-            section2.Footer.Default.AddParagraph("Footer2");
+            section2.Header!.Default.AddParagraph("Header2");
+            section2.Footer!.Default.AddParagraph("Footer2");
             document.AddParagraph("Section2 Paragraph");
 
             document.Save();
@@ -37,8 +37,8 @@ public partial class Word {
 
         using (WordDocument document = WordDocument.Create(docPath)) {
             document.AddHeadersAndFooters();
-            document.Header.Default.AddParagraph("DefaultHeader");
-            document.Footer.Default.AddParagraph("DefaultFooter");
+            document.Header!.Default.AddParagraph("DefaultHeader");
+            document.Footer!.Default.AddParagraph("DefaultFooter");
 
             for (int i = 0; i < 100; i++) {
                 document.AddParagraph($"Paragraph {i}");

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
@@ -19,11 +19,11 @@ public partial class Word {
 
         using (WordDocument document = WordDocument.Create(docPath)) {
             document.AddHeadersAndFooters();
-            document.Header.Default.AddParagraph("Sample Header");
-            WordTable headerTable = document.Header.Default.AddTable(1, 1);
+            document.Header!.Default.AddParagraph("Sample Header");
+            WordTable headerTable = document.Header!.Default.AddTable(1, 1);
             headerTable.Rows[0].Cells[0].Paragraphs[0].Text = "H1";
-            document.Footer.Default.AddParagraph("Sample Footer");
-            WordTable footerTable = document.Footer.Default.AddTable(1, 1);
+            document.Footer!.Default.AddParagraph("Sample Footer");
+            WordTable footerTable = document.Footer!.Default.AddTable(1, 1);
             footerTable.Rows[0].Cells[0].Paragraphs[0].Text = "F1";
 
             WordParagraph heading = document.AddParagraph("Heading One");
@@ -65,8 +65,8 @@ public partial class Word {
 
         using (WordDocument document = WordDocument.Create(docPath)) {
             document.AddHeadersAndFooters();
-            document.Header.Default.AddParagraph().AddImage(imagePath, 20, 20);
-            document.Footer.Default.AddParagraph().AddImage(imagePath, 400, 400);
+            document.Header!.Default.AddParagraph().AddImage(imagePath, 20, 20);
+            document.Footer!.Default.AddParagraph().AddImage(imagePath, 400, 400);
             document.Save();
             document.SaveAsPdf(pdfPath);
         }

--- a/OfficeIMO.Tests/Word.CleanupHeadersFooters.cs
+++ b/OfficeIMO.Tests/Word.CleanupHeadersFooters.cs
@@ -11,41 +11,41 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
-                var headerParagraph = document.Header.Default.AddParagraph("Header ");
+                var headerParagraph = document.Header!.Default.AddParagraph("Header ");
                 headerParagraph.AddText("clutter ");
                 headerParagraph.AddText("text");
-                document.Header.Default.AddParagraph();
+                document.Header!.Default.AddParagraph();
 
-                var footerParagraph = document.Footer.Default.AddParagraph("Footer ");
+                var footerParagraph = document.Footer!.Default.AddParagraph("Footer ");
                 footerParagraph.AddText("clutter ");
                 footerParagraph.AddText("text");
-                document.Footer.Default.AddParagraph();
+                document.Footer!.Default.AddParagraph();
 
-                Assert.True(document.Header.Default.Paragraphs.Count > 1);
+                Assert.True(document.Header!.Default.Paragraphs.Count > 1);
                 Assert.True(headerParagraph.GetRuns().Count() > 1);
-                Assert.True(document.Footer.Default.Paragraphs.Count > 1);
+                Assert.True(document.Footer!.Default.Paragraphs.Count > 1);
                 Assert.True(footerParagraph.GetRuns().Count() > 1);
 
                 document.CleanupDocument();
 
-                Assert.True(document.Header.Default.Paragraphs.Count == 1);
-                Assert.True(document.Header.Default.Paragraphs[0].GetRuns().Count() == 1);
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Header clutter text");
+                Assert.True(document.Header!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Header!.Default.Paragraphs[0].GetRuns().Count() == 1);
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Header clutter text");
 
-                Assert.True(document.Footer.Default.Paragraphs.Count == 1);
-                Assert.True(document.Footer.Default.Paragraphs[0].GetRuns().Count() == 1);
-                Assert.True(document.Footer.Default.Paragraphs[0].Text == "Footer clutter text");
+                Assert.True(document.Footer!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.Default.Paragraphs[0].GetRuns().Count() == 1);
+                Assert.True(document.Footer!.Default.Paragraphs[0].Text == "Footer clutter text");
 
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CleanupHeadersAndFooters.docx"))) {
-                Assert.True(document.Header.Default.Paragraphs.Count == 1);
-                Assert.True(document.Header.Default.Paragraphs[0].GetRuns().Count() == 1);
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Header clutter text");
+                Assert.True(document.Header!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Header!.Default.Paragraphs[0].GetRuns().Count() == 1);
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Header clutter text");
 
-                Assert.True(document.Footer.Default.Paragraphs.Count == 1);
-                Assert.True(document.Footer.Default.Paragraphs[0].GetRuns().Count() == 1);
-                Assert.True(document.Footer.Default.Paragraphs[0].Text == "Footer clutter text");
+                Assert.True(document.Footer!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.Default.Paragraphs[0].GetRuns().Count() == 1);
+                Assert.True(document.Footer!.Default.Paragraphs[0].Text == "Footer clutter text");
             }
         }
     }

--- a/OfficeIMO.Tests/Word.CultureInvariant.cs
+++ b/OfficeIMO.Tests/Word.CultureInvariant.cs
@@ -32,7 +32,7 @@ namespace OfficeIMO.Tests {
                 document.AddParagraph("Section 0");
                 document.AddHeadersAndFooters();
 
-                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Watermark");
+                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Watermark");
 
                 Assert.Equal(90, watermark.Rotation);
 

--- a/OfficeIMO.Tests/Word.FindAndReplace.cs
+++ b/OfficeIMO.Tests/Word.FindAndReplace.cs
@@ -60,13 +60,13 @@ namespace OfficeIMO.Tests {
 
                 document.AddHeadersAndFooters();
 
-                var header = document.Header.Default;
+                var header = document.Header!.Default;
                 var tableInHeader = document.AddTable(3, 3);
                 tableInHeader.Rows[0].Cells[0].Paragraphs[0].AddText("Prod Section");
                 tableInHeader.Rows[0].Cells[1].Paragraphs[0].AddText("Prod Section");
                 tableInHeader.Rows[0].Cells[2].Paragraphs[0].AddText("Prod ").AddText("Sect").AddText("ion");
 
-                var footer = document.Footer.Default;
+                var footer = document.Footer!.Default;
                 var tableInFooter = document.AddTable(3, 3);
                 tableInFooter.Rows[0].Cells[0].Paragraphs[0].AddText("Prod Section");
                 tableInFooter.Rows[0].Cells[1].Paragraphs[0].AddText("Prod Section");

--- a/OfficeIMO.Tests/Word.Fluent.HeadersFooters.cs
+++ b/OfficeIMO.Tests/Word.Fluent.HeadersFooters.cs
@@ -35,20 +35,20 @@ namespace OfficeIMO.Tests {
             using var loaded = WordDocument.Load(filePath);
             Assert.Equal(2, loaded.Sections.Count);
 
-            var defaultHeader = loaded.Sections[1].Header.Default;
+            var defaultHeader = loaded.Sections[1].Header!.Default;
             Assert.Equal(3, defaultHeader.Paragraphs.Count);
             Assert.Single(defaultHeader.Tables);
             Assert.Single(defaultHeader.ParagraphsImages);
 
-            Assert.Equal("First header", loaded.Sections[1].Header.First.Paragraphs[0].Text);
-            Assert.Equal("Even header", loaded.Sections[1].Header.Even.Paragraphs[0].Text);
+            Assert.Equal("First header", loaded.Sections[1].Header!.First.Paragraphs[0].Text);
+            Assert.Equal("Even header", loaded.Sections[1].Header!.Even.Paragraphs[0].Text);
 
-            Assert.Equal("Default footer", loaded.Sections[1].Footer.Default.Paragraphs[0].Text);
-            Assert.Equal("First footer", loaded.Sections[1].Footer.First.Paragraphs[0].Text);
-            Assert.Equal("Even footer", loaded.Sections[1].Footer.Even.Paragraphs[0].Text);
+            Assert.Equal("Default footer", loaded.Sections[1].Footer!.Default.Paragraphs[0].Text);
+            Assert.Equal("First footer", loaded.Sections[1].Footer!.First.Paragraphs[0].Text);
+            Assert.Equal("Even footer", loaded.Sections[1].Footer!.Even.Paragraphs[0].Text);
 
-            Assert.Null(loaded.Sections[0].Header.Default);
-            Assert.Null(loaded.Sections[0].Footer.Default);
+            Assert.Null(loaded.Sections[0].Header!.Default);
+            Assert.Null(loaded.Sections[0].Footer!.Default);
         }
     }
 }

--- a/OfficeIMO.Tests/Word.HeadersAndFooter.cs
+++ b/OfficeIMO.Tests/Word.HeadersAndFooter.cs
@@ -19,7 +19,7 @@ namespace OfficeIMO.Tests {
                 paragraph.ParagraphAlignment = JustificationValues.Center;
                 paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
-                var paragraphInHeader = document.Header.Default.AddParagraph();
+                var paragraphInHeader = document.Header!.Default.AddParagraph();
                 paragraphInHeader.Text = "Default Header / Section 0";
 
                 document.AddPageBreak();
@@ -34,7 +34,7 @@ namespace OfficeIMO.Tests {
                 paragraph.ParagraphAlignment = JustificationValues.Center;
                 paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Default Header / Section 0", "Text for default header is wrong (section 0)");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Default Header / Section 0", "Text for default header is wrong (section 0)");
 
                 Assert.True(document.Paragraphs.Count == 5, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 2, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);
@@ -46,7 +46,7 @@ namespace OfficeIMO.Tests {
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithHeadersAndFootersDefault1.docx"))) {
                 // There is only one Paragraph at the document level.
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Default Header / Section 0", "Text for default header is wrong (section 0) (load)");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Default Header / Section 0", "Text for default header is wrong (section 0) (load)");
 
                 Assert.True(document.Paragraphs.Count == 5, "Number of paragraphs during read is wrong (load). Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 2, "Number of page breaks during read is wrong (load). Current: " + document.PageBreaks.Count);
@@ -65,10 +65,10 @@ namespace OfficeIMO.Tests {
                 paragraph.ParagraphAlignment = JustificationValues.Center;
                 paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
-                var paragraphInHeaderO = document.Header.Default.AddParagraph();
+                var paragraphInHeaderO = document.Header!.Default.AddParagraph();
                 paragraphInHeaderO.Text = "Odd Header / Section 0";
 
-                var paragraphInHeaderE = document.Header.Even.AddParagraph();
+                var paragraphInHeaderE = document.Header!.Even.AddParagraph();
                 paragraphInHeaderE.Text = "Even Header / Section 0";
 
                 document.AddPageBreak();
@@ -83,11 +83,11 @@ namespace OfficeIMO.Tests {
                 paragraph.ParagraphAlignment = JustificationValues.Center;
                 paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
-                Assert.True(document.Header.Default.Paragraphs.Count == 1, "Should only have X paragraphs");
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Odd Header / Section 0", "Text for default header is wrong (section 0)");
+                Assert.True(document.Header!.Default.Paragraphs.Count == 1, "Should only have X paragraphs");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Odd Header / Section 0", "Text for default header is wrong (section 0)");
 
-                Assert.True(document.Header.Even.Paragraphs.Count == 1, "Should only have X paragraphs");
-                Assert.True(document.Header.Even.Paragraphs[0].Text == "Even Header / Section 0", "Text for default header is wrong (section 0)");
+                Assert.True(document.Header!.Even.Paragraphs.Count == 1, "Should only have X paragraphs");
+                Assert.True(document.Header!.Even.Paragraphs[0].Text == "Even Header / Section 0", "Text for default header is wrong (section 0)");
 
                 Assert.True(document.Paragraphs.Count == 5, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 2, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);
@@ -99,11 +99,11 @@ namespace OfficeIMO.Tests {
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithHeadersAndFootersDefault2.docx"))) {
                 // There is only one Paragraph at the document level.
-                Assert.True(document.Header.Default.Paragraphs.Count == 1, "Should only have X paragraphs");
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Odd Header / Section 0", "Text for default header is wrong (section 0)");
+                Assert.True(document.Header!.Default.Paragraphs.Count == 1, "Should only have X paragraphs");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Odd Header / Section 0", "Text for default header is wrong (section 0)");
 
-                Assert.True(document.Header.Even.Paragraphs.Count == 1, "Should only have X paragraphs");
-                Assert.True(document.Header.Even.Paragraphs[0].Text == "Even Header / Section 0", "Text for default header is wrong (section 0)");
+                Assert.True(document.Header!.Even.Paragraphs.Count == 1, "Should only have X paragraphs");
+                Assert.True(document.Header!.Even.Paragraphs[0].Text == "Even Header / Section 0", "Text for default header is wrong (section 0)");
 
                 Assert.True(document.Paragraphs.Count == 5, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 2, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);
@@ -124,13 +124,13 @@ namespace OfficeIMO.Tests {
                 paragraph.ParagraphAlignment = JustificationValues.Center;
                 paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
-                var paragraphInHeaderF = document.Header.First.AddParagraph();
+                var paragraphInHeaderF = document.Header!.First.AddParagraph();
                 paragraphInHeaderF.Text = "First Header / Section 0";
 
-                var paragraphInHeaderO = document.Header.Default.AddParagraph();
+                var paragraphInHeaderO = document.Header!.Default.AddParagraph();
                 paragraphInHeaderO.Text = "Odd Header / Section 0";
 
-                var paragraphInHeaderE = document.Header.Even.AddParagraph();
+                var paragraphInHeaderE = document.Header!.Even.AddParagraph();
                 paragraphInHeaderE.Text = "Even Header / Section 0";
 
                 document.AddPageBreak();
@@ -145,14 +145,14 @@ namespace OfficeIMO.Tests {
                 paragraph.ParagraphAlignment = JustificationValues.Center;
                 paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
-                Assert.True(document.Header.Default.Paragraphs.Count == 1, "Should only have X paragraphs");
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Odd Header / Section 0", "Text for default header is wrong (section 0)");
+                Assert.True(document.Header!.Default.Paragraphs.Count == 1, "Should only have X paragraphs");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Odd Header / Section 0", "Text for default header is wrong (section 0)");
 
-                Assert.True(document.Header.Even.Paragraphs.Count == 1, "Should only have X paragraphs");
-                Assert.True(document.Header.Even.Paragraphs[0].Text == "Even Header / Section 0", "Text for even header is wrong (section 0)");
+                Assert.True(document.Header!.Even.Paragraphs.Count == 1, "Should only have X paragraphs");
+                Assert.True(document.Header!.Even.Paragraphs[0].Text == "Even Header / Section 0", "Text for even header is wrong (section 0)");
 
-                Assert.True(document.Header.First.Paragraphs.Count == 1, "Should only have X paragraphs");
-                Assert.True(document.Header.First.Paragraphs[0].Text == "First Header / Section 0", "Text for first header is wrong (section 0)");
+                Assert.True(document.Header!.First.Paragraphs.Count == 1, "Should only have X paragraphs");
+                Assert.True(document.Header!.First.Paragraphs[0].Text == "First Header / Section 0", "Text for first header is wrong (section 0)");
 
                 Assert.True(document.Paragraphs.Count == 5, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 2, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);
@@ -164,14 +164,14 @@ namespace OfficeIMO.Tests {
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithHeadersAndFootersDefaultFirst1.docx"))) {
                 // There is only one Paragraph at the document level.
-                Assert.True(document.Header.Default.Paragraphs.Count == 1, "Should only have X paragraphs");
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Odd Header / Section 0", "Text for default header is wrong (section 0)");
+                Assert.True(document.Header!.Default.Paragraphs.Count == 1, "Should only have X paragraphs");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Odd Header / Section 0", "Text for default header is wrong (section 0)");
 
-                Assert.True(document.Header.Even.Paragraphs.Count == 1, "Should only have X paragraphs");
-                Assert.True(document.Header.Even.Paragraphs[0].Text == "Even Header / Section 0", "Text for even header is wrong (section 0)");
+                Assert.True(document.Header!.Even.Paragraphs.Count == 1, "Should only have X paragraphs");
+                Assert.True(document.Header!.Even.Paragraphs[0].Text == "Even Header / Section 0", "Text for even header is wrong (section 0)");
 
-                Assert.True(document.Header.First.Paragraphs.Count == 1, "Should only have X paragraphs");
-                Assert.True(document.Header.First.Paragraphs[0].Text == "First Header / Section 0", "Text for first header is wrong (section 0)");
+                Assert.True(document.Header!.First.Paragraphs.Count == 1, "Should only have X paragraphs");
+                Assert.True(document.Header!.First.Paragraphs[0].Text == "First Header / Section 0", "Text for first header is wrong (section 0)");
 
                 Assert.True(document.Paragraphs.Count == 5, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 2, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);
@@ -188,43 +188,43 @@ namespace OfficeIMO.Tests {
                 document.AddParagraph("Test Section0");
                 document.AddHeadersAndFooters();
 
-                document.Header.Default.AddParagraph().SetText("Test Section 0 - Header");
-                document.Footer.Default.AddParagraph().SetText("Test Section 0 - Footer");
+                document.Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
+                document.Footer!.Default.AddParagraph().SetText("Test Section 0 - Footer");
 
-                Assert.True(document.Header.First == null);
-                Assert.True(document.Footer.First == null);
+                Assert.True(document.Header!.First == null);
+                Assert.True(document.Footer!.First == null);
 
                 document.DifferentFirstPage = true;
 
-                Assert.True(document.Header.First != null);
-                Assert.True(document.Footer.First != null);
-                document.Header.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Footer.First.AddParagraph().SetText("Test Section 0 - First Footer");
+                Assert.True(document.Header!.First != null);
+                Assert.True(document.Footer!.First != null);
+                document.Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
+                document.Footer!.First.AddParagraph().SetText("Test Section 0 - First Footer");
 
-                Assert.True(document.Header.Even == null);
-                Assert.True(document.Footer.Even == null);
+                Assert.True(document.Header!.Even == null);
+                Assert.True(document.Footer!.Even == null);
 
                 document.DifferentOddAndEvenPages = true;
 
-                Assert.True(document.Header.Even != null);
-                Assert.True(document.Footer.Even != null);
+                Assert.True(document.Header!.Even != null);
+                Assert.True(document.Footer!.Even != null);
 
-                document.Header.Even.AddParagraph().SetText("Test Section 0 - Header Even");
-                document.Footer.Even.AddParagraph().SetText("Test Section 0 - Footer Even");
+                document.Header!.Even.AddParagraph().SetText("Test Section 0 - Header Even");
+                document.Footer!.Even.AddParagraph().SetText("Test Section 0 - Footer Even");
 
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Test Section 0 - Header");
-                Assert.True(document.Footer.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
-                Assert.True(document.Header.First.Paragraphs[0].Text == "Test Section 0 - First Header");
-                Assert.True(document.Footer.First.Paragraphs[0].Text == "Test Section 0 - First Footer");
-                Assert.True(document.Header.Even.Paragraphs[0].Text == "Test Section 0 - Header Even");
-                Assert.True(document.Footer.Even.Paragraphs[0].Text == "Test Section 0 - Footer Even");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header");
+                Assert.True(document.Footer!.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
+                Assert.True(document.Header!.First.Paragraphs[0].Text == "Test Section 0 - First Header");
+                Assert.True(document.Footer!.First.Paragraphs[0].Text == "Test Section 0 - First Footer");
+                Assert.True(document.Header!.Even.Paragraphs[0].Text == "Test Section 0 - Header Even");
+                Assert.True(document.Footer!.Even.Paragraphs[0].Text == "Test Section 0 - Footer Even");
 
-                Assert.True(document.Header.Default.Paragraphs.Count == 1);
-                Assert.True(document.Footer.Default.Paragraphs.Count == 1);
-                Assert.True(document.Header.First.Paragraphs.Count == 1);
-                Assert.True(document.Footer.First.Paragraphs.Count == 1);
-                Assert.True(document.Header.Even.Paragraphs.Count == 1);
-                Assert.True(document.Footer.Even.Paragraphs.Count == 1);
+                Assert.True(document.Header!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Header!.First.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.First.Paragraphs.Count == 1);
+                Assert.True(document.Header!.Even.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.Even.Paragraphs.Count == 1);
 
                 Assert.True(document.Paragraphs.Count == 1, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 0, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);
@@ -235,19 +235,19 @@ namespace OfficeIMO.Tests {
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithHeaders.docx"))) {
 
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Test Section 0 - Header");
-                Assert.True(document.Footer.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
-                Assert.True(document.Header.First.Paragraphs[0].Text == "Test Section 0 - First Header");
-                Assert.True(document.Footer.First.Paragraphs[0].Text == "Test Section 0 - First Footer");
-                Assert.True(document.Header.Even.Paragraphs[0].Text == "Test Section 0 - Header Even");
-                Assert.True(document.Footer.Even.Paragraphs[0].Text == "Test Section 0 - Footer Even");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header");
+                Assert.True(document.Footer!.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
+                Assert.True(document.Header!.First.Paragraphs[0].Text == "Test Section 0 - First Header");
+                Assert.True(document.Footer!.First.Paragraphs[0].Text == "Test Section 0 - First Footer");
+                Assert.True(document.Header!.Even.Paragraphs[0].Text == "Test Section 0 - Header Even");
+                Assert.True(document.Footer!.Even.Paragraphs[0].Text == "Test Section 0 - Footer Even");
 
-                Assert.True(document.Header.Default.Paragraphs.Count == 1);
-                Assert.True(document.Footer.Default.Paragraphs.Count == 1);
-                Assert.True(document.Header.First.Paragraphs.Count == 1);
-                Assert.True(document.Footer.First.Paragraphs.Count == 1);
-                Assert.True(document.Header.Even.Paragraphs.Count == 1);
-                Assert.True(document.Footer.Even.Paragraphs.Count == 1);
+                Assert.True(document.Header!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Header!.First.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.First.Paragraphs.Count == 1);
+                Assert.True(document.Header!.Even.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.Even.Paragraphs.Count == 1);
 
                 Assert.True(document.Paragraphs.Count == 1, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 0, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);
@@ -263,29 +263,29 @@ namespace OfficeIMO.Tests {
                 document.AddParagraph("Test Section0");
                 document.AddHeadersAndFooters();
 
-                document.Header.Default.AddParagraph().SetText("Test Section 0 - Header");
-                document.Footer.Default.AddParagraph().SetText("Test Section 0 - Footer");
+                document.Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
+                document.Footer!.Default.AddParagraph().SetText("Test Section 0 - Footer");
 
-                Assert.True(document.Header.First == null);
-                Assert.True(document.Footer.First == null);
+                Assert.True(document.Header!.First == null);
+                Assert.True(document.Footer!.First == null);
 
                 document.DifferentFirstPage = true;
 
-                Assert.True(document.Header.First != null);
-                Assert.True(document.Footer.First != null);
-                document.Header.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Footer.First.AddParagraph().SetText("Test Section 0 - First Footer");
+                Assert.True(document.Header!.First != null);
+                Assert.True(document.Footer!.First != null);
+                document.Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
+                document.Footer!.First.AddParagraph().SetText("Test Section 0 - First Footer");
 
-                Assert.True(document.Header.Even == null);
-                Assert.True(document.Footer.Even == null);
+                Assert.True(document.Header!.Even == null);
+                Assert.True(document.Footer!.Even == null);
 
                 document.DifferentOddAndEvenPages = true;
 
-                Assert.True(document.Header.Even != null);
-                Assert.True(document.Footer.Even != null);
+                Assert.True(document.Header!.Even != null);
+                Assert.True(document.Footer!.Even != null);
 
-                document.Header.Even.AddParagraph().SetText("Test Section 0 - Header Even");
-                document.Footer.Even.AddParagraph().SetText("Test Section 0 - Footer Even");
+                document.Header!.Even.AddParagraph().SetText("Test Section 0 - Header Even");
+                document.Footer!.Even.AddParagraph().SetText("Test Section 0 - Footer Even");
 
 
                 var section1 = document.AddSection();
@@ -293,27 +293,27 @@ namespace OfficeIMO.Tests {
                 section1.DifferentFirstPage = true;
                 section1.DifferentOddAndEvenPages = true;
 
-                section1.Header.Default.AddParagraph().SetText("Test Section 0 - Header");
-                section1.Footer.Default.AddParagraph().SetText("Test Section 0 - Footer");
-                section1.Header.First.AddParagraph().SetText("Test Section 0 - First Header");
-                section1.Footer.First.AddParagraph().SetText("Test Section 0 - First Footer");
-                section1.Header.Even.AddParagraph().SetText("Test Section 0 - Header Even");
-                section1.Footer.Even.AddParagraph().SetText("Test Section 0 - Footer Even");
+                section1.Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
+                section1.Footer!.Default.AddParagraph().SetText("Test Section 0 - Footer");
+                section1.Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
+                section1.Footer!.First.AddParagraph().SetText("Test Section 0 - First Footer");
+                section1.Header!.Even.AddParagraph().SetText("Test Section 0 - Header Even");
+                section1.Footer!.Even.AddParagraph().SetText("Test Section 0 - Footer Even");
 
 
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Test Section 0 - Header");
-                Assert.True(document.Footer.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
-                Assert.True(document.Header.First.Paragraphs[0].Text == "Test Section 0 - First Header");
-                Assert.True(document.Footer.First.Paragraphs[0].Text == "Test Section 0 - First Footer");
-                Assert.True(document.Header.Even.Paragraphs[0].Text == "Test Section 0 - Header Even");
-                Assert.True(document.Footer.Even.Paragraphs[0].Text == "Test Section 0 - Footer Even");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header");
+                Assert.True(document.Footer!.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
+                Assert.True(document.Header!.First.Paragraphs[0].Text == "Test Section 0 - First Header");
+                Assert.True(document.Footer!.First.Paragraphs[0].Text == "Test Section 0 - First Footer");
+                Assert.True(document.Header!.Even.Paragraphs[0].Text == "Test Section 0 - Header Even");
+                Assert.True(document.Footer!.Even.Paragraphs[0].Text == "Test Section 0 - Footer Even");
 
-                Assert.True(document.Header.Default.Paragraphs.Count == 1);
-                Assert.True(document.Footer.Default.Paragraphs.Count == 1);
-                Assert.True(document.Header.First.Paragraphs.Count == 1);
-                Assert.True(document.Footer.First.Paragraphs.Count == 1);
-                Assert.True(document.Header.Even.Paragraphs.Count == 1);
-                Assert.True(document.Footer.Even.Paragraphs.Count == 1);
+                Assert.True(document.Header!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Header!.First.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.First.Paragraphs.Count == 1);
+                Assert.True(document.Header!.Even.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.Even.Paragraphs.Count == 1);
 
                 Assert.True(document.Paragraphs.Count == 1, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 0, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);
@@ -328,19 +328,19 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithHeadersAndRemoveThem.docx"))) {
 
-                Assert.True(document.Header.Default == null);
-                Assert.True(document.Footer.Default == null);
-                Assert.True(document.Header.First == null);
-                Assert.True(document.Footer.First == null);
-                Assert.True(document.Header.Even == null);
-                Assert.True(document.Footer.Even == null);
+                Assert.True(document.Header!.Default == null);
+                Assert.True(document.Footer!.Default == null);
+                Assert.True(document.Header!.First == null);
+                Assert.True(document.Footer!.First == null);
+                Assert.True(document.Header!.Even == null);
+                Assert.True(document.Footer!.Even == null);
 
-                Assert.True(document.Sections[1].Header.Default == null);
-                Assert.True(document.Sections[1].Footer.Default == null);
-                Assert.True(document.Sections[1].Header.First == null);
-                Assert.True(document.Sections[1].Footer.First == null);
-                Assert.True(document.Sections[1].Header.Even == null);
-                Assert.True(document.Sections[1].Footer.Even == null);
+                Assert.True(document.Sections[1].Header!.Default == null);
+                Assert.True(document.Sections[1].Footer!.Default == null);
+                Assert.True(document.Sections[1].Header!.First == null);
+                Assert.True(document.Sections[1].Footer!.First == null);
+                Assert.True(document.Sections[1].Header!.Even == null);
+                Assert.True(document.Sections[1].Footer!.Even == null);
 
                 Assert.True(document.Paragraphs.Count == 1, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 0, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);

--- a/OfficeIMO.Tests/Word.HeadersAndFootersWithSections.cs
+++ b/OfficeIMO.Tests/Word.HeadersAndFootersWithSections.cs
@@ -14,13 +14,13 @@ namespace OfficeIMO.Tests {
                 document.Sections[0].PageOrientation = PageOrientationValues.Landscape;
                 document.AddParagraph("Test Section0");
                 document.AddHeadersAndFooters();
-                document.Sections[0].Header.Default.AddParagraph().SetText("Test Section 0 - Header");
+                document.Sections[0].Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
 
                 var section1 = document.AddSection();
                 section1.PageOrientation = PageOrientationValues.Portrait;
                 section1.AddParagraph("Test Section1");
                 section1.AddHeadersAndFooters();
-                section1.Header.Default.AddParagraph().SetText("Test Section 1 - Header");
+                section1.Header!.Default.AddParagraph().SetText("Test Section 1 - Header");
                 //Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Paragraphs[0].Text);
 
                 var section2 = document.AddSection();
@@ -28,9 +28,9 @@ namespace OfficeIMO.Tests {
                 section2.PageOrientation = PageOrientationValues.Landscape;
 
 
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for default header is wrong (section 0)");
-                Assert.True(document.Sections[0].Header.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for section header is wrong (section 0)");
-                Assert.True(document.Sections[1].Header.Default.Paragraphs[0].Text == "Test Section 1 - Header", "Text for section header is wrong (section 1)");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for default header is wrong (section 0)");
+                Assert.True(document.Sections[0].Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for section header is wrong (section 0)");
+                Assert.True(document.Sections[1].Header!.Default.Paragraphs[0].Text == "Test Section 1 - Header", "Text for section header is wrong (section 1)");
                 Assert.True(document.Paragraphs.Count == 3, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 0, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);
                 Assert.True(document.Sections.Count == 3, "Number of sections during creation is wrong.");
@@ -41,9 +41,9 @@ namespace OfficeIMO.Tests {
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithHeadersAndFootersSection1.docx"))) {
                 // There is only one Paragraph at the document level.
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for default header is wrong (section 0)");
-                Assert.True(document.Sections[0].Header.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for section header is wrong (section 0)");
-                Assert.True(document.Sections[1].Header.Default.Paragraphs[0].Text == "Test Section 1 - Header", "Text for section header is wrong (section 1)");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for default header is wrong (section 0)");
+                Assert.True(document.Sections[0].Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for section header is wrong (section 0)");
+                Assert.True(document.Sections[1].Header!.Default.Paragraphs[0].Text == "Test Section 1 - Header", "Text for section header is wrong (section 1)");
 
 
                 Assert.True(document.Paragraphs.Count == 3, "Number of paragraphs during read is wrong (load). Current: " + document.Paragraphs.Count);
@@ -63,16 +63,16 @@ namespace OfficeIMO.Tests {
                 document.AddHeadersAndFooters();
                 document.DifferentFirstPage = true;
 
-                Assert.True(document.Header.First.Paragraphs.Count == 0, "First paragraph should not be there");
-                document.Sections[0].Header.First.AddParagraph().SetText("Test Section 0 - First Header");
-                Assert.True(document.Header.First.Paragraphs[0].Text == "Test Section 0 - First Header", "First Header Should be correct");
-                document.Sections[0].Header.Default.AddParagraph().SetText("Test Section 0 - Header");
+                Assert.True(document.Header!.First.Paragraphs.Count == 0, "First paragraph should not be there");
+                document.Sections[0].Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
+                Assert.True(document.Header!.First.Paragraphs[0].Text == "Test Section 0 - First Header", "First Header Should be correct");
+                document.Sections[0].Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
 
                 var section1 = document.AddSection();
                 section1.PageOrientation = PageOrientationValues.Portrait;
                 section1.AddParagraph("Test Section1");
                 section1.AddHeadersAndFooters();
-                section1.Header.Default.AddParagraph().SetText("Test Section 1 - Header");
+                section1.Header!.Default.AddParagraph().SetText("Test Section 1 - Header");
                 //Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Paragraphs[0].Text);
 
                 var section2 = document.AddSection();
@@ -80,9 +80,9 @@ namespace OfficeIMO.Tests {
                 section2.PageOrientation = PageOrientationValues.Landscape;
 
 
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for default header is wrong (section 0)");
-                Assert.True(document.Sections[0].Header.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for section header is wrong (section 0)");
-                Assert.True(document.Sections[1].Header.Default.Paragraphs[0].Text == "Test Section 1 - Header", "Text for section header is wrong (section 1)");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for default header is wrong (section 0)");
+                Assert.True(document.Sections[0].Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for section header is wrong (section 0)");
+                Assert.True(document.Sections[1].Header!.Default.Paragraphs[0].Text == "Test Section 1 - Header", "Text for section header is wrong (section 1)");
                 Assert.True(document.Paragraphs.Count == 3, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 0, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);
                 Assert.True(document.Sections.Count == 3, "Number of sections during creation is wrong.");
@@ -93,12 +93,12 @@ namespace OfficeIMO.Tests {
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithHeadersAndFootersSection1.docx"))) {
                 // There is only one Paragraph at the document level.
-                Assert.True(document.Header.First.Paragraphs[0].Text == "Test Section 0 - First Header", "First Header Should be correct");
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for default header is wrong (section 0)");
-                Assert.True(document.Sections[0].Header.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for section header is wrong (section 0)");
-                Assert.True(document.Sections[1].Header.Default.Paragraphs[0].Text == "Test Section 1 - Header", "Text for section header is wrong (section 1)");
+                Assert.True(document.Header!.First.Paragraphs[0].Text == "Test Section 0 - First Header", "First Header Should be correct");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for default header is wrong (section 0)");
+                Assert.True(document.Sections[0].Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for section header is wrong (section 0)");
+                Assert.True(document.Sections[1].Header!.Default.Paragraphs[0].Text == "Test Section 1 - Header", "Text for section header is wrong (section 1)");
 
-                document.Sections[0].Header.First.Paragraphs[0].Text = "Test Section 0 - First Header After mods";
+                document.Sections[0].Header!.First.Paragraphs[0].Text = "Test Section 0 - First Header After mods";
 
                 Assert.True(document.Paragraphs.Count == 3, "Number of paragraphs during read is wrong (load). Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 0, "Number of page breaks during read is wrong (load). Current: " + document.PageBreaks.Count);
@@ -109,10 +109,10 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithHeadersAndFootersSection1.docx"))) {
                 // There is only one Paragraph at the document level.
-                Assert.True(document.Header.First.Paragraphs[0].Text == "Test Section 0 - First Header After mods", "First Header Should be correct");
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for default header is wrong (section 0)");
-                Assert.True(document.Sections[0].Header.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for section header is wrong (section 0)");
-                Assert.True(document.Sections[1].Header.Default.Paragraphs[0].Text == "Test Section 1 - Header", "Text for section header is wrong (section 1)");
+                Assert.True(document.Header!.First.Paragraphs[0].Text == "Test Section 0 - First Header After mods", "First Header Should be correct");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for default header is wrong (section 0)");
+                Assert.True(document.Sections[0].Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header", "Text for section header is wrong (section 0)");
+                Assert.True(document.Sections[1].Header!.Default.Paragraphs[0].Text == "Test Section 1 - Header", "Text for section header is wrong (section 1)");
 
 
                 Assert.True(document.Paragraphs.Count == 3, "Number of paragraphs during read is wrong (load). Current: " + document.Paragraphs.Count);
@@ -130,43 +130,43 @@ namespace OfficeIMO.Tests {
                 document.AddParagraph("Test Section0");
                 document.AddHeadersAndFooters();
 
-                document.Header.Default.AddParagraph().SetText("Test Section 0 - Header");
-                document.Footer.Default.AddParagraph().SetText("Test Section 0 - Footer");
+                document.Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
+                document.Footer!.Default.AddParagraph().SetText("Test Section 0 - Footer");
 
-                Assert.True(document.Header.First == null);
-                Assert.True(document.Footer.First == null);
+                Assert.True(document.Header!.First == null);
+                Assert.True(document.Footer!.First == null);
 
                 document.DifferentFirstPage = true;
 
-                Assert.True(document.Header.First != null);
-                Assert.True(document.Footer.First != null);
-                document.Header.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Footer.First.AddParagraph().SetText("Test Section 0 - First Footer");
+                Assert.True(document.Header!.First != null);
+                Assert.True(document.Footer!.First != null);
+                document.Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
+                document.Footer!.First.AddParagraph().SetText("Test Section 0 - First Footer");
 
-                Assert.True(document.Header.Even == null);
-                Assert.True(document.Footer.Even == null);
+                Assert.True(document.Header!.Even == null);
+                Assert.True(document.Footer!.Even == null);
 
                 document.DifferentOddAndEvenPages = true;
 
-                Assert.True(document.Header.Even != null);
-                Assert.True(document.Footer.Even != null);
+                Assert.True(document.Header!.Even != null);
+                Assert.True(document.Footer!.Even != null);
 
-                document.Header.Even.AddParagraph().SetText("Test Section 0 - Header Even");
-                document.Footer.Even.AddParagraph().SetText("Test Section 0 - Footer Even");
+                document.Header!.Even.AddParagraph().SetText("Test Section 0 - Header Even");
+                document.Footer!.Even.AddParagraph().SetText("Test Section 0 - Footer Even");
 
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Test Section 0 - Header");
-                Assert.True(document.Footer.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
-                Assert.True(document.Header.First.Paragraphs[0].Text == "Test Section 0 - First Header");
-                Assert.True(document.Footer.First.Paragraphs[0].Text == "Test Section 0 - First Footer");
-                Assert.True(document.Header.Even.Paragraphs[0].Text == "Test Section 0 - Header Even");
-                Assert.True(document.Footer.Even.Paragraphs[0].Text == "Test Section 0 - Footer Even");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header");
+                Assert.True(document.Footer!.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
+                Assert.True(document.Header!.First.Paragraphs[0].Text == "Test Section 0 - First Header");
+                Assert.True(document.Footer!.First.Paragraphs[0].Text == "Test Section 0 - First Footer");
+                Assert.True(document.Header!.Even.Paragraphs[0].Text == "Test Section 0 - Header Even");
+                Assert.True(document.Footer!.Even.Paragraphs[0].Text == "Test Section 0 - Footer Even");
 
-                Assert.True(document.Header.Default.Paragraphs.Count == 1);
-                Assert.True(document.Footer.Default.Paragraphs.Count == 1);
-                Assert.True(document.Header.First.Paragraphs.Count == 1);
-                Assert.True(document.Footer.First.Paragraphs.Count == 1);
-                Assert.True(document.Header.Even.Paragraphs.Count == 1);
-                Assert.True(document.Footer.Even.Paragraphs.Count == 1);
+                Assert.True(document.Header!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Header!.First.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.First.Paragraphs.Count == 1);
+                Assert.True(document.Header!.Even.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.Even.Paragraphs.Count == 1);
 
                 Assert.True(document.Paragraphs.Count == 1, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 0, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);
@@ -177,19 +177,19 @@ namespace OfficeIMO.Tests {
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithHeadersAndSections.docx"))) {
 
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Test Section 0 - Header");
-                Assert.True(document.Footer.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
-                Assert.True(document.Header.First.Paragraphs[0].Text == "Test Section 0 - First Header");
-                Assert.True(document.Footer.First.Paragraphs[0].Text == "Test Section 0 - First Footer");
-                Assert.True(document.Header.Even.Paragraphs[0].Text == "Test Section 0 - Header Even");
-                Assert.True(document.Footer.Even.Paragraphs[0].Text == "Test Section 0 - Footer Even");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header");
+                Assert.True(document.Footer!.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
+                Assert.True(document.Header!.First.Paragraphs[0].Text == "Test Section 0 - First Header");
+                Assert.True(document.Footer!.First.Paragraphs[0].Text == "Test Section 0 - First Footer");
+                Assert.True(document.Header!.Even.Paragraphs[0].Text == "Test Section 0 - Header Even");
+                Assert.True(document.Footer!.Even.Paragraphs[0].Text == "Test Section 0 - Footer Even");
 
-                Assert.True(document.Header.Default.Paragraphs.Count == 1);
-                Assert.True(document.Footer.Default.Paragraphs.Count == 1);
-                Assert.True(document.Header.First.Paragraphs.Count == 1);
-                Assert.True(document.Footer.First.Paragraphs.Count == 1);
-                Assert.True(document.Header.Even.Paragraphs.Count == 1);
-                Assert.True(document.Footer.Even.Paragraphs.Count == 1);
+                Assert.True(document.Header!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Header!.First.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.First.Paragraphs.Count == 1);
+                Assert.True(document.Header!.Even.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.Even.Paragraphs.Count == 1);
 
                 Assert.True(document.Paragraphs.Count == 1, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 0, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);
@@ -200,19 +200,19 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithHeadersAndSections.docx"))) {
 
-                Assert.True(document.Header.Default.Paragraphs[0].Text == "Test Section 0 - Header");
-                Assert.True(document.Footer.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
-                Assert.True(document.Header.First.Paragraphs[0].Text == "Test Section 0 - First Header");
-                Assert.True(document.Footer.First.Paragraphs[0].Text == "Test Section 0 - First Footer");
-                Assert.True(document.Header.Even.Paragraphs[0].Text == "Test Section 0 - Header Even");
-                Assert.True(document.Footer.Even.Paragraphs[0].Text == "Test Section 0 - Footer Even");
+                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header");
+                Assert.True(document.Footer!.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
+                Assert.True(document.Header!.First.Paragraphs[0].Text == "Test Section 0 - First Header");
+                Assert.True(document.Footer!.First.Paragraphs[0].Text == "Test Section 0 - First Footer");
+                Assert.True(document.Header!.Even.Paragraphs[0].Text == "Test Section 0 - Header Even");
+                Assert.True(document.Footer!.Even.Paragraphs[0].Text == "Test Section 0 - Footer Even");
 
-                Assert.True(document.Header.Default.Paragraphs.Count == 1);
-                Assert.True(document.Footer.Default.Paragraphs.Count == 1);
-                Assert.True(document.Header.First.Paragraphs.Count == 1);
-                Assert.True(document.Footer.First.Paragraphs.Count == 1);
-                Assert.True(document.Header.Even.Paragraphs.Count == 1);
-                Assert.True(document.Footer.Even.Paragraphs.Count == 1);
+                Assert.True(document.Header!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.Default.Paragraphs.Count == 1);
+                Assert.True(document.Header!.First.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.First.Paragraphs.Count == 1);
+                Assert.True(document.Header!.Even.Paragraphs.Count == 1);
+                Assert.True(document.Footer!.Even.Paragraphs.Count == 1);
 
                 Assert.True(document.Paragraphs.Count == 1, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 0, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);
@@ -228,31 +228,31 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs.Count == 1, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.Sections.Count == 2, "Number of sections during creation is wrong.");
 
-                Assert.True(document.Sections[1].Header.Default == null);
-                Assert.True(document.Sections[1].Footer.Default == null);
-                Assert.True(document.Sections[1].Header.First == null);
-                Assert.True(document.Sections[1].Footer.First == null);
-                Assert.True(document.Sections[1].Header.Even == null);
-                Assert.True(document.Sections[1].Footer.Even == null);
+                Assert.True(document.Sections[1].Header!.Default == null);
+                Assert.True(document.Sections[1].Footer!.Default == null);
+                Assert.True(document.Sections[1].Header!.First == null);
+                Assert.True(document.Sections[1].Footer!.First == null);
+                Assert.True(document.Sections[1].Header!.Even == null);
+                Assert.True(document.Sections[1].Footer!.Even == null);
 
                 document.AddSection();
                 document.Sections[2].PageOrientation = PageOrientationValues.Landscape;
 
-                Assert.True(document.Sections[2].Header.Default == null);
-                Assert.True(document.Sections[2].Footer.Default == null);
-                Assert.True(document.Sections[2].Header.First == null);
-                Assert.True(document.Sections[2].Footer.First == null);
-                Assert.True(document.Sections[2].Header.Even == null);
-                Assert.True(document.Sections[2].Footer.Even == null);
+                Assert.True(document.Sections[2].Header!.Default == null);
+                Assert.True(document.Sections[2].Footer!.Default == null);
+                Assert.True(document.Sections[2].Header!.First == null);
+                Assert.True(document.Sections[2].Footer!.First == null);
+                Assert.True(document.Sections[2].Header!.Even == null);
+                Assert.True(document.Sections[2].Footer!.Even == null);
 
                 document.Sections[2].AddHeadersAndFooters();
 
-                Assert.True(document.Sections[2].Header.Default != null);
-                Assert.True(document.Sections[2].Footer.Default != null);
-                Assert.True(document.Sections[2].Header.First == null);
-                Assert.True(document.Sections[2].Footer.First == null);
-                Assert.True(document.Sections[2].Header.Even == null);
-                Assert.True(document.Sections[2].Footer.Even == null);
+                Assert.True(document.Sections[2].Header!.Default != null);
+                Assert.True(document.Sections[2].Footer!.Default != null);
+                Assert.True(document.Sections[2].Header!.First == null);
+                Assert.True(document.Sections[2].Footer!.First == null);
+                Assert.True(document.Sections[2].Header!.Even == null);
+                Assert.True(document.Sections[2].Footer!.Even == null);
 
                 document.Save();
             }
@@ -260,9 +260,9 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs.Count == 1, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.Sections.Count == 3, "Number of sections during creation is wrong.");
 
-                document.Sections[2].Header.Default.AddParagraph().SetText("Test Section 0 - Header");
+                document.Sections[2].Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
 
-                Assert.True(document.Sections[2].Header.Default.Paragraphs.Count == 1);
+                Assert.True(document.Sections[2].Header!.Default.Paragraphs.Count == 1);
 
                 document.AddSection();
                 document.Sections[3].AddHeadersAndFooters();
@@ -271,7 +271,7 @@ namespace OfficeIMO.Tests {
                 document.Sections[1].AddHeadersAndFooters();
                 document.Sections[1].DifferentOddAndEvenPages = true;
 
-                document.Sections[1].Footer.Even.AddParagraph().SetText("Test Section 1 - Even");
+                document.Sections[1].Footer!.Even.AddParagraph().SetText("Test Section 1 - Even");
 
                 Assert.True(document.Sections.Count == 4, "Number of sections during creation is wrong.");
 
@@ -282,30 +282,30 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs.Count == 1, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.Sections.Count == 4, "Number of sections during creation is wrong.");
 
-                Assert.True(document.Sections[3].Header.Default != null);
-                Assert.True(document.Sections[3].Footer.Default != null);
-                Assert.True(document.Sections[3].Header.First == null);
-                Assert.True(document.Sections[3].Footer.First == null);
-                Assert.True(document.Sections[3].Header.Even == null);
-                Assert.True(document.Sections[3].Footer.Even == null);
+                Assert.True(document.Sections[3].Header!.Default != null);
+                Assert.True(document.Sections[3].Footer!.Default != null);
+                Assert.True(document.Sections[3].Header!.First == null);
+                Assert.True(document.Sections[3].Footer!.First == null);
+                Assert.True(document.Sections[3].Header!.Even == null);
+                Assert.True(document.Sections[3].Footer!.Even == null);
 
                 document.Sections[3].DifferentFirstPage = true;
                 document.Sections[3].DifferentOddAndEvenPages = true;
 
-                document.Sections[3].Header.Default.AddParagraph().SetText("Test Section 0 - Header");
-                document.Sections[3].Header.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Sections[3].Header.Even.AddParagraph().SetText("Test Section 0 - Even");
+                document.Sections[3].Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
+                document.Sections[3].Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
+                document.Sections[3].Header!.Even.AddParagraph().SetText("Test Section 0 - Even");
 
-                Assert.True(document.Sections[3].Header.Default != null);
-                Assert.True(document.Sections[3].Footer.Default != null);
-                Assert.True(document.Sections[3].Header.First != null);
-                Assert.True(document.Sections[3].Footer.First != null);
-                Assert.True(document.Sections[3].Header.Even != null);
-                Assert.True(document.Sections[3].Footer.Even != null);
+                Assert.True(document.Sections[3].Header!.Default != null);
+                Assert.True(document.Sections[3].Footer!.Default != null);
+                Assert.True(document.Sections[3].Header!.First != null);
+                Assert.True(document.Sections[3].Footer!.First != null);
+                Assert.True(document.Sections[3].Header!.Even != null);
+                Assert.True(document.Sections[3].Footer!.Even != null);
 
 
-                Assert.True(document.Sections[2].Header.Default.Paragraphs[0].Text == "Test Section 0 - Header");
-                Assert.True(document.Sections[1].Footer.Even.Paragraphs[0].Text == "Test Section 1 - Even");
+                Assert.True(document.Sections[2].Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header");
+                Assert.True(document.Sections[1].Footer!.Even.Paragraphs[0].Text == "Test Section 1 - Even");
 
 
                 Assert.True(document.Sections.Count == 4, "Number of sections during creation is wrong.");
@@ -322,29 +322,29 @@ namespace OfficeIMO.Tests {
                 var paragraph = document.AddParagraph("Basic paragraph");
 
                 document.AddHeadersAndFooters();
-                document.Sections[0].Header.Default.AddParagraph("Test2").AddText("Section 0");
+                document.Sections[0].Header!.Default.AddParagraph("Test2").AddText("Section 0");
 
                 var section1 = document.AddSection();
                 section1.AddParagraph("Test Middle1 Section - 1");
                 section1.AddHeadersAndFooters();
-                section1.Header.Default.AddParagraph().AddText("Section 1 - Header");
-                section1.Footer.Default.AddParagraph().AddText("Section 1 - Footer");
+                section1.Header!.Default.AddParagraph().AddText("Section 1 - Header");
+                section1.Footer!.Default.AddParagraph().AddText("Section 1 - Footer");
 
                 var section2 = document.AddSection();
                 section2.AddParagraph("Test Middle2 Section - 1");
                 section2.AddHeadersAndFooters();
-                section2.Header.Default.AddParagraph().AddText("Section 2 - Header");
-                section2.Footer.Default.AddParagraph().AddText("Section 2 - Footer");
+                section2.Header!.Default.AddParagraph().AddText("Section 2 - Header");
+                section2.Footer!.Default.AddParagraph().AddText("Section 2 - Footer");
 
                 var section3 = document.AddSection();
                 section3.AddParagraph("Test Last Section - 1");
                 section3.AddHeadersAndFooters();
                 section3.DifferentOddAndEvenPages = true;
                 section3.DifferentFirstPage = true;
-                section3.Header.Default.AddParagraph().AddText("Section 3 - Header Odd/Default");
-                section3.Footer.Default.AddParagraph().AddText("Section 3 - Footer Odd/Default");
-                section3.Header.Even.AddParagraph().AddText("Section 3 - Header Even");
-                section3.Footer.Even.AddParagraph().AddText("Section 3 - Footer Even");
+                section3.Header!.Default.AddParagraph().AddText("Section 3 - Header Odd/Default");
+                section3.Footer!.Default.AddParagraph().AddText("Section 3 - Footer Odd/Default");
+                section3.Header!.Even.AddParagraph().AddText("Section 3 - Header Even");
+                section3.Footer!.Even.AddParagraph().AddText("Section 3 - Footer Even");
 
                 document.AddPageBreak();
                 section3.AddParagraph("Test Last Section - 2");
@@ -353,39 +353,39 @@ namespace OfficeIMO.Tests {
 
 
 
-                document.Sections[0].Header.Default.AddParagraph("Section 0").AddBookmark("BookmarkInSection0Header1");
-                var tableHeader = document.Sections[0].Header.Default.AddTable(3, 4);
+                document.Sections[0].Header!.Default.AddParagraph("Section 0").AddBookmark("BookmarkInSection0Header1");
+                var tableHeader = document.Sections[0].Header!.Default.AddTable(3, 4);
                 tableHeader.Rows[0].Cells[3].Paragraphs[0].Text = "This is sparta";
 
-                document.Sections[0].Header.Default.AddHorizontalLine();
-                document.Sections[0].Header.Default.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
-                document.Sections[0].Header.Default.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
-                document.Sections[0].Header.Default.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
+                document.Sections[0].Header!.Default.AddHorizontalLine();
+                document.Sections[0].Header!.Default.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
+                document.Sections[0].Header!.Default.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
+                document.Sections[0].Header!.Default.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
 
-                Assert.True(document.Sections[0].Header.Default.Paragraphs.Count == 8);
+                Assert.True(document.Sections[0].Header!.Default.Paragraphs.Count == 8);
 
-                section2.Footer.Default.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header2");
-                var tableFooter = section2.Footer.Default.AddTable(2, 3);
+                section2.Footer!.Default.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header2");
+                var tableFooter = section2.Footer!.Default.AddTable(2, 3);
                 tableFooter.Rows[0].Cells[2].Paragraphs[0].Text = "This is not sparta";
-                section2.Footer.Default.AddHorizontalLine();
-                section2.Footer.Default.AddHyperLink("Link to website!", new Uri("https://evotec.pl"));
-                section2.Footer.Default.AddHyperLink("Przemysław Email Me", new Uri("mailto:contact@evotec.pl?subject=Test Subject"));
-                section2.Footer.Default.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
+                section2.Footer!.Default.AddHorizontalLine();
+                section2.Footer!.Default.AddHyperLink("Link to website!", new Uri("https://evotec.pl"));
+                section2.Footer!.Default.AddHyperLink("Przemysław Email Me", new Uri("mailto:contact@evotec.pl?subject=Test Subject"));
+                section2.Footer!.Default.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
 
-                Assert.True(document.Sections[0].Header.Default.Paragraphs.Count == 8);
-                Assert.True(document.Sections[0].Header.Default.ParagraphsHyperLinks.Count == 2);
-                Assert.True(document.Sections[0].Header.Default.ParagraphsFields.Count == 1);
-                Assert.True(document.Sections[0].Header.Default.Tables.Count == 1);
+                Assert.True(document.Sections[0].Header!.Default.Paragraphs.Count == 8);
+                Assert.True(document.Sections[0].Header!.Default.ParagraphsHyperLinks.Count == 2);
+                Assert.True(document.Sections[0].Header!.Default.ParagraphsFields.Count == 1);
+                Assert.True(document.Sections[0].Header!.Default.Tables.Count == 1);
 
-                Assert.True(document.Sections[2].Footer.Default.Paragraphs.Count == 7);
-                Assert.True(document.Sections[2].Footer.Default.ParagraphsHyperLinks.Count == 2);
-                Assert.True(document.Sections[2].Footer.Default.ParagraphsFields.Count == 1);
-                Assert.True(document.Sections[2].Footer.Default.Tables.Count == 1);
+                Assert.True(document.Sections[2].Footer!.Default.Paragraphs.Count == 7);
+                Assert.True(document.Sections[2].Footer!.Default.ParagraphsHyperLinks.Count == 2);
+                Assert.True(document.Sections[2].Footer!.Default.ParagraphsFields.Count == 1);
+                Assert.True(document.Sections[2].Footer!.Default.Tables.Count == 1);
 
-                Assert.True(section2.Footer.Default.Paragraphs.Count == 7);
-                Assert.True(section2.Footer.Default.ParagraphsHyperLinks.Count == 2);
-                Assert.True(section2.Footer.Default.ParagraphsFields.Count == 1);
-                Assert.True(section2.Footer.Default.Tables.Count == 1);
+                Assert.True(section2.Footer!.Default.Paragraphs.Count == 7);
+                Assert.True(section2.Footer!.Default.ParagraphsHyperLinks.Count == 2);
+                Assert.True(section2.Footer!.Default.ParagraphsFields.Count == 1);
+                Assert.True(section2.Footer!.Default.Tables.Count == 1);
 
 
                 document.Save(false);

--- a/OfficeIMO.Tests/Word.Hyperlinks.cs
+++ b/OfficeIMO.Tests/Word.Hyperlinks.cs
@@ -465,14 +465,14 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "FormattedHeaderFooter.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var header = document.Header.Default;
+                var header = document.Header!.Default;
                 var paraHeader = header.AddParagraph("Search using ");
                 paraHeader.AddHyperLink("Google", new Uri("https://google.com"), addStyle: true);
                 var refHeader = paraHeader.Hyperlink;
                 Assert.NotNull(refHeader);
                 refHeader!.InsertFormattedHyperlinkAfter("Bing", new Uri("https://bing.com"));
 
-                var footer = document.Footer.Default;
+                var footer = document.Footer!.Default;
                 var paraFooter = footer.AddParagraph("Find us on ");
                 paraFooter.AddHyperLink("Yahoo", new Uri("https://yahoo.com"), addStyle: true);
                 var refFooter = paraFooter.Hyperlink;
@@ -485,9 +485,9 @@ namespace OfficeIMO.Tests {
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var headerPara = document.Header.Default.Paragraphs[0];
+                var headerPara = document.Header!.Default.Paragraphs[0];
                 Assert.Equal(2, headerPara._paragraph.Elements<Hyperlink>().Count());
-                var footerPara = document.Footer.Default.Paragraphs[0];
+                var footerPara = document.Footer!.Default.Paragraphs[0];
                 Assert.Equal(2, footerPara._paragraph.Elements<Hyperlink>().Count());
                 document.Save();
             }

--- a/OfficeIMO.Tests/Word.ImageLocation.cs
+++ b/OfficeIMO.Tests/Word.ImageLocation.cs
@@ -29,7 +29,7 @@ namespace OfficeIMO.Tests {
             using var document = WordDocument.Create(filePath);
             document.AddHeadersAndFooters();
 
-            var paragraph = document.Header.Default.AddParagraph();
+            var paragraph = document.Header!.Default.AddParagraph();
             paragraph.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 50, 50);
 
             var mainPart = document._wordprocessingDocument.MainDocumentPart!;
@@ -48,7 +48,7 @@ namespace OfficeIMO.Tests {
             using var document = WordDocument.Create(filePath);
             document.AddHeadersAndFooters();
 
-            var paragraph = document.Footer.Default.AddParagraph();
+            var paragraph = document.Footer!.Default.AddParagraph();
             paragraph.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 50, 50);
 
             var mainPart = document._wordprocessingDocument.MainDocumentPart!;

--- a/OfficeIMO.Tests/Word.Images.cs
+++ b/OfficeIMO.Tests/Word.Images.cs
@@ -114,26 +114,26 @@ namespace OfficeIMO.Tests {
             document.AddHeadersAndFooters();
             document.DifferentOddAndEvenPages = true;
 
-            Assert.True(document.Header.Default.Images.Count == 0);
-            Assert.True(document.Header.Even.Images.Count == 0);
+            Assert.True(document.Header!.Default.Images.Count == 0);
+            Assert.True(document.Header!.Even.Images.Count == 0);
             Assert.True(document.Images.Count == 0);
-            Assert.True(document.Footer.Default.Images.Count == 0);
-            Assert.True(document.Footer.Even.Images.Count == 0);
+            Assert.True(document.Footer!.Default.Images.Count == 0);
+            Assert.True(document.Footer!.Even.Images.Count == 0);
 
 
-            var header = document.Header.Default;
+            var header = document.Header!.Default;
             // add image to header, directly to paragraph
             header.AddParagraph().AddImage(image, 100, 100);
 
-            var footer = document.Footer.Default;
+            var footer = document.Footer!.Default;
             // add image to footer, directly to paragraph
             footer.AddParagraph().AddImage(image, 200, 200);
 
-            Assert.True(document.Header.Default.Images.Count == 1);
-            Assert.True(document.Header.Even.Images.Count == 0);
+            Assert.True(document.Header!.Default.Images.Count == 1);
+            Assert.True(document.Header!.Even.Images.Count == 0);
             Assert.True(document.Images.Count == 0);
-            Assert.True(document.Footer.Default.Images.Count == 1);
-            Assert.True(document.Footer.Even.Images.Count == 0);
+            Assert.True(document.Footer!.Default.Images.Count == 1);
+            Assert.True(document.Footer!.Even.Images.Count == 0);
 
             const string fileNameImage = "Kulek.jpg";
             var filePathImage = System.IO.Path.Combine(imagePaths, fileNameImage);
@@ -141,12 +141,12 @@ namespace OfficeIMO.Tests {
             using (var imageStream = System.IO.File.OpenRead(filePathImage)) {
                 paragraph.AddImage(imageStream, fileNameImage, 300, 300);
             }
-            Assert.True(document.Header.Default.Images.Count == 1);
-            Assert.True(document.Header.Even.Images.Count == 0);
+            Assert.True(document.Header!.Default.Images.Count == 1);
+            Assert.True(document.Header!.Even.Images.Count == 0);
 
             Assert.True(document.Images.Count == 1);
-            Assert.True(document.Footer.Default.Images.Count == 1);
-            Assert.True(document.Footer.Even.Images.Count == 0);
+            Assert.True(document.Footer!.Default.Images.Count == 1);
+            Assert.True(document.Footer!.Even.Images.Count == 0);
 
             Assert.True(document.Images[0].FileName == fileNameImage);
             Assert.True(document.Images[0].Rotation == null);
@@ -155,7 +155,7 @@ namespace OfficeIMO.Tests {
 
             const string fileNameImageEvotec = "EvotecLogo.png";
             var filePathImageEvotec = System.IO.Path.Combine(imagePaths, fileNameImageEvotec);
-            var paragraphHeader = document.Header.Even.AddParagraph();
+            var paragraphHeader = document.Header!.Even.AddParagraph();
             using (var imageStream = System.IO.File.OpenRead(filePathImageEvotec)) {
                 paragraphHeader.AddImage(imageStream, fileNameImageEvotec, 300, 300, WrapTextImage.InLineWithText, "This is a test");
                 var headerImage = paragraphHeader.Image;
@@ -163,12 +163,12 @@ namespace OfficeIMO.Tests {
                 Assert.True(headerImage!.CompressionQuality == BlipCompressionValues.Print);
             }
 
-            Assert.True(document.Header.Default.Images.Count == 1);
-            Assert.True(document.Header.Even.Images.Count == 1);
-            Assert.True(document.Header.Even.Images[0].FileName == fileNameImageEvotec);
-            Assert.True(document.Header.Even.Images[0].Description == "This is a test");
+            Assert.True(document.Header!.Default.Images.Count == 1);
+            Assert.True(document.Header!.Even.Images.Count == 1);
+            Assert.True(document.Header!.Even.Images[0].FileName == fileNameImageEvotec);
+            Assert.True(document.Header!.Even.Images[0].Description == "This is a test");
 
-            var headerEvenImage = document.Header.Even.Images[0];
+            var headerEvenImage = document.Header!.Even.Images[0];
             Assert.NotNull(headerEvenImage);
             headerEvenImage!.Description = "Different description";
             Assert.True(headerEvenImage.VerticalFlip == null);
@@ -195,14 +195,14 @@ namespace OfficeIMO.Tests {
             using (var document = WordDocument.Load(filePath)) {
                 Assert.True(document.Paragraphs.Count == 36);
                 Assert.True(document.Images.Count == 4);
-                Assert.True(document.Header.Default.Images.Count == 1);
-                Assert.True(document.Footer.Default.Images.Count == 0);
+                Assert.True(document.Header!.Default.Images.Count == 1);
+                Assert.True(document.Footer!.Default.Images.Count == 0);
 
                 Assert.True(document.Images[0].WrapText == WrapTextImage.InLineWithText);
                 Assert.True(document.Images[1].WrapText == WrapTextImage.Square);
                 Assert.True(document.Images[2].WrapText == WrapTextImage.InFrontOfText);
                 Assert.True(document.Images[3].WrapText == WrapTextImage.BehindText);
-                Assert.True(document.Header.Default.Images[0].WrapText == WrapTextImage.InLineWithText);
+                Assert.True(document.Header!.Default.Images[0].WrapText == WrapTextImage.InLineWithText);
 
                 Assert.NotNull(document.Images[0].Shape);
                 Assert.NotNull(document.Images[1].Shape);
@@ -356,7 +356,7 @@ namespace OfficeIMO.Tests {
 
             document.AddHeadersAndFooters();
 
-            var tableInHeader = document.Header.Default.AddTable(2, 2);
+            var tableInHeader = document.Header!.Default.AddTable(2, 2);
             tableInHeader.Rows[0].Cells[0].Paragraphs[0].AddImage(filePathImage, 200, 200);
 
             // not really necessary to add new paragraph since one is already there by default
@@ -367,7 +367,7 @@ namespace OfficeIMO.Tests {
             Assert.True(document.Tables[0].Rows.Count == 2);
             Assert.True(document.Tables[0].Rows[0].Cells.Count == 2);
 
-            Assert.True(document.Header.Default.Tables.Count == 1);
+            Assert.True(document.Header!.Default.Tables.Count == 1);
 
             document.Save(false);
 

--- a/OfficeIMO.Tests/Word.ListItemsEnumerator.cs
+++ b/OfficeIMO.Tests/Word.ListItemsEnumerator.cs
@@ -27,11 +27,11 @@ namespace OfficeIMO.Tests {
                 tableList.AddItem("Table2");
 
                 document.AddHeadersAndFooters();
-                var headerList = document.Header.Default.AddList(WordListStyle.Bulleted);
+                var headerList = document.Header!.Default.AddList(WordListStyle.Bulleted);
                 headerList.AddItem("Header1");
                 headerList.AddItem("Header2");
 
-                var footerList = document.Footer.Default.AddList(WordListStyle.Bulleted);
+                var footerList = document.Footer!.Default.AddList(WordListStyle.Bulleted);
                 footerList.AddItem("Footer1");
                 footerList.AddItem("Footer2");
 

--- a/OfficeIMO.Tests/Word.Lists.cs
+++ b/OfficeIMO.Tests/Word.Lists.cs
@@ -554,23 +554,23 @@ public partial class Word {
 
             document.AddHeadersAndFooters();
 
-            var listInHeader = document.Header.Default.AddList(WordListStyle.Bulleted);
+            var listInHeader = document.Header!.Default.AddList(WordListStyle.Bulleted);
 
             Assert.True(document.Lists.Count == 12);
 
             listInHeader.AddItem("Test Header 1");
 
-            document.Footer.Default.AddParagraph("Test Me Header");
+            document.Footer!.Default.AddParagraph("Test Me Header");
 
             listInHeader.AddItem("Test Header 2");
 
-            var listInFooter = document.Footer.Default.AddList(WordListStyle.Numbered);
+            var listInFooter = document.Footer!.Default.AddList(WordListStyle.Numbered);
 
             Assert.True(document.Lists.Count == 13);
 
             listInFooter.AddItem("Test Footer 1");
 
-            document.Footer.Default.AddParagraph("Test Me Footer");
+            document.Footer!.Default.AddParagraph("Test Me Footer");
 
             listInFooter.AddItem("Test Footer 2");
 
@@ -743,11 +743,11 @@ public partial class Word {
         using (var document = WordDocument.Create(filePath)) {
             document.AddHeadersAndFooters();
 
-            var headerList = document.Header.Default.AddList(WordListStyle.Bulleted);
+            var headerList = document.Header!.Default.AddList(WordListStyle.Bulleted);
             headerList.AddItem("Header 1");
             headerList.AddItem("Header 2");
 
-            var footerList = document.Footer.Default.AddList(WordListStyle.Bulleted);
+            var footerList = document.Footer!.Default.AddList(WordListStyle.Bulleted);
             footerList.AddItem("Footer 1");
             footerList.AddItem("Footer 2");
 
@@ -757,16 +757,16 @@ public partial class Word {
             footerList.Remove();
 
             Assert.Empty(document.Lists);
-            Assert.Empty(document.Header.Default.Paragraphs);
-            Assert.Empty(document.Footer.Default.Paragraphs);
+            Assert.Empty(document.Header!.Default.Paragraphs);
+            Assert.Empty(document.Footer!.Default.Paragraphs);
 
             document.Save(false);
         }
 
         using (var document = WordDocument.Load(filePath)) {
             Assert.Empty(document.Lists);
-            Assert.Empty(document.Header.Default.Paragraphs);
-            Assert.Empty(document.Footer.Default.Paragraphs);
+            Assert.Empty(document.Header!.Default.Paragraphs);
+            Assert.Empty(document.Footer!.Default.Paragraphs);
         }
     }
 

--- a/OfficeIMO.Tests/Word.PageNumbers.cs
+++ b/OfficeIMO.Tests/Word.PageNumbers.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "PageNumberParagraph.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var table = document.Footer.Default.AddTable(1, 2);
+                var table = document.Footer!.Default.AddTable(1, 2);
                 table.Rows[0].Cells[0].AddParagraph("Footer");
                 var para = table.Rows[0].Cells[1].AddParagraph();
                 para.AddPageNumber(includeTotalPages: true);
@@ -33,7 +33,7 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.Sections[0].AddPageNumbering(2, NumberFormatValues.LowerRoman);
                 document.AddHeadersAndFooters();
-                document.Footer.Default.AddParagraph().AddPageNumber();
+                document.Footer!.Default.AddParagraph().AddPageNumber();
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
@@ -54,7 +54,7 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "PageNumberSeparator.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var para = document.Footer.Default.AddParagraph();
+                var para = document.Footer!.Default.AddParagraph();
                 para.AddPageNumber(includeTotalPages: true, separator: " / ");
                 document.Save(false);
             }
@@ -71,7 +71,7 @@ namespace OfficeIMO.Tests {
                 string filePath = Path.Combine(_directoryWithFiles, $"PageNumberStyle_{style}.docx");
                 using (WordDocument document = WordDocument.Create(filePath)) {
                     document.AddHeadersAndFooters();
-                    document.Header.Default.AddPageNumber(style);
+                    document.Header!.Default.AddPageNumber(style);
                     document.Save(false);
                 }
 
@@ -88,7 +88,7 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "PageNumberCustomText.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var pageNumber = document.Header.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                var pageNumber = document.Header!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
                 pageNumber.AppendText(" custom");
                 document.Save(false);
             }
@@ -97,7 +97,7 @@ namespace OfficeIMO.Tests {
                 var mainPart = document._wordprocessingDocument.MainDocumentPart;
                 Assert.NotNull(mainPart);
                 var headerPart = mainPart.HeaderParts.First();
-                string text = headerPart.Header.InnerText;
+                string text = headerPart.Header!.InnerText;
                 Assert.Contains("custom", text);
                 var errors = document.ValidateDocument();
                 errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue").ToList();
@@ -110,7 +110,7 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "PageNumberTotalPages.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var pageNumber = document.Footer.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
                 pageNumber.AppendText(" of ");
                 pageNumber.Paragraph.AddField(WordFieldType.NumPages);
                 document.Save(false);
@@ -120,7 +120,7 @@ namespace OfficeIMO.Tests {
                 var mainPart = document._wordprocessingDocument.MainDocumentPart;
                 Assert.NotNull(mainPart);
                 var footerPart = mainPart.FooterParts.First();
-                string text = footerPart.Footer.InnerText;
+                string text = footerPart.Footer!.InnerText;
                 Assert.Contains(" of ", text);
                 var errors = document.ValidateDocument();
                 errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue").ToList();
@@ -133,13 +133,13 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "SectionPageNumberReset.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                document.Footer.Default.AddParagraph().AddPageNumber();
+                document.Footer!.Default.AddParagraph().AddPageNumber();
 
                 document.AddParagraph("Section 1");
                 var section = document.AddSection();
                 section.AddPageNumbering(1);
                 section.AddParagraph("Section 2");
-                document.Footer.Default.AddParagraph().AddPageNumber();
+                document.Footer!.Default.AddParagraph().AddPageNumber();
 
                 document.Save(false);
             }
@@ -164,7 +164,7 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.Sections[0].AddPageNumbering(1, NumberFormatValues.UpperRoman);
                 document.AddHeadersAndFooters();
-                var para = document.Footer.Default.AddParagraph();
+                var para = document.Footer!.Default.AddParagraph();
                 para.AddPageNumber(includeTotalPages: true, format: WordFieldFormat.Roman);
                 document.Save(false);
             }
@@ -175,7 +175,7 @@ namespace OfficeIMO.Tests {
                 var formatA = pageNumberTypeA.Format;
                 Assert.NotNull(formatA);
                 Assert.Equal(NumberFormatValues.UpperRoman, formatA.Value);
-                Assert.Contains(document.Sections[0].Footer.Default.Fields, f => f.FieldType == WordFieldType.Page && f.FieldFormat.Contains(WordFieldFormat.Roman));
+                Assert.Contains(document.Sections[0].Footer!.Default.Fields, f => f.FieldType == WordFieldType.Page && f.FieldFormat.Contains(WordFieldFormat.Roman));
                 var errors = document.ValidateDocument();
                 errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();
                 Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
@@ -202,7 +202,7 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, $"PageNumberCustomFormat_{Guid.NewGuid()}.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var pageNumber = document.Footer.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
                 pageNumber.CustomFormat = format;
                 Assert.Equal(format, pageNumber.CustomFormat);
                 document.Save(false);
@@ -211,7 +211,7 @@ namespace OfficeIMO.Tests {
                 var mainPart2 = document._wordprocessingDocument.MainDocumentPart;
                 Assert.NotNull(mainPart2);
                 var footerPart = mainPart2.FooterParts.First();
-                string xml = footerPart.Footer.InnerXml;
+                string xml = footerPart.Footer!.InnerXml;
                 Assert.Contains($"\\@ \"{format}\"", xml);
                 var errors = document.ValidateDocument();
                 errors = errors.Where(e => e.Id != "Sem_UniqueAttributeValue" && e.Id != "Sch_UnexpectedElementContentExpectingComplex").ToList();

--- a/OfficeIMO.Tests/Word.RemoveSpecificHeadersFooters.cs
+++ b/OfficeIMO.Tests/Word.RemoveSpecificHeadersFooters.cs
@@ -16,12 +16,12 @@ namespace OfficeIMO.Tests {
                 document.DifferentOddAndEvenPages = true;
                 document.DifferentFirstPage = true;
 
-                document.Header.Default.AddParagraph().SetText("Default Header");
-                document.Footer.Default.AddParagraph().SetText("Default Footer");
-                document.Header.Even.AddParagraph().SetText("Even Header");
-                document.Footer.Even.AddParagraph().SetText("Even Footer");
-                document.Header.First.AddParagraph().SetText("First Header");
-                document.Footer.First.AddParagraph().SetText("First Footer");
+                document.Header!.Default.AddParagraph().SetText("Default Header");
+                document.Footer!.Default.AddParagraph().SetText("Default Footer");
+                document.Header!.Even.AddParagraph().SetText("Even Header");
+                document.Footer!.Even.AddParagraph().SetText("Even Footer");
+                document.Header!.First.AddParagraph().SetText("First Header");
+                document.Footer!.First.AddParagraph().SetText("First Footer");
 
                 document.Save(false);
             }
@@ -29,12 +29,12 @@ namespace OfficeIMO.Tests {
             WordHelpers.RemoveHeadersAndFooters(filePath, HeaderFooterValues.Default);
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Null(document.Header.Default);
-                Assert.Null(document.Footer.Default);
-                Assert.NotNull(document.Header.First);
-                Assert.NotNull(document.Footer.First);
-                Assert.NotNull(document.Header.Even);
-                Assert.NotNull(document.Footer.Even);
+                Assert.Null(document.Header!.Default);
+                Assert.Null(document.Footer!.Default);
+                Assert.NotNull(document.Header!.First);
+                Assert.NotNull(document.Footer!.First);
+                Assert.NotNull(document.Header!.Even);
+                Assert.NotNull(document.Footer!.Even);
             }
         }
 
@@ -46,12 +46,12 @@ namespace OfficeIMO.Tests {
                 document.DifferentOddAndEvenPages = true;
                 document.DifferentFirstPage = true;
 
-                document.Header.Default.AddParagraph().SetText("Default Header");
-                document.Footer.Default.AddParagraph().SetText("Default Footer");
-                document.Header.Even.AddParagraph().SetText("Even Header");
-                document.Footer.Even.AddParagraph().SetText("Even Footer");
-                document.Header.First.AddParagraph().SetText("First Header");
-                document.Footer.First.AddParagraph().SetText("First Footer");
+                document.Header!.Default.AddParagraph().SetText("Default Header");
+                document.Footer!.Default.AddParagraph().SetText("Default Footer");
+                document.Header!.Even.AddParagraph().SetText("Even Header");
+                document.Footer!.Even.AddParagraph().SetText("Even Footer");
+                document.Header!.First.AddParagraph().SetText("First Header");
+                document.Footer!.First.AddParagraph().SetText("First Footer");
 
                 document.Save(false);
             }
@@ -59,12 +59,12 @@ namespace OfficeIMO.Tests {
             WordHelpers.RemoveHeadersAndFooters(filePath, HeaderFooterValues.Even);
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Null(document.Header.Even);
-                Assert.Null(document.Footer.Even);
-                Assert.NotNull(document.Header.First);
-                Assert.NotNull(document.Footer.First);
-                Assert.NotNull(document.Header.Default);
-                Assert.NotNull(document.Footer.Default);
+                Assert.Null(document.Header!.Even);
+                Assert.Null(document.Footer!.Even);
+                Assert.NotNull(document.Header!.First);
+                Assert.NotNull(document.Footer!.First);
+                Assert.NotNull(document.Header!.Default);
+                Assert.NotNull(document.Footer!.Default);
             }
         }
 
@@ -76,12 +76,12 @@ namespace OfficeIMO.Tests {
                 document.DifferentOddAndEvenPages = true;
                 document.DifferentFirstPage = true;
 
-                document.Header.Default.AddParagraph().SetText("Default Header");
-                document.Footer.Default.AddParagraph().SetText("Default Footer");
-                document.Header.Even.AddParagraph().SetText("Even Header");
-                document.Footer.Even.AddParagraph().SetText("Even Footer");
-                document.Header.First.AddParagraph().SetText("First Header");
-                document.Footer.First.AddParagraph().SetText("First Footer");
+                document.Header!.Default.AddParagraph().SetText("Default Header");
+                document.Footer!.Default.AddParagraph().SetText("Default Footer");
+                document.Header!.Even.AddParagraph().SetText("Even Header");
+                document.Footer!.Even.AddParagraph().SetText("Even Footer");
+                document.Header!.First.AddParagraph().SetText("First Header");
+                document.Footer!.First.AddParagraph().SetText("First Footer");
 
                 document.Save(false);
             }
@@ -89,12 +89,12 @@ namespace OfficeIMO.Tests {
             WordHelpers.RemoveHeadersAndFooters(filePath, HeaderFooterValues.First);
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Null(document.Header.First);
-                Assert.Null(document.Footer.First);
-                Assert.NotNull(document.Header.Even);
-                Assert.NotNull(document.Footer.Even);
-                Assert.NotNull(document.Header.Default);
-                Assert.NotNull(document.Footer.Default);
+                Assert.Null(document.Header!.First);
+                Assert.Null(document.Footer!.First);
+                Assert.NotNull(document.Header!.Even);
+                Assert.NotNull(document.Footer!.Even);
+                Assert.NotNull(document.Header!.Default);
+                Assert.NotNull(document.Footer!.Default);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.Sections.cs
+++ b/OfficeIMO.Tests/Word.Sections.cs
@@ -506,19 +506,19 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "RemoveSection.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                document.Header.Default.AddParagraph().SetText("Header 0");
+                document.Header!.Default.AddParagraph().SetText("Header 0");
                 var p0 = document.AddParagraph("Section0");
                 p0.AddList(WordListStyle.Bulleted).AddItem("0");
 
                 var section1 = document.AddSection();
                 section1.AddHeadersAndFooters();
-                section1.Header.Default.AddParagraph().SetText("Header 1");
+                section1.Header!.Default.AddParagraph().SetText("Header 1");
                 var p1 = section1.AddParagraph("Section1");
                 p1.AddList(WordListStyle.Bulleted).AddItem("1");
 
                 var section2 = document.AddSection();
                 section2.AddHeadersAndFooters();
-                section2.Header.Default.AddParagraph().SetText("Header 2");
+                section2.Header!.Default.AddParagraph().SetText("Header 2");
                 var p2 = section2.AddParagraph("Section2");
                 p2.AddList(WordListStyle.Bulleted).AddItem("2");
 
@@ -533,8 +533,8 @@ namespace OfficeIMO.Tests {
 
                 Assert.Equal(2, document.Sections.Count);
                 Assert.Equal(2, document.Lists.Count);
-                Assert.Equal("Header 0", document.Sections[0].Header.Default.Paragraphs[0].Text);
-                Assert.Equal("Header 2", document.Sections[1].Header.Default.Paragraphs[0].Text);
+                Assert.Equal("Header 0", document.Sections[0].Header!.Default.Paragraphs[0].Text);
+                Assert.Equal("Header 2", document.Sections[1].Header!.Default.Paragraphs[0].Text);
 
                 document.Save();
             }
@@ -542,8 +542,8 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.Equal(2, document.Sections.Count);
                 Assert.Equal(2, document.Lists.Count);
-                Assert.Equal("Header 0", document.Sections[0].Header.Default.Paragraphs[0].Text);
-                Assert.Equal("Header 2", document.Sections[1].Header.Default.Paragraphs[0].Text);
+                Assert.Equal("Header 0", document.Sections[0].Header!.Default.Paragraphs[0].Text);
+                Assert.Equal("Header 2", document.Sections[1].Header!.Default.Paragraphs[0].Text);
             }
         }
 

--- a/OfficeIMO.Tests/Word.Shapes.cs
+++ b/OfficeIMO.Tests/Word.Shapes.cs
@@ -140,9 +140,9 @@ namespace OfficeIMO.Tests {
                 section.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
 
                 section.AddHeadersAndFooters();
-                section.Header.Default.AddShape(ShapeType.Rectangle, 30, 15, Color.Blue, Color.Black);
-                section.Header.Default.AddShape(ShapeType.RoundedRectangle, 25, 15, Color.Green, Color.Black, 1, arcSize: 0.3);
-                section.Header.Default.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
+                section.Header!.Default.AddShape(ShapeType.Rectangle, 30, 15, Color.Blue, Color.Black);
+                section.Header!.Default.AddShape(ShapeType.RoundedRectangle, 25, 15, Color.Green, Color.Black, 1, arcSize: 0.3);
+                section.Header!.Default.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
 
                 document.Save(false);
             }
@@ -153,7 +153,7 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(3, section.Shapes.Count);
                 Assert.NotNull(section.Header);
                 Assert.NotNull(section.Header!.Default);
-                var headerDefault = section.Header.Default!;
+                var headerDefault = section.Header!.Default!;
                 Assert.True(headerDefault.Paragraphs[0].IsShape);
                 Assert.True(headerDefault.Paragraphs[1].IsShape);
                 Assert.True(headerDefault.Paragraphs[2].IsShape);

--- a/OfficeIMO.Tests/Word.SmartArt.cs
+++ b/OfficeIMO.Tests/Word.SmartArt.cs
@@ -60,7 +60,7 @@ namespace OfficeIMO.Tests {
                     var xdoc = System.Xml.Linq.XDocument.Load(s);
                     var dgm = (System.Xml.Linq.XNamespace)"http://schemas.openxmlformats.org/drawingml/2006/diagram";
                     var a = (System.Xml.Linq.XNamespace)"http://schemas.openxmlformats.org/drawingml/2006/main";
-                    var nodePts = xdoc.Descendants(dgm + "pt").Where(p => (string)p.Attribute("type") == null && (p.Element(dgm + "t") != null || p.Element(dgm + "txBody") != null)).ToList();
+                    var nodePts = xdoc.Descendants(dgm + "pt").Where(p => p.Attribute("type") == null && (p.Element(dgm + "t") != null || p.Element(dgm + "txBody") != null)).ToList();
                     var paras = nodePts.Select(p => (p.Element(dgm + "t") ?? p.Element(dgm + "txBody"))?.Element(a + "p")).Where(p => p != null).ToList();
                     if (paras.Count < 1) {
                         var debugDir = Path.Combine(_directoryWithFiles, "_debug");

--- a/OfficeIMO.Tests/Word.TOC.cs
+++ b/OfficeIMO.Tests/Word.TOC.cs
@@ -91,8 +91,8 @@ namespace OfficeIMO.Tests {
                 document.Settings.UpdateFieldsOnOpen = true;
                 document.AddTableOfContent(tableOfContentStyle: TableOfContentStyle.Template2);
                 document.AddHeadersAndFooters();
-                //var pageNumber = document.Header.Default.AddPageNumber(WordPageNumberStyle.Circle);
-                var pageNumber = document.Footer.Default.AddPageNumber(WordPageNumberStyle.VerticalOutline2);
+                //var pageNumber = document.Header!.Default.AddPageNumber(WordPageNumberStyle.Circle);
+                var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.VerticalOutline2);
                 pageNumber.ParagraphAlignment = JustificationValues.Center;
 
                 document.AddPageBreak();

--- a/OfficeIMO.Tests/Word.TextBox.cs
+++ b/OfficeIMO.Tests/Word.TextBox.cs
@@ -478,14 +478,14 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "HeaderTextBoxWithHyperlink.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var textBox = document.Sections[0].Header.Default.AddTextBox("Header hyperlink test");
+                var textBox = document.Sections[0].Header!.Default.AddTextBox("Header hyperlink test");
 
                 textBox.Paragraphs[0].AddHyperLink(" to website?", new Uri("https://evotec.xyz"), addStyle: true);
 
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Contains(document.Sections[0].Header.Default.Paragraphs, p => p.IsTextBox);
+                Assert.Contains(document.Sections[0].Header!.Default.Paragraphs, p => p.IsTextBox);
 
             }
         }

--- a/OfficeIMO.Tests/Word.Watermark.cs
+++ b/OfficeIMO.Tests/Word.Watermark.cs
@@ -18,7 +18,7 @@ namespace OfficeIMO.Tests {
                 document.AddHeadersAndFooters();
                 document.Sections[0].SetMargins(WordMargin.Normal);
 
-                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Watermark");
+                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Watermark");
                 document.AddSection();
                 document.Sections[1].AddHeadersAndFooters();
                 document.Sections[1].Margins.Type = WordMargin.Narrow;
@@ -33,14 +33,14 @@ namespace OfficeIMO.Tests {
                 Assert.True(watermark.Color == Color.Silver);
                 Assert.True(watermark.Text == "Watermark");
 
-                document.Sections[1].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Draft");
+                document.Sections[1].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Draft");
 
                 document.Settings.SetBackgroundColor(Color.Azure);
 
                 Assert.True(document.Watermarks.Count == 2);
-                Assert.True(document.Header.Default.Watermarks.Count == 1); // this is actually first section's header.default
-                Assert.True(document.Sections[0].Header.Default.Watermarks.Count == 1);
-                Assert.True(document.Sections[1].Header.Default.Watermarks.Count == 1);
+                Assert.True(document.Header!.Default.Watermarks.Count == 1); // this is actually first section's header.default
+                Assert.True(document.Sections[0].Header!.Default.Watermarks.Count == 1);
+                Assert.True(document.Sections[1].Header!.Default.Watermarks.Count == 1);
 
                 document.AddSection();
 
@@ -49,49 +49,49 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_CreatingWordDocumentWithWatermark.docx"))) {
 
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].Color == Color.Silver);
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].ColorHex == "silver");
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].Text == "Watermark");
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].Height == 131.95);
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].Width == 527.85);
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].Rotation == 90);
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].Stroked == false);
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].AllowInCell == false);
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].Color == Color.Silver);
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].ColorHex == "silver");
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].Text == "Watermark");
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].Height == 131.95);
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].Width == 527.85);
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].Rotation == 90);
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].Stroked == false);
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].AllowInCell == false);
 
-                document.Sections[0].Header.Default.Watermarks[0].Stroked = true;
+                document.Sections[0].Header!.Default.Watermarks[0].Stroked = true;
 
                 // let's add first headers and footers to section 2 so we can add watermark to it
                 document.Sections[2].AddHeadersAndFooters();
-                var watermark = document.Sections[2].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Check me");
+                var watermark = document.Sections[2].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Check me");
                 watermark.Rotation = 180;
 
-                Assert.True(document.Sections[2].Header.Default.Watermarks[0].Color == Color.Silver);
-                Assert.True(document.Sections[2].Header.Default.Watermarks[0].ColorHex == "silver");
-                Assert.True(document.Sections[2].Header.Default.Watermarks[0].Text == "Check me");
-                Assert.True(document.Sections[2].Header.Default.Watermarks[0].Height == 131.95);
-                Assert.True(document.Sections[2].Header.Default.Watermarks[0].Width == 527.85);
-                Assert.True(document.Sections[2].Header.Default.Watermarks[0].Rotation == 180);
-                Assert.True(document.Sections[2].Header.Default.Watermarks[0].Stroked == false);
+                Assert.True(document.Sections[2].Header!.Default.Watermarks[0].Color == Color.Silver);
+                Assert.True(document.Sections[2].Header!.Default.Watermarks[0].ColorHex == "silver");
+                Assert.True(document.Sections[2].Header!.Default.Watermarks[0].Text == "Check me");
+                Assert.True(document.Sections[2].Header!.Default.Watermarks[0].Height == 131.95);
+                Assert.True(document.Sections[2].Header!.Default.Watermarks[0].Width == 527.85);
+                Assert.True(document.Sections[2].Header!.Default.Watermarks[0].Rotation == 180);
+                Assert.True(document.Sections[2].Header!.Default.Watermarks[0].Stroked == false);
 
                 document.Save();
             }
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_CreatingWordDocumentWithWatermark.docx"))) {
 
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].Color == Color.Silver);
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].ColorHex == "silver");
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].Text == "Watermark");
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].Height == 131.95);
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].Width == 527.85);
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].Rotation == 90);
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].Stroked == true);
-                Assert.True(document.Sections[0].Header.Default.Watermarks[0].AllowInCell == false);
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].Color == Color.Silver);
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].ColorHex == "silver");
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].Text == "Watermark");
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].Height == 131.95);
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].Width == 527.85);
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].Rotation == 90);
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].Stroked == true);
+                Assert.True(document.Sections[0].Header!.Default.Watermarks[0].AllowInCell == false);
 
                 Assert.True(document.Watermarks.Count == 3);
-                Assert.True(document.Header.Default.Watermarks.Count == 1); // this is actually first section's header.default
-                Assert.True(document.Sections[0].Header.Default.Watermarks.Count == 1);
-                Assert.True(document.Sections[1].Header.Default.Watermarks.Count == 1);
-                Assert.True(document.Sections[2].Header.Default.Watermarks.Count == 1);
+                Assert.True(document.Header!.Default.Watermarks.Count == 1); // this is actually first section's header.default
+                Assert.True(document.Sections[0].Header!.Default.Watermarks.Count == 1);
+                Assert.True(document.Sections[1].Header!.Default.Watermarks.Count == 1);
+                Assert.True(document.Sections[2].Header!.Default.Watermarks.Count == 1);
 
                 document.Save();
             }
@@ -105,27 +105,27 @@ namespace OfficeIMO.Tests {
                 document.AddParagraph("Section 0");
 
                 document.AddHeadersAndFooters();
-                document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Watermark");
+                document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Watermark");
 
                 document.AddSection();
                 document.Sections[1].AddHeadersAndFooters();
-                document.Sections[1].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Draft");
+                document.Sections[1].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Draft");
                 document.Settings.SetBackgroundColor(Color.Azure);
                 document.AddSection();
 
                 Assert.True(document.Watermarks.Count == 2);
-                Assert.True(document.Header.Default.Watermarks.Count == 1); // this is actually first section's header.default
-                Assert.True(document.Sections[0].Header.Default.Watermarks.Count == 1);
-                Assert.True(document.Sections[1].Header.Default.Watermarks.Count == 1);
+                Assert.True(document.Header!.Default.Watermarks.Count == 1); // this is actually first section's header.default
+                Assert.True(document.Sections[0].Header!.Default.Watermarks.Count == 1);
+                Assert.True(document.Sections[1].Header!.Default.Watermarks.Count == 1);
 
                 document.Save();
             }
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "Test_CreatingWordDocumentWithWatermark2.docx"))) {
                 Assert.True(document.Watermarks.Count == 2);
-                Assert.True(document.Header.Default.Watermarks.Count == 1); // this is actually first section's header.default
-                Assert.True(document.Sections[0].Header.Default.Watermarks.Count == 1);
-                Assert.True(document.Sections[1].Header.Default.Watermarks.Count == 1);
+                Assert.True(document.Header!.Default.Watermarks.Count == 1); // this is actually first section's header.default
+                Assert.True(document.Sections[0].Header!.Default.Watermarks.Count == 1);
+                Assert.True(document.Sections[1].Header!.Default.Watermarks.Count == 1);
 
                 document.Save();
             }
@@ -207,9 +207,9 @@ namespace OfficeIMO.Tests {
                 document.DifferentFirstPage = true;
                 document.DifferentOddAndEvenPages = true;
 
-                document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Default");
-                document.Sections[0].Header.First.AddWatermark(WordWatermarkStyle.Text, "First");
-                document.Sections[0].Header.Even.AddWatermark(WordWatermarkStyle.Text, "Even");
+                document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Default");
+                document.Sections[0].Header!.First.AddWatermark(WordWatermarkStyle.Text, "First");
+                document.Sections[0].Header!.Even.AddWatermark(WordWatermarkStyle.Text, "Even");
 
                 Assert.True(document.Sections[0].Watermarks.Count == 3);
 
@@ -218,9 +218,9 @@ namespace OfficeIMO.Tests {
                 }
 
                 Assert.True(document.Sections[0].Watermarks.Count == 0);
-                Assert.True(document.Sections[0].Header.Default.Watermarks.Count == 0);
-                Assert.True(document.Sections[0].Header.First.Watermarks.Count == 0);
-                Assert.True(document.Sections[0].Header.Even.Watermarks.Count == 0);
+                Assert.True(document.Sections[0].Header!.Default.Watermarks.Count == 0);
+                Assert.True(document.Sections[0].Header!.First.Watermarks.Count == 0);
+                Assert.True(document.Sections[0].Header!.Even.Watermarks.Count == 0);
             }
         }
 
@@ -231,13 +231,13 @@ namespace OfficeIMO.Tests {
                 document.AddParagraph("Test");
                 document.AddHeadersAndFooters();
                 var imagePath = Path.Combine(_directoryWithImages, "Kulek.jpg");
-                document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Image, imagePath);
+                document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Image, imagePath);
                 document.Save();
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.True(document.Watermarks.Count == 1);
-                Assert.True(document.Sections[0].Header.Default.Watermarks.Count == 1);
+                Assert.True(document.Sections[0].Header!.Default.Watermarks.Count == 1);
             }
         }
 
@@ -248,14 +248,14 @@ namespace OfficeIMO.Tests {
                 document.AddParagraph("Test");
                 document.AddHeadersAndFooters();
                 var imagePath = Path.Combine(_directoryWithImages, "Kulek.jpg");
-                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Image, imagePath);
+                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Image, imagePath);
                 Assert.True(watermark.Width > 0);
                 Assert.True(watermark.Height > 0);
                 document.Save();
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var watermark = document.Sections[0].Header.Default.Watermarks[0];
+                var watermark = document.Sections[0].Header!.Default.Watermarks[0];
                 Assert.True(watermark.Width > 0);
                 Assert.True(watermark.Height > 0);
             }
@@ -267,7 +267,7 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddParagraph("Test");
                 document.AddHeadersAndFooters();
-                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Offset", 10, 20, 2.0);
+                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Offset", 10, 20, 2.0);
                 Assert.Equal(10, watermark.HorizontalOffset);
                 Assert.Equal(20, watermark.VerticalOffset);
                 Assert.True(watermark.Width > 0);
@@ -276,7 +276,7 @@ namespace OfficeIMO.Tests {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var watermark = document.Sections[0].Header.Default.Watermarks[0];
+                var watermark = document.Sections[0].Header!.Default.Watermarks[0];
                 Assert.Equal(10, watermark.HorizontalOffset);
                 Assert.Equal(20, watermark.VerticalOffset);
                 Assert.True(watermark.Width > 0);
@@ -289,13 +289,13 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "Test_WatermarkColorSupportsHex.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Hex");
+                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Hex");
                 watermark.Color = Color.Red;
                 document.Save();
             }
 
             using (WordprocessingDocument wordDoc = WordprocessingDocument.Open(filePath, false)) {
-                var fill = wordDoc.MainDocumentPart!.HeaderParts.First().Header.Descendants<V.Shape>().First().FillColor?.Value;
+                var fill = wordDoc.MainDocumentPart!.HeaderParts.First().Header!.Descendants<V.Shape>().First().FillColor?.Value;
                 Assert.True(fill == "#ff0000");
             }
 
@@ -311,7 +311,7 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "Test_WatermarkColorSupportsUppercaseHexWithHash.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Upper");
+                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Upper");
                 watermark.ColorHex = "#FF00FF";
                 document.Save();
             }
@@ -330,58 +330,58 @@ namespace OfficeIMO.Tests {
                 document.AddHeadersAndFooters();
 
                 // SixLabors colors
-                var red = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Red");
+                var red = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Red");
                 red.Color = Color.Red;
 
                 document.AddSection();
                 document.Sections[1].AddHeadersAndFooters();
-                var green = document.Sections[1].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Green");
+                var green = document.Sections[1].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Green");
                 green.Color = Color.Green;
 
                 document.AddSection();
                 document.Sections[2].AddHeadersAndFooters();
-                var blue = document.Sections[2].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Blue");
+                var blue = document.Sections[2].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Blue");
                 blue.Color = Color.Blue;
 
                 // Hex without '#'
                 document.AddSection();
                 document.Sections[3].AddHeadersAndFooters();
-                var magenta = document.Sections[3].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Magenta");
+                var magenta = document.Sections[3].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Magenta");
                 magenta.ColorHex = "ff00ff";
 
                 // Hex with '#'
                 document.AddSection();
                 document.Sections[4].AddHeadersAndFooters();
-                var cyan = document.Sections[4].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Cyan");
+                var cyan = document.Sections[4].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Cyan");
                 cyan.ColorHex = "#00ffff";
 
                 // Named color string
                 document.AddSection();
                 document.Sections[5].AddHeadersAndFooters();
-                var yellow = document.Sections[5].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Yellow");
+                var yellow = document.Sections[5].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Yellow");
                 yellow.ColorHex = "yellow";
 
                 document.Save();
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Equal("ff0000", document.Sections[0].Header.Default.Watermarks[0].ColorHex);
-                Assert.Equal(Color.Red, document.Sections[0].Header.Default.Watermarks[0].Color);
+                Assert.Equal("ff0000", document.Sections[0].Header!.Default.Watermarks[0].ColorHex);
+                Assert.Equal(Color.Red, document.Sections[0].Header!.Default.Watermarks[0].Color);
 
-                Assert.Equal("008000", document.Sections[1].Header.Default.Watermarks[0].ColorHex);
-                Assert.Equal(Color.Green, document.Sections[1].Header.Default.Watermarks[0].Color);
+                Assert.Equal("008000", document.Sections[1].Header!.Default.Watermarks[0].ColorHex);
+                Assert.Equal(Color.Green, document.Sections[1].Header!.Default.Watermarks[0].Color);
 
-                Assert.Equal("0000ff", document.Sections[2].Header.Default.Watermarks[0].ColorHex);
-                Assert.Equal(Color.Blue, document.Sections[2].Header.Default.Watermarks[0].Color);
+                Assert.Equal("0000ff", document.Sections[2].Header!.Default.Watermarks[0].ColorHex);
+                Assert.Equal(Color.Blue, document.Sections[2].Header!.Default.Watermarks[0].Color);
 
-                Assert.Equal("ff00ff", document.Sections[3].Header.Default.Watermarks[0].ColorHex);
-                Assert.Equal(Color.Magenta, document.Sections[3].Header.Default.Watermarks[0].Color);
+                Assert.Equal("ff00ff", document.Sections[3].Header!.Default.Watermarks[0].ColorHex);
+                Assert.Equal(Color.Magenta, document.Sections[3].Header!.Default.Watermarks[0].Color);
 
-                Assert.Equal("00ffff", document.Sections[4].Header.Default.Watermarks[0].ColorHex);
-                Assert.Equal(Color.Cyan, document.Sections[4].Header.Default.Watermarks[0].Color);
+                Assert.Equal("00ffff", document.Sections[4].Header!.Default.Watermarks[0].ColorHex);
+                Assert.Equal(Color.Cyan, document.Sections[4].Header!.Default.Watermarks[0].Color);
 
-                Assert.Equal("ffff00", document.Sections[5].Header.Default.Watermarks[0].ColorHex);
-                Assert.Equal(Color.Yellow, document.Sections[5].Header.Default.Watermarks[0].Color);
+                Assert.Equal("ffff00", document.Sections[5].Header!.Default.Watermarks[0].ColorHex);
+                Assert.Equal(Color.Yellow, document.Sections[5].Header!.Default.Watermarks[0].Color);
             }
         }
 
@@ -396,20 +396,20 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Color");
+                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Color");
                 watermark.ColorHex = input;
                 document.Save();
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                var watermark = document.Sections[0].Header.Default.Watermarks[0];
+                var watermark = document.Sections[0].Header!.Default.Watermarks[0];
                 Assert.Equal(expectedHex, watermark.ColorHex);
                 Assert.Equal(Color.Parse(expectedHex), watermark.Color);
             }
 
             using (WordprocessingDocument wordDoc = WordprocessingDocument.Open(filePath, false)) {
                 var headerPart = wordDoc.MainDocumentPart!.HeaderParts.First();
-                var shape = headerPart.Header.Descendants<V.Shape>().First();
+                var shape = headerPart.Header!.Descendants<V.Shape>().First();
                 var fill = shape.GetFirstChild<V.Fill>();
                 var textPath = shape.GetFirstChild<V.TextPath>();
 
@@ -427,7 +427,7 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "Test_WatermarkInvalidColorThrows.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Invalid");
+                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Invalid");
                 Assert.Throws<ArgumentException>(() => watermark.ColorHex = "notacolor");
             }
         }
@@ -437,7 +437,7 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "Test_WatermarkEmptyColorThrows.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var watermark = document.Sections[0].Header.Default.AddWatermark(WordWatermarkStyle.Text, "Invalid");
+                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Invalid");
                 Assert.Throws<ArgumentException>(() => watermark.ColorHex = "");
             }
         }

--- a/OfficeIMO.VerifyTests/Word/AdvancedDocumentTests.cs
+++ b/OfficeIMO.VerifyTests/Word/AdvancedDocumentTests.cs
@@ -98,7 +98,7 @@ public class AdvancedDocumentTests : VerifyTestBase {
         document.AddHeadersAndFooters();
 
         // adding text to default header
-        document.Header.Default.AddParagraph("Text added to header - Default");
+        document.Header!.Default.AddParagraph("Text added to header - Default");
 
         var section1 = document.AddSection();
         section1.PageOrientation = PageOrientationValues.Portrait;
@@ -111,7 +111,7 @@ public class AdvancedDocumentTests : VerifyTestBase {
         document.CustomDocumentProperties.Add("IsTodayGreatDay", new WordCustomProperty(true));
 
         // add page numbers
-        document.Footer.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+        document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
 
         // add watermark
         document.Sections[0].AddWatermark(WordWatermarkStyle.Text, "Draft");

--- a/OfficeIMO.VerifyTests/Word/ImageRemoveTests.cs
+++ b/OfficeIMO.VerifyTests/Word/ImageRemoveTests.cs
@@ -28,16 +28,16 @@ public class ImageRemoveTests : VerifyTestBase {
         stream.Position = 0;
         using var document = WordDocument.Create();
         document.AddHeadersAndFooters();
-        var paragraph = document.Header.Default.AddParagraph();
+        var paragraph = document.Header!.Default.AddParagraph();
         paragraph.AddImage(stream, "tiny.png", 50, 50);
 
-        Assert.Single(document.Header.Default.Images);
+        Assert.Single(document.Header!.Default.Images);
         var headerPart = document._wordprocessingDocument.MainDocumentPart!.HeaderParts.First();
         Assert.Single(headerPart.ImageParts);
 
-        document.Header.Default.Images[0].Remove();
+        document.Header!.Default.Images[0].Remove();
 
-        Assert.Empty(document.Header.Default.Images);
+        Assert.Empty(document.Header!.Default.Images);
         Assert.Empty(headerPart.ImageParts);
 
         document.Save();


### PR DESCRIPTION
## Summary
- ensure Word samples log and access headers/footers without nullable warnings
- update tests and verify fixtures to guard Word document usage and address remaining nullability diagnostics
- guard Markdown CSS scoping with a fallback selector to silence the remaining warning

## Testing
- dotnet build -t:Rebuild


------
https://chatgpt.com/codex/tasks/task_e_68ca7abf9700832e9e517abeb2ced2b5