### PR TITLE
Add header/footer guard assertions to tests

### DIFF
--- a/OfficeIMO.Tests/Word.Fluent.HeadersFooters.cs
+++ b/OfficeIMO.Tests/Word.Fluent.HeadersFooters.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
@@ -35,20 +36,52 @@ namespace OfficeIMO.Tests {
             using var loaded = WordDocument.Load(filePath);
             Assert.Equal(2, loaded.Sections.Count);
 
-            var defaultHeader = loaded.Sections[1].Header!.Default;
-            Assert.Equal(3, defaultHeader.Paragraphs.Count);
+            var sectionHeaders = Assert.NotNull(loaded.Sections[1].Header);
+            WordHeader GetHeader(Func<WordHeaders, WordHeader?> selector) {
+                return Assert.IsType<WordHeader>(Assert.NotNull(selector(sectionHeaders)));
+            }
+
+            var defaultHeader = GetHeader(h => h.Default);
+            var defaultHeaderParagraphs = defaultHeader.Paragraphs;
+            Assert.Equal(3, defaultHeaderParagraphs.Count);
             Assert.Single(defaultHeader.Tables);
             Assert.Single(defaultHeader.ParagraphsImages);
 
-            Assert.Equal("First header", loaded.Sections[1].Header!.First.Paragraphs[0].Text);
-            Assert.Equal("Even header", loaded.Sections[1].Header!.Even.Paragraphs[0].Text);
+            var firstHeader = GetHeader(h => h.First);
+            var firstHeaderParagraphs = firstHeader.Paragraphs;
+            Assert.NotEmpty(firstHeaderParagraphs);
+            Assert.Equal("First header", firstHeaderParagraphs[0].Text);
 
-            Assert.Equal("Default footer", loaded.Sections[1].Footer!.Default.Paragraphs[0].Text);
-            Assert.Equal("First footer", loaded.Sections[1].Footer!.First.Paragraphs[0].Text);
-            Assert.Equal("Even footer", loaded.Sections[1].Footer!.Even.Paragraphs[0].Text);
+            var evenHeader = GetHeader(h => h.Even);
+            var evenHeaderParagraphs = evenHeader.Paragraphs;
+            Assert.NotEmpty(evenHeaderParagraphs);
+            Assert.Equal("Even header", evenHeaderParagraphs[0].Text);
 
-            Assert.Null(loaded.Sections[0].Header!.Default);
-            Assert.Null(loaded.Sections[0].Footer!.Default);
+            var sectionFooters = Assert.NotNull(loaded.Sections[1].Footer);
+            WordFooter GetFooter(Func<WordFooters, WordFooter?> selector) {
+                return Assert.IsType<WordFooter>(Assert.NotNull(selector(sectionFooters)));
+            }
+
+            var defaultFooter = GetFooter(f => f.Default);
+            var defaultFooterParagraphs = defaultFooter.Paragraphs;
+            Assert.NotEmpty(defaultFooterParagraphs);
+            Assert.Equal("Default footer", defaultFooterParagraphs[0].Text);
+
+            var firstFooter = GetFooter(f => f.First);
+            var firstFooterParagraphs = firstFooter.Paragraphs;
+            Assert.NotEmpty(firstFooterParagraphs);
+            Assert.Equal("First footer", firstFooterParagraphs[0].Text);
+
+            var evenFooter = GetFooter(f => f.Even);
+            var evenFooterParagraphs = evenFooter.Paragraphs;
+            Assert.NotEmpty(evenFooterParagraphs);
+            Assert.Equal("Even footer", evenFooterParagraphs[0].Text);
+
+            var firstSectionHeaders = Assert.NotNull(loaded.Sections[0].Header);
+            Assert.Null(firstSectionHeaders.Default);
+
+            var firstSectionFooters = Assert.NotNull(loaded.Sections[0].Footer);
+            Assert.Null(firstSectionFooters.Default);
         }
     }
 }

--- a/OfficeIMO.Tests/Word.RemoveSpecificHeadersFooters.cs
+++ b/OfficeIMO.Tests/Word.RemoveSpecificHeadersFooters.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
@@ -16,12 +17,14 @@ namespace OfficeIMO.Tests {
                 document.DifferentOddAndEvenPages = true;
                 document.DifferentFirstPage = true;
 
-                document.Header!.Default.AddParagraph().SetText("Default Header");
-                document.Footer!.Default.AddParagraph().SetText("Default Footer");
-                document.Header!.Even.AddParagraph().SetText("Even Header");
-                document.Footer!.Even.AddParagraph().SetText("Even Footer");
-                document.Header!.First.AddParagraph().SetText("First Header");
-                document.Footer!.First.AddParagraph().SetText("First Footer");
+                var (defaultHeader, defaultFooter, evenHeader, evenFooter, firstHeader, firstFooter) = RequireHeaderFooterVariants(document);
+
+                defaultHeader.AddParagraph().SetText("Default Header");
+                defaultFooter.AddParagraph().SetText("Default Footer");
+                evenHeader.AddParagraph().SetText("Even Header");
+                evenFooter.AddParagraph().SetText("Even Footer");
+                firstHeader.AddParagraph().SetText("First Header");
+                firstFooter.AddParagraph().SetText("First Footer");
 
                 document.Save(false);
             }
@@ -29,12 +32,14 @@ namespace OfficeIMO.Tests {
             WordHelpers.RemoveHeadersAndFooters(filePath, HeaderFooterValues.Default);
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Null(document.Header!.Default);
-                Assert.Null(document.Footer!.Default);
-                Assert.NotNull(document.Header!.First);
-                Assert.NotNull(document.Footer!.First);
-                Assert.NotNull(document.Header!.Even);
-                Assert.NotNull(document.Footer!.Even);
+                var headers = Assert.NotNull(document.Header);
+                var footers = Assert.NotNull(document.Footer);
+                Assert.Null(headers.Default);
+                Assert.Null(footers.Default);
+                Assert.NotNull(headers.First);
+                Assert.NotNull(footers.First);
+                Assert.NotNull(headers.Even);
+                Assert.NotNull(footers.Even);
             }
         }
 
@@ -46,12 +51,14 @@ namespace OfficeIMO.Tests {
                 document.DifferentOddAndEvenPages = true;
                 document.DifferentFirstPage = true;
 
-                document.Header!.Default.AddParagraph().SetText("Default Header");
-                document.Footer!.Default.AddParagraph().SetText("Default Footer");
-                document.Header!.Even.AddParagraph().SetText("Even Header");
-                document.Footer!.Even.AddParagraph().SetText("Even Footer");
-                document.Header!.First.AddParagraph().SetText("First Header");
-                document.Footer!.First.AddParagraph().SetText("First Footer");
+                var (defaultHeader, defaultFooter, evenHeader, evenFooter, firstHeader, firstFooter) = RequireHeaderFooterVariants(document);
+
+                defaultHeader.AddParagraph().SetText("Default Header");
+                defaultFooter.AddParagraph().SetText("Default Footer");
+                evenHeader.AddParagraph().SetText("Even Header");
+                evenFooter.AddParagraph().SetText("Even Footer");
+                firstHeader.AddParagraph().SetText("First Header");
+                firstFooter.AddParagraph().SetText("First Footer");
 
                 document.Save(false);
             }
@@ -59,12 +66,14 @@ namespace OfficeIMO.Tests {
             WordHelpers.RemoveHeadersAndFooters(filePath, HeaderFooterValues.Even);
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Null(document.Header!.Even);
-                Assert.Null(document.Footer!.Even);
-                Assert.NotNull(document.Header!.First);
-                Assert.NotNull(document.Footer!.First);
-                Assert.NotNull(document.Header!.Default);
-                Assert.NotNull(document.Footer!.Default);
+                var headers = Assert.NotNull(document.Header);
+                var footers = Assert.NotNull(document.Footer);
+                Assert.Null(headers.Even);
+                Assert.Null(footers.Even);
+                Assert.NotNull(headers.First);
+                Assert.NotNull(footers.First);
+                Assert.NotNull(headers.Default);
+                Assert.NotNull(footers.Default);
             }
         }
 
@@ -76,12 +85,14 @@ namespace OfficeIMO.Tests {
                 document.DifferentOddAndEvenPages = true;
                 document.DifferentFirstPage = true;
 
-                document.Header!.Default.AddParagraph().SetText("Default Header");
-                document.Footer!.Default.AddParagraph().SetText("Default Footer");
-                document.Header!.Even.AddParagraph().SetText("Even Header");
-                document.Footer!.Even.AddParagraph().SetText("Even Footer");
-                document.Header!.First.AddParagraph().SetText("First Header");
-                document.Footer!.First.AddParagraph().SetText("First Footer");
+                var (defaultHeader, defaultFooter, evenHeader, evenFooter, firstHeader, firstFooter) = RequireHeaderFooterVariants(document);
+
+                defaultHeader.AddParagraph().SetText("Default Header");
+                defaultFooter.AddParagraph().SetText("Default Footer");
+                evenHeader.AddParagraph().SetText("Even Header");
+                evenFooter.AddParagraph().SetText("Even Footer");
+                firstHeader.AddParagraph().SetText("First Header");
+                firstFooter.AddParagraph().SetText("First Footer");
 
                 document.Save(false);
             }
@@ -89,13 +100,28 @@ namespace OfficeIMO.Tests {
             WordHelpers.RemoveHeadersAndFooters(filePath, HeaderFooterValues.First);
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Null(document.Header!.First);
-                Assert.Null(document.Footer!.First);
-                Assert.NotNull(document.Header!.Even);
-                Assert.NotNull(document.Footer!.Even);
-                Assert.NotNull(document.Header!.Default);
-                Assert.NotNull(document.Footer!.Default);
+                var headers = Assert.NotNull(document.Header);
+                var footers = Assert.NotNull(document.Footer);
+                Assert.Null(headers.First);
+                Assert.Null(footers.First);
+                Assert.NotNull(headers.Even);
+                Assert.NotNull(footers.Even);
+                Assert.NotNull(headers.Default);
+                Assert.NotNull(footers.Default);
             }
+        }
+
+        private static (WordHeader DefaultHeader, WordFooter DefaultFooter, WordHeader EvenHeader, WordFooter EvenFooter, WordHeader FirstHeader, WordFooter FirstFooter) RequireHeaderFooterVariants(WordDocument document) {
+            var headers = Assert.NotNull(document.Header);
+            var footers = Assert.NotNull(document.Footer);
+            return (
+                Assert.IsType<WordHeader>(Assert.NotNull(headers.Default)),
+                Assert.IsType<WordFooter>(Assert.NotNull(footers.Default)),
+                Assert.IsType<WordHeader>(Assert.NotNull(headers.Even)),
+                Assert.IsType<WordFooter>(Assert.NotNull(footers.Even)),
+                Assert.IsType<WordHeader>(Assert.NotNull(headers.First)),
+                Assert.IsType<WordFooter>(Assert.NotNull(footers.First))
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- update fluent header/footer persistence test to verify header variants through local helpers
- consolidate header/footer setup in remove-specific tests with Assert-based helper to avoid null dereferences

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -f net472`


------
https://chatgpt.com/codex/tasks/task_e_68cb0ee8caf8832ebc275f1d63379cbc