### PR TITLE
Add header/footer guards across examples and tests

### DIFF
--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.HeaderFooterImages.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.HeaderFooterImages.cs
@@ -1,3 +1,4 @@
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word.Pdf;
 using OfficeIMO.Word;
 using System;
@@ -13,8 +14,12 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Create(docPath)) {
                 document.AddHeadersAndFooters();
-                document.Header!.Default.AddParagraph().AddImage(imagePath, 50, 50);
-                document.Footer!.Default.AddParagraph().AddImage(imagePath, 300, 300);
+                var headers = Guard.NotNull(document.Header, "Headers should exist after calling AddHeadersAndFooters.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                defaultHeader.AddParagraph().AddImage(imagePath, 50, 50);
+                var footers = Guard.NotNull(document.Footer, "Footers should exist after calling AddHeadersAndFooters.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+                defaultFooter.AddParagraph().AddImage(imagePath, 300, 300);
                 document.Save();
                 document.SaveAsPdf(pdfPath);
             }

--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdf.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdf.cs
@@ -1,3 +1,4 @@
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word.Pdf;
 using OfficeIMO.Word;
 using QuestPDF.Helpers;
@@ -22,11 +23,15 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Create(docPath)) {
                 document.AddHeadersAndFooters();
-                document.Header!.Default.AddParagraph("Example Header");
-                WordTable headerTable = document.Header!.Default.AddTable(1, 1);
+                var headers = Guard.NotNull(document.Header, "Headers should exist after calling AddHeadersAndFooters.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                defaultHeader.AddParagraph("Example Header");
+                WordTable headerTable = defaultHeader.AddTable(1, 1);
                 headerTable.Rows[0].Cells[0].Paragraphs[0].Text = "H1";
-                document.Footer!.Default.AddParagraph("Example Footer");
-                WordTable footerTable = document.Footer!.Default.AddTable(1, 1);
+                var footers = Guard.NotNull(document.Footer, "Footers should exist after calling AddHeadersAndFooters.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+                defaultFooter.AddParagraph("Example Footer");
+                WordTable footerTable = defaultFooter.AddTable(1, 1);
                 footerTable.Rows[0].Cells[0].Paragraphs[0].Text = "F1";
 
                 WordParagraph heading = document.AddParagraph("Sample Heading");

--- a/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.Create.cs
+++ b/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.Create.cs
@@ -92,7 +92,9 @@ namespace OfficeIMO.Examples.Word {
                 document.AddHeadersAndFooters();
 
                 // adding text to default header
-                document.Header!.Default.AddParagraph("Text added to header - Default");
+                var headers = Guard.NotNull(document.Header, "Headers should exist after calling AddHeadersAndFooters.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                defaultHeader.AddParagraph("Text added to header - Default");
 
                 var section1 = document.AddSection();
                 section1.PageOrientation = PageOrientationValues.Portrait;
@@ -105,7 +107,9 @@ namespace OfficeIMO.Examples.Word {
                 document.CustomDocumentProperties.Add("IsTodayGreatDay", new WordCustomProperty(true));
 
                 // add page numbers
-                document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                var footers = Guard.NotNull(document.Footer, "Footers should exist after calling AddHeadersAndFooters.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+                defaultFooter.AddPageNumber(WordPageNumberStyle.PlainNumber);
 
                 // add watermark
                 document.Sections[0].AddWatermark(WordWatermarkStyle.Text, "Draft");

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create05.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create05.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -24,29 +25,31 @@ namespace OfficeIMO.Examples.Word {
 
                 Console.WriteLine("Images count: " + document.Images.Count);
 
-                document.Header!.Default.AddParagraph().AddImage(filePathImage, 734, 92);
-                document.Header!.Default.Paragraphs[0].SetFontFamily("Arial");
-                document.Header!.Default.Paragraphs[0].SetFontSize(7).Bold = false;
+                var defaultHeader = Guard.NotNull(document.Header?.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                defaultHeader.AddParagraph().AddImage(filePathImage, 734, 92);
+                defaultHeader.Paragraphs[0].SetFontFamily("Arial");
+                defaultHeader.Paragraphs[0].SetFontSize(7).Bold = false;
 
                 Console.WriteLine("Images Count: " + document.Images.Count);
-                Console.WriteLine("Images in Header Count: " + document.Header!.Default.Images.Count);
+                Console.WriteLine("Images in Header Count: " + defaultHeader.Images.Count);
 
-                document.Footer!.Default.AddParagraph();
-                document.Footer!.Default.Paragraphs[0].SetFontFamily("Arial");
-                document.Footer!.Default.Paragraphs[0].SetFontSize(7).Bold = false;
-                document.Footer!.Default.Paragraphs[0].ParagraphAlignment = JustificationValues.Right;
-                document.Footer!.Default.Paragraphs[0].Text = "SMA.5.doc 04/10/19";
-                document.Footer!.Default.Paragraphs[0].LineSpacingAfter = 0;
-                document.Footer!.Default.Paragraphs[0].LineSpacingBefore = 0;
-                document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PageNumberXofY);
+                var defaultFooter = Guard.NotNull(document.Footer?.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+                defaultFooter.AddParagraph();
+                defaultFooter.Paragraphs[0].SetFontFamily("Arial");
+                defaultFooter.Paragraphs[0].SetFontSize(7).Bold = false;
+                defaultFooter.Paragraphs[0].ParagraphAlignment = JustificationValues.Right;
+                defaultFooter.Paragraphs[0].Text = "SMA.5.doc 04/10/19";
+                defaultFooter.Paragraphs[0].LineSpacingAfter = 0;
+                defaultFooter.Paragraphs[0].LineSpacingBefore = 0;
+                defaultFooter.AddPageNumber(WordPageNumberStyle.PageNumberXofY);
 
-                document.Footer!.Default.AddParagraph();
-                document.Footer!.Default.Paragraphs[1].SetFontFamily("Arial");
-                document.Footer!.Default.Paragraphs[1].SetFontSize(7).Bold = false;
-                document.Footer!.Default.Paragraphs[1].ParagraphAlignment = JustificationValues.Center;
-                document.Footer!.Default.Paragraphs[1].Text = "My address";
-                document.Footer!.Default.Paragraphs[1].LineSpacingAfter = 0;
-                document.Footer!.Default.Paragraphs[1].LineSpacingBefore = 0;
+                defaultFooter.AddParagraph();
+                defaultFooter.Paragraphs[1].SetFontFamily("Arial");
+                defaultFooter.Paragraphs[1].SetFontSize(7).Bold = false;
+                defaultFooter.Paragraphs[1].ParagraphAlignment = JustificationValues.Center;
+                defaultFooter.Paragraphs[1].Text = "My address";
+                defaultFooter.Paragraphs[1].LineSpacingAfter = 0;
+                defaultFooter.Paragraphs[1].LineSpacingBefore = 0;
 
                 var par00 = document.AddParagraph("My text");
                 par00.ParagraphAlignment = JustificationValues.Left;

--- a/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample04.cs
+++ b/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample04.cs
@@ -1,4 +1,5 @@
 using System;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word;
@@ -17,15 +18,17 @@ internal static partial class CleanupDocuments {
         using (WordDocument document = WordDocument.Create(filePath)) {
             document.AddHeadersAndFooters();
 
-            var headerParagraph = document.Header!.Default.AddParagraph("Header ");
+            var defaultHeader = Guard.NotNull(document.Header?.Default, "Default header should exist after calling AddHeadersAndFooters.");
+            var headerParagraph = defaultHeader.AddParagraph("Header ");
             headerParagraph.AddText("clutter ");
             headerParagraph.AddText("text");
-            document.Header!.Default.AddParagraph();
+            defaultHeader.AddParagraph();
 
-            var footerParagraph = document.Footer!.Default.AddParagraph("Footer ");
+            var defaultFooter = Guard.NotNull(document.Footer?.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+            var footerParagraph = defaultFooter.AddParagraph("Footer ");
             footerParagraph.AddText("clutter ");
             footerParagraph.AddText("text");
-            document.Footer!.Default.AddParagraph();
+            defaultFooter.AddParagraph();
 
             document.CleanupDocument();
             document.Save(openWord);

--- a/OfficeIMO.Examples/Word/EndToEnd/Word.EndToEnd.cs
+++ b/OfficeIMO.Examples/Word/EndToEnd/Word.EndToEnd.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
 using OfficeIMO.Word.Markdown;
@@ -18,8 +19,10 @@ namespace OfficeIMO.Examples.Word.EndToEnd {
             using (var doc = WordDocument.Create()) {
                 // Headers/Footers + page numbering
                 doc.AddHeadersAndFooters();
-                doc.Header!.Default.AddParagraph("End-to-End Demo");
-                doc.Footer!.Default.AddParagraph().AddPageNumber(includeTotalPages: true);
+                var defaultHeader = Guard.NotNull(doc.Header?.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                defaultHeader.AddParagraph("End-to-End Demo");
+                var defaultFooter = Guard.NotNull(doc.Footer?.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+                defaultFooter.AddParagraph().AddPageNumber(includeTotalPages: true);
 
                 // TOC at top (updates on open)
                 new WordFluentDocument(doc).TocAtTop("Contents", minLevel: 1, maxLevel: 3, titleLevel: 2);

--- a/OfficeIMO.Examples/Word/Fields/Fields.CustomFormat.cs
+++ b/OfficeIMO.Examples/Word/Fields/Fields.CustomFormat.cs
@@ -1,4 +1,5 @@
 using System;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -26,7 +27,8 @@ namespace OfficeIMO.Examples.Word {
             string filePath = System.IO.Path.Combine(folderPath, "CustomFormattedHeaderDate.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                document.Header!.Default.AddField(WordFieldType.Date, customFormat: "yyyy-MM-dd", advanced: true);
+                var defaultHeader = Guard.NotNull(document.Header?.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                defaultHeader.AddField(WordFieldType.Date, customFormat: "yyyy-MM-dd", advanced: true);
                 document.AddParagraph("Body paragraph");
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/Fields/Fields02.cs
+++ b/OfficeIMO.Examples/Word/Fields/Fields02.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -27,7 +28,8 @@ namespace OfficeIMO.Examples.Word {
                 document.AddField(WordFieldType.GreetingLine);
 
                 // added page number using dedicated way
-                var pageNumber = document.Header!.Default.AddPageNumber(WordPageNumberStyle.Roman);
+                var defaultHeader = Guard.NotNull(document.Header?.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                var pageNumber = defaultHeader.AddPageNumber(WordPageNumberStyle.Roman);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example1.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example1.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 using SixLabors.ImageSharp;
 
@@ -16,37 +17,53 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentOddAndEvenPages = true;
                 document.DifferentFirstPage = true;
 
-                document.Header!.Default.AddParagraph().SetColor(Color.Red).SetText("Test Header");
+                var defaultHeader = Guard.NotNull(document.Header?.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                defaultHeader.AddParagraph().SetColor(Color.Red).SetText("Test Header");
 
-                document.Footer!.Default.AddParagraph().SetColor(Color.Blue).SetText("Test Footer");
+                var defaultFooter = Guard.NotNull(document.Footer?.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+                defaultFooter.AddParagraph().SetColor(Color.Blue).SetText("Test Footer");
 
-                Console.WriteLine("Header Default Count: " + document.Header!.Default.Paragraphs.Count);
-                Console.WriteLine("Header Even Count: " + document.Header!.Even.Paragraphs.Count);
-                Console.WriteLine("Header First Count: " + document.Header!.First.Paragraphs.Count);
+                var evenHeader = Guard.NotNull(document.Header?.Even, "Even header should exist after enabling different odd and even pages.");
+                var firstHeader = Guard.NotNull(document.Header?.First, "First header should exist after enabling different first page.");
 
-                Console.WriteLine("Header text: " + document.Header!.Default.Paragraphs[0].Text);
+                var evenFooter = Guard.NotNull(document.Footer?.Even, "Even footer should exist after enabling different odd and even pages.");
+                var firstFooter = Guard.NotNull(document.Footer?.First, "First footer should exist after enabling different first page.");
 
-                Console.WriteLine("Footer Default Count: " + document.Footer!.Default.Paragraphs.Count);
-                Console.WriteLine("Footer Even Count: " + document.Footer!.Even.Paragraphs.Count);
-                Console.WriteLine("Footer First Count: " + document.Footer!.First.Paragraphs.Count);
+                Console.WriteLine("Header Default Count: " + defaultHeader.Paragraphs.Count);
+                Console.WriteLine("Header Even Count: " + evenHeader.Paragraphs.Count);
+                Console.WriteLine("Header First Count: " + firstHeader.Paragraphs.Count);
 
-                Console.WriteLine("Footer text: " + document.Footer!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Header text: " + defaultHeader.Paragraphs[0].Text);
+
+                Console.WriteLine("Footer Default Count: " + defaultFooter.Paragraphs.Count);
+                Console.WriteLine("Footer Even Count: " + evenFooter.Paragraphs.Count);
+                Console.WriteLine("Footer First Count: " + firstFooter.Paragraphs.Count);
+
+                Console.WriteLine("Footer text: " + defaultFooter.Paragraphs[0].Text);
 
                 document.Save();
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Console.WriteLine("Header Default Count: " + document.Header!.Default.Paragraphs.Count);
-                Console.WriteLine("Header Even Count: " + document.Header!.Even.Paragraphs.Count);
-                Console.WriteLine("Header First Count: " + document.Header!.First.Paragraphs.Count);
+                var loadDefaultHeader = Guard.NotNull(document.Header?.Default, "Default header should exist when reloading the document.");
+                var loadEvenHeader = Guard.NotNull(document.Header?.Even, "Even header should exist when reloading the document.");
+                var loadFirstHeader = Guard.NotNull(document.Header?.First, "First header should exist when reloading the document.");
 
-                Console.WriteLine("Header text: " + document.Header!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Header Default Count: " + loadDefaultHeader.Paragraphs.Count);
+                Console.WriteLine("Header Even Count: " + loadEvenHeader.Paragraphs.Count);
+                Console.WriteLine("Header First Count: " + loadFirstHeader.Paragraphs.Count);
 
-                Console.WriteLine("Footer Default Count: " + document.Footer!.Default.Paragraphs.Count);
-                Console.WriteLine("Footer Even Count: " + document.Footer!.Even.Paragraphs.Count);
-                Console.WriteLine("Footer First Count: " + document.Footer!.First.Paragraphs.Count);
+                Console.WriteLine("Header text: " + loadDefaultHeader.Paragraphs[0].Text);
 
-                Console.WriteLine("Footer text: " + document.Footer!.Default.Paragraphs[0].Text);
+                var loadDefaultFooter = Guard.NotNull(document.Footer?.Default, "Default footer should exist when reloading the document.");
+                var loadEvenFooter = Guard.NotNull(document.Footer?.Even, "Even footer should exist when reloading the document.");
+                var loadFirstFooter = Guard.NotNull(document.Footer?.First, "First footer should exist when reloading the document.");
+
+                Console.WriteLine("Footer Default Count: " + loadDefaultFooter.Paragraphs.Count);
+                Console.WriteLine("Footer Even Count: " + loadEvenFooter.Paragraphs.Count);
+                Console.WriteLine("Footer First Count: " + loadFirstFooter.Paragraphs.Count);
+
+                Console.WriteLine("Footer text: " + loadDefaultFooter.Paragraphs[0].Text);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example2.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example2.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -26,10 +27,12 @@ namespace OfficeIMO.Examples.Word {
                 //var paragraphInFooter = document.Footer!.Default.InsertParagraph();
                 //paragraphInFooter.Text = "This is a test on odd pages (aka default if no options are set)";
 
-                var paragraphInHeader = document.Header!.Default.AddParagraph();
+                var defaultHeader = Guard.NotNull(document.Header?.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                var paragraphInHeader = defaultHeader.AddParagraph();
                 paragraphInHeader.Text = "Default Header / Section 0";
 
-                paragraphInHeader = document.Header!.First.AddParagraph();
+                var firstHeader = Guard.NotNull(document.Header?.First, "First header should exist after enabling different first page.");
+                paragraphInHeader = firstHeader.AddParagraph();
                 paragraphInHeader.Text = "First Header / Section 0";
 
                 //var paragraphInFooterFirst = document.Footer!.First.InsertParagraph();
@@ -87,14 +90,17 @@ namespace OfficeIMO.Examples.Word {
                 //var paragraghInHeaderSection = section2.Header!.First.InsertParagraph();
                 //paragraghInHeaderSection.Text = "Ok, work please?";
 
-                var paragraghInHeaderSection1 = section2.Header!.Default.AddParagraph();
+                var section2DefaultHeader = Guard.NotNull(section2.Header?.Default, "Section 2 should expose a default header after adding headers and footers.");
+                var paragraghInHeaderSection1 = section2DefaultHeader.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit? 1";
 
-                paragraghInHeaderSection1 = section2.Header!.First.AddParagraph();
+                var section2FirstHeader = Guard.NotNull(section2.Header?.First, "Section 2 should expose a first header after enabling different first page.");
+                paragraghInHeaderSection1 = section2FirstHeader.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit 2?";
                 // paragraghInHeaderSection1.InsertText("ok?");
 
-                paragraghInHeaderSection1 = section2.Header!.Even.AddParagraph();
+                var section2EvenHeader = Guard.NotNull(section2.Header?.Even, "Section 2 should expose an even header after enabling different odd and even pages.");
+                paragraghInHeaderSection1 = section2EvenHeader.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit? 3";
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 6");

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example3.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example3.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -17,7 +18,8 @@ namespace OfficeIMO.Examples.Word {
 
                 document.Sections[0].PageOrientation = PageOrientationValues.Landscape;
 
-                var paragraphInHeader = document.Header!.Default.AddParagraph();
+                var defaultHeader = Guard.NotNull(document.Header?.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                var paragraphInHeader = defaultHeader.AddParagraph();
                 paragraphInHeader.Text = "Default Header / Section 0";
 
                 document.AddPageBreak();
@@ -29,7 +31,8 @@ namespace OfficeIMO.Examples.Word {
                 var section2 = document.AddSection();
                 section2.AddHeadersAndFooters();
 
-                var paragraghInHeaderSection1 = section2.Header!.Default.AddParagraph();
+                var section2DefaultHeader = Guard.NotNull(section2.Header?.Default, "Section 2 should expose a default header after adding headers and footers.");
+                var paragraghInHeaderSection1 = section2DefaultHeader.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit? 1";
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 2");
@@ -39,7 +42,8 @@ namespace OfficeIMO.Examples.Word {
                 var section3 = document.AddSection();
                 section3.AddHeadersAndFooters();
 
-                var paragraghInHeaderSection3 = section3.Header!.Default.AddParagraph();
+                var section3DefaultHeader = Guard.NotNull(section3.Header?.Default, "Section 3 should expose a default header after adding headers and footers.");
+                var paragraghInHeaderSection3 = section3DefaultHeader.AddParagraph();
                 paragraghInHeaderSection3.Text = "Weird shit? 2";
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 3");

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.ExampleNoSection.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.ExampleNoSection.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -23,10 +24,12 @@ namespace OfficeIMO.Examples.Word {
                 paragraph.ParagraphAlignment = JustificationValues.Center;
                 paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
-                var paragraphInHeaderO = document.Header!.Default.AddParagraph();
+                var defaultHeader = Guard.NotNull(document.Header?.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                var paragraphInHeaderO = defaultHeader.AddParagraph();
                 paragraphInHeaderO.Text = "Odd Header / Section 0";
 
-                var paragraphInHeaderE = document.Header!.Even.AddParagraph();
+                var evenHeader = Guard.NotNull(document.Header?.Even, "Even header should exist after enabling different odd and even pages.");
+                var paragraphInHeaderE = evenHeader.AddParagraph();
                 paragraphInHeaderE.Text = "Even Header / Section 0";
 
                 document.AddPageBreak();

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Sections1.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Sections1.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System;
 using System.Text;
 using System.Threading.Tasks;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -23,56 +25,67 @@ namespace OfficeIMO.Examples.Word {
                 document.AddPageBreak();
 
                 document.AddHeadersAndFooters();
-                document.Sections[0].Header!.Default.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header1");
+                var section0 = document.Sections[0];
+                var section0DefaultHeader = Guard.NotNull(section0.Header?.Default, "Section 0 should expose a default header after adding headers and footers.");
+                section0DefaultHeader.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header1");
 
-                var tableHeader = document.Sections[0].Header!.Default.AddTable(3, 4);
+                var tableHeader = section0DefaultHeader.AddTable(3, 4);
                 tableHeader.Rows[0].Cells[3].Paragraphs[0].Text = "This is sparta";
-                Console.WriteLine(document.Sections[0].Header!.Default.Tables.Count);
+                Console.WriteLine(section0DefaultHeader.Tables.Count);
 
-                document.Sections[0].Header!.Default.AddHorizontalLine();
+                section0DefaultHeader.AddHorizontalLine();
 
-                document.Sections[0].Header!.Default.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
+                section0DefaultHeader.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
 
-                document.Sections[0].Header!.Default.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
+                section0DefaultHeader.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
 
-                document.Sections[0].Header!.Default.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
+                section0DefaultHeader.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
 
 
-                document.Sections[0].Footer!.Default.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header2");
+                var section0DefaultFooter = Guard.NotNull(section0.Footer?.Default, "Section 0 should expose a default footer after adding headers and footers.");
+                section0DefaultFooter.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header2");
 
-                var tableFooter = document.Sections[0].Footer!.Default.AddTable(2, 3);
+                var tableFooter = section0DefaultFooter.AddTable(2, 3);
                 tableFooter.Rows[0].Cells[2].Paragraphs[0].Text = "This is not sparta";
 
-                document.Sections[0].Footer!.Default.AddHorizontalLine();
+                section0DefaultFooter.AddHorizontalLine();
 
-                document.Sections[0].Footer!.Default.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
+                section0DefaultFooter.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
 
-                document.Sections[0].Footer!.Default.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
+                section0DefaultFooter.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
 
-                document.Sections[0].Footer!.Default.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
+                section0DefaultFooter.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
 
 
                 var section1 = document.AddSection();
                 section1.AddParagraph("Test Middle1 Section - 1");
                 section1.AddHeadersAndFooters();
-                section1.Header!.Default.AddParagraph().AddText("Section 1 - Header");
-                section1.Footer!.Default.AddParagraph().AddText("Section 1 - Footer");
+                var section1DefaultHeader = Guard.NotNull(section1.Header?.Default, "Section 1 should expose a default header after adding headers and footers.");
+                section1DefaultHeader.AddParagraph().AddText("Section 1 - Header");
+                var section1DefaultFooter = Guard.NotNull(section1.Footer?.Default, "Section 1 should expose a default footer after adding headers and footers.");
+                section1DefaultFooter.AddParagraph().AddText("Section 1 - Footer");
 
                 var section2 = document.AddSection();
                 section2.AddParagraph("Test Middle2 Section - 1");
                 section2.AddHeadersAndFooters();
-                section2.Header!.Default.AddParagraph().AddText("Section 2 - Header");
-                section2.Footer!.Default.AddParagraph().AddText("Section 2 - Footer");
+                var section2DefaultHeader = Guard.NotNull(section2.Header?.Default, "Section 2 should expose a default header after adding headers and footers.");
+                section2DefaultHeader.AddParagraph().AddText("Section 2 - Header");
+                var section2DefaultFooter = Guard.NotNull(section2.Footer?.Default, "Section 2 should expose a default footer after adding headers and footers.");
+                section2DefaultFooter.AddParagraph().AddText("Section 2 - Footer");
 
                 var section3 = document.AddSection();
                 section3.AddParagraph("Test Last Section - 1");
                 section3.AddHeadersAndFooters();
                 section3.DifferentOddAndEvenPages = true;
                 section3.DifferentFirstPage = true;
-                section3.Header!.Default.AddParagraph().AddText("Section 3 - Header Odd/Default");
-                section3.Footer!.Default.AddParagraph().AddText("Section 3 - Footer Odd/Default");
-                section3.Header!.Even.AddParagraph().AddText("Section 3 - Header Even");
-                section3.Footer!.Even.AddParagraph().AddText("Section 3 - Footer Even");
+                var section3DefaultHeader = Guard.NotNull(section3.Header?.Default, "Section 3 should expose a default header after adding headers and footers.");
+                section3DefaultHeader.AddParagraph().AddText("Section 3 - Header Odd/Default");
+                var section3DefaultFooter = Guard.NotNull(section3.Footer?.Default, "Section 3 should expose a default footer after adding headers and footers.");
+                section3DefaultFooter.AddParagraph().AddText("Section 3 - Footer Odd/Default");
+                var section3EvenHeader = Guard.NotNull(section3.Header?.Even, "Section 3 should expose an even header after enabling different odd and even pages.");
+                section3EvenHeader.AddParagraph().AddText("Section 3 - Header Even");
+                var section3EvenFooter = Guard.NotNull(section3.Footer?.Even, "Section 3 should expose an even footer after enabling different odd and even pages.");
+                section3EvenFooter.AddParagraph().AddText("Section 3 - Footer Even");
 
                 document.AddPageBreak();
                 section3.AddParagraph("Test Last Section - 2");

--- a/OfficeIMO.Examples/Word/HyperLinksAndFields/HyperLinks.FormattedAdvancedExample.cs
+++ b/OfficeIMO.Examples/Word/HyperLinksAndFields/HyperLinks.FormattedAdvancedExample.cs
@@ -24,12 +24,14 @@ namespace OfficeIMO.Examples.Word {
                 var yahoo = baseLink.InsertFormattedHyperlinkAfter("Yahoo", new Uri("https://yahoo.com"));
                 yahoo.CopyFormattingFrom(baseLink);
 
-                var headerPara = document.Header!.Default.AddParagraph("Search with ");
+                var headerDefault = Guard.NotNull(document.Header?.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                var headerPara = headerDefault.AddParagraph("Search with ");
                 var duck = headerPara.AddHyperLink("DuckDuckGo", new Uri("https://duckduckgo.com"), addStyle: true);
                 var duckLink = Guard.NotNull(duck.Hyperlink, "Expected DuckDuckGo hyperlink to be created.");
                 duckLink.InsertFormattedHyperlinkAfter("Startpage", new Uri("https://startpage.com"));
 
-                var footerPara = document.Footer!.Default.AddParagraph("Code on ");
+                var footerDefault = Guard.NotNull(document.Footer?.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+                var footerPara = footerDefault.AddParagraph("Code on ");
                 var gitHub = footerPara.AddHyperLink("GitHub", new Uri("https://github.com"), addStyle: true);
                 var gitHubLink = Guard.NotNull(gitHub.Hyperlink, "Expected GitHub hyperlink to be created.");
                 gitHubLink.InsertFormattedHyperlinkBefore("GitLab", new Uri("https://gitlab.com"));

--- a/OfficeIMO.Examples/Word/Images/Images.HeadersFooters.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.HeadersFooters.cs
@@ -21,14 +21,14 @@ namespace OfficeIMO.Examples.Word {
                 document.AddHeadersAndFooters();
                 document.DifferentOddAndEvenPages = true;
 
-                var header = Guard.NotNull(document.Header!.Default, "Default header must exist after enabling headers.");
+                var header = Guard.NotNull(document.Header?.Default, "Default header must exist after enabling headers.");
                 var paragraphHeader = header.AddParagraph("This is header");
 
                 // add image to header, directly to paragraph
                 header.AddParagraph().AddImage(filePathImage, 100, 100);
 
                 // add image to footer, directly to paragraph
-                var footer = Guard.NotNull(document.Footer!.Default, "Default footer must exist after enabling headers.");
+                var footer = Guard.NotNull(document.Footer?.Default, "Default footer must exist after enabling headers.");
                 footer.AddParagraph().AddImage(filePathImage, 100, 100);
 
                 // add image to header, but to a table
@@ -93,7 +93,7 @@ namespace OfficeIMO.Examples.Word {
                 string fileToSave = System.IO.Path.Combine(imagePaths, "OutputPrzemyslawKlysAndKulkozaurr.jpg");
                 firstImage.SaveToFile(fileToSave);
 
-                var headerEven = Guard.NotNull(document.Header!.Even, "Even header must exist after enabling different odd/even pages.");
+                var headerEven = Guard.NotNull(document.Header?.Even, "Even header must exist after enabling different odd/even pages.");
                 var paragraphHeaderEven = headerEven.AddParagraph("This adds another picture via Stream with 100x100 to Header Even");
                 const string fileNameImageEvotec = "EvotecLogo.png";
                 var filePathImageEvotec = System.IO.Path.Combine(imagePaths, fileNameImageEvotec);

--- a/OfficeIMO.Examples/Word/Images/Images.InTable.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.InTable.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Drawing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -20,7 +21,8 @@ namespace OfficeIMO.Examples.Word {
 
             document.AddHeadersAndFooters();
 
-            var tableInHeader = document.Header!.Default.AddTable(2, 2);
+            var defaultHeader = Guard.NotNull(document.Header?.Default, "Default header should exist after calling AddHeadersAndFooters.");
+            var tableInHeader = defaultHeader.AddTable(2, 2);
             tableInHeader.Rows[0].Cells[0].Paragraphs[0].AddImage(System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg"), 200, 200);
 
             // not really nessessary to add new paragraph since one is already there by default

--- a/OfficeIMO.Examples/Word/Images/Images.Sample2.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.Sample2.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -16,8 +17,12 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Load(System.IO.Path.Combine(documentPaths, "DocumentWithImagesWraps.docx"), true)) {
                 Console.WriteLine("+ Document paragraphs: " + document.Paragraphs.Count);
                 Console.WriteLine("+ Document images: " + document.Images.Count);
-                Console.WriteLine("+ Document images in header: " + document.Header!.Default.Images.Count);
-                Console.WriteLine("+ Document images in footer: " + document.Footer!.Default.Images.Count);
+                var headers = Guard.NotNull(document.Header, "Loaded document is expected to contain headers.");
+                var headerDefault = Guard.NotNull(headers.Default, "Loaded document must contain a default header.");
+                Console.WriteLine("+ Document images in header: " + headerDefault.Images.Count);
+                var footers = Guard.NotNull(document.Footer, "Loaded document is expected to contain footers.");
+                var footerDefault = Guard.NotNull(footers.Default, "Loaded document must contain a default footer.");
+                Console.WriteLine("+ Document images in footer: " + footerDefault.Images.Count);
                 //document.Images[0].SaveToFile(System.IO.Path.Combine(outputPath, "random.jpg"));
 
                 Console.WriteLine("----");

--- a/OfficeIMO.Examples/Word/Lists/Lists.Create7.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.Create7.cs
@@ -1,4 +1,5 @@
 using System;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -130,20 +131,22 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddHeadersAndFooters();
 
-                var listInHeader = document.Header!.Default.AddList(WordListStyle.Bulleted);
+                var defaultHeader = Guard.NotNull(document.Header?.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                var listInHeader = defaultHeader.AddList(WordListStyle.Bulleted);
 
                 listInHeader.AddItem("Test Header 1");
 
-                document.Footer!.Default.AddParagraph("Test Me Header");
+                var defaultFooter = Guard.NotNull(document.Footer?.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+                defaultFooter.AddParagraph("Test Me Header");
 
                 listInHeader.AddItem("Test Header 2");
 
 
-                var listInFooter = document.Footer!.Default.AddList(WordListStyle.Numbered);
+                var listInFooter = defaultFooter.AddList(WordListStyle.Numbered);
 
                 listInFooter.AddItem("Test Footer 1");
 
-                document.Footer!.Default.AddParagraph("Test Me Footer");
+                defaultFooter.AddParagraph("Test Me Footer");
 
                 listInFooter.AddItem("Test Footer 2");
 

--- a/OfficeIMO.Examples/Word/Lists/Lists.NumberingDefinition.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.NumberingDefinition.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -9,7 +10,7 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var numbering = document.CreateNumberingDefinition();
                 numbering.AddLevel(new WordListLevel(WordListLevelKind.Decimal));
-                var retrieved = document.GetNumberingDefinition(numbering.AbstractNumberId);
+                var retrieved = Guard.NotNull(document.GetNumberingDefinition(numbering.AbstractNumberId), "Numbering definition should exist after creation.");
                 Console.WriteLine("Numbering levels: " + retrieved.Levels.Count);
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example1.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example1.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 using Color = SixLabors.ImageSharp.Color;
 
@@ -17,7 +18,8 @@ namespace OfficeIMO.Examples.Word {
                 document.Settings.UpdateFieldsOnOpen = true;
                 document.AddTableOfContent(tableOfContentStyle: TableOfContentStyle.Template2);
                 document.AddHeadersAndFooters();
-                var pageNumber = document.Header!.Default.AddPageNumber(WordPageNumberStyle.Dots);
+                var defaultHeader = Guard.NotNull(document.Header?.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                var pageNumber = defaultHeader.AddPageNumber(WordPageNumberStyle.Dots);
                 //var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.VerticalOutline2);
                 //var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.Dots);
 

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example2.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example2.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -10,7 +11,8 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
-                var table = document.Footer!.Default.AddTable(1, 2, WordTableStyle.TableGrid);
+                var defaultFooter = Guard.NotNull(document.Footer?.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+                var table = defaultFooter.AddTable(1, 2, WordTableStyle.TableGrid);
                 table.WidthType = TableWidthUnitValues.Pct;
                 // 5000 represents 100% when using Pct width
                 table.Width = 5000;

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example3.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example3.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -11,7 +12,8 @@ namespace OfficeIMO.Examples.Word {
                 document.Sections[0].AddPageNumbering(2, NumberFormatValues.LowerRoman);
                 document.AddHeadersAndFooters();
 
-                var para = document.Footer!.Default.AddParagraph();
+                var defaultFooter = Guard.NotNull(document.Footer?.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+                var para = defaultFooter.AddParagraph();
                 para.AddText("Page ");
                 para.AddPageNumber();
 

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example4.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example4.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -10,7 +11,8 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
-                var para = document.Header!.Default.AddParagraph();
+                var defaultHeader = Guard.NotNull(document.Header?.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                var para = defaultHeader.AddParagraph();
                 para.ParagraphAlignment = JustificationValues.Center;
                 para.AddPageNumber();
 

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example5.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example5.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -10,7 +11,8 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
-                var firstFooter = document.Footer!.Default.AddParagraph();
+                var defaultFooter = Guard.NotNull(document.Footer?.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+                var firstFooter = defaultFooter.AddParagraph();
                 firstFooter.ParagraphAlignment = JustificationValues.Right;
                 firstFooter.AddText("Page ");
                 firstFooter.AddPageNumber(includeTotalPages: true, separator: " of ");
@@ -21,7 +23,7 @@ namespace OfficeIMO.Examples.Word {
                 section.AddPageNumbering(1);
                 section.AddParagraph("Section 2");
 
-                var secondFooter = document.Footer!.Default.AddParagraph();
+                var secondFooter = defaultFooter.AddParagraph();
                 secondFooter.ParagraphAlignment = JustificationValues.Right;
                 secondFooter.AddText("Page ");
                 secondFooter.AddPageNumber(includeTotalPages: true, separator: " of ");

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example6.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example6.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -11,7 +12,8 @@ namespace OfficeIMO.Examples.Word {
                 document.Sections[0].AddPageNumbering(1, NumberFormatValues.UpperRoman);
                 document.AddHeadersAndFooters();
 
-                var para = document.Footer!.Default.AddParagraph();
+                var defaultFooter = Guard.NotNull(document.Footer?.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+                var para = defaultFooter.AddParagraph();
                 para.ParagraphAlignment = JustificationValues.Right;
                 para.AddText("Page ");
                 para.AddPageNumber(includeTotalPages: true, format: WordFieldFormat.Roman, separator: " of ");

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example7.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example7.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -9,7 +10,8 @@ namespace OfficeIMO.Examples.Word {
             string filePath = System.IO.Path.Combine(folderPath, "Document with PageNumbers7.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                var defaultFooter = Guard.NotNull(document.Footer?.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+                var pageNumber = defaultFooter.AddPageNumber(WordPageNumberStyle.PlainNumber);
                 pageNumber.AppendText(" of ");
                 pageNumber.Paragraph.AddField(WordFieldType.NumPages);
                 document.Save(openWord);

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example8.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example8.cs
@@ -1,4 +1,5 @@
 using System;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -15,7 +16,8 @@ namespace OfficeIMO.Examples.Word {
                 string filePath = System.IO.Path.Combine(folderPath, $"Document_PageNumbers_{safeFormat}.docx");
                 using (WordDocument document = WordDocument.Create(filePath)) {
                     document.AddHeadersAndFooters();
-                    var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                    var defaultFooter = Guard.NotNull(document.Footer?.Default, "Default footer should exist after calling AddHeadersAndFooters.");
+                    var pageNumber = defaultFooter.AddPageNumber(WordPageNumberStyle.PlainNumber);
                     pageNumber.CustomFormat = format;
                     document.Save(openWord);
                 }

--- a/OfficeIMO.Examples/Word/Sections/Sections.Example6.cs
+++ b/OfficeIMO.Examples/Word/Sections/Sections.Example6.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -23,9 +25,13 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentFirstPage = true;
                 document.DifferentOddAndEvenPages = true;
 
-                document.Sections[0].Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
-                document.Sections[0].Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Sections[0].Header!.Even.AddParagraph().SetText("Test Section 0 - Even");
+                var section0 = document.Sections[0];
+                var section0DefaultHeader = Guard.NotNull(section0.Header?.Default, "Section 0 should expose a default header after adding headers and footers.");
+                section0DefaultHeader.AddParagraph().SetText("Test Section 0 - Header");
+                var section0FirstHeader = Guard.NotNull(section0.Header?.First, "Section 0 should expose a first header after enabling different first page.");
+                section0FirstHeader.AddParagraph().SetText("Test Section 0 - First Header");
+                var section0EvenHeader = Guard.NotNull(section0.Header?.Even, "Section 0 should expose an even header after enabling different odd and even pages.");
+                section0EvenHeader.AddParagraph().SetText("Test Section 0 - Even");
 
                 document.Sections[0].Paragraphs[0].AddComment("Przemysław Kłys", "PK", "This should be a comment");
 
@@ -57,17 +63,24 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 document.Sections[1].AddHeadersAndFooters();
-                document.Sections[1].Header!.Default.AddParagraph().SetText("Test Section 1 - Header");
-                document.Sections[1].Footer!.Default.AddParagraph().SetText("Test Section 1 - Header");
+                var section1 = document.Sections[1];
+                var section1DefaultHeader = Guard.NotNull(section1.Header?.Default, "Section 1 should expose a default header after adding headers and footers.");
+                section1DefaultHeader.AddParagraph().SetText("Test Section 1 - Header");
+                var section1DefaultFooter = Guard.NotNull(section1.Footer?.Default, "Section 1 should expose a default footer after adding headers and footers.");
+                section1DefaultFooter.AddParagraph().SetText("Test Section 1 - Header");
 
                 document.Sections[1].DifferentFirstPage = true;
-                document.Sections[1].Header!.First.AddParagraph().SetText("Test Section 1 - First Header");
-                document.Sections[1].Footer!.First.AddParagraph().SetText("Test Section 1 - First Footer");
+                var section1FirstHeader = Guard.NotNull(section1.Header?.First, "Section 1 should expose a first header after enabling different first page.");
+                section1FirstHeader.AddParagraph().SetText("Test Section 1 - First Header");
+                var section1FirstFooter = Guard.NotNull(section1.Footer?.First, "Section 1 should expose a first footer after enabling different first page.");
+                section1FirstFooter.AddParagraph().SetText("Test Section 1 - First Footer");
 
                 document.Sections[1].DifferentOddAndEvenPages = true;
 
-                document.Sections[1].Header!.Even.AddParagraph().SetText("Test Section 1 - Even Header");
-                document.Sections[1].Footer!.Even.AddParagraph().SetText("Test Section 1 - Even Footer");
+                var section1EvenHeader = Guard.NotNull(section1.Header?.Even, "Section 1 should expose an even header after enabling different odd and even pages.");
+                section1EvenHeader.AddParagraph().SetText("Test Section 1 - Even Header");
+                var section1EvenFooter = Guard.NotNull(section1.Footer?.Even, "Section 1 should expose an even footer after enabling different odd and even pages.");
+                section1EvenFooter.AddParagraph().SetText("Test Section 1 - Even Footer");
 
                 document.Settings.ProtectionPassword = "ThisIsTest";
                 document.Settings.ProtectionType = DocumentProtectionValues.ReadOnly;

--- a/OfficeIMO.Examples/Word/Sections/Sections.Example7.cs
+++ b/OfficeIMO.Examples/Word/Sections/Sections.Example7.cs
@@ -1,9 +1,11 @@
 using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -19,9 +21,13 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentFirstPage = true;
                 document.DifferentOddAndEvenPages = true;
 
-                document.Sections[0].Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Sections[0].Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
-                document.Sections[0].Header!.Even.AddParagraph().SetText("Test Section 0 - Even");
+                var section0 = document.Sections[0];
+                var section0FirstHeader = Guard.NotNull(section0.Header?.First, "Section 0 should expose a first header after enabling different first page.");
+                section0FirstHeader.AddParagraph().SetText("Test Section 0 - First Header");
+                var section0DefaultHeader = Guard.NotNull(section0.Header?.Default, "Section 0 should expose a default header after adding headers and footers.");
+                section0DefaultHeader.AddParagraph().SetText("Test Section 0 - Header");
+                var section0EvenHeader = Guard.NotNull(section0.Header?.Even, "Section 0 should expose an even header after enabling different odd and even pages.");
+                section0EvenHeader.AddParagraph().SetText("Test Section 0 - Even");
 
                 document.AddPageBreak();
 
@@ -39,9 +45,11 @@ namespace OfficeIMO.Examples.Word {
                 section1.PageOrientation = PageOrientationValues.Portrait;
                 section1.AddParagraph("Test Section1");
                 section1.AddHeadersAndFooters();
-                section1.Header!.Default.AddParagraph().SetText("Test Section 1 - Header");
+                var section1DefaultHeader = Guard.NotNull(section1.Header?.Default, "Section 1 should expose a default header after adding headers and footers.");
+                section1DefaultHeader.AddParagraph().SetText("Test Section 1 - Header");
                 section1.DifferentFirstPage = true;
-                section1.Header!.First.AddParagraph().SetText("Test Section 1 - First Header");
+                var section1FirstHeader = Guard.NotNull(section1.Header?.First, "Section 1 should expose a first header after enabling different first page.");
+                section1FirstHeader.AddParagraph().SetText("Test Section 1 - First Header");
 
 
                 document.AddPageBreak();
@@ -60,7 +68,8 @@ namespace OfficeIMO.Examples.Word {
                 section2.AddParagraph("Test Section2");
                 section2.PageOrientation = PageOrientationValues.Landscape;
                 section2.AddHeadersAndFooters();
-                section2.Header!.Default.AddParagraph().SetText("Test Section 2 - Header");
+                var section2DefaultHeader = Guard.NotNull(section2.Header?.Default, "Section 2 should expose a default header after adding headers and footers.");
+                section2DefaultHeader.AddParagraph().SetText("Test Section 2 - Header");
 
                 document.AddParagraph("Test Section2 - Paragraph 1");
 
@@ -68,7 +77,8 @@ namespace OfficeIMO.Examples.Word {
                 var section3 = document.AddSection();
                 section3.AddParagraph("Test Section3");
                 section3.AddHeadersAndFooters();
-                section3.Header!.Default.AddParagraph().SetText("Test Section 3 - Header");
+                var section3DefaultHeader = Guard.NotNull(section3.Header?.Default, "Section 3 should expose a default header after adding headers and footers.");
+                section3DefaultHeader.AddParagraph().SetText("Test Section 3 - Header");
 
 
                 Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Paragraphs[0].Text);
@@ -77,10 +87,10 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine("Section 2 - Text 1: " + document.Sections[2].Paragraphs[1].Text);
                 Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Paragraphs[0].Text);
 
-                Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 1 - Text 0: " + document.Sections[1].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Header!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Section 0 - Text 0: " + Guard.NotNull(document.Sections[0].Header?.Default, "Section 0 should expose a default header after adding headers and footers.").Paragraphs[0].Text);
+                Console.WriteLine("Section 1 - Text 0: " + Guard.NotNull(document.Sections[1].Header?.Default, "Section 1 should expose a default header after adding headers and footers.").Paragraphs[0].Text);
+                Console.WriteLine("Section 2 - Text 0: " + Guard.NotNull(document.Sections[2].Header?.Default, "Section 2 should expose a default header after adding headers and footers.").Paragraphs[0].Text);
+                Console.WriteLine("Section 3 - Text 0: " + Guard.NotNull(document.Sections[3].Header?.Default, "Section 3 should expose a default header after adding headers and footers.").Paragraphs[0].Text);
                 document.Save(false);
             }
 
@@ -91,13 +101,14 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Paragraphs[0].Text);
                 Console.WriteLine("Section 2 - Text 1: " + document.Sections[2].Paragraphs[1].Text);
                 Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Paragraphs[0].Text);
-                Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 1 - Text 0: " + document.Sections[1].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Header!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Section 0 - Text 0: " + Guard.NotNull(document.Sections[0].Header?.Default, "Section 0 should expose a default header after adding headers and footers.").Paragraphs[0].Text);
+                Console.WriteLine("Section 1 - Text 0: " + Guard.NotNull(document.Sections[1].Header?.Default, "Section 1 should expose a default header after adding headers and footers.").Paragraphs[0].Text);
+                Console.WriteLine("Section 2 - Text 0: " + Guard.NotNull(document.Sections[2].Header?.Default, "Section 2 should expose a default header after adding headers and footers.").Paragraphs[0].Text);
+                Console.WriteLine("Section 3 - Text 0: " + Guard.NotNull(document.Sections[3].Header?.Default, "Section 3 should expose a default header after adding headers and footers.").Paragraphs[0].Text);
                 Console.WriteLine("-----");
-                document.Sections[1].Header!.Default.AddParagraph().SetText("Test Section 1 - Header-Par1");
-                Console.WriteLine("Section 1 - Text 1: " + document.Sections[1].Header!.Default.Paragraphs[1].Text);
+                var section1Header = Guard.NotNull(document.Sections[1].Header?.Default, "Section 1 should expose a default header after adding headers and footers.");
+                section1Header.AddParagraph().SetText("Test Section 1 - Header-Par1");
+                Console.WriteLine("Section 1 - Text 1: " + section1Header.Paragraphs[1].Text);
                 document.Save(openWord);
             }
         }

--- a/OfficeIMO.Examples/Word/Shapes/Shapes.SectionAndHeader.cs
+++ b/OfficeIMO.Examples/Word/Shapes/Shapes.SectionAndHeader.cs
@@ -1,4 +1,5 @@
 using System;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 using SixLabors.ImageSharp;
 
@@ -15,9 +16,10 @@ namespace OfficeIMO.Examples.Word {
                 section.AddShapeDrawing(ShapeType.Ellipse, 40, 40);
 
                 section.AddHeadersAndFooters();
-                section.Header!.Default.AddShape(ShapeType.Rectangle, 30, 20, Color.Blue, Color.Black);
-                section.Header!.Default.AddShape(ShapeType.RoundedRectangle, 25, 15, Color.Green, Color.Black, 1, arcSize: 0.3);
-                section.Header!.Default.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
+                var sectionDefaultHeader = Guard.NotNull(section.Header?.Default, "Section should expose a default header after adding headers and footers.");
+                sectionDefaultHeader.AddShape(ShapeType.Rectangle, 30, 20, Color.Blue, Color.Black);
+                sectionDefaultHeader.AddShape(ShapeType.RoundedRectangle, 25, 15, Color.Green, Color.Black, 1, arcSize: 0.3);
+                sectionDefaultHeader.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Remove.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Remove.cs
@@ -1,4 +1,5 @@
 using System;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -18,9 +19,14 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentFirstPage = true;
                 document.DifferentOddAndEvenPages = true;
 
-                document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Default");
-                document.Sections[0].Header!.First.AddWatermark(WordWatermarkStyle.Text, "First");
-                document.Sections[0].Header!.Even.AddWatermark(WordWatermarkStyle.Text, "Even");
+                var firstSection = document.Sections[0];
+                var headers = Guard.NotNull(firstSection.Header, "Headers should exist after calling AddHeadersAndFooters.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                defaultHeader.AddWatermark(WordWatermarkStyle.Text, "Default");
+                var firstHeader = Guard.NotNull(headers.First, "First header should exist after enabling different first page.");
+                firstHeader.AddWatermark(WordWatermarkStyle.Text, "First");
+                var evenHeader = Guard.NotNull(headers.Even, "Even header should exist after enabling different odd and even pages.");
+                evenHeader.AddWatermark(WordWatermarkStyle.Text, "Even");
 
                 Console.WriteLine("Watermarks before: " + document.Watermarks.Count);
                 foreach (var watermark in document.Watermarks.ToList()) {

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Sample1.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Sample1.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 using SixLabors.ImageSharp;
 
@@ -20,7 +21,8 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddParagraph("Section 0");
                 document.AddHeadersAndFooters();
-                document.Sections[0].Header!.Default.AddParagraph("Section 0 - In header");
+                var section0DefaultHeader = Guard.NotNull(document.Sections[0].Header?.Default, "Section 0 should expose a default header after adding headers and footers.");
+                section0DefaultHeader.AddParagraph("Section 0 - In header");
                 document.Sections[0].SetMargins(WordMargin.Normal);
 
                 Console.WriteLine(document.Sections[0].Margins.Left.Value);
@@ -33,7 +35,7 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine(document.Sections[0].Margins.Type);
 
                 Console.WriteLine("----");
-                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Watermark");
+                var watermark = section0DefaultHeader.AddWatermark(WordWatermarkStyle.Text, "Watermark");
                 watermark.Color = Color.Red;
 
                 // ColorHex normally returns hex colors, but for watermark it returns string as the underlying value is in string name, not hex
@@ -62,16 +64,17 @@ namespace OfficeIMO.Examples.Word {
                 document.AddParagraph("Section 1");
 
                 document.Sections[1].AddHeadersAndFooters();
-                document.Sections[1].Header!.Default.AddParagraph("Section 1 - In header");
+                var section1DefaultHeader = Guard.NotNull(document.Sections[1].Header?.Default, "Section 1 should expose a default header after adding headers and footers.");
+                section1DefaultHeader.AddParagraph("Section 1 - In header");
                 document.Sections[1].Margins.Type = WordMargin.Narrow;
                 Console.WriteLine("----");
 
-                Console.WriteLine("Section 0 - Paragraphs Count: " + document.Sections[0].Header!.Default.Paragraphs.Count);
-                Console.WriteLine("Section 1 - Paragraphs Count: " + document.Sections[1].Header!.Default.Paragraphs.Count);
+                Console.WriteLine("Section 0 - Paragraphs Count: " + section0DefaultHeader.Paragraphs.Count);
+                Console.WriteLine("Section 1 - Paragraphs Count: " + section1DefaultHeader.Paragraphs.Count);
 
                 Console.WriteLine("----");
                 document.Sections[1].AddParagraph("Test");
-                document.Sections[1].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Draft");
+                section1DefaultHeader.AddWatermark(WordWatermarkStyle.Text, "Draft");
 
                 Console.WriteLine(document.Sections[0].Margins.Left.Value);
                 Console.WriteLine(document.Sections[0].Margins.Right.Value);
@@ -86,17 +89,19 @@ namespace OfficeIMO.Examples.Word {
 
                 Console.WriteLine("----");
 
-                Console.WriteLine("Watermarks in default header: " + document.Header!.Default.Watermarks.Count);
+                var defaultHeader = Guard.NotNull(document.Header?.Default, "Document should expose a default header after adding headers and footers.");
+                Console.WriteLine("Watermarks in default header: " + defaultHeader.Watermarks.Count);
 
-                Console.WriteLine("Watermarks in default footer: " + document.Footer!.Default.Watermarks.Count);
+                var defaultFooter = Guard.NotNull(document.Footer?.Default, "Document should expose a default footer after adding headers and footers.");
+                Console.WriteLine("Watermarks in default footer: " + defaultFooter.Watermarks.Count);
 
                 Console.WriteLine("Watermarks in section 0: " + document.Sections[0].Watermarks.Count);
-                Console.WriteLine("Watermarks in section 0 (header): " + document.Sections[0].Header!.Default.Watermarks.Count);
-                Console.WriteLine("Paragraphs in section 0 (header): " + document.Sections[0].Header!.Default.Paragraphs.Count);
+                Console.WriteLine("Watermarks in section 0 (header): " + section0DefaultHeader.Watermarks.Count);
+                Console.WriteLine("Paragraphs in section 0 (header): " + section0DefaultHeader.Paragraphs.Count);
 
                 Console.WriteLine("Watermarks in section 1: " + document.Sections[1].Watermarks.Count);
-                Console.WriteLine("Watermarks in section 1 (header): " + document.Sections[1].Header!.Default.Watermarks.Count);
-                Console.WriteLine("Paragraphs in section 1 (header): " + document.Sections[1].Header!.Default.Paragraphs.Count);
+                Console.WriteLine("Watermarks in section 1 (header): " + section1DefaultHeader.Watermarks.Count);
+                Console.WriteLine("Paragraphs in section 1 (header): " + section1DefaultHeader.Paragraphs.Count);
 
                 Console.WriteLine("Watermarks in document: " + document.Watermarks.Count);
 

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Sample4.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Sample4.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 using SixLabors.ImageSharp;
 
@@ -19,7 +21,8 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddParagraph("Section 0");
                 document.AddHeadersAndFooters();
-                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "HexColor");
+                var section0DefaultHeader = Guard.NotNull(document.Sections[0].Header?.Default, "Section 0 should expose a default header after adding headers and footers.");
+                var watermark = section0DefaultHeader.AddWatermark(WordWatermarkStyle.Text, "HexColor");
                 watermark.ColorHex = "00ff00";
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.SampleImage1.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.SampleImage1.cs
@@ -1,3 +1,5 @@
+using System;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -17,7 +19,8 @@ namespace OfficeIMO.Examples.Word {
                 document.AddHeadersAndFooters();
 
                 var imagePathToAdd = System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg");
-                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Image, imagePathToAdd);
+                var watermark = Guard.NotNull(document.Sections[0].Header?.Default, "Section 0 should expose a default header after adding headers and footers.")
+                    .AddWatermark(WordWatermarkStyle.Image, imagePathToAdd);
 
                 //Console.WriteLine(watermark.Height);
                 //Console.WriteLine(watermark.Width);

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample3.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample3.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -13,7 +14,9 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddHeadersAndFooters();
 
-                var textBox = document.Header!.Default.AddTextBox("My textbox on the left");
+                var headers = Guard.NotNull(document.Header, "Headers should exist after calling AddHeadersAndFooters.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                var textBox = defaultHeader.AddTextBox("My textbox on the left");
 
                 textBox.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
                 // horizontal alignment overwrites the horizontal position offset so only one will work

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample4.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample4.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -13,7 +14,9 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddHeadersAndFooters();
 
-                var textBox = document.Header!.Default.AddTextBox("My textbox in header");
+                var headers = Guard.NotNull(document.Header, "Headers should exist after calling AddHeadersAndFooters.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header should exist after calling AddHeadersAndFooters.");
+                var textBox = defaultHeader.AddTextBox("My textbox in header");
 
                 Console.WriteLine("Textbox (header) wraptext: " + textBox.WrapText);
 

--- a/OfficeIMO.Tests/Excel.BasicDocuments.cs
+++ b/OfficeIMO.Tests/Excel.BasicDocuments.cs
@@ -61,7 +61,7 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void Test_OpeningExcel() {
             using (var document = ExcelDocument.Load(Path.Combine(_directoryDocuments, "BasicExcel.xlsx"))) {
-                Assert.True(document.FilePath != null);
+                Assert.NotNull(document.FilePath);
                 Assert.True(document.Sheets.Count == 4);
 
                 Assert.True(document.Sheets[0].Name == "Sheet1");

--- a/OfficeIMO.Tests/Word.DigitalSignature.cs
+++ b/OfficeIMO.Tests/Word.DigitalSignature.cs
@@ -9,7 +9,7 @@ namespace OfficeIMO.Tests {
         public void Test_DigitalSignature_MissingPart_ReturnsNull() {
             string tempFile = Path.GetTempFileName();
             using (WordDocument document = WordDocument.Create(tempFile)) {
-                Assert.True(document.ApplicationProperties.DigitalSignature == null);
+                Assert.Null(document.ApplicationProperties.DigitalSignature);
             }
         }
 
@@ -18,11 +18,11 @@ namespace OfficeIMO.Tests {
             string tempFile = Path.GetTempFileName();
             using (WordDocument document = WordDocument.Create(tempFile)) {
                 document.ApplicationProperties.DigitalSignature = new DigitalSignature();
-                Assert.True(document.ApplicationProperties.DigitalSignature != null);
+                Assert.NotNull(document.ApplicationProperties.DigitalSignature);
                 var extendedPart = document._wordprocessingDocument!.ExtendedFilePropertiesPart;
                 Assert.NotNull(extendedPart);
                 document._wordprocessingDocument!.DeletePart(extendedPart);
-                Assert.True(document.ApplicationProperties.DigitalSignature == null);
+                Assert.Null(document.ApplicationProperties.DigitalSignature);
             }
         }
     }

--- a/OfficeIMO.Tests/Word.HeadersAndFooter.cs
+++ b/OfficeIMO.Tests/Word.HeadersAndFooter.cs
@@ -191,26 +191,30 @@ namespace OfficeIMO.Tests {
                 document.Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
                 document.Footer!.Default.AddParagraph().SetText("Test Section 0 - Footer");
 
-                Assert.True(document.Header!.First == null);
-                Assert.True(document.Footer!.First == null);
+                Assert.Null(document.Header!.First);
+                Assert.Null(document.Footer!.First);
 
                 document.DifferentFirstPage = true;
 
-                Assert.True(document.Header!.First != null);
-                Assert.True(document.Footer!.First != null);
-                document.Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Footer!.First.AddParagraph().SetText("Test Section 0 - First Footer");
+                var firstHeader = document.Header!.First;
+                var firstFooter = document.Footer!.First;
+                Assert.NotNull(firstHeader);
+                Assert.NotNull(firstFooter);
+                firstHeader!.AddParagraph().SetText("Test Section 0 - First Header");
+                firstFooter!.AddParagraph().SetText("Test Section 0 - First Footer");
 
-                Assert.True(document.Header!.Even == null);
-                Assert.True(document.Footer!.Even == null);
+                Assert.Null(document.Header!.Even);
+                Assert.Null(document.Footer!.Even);
 
                 document.DifferentOddAndEvenPages = true;
 
-                Assert.True(document.Header!.Even != null);
-                Assert.True(document.Footer!.Even != null);
+                var evenHeader = document.Header!.Even;
+                var evenFooter = document.Footer!.Even;
+                Assert.NotNull(evenHeader);
+                Assert.NotNull(evenFooter);
 
-                document.Header!.Even.AddParagraph().SetText("Test Section 0 - Header Even");
-                document.Footer!.Even.AddParagraph().SetText("Test Section 0 - Footer Even");
+                evenHeader!.AddParagraph().SetText("Test Section 0 - Header Even");
+                evenFooter!.AddParagraph().SetText("Test Section 0 - Footer Even");
 
                 Assert.True(document.Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header");
                 Assert.True(document.Footer!.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
@@ -266,26 +270,30 @@ namespace OfficeIMO.Tests {
                 document.Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
                 document.Footer!.Default.AddParagraph().SetText("Test Section 0 - Footer");
 
-                Assert.True(document.Header!.First == null);
-                Assert.True(document.Footer!.First == null);
+                Assert.Null(document.Header!.First);
+                Assert.Null(document.Footer!.First);
 
                 document.DifferentFirstPage = true;
 
-                Assert.True(document.Header!.First != null);
-                Assert.True(document.Footer!.First != null);
-                document.Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Footer!.First.AddParagraph().SetText("Test Section 0 - First Footer");
+                var sectionFirstHeader = document.Header!.First;
+                var sectionFirstFooter = document.Footer!.First;
+                Assert.NotNull(sectionFirstHeader);
+                Assert.NotNull(sectionFirstFooter);
+                sectionFirstHeader!.AddParagraph().SetText("Test Section 0 - First Header");
+                sectionFirstFooter!.AddParagraph().SetText("Test Section 0 - First Footer");
 
-                Assert.True(document.Header!.Even == null);
-                Assert.True(document.Footer!.Even == null);
+                Assert.Null(document.Header!.Even);
+                Assert.Null(document.Footer!.Even);
 
                 document.DifferentOddAndEvenPages = true;
 
-                Assert.True(document.Header!.Even != null);
-                Assert.True(document.Footer!.Even != null);
+                var sectionEvenHeader = document.Header!.Even;
+                var sectionEvenFooter = document.Footer!.Even;
+                Assert.NotNull(sectionEvenHeader);
+                Assert.NotNull(sectionEvenFooter);
 
-                document.Header!.Even.AddParagraph().SetText("Test Section 0 - Header Even");
-                document.Footer!.Even.AddParagraph().SetText("Test Section 0 - Footer Even");
+                sectionEvenHeader!.AddParagraph().SetText("Test Section 0 - Header Even");
+                sectionEvenFooter!.AddParagraph().SetText("Test Section 0 - Footer Even");
 
 
                 var section1 = document.AddSection();

--- a/OfficeIMO.Tests/Word.HeadersAndFootersWithSections.cs
+++ b/OfficeIMO.Tests/Word.HeadersAndFootersWithSections.cs
@@ -133,26 +133,30 @@ namespace OfficeIMO.Tests {
                 document.Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
                 document.Footer!.Default.AddParagraph().SetText("Test Section 0 - Footer");
 
-                Assert.True(document.Header!.First == null);
-                Assert.True(document.Footer!.First == null);
+                Assert.Null(document.Header!.First);
+                Assert.Null(document.Footer!.First);
 
                 document.DifferentFirstPage = true;
 
-                Assert.True(document.Header!.First != null);
-                Assert.True(document.Footer!.First != null);
-                document.Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Footer!.First.AddParagraph().SetText("Test Section 0 - First Footer");
+                var firstHeader = document.Header!.First;
+                var firstFooter = document.Footer!.First;
+                Assert.NotNull(firstHeader);
+                Assert.NotNull(firstFooter);
+                firstHeader!.AddParagraph().SetText("Test Section 0 - First Header");
+                firstFooter!.AddParagraph().SetText("Test Section 0 - First Footer");
 
-                Assert.True(document.Header!.Even == null);
-                Assert.True(document.Footer!.Even == null);
+                Assert.Null(document.Header!.Even);
+                Assert.Null(document.Footer!.Even);
 
                 document.DifferentOddAndEvenPages = true;
 
-                Assert.True(document.Header!.Even != null);
-                Assert.True(document.Footer!.Even != null);
+                var evenHeader = document.Header!.Even;
+                var evenFooter = document.Footer!.Even;
+                Assert.NotNull(evenHeader);
+                Assert.NotNull(evenFooter);
 
-                document.Header!.Even.AddParagraph().SetText("Test Section 0 - Header Even");
-                document.Footer!.Even.AddParagraph().SetText("Test Section 0 - Footer Even");
+                evenHeader!.AddParagraph().SetText("Test Section 0 - Header Even");
+                evenFooter!.AddParagraph().SetText("Test Section 0 - Footer Even");
 
                 Assert.True(document.Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header");
                 Assert.True(document.Footer!.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
@@ -228,31 +232,31 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs.Count == 1, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.Sections.Count == 2, "Number of sections during creation is wrong.");
 
-                Assert.True(document.Sections[1].Header!.Default == null);
-                Assert.True(document.Sections[1].Footer!.Default == null);
-                Assert.True(document.Sections[1].Header!.First == null);
-                Assert.True(document.Sections[1].Footer!.First == null);
-                Assert.True(document.Sections[1].Header!.Even == null);
-                Assert.True(document.Sections[1].Footer!.Even == null);
+                Assert.Null(document.Sections[1].Header!.Default);
+                Assert.Null(document.Sections[1].Footer!.Default);
+                Assert.Null(document.Sections[1].Header!.First);
+                Assert.Null(document.Sections[1].Footer!.First);
+                Assert.Null(document.Sections[1].Header!.Even);
+                Assert.Null(document.Sections[1].Footer!.Even);
 
                 document.AddSection();
                 document.Sections[2].PageOrientation = PageOrientationValues.Landscape;
 
-                Assert.True(document.Sections[2].Header!.Default == null);
-                Assert.True(document.Sections[2].Footer!.Default == null);
-                Assert.True(document.Sections[2].Header!.First == null);
-                Assert.True(document.Sections[2].Footer!.First == null);
-                Assert.True(document.Sections[2].Header!.Even == null);
-                Assert.True(document.Sections[2].Footer!.Even == null);
+                Assert.Null(document.Sections[2].Header!.Default);
+                Assert.Null(document.Sections[2].Footer!.Default);
+                Assert.Null(document.Sections[2].Header!.First);
+                Assert.Null(document.Sections[2].Footer!.First);
+                Assert.Null(document.Sections[2].Header!.Even);
+                Assert.Null(document.Sections[2].Footer!.Even);
 
                 document.Sections[2].AddHeadersAndFooters();
 
-                Assert.True(document.Sections[2].Header!.Default != null);
-                Assert.True(document.Sections[2].Footer!.Default != null);
-                Assert.True(document.Sections[2].Header!.First == null);
-                Assert.True(document.Sections[2].Footer!.First == null);
-                Assert.True(document.Sections[2].Header!.Even == null);
-                Assert.True(document.Sections[2].Footer!.Even == null);
+                Assert.NotNull(document.Sections[2].Header!.Default);
+                Assert.NotNull(document.Sections[2].Footer!.Default);
+                Assert.Null(document.Sections[2].Header!.First);
+                Assert.Null(document.Sections[2].Footer!.First);
+                Assert.Null(document.Sections[2].Header!.Even);
+                Assert.Null(document.Sections[2].Footer!.Even);
 
                 document.Save();
             }
@@ -282,12 +286,12 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs.Count == 1, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.Sections.Count == 4, "Number of sections during creation is wrong.");
 
-                Assert.True(document.Sections[3].Header!.Default != null);
-                Assert.True(document.Sections[3].Footer!.Default != null);
-                Assert.True(document.Sections[3].Header!.First == null);
-                Assert.True(document.Sections[3].Footer!.First == null);
-                Assert.True(document.Sections[3].Header!.Even == null);
-                Assert.True(document.Sections[3].Footer!.Even == null);
+                Assert.NotNull(document.Sections[3].Header!.Default);
+                Assert.NotNull(document.Sections[3].Footer!.Default);
+                Assert.Null(document.Sections[3].Header!.First);
+                Assert.Null(document.Sections[3].Footer!.First);
+                Assert.Null(document.Sections[3].Header!.Even);
+                Assert.Null(document.Sections[3].Footer!.Even);
 
                 document.Sections[3].DifferentFirstPage = true;
                 document.Sections[3].DifferentOddAndEvenPages = true;
@@ -296,12 +300,12 @@ namespace OfficeIMO.Tests {
                 document.Sections[3].Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
                 document.Sections[3].Header!.Even.AddParagraph().SetText("Test Section 0 - Even");
 
-                Assert.True(document.Sections[3].Header!.Default != null);
-                Assert.True(document.Sections[3].Footer!.Default != null);
-                Assert.True(document.Sections[3].Header!.First != null);
-                Assert.True(document.Sections[3].Footer!.First != null);
-                Assert.True(document.Sections[3].Header!.Even != null);
-                Assert.True(document.Sections[3].Footer!.Even != null);
+                Assert.NotNull(document.Sections[3].Header!.Default);
+                Assert.NotNull(document.Sections[3].Footer!.Default);
+                Assert.NotNull(document.Sections[3].Header!.First);
+                Assert.NotNull(document.Sections[3].Footer!.First);
+                Assert.NotNull(document.Sections[3].Header!.Even);
+                Assert.NotNull(document.Sections[3].Footer!.Even);
 
 
                 Assert.True(document.Sections[2].Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header");

--- a/OfficeIMO.Tests/Word.TOC.cs
+++ b/OfficeIMO.Tests/Word.TOC.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.Paragraphs.Count == 0, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.Tables.Count == 0, "Tables count matches");
                 Assert.True(document.Lists.Count == 0, "List count matches");
-                Assert.True(document.TableOfContent == null, "TableOfContent Should not be set");
+                Assert.Null(document.TableOfContent);
                 Assert.True(document.Settings.UpdateFieldsOnOpen == false, "UpdateFieldsOnOpen should not be set");
 
                 WordTableOfContent wordTableContent = document.AddTableOfContent(TableOfContentStyle.Template1);
@@ -34,7 +34,7 @@ namespace OfficeIMO.Tests {
                 paragraph.Style = WordParagraphStyles.Heading1;
 
                 Assert.True(document.Settings.UpdateFieldsOnOpen == true, "UpdateFieldsOnOpen should be set");
-                Assert.True(document.TableOfContent != null, "TableOfContent Should be set");
+                Assert.NotNull(document.TableOfContent);
                 Assert.True(document.Tables.Count == 0, "Tables count matches");
                 Assert.True(document.Lists.Count == 0, "List count matches");
                 Assert.True(document.PageBreaks.Count == 1, "PageBreak count should be 1");
@@ -47,7 +47,7 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithTOC.docx"))) {
                 Assert.True(document.Settings.UpdateFieldsOnOpen == true, "UpdateFieldsOnOpen should be set");
-                Assert.True(document.TableOfContent != null, "TableOfContent Should be set");
+                Assert.NotNull(document.TableOfContent);
                 Assert.True(document.Tables.Count == 0, "Tables count matches");
                 Assert.True(document.Lists.Count == 0, "List count matches");
                 Assert.True(document.PageBreaks.Count == 1, "PageBreak count should be 1");
@@ -67,7 +67,7 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithTOC.docx"))) {
                 Assert.True(document.Settings.UpdateFieldsOnOpen == false, "UpdateFieldsOnOpen should not be set");
-                Assert.True(document.TableOfContent != null, "TableOfContent Should be set");
+                Assert.NotNull(document.TableOfContent);
                 Assert.True(document.Tables.Count == 0, "Tables count matches");
                 Assert.True(document.Lists.Count == 0, "List count matches");
                 Assert.True(document.PageBreaks.Count == 1, "PageBreak count should be 1");

--- a/OfficeIMO.Tests/Word.TablesLoading.cs
+++ b/OfficeIMO.Tests/Word.TablesLoading.cs
@@ -17,7 +17,7 @@ namespace OfficeIMO.Tests {
                 // We check for style definition part.
                 StyleDefinitionsPart? styleDefinitionsPart = document._document?.MainDocumentPart?.GetPartsOfType<StyleDefinitionsPart>().FirstOrDefault();
                 // It should exists
-                Assert.True(styleDefinitionsPart != null);
+                Assert.NotNull(styleDefinitionsPart);
 
                 // we now check if all table styles are available for use
                 List<Style> listTableStyles = new List<Style>();

--- a/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
+++ b/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
@@ -182,11 +183,16 @@ namespace OfficeIMO.Word.Html {
 
             // Prefer section-scoped headers to avoid multi-section warnings
             var targetSection = doc.Sections.Last();
-            var headers = targetSection.Header;
-            WordHeader header;
-            if (type == HeaderFooterValues.First) header = headers.First;
-            else if (type == HeaderFooterValues.Even) header = headers.Even;
-            else header = headers.Default;
+            var headers = targetSection.Header ?? throw new InvalidOperationException("Headers should exist after calling AddHeadersAndFooters.");
+            WordHeader? selectedHeader;
+            if (type == HeaderFooterValues.First) {
+                selectedHeader = headers.First;
+            } else if (type == HeaderFooterValues.Even) {
+                selectedHeader = headers.Even;
+            } else {
+                selectedHeader = headers.Default;
+            }
+            var header = selectedHeader ?? throw new InvalidOperationException($"The {type} header is not available after adding headers and footers.");
 
             var converter = new HtmlToWordConverter();
             await converter.AddHtmlToHeaderAsync(doc, header, html, options, cancellationToken).ConfigureAwait(false);
@@ -223,11 +229,16 @@ namespace OfficeIMO.Word.Html {
 
             // Prefer section-scoped footers to avoid multi-section warnings
             var targetSection = doc.Sections.Last();
-            var footers = targetSection.Footer;
-            WordFooter footer;
-            if (type == HeaderFooterValues.First) footer = footers.First;
-            else if (type == HeaderFooterValues.Even) footer = footers.Even;
-            else footer = footers.Default;
+            var footers = targetSection.Footer ?? throw new InvalidOperationException("Footers should exist after calling AddHeadersAndFooters.");
+            WordFooter? selectedFooter;
+            if (type == HeaderFooterValues.First) {
+                selectedFooter = footers.First;
+            } else if (type == HeaderFooterValues.Even) {
+                selectedFooter = footers.Even;
+            } else {
+                selectedFooter = footers.Default;
+            }
+            var footer = selectedFooter ?? throw new InvalidOperationException($"The {type} footer is not available after adding headers and footers.");
 
             var converter = new HtmlToWordConverter();
             await converter.AddHtmlToFooterAsync(doc, footer, html, options, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- guard header and footer access across Word examples to avoid null dereferences
- harden HTML conversion helpers against missing header or footer parts
- replace null comparisons in tests with Assert.Null/Assert.NotNull to clarify expectations

## Testing
- dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cb13127b44832e9485e55d40a8627a