### PR TITLE
Adjust CSS scoping null checks

### DIFF
--- a/OfficeIMO.Markdown/Utilities/AssetFactory.cs
+++ b/OfficeIMO.Markdown/Utilities/AssetFactory.cs
@@ -30,7 +30,7 @@ internal static class AssetFactory {
                 yield return new HtmlAsset($"prism-theme:{po.Theme}", HtmlAssetKind.Css, themeCss, null);
             } else {
                 var css = HtmlRenderer.TryDownloadText(themeCss);
-                if (!string.IsNullOrEmpty(css)) css = HtmlRenderer.ScopeCss(css!, scopeSelector);
+                if (!string.IsNullOrEmpty(css)) css = HtmlRenderer.ScopeCss(css, scopeSelector);
                 yield return new HtmlAsset($"prism-theme:{po.Theme}", HtmlAssetKind.Css, null, css);
             }
         }

--- a/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
+++ b/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
@@ -498,11 +498,11 @@ internal static class HtmlRenderer {
     }
 
     internal static string ScopeCss(string? css, string? scopeSelector) {
-        if (string.IsNullOrEmpty(css)) return string.Empty;
+        string? cssText = css;
+        if (string.IsNullOrEmpty(cssText)) return string.Empty;
         var scope = NormalizeScope(scopeSelector);
         // Naive scoping: prefix common selectors with the scope to avoid global bleed.
         // This is intentionally conservative.
-        var cssText = css!; // guarded by IsNullOrEmpty above
         var s = cssText.Replace("code[class*=\"language-\"]", scope + " code[class*=\\\"language-\\\"]")
                    .Replace("pre[class*=\"language-\"]", scope + " pre[class*=\\\"language-\\\"]")
                    .Replace("pre[class*=\"language-\"] code", scope + " pre[class*=\\\"language-\\\"] code");


### PR DESCRIPTION
## Summary
- update HtmlRenderer.ScopeCss to store the nullable CSS input and return early for empty values
- remove the downstream null-forgiving operator when scoping downloaded theme CSS

## Testing
- dotnet build OfficeIMO.Markdown/OfficeIMO.Markdown.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cb0edd7484832e81850a5de7af0ea0