### PR TITLE
Guard watermark examples against missing headers

### DIFF
--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Helpers.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Helpers.cs
@@ -1,0 +1,36 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Watermark {
+        private static WordHeader GetRequiredHeader(WordSection section) {
+            return GetRequiredHeader(section, HeaderFooterValues.Default);
+        }
+
+        private static WordHeader GetRequiredHeader(WordSection section, HeaderFooterValues type) {
+            if (section is null) {
+                throw new ArgumentNullException(nameof(section));
+            }
+
+            WordHeader? header;
+            string description;
+
+            if (type == HeaderFooterValues.Default) {
+                header = section.Header.Default;
+                description = "default";
+            } else if (type == HeaderFooterValues.Even) {
+                header = section.Header.Even;
+                description = "even";
+            } else if (type == HeaderFooterValues.First) {
+                header = section.Header.First;
+                description = "first";
+            } else {
+                throw new ArgumentOutOfRangeException(nameof(type), type, "Unsupported header type.");
+            }
+
+            return Guard.NotNull(header, $"Call AddHeadersAndFooters before accessing the {description} header.");
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Remove.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Remove.cs
@@ -1,4 +1,5 @@
 using System;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -18,9 +19,14 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentFirstPage = true;
                 document.DifferentOddAndEvenPages = true;
 
-                document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Default");
-                document.Sections[0].Header!.First.AddWatermark(WordWatermarkStyle.Text, "First");
-                document.Sections[0].Header!.Even.AddWatermark(WordWatermarkStyle.Text, "Even");
+                var section0 = document.Sections[0];
+                var defaultHeader = GetRequiredHeader(section0);
+                var firstHeader = GetRequiredHeader(section0, HeaderFooterValues.First);
+                var evenHeader = GetRequiredHeader(section0, HeaderFooterValues.Even);
+
+                defaultHeader.AddWatermark(WordWatermarkStyle.Text, "Default");
+                firstHeader.AddWatermark(WordWatermarkStyle.Text, "First");
+                evenHeader.AddWatermark(WordWatermarkStyle.Text, "Even");
 
                 Console.WriteLine("Watermarks before: " + document.Watermarks.Count);
                 foreach (var watermark in document.Watermarks.ToList()) {

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Sample1.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Sample1.cs
@@ -20,8 +20,11 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddParagraph("Section 0");
                 document.AddHeadersAndFooters();
-                document.Sections[0].Header!.Default.AddParagraph("Section 0 - In header");
-                document.Sections[0].SetMargins(WordMargin.Normal);
+
+                var section0 = document.Sections[0];
+                var section0Header = GetRequiredHeader(section0);
+                section0Header.AddParagraph("Section 0 - In header");
+                section0.SetMargins(WordMargin.Normal);
 
                 Console.WriteLine(document.Sections[0].Margins.Left.Value);
                 Console.WriteLine(document.Sections[0].Margins.Right.Value);
@@ -33,7 +36,7 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine(document.Sections[0].Margins.Type);
 
                 Console.WriteLine("----");
-                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Watermark");
+                var watermark = section0Header.AddWatermark(WordWatermarkStyle.Text, "Watermark");
                 watermark.Color = Color.Red;
 
                 // ColorHex normally returns hex colors, but for watermark it returns string as the underlying value is in string name, not hex
@@ -61,17 +64,19 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddParagraph("Section 1");
 
-                document.Sections[1].AddHeadersAndFooters();
-                document.Sections[1].Header!.Default.AddParagraph("Section 1 - In header");
-                document.Sections[1].Margins.Type = WordMargin.Narrow;
+                var section1 = document.Sections[1];
+                section1.AddHeadersAndFooters();
+                var section1Header = GetRequiredHeader(section1);
+                section1Header.AddParagraph("Section 1 - In header");
+                section1.Margins.Type = WordMargin.Narrow;
                 Console.WriteLine("----");
 
                 Console.WriteLine("Section 0 - Paragraphs Count: " + document.Sections[0].Header!.Default.Paragraphs.Count);
                 Console.WriteLine("Section 1 - Paragraphs Count: " + document.Sections[1].Header!.Default.Paragraphs.Count);
 
                 Console.WriteLine("----");
-                document.Sections[1].AddParagraph("Test");
-                document.Sections[1].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Draft");
+                section1.AddParagraph("Test");
+                section1Header.AddWatermark(WordWatermarkStyle.Text, "Draft");
 
                 Console.WriteLine(document.Sections[0].Margins.Left.Value);
                 Console.WriteLine(document.Sections[0].Margins.Right.Value);

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Sample4.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Sample4.cs
@@ -19,7 +19,10 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddParagraph("Section 0");
                 document.AddHeadersAndFooters();
-                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "HexColor");
+
+                var section0 = document.Sections[0];
+                var section0Header = GetRequiredHeader(section0);
+                var watermark = section0Header.AddWatermark(WordWatermarkStyle.Text, "HexColor");
                 watermark.ColorHex = "00ff00";
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.SampleImage1.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.SampleImage1.cs
@@ -16,8 +16,11 @@ namespace OfficeIMO.Examples.Word {
                 document.AddParagraph("Section 0");
                 document.AddHeadersAndFooters();
 
+                var section0 = document.Sections[0];
+                var section0Header = GetRequiredHeader(section0);
+
                 var imagePathToAdd = System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg");
-                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Image, imagePathToAdd);
+                var watermark = section0Header.AddWatermark(WordWatermarkStyle.Image, imagePathToAdd);
 
                 //Console.WriteLine(watermark.Height);
                 //Console.WriteLine(watermark.Width);


### PR DESCRIPTION
## Summary
- add a helper that validates headers are present before using them in watermark examples
- update the watermark examples to cache the validated headers before adding content

## Testing
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68cb1318626c832e93f264a61d6c8393