### PR TITLE
fix(WordDocument): 🐛 ensure style overrides are applied after documen…

### DIFF
--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1266,6 +1266,10 @@ namespace OfficeIMO.Word {
                 word._wordprocessingDocument = wordDocument;
                     word._document = wordDocument.MainDocumentPart!.Document;
                 word.LoadDocument();
+                if (applyOverrideStyles) {
+                    // Ensure overrides are applied after any document initialization that may touch styles
+                    InitialiseStyleDefinitions(wordDocument, readOnly, applyOverrideStyles);
+                }
                 WordChart.InitializeAxisIdSeed(wordDocument);
                 WordChart.InitializeDocPrIdSeed(wordDocument);
 
@@ -1313,6 +1317,9 @@ namespace OfficeIMO.Word {
             bool applyOverrideStyles = overrideStyles && !readOnly;
             InitialiseStyleDefinitions(wordDocument, readOnly, applyOverrideStyles);
             word.LoadDocument();
+            if (applyOverrideStyles) {
+                InitialiseStyleDefinitions(wordDocument, readOnly, applyOverrideStyles);
+            }
             WordChart.InitializeAxisIdSeed(wordDocument);
             WordChart.InitializeDocPrIdSeed(wordDocument);
             WordListStyles.InitializeAbstractNumberId(word._wordprocessingDocument);
@@ -1343,6 +1350,9 @@ namespace OfficeIMO.Word {
             document._wordprocessingDocument = wordDocument;
             document._document = wordDocument.MainDocumentPart!.Document;
             document.LoadDocument();
+            if (applyOverrideStyles) {
+                InitialiseStyleDefinitions(wordDocument, readOnly, applyOverrideStyles);
+            }
             WordChart.InitializeAxisIdSeed(wordDocument);
             WordChart.InitializeDocPrIdSeed(wordDocument);
 


### PR DESCRIPTION
…t initialization

* Updated `InitialiseStyleDefinitions` calls to ensure style overrides are applied correctly.
* This change addresses potential issues with style definitions not being updated as expected during document loading.