### PR TITLE
Clarify zero-based table removal XML doc comments

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointTable.cs
+++ b/OfficeIMO.PowerPoint/PowerPointTable.cs
@@ -62,6 +62,7 @@ namespace OfficeIMO.PowerPoint {
         /// <summary>
         ///     Removes a row at the specified index.
         /// </summary>
+        /// <param name="index">Zero-based index of the row to remove.</param>
         public void RemoveRow(int index) {
             A.Table table = Frame.Graphic!.GraphicData!.GetFirstChild<A.Table>()!;
             A.TableRow row = table.Elements<A.TableRow>().ElementAt(index);
@@ -103,6 +104,7 @@ namespace OfficeIMO.PowerPoint {
         /// <summary>
         ///     Removes a column at the specified index.
         /// </summary>
+        /// <param name="index">Zero-based index of the column to remove.</param>
         public void RemoveColumn(int index) {
             A.Table table = Frame.Graphic!.GraphicData!.GetFirstChild<A.Table>()!;
             A.TableGrid grid = table.TableGrid!;


### PR DESCRIPTION
## Summary
- Clarify the XML documentation for `PowerPointTable.RemoveRow` and `PowerPointTable.RemoveColumn` to indicate their zero-based index parameters.

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68caf5a83dd8832e8b73e12763478d04