### PR TITLE
Guard header/footer usage in Word examples

### DIFF
--- a/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.Create.cs
+++ b/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.Create.cs
@@ -91,8 +91,11 @@ namespace OfficeIMO.Examples.Word {
                 // lets add headers and footers
                 document.AddHeadersAndFooters();
 
+                var headers = Guard.NotNull(document.Header, "Document headers must exist after enabling headers.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+
                 // adding text to default header
-                document.Header!.Default.AddParagraph("Text added to header - Default");
+                defaultHeader.AddParagraph("Text added to header - Default");
 
                 var section1 = document.AddSection();
                 section1.PageOrientation = PageOrientationValues.Portrait;
@@ -105,7 +108,10 @@ namespace OfficeIMO.Examples.Word {
                 document.CustomDocumentProperties.Add("IsTodayGreatDay", new WordCustomProperty(true));
 
                 // add page numbers
-                document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                var footers = Guard.NotNull(document.Footer, "Document footers must exist after enabling headers.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist after enabling headers.");
+
+                defaultFooter.AddPageNumber(WordPageNumberStyle.PlainNumber);
 
                 // add watermark
                 document.Sections[0].AddWatermark(WordWatermarkStyle.Text, "Draft");

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create05.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create05.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -22,31 +23,41 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddHeadersAndFooters();
 
+                var headers = Guard.NotNull(document.Header, "Document headers must exist after enabling headers.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+                var footers = Guard.NotNull(document.Footer, "Document footers must exist after enabling headers.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist after enabling headers.");
+
                 Console.WriteLine("Images count: " + document.Images.Count);
 
-                document.Header!.Default.AddParagraph().AddImage(filePathImage, 734, 92);
-                document.Header!.Default.Paragraphs[0].SetFontFamily("Arial");
-                document.Header!.Default.Paragraphs[0].SetFontSize(7).Bold = false;
+                var headerParagraph = defaultHeader.AddParagraph();
+                headerParagraph.AddImage(filePathImage, 734, 92);
+
+                var firstHeaderParagraph = Guard.GetRequiredItem(defaultHeader.Paragraphs, 0, "Default header should expose the inserted paragraph.");
+                firstHeaderParagraph.SetFontFamily("Arial");
+                firstHeaderParagraph.SetFontSize(7).Bold = false;
 
                 Console.WriteLine("Images Count: " + document.Images.Count);
-                Console.WriteLine("Images in Header Count: " + document.Header!.Default.Images.Count);
+                Console.WriteLine("Images in Header Count: " + defaultHeader.Images.Count);
 
-                document.Footer!.Default.AddParagraph();
-                document.Footer!.Default.Paragraphs[0].SetFontFamily("Arial");
-                document.Footer!.Default.Paragraphs[0].SetFontSize(7).Bold = false;
-                document.Footer!.Default.Paragraphs[0].ParagraphAlignment = JustificationValues.Right;
-                document.Footer!.Default.Paragraphs[0].Text = "SMA.5.doc 04/10/19";
-                document.Footer!.Default.Paragraphs[0].LineSpacingAfter = 0;
-                document.Footer!.Default.Paragraphs[0].LineSpacingBefore = 0;
-                document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PageNumberXofY);
+                defaultFooter.AddParagraph();
+                var firstFooterParagraph = Guard.GetRequiredItem(defaultFooter.Paragraphs, 0, "Default footer should expose the first paragraph after adding one.");
+                firstFooterParagraph.SetFontFamily("Arial");
+                firstFooterParagraph.SetFontSize(7).Bold = false;
+                firstFooterParagraph.ParagraphAlignment = JustificationValues.Right;
+                firstFooterParagraph.Text = "SMA.5.doc 04/10/19";
+                firstFooterParagraph.LineSpacingAfter = 0;
+                firstFooterParagraph.LineSpacingBefore = 0;
+                defaultFooter.AddPageNumber(WordPageNumberStyle.PageNumberXofY);
 
-                document.Footer!.Default.AddParagraph();
-                document.Footer!.Default.Paragraphs[1].SetFontFamily("Arial");
-                document.Footer!.Default.Paragraphs[1].SetFontSize(7).Bold = false;
-                document.Footer!.Default.Paragraphs[1].ParagraphAlignment = JustificationValues.Center;
-                document.Footer!.Default.Paragraphs[1].Text = "My address";
-                document.Footer!.Default.Paragraphs[1].LineSpacingAfter = 0;
-                document.Footer!.Default.Paragraphs[1].LineSpacingBefore = 0;
+                defaultFooter.AddParagraph();
+                var secondFooterParagraph = Guard.GetRequiredItem(defaultFooter.Paragraphs, 1, "Default footer should expose the second paragraph after adding two paragraphs.");
+                secondFooterParagraph.SetFontFamily("Arial");
+                secondFooterParagraph.SetFontSize(7).Bold = false;
+                secondFooterParagraph.ParagraphAlignment = JustificationValues.Center;
+                secondFooterParagraph.Text = "My address";
+                secondFooterParagraph.LineSpacingAfter = 0;
+                secondFooterParagraph.LineSpacingBefore = 0;
 
                 var par00 = document.AddParagraph("My text");
                 par00.ParagraphAlignment = JustificationValues.Left;

--- a/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample04.cs
+++ b/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample04.cs
@@ -1,4 +1,5 @@
 using System;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word;
@@ -17,15 +18,21 @@ internal static partial class CleanupDocuments {
         using (WordDocument document = WordDocument.Create(filePath)) {
             document.AddHeadersAndFooters();
 
-            var headerParagraph = document.Header!.Default.AddParagraph("Header ");
+            var headers = Guard.NotNull(document.Header, "Document headers must exist after enabling headers.");
+            var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+
+            var headerParagraph = defaultHeader.AddParagraph("Header ");
             headerParagraph.AddText("clutter ");
             headerParagraph.AddText("text");
-            document.Header!.Default.AddParagraph();
+            defaultHeader.AddParagraph();
 
-            var footerParagraph = document.Footer!.Default.AddParagraph("Footer ");
+            var footers = Guard.NotNull(document.Footer, "Document footers must exist after enabling headers.");
+            var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist after enabling headers.");
+
+            var footerParagraph = defaultFooter.AddParagraph("Footer ");
             footerParagraph.AddText("clutter ");
             footerParagraph.AddText("text");
-            document.Footer!.Default.AddParagraph();
+            defaultFooter.AddParagraph();
 
             document.CleanupDocument();
             document.Save(openWord);

--- a/OfficeIMO.Examples/Word/EndToEnd/Word.EndToEnd.cs
+++ b/OfficeIMO.Examples/Word/EndToEnd/Word.EndToEnd.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
 using OfficeIMO.Word.Markdown;
@@ -18,8 +19,12 @@ namespace OfficeIMO.Examples.Word.EndToEnd {
             using (var doc = WordDocument.Create()) {
                 // Headers/Footers + page numbering
                 doc.AddHeadersAndFooters();
-                doc.Header!.Default.AddParagraph("End-to-End Demo");
-                doc.Footer!.Default.AddParagraph().AddPageNumber(includeTotalPages: true);
+                var headers = Guard.NotNull(doc.Header, "Document headers must exist after enabling headers.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+                var footers = Guard.NotNull(doc.Footer, "Document footers must exist after enabling headers.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist after enabling headers.");
+                defaultHeader.AddParagraph("End-to-End Demo");
+                defaultFooter.AddParagraph().AddPageNumber(includeTotalPages: true);
 
                 // TOC at top (updates on open)
                 new WordFluentDocument(doc).TocAtTop("Contents", minLevel: 1, maxLevel: 3, titleLevel: 2);

--- a/OfficeIMO.Examples/Word/HyperLinksAndFields/HyperLinks.FormattedAdvancedExample.cs
+++ b/OfficeIMO.Examples/Word/HyperLinksAndFields/HyperLinks.FormattedAdvancedExample.cs
@@ -12,6 +12,11 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
+                var headers = Guard.NotNull(document.Header, "Document headers must exist after enabling headers.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+                var footers = Guard.NotNull(document.Footer, "Document footers must exist after enabling headers.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist after enabling headers.");
+
                 var paragraph = document.AddParagraph("Visit ");
                 var google = paragraph.AddHyperLink("Google", new Uri("https://google.com"), addStyle: true);
                 google.Bold = true;
@@ -24,12 +29,12 @@ namespace OfficeIMO.Examples.Word {
                 var yahoo = baseLink.InsertFormattedHyperlinkAfter("Yahoo", new Uri("https://yahoo.com"));
                 yahoo.CopyFormattingFrom(baseLink);
 
-                var headerPara = document.Header!.Default.AddParagraph("Search with ");
+                var headerPara = defaultHeader.AddParagraph("Search with ");
                 var duck = headerPara.AddHyperLink("DuckDuckGo", new Uri("https://duckduckgo.com"), addStyle: true);
                 var duckLink = Guard.NotNull(duck.Hyperlink, "Expected DuckDuckGo hyperlink to be created.");
                 duckLink.InsertFormattedHyperlinkAfter("Startpage", new Uri("https://startpage.com"));
 
-                var footerPara = document.Footer!.Default.AddParagraph("Code on ");
+                var footerPara = defaultFooter.AddParagraph("Code on ");
                 var gitHub = footerPara.AddHyperLink("GitHub", new Uri("https://github.com"), addStyle: true);
                 var gitHubLink = Guard.NotNull(gitHub.Hyperlink, "Expected GitHub hyperlink to be created.");
                 gitHubLink.InsertFormattedHyperlinkBefore("GitLab", new Uri("https://gitlab.com"));

--- a/OfficeIMO.Examples/Word/Images/Images.LoadDocument.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.LoadDocument.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -15,9 +16,11 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Load(System.IO.Path.Combine(documentPaths, "BasicDocumentWithImages.docx"), true)) {
                 Console.WriteLine("+ Document paragraphs: " + document.Paragraphs.Count);
-                Console.WriteLine("+ Document images: " + document.Images.Count);
+                var images = document.Images;
+                Console.WriteLine("+ Document images: " + images.Count);
 
-                document.Images[0].SaveToFile(System.IO.Path.Combine(outputPath, "random.jpg"));
+                var firstImage = Guard.GetRequiredItem(images, 0, "Template should contain at least one image to export.");
+                firstImage.SaveToFile(System.IO.Path.Combine(outputPath, "random.jpg"));
             }
         }
     }

--- a/OfficeIMO.Examples/Word/Images/Images.Sample2.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.Sample2.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -15,13 +16,22 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Load(System.IO.Path.Combine(documentPaths, "DocumentWithImagesWraps.docx"), true)) {
                 Console.WriteLine("+ Document paragraphs: " + document.Paragraphs.Count);
-                Console.WriteLine("+ Document images: " + document.Images.Count);
-                Console.WriteLine("+ Document images in header: " + document.Header!.Default.Images.Count);
-                Console.WriteLine("+ Document images in footer: " + document.Footer!.Default.Images.Count);
+                var images = document.Images;
+                Console.WriteLine("+ Document images: " + images.Count);
+
+                var headers = Guard.NotNull(document.Header, "Document headers must exist when inspecting header images.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist when inspecting header images.");
+                var headerImages = defaultHeader.Images;
+                Console.WriteLine("+ Document images in header: " + headerImages.Count);
+
+                var footers = Guard.NotNull(document.Footer, "Document footers must exist when inspecting footer images.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist when inspecting footer images.");
+                var footerImages = defaultFooter.Images;
+                Console.WriteLine("+ Document images in footer: " + footerImages.Count);
                 //document.Images[0].SaveToFile(System.IO.Path.Combine(outputPath, "random.jpg"));
 
                 Console.WriteLine("----");
-                foreach (var image in document.Images) {
+                foreach (var image in images) {
                     Console.WriteLine("+ Image: " + image.FileName);
                     Console.WriteLine("+ Image: " + image.Width);
                     Console.WriteLine("+ Image: " + image.Height);

--- a/OfficeIMO.Examples/Word/Images/Images.Transparency.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.Transparency.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -13,7 +14,9 @@ namespace OfficeIMO.Examples.Word {
                 var paragraph = document.AddParagraph();
                 // AddImage returns the paragraph (fluent API). Set transparency on the last added image.
                 paragraph.AddImage(Path.Combine(imagePaths, "Kulek.jpg"), 100, 100);
-                document.Images[document.Images.Count - 1].Transparency = 30;
+                var images = document.Images;
+                var insertedImage = Guard.GetRequiredItem(images, images.Count - 1, "Document should contain the inserted image before setting transparency.");
+                insertedImage.Transparency = 30;
                 document.Save(openWord);
             }
         }
@@ -25,7 +28,9 @@ namespace OfficeIMO.Examples.Word {
             File.Copy(Path.Combine(templatesPath, "BasicDocumentWithImages.docx"), filePath, true);
 
             using (WordDocument document = WordDocument.Load(filePath, false)) {
-                document.Images[0].Transparency = 75;
+                var loadedImages = document.Images;
+                var firstImage = Guard.GetRequiredItem(loadedImages, 0, "Template document should contain at least one image before adjusting transparency.");
+                firstImage.Transparency = 75;
                 document.Save(openWord);
             }
         }

--- a/OfficeIMO.Examples/Word/Lists/Lists.Create7.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.Create7.cs
@@ -1,4 +1,5 @@
 using System;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -130,20 +131,25 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddHeadersAndFooters();
 
-                var listInHeader = document.Header!.Default.AddList(WordListStyle.Bulleted);
+                var headers = Guard.NotNull(document.Header, "Document headers must exist after enabling headers.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+                var footers = Guard.NotNull(document.Footer, "Document footers must exist after enabling headers.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist after enabling headers.");
+
+                var listInHeader = defaultHeader.AddList(WordListStyle.Bulleted);
 
                 listInHeader.AddItem("Test Header 1");
 
-                document.Footer!.Default.AddParagraph("Test Me Header");
+                defaultFooter.AddParagraph("Test Me Header");
 
                 listInHeader.AddItem("Test Header 2");
 
 
-                var listInFooter = document.Footer!.Default.AddList(WordListStyle.Numbered);
+                var listInFooter = defaultFooter.AddList(WordListStyle.Numbered);
 
                 listInFooter.AddItem("Test Footer 1");
 
-                document.Footer!.Default.AddParagraph("Test Me Footer");
+                defaultFooter.AddParagraph("Test Me Footer");
 
                 listInFooter.AddItem("Test Footer 2");
 

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example1.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example1.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 using Color = SixLabors.ImageSharp.Color;
 
@@ -17,7 +18,9 @@ namespace OfficeIMO.Examples.Word {
                 document.Settings.UpdateFieldsOnOpen = true;
                 document.AddTableOfContent(tableOfContentStyle: TableOfContentStyle.Template2);
                 document.AddHeadersAndFooters();
-                var pageNumber = document.Header!.Default.AddPageNumber(WordPageNumberStyle.Dots);
+                var headers = Guard.NotNull(document.Header, "Document headers must exist after enabling headers.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+                var pageNumber = defaultHeader.AddPageNumber(WordPageNumberStyle.Dots);
                 //var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.VerticalOutline2);
                 //var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.Dots);
 

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example2.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example2.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -10,7 +11,10 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
-                var table = document.Footer!.Default.AddTable(1, 2, WordTableStyle.TableGrid);
+                var footers = Guard.NotNull(document.Footer, "Document footers must exist after enabling headers.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist after enabling headers.");
+
+                var table = defaultFooter.AddTable(1, 2, WordTableStyle.TableGrid);
                 table.WidthType = TableWidthUnitValues.Pct;
                 // 5000 represents 100% when using Pct width
                 table.Width = 5000;

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example3.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example3.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -11,7 +12,10 @@ namespace OfficeIMO.Examples.Word {
                 document.Sections[0].AddPageNumbering(2, NumberFormatValues.LowerRoman);
                 document.AddHeadersAndFooters();
 
-                var para = document.Footer!.Default.AddParagraph();
+                var footers = Guard.NotNull(document.Footer, "Document footers must exist after enabling headers.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist after enabling headers.");
+
+                var para = defaultFooter.AddParagraph();
                 para.AddText("Page ");
                 para.AddPageNumber();
 

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example4.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example4.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -10,7 +11,10 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
-                var para = document.Header!.Default.AddParagraph();
+                var headers = Guard.NotNull(document.Header, "Document headers must exist after enabling headers.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+
+                var para = defaultHeader.AddParagraph();
                 para.ParagraphAlignment = JustificationValues.Center;
                 para.AddPageNumber();
 

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example5.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example5.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -10,7 +11,10 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
-                var firstFooter = document.Footer!.Default.AddParagraph();
+                var footers = Guard.NotNull(document.Footer, "Document footers must exist after enabling headers.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist after enabling headers.");
+
+                var firstFooter = defaultFooter.AddParagraph();
                 firstFooter.ParagraphAlignment = JustificationValues.Right;
                 firstFooter.AddText("Page ");
                 firstFooter.AddPageNumber(includeTotalPages: true, separator: " of ");
@@ -21,7 +25,7 @@ namespace OfficeIMO.Examples.Word {
                 section.AddPageNumbering(1);
                 section.AddParagraph("Section 2");
 
-                var secondFooter = document.Footer!.Default.AddParagraph();
+                var secondFooter = defaultFooter.AddParagraph();
                 secondFooter.ParagraphAlignment = JustificationValues.Right;
                 secondFooter.AddText("Page ");
                 secondFooter.AddPageNumber(includeTotalPages: true, separator: " of ");

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example6.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example6.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -11,7 +12,10 @@ namespace OfficeIMO.Examples.Word {
                 document.Sections[0].AddPageNumbering(1, NumberFormatValues.UpperRoman);
                 document.AddHeadersAndFooters();
 
-                var para = document.Footer!.Default.AddParagraph();
+                var footers = Guard.NotNull(document.Footer, "Document footers must exist after enabling headers.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist after enabling headers.");
+
+                var para = defaultFooter.AddParagraph();
                 para.ParagraphAlignment = JustificationValues.Right;
                 para.AddText("Page ");
                 para.AddPageNumber(includeTotalPages: true, format: WordFieldFormat.Roman, separator: " of ");

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example7.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example7.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -9,7 +10,9 @@ namespace OfficeIMO.Examples.Word {
             string filePath = System.IO.Path.Combine(folderPath, "Document with PageNumbers7.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                var footers = Guard.NotNull(document.Footer, "Document footers must exist after enabling headers.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist after enabling headers.");
+                var pageNumber = defaultFooter.AddPageNumber(WordPageNumberStyle.PlainNumber);
                 pageNumber.AppendText(" of ");
                 pageNumber.Paragraph.AddField(WordFieldType.NumPages);
                 document.Save(openWord);

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example8.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example8.cs
@@ -1,4 +1,5 @@
 using System;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -15,7 +16,9 @@ namespace OfficeIMO.Examples.Word {
                 string filePath = System.IO.Path.Combine(folderPath, $"Document_PageNumbers_{safeFormat}.docx");
                 using (WordDocument document = WordDocument.Create(filePath)) {
                     document.AddHeadersAndFooters();
-                    var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                    var footers = Guard.NotNull(document.Footer, "Document footers must exist after enabling headers.");
+                    var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist after enabling headers.");
+                    var pageNumber = defaultFooter.AddPageNumber(WordPageNumberStyle.PlainNumber);
                     pageNumber.CustomFormat = format;
                     document.Save(openWord);
                 }


### PR DESCRIPTION
## Summary
- wrap header and footer usage in advanced, cleanup, list, and end-to-end Word examples with guard checks
- cache image collections before indexing in image transparency and load samples
- update page number walkthroughs to guard footer access prior to adding numbering elements

## Testing
- dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cb132d1360832e87f2a46c378ba4d4