### PR TITLE
Synchronize Word tests to avoid parallel custom style interference

### DIFF
--- a/OfficeIMO.Tests/Markdown.MoreCases.cs
+++ b/OfficeIMO.Tests/Markdown.MoreCases.cs
@@ -6,6 +6,7 @@ using OfficeIMO.Word.Markdown;
 using Xunit;
 
 namespace OfficeIMO.Tests {
+    [Collection("WordTests")]
     public class MarkdownMoreCasesTests : Word {
         [Fact]
         public void ReferenceStyleLinks_WithAngleBrackets_AndTitle() {

--- a/OfficeIMO.Tests/Markdown.RoundTrip.cs
+++ b/OfficeIMO.Tests/Markdown.RoundTrip.cs
@@ -6,6 +6,7 @@ using OfficeIMO.Word.Fluent;
 using Xunit;
 
 namespace OfficeIMO.Tests {
+    [Collection("WordTests")]
     public class MarkdownRoundTripTests : Word {
         [Fact]
         public void Markdown_To_Word_To_Markdown_RoundTrip_Preserves_CoreFeatures() {

--- a/OfficeIMO.Tests/Word.cs
+++ b/OfficeIMO.Tests/Word.cs
@@ -11,6 +11,7 @@ using OfficeIMO.Word;
 using Xunit;
 
 namespace OfficeIMO.Tests {
+    [Collection("WordTests")]
     public partial class Word {
         private readonly string _directoryDocuments;
         private readonly string _directoryWithFiles;

--- a/OfficeIMO.Tests/WordTestsCollection.cs
+++ b/OfficeIMO.Tests/WordTestsCollection.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    [CollectionDefinition("WordTests", DisableParallelization = true)]
+    public sealed class WordTestsCollection { }
+}


### PR DESCRIPTION
## Summary
- group all Word-based tests into a shared xUnit collection to run serially
- disable parallel execution for that collection to prevent shared custom-style state from racing

## Testing
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68caed9c7984832e82be7f7ac65cfef7