### PR TITLE
Add XML docs for ColumnStyleByHeader parameters

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.Headers.Style.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.Style.cs
@@ -14,6 +14,9 @@ namespace OfficeIMO.Excel
         /// <summary>
         /// Returns a builder for styling a column resolved by header with discoverable methods.
         /// </summary>
+        /// <param name="header">Header text used to resolve the target column after applying any configured normalization.</param>
+        /// <param name="includeHeader">True to include the header row when styling; false to begin styling from the first data row.</param>
+        /// <param name="options">Read options that control header normalization and other resolution behavior.</param>
         public ColumnStyleByHeaderBuilder ColumnStyleByHeader(string header, bool includeHeader = false, ExcelReadOptions? options = null)
         {
             int colIndex = ColumnIndexByHeader(header, options);


### PR DESCRIPTION
## Summary
- document the parameters of `ColumnStyleByHeader` to explain header normalization and header row inclusion behavior

## Testing
- dotnet build OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68caf6f9a448832e8aa76a73219fee66