### PR TITLE
Guard header and footer usage in header/footer examples

### DIFF
--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example1.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example1.cs
@@ -11,42 +11,95 @@ namespace OfficeIMO.Examples.Word {
         internal static void Example_BasicWordWithHeaderAndFooter0(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating standard document with Headers and Footers");
             string filePath = System.IO.Path.Combine(folderPath, "Basic Document with Headers and Footers Default.docx");
+
+            WordHeaders RequireHeaders(WordHeaders? headers, string description) {
+                if (headers == null) {
+                    throw new InvalidOperationException($"{description} are not available.");
+                }
+
+                return headers;
+            }
+
+            WordHeader RequireHeader(WordHeader? header, string description) {
+                if (header == null) {
+                    throw new InvalidOperationException($"{description} is not available.");
+                }
+
+                return header;
+            }
+
+            WordFooters RequireFooters(WordFooters? footers, string description) {
+                if (footers == null) {
+                    throw new InvalidOperationException($"{description} are not available.");
+                }
+
+                return footers;
+            }
+
+            WordFooter RequireFooter(WordFooter? footer, string description) {
+                if (footer == null) {
+                    throw new InvalidOperationException($"{description} is not available.");
+                }
+
+                return footer;
+            }
+
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
                 document.DifferentOddAndEvenPages = true;
                 document.DifferentFirstPage = true;
 
-                document.Header!.Default.AddParagraph().SetColor(Color.Red).SetText("Test Header");
+                var headers = RequireHeaders(document.Header, "Document headers");
+                var defaultHeader = RequireHeader(headers.Default, "Default header");
+                var evenHeader = RequireHeader(headers.Even, "Even header");
+                var firstHeader = RequireHeader(headers.First, "First header");
 
-                document.Footer!.Default.AddParagraph().SetColor(Color.Blue).SetText("Test Footer");
+                defaultHeader.AddParagraph().SetColor(Color.Red).SetText("Test Header");
 
-                Console.WriteLine("Header Default Count: " + document.Header!.Default.Paragraphs.Count);
-                Console.WriteLine("Header Even Count: " + document.Header!.Even.Paragraphs.Count);
-                Console.WriteLine("Header First Count: " + document.Header!.First.Paragraphs.Count);
+                var footers = RequireFooters(document.Footer, "Document footers");
+                var defaultFooter = RequireFooter(footers.Default, "Default footer");
+                var evenFooter = RequireFooter(footers.Even, "Even footer");
+                var firstFooter = RequireFooter(footers.First, "First footer");
 
-                Console.WriteLine("Header text: " + document.Header!.Default.Paragraphs[0].Text);
+                defaultFooter.AddParagraph().SetColor(Color.Blue).SetText("Test Footer");
 
-                Console.WriteLine("Footer Default Count: " + document.Footer!.Default.Paragraphs.Count);
-                Console.WriteLine("Footer Even Count: " + document.Footer!.Even.Paragraphs.Count);
-                Console.WriteLine("Footer First Count: " + document.Footer!.First.Paragraphs.Count);
+                Console.WriteLine("Header Default Count: " + defaultHeader.Paragraphs.Count);
+                Console.WriteLine("Header Even Count: " + evenHeader.Paragraphs.Count);
+                Console.WriteLine("Header First Count: " + firstHeader.Paragraphs.Count);
 
-                Console.WriteLine("Footer text: " + document.Footer!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Header text: " + defaultHeader.Paragraphs[0].Text);
+
+                Console.WriteLine("Footer Default Count: " + defaultFooter.Paragraphs.Count);
+                Console.WriteLine("Footer Even Count: " + evenFooter.Paragraphs.Count);
+                Console.WriteLine("Footer First Count: " + firstFooter.Paragraphs.Count);
+
+                Console.WriteLine("Footer text: " + defaultFooter.Paragraphs[0].Text);
 
                 document.Save();
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Console.WriteLine("Header Default Count: " + document.Header!.Default.Paragraphs.Count);
-                Console.WriteLine("Header Even Count: " + document.Header!.Even.Paragraphs.Count);
-                Console.WriteLine("Header First Count: " + document.Header!.First.Paragraphs.Count);
+                var headers = RequireHeaders(document.Header, "Document headers");
+                var defaultHeader = RequireHeader(headers.Default, "Default header");
+                var evenHeader = RequireHeader(headers.Even, "Even header");
+                var firstHeader = RequireHeader(headers.First, "First header");
 
-                Console.WriteLine("Header text: " + document.Header!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Header Default Count: " + defaultHeader.Paragraphs.Count);
+                Console.WriteLine("Header Even Count: " + evenHeader.Paragraphs.Count);
+                Console.WriteLine("Header First Count: " + firstHeader.Paragraphs.Count);
 
-                Console.WriteLine("Footer Default Count: " + document.Footer!.Default.Paragraphs.Count);
-                Console.WriteLine("Footer Even Count: " + document.Footer!.Even.Paragraphs.Count);
-                Console.WriteLine("Footer First Count: " + document.Footer!.First.Paragraphs.Count);
+                Console.WriteLine("Header text: " + defaultHeader.Paragraphs[0].Text);
 
-                Console.WriteLine("Footer text: " + document.Footer!.Default.Paragraphs[0].Text);
+                var footers = RequireFooters(document.Footer, "Document footers");
+                var defaultFooter = RequireFooter(footers.Default, "Default footer");
+                var evenFooter = RequireFooter(footers.Even, "Even footer");
+                var firstFooter = RequireFooter(footers.First, "First footer");
+
+                Console.WriteLine("Footer Default Count: " + defaultFooter.Paragraphs.Count);
+                Console.WriteLine("Footer Even Count: " + evenFooter.Paragraphs.Count);
+                Console.WriteLine("Footer First Count: " + firstFooter.Paragraphs.Count);
+
+                Console.WriteLine("Footer text: " + defaultFooter.Paragraphs[0].Text);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example2.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example2.cs
@@ -9,6 +9,23 @@ namespace OfficeIMO.Examples.Word {
         internal static void Example_BasicWordWithHeaderAndFooter1(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating standard document with Headers and Footers 1");
             string filePath = System.IO.Path.Combine(folderPath, "Basic Document with Headers and Footers Default 1.docx");
+
+            WordHeaders RequireHeaders(WordHeaders? headers, string description) {
+                if (headers == null) {
+                    throw new InvalidOperationException($"{description} are not available.");
+                }
+
+                return headers;
+            }
+
+            WordHeader RequireHeader(WordHeader? header, string description) {
+                if (header == null) {
+                    throw new InvalidOperationException($"{description} is not available.");
+                }
+
+                return header;
+            }
+
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.Sections[0].ColumnsSpace = 50;
                 Console.WriteLine("+ Settings Zoom Preset: " + document.Settings.ZoomPreset);
@@ -26,10 +43,14 @@ namespace OfficeIMO.Examples.Word {
                 //var paragraphInFooter = document.Footer!.Default.InsertParagraph();
                 //paragraphInFooter.Text = "This is a test on odd pages (aka default if no options are set)";
 
-                var paragraphInHeader = document.Header!.Default.AddParagraph();
+                var headers = RequireHeaders(document.Header, "Document headers");
+                var defaultHeader = RequireHeader(headers.Default, "Default header");
+                var firstHeader = RequireHeader(headers.First, "First header");
+
+                var paragraphInHeader = defaultHeader.AddParagraph();
                 paragraphInHeader.Text = "Default Header / Section 0";
 
-                paragraphInHeader = document.Header!.First.AddParagraph();
+                paragraphInHeader = firstHeader.AddParagraph();
                 paragraphInHeader.Text = "First Header / Section 0";
 
                 //var paragraphInFooterFirst = document.Footer!.First.InsertParagraph();
@@ -87,14 +108,19 @@ namespace OfficeIMO.Examples.Word {
                 //var paragraghInHeaderSection = section2.Header!.First.InsertParagraph();
                 //paragraghInHeaderSection.Text = "Ok, work please?";
 
-                var paragraghInHeaderSection1 = section2.Header!.Default.AddParagraph();
+                var section2Headers = RequireHeaders(section2.Header, "Section 2 headers");
+                var section2DefaultHeader = RequireHeader(section2Headers.Default, "Section 2 default header");
+                var section2FirstHeader = RequireHeader(section2Headers.First, "Section 2 first header");
+                var section2EvenHeader = RequireHeader(section2Headers.Even, "Section 2 even header");
+
+                var paragraghInHeaderSection1 = section2DefaultHeader.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit? 1";
 
-                paragraghInHeaderSection1 = section2.Header!.First.AddParagraph();
+                paragraghInHeaderSection1 = section2FirstHeader.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit 2?";
                 // paragraghInHeaderSection1.InsertText("ok?");
 
-                paragraghInHeaderSection1 = section2.Header!.Even.AddParagraph();
+                paragraghInHeaderSection1 = section2EvenHeader.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit? 3";
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 6");

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example3.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example3.cs
@@ -12,12 +12,32 @@ namespace OfficeIMO.Examples.Word {
         internal static void Example_BasicWordWithHeaderAndFooter(string folderPath, bool openWord) {
             Console.WriteLine("[*] Creating standard document with Headers and Footers including Sections");
             string filePath = System.IO.Path.Combine(folderPath, "Basic Document with Headers and Footers.docx");
+
+            WordHeaders RequireHeaders(WordHeaders? headers, string description) {
+                if (headers == null) {
+                    throw new InvalidOperationException($"{description} are not available.");
+                }
+
+                return headers;
+            }
+
+            WordHeader RequireHeader(WordHeader? header, string description) {
+                if (header == null) {
+                    throw new InvalidOperationException($"{description} is not available.");
+                }
+
+                return header;
+            }
+
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
                 document.Sections[0].PageOrientation = PageOrientationValues.Landscape;
 
-                var paragraphInHeader = document.Header!.Default.AddParagraph();
+                var headers = RequireHeaders(document.Header, "Document headers");
+                var defaultHeader = RequireHeader(headers.Default, "Default header");
+
+                var paragraphInHeader = defaultHeader.AddParagraph();
                 paragraphInHeader.Text = "Default Header / Section 0";
 
                 document.AddPageBreak();
@@ -29,7 +49,10 @@ namespace OfficeIMO.Examples.Word {
                 var section2 = document.AddSection();
                 section2.AddHeadersAndFooters();
 
-                var paragraghInHeaderSection1 = section2.Header!.Default.AddParagraph();
+                var section2Headers = RequireHeaders(section2.Header, "Section 2 headers");
+                var section2DefaultHeader = RequireHeader(section2Headers.Default, "Section 2 default header");
+
+                var paragraghInHeaderSection1 = section2DefaultHeader.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit? 1";
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 2");
@@ -39,7 +62,10 @@ namespace OfficeIMO.Examples.Word {
                 var section3 = document.AddSection();
                 section3.AddHeadersAndFooters();
 
-                var paragraghInHeaderSection3 = section3.Header!.Default.AddParagraph();
+                var section3Headers = RequireHeaders(section3.Header, "Section 3 headers");
+                var section3DefaultHeader = RequireHeader(section3Headers.Default, "Section 3 default header");
+
+                var paragraghInHeaderSection3 = section3DefaultHeader.AddParagraph();
                 paragraghInHeaderSection3.Text = "Weird shit? 2";
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 3");

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.ExampleNoSection.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.ExampleNoSection.cs
@@ -18,15 +18,35 @@ namespace OfficeIMO.Examples.Word {
                 document.AddHeadersAndFooters();
                 document.DifferentOddAndEvenPages = true;
 
+                WordHeaders RequireHeaders(WordHeaders? headers, string description) {
+                    if (headers == null) {
+                        throw new InvalidOperationException($"{description} are not available.");
+                    }
+
+                    return headers;
+                }
+
+                WordHeader RequireHeader(WordHeader? header, string description) {
+                    if (header == null) {
+                        throw new InvalidOperationException($"{description} is not available.");
+                    }
+
+                    return header;
+                }
+
 
                 var paragraph = document.AddParagraph("Basic paragraph - Page 1");
                 paragraph.ParagraphAlignment = JustificationValues.Center;
                 paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
-                var paragraphInHeaderO = document.Header!.Default.AddParagraph();
+                var headers = RequireHeaders(document.Header, "Document headers");
+                var defaultHeader = RequireHeader(headers.Default, "Default header");
+                var evenHeader = RequireHeader(headers.Even, "Even header");
+
+                var paragraphInHeaderO = defaultHeader.AddParagraph();
                 paragraphInHeaderO.Text = "Odd Header / Section 0";
 
-                var paragraphInHeaderE = document.Header!.Even.AddParagraph();
+                var paragraphInHeaderE = evenHeader.AddParagraph();
                 paragraphInHeaderE.Text = "Even Header / Section 0";
 
                 document.AddPageBreak();

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Sections1.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Sections1.cs
@@ -11,6 +11,38 @@ namespace OfficeIMO.Examples.Word {
             Console.WriteLine("[*] Creating standard document with Sections - Headers/Footers");
             string filePath = System.IO.Path.Combine(folderPath, "Basic Document with Sections - HeadersAndFooters.docx");
 
+            WordHeaders RequireHeaders(WordHeaders? headers, string description) {
+                if (headers == null) {
+                    throw new InvalidOperationException($"{description} are not available.");
+                }
+
+                return headers;
+            }
+
+            WordHeader RequireHeader(WordHeader? header, string description) {
+                if (header == null) {
+                    throw new InvalidOperationException($"{description} is not available.");
+                }
+
+                return header;
+            }
+
+            WordFooters RequireFooters(WordFooters? footers, string description) {
+                if (footers == null) {
+                    throw new InvalidOperationException($"{description} are not available.");
+                }
+
+                return footers;
+            }
+
+            WordFooter RequireFooter(WordFooter? footer, string description) {
+                if (footer == null) {
+                    throw new InvalidOperationException($"{description} is not available.");
+                }
+
+                return footer;
+            }
+
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddParagraph("Basic paragraph");
                 document.AddTable(1, 1);
@@ -23,56 +55,77 @@ namespace OfficeIMO.Examples.Word {
                 document.AddPageBreak();
 
                 document.AddHeadersAndFooters();
-                document.Sections[0].Header!.Default.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header1");
+                var section0 = document.Sections[0];
+                var section0Headers = RequireHeaders(section0.Header, "Section 0 headers");
+                var section0DefaultHeader = RequireHeader(section0Headers.Default, "Section 0 default header");
 
-                var tableHeader = document.Sections[0].Header!.Default.AddTable(3, 4);
+                section0DefaultHeader.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header1");
+
+                var tableHeader = section0DefaultHeader.AddTable(3, 4);
                 tableHeader.Rows[0].Cells[3].Paragraphs[0].Text = "This is sparta";
-                Console.WriteLine(document.Sections[0].Header!.Default.Tables.Count);
+                Console.WriteLine(section0DefaultHeader.Tables.Count);
 
-                document.Sections[0].Header!.Default.AddHorizontalLine();
+                section0DefaultHeader.AddHorizontalLine();
 
-                document.Sections[0].Header!.Default.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
+                section0DefaultHeader.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
 
-                document.Sections[0].Header!.Default.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
+                section0DefaultHeader.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
 
-                document.Sections[0].Header!.Default.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
+                section0DefaultHeader.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
 
 
-                document.Sections[0].Footer!.Default.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header2");
+                var section0Footers = RequireFooters(section0.Footer, "Section 0 footers");
+                var section0DefaultFooter = RequireFooter(section0Footers.Default, "Section 0 default footer");
 
-                var tableFooter = document.Sections[0].Footer!.Default.AddTable(2, 3);
+                section0DefaultFooter.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header2");
+
+                var tableFooter = section0DefaultFooter.AddTable(2, 3);
                 tableFooter.Rows[0].Cells[2].Paragraphs[0].Text = "This is not sparta";
 
-                document.Sections[0].Footer!.Default.AddHorizontalLine();
+                section0DefaultFooter.AddHorizontalLine();
 
-                document.Sections[0].Footer!.Default.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
+                section0DefaultFooter.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
 
-                document.Sections[0].Footer!.Default.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
+                section0DefaultFooter.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
 
-                document.Sections[0].Footer!.Default.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
+                section0DefaultFooter.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
 
 
                 var section1 = document.AddSection();
                 section1.AddParagraph("Test Middle1 Section - 1");
                 section1.AddHeadersAndFooters();
-                section1.Header!.Default.AddParagraph().AddText("Section 1 - Header");
-                section1.Footer!.Default.AddParagraph().AddText("Section 1 - Footer");
+                var section1Headers = RequireHeaders(section1.Header, "Section 1 headers");
+                var section1DefaultHeader = RequireHeader(section1Headers.Default, "Section 1 default header");
+                section1DefaultHeader.AddParagraph().AddText("Section 1 - Header");
+                var section1Footers = RequireFooters(section1.Footer, "Section 1 footers");
+                var section1DefaultFooter = RequireFooter(section1Footers.Default, "Section 1 default footer");
+                section1DefaultFooter.AddParagraph().AddText("Section 1 - Footer");
 
                 var section2 = document.AddSection();
                 section2.AddParagraph("Test Middle2 Section - 1");
                 section2.AddHeadersAndFooters();
-                section2.Header!.Default.AddParagraph().AddText("Section 2 - Header");
-                section2.Footer!.Default.AddParagraph().AddText("Section 2 - Footer");
+                var section2Headers = RequireHeaders(section2.Header, "Section 2 headers");
+                var section2DefaultHeader = RequireHeader(section2Headers.Default, "Section 2 default header");
+                section2DefaultHeader.AddParagraph().AddText("Section 2 - Header");
+                var section2Footers = RequireFooters(section2.Footer, "Section 2 footers");
+                var section2DefaultFooter = RequireFooter(section2Footers.Default, "Section 2 default footer");
+                section2DefaultFooter.AddParagraph().AddText("Section 2 - Footer");
 
                 var section3 = document.AddSection();
                 section3.AddParagraph("Test Last Section - 1");
                 section3.AddHeadersAndFooters();
                 section3.DifferentOddAndEvenPages = true;
                 section3.DifferentFirstPage = true;
-                section3.Header!.Default.AddParagraph().AddText("Section 3 - Header Odd/Default");
-                section3.Footer!.Default.AddParagraph().AddText("Section 3 - Footer Odd/Default");
-                section3.Header!.Even.AddParagraph().AddText("Section 3 - Header Even");
-                section3.Footer!.Even.AddParagraph().AddText("Section 3 - Footer Even");
+                var section3Headers = RequireHeaders(section3.Header, "Section 3 headers");
+                var section3DefaultHeader = RequireHeader(section3Headers.Default, "Section 3 default header");
+                section3DefaultHeader.AddParagraph().AddText("Section 3 - Header Odd/Default");
+                var section3Footers = RequireFooters(section3.Footer, "Section 3 footers");
+                var section3DefaultFooter = RequireFooter(section3Footers.Default, "Section 3 default footer");
+                section3DefaultFooter.AddParagraph().AddText("Section 3 - Footer Odd/Default");
+                var section3EvenHeader = RequireHeader(section3Headers.Even, "Section 3 even header");
+                section3EvenHeader.AddParagraph().AddText("Section 3 - Header Even");
+                var section3EvenFooter = RequireFooter(section3Footers.Even, "Section 3 even footer");
+                section3EvenFooter.AddParagraph().AddText("Section 3 - Footer Even");
 
                 document.AddPageBreak();
                 section3.AddParagraph("Test Last Section - 2");


### PR DESCRIPTION
## Summary
- add local helpers to ensure header and footer collections exist before each example manipulates them
- replace direct nullable-suppressed header/footer usage with guarded variables across header/footer examples

## Testing
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68cb0fd542c0832eb8fa40fb7fc03801