### PR TITLE
Add safe header/footer access helpers to examples

### DIFF
--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.HeaderFooterImages.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.HeaderFooterImages.cs
@@ -13,8 +13,11 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Create(docPath)) {
                 document.AddHeadersAndFooters();
-                document.Header!.Default.AddParagraph().AddImage(imagePath, 50, 50);
-                document.Footer!.Default.AddParagraph().AddImage(imagePath, 300, 300);
+                var header = GetDocumentHeaderOrThrow(document);
+                header.AddParagraph().AddImage(imagePath, 50, 50);
+
+                var footer = GetDocumentFooterOrThrow(document);
+                footer.AddParagraph().AddImage(imagePath, 300, 300);
                 document.Save();
                 document.SaveAsPdf(pdfPath);
             }

--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdf.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdf.cs
@@ -22,11 +22,13 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Create(docPath)) {
                 document.AddHeadersAndFooters();
-                document.Header!.Default.AddParagraph("Example Header");
-                WordTable headerTable = document.Header!.Default.AddTable(1, 1);
+                var header = GetDocumentHeaderOrThrow(document);
+                header.AddParagraph("Example Header");
+                WordTable headerTable = header.AddTable(1, 1);
                 headerTable.Rows[0].Cells[0].Paragraphs[0].Text = "H1";
-                document.Footer!.Default.AddParagraph("Example Footer");
-                WordTable footerTable = document.Footer!.Default.AddTable(1, 1);
+                var footer = GetDocumentFooterOrThrow(document);
+                footer.AddParagraph("Example Footer");
+                WordTable footerTable = footer.AddTable(1, 1);
                 footerTable.Rows[0].Cells[0].Paragraphs[0].Text = "F1";
 
                 WordParagraph heading = document.AddParagraph("Sample Heading");

--- a/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.Create.cs
+++ b/OfficeIMO.Examples/Word/AdvancedDocument/AdvancedDocument.Create.cs
@@ -92,7 +92,7 @@ namespace OfficeIMO.Examples.Word {
                 document.AddHeadersAndFooters();
 
                 // adding text to default header
-                document.Header!.Default.AddParagraph("Text added to header - Default");
+                GetDocumentHeaderOrThrow(document).AddParagraph("Text added to header - Default");
 
                 var section1 = document.AddSection();
                 section1.PageOrientation = PageOrientationValues.Portrait;
@@ -105,7 +105,7 @@ namespace OfficeIMO.Examples.Word {
                 document.CustomDocumentProperties.Add("IsTodayGreatDay", new WordCustomProperty(true));
 
                 // add page numbers
-                document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                GetDocumentFooterOrThrow(document).AddPageNumber(WordPageNumberStyle.PlainNumber);
 
                 // add watermark
                 document.Sections[0].AddWatermark(WordWatermarkStyle.Text, "Draft");

--- a/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create05.cs
+++ b/OfficeIMO.Examples/Word/BasicDocument/BasicDocument.Create05.cs
@@ -24,29 +24,31 @@ namespace OfficeIMO.Examples.Word {
 
                 Console.WriteLine("Images count: " + document.Images.Count);
 
-                document.Header!.Default.AddParagraph().AddImage(filePathImage, 734, 92);
-                document.Header!.Default.Paragraphs[0].SetFontFamily("Arial");
-                document.Header!.Default.Paragraphs[0].SetFontSize(7).Bold = false;
+                var header = GetDocumentHeaderOrThrow(document);
+                header.AddParagraph().AddImage(filePathImage, 734, 92);
+                header.Paragraphs[0].SetFontFamily("Arial");
+                header.Paragraphs[0].SetFontSize(7).Bold = false;
 
                 Console.WriteLine("Images Count: " + document.Images.Count);
-                Console.WriteLine("Images in Header Count: " + document.Header!.Default.Images.Count);
+                Console.WriteLine("Images in Header Count: " + header.Images.Count);
 
-                document.Footer!.Default.AddParagraph();
-                document.Footer!.Default.Paragraphs[0].SetFontFamily("Arial");
-                document.Footer!.Default.Paragraphs[0].SetFontSize(7).Bold = false;
-                document.Footer!.Default.Paragraphs[0].ParagraphAlignment = JustificationValues.Right;
-                document.Footer!.Default.Paragraphs[0].Text = "SMA.5.doc 04/10/19";
-                document.Footer!.Default.Paragraphs[0].LineSpacingAfter = 0;
-                document.Footer!.Default.Paragraphs[0].LineSpacingBefore = 0;
-                document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PageNumberXofY);
+                var footer = GetDocumentFooterOrThrow(document);
+                footer.AddParagraph();
+                footer.Paragraphs[0].SetFontFamily("Arial");
+                footer.Paragraphs[0].SetFontSize(7).Bold = false;
+                footer.Paragraphs[0].ParagraphAlignment = JustificationValues.Right;
+                footer.Paragraphs[0].Text = "SMA.5.doc 04/10/19";
+                footer.Paragraphs[0].LineSpacingAfter = 0;
+                footer.Paragraphs[0].LineSpacingBefore = 0;
+                footer.AddPageNumber(WordPageNumberStyle.PageNumberXofY);
 
-                document.Footer!.Default.AddParagraph();
-                document.Footer!.Default.Paragraphs[1].SetFontFamily("Arial");
-                document.Footer!.Default.Paragraphs[1].SetFontSize(7).Bold = false;
-                document.Footer!.Default.Paragraphs[1].ParagraphAlignment = JustificationValues.Center;
-                document.Footer!.Default.Paragraphs[1].Text = "My address";
-                document.Footer!.Default.Paragraphs[1].LineSpacingAfter = 0;
-                document.Footer!.Default.Paragraphs[1].LineSpacingBefore = 0;
+                footer.AddParagraph();
+                footer.Paragraphs[1].SetFontFamily("Arial");
+                footer.Paragraphs[1].SetFontSize(7).Bold = false;
+                footer.Paragraphs[1].ParagraphAlignment = JustificationValues.Center;
+                footer.Paragraphs[1].Text = "My address";
+                footer.Paragraphs[1].LineSpacingAfter = 0;
+                footer.Paragraphs[1].LineSpacingBefore = 0;
 
                 var par00 = document.AddParagraph("My text");
                 par00.ParagraphAlignment = JustificationValues.Left;

--- a/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample04.cs
+++ b/OfficeIMO.Examples/Word/CleanupDocuments/Cleanup.Sample04.cs
@@ -17,15 +17,17 @@ internal static partial class CleanupDocuments {
         using (WordDocument document = WordDocument.Create(filePath)) {
             document.AddHeadersAndFooters();
 
-            var headerParagraph = document.Header!.Default.AddParagraph("Header ");
+            var header = GetDocumentHeaderOrThrow(document);
+            var headerParagraph = header.AddParagraph("Header ");
             headerParagraph.AddText("clutter ");
             headerParagraph.AddText("text");
-            document.Header!.Default.AddParagraph();
+            header.AddParagraph();
 
-            var footerParagraph = document.Footer!.Default.AddParagraph("Footer ");
+            var footer = GetDocumentFooterOrThrow(document);
+            var footerParagraph = footer.AddParagraph("Footer ");
             footerParagraph.AddText("clutter ");
             footerParagraph.AddText("text");
-            document.Footer!.Default.AddParagraph();
+            footer.AddParagraph();
 
             document.CleanupDocument();
             document.Save(openWord);

--- a/OfficeIMO.Examples/Word/EndToEnd/Word.EndToEnd.cs
+++ b/OfficeIMO.Examples/Word/EndToEnd/Word.EndToEnd.cs
@@ -18,8 +18,8 @@ namespace OfficeIMO.Examples.Word.EndToEnd {
             using (var doc = WordDocument.Create()) {
                 // Headers/Footers + page numbering
                 doc.AddHeadersAndFooters();
-                doc.Header!.Default.AddParagraph("End-to-End Demo");
-                doc.Footer!.Default.AddParagraph().AddPageNumber(includeTotalPages: true);
+                GetDocumentHeaderOrThrow(doc).AddParagraph("End-to-End Demo");
+                GetDocumentFooterOrThrow(doc).AddParagraph().AddPageNumber(includeTotalPages: true);
 
                 // TOC at top (updates on open)
                 new WordFluentDocument(doc).TocAtTop("Contents", minLevel: 1, maxLevel: 3, titleLevel: 2);
@@ -122,5 +122,17 @@ namespace OfficeIMO.Examples.Word.EndToEnd {
                 Console.WriteLine("✓ Round-trip: Word ⇄ Markdown and Word ⇄ HTML written");
             }
         }
+
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, type);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, type);
     }
 }

--- a/OfficeIMO.Examples/Word/Fields/Fields.CustomFormat.cs
+++ b/OfficeIMO.Examples/Word/Fields/Fields.CustomFormat.cs
@@ -26,7 +26,7 @@ namespace OfficeIMO.Examples.Word {
             string filePath = System.IO.Path.Combine(folderPath, "CustomFormattedHeaderDate.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                document.Header!.Default.AddField(WordFieldType.Date, customFormat: "yyyy-MM-dd", advanced: true);
+                GetDocumentHeaderOrThrow(document).AddField(WordFieldType.Date, customFormat: "yyyy-MM-dd", advanced: true);
                 document.AddParagraph("Body paragraph");
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/Fields/Fields02.cs
+++ b/OfficeIMO.Examples/Word/Fields/Fields02.cs
@@ -27,7 +27,7 @@ namespace OfficeIMO.Examples.Word {
                 document.AddField(WordFieldType.GreetingLine);
 
                 // added page number using dedicated way
-                var pageNumber = document.Header!.Default.AddPageNumber(WordPageNumberStyle.Roman);
+                var pageNumber = GetDocumentHeaderOrThrow(document).AddPageNumber(WordPageNumberStyle.Roman);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example1.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example1.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using SixLabors.ImageSharp;
 
@@ -16,37 +17,53 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentOddAndEvenPages = true;
                 document.DifferentFirstPage = true;
 
-                document.Header!.Default.AddParagraph().SetColor(Color.Red).SetText("Test Header");
+                var defaultHeader = GetDocumentHeaderOrThrow(document);
+                defaultHeader.AddParagraph().SetColor(SixLabors.ImageSharp.Color.Red).SetText("Test Header");
 
-                document.Footer!.Default.AddParagraph().SetColor(Color.Blue).SetText("Test Footer");
+                var defaultFooter = GetDocumentFooterOrThrow(document);
+                defaultFooter.AddParagraph().SetColor(SixLabors.ImageSharp.Color.Blue).SetText("Test Footer");
 
-                Console.WriteLine("Header Default Count: " + document.Header!.Default.Paragraphs.Count);
-                Console.WriteLine("Header Even Count: " + document.Header!.Even.Paragraphs.Count);
-                Console.WriteLine("Header First Count: " + document.Header!.First.Paragraphs.Count);
+                var evenHeader = GetDocumentHeaderOrThrow(document, HeaderFooterValues.Even);
+                var firstHeader = GetDocumentHeaderOrThrow(document, HeaderFooterValues.First);
 
-                Console.WriteLine("Header text: " + document.Header!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Header Default Count: " + defaultHeader.Paragraphs.Count);
+                Console.WriteLine("Header Even Count: " + evenHeader.Paragraphs.Count);
+                Console.WriteLine("Header First Count: " + firstHeader.Paragraphs.Count);
 
-                Console.WriteLine("Footer Default Count: " + document.Footer!.Default.Paragraphs.Count);
-                Console.WriteLine("Footer Even Count: " + document.Footer!.Even.Paragraphs.Count);
-                Console.WriteLine("Footer First Count: " + document.Footer!.First.Paragraphs.Count);
+                Console.WriteLine("Header text: " + defaultHeader.Paragraphs[0].Text);
 
-                Console.WriteLine("Footer text: " + document.Footer!.Default.Paragraphs[0].Text);
+                var evenFooter = GetDocumentFooterOrThrow(document, HeaderFooterValues.Even);
+                var firstFooter = GetDocumentFooterOrThrow(document, HeaderFooterValues.First);
+
+                Console.WriteLine("Footer Default Count: " + defaultFooter.Paragraphs.Count);
+                Console.WriteLine("Footer Even Count: " + evenFooter.Paragraphs.Count);
+                Console.WriteLine("Footer First Count: " + firstFooter.Paragraphs.Count);
+
+                Console.WriteLine("Footer text: " + defaultFooter.Paragraphs[0].Text);
 
                 document.Save();
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Console.WriteLine("Header Default Count: " + document.Header!.Default.Paragraphs.Count);
-                Console.WriteLine("Header Even Count: " + document.Header!.Even.Paragraphs.Count);
-                Console.WriteLine("Header First Count: " + document.Header!.First.Paragraphs.Count);
+                var defaultHeader = GetDocumentHeaderOrThrow(document);
+                var evenHeader = GetDocumentHeaderOrThrow(document, HeaderFooterValues.Even);
+                var firstHeader = GetDocumentHeaderOrThrow(document, HeaderFooterValues.First);
 
-                Console.WriteLine("Header text: " + document.Header!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Header Default Count: " + defaultHeader.Paragraphs.Count);
+                Console.WriteLine("Header Even Count: " + evenHeader.Paragraphs.Count);
+                Console.WriteLine("Header First Count: " + firstHeader.Paragraphs.Count);
 
-                Console.WriteLine("Footer Default Count: " + document.Footer!.Default.Paragraphs.Count);
-                Console.WriteLine("Footer Even Count: " + document.Footer!.Even.Paragraphs.Count);
-                Console.WriteLine("Footer First Count: " + document.Footer!.First.Paragraphs.Count);
+                Console.WriteLine("Header text: " + defaultHeader.Paragraphs[0].Text);
 
-                Console.WriteLine("Footer text: " + document.Footer!.Default.Paragraphs[0].Text);
+                var defaultFooter = GetDocumentFooterOrThrow(document);
+                var evenFooter = GetDocumentFooterOrThrow(document, HeaderFooterValues.Even);
+                var firstFooter = GetDocumentFooterOrThrow(document, HeaderFooterValues.First);
+
+                Console.WriteLine("Footer Default Count: " + defaultFooter.Paragraphs.Count);
+                Console.WriteLine("Footer Even Count: " + evenFooter.Paragraphs.Count);
+                Console.WriteLine("Footer First Count: " + firstFooter.Paragraphs.Count);
+
+                Console.WriteLine("Footer text: " + defaultFooter.Paragraphs[0].Text);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example2.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example2.cs
@@ -1,6 +1,7 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
+using SixLabors.ImageSharp;
 
 namespace OfficeIMO.Examples.Word {
     internal static partial class HeadersAndFooters {
@@ -26,10 +27,12 @@ namespace OfficeIMO.Examples.Word {
                 //var paragraphInFooter = document.Footer!.Default.InsertParagraph();
                 //paragraphInFooter.Text = "This is a test on odd pages (aka default if no options are set)";
 
-                var paragraphInHeader = document.Header!.Default.AddParagraph();
+                var defaultHeader = GetDocumentHeaderOrThrow(document);
+                var paragraphInHeader = defaultHeader.AddParagraph();
                 paragraphInHeader.Text = "Default Header / Section 0";
 
-                paragraphInHeader = document.Header!.First.AddParagraph();
+                var firstHeader = GetDocumentHeaderOrThrow(document, HeaderFooterValues.First);
+                paragraphInHeader = firstHeader.AddParagraph();
                 paragraphInHeader.Text = "First Header / Section 0";
 
                 //var paragraphInFooterFirst = document.Footer!.First.InsertParagraph();
@@ -87,14 +90,17 @@ namespace OfficeIMO.Examples.Word {
                 //var paragraghInHeaderSection = section2.Header!.First.InsertParagraph();
                 //paragraghInHeaderSection.Text = "Ok, work please?";
 
-                var paragraghInHeaderSection1 = section2.Header!.Default.AddParagraph();
+                var section2HeaderDefault = GetSectionHeaderOrThrow(section2);
+                var paragraghInHeaderSection1 = section2HeaderDefault.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit? 1";
 
-                paragraghInHeaderSection1 = section2.Header!.First.AddParagraph();
+                var section2HeaderFirst = GetSectionHeaderOrThrow(section2, HeaderFooterValues.First);
+                paragraghInHeaderSection1 = section2HeaderFirst.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit 2?";
                 // paragraghInHeaderSection1.InsertText("ok?");
 
-                paragraghInHeaderSection1 = section2.Header!.Even.AddParagraph();
+                var section2HeaderEven = GetSectionHeaderOrThrow(section2, HeaderFooterValues.Even);
+                paragraghInHeaderSection1 = section2HeaderEven.AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit? 3";
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 6");

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example3.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Example3.cs
@@ -17,7 +17,7 @@ namespace OfficeIMO.Examples.Word {
 
                 document.Sections[0].PageOrientation = PageOrientationValues.Landscape;
 
-                var paragraphInHeader = document.Header!.Default.AddParagraph();
+                var paragraphInHeader = GetDocumentHeaderOrThrow(document).AddParagraph();
                 paragraphInHeader.Text = "Default Header / Section 0";
 
                 document.AddPageBreak();
@@ -29,7 +29,7 @@ namespace OfficeIMO.Examples.Word {
                 var section2 = document.AddSection();
                 section2.AddHeadersAndFooters();
 
-                var paragraghInHeaderSection1 = section2.Header!.Default.AddParagraph();
+                var paragraghInHeaderSection1 = GetSectionHeaderOrThrow(section2).AddParagraph();
                 paragraghInHeaderSection1.Text = "Weird shit? 1";
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 2");
@@ -39,7 +39,7 @@ namespace OfficeIMO.Examples.Word {
                 var section3 = document.AddSection();
                 section3.AddHeadersAndFooters();
 
-                var paragraghInHeaderSection3 = section3.Header!.Default.AddParagraph();
+                var paragraghInHeaderSection3 = GetSectionHeaderOrThrow(section3).AddParagraph();
                 paragraghInHeaderSection3.Text = "Weird shit? 2";
 
                 paragraph = document.AddParagraph("Basic paragraph - Page 3");

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.ExampleNoSection.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.ExampleNoSection.cs
@@ -23,10 +23,10 @@ namespace OfficeIMO.Examples.Word {
                 paragraph.ParagraphAlignment = JustificationValues.Center;
                 paragraph.Color = SixLabors.ImageSharp.Color.Red;
 
-                var paragraphInHeaderO = document.Header!.Default.AddParagraph();
+                var paragraphInHeaderO = GetDocumentHeaderOrThrow(document).AddParagraph();
                 paragraphInHeaderO.Text = "Odd Header / Section 0";
 
-                var paragraphInHeaderE = document.Header!.Even.AddParagraph();
+                var paragraphInHeaderE = GetDocumentHeaderOrThrow(document, HeaderFooterValues.Even).AddParagraph();
                 paragraphInHeaderE.Text = "Even Header / Section 0";
 
                 document.AddPageBreak();

--- a/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Sections1.cs
+++ b/OfficeIMO.Examples/Word/HeadersAndFooters/HeadersAndFooters.Sections1.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -23,56 +24,61 @@ namespace OfficeIMO.Examples.Word {
                 document.AddPageBreak();
 
                 document.AddHeadersAndFooters();
-                document.Sections[0].Header!.Default.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header1");
+                var section0 = document.Sections[0];
+                var section0Header = GetSectionHeaderOrThrow(section0);
+                section0Header.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header1");
 
-                var tableHeader = document.Sections[0].Header!.Default.AddTable(3, 4);
+                var tableHeader = section0Header.AddTable(3, 4);
                 tableHeader.Rows[0].Cells[3].Paragraphs[0].Text = "This is sparta";
-                Console.WriteLine(document.Sections[0].Header!.Default.Tables.Count);
+                Console.WriteLine(section0Header.Tables.Count);
 
-                document.Sections[0].Header!.Default.AddHorizontalLine();
+                section0Header.AddHorizontalLine();
 
-                document.Sections[0].Header!.Default.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
+                section0Header.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
 
-                document.Sections[0].Header!.Default.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
+                section0Header.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
 
-                document.Sections[0].Header!.Default.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
+                section0Header.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
 
 
-                document.Sections[0].Footer!.Default.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header2");
+                var section0Footer = GetSectionFooterOrThrow(section0);
+                section0Footer.AddParagraph().AddText("Section 0").AddBookmark("BookmarkInSection0Header2");
 
-                var tableFooter = document.Sections[0].Footer!.Default.AddTable(2, 3);
+                var tableFooter = section0Footer.AddTable(2, 3);
                 tableFooter.Rows[0].Cells[2].Paragraphs[0].Text = "This is not sparta";
 
-                document.Sections[0].Footer!.Default.AddHorizontalLine();
+                section0Footer.AddHorizontalLine();
 
-                document.Sections[0].Footer!.Default.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
+                section0Footer.AddHyperLink("Link to website!", new Uri("https://evotec.xyz"));
 
-                document.Sections[0].Footer!.Default.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
+                section0Footer.AddHyperLink("Przemysław Klys Email Me", new Uri("mailto:kontakt@evotec.pl?subject=Test Subject"));
 
-                document.Sections[0].Footer!.Default.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
+                section0Footer.AddField(WordFieldType.Author, WordFieldFormat.FirstCap);
 
 
                 var section1 = document.AddSection();
                 section1.AddParagraph("Test Middle1 Section - 1");
                 section1.AddHeadersAndFooters();
-                section1.Header!.Default.AddParagraph().AddText("Section 1 - Header");
-                section1.Footer!.Default.AddParagraph().AddText("Section 1 - Footer");
+                GetSectionHeaderOrThrow(section1).AddParagraph().AddText("Section 1 - Header");
+                GetSectionFooterOrThrow(section1).AddParagraph().AddText("Section 1 - Footer");
 
                 var section2 = document.AddSection();
                 section2.AddParagraph("Test Middle2 Section - 1");
                 section2.AddHeadersAndFooters();
-                section2.Header!.Default.AddParagraph().AddText("Section 2 - Header");
-                section2.Footer!.Default.AddParagraph().AddText("Section 2 - Footer");
+                GetSectionHeaderOrThrow(section2).AddParagraph().AddText("Section 2 - Header");
+                GetSectionFooterOrThrow(section2).AddParagraph().AddText("Section 2 - Footer");
 
                 var section3 = document.AddSection();
                 section3.AddParagraph("Test Last Section - 1");
                 section3.AddHeadersAndFooters();
                 section3.DifferentOddAndEvenPages = true;
                 section3.DifferentFirstPage = true;
-                section3.Header!.Default.AddParagraph().AddText("Section 3 - Header Odd/Default");
-                section3.Footer!.Default.AddParagraph().AddText("Section 3 - Footer Odd/Default");
-                section3.Header!.Even.AddParagraph().AddText("Section 3 - Header Even");
-                section3.Footer!.Even.AddParagraph().AddText("Section 3 - Footer Even");
+                var section3HeaderDefault = GetSectionHeaderOrThrow(section3);
+                section3HeaderDefault.AddParagraph().AddText("Section 3 - Header Odd/Default");
+                var section3FooterDefault = GetSectionFooterOrThrow(section3);
+                section3FooterDefault.AddParagraph().AddText("Section 3 - Footer Odd/Default");
+                GetSectionHeaderOrThrow(section3, HeaderFooterValues.Even).AddParagraph().AddText("Section 3 - Header Even");
+                GetSectionFooterOrThrow(section3, HeaderFooterValues.Even).AddParagraph().AddText("Section 3 - Footer Even");
 
                 document.AddPageBreak();
                 section3.AddParagraph("Test Last Section - 2");

--- a/OfficeIMO.Examples/Word/HyperLinksAndFields/HyperLinks.FormattedAdvancedExample.cs
+++ b/OfficeIMO.Examples/Word/HyperLinksAndFields/HyperLinks.FormattedAdvancedExample.cs
@@ -24,12 +24,12 @@ namespace OfficeIMO.Examples.Word {
                 var yahoo = baseLink.InsertFormattedHyperlinkAfter("Yahoo", new Uri("https://yahoo.com"));
                 yahoo.CopyFormattingFrom(baseLink);
 
-                var headerPara = document.Header!.Default.AddParagraph("Search with ");
+                var headerPara = GetDocumentHeaderOrThrow(document).AddParagraph("Search with ");
                 var duck = headerPara.AddHyperLink("DuckDuckGo", new Uri("https://duckduckgo.com"), addStyle: true);
                 var duckLink = Guard.NotNull(duck.Hyperlink, "Expected DuckDuckGo hyperlink to be created.");
                 duckLink.InsertFormattedHyperlinkAfter("Startpage", new Uri("https://startpage.com"));
 
-                var footerPara = document.Footer!.Default.AddParagraph("Code on ");
+                var footerPara = GetDocumentFooterOrThrow(document).AddParagraph("Code on ");
                 var gitHub = footerPara.AddHyperLink("GitHub", new Uri("https://github.com"), addStyle: true);
                 var gitHubLink = Guard.NotNull(gitHub.Hyperlink, "Expected GitHub hyperlink to be created.");
                 gitHubLink.InsertFormattedHyperlinkBefore("GitLab", new Uri("https://gitlab.com"));

--- a/OfficeIMO.Examples/Word/Images/Images.HeadersFooters.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.HeadersFooters.cs
@@ -21,14 +21,14 @@ namespace OfficeIMO.Examples.Word {
                 document.AddHeadersAndFooters();
                 document.DifferentOddAndEvenPages = true;
 
-                var header = Guard.NotNull(document.Header!.Default, "Default header must exist after enabling headers.");
+                var header = GetDocumentHeaderOrThrow(document);
                 var paragraphHeader = header.AddParagraph("This is header");
 
                 // add image to header, directly to paragraph
                 header.AddParagraph().AddImage(filePathImage, 100, 100);
 
                 // add image to footer, directly to paragraph
-                var footer = Guard.NotNull(document.Footer!.Default, "Default footer must exist after enabling headers.");
+                var footer = GetDocumentFooterOrThrow(document);
                 footer.AddParagraph().AddImage(filePathImage, 100, 100);
 
                 // add image to header, but to a table
@@ -93,7 +93,7 @@ namespace OfficeIMO.Examples.Word {
                 string fileToSave = System.IO.Path.Combine(imagePaths, "OutputPrzemyslawKlysAndKulkozaurr.jpg");
                 firstImage.SaveToFile(fileToSave);
 
-                var headerEven = Guard.NotNull(document.Header!.Even, "Even header must exist after enabling different odd/even pages.");
+                var headerEven = GetDocumentHeaderOrThrow(document, HeaderFooterValues.Even);
                 var paragraphHeaderEven = headerEven.AddParagraph("This adds another picture via Stream with 100x100 to Header Even");
                 const string fileNameImageEvotec = "EvotecLogo.png";
                 var filePathImageEvotec = System.IO.Path.Combine(imagePaths, fileNameImageEvotec);

--- a/OfficeIMO.Examples/Word/Images/Images.InTable.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.InTable.cs
@@ -20,7 +20,7 @@ namespace OfficeIMO.Examples.Word {
 
             document.AddHeadersAndFooters();
 
-            var tableInHeader = document.Header!.Default.AddTable(2, 2);
+            var tableInHeader = GetDocumentHeaderOrThrow(document).AddTable(2, 2);
             tableInHeader.Rows[0].Cells[0].Paragraphs[0].AddImage(System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg"), 200, 200);
 
             // not really nessessary to add new paragraph since one is already there by default

--- a/OfficeIMO.Examples/Word/Images/Images.Sample2.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.Sample2.cs
@@ -16,8 +16,9 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Load(System.IO.Path.Combine(documentPaths, "DocumentWithImagesWraps.docx"), true)) {
                 Console.WriteLine("+ Document paragraphs: " + document.Paragraphs.Count);
                 Console.WriteLine("+ Document images: " + document.Images.Count);
-                Console.WriteLine("+ Document images in header: " + document.Header!.Default.Images.Count);
-                Console.WriteLine("+ Document images in footer: " + document.Footer!.Default.Images.Count);
+                var header = GetDocumentHeaderOrThrow(document);
+                Console.WriteLine("+ Document images in header: " + header.Images.Count);
+                Console.WriteLine("+ Document images in footer: " + GetDocumentFooterOrThrow(document).Images.Count);
                 //document.Images[0].SaveToFile(System.IO.Path.Combine(outputPath, "random.jpg"));
 
                 Console.WriteLine("----");

--- a/OfficeIMO.Examples/Word/Lists/Lists.Create7.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.Create7.cs
@@ -130,20 +130,22 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddHeadersAndFooters();
 
-                var listInHeader = document.Header!.Default.AddList(WordListStyle.Bulleted);
+                var header = GetDocumentHeaderOrThrow(document);
+                var listInHeader = header.AddList(WordListStyle.Bulleted);
 
                 listInHeader.AddItem("Test Header 1");
 
-                document.Footer!.Default.AddParagraph("Test Me Header");
+                var footer = GetDocumentFooterOrThrow(document);
+                footer.AddParagraph("Test Me Header");
 
                 listInHeader.AddItem("Test Header 2");
 
 
-                var listInFooter = document.Footer!.Default.AddList(WordListStyle.Numbered);
+                var listInFooter = footer.AddList(WordListStyle.Numbered);
 
                 listInFooter.AddItem("Test Footer 1");
 
-                document.Footer!.Default.AddParagraph("Test Me Footer");
+                footer.AddParagraph("Test Me Footer");
 
                 listInFooter.AddItem("Test Footer 2");
 

--- a/OfficeIMO.Examples/Word/Lists/Lists.NumberingDefinition.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.NumberingDefinition.cs
@@ -10,6 +10,10 @@ namespace OfficeIMO.Examples.Word {
                 var numbering = document.CreateNumberingDefinition();
                 numbering.AddLevel(new WordListLevel(WordListLevelKind.Decimal));
                 var retrieved = document.GetNumberingDefinition(numbering.AbstractNumberId);
+                if (retrieved == null) {
+                    throw new InvalidOperationException("Numbering definition should exist after creation.");
+                }
+
                 Console.WriteLine("Numbering levels: " + retrieved.Levels.Count);
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example1.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example1.cs
@@ -17,7 +17,7 @@ namespace OfficeIMO.Examples.Word {
                 document.Settings.UpdateFieldsOnOpen = true;
                 document.AddTableOfContent(tableOfContentStyle: TableOfContentStyle.Template2);
                 document.AddHeadersAndFooters();
-                var pageNumber = document.Header!.Default.AddPageNumber(WordPageNumberStyle.Dots);
+                var pageNumber = GetDocumentHeaderOrThrow(document).AddPageNumber(WordPageNumberStyle.Dots);
                 //var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.VerticalOutline2);
                 //var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.Dots);
 

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example2.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example2.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
-                var table = document.Footer!.Default.AddTable(1, 2, WordTableStyle.TableGrid);
+                var table = GetDocumentFooterOrThrow(document).AddTable(1, 2, WordTableStyle.TableGrid);
                 table.WidthType = TableWidthUnitValues.Pct;
                 // 5000 represents 100% when using Pct width
                 table.Width = 5000;

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example3.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example3.cs
@@ -11,7 +11,7 @@ namespace OfficeIMO.Examples.Word {
                 document.Sections[0].AddPageNumbering(2, NumberFormatValues.LowerRoman);
                 document.AddHeadersAndFooters();
 
-                var para = document.Footer!.Default.AddParagraph();
+                var para = GetDocumentFooterOrThrow(document).AddParagraph();
                 para.AddText("Page ");
                 para.AddPageNumber();
 

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example4.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example4.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
-                var para = document.Header!.Default.AddParagraph();
+                var para = GetDocumentHeaderOrThrow(document).AddParagraph();
                 para.ParagraphAlignment = JustificationValues.Center;
                 para.AddPageNumber();
 

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example5.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example5.cs
@@ -10,7 +10,8 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
-                var firstFooter = document.Footer!.Default.AddParagraph();
+                var footer = GetDocumentFooterOrThrow(document);
+                var firstFooter = footer.AddParagraph();
                 firstFooter.ParagraphAlignment = JustificationValues.Right;
                 firstFooter.AddText("Page ");
                 firstFooter.AddPageNumber(includeTotalPages: true, separator: " of ");
@@ -21,7 +22,7 @@ namespace OfficeIMO.Examples.Word {
                 section.AddPageNumbering(1);
                 section.AddParagraph("Section 2");
 
-                var secondFooter = document.Footer!.Default.AddParagraph();
+                var secondFooter = footer.AddParagraph();
                 secondFooter.ParagraphAlignment = JustificationValues.Right;
                 secondFooter.AddText("Page ");
                 secondFooter.AddPageNumber(includeTotalPages: true, separator: " of ");

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example6.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example6.cs
@@ -11,7 +11,7 @@ namespace OfficeIMO.Examples.Word {
                 document.Sections[0].AddPageNumbering(1, NumberFormatValues.UpperRoman);
                 document.AddHeadersAndFooters();
 
-                var para = document.Footer!.Default.AddParagraph();
+                var para = GetDocumentFooterOrThrow(document).AddParagraph();
                 para.ParagraphAlignment = JustificationValues.Right;
                 para.AddText("Page ");
                 para.AddPageNumber(includeTotalPages: true, format: WordFieldFormat.Roman, separator: " of ");

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example7.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example7.cs
@@ -9,7 +9,7 @@ namespace OfficeIMO.Examples.Word {
             string filePath = System.IO.Path.Combine(folderPath, "Document with PageNumbers7.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                var pageNumber = GetDocumentFooterOrThrow(document).AddPageNumber(WordPageNumberStyle.PlainNumber);
                 pageNumber.AppendText(" of ");
                 pageNumber.Paragraph.AddField(WordFieldType.NumPages);
                 document.Save(openWord);

--- a/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example8.cs
+++ b/OfficeIMO.Examples/Word/PageNumbers/PageNumbers.Example8.cs
@@ -15,7 +15,7 @@ namespace OfficeIMO.Examples.Word {
                 string filePath = System.IO.Path.Combine(folderPath, $"Document_PageNumbers_{safeFormat}.docx");
                 using (WordDocument document = WordDocument.Create(filePath)) {
                     document.AddHeadersAndFooters();
-                    var pageNumber = document.Footer!.Default.AddPageNumber(WordPageNumberStyle.PlainNumber);
+                    var pageNumber = GetDocumentFooterOrThrow(document).AddPageNumber(WordPageNumberStyle.PlainNumber);
                     pageNumber.CustomFormat = format;
                     document.Save(openWord);
                 }

--- a/OfficeIMO.Examples/Word/Sections/Sections.Example6.cs
+++ b/OfficeIMO.Examples/Word/Sections/Sections.Example6.cs
@@ -23,9 +23,10 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentFirstPage = true;
                 document.DifferentOddAndEvenPages = true;
 
-                document.Sections[0].Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
-                document.Sections[0].Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Sections[0].Header!.Even.AddParagraph().SetText("Test Section 0 - Even");
+                var section0 = document.Sections[0];
+                GetSectionHeaderOrThrow(section0).AddParagraph().SetText("Test Section 0 - Header");
+                GetSectionHeaderOrThrow(section0, HeaderFooterValues.First).AddParagraph().SetText("Test Section 0 - First Header");
+                GetSectionHeaderOrThrow(section0, HeaderFooterValues.Even).AddParagraph().SetText("Test Section 0 - Even");
 
                 document.Sections[0].Paragraphs[0].AddComment("Przemysław Kłys", "PK", "This should be a comment");
 
@@ -56,18 +57,19 @@ namespace OfficeIMO.Examples.Word {
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                document.Sections[1].AddHeadersAndFooters();
-                document.Sections[1].Header!.Default.AddParagraph().SetText("Test Section 1 - Header");
-                document.Sections[1].Footer!.Default.AddParagraph().SetText("Test Section 1 - Header");
+                var section1 = document.Sections[1];
+                section1.AddHeadersAndFooters();
+                GetSectionHeaderOrThrow(section1).AddParagraph().SetText("Test Section 1 - Header");
+                GetSectionFooterOrThrow(section1).AddParagraph().SetText("Test Section 1 - Header");
 
-                document.Sections[1].DifferentFirstPage = true;
-                document.Sections[1].Header!.First.AddParagraph().SetText("Test Section 1 - First Header");
-                document.Sections[1].Footer!.First.AddParagraph().SetText("Test Section 1 - First Footer");
+                section1.DifferentFirstPage = true;
+                GetSectionHeaderOrThrow(section1, HeaderFooterValues.First).AddParagraph().SetText("Test Section 1 - First Header");
+                GetSectionFooterOrThrow(section1, HeaderFooterValues.First).AddParagraph().SetText("Test Section 1 - First Footer");
 
-                document.Sections[1].DifferentOddAndEvenPages = true;
+                section1.DifferentOddAndEvenPages = true;
 
-                document.Sections[1].Header!.Even.AddParagraph().SetText("Test Section 1 - Even Header");
-                document.Sections[1].Footer!.Even.AddParagraph().SetText("Test Section 1 - Even Footer");
+                GetSectionHeaderOrThrow(section1, HeaderFooterValues.Even).AddParagraph().SetText("Test Section 1 - Even Header");
+                GetSectionFooterOrThrow(section1, HeaderFooterValues.Even).AddParagraph().SetText("Test Section 1 - Even Footer");
 
                 document.Settings.ProtectionPassword = "ThisIsTest";
                 document.Settings.ProtectionType = DocumentProtectionValues.ReadOnly;

--- a/OfficeIMO.Examples/Word/Sections/Sections.Example7.cs
+++ b/OfficeIMO.Examples/Word/Sections/Sections.Example7.cs
@@ -19,9 +19,10 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentFirstPage = true;
                 document.DifferentOddAndEvenPages = true;
 
-                document.Sections[0].Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Sections[0].Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
-                document.Sections[0].Header!.Even.AddParagraph().SetText("Test Section 0 - Even");
+                var section0 = document.Sections[0];
+                GetSectionHeaderOrThrow(section0, HeaderFooterValues.First).AddParagraph().SetText("Test Section 0 - First Header");
+                GetSectionHeaderOrThrow(section0).AddParagraph().SetText("Test Section 0 - Header");
+                GetSectionHeaderOrThrow(section0, HeaderFooterValues.Even).AddParagraph().SetText("Test Section 0 - Even");
 
                 document.AddPageBreak();
 
@@ -39,9 +40,9 @@ namespace OfficeIMO.Examples.Word {
                 section1.PageOrientation = PageOrientationValues.Portrait;
                 section1.AddParagraph("Test Section1");
                 section1.AddHeadersAndFooters();
-                section1.Header!.Default.AddParagraph().SetText("Test Section 1 - Header");
+                GetSectionHeaderOrThrow(section1).AddParagraph().SetText("Test Section 1 - Header");
                 section1.DifferentFirstPage = true;
-                section1.Header!.First.AddParagraph().SetText("Test Section 1 - First Header");
+                GetSectionHeaderOrThrow(section1, HeaderFooterValues.First).AddParagraph().SetText("Test Section 1 - First Header");
 
 
                 document.AddPageBreak();
@@ -60,7 +61,7 @@ namespace OfficeIMO.Examples.Word {
                 section2.AddParagraph("Test Section2");
                 section2.PageOrientation = PageOrientationValues.Landscape;
                 section2.AddHeadersAndFooters();
-                section2.Header!.Default.AddParagraph().SetText("Test Section 2 - Header");
+                GetSectionHeaderOrThrow(section2).AddParagraph().SetText("Test Section 2 - Header");
 
                 document.AddParagraph("Test Section2 - Paragraph 1");
 
@@ -68,7 +69,7 @@ namespace OfficeIMO.Examples.Word {
                 var section3 = document.AddSection();
                 section3.AddParagraph("Test Section3");
                 section3.AddHeadersAndFooters();
-                section3.Header!.Default.AddParagraph().SetText("Test Section 3 - Header");
+                GetSectionHeaderOrThrow(section3).AddParagraph().SetText("Test Section 3 - Header");
 
 
                 Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Paragraphs[0].Text);
@@ -77,10 +78,10 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine("Section 2 - Text 1: " + document.Sections[2].Paragraphs[1].Text);
                 Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Paragraphs[0].Text);
 
-                Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 1 - Text 0: " + document.Sections[1].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Header!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Section 0 - Text 0: " + GetSectionHeaderOrThrow(document.Sections[0]).Paragraphs[0].Text);
+                Console.WriteLine("Section 1 - Text 0: " + GetSectionHeaderOrThrow(document.Sections[1]).Paragraphs[0].Text);
+                Console.WriteLine("Section 2 - Text 0: " + GetSectionHeaderOrThrow(document.Sections[2]).Paragraphs[0].Text);
+                Console.WriteLine("Section 3 - Text 0: " + GetSectionHeaderOrThrow(document.Sections[3]).Paragraphs[0].Text);
                 document.Save(false);
             }
 
@@ -91,13 +92,14 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Paragraphs[0].Text);
                 Console.WriteLine("Section 2 - Text 1: " + document.Sections[2].Paragraphs[1].Text);
                 Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Paragraphs[0].Text);
-                Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 1 - Text 0: " + document.Sections[1].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Header!.Default.Paragraphs[0].Text);
+                Console.WriteLine("Section 0 - Text 0: " + GetSectionHeaderOrThrow(document.Sections[0]).Paragraphs[0].Text);
+                Console.WriteLine("Section 1 - Text 0: " + GetSectionHeaderOrThrow(document.Sections[1]).Paragraphs[0].Text);
+                Console.WriteLine("Section 2 - Text 0: " + GetSectionHeaderOrThrow(document.Sections[2]).Paragraphs[0].Text);
+                Console.WriteLine("Section 3 - Text 0: " + GetSectionHeaderOrThrow(document.Sections[3]).Paragraphs[0].Text);
                 Console.WriteLine("-----");
-                document.Sections[1].Header!.Default.AddParagraph().SetText("Test Section 1 - Header-Par1");
-                Console.WriteLine("Section 1 - Text 1: " + document.Sections[1].Header!.Default.Paragraphs[1].Text);
+                var loadedSection1Header = GetSectionHeaderOrThrow(document.Sections[1]);
+                loadedSection1Header.AddParagraph().SetText("Test Section 1 - Header-Par1");
+                Console.WriteLine("Section 1 - Text 1: " + loadedSection1Header.Paragraphs[1].Text);
                 document.Save(openWord);
             }
         }

--- a/OfficeIMO.Examples/Word/Shapes/Shapes.SectionAndHeader.cs
+++ b/OfficeIMO.Examples/Word/Shapes/Shapes.SectionAndHeader.cs
@@ -15,9 +15,10 @@ namespace OfficeIMO.Examples.Word {
                 section.AddShapeDrawing(ShapeType.Ellipse, 40, 40);
 
                 section.AddHeadersAndFooters();
-                section.Header!.Default.AddShape(ShapeType.Rectangle, 30, 20, Color.Blue, Color.Black);
-                section.Header!.Default.AddShape(ShapeType.RoundedRectangle, 25, 15, Color.Green, Color.Black, 1, arcSize: 0.3);
-                section.Header!.Default.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
+                var sectionHeader = GetSectionHeaderOrThrow(section);
+                sectionHeader.AddShape(ShapeType.Rectangle, 30, 20, Color.Blue, Color.Black);
+                sectionHeader.AddShape(ShapeType.RoundedRectangle, 25, 15, Color.Green, Color.Black, 1, arcSize: 0.3);
+                sectionHeader.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Remove.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Remove.cs
@@ -1,4 +1,5 @@
 using System;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -18,9 +19,14 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentFirstPage = true;
                 document.DifferentOddAndEvenPages = true;
 
-                document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Default");
-                document.Sections[0].Header!.First.AddWatermark(WordWatermarkStyle.Text, "First");
-                document.Sections[0].Header!.Even.AddWatermark(WordWatermarkStyle.Text, "Even");
+                var section = document.Sections[0];
+                var defaultHeader = GetSectionHeaderOrThrow(section);
+                var firstHeader = GetSectionHeaderOrThrow(section, HeaderFooterValues.First);
+                var evenHeader = GetSectionHeaderOrThrow(section, HeaderFooterValues.Even);
+
+                defaultHeader.AddWatermark(WordWatermarkStyle.Text, "Default");
+                firstHeader.AddWatermark(WordWatermarkStyle.Text, "First");
+                evenHeader.AddWatermark(WordWatermarkStyle.Text, "Even");
 
                 Console.WriteLine("Watermarks before: " + document.Watermarks.Count);
                 foreach (var watermark in document.Watermarks.ToList()) {

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Sample1.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Sample1.cs
@@ -20,7 +20,9 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddParagraph("Section 0");
                 document.AddHeadersAndFooters();
-                document.Sections[0].Header!.Default.AddParagraph("Section 0 - In header");
+                var section0 = document.Sections[0];
+                var section0Header = GetSectionHeaderOrThrow(section0);
+                section0Header.AddParagraph("Section 0 - In header");
                 document.Sections[0].SetMargins(WordMargin.Normal);
 
                 Console.WriteLine(document.Sections[0].Margins.Left.Value);
@@ -33,7 +35,7 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine(document.Sections[0].Margins.Type);
 
                 Console.WriteLine("----");
-                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Watermark");
+                var watermark = section0Header.AddWatermark(WordWatermarkStyle.Text, "Watermark");
                 watermark.Color = Color.Red;
 
                 // ColorHex normally returns hex colors, but for watermark it returns string as the underlying value is in string name, not hex
@@ -61,17 +63,19 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddParagraph("Section 1");
 
-                document.Sections[1].AddHeadersAndFooters();
-                document.Sections[1].Header!.Default.AddParagraph("Section 1 - In header");
-                document.Sections[1].Margins.Type = WordMargin.Narrow;
+                var section1 = document.Sections[1];
+                section1.AddHeadersAndFooters();
+                var section1Header = GetSectionHeaderOrThrow(section1);
+                section1Header.AddParagraph("Section 1 - In header");
+                section1.Margins.Type = WordMargin.Narrow;
                 Console.WriteLine("----");
 
-                Console.WriteLine("Section 0 - Paragraphs Count: " + document.Sections[0].Header!.Default.Paragraphs.Count);
-                Console.WriteLine("Section 1 - Paragraphs Count: " + document.Sections[1].Header!.Default.Paragraphs.Count);
+                Console.WriteLine("Section 0 - Paragraphs Count: " + section0Header.Paragraphs.Count);
+                Console.WriteLine("Section 1 - Paragraphs Count: " + section1Header.Paragraphs.Count);
 
                 Console.WriteLine("----");
-                document.Sections[1].AddParagraph("Test");
-                document.Sections[1].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Draft");
+                section1.AddParagraph("Test");
+                section1Header.AddWatermark(WordWatermarkStyle.Text, "Draft");
 
                 Console.WriteLine(document.Sections[0].Margins.Left.Value);
                 Console.WriteLine(document.Sections[0].Margins.Right.Value);
@@ -86,17 +90,17 @@ namespace OfficeIMO.Examples.Word {
 
                 Console.WriteLine("----");
 
-                Console.WriteLine("Watermarks in default header: " + document.Header!.Default.Watermarks.Count);
+                Console.WriteLine("Watermarks in default header: " + GetDocumentHeaderOrThrow(document).Watermarks.Count);
 
-                Console.WriteLine("Watermarks in default footer: " + document.Footer!.Default.Watermarks.Count);
+                Console.WriteLine("Watermarks in default footer: " + GetDocumentFooterOrThrow(document).Watermarks.Count);
 
                 Console.WriteLine("Watermarks in section 0: " + document.Sections[0].Watermarks.Count);
-                Console.WriteLine("Watermarks in section 0 (header): " + document.Sections[0].Header!.Default.Watermarks.Count);
-                Console.WriteLine("Paragraphs in section 0 (header): " + document.Sections[0].Header!.Default.Paragraphs.Count);
+                Console.WriteLine("Watermarks in section 0 (header): " + section0Header.Watermarks.Count);
+                Console.WriteLine("Paragraphs in section 0 (header): " + section0Header.Paragraphs.Count);
 
                 Console.WriteLine("Watermarks in section 1: " + document.Sections[1].Watermarks.Count);
-                Console.WriteLine("Watermarks in section 1 (header): " + document.Sections[1].Header!.Default.Watermarks.Count);
-                Console.WriteLine("Paragraphs in section 1 (header): " + document.Sections[1].Header!.Default.Paragraphs.Count);
+                Console.WriteLine("Watermarks in section 1 (header): " + section1Header.Watermarks.Count);
+                Console.WriteLine("Paragraphs in section 1 (header): " + section1Header.Paragraphs.Count);
 
                 Console.WriteLine("Watermarks in document: " + document.Watermarks.Count);
 

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Sample4.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Sample4.cs
@@ -19,7 +19,9 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddParagraph("Section 0");
                 document.AddHeadersAndFooters();
-                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "HexColor");
+                var section = document.Sections[0];
+                var header = GetSectionHeaderOrThrow(section);
+                var watermark = header.AddWatermark(WordWatermarkStyle.Text, "HexColor");
                 watermark.ColorHex = "00ff00";
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.SampleImage1.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.SampleImage1.cs
@@ -17,7 +17,9 @@ namespace OfficeIMO.Examples.Word {
                 document.AddHeadersAndFooters();
 
                 var imagePathToAdd = System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg");
-                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Image, imagePathToAdd);
+                var section = document.Sections[0];
+                var header = GetSectionHeaderOrThrow(section);
+                var watermark = header.AddWatermark(WordWatermarkStyle.Image, imagePathToAdd);
 
                 //Console.WriteLine(watermark.Height);
                 //Console.WriteLine(watermark.Width);

--- a/OfficeIMO.Examples/Word/WordHeaderFooterAccessHelper.cs
+++ b/OfficeIMO.Examples/Word/WordHeaderFooterAccessHelper.cs
@@ -1,0 +1,135 @@
+using System;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static class WordHeaderFooterAccessHelper {
+        internal static WordHeader GetSectionHeaderOrThrow(WordSection section, HeaderFooterValues type) {
+            if (section == null) {
+                throw new ArgumentNullException(nameof(section));
+            }
+
+            var header = section.GetHeader(type);
+            if (header != null) {
+                return header;
+            }
+
+            section.AddHeadersAndFooters();
+            header = section.GetHeader(type);
+            if (header == null) {
+                throw new InvalidOperationException($"Section header '{type}' is not available.");
+            }
+
+            return header;
+        }
+
+        internal static WordFooter GetSectionFooterOrThrow(WordSection section, HeaderFooterValues type) {
+            if (section == null) {
+                throw new ArgumentNullException(nameof(section));
+            }
+
+            var footer = section.GetFooter(type);
+            if (footer != null) {
+                return footer;
+            }
+
+            section.AddHeadersAndFooters();
+            footer = section.GetFooter(type);
+            if (footer == null) {
+                throw new InvalidOperationException($"Section footer '{type}' is not available.");
+            }
+
+            return footer;
+        }
+
+        internal static WordHeader GetDocumentHeaderOrThrow(WordDocument document, HeaderFooterValues type) {
+            if (document == null) {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            var headers = document.Header;
+            if (headers == null) {
+                document.AddHeadersAndFooters();
+                headers = document.Header;
+            }
+
+            if (headers == null) {
+                throw new InvalidOperationException("Document headers are not available after AddHeadersAndFooters().");
+            }
+
+            WordHeader? header;
+            if (type == HeaderFooterValues.First) {
+                header = headers.First;
+            } else if (type == HeaderFooterValues.Even) {
+                header = headers.Even;
+            } else {
+                header = headers.Default;
+            }
+
+            if (header != null) {
+                return header;
+            }
+
+            document.AddHeadersAndFooters();
+            headers = document.Header ?? throw new InvalidOperationException("Document headers are not available after AddHeadersAndFooters().");
+            if (type == HeaderFooterValues.First) {
+                header = headers.First;
+            } else if (type == HeaderFooterValues.Even) {
+                header = headers.Even;
+            } else {
+                header = headers.Default;
+            }
+
+            if (header == null) {
+                throw new InvalidOperationException($"Document header '{type}' is not available.");
+            }
+
+            return header;
+        }
+
+        internal static WordFooter GetDocumentFooterOrThrow(WordDocument document, HeaderFooterValues type) {
+            if (document == null) {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            var footers = document.Footer;
+            if (footers == null) {
+                document.AddHeadersAndFooters();
+                footers = document.Footer;
+            }
+
+            if (footers == null) {
+                throw new InvalidOperationException("Document footers are not available after AddHeadersAndFooters().");
+            }
+
+            WordFooter? footer;
+            if (type == HeaderFooterValues.First) {
+                footer = footers.First;
+            } else if (type == HeaderFooterValues.Even) {
+                footer = footers.Even;
+            } else {
+                footer = footers.Default;
+            }
+
+            if (footer != null) {
+                return footer;
+            }
+
+            document.AddHeadersAndFooters();
+            footers = document.Footer ?? throw new InvalidOperationException("Document footers are not available after AddHeadersAndFooters().");
+            if (type == HeaderFooterValues.First) {
+                footer = footers.First;
+            } else if (type == HeaderFooterValues.Even) {
+                footer = footers.Even;
+            } else {
+                footer = footers.Default;
+            }
+
+            if (footer == null) {
+                throw new InvalidOperationException($"Document footer '{type}' is not available.");
+            }
+
+            return footer;
+        }
+    }
+}

--- a/OfficeIMO.Examples/Word/WordHeaderFooterClassHelpers.cs
+++ b/OfficeIMO.Examples/Word/WordHeaderFooterClassHelpers.cs
@@ -1,0 +1,236 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class AdvancedDocument {
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, type);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, type);
+    }
+
+    internal static partial class BasicDocument {
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, type);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, type);
+    }
+
+    internal static partial class CleanupDocuments {
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, type);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, type);
+    }
+
+    internal static partial class Fields {
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, type);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, type);
+    }
+
+    internal static partial class HeadersAndFooters {
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, type);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, type);
+
+        private static WordHeader GetSectionHeaderOrThrow(WordSection section) =>
+            WordHeaderFooterAccessHelper.GetSectionHeaderOrThrow(section, HeaderFooterValues.Default);
+
+        private static WordHeader GetSectionHeaderOrThrow(WordSection section, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetSectionHeaderOrThrow(section, type);
+
+        private static WordFooter GetSectionFooterOrThrow(WordSection section) =>
+            WordHeaderFooterAccessHelper.GetSectionFooterOrThrow(section, HeaderFooterValues.Default);
+
+        private static WordFooter GetSectionFooterOrThrow(WordSection section, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetSectionFooterOrThrow(section, type);
+    }
+
+    internal static partial class HyperLinks {
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, type);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, type);
+    }
+
+    internal static partial class Images {
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, type);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, type);
+
+        private static WordHeader GetSectionHeaderOrThrow(WordSection section) =>
+            WordHeaderFooterAccessHelper.GetSectionHeaderOrThrow(section, HeaderFooterValues.Default);
+
+        private static WordHeader GetSectionHeaderOrThrow(WordSection section, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetSectionHeaderOrThrow(section, type);
+    }
+
+    internal static partial class Lists {
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, type);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, type);
+    }
+
+    internal static partial class PageNumbers {
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, type);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, type);
+
+        private static WordHeader GetSectionHeaderOrThrow(WordSection section) =>
+            WordHeaderFooterAccessHelper.GetSectionHeaderOrThrow(section, HeaderFooterValues.Default);
+
+        private static WordHeader GetSectionHeaderOrThrow(WordSection section, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetSectionHeaderOrThrow(section, type);
+
+        private static WordFooter GetSectionFooterOrThrow(WordSection section) =>
+            WordHeaderFooterAccessHelper.GetSectionFooterOrThrow(section, HeaderFooterValues.Default);
+
+        private static WordFooter GetSectionFooterOrThrow(WordSection section, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetSectionFooterOrThrow(section, type);
+    }
+
+    internal static partial class Pdf {
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, type);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, type);
+    }
+
+    internal static partial class Sections {
+        private static WordHeader GetSectionHeaderOrThrow(WordSection section) =>
+            WordHeaderFooterAccessHelper.GetSectionHeaderOrThrow(section, HeaderFooterValues.Default);
+
+        private static WordHeader GetSectionHeaderOrThrow(WordSection section, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetSectionHeaderOrThrow(section, type);
+
+        private static WordFooter GetSectionFooterOrThrow(WordSection section) =>
+            WordHeaderFooterAccessHelper.GetSectionFooterOrThrow(section, HeaderFooterValues.Default);
+
+        private static WordFooter GetSectionFooterOrThrow(WordSection section, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetSectionFooterOrThrow(section, type);
+    }
+
+    internal static partial class Shapes {
+        private static WordHeader GetSectionHeaderOrThrow(WordSection section) =>
+            WordHeaderFooterAccessHelper.GetSectionHeaderOrThrow(section, HeaderFooterValues.Default);
+
+        private static WordHeader GetSectionHeaderOrThrow(WordSection section, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetSectionHeaderOrThrow(section, type);
+    }
+
+    internal static partial class Watermark {
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, type);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, type);
+
+        private static WordHeader GetSectionHeaderOrThrow(WordSection section) =>
+            WordHeaderFooterAccessHelper.GetSectionHeaderOrThrow(section, HeaderFooterValues.Default);
+
+        private static WordHeader GetSectionHeaderOrThrow(WordSection section, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetSectionHeaderOrThrow(section, type);
+
+        private static WordFooter GetSectionFooterOrThrow(WordSection section) =>
+            WordHeaderFooterAccessHelper.GetSectionFooterOrThrow(section, HeaderFooterValues.Default);
+
+        private static WordFooter GetSectionFooterOrThrow(WordSection section, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetSectionFooterOrThrow(section, type);
+    }
+
+    internal static partial class WordTextBox {
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordHeader GetDocumentHeaderOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentHeaderOrThrow(document, type);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, HeaderFooterValues.Default);
+
+        private static WordFooter GetDocumentFooterOrThrow(WordDocument document, HeaderFooterValues type) =>
+            WordHeaderFooterAccessHelper.GetDocumentFooterOrThrow(document, type);
+    }
+}

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample3.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample3.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddHeadersAndFooters();
 
-                var textBox = document.Header!.Default.AddTextBox("My textbox on the left");
+                var textBox = GetDocumentHeaderOrThrow(document).AddTextBox("My textbox on the left");
 
                 textBox.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
                 // horizontal alignment overwrites the horizontal position offset so only one will work

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample4.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample4.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddHeadersAndFooters();
 
-                var textBox = document.Header!.Default.AddTextBox("My textbox in header");
+                var textBox = GetDocumentHeaderOrThrow(document).AddTextBox("My textbox in header");
 
                 Console.WriteLine("Textbox (header) wraptext: " + textBox.WrapText);
 


### PR DESCRIPTION
## Summary
- add shared helpers for retrieving document and section headers/footers with validation in OfficeIMO examples
- update Word and PDF examples to rely on the helpers instead of null-forgiving accessors and add explicit null handling
- clean up existing examples to remove nullable warnings and ensure numbering definitions are validated

## Testing
- dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cb1328198c832eaefaebe2071fd740