### PR TITLE
Capture header and footer asserts in Verify tests

### DIFF
--- a/OfficeIMO.VerifyTests/TestAssert.cs
+++ b/OfficeIMO.VerifyTests/TestAssert.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace OfficeIMO.VerifyTests;
+
+internal static class TestAssert {
+    public static T NotNull<T>(T? value) where T : class {
+        global::Xunit.Assert.NotNull(value);
+        return value!;
+    }
+
+    public static T IsType<T>(object? value) {
+        return global::Xunit.Assert.IsType<T>(value);
+    }
+
+    public static void Single<T>(IEnumerable<T> collection) {
+        global::Xunit.Assert.Single(collection);
+    }
+
+    public static void Single(IEnumerable collection) {
+        global::Xunit.Assert.Single(collection);
+    }
+
+    public static void Empty<T>(IEnumerable<T> collection) {
+        global::Xunit.Assert.Empty(collection);
+    }
+
+    public static void Empty(IEnumerable collection) {
+        global::Xunit.Assert.Empty(collection);
+    }
+}

--- a/OfficeIMO.VerifyTests/Word/AdvancedDocumentTests.cs
+++ b/OfficeIMO.VerifyTests/Word/AdvancedDocumentTests.cs
@@ -5,6 +5,7 @@ using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using VerifyXunit;
 using Xunit;
+using Assert = OfficeIMO.VerifyTests.TestAssert;
 
 using Color = SixLabors.ImageSharp.Color;
 
@@ -98,7 +99,9 @@ public class AdvancedDocumentTests : VerifyTestBase {
         document.AddHeadersAndFooters();
 
         // adding text to default header
-        document.Header!.Default.AddParagraph("Text added to header - Default");
+        var headers = Assert.NotNull(document.Header);
+        var defaultHeader = Assert.IsType<WordHeader>(headers.Default);
+        defaultHeader.AddParagraph("Text added to header - Default");
 
         var section1 = document.AddSection();
         section1.PageOrientation = PageOrientationValues.Portrait;
@@ -111,7 +114,9 @@ public class AdvancedDocumentTests : VerifyTestBase {
         document.CustomDocumentProperties.Add("IsTodayGreatDay", new WordCustomProperty(true));
 
         // add page numbers
-        document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+        var footers = Assert.NotNull(document.Footer);
+        var defaultFooter = Assert.IsType<WordFooter>(footers.Default);
+        defaultFooter.AddPageNumber(WordPageNumberStyle.PlainNumber);
 
         // add watermark
         document.Sections[0].AddWatermark(WordWatermarkStyle.Text, "Draft");

--- a/OfficeIMO.VerifyTests/Word/ImageRemoveTests.cs
+++ b/OfficeIMO.VerifyTests/Word/ImageRemoveTests.cs
@@ -7,6 +7,7 @@ using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Word;
 using VerifyXunit;
 using Xunit;
+using Assert = OfficeIMO.VerifyTests.TestAssert;
 
 namespace OfficeIMO.VerifyTests.Word;
 
@@ -28,16 +29,18 @@ public class ImageRemoveTests : VerifyTestBase {
         stream.Position = 0;
         using var document = WordDocument.Create();
         document.AddHeadersAndFooters();
-        var paragraph = document.Header!.Default.AddParagraph();
+        var headers = Assert.NotNull(document.Header);
+        var defaultHeader = Assert.IsType<WordHeader>(headers.Default);
+        var paragraph = defaultHeader.AddParagraph();
         paragraph.AddImage(stream, "tiny.png", 50, 50);
 
-        Assert.Single(document.Header!.Default.Images);
+        Assert.Single(defaultHeader.Images);
         var headerPart = document._wordprocessingDocument.MainDocumentPart!.HeaderParts.First();
         Assert.Single(headerPart.ImageParts);
 
-        document.Header!.Default.Images[0].Remove();
+        defaultHeader.Images[0].Remove();
 
-        Assert.Empty(document.Header!.Default.Images);
+        Assert.Empty(defaultHeader.Images);
         Assert.Empty(headerPart.ImageParts);
 
         document.Save();


### PR DESCRIPTION
## Summary
- add a reusable TestAssert wrapper so tests can capture NotNull results while reusing xUnit assertions
- update Word Verify tests to store header and footer references via Assert.NotNull/Assert.IsType before use

## Testing
- `dotnet test OfficeIMO.VerifyTests/OfficeIMO.VerifyTests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68cb0ee23d8c832e89cbd01c126863d5