### PR TITLE
Improve footer HTML conversion guards

### DIFF
--- a/OfficeIMO.Tests/Html.HeaderFooter.cs
+++ b/OfficeIMO.Tests/Html.HeaderFooter.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
 using Xunit;
@@ -27,5 +30,32 @@ namespace OfficeIMO.Tests {
             var footerPart = docx.MainDocumentPart!.FooterParts.First();
             Assert.Contains("Footer content", footerPart.RootElement!.InnerText);
         }
+
+        [Fact]
+        public void AddHtmlToFooter_CreatesFirstFooter() {
+            AssertFooterCreated(HeaderFooterValues.First, "Sync first footer", doc => doc.DifferentFirstPage = true);
+        }
+
+        [Fact]
+        public void AddHtmlToFooter_CreatesEvenFooter() {
+            AssertFooterCreated(HeaderFooterValues.Even, "Sync even footer", doc => doc.DifferentOddAndEvenPages = true);
+        }
+
+        private static void AssertFooterCreated(HeaderFooterValues footerType, string expectedText, Action<WordDocument> configure) {
+            using WordDocument document = WordDocument.Create();
+            configure(document);
+
+            string html = $"<p>{expectedText}</p>";
+            document.AddHtmlToFooter(html, footerType);
+
+            var section = document.Sections.Last();
+            var footers = section.Footer;
+            Assert.NotNull(footers);
+            Assert.NotNull(ResolveFooter(footers!, footerType));
+
+            string innerText = GetFooterInnerText(document, footerType);
+            Assert.Contains(expectedText, innerText);
+        }
+
     }
 }

--- a/OfficeIMO.Word/OfficeIMO.Word.csproj
+++ b/OfficeIMO.Word/OfficeIMO.Word.csproj
@@ -80,6 +80,7 @@
 
     <ItemGroup>
         <InternalsVisibleTo Include="OfficeIMO.Tests" />
+        <InternalsVisibleTo Include="OfficeIMO.Word.Html" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- guard against empty section collections in HTML conversion helpers
- ensure footer references are created when missing and validate header/footer availability
- add synchronous/asynchronous footer tests that verify content creation for default, first, and even footers

## Testing
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68cb0ed372f0832e88740d9dc30d3fa3