### PR TITLE
Ensure Word section examples safely access headers and footers

### DIFF
--- a/OfficeIMO.Examples/Word/Sections/Sections.Example6.cs
+++ b/OfficeIMO.Examples/Word/Sections/Sections.Example6.cs
@@ -23,9 +23,15 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentFirstPage = true;
                 document.DifferentOddAndEvenPages = true;
 
-                document.Sections[0].Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
-                document.Sections[0].Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Sections[0].Header!.Even.AddParagraph().SetText("Test Section 0 - Even");
+                var section0 = document.Sections[0];
+                var section0DefaultHeader = RequireSectionHeader(section0, HeaderFooterValues.Default, "Section 0 default header");
+                section0DefaultHeader.AddParagraph().SetText("Test Section 0 - Header");
+
+                var section0FirstHeader = RequireSectionHeader(section0, HeaderFooterValues.First, "Section 0 first header");
+                section0FirstHeader.AddParagraph().SetText("Test Section 0 - First Header");
+
+                var section0EvenHeader = RequireSectionHeader(section0, HeaderFooterValues.Even, "Section 0 even header");
+                section0EvenHeader.AddParagraph().SetText("Test Section 0 - Even");
 
                 document.Sections[0].Paragraphs[0].AddComment("Przemysław Kłys", "PK", "This should be a comment");
 
@@ -48,26 +54,36 @@ namespace OfficeIMO.Examples.Word {
                 //Console.WriteLine("Section 2 - Text 1: " + document.Sections[2].Paragraphs[1].Text);
                 //Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Paragraphs[0].Text);
 
-                //Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Header!.Default.Paragraphs[0].Text);
-                //Console.WriteLine("Section 1 - Text 0: " + document.Sections[1].Header!.Default.Paragraphs[0].Text);
-                //Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Header!.Default.Paragraphs[0].Text);
-                //Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Header!.Default.Paragraphs[0].Text);
+                //Console.WriteLine("Section 0 - Text 0: " + RequireSectionHeader(document.Sections[0], HeaderFooterValues.Default, "Section 0 default header").Paragraphs[0].Text);
+                //Console.WriteLine("Section 1 - Text 0: " + RequireSectionHeader(document.Sections[1], HeaderFooterValues.Default, "Section 1 default header").Paragraphs[0].Text);
+                //Console.WriteLine("Section 2 - Text 0: " + RequireSectionHeader(document.Sections[2], HeaderFooterValues.Default, "Section 2 default header").Paragraphs[0].Text);
+                //Console.WriteLine("Section 3 - Text 0: " + RequireSectionHeader(document.Sections[3], HeaderFooterValues.Default, "Section 3 default header").Paragraphs[0].Text);
                 document.Save(false);
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
-                document.Sections[1].AddHeadersAndFooters();
-                document.Sections[1].Header!.Default.AddParagraph().SetText("Test Section 1 - Header");
-                document.Sections[1].Footer!.Default.AddParagraph().SetText("Test Section 1 - Header");
+                var section1 = document.Sections[1];
+                var section1DefaultHeader = RequireSectionHeader(section1, HeaderFooterValues.Default, "Section 1 default header");
+                section1DefaultHeader.AddParagraph().SetText("Test Section 1 - Header");
 
-                document.Sections[1].DifferentFirstPage = true;
-                document.Sections[1].Header!.First.AddParagraph().SetText("Test Section 1 - First Header");
-                document.Sections[1].Footer!.First.AddParagraph().SetText("Test Section 1 - First Footer");
+                var section1DefaultFooter = RequireSectionFooter(section1, HeaderFooterValues.Default, "Section 1 default footer");
+                section1DefaultFooter.AddParagraph().SetText("Test Section 1 - Header");
 
-                document.Sections[1].DifferentOddAndEvenPages = true;
+                section1.DifferentFirstPage = true;
 
-                document.Sections[1].Header!.Even.AddParagraph().SetText("Test Section 1 - Even Header");
-                document.Sections[1].Footer!.Even.AddParagraph().SetText("Test Section 1 - Even Footer");
+                var section1FirstHeader = RequireSectionHeader(section1, HeaderFooterValues.First, "Section 1 first header");
+                section1FirstHeader.AddParagraph().SetText("Test Section 1 - First Header");
+
+                var section1FirstFooter = RequireSectionFooter(section1, HeaderFooterValues.First, "Section 1 first footer");
+                section1FirstFooter.AddParagraph().SetText("Test Section 1 - First Footer");
+
+                section1.DifferentOddAndEvenPages = true;
+
+                var section1EvenHeader = RequireSectionHeader(section1, HeaderFooterValues.Even, "Section 1 even header");
+                section1EvenHeader.AddParagraph().SetText("Test Section 1 - Even Header");
+
+                var section1EvenFooter = RequireSectionFooter(section1, HeaderFooterValues.Even, "Section 1 even footer");
+                section1EvenFooter.AddParagraph().SetText("Test Section 1 - Even Footer");
 
                 document.Settings.ProtectionPassword = "ThisIsTest";
                 document.Settings.ProtectionType = DocumentProtectionValues.ReadOnly;
@@ -77,5 +93,70 @@ namespace OfficeIMO.Examples.Word {
         }
 
 
+        private static WordHeader RequireSectionHeader(WordSection section, HeaderFooterValues type, string description) {
+            if (section == null) {
+                throw new ArgumentNullException(nameof(section));
+            }
+
+            EnsureSectionHeadersAndFooters(section);
+
+            var headers = section.Header;
+            if (headers == null) {
+                throw new InvalidOperationException($"{description} are not available.");
+            }
+
+            WordHeader? header;
+            if (type == HeaderFooterValues.Default) {
+                header = headers.Default;
+            } else if (type == HeaderFooterValues.Even) {
+                header = headers.Even;
+            } else if (type == HeaderFooterValues.First) {
+                header = headers.First;
+            } else {
+                throw new ArgumentOutOfRangeException(nameof(type), type, "Unsupported header type.");
+            }
+
+            if (header == null) {
+                throw new InvalidOperationException($"{description} is not available.");
+            }
+
+            return header;
+        }
+
+        private static WordFooter RequireSectionFooter(WordSection section, HeaderFooterValues type, string description) {
+            if (section == null) {
+                throw new ArgumentNullException(nameof(section));
+            }
+
+            EnsureSectionHeadersAndFooters(section);
+
+            var footers = section.Footer;
+            if (footers == null) {
+                throw new InvalidOperationException($"{description} are not available.");
+            }
+
+            WordFooter? footer;
+            if (type == HeaderFooterValues.Default) {
+                footer = footers.Default;
+            } else if (type == HeaderFooterValues.Even) {
+                footer = footers.Even;
+            } else if (type == HeaderFooterValues.First) {
+                footer = footers.First;
+            } else {
+                throw new ArgumentOutOfRangeException(nameof(type), type, "Unsupported footer type.");
+            }
+
+            if (footer == null) {
+                throw new InvalidOperationException($"{description} is not available.");
+            }
+
+            return footer;
+        }
+
+        private static void EnsureSectionHeadersAndFooters(WordSection section) {
+            if (section.Header == null || section.Footer == null) {
+                section.AddHeadersAndFooters();
+            }
+        }
     }
 }

--- a/OfficeIMO.Examples/Word/Sections/Sections.Example7.cs
+++ b/OfficeIMO.Examples/Word/Sections/Sections.Example7.cs
@@ -19,9 +19,15 @@ namespace OfficeIMO.Examples.Word {
                 document.DifferentFirstPage = true;
                 document.DifferentOddAndEvenPages = true;
 
-                document.Sections[0].Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Sections[0].Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
-                document.Sections[0].Header!.Even.AddParagraph().SetText("Test Section 0 - Even");
+                var section0 = document.Sections[0];
+                var section0FirstHeader = RequireSectionHeader(section0, HeaderFooterValues.First, "Section 0 first header");
+                section0FirstHeader.AddParagraph().SetText("Test Section 0 - First Header");
+
+                var section0DefaultHeader = RequireSectionHeader(section0, HeaderFooterValues.Default, "Section 0 default header");
+                section0DefaultHeader.AddParagraph().SetText("Test Section 0 - Header");
+
+                var section0EvenHeader = RequireSectionHeader(section0, HeaderFooterValues.Even, "Section 0 even header");
+                section0EvenHeader.AddParagraph().SetText("Test Section 0 - Even");
 
                 document.AddPageBreak();
 
@@ -39,9 +45,13 @@ namespace OfficeIMO.Examples.Word {
                 section1.PageOrientation = PageOrientationValues.Portrait;
                 section1.AddParagraph("Test Section1");
                 section1.AddHeadersAndFooters();
-                section1.Header!.Default.AddParagraph().SetText("Test Section 1 - Header");
+
+                var section1DefaultHeader = RequireSectionHeader(section1, HeaderFooterValues.Default, "Section 1 default header");
+                section1DefaultHeader.AddParagraph().SetText("Test Section 1 - Header");
+
                 section1.DifferentFirstPage = true;
-                section1.Header!.First.AddParagraph().SetText("Test Section 1 - First Header");
+                var section1FirstHeader = RequireSectionHeader(section1, HeaderFooterValues.First, "Section 1 first header");
+                section1FirstHeader.AddParagraph().SetText("Test Section 1 - First Header");
 
 
                 document.AddPageBreak();
@@ -60,7 +70,8 @@ namespace OfficeIMO.Examples.Word {
                 section2.AddParagraph("Test Section2");
                 section2.PageOrientation = PageOrientationValues.Landscape;
                 section2.AddHeadersAndFooters();
-                section2.Header!.Default.AddParagraph().SetText("Test Section 2 - Header");
+                var section2DefaultHeader = RequireSectionHeader(section2, HeaderFooterValues.Default, "Section 2 default header");
+                section2DefaultHeader.AddParagraph().SetText("Test Section 2 - Header");
 
                 document.AddParagraph("Test Section2 - Paragraph 1");
 
@@ -68,7 +79,8 @@ namespace OfficeIMO.Examples.Word {
                 var section3 = document.AddSection();
                 section3.AddParagraph("Test Section3");
                 section3.AddHeadersAndFooters();
-                section3.Header!.Default.AddParagraph().SetText("Test Section 3 - Header");
+                var section3DefaultHeader = RequireSectionHeader(section3, HeaderFooterValues.Default, "Section 3 default header");
+                section3DefaultHeader.AddParagraph().SetText("Test Section 3 - Header");
 
 
                 Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Paragraphs[0].Text);
@@ -77,10 +89,15 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine("Section 2 - Text 1: " + document.Sections[2].Paragraphs[1].Text);
                 Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Paragraphs[0].Text);
 
-                Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 1 - Text 0: " + document.Sections[1].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Header!.Default.Paragraphs[0].Text);
+                var section0DefaultHeaderCreated = RequireSectionHeader(document.Sections[0], HeaderFooterValues.Default, "Section 0 default header");
+                var section1DefaultHeaderCreated = RequireSectionHeader(document.Sections[1], HeaderFooterValues.Default, "Section 1 default header");
+                var section2DefaultHeaderCreated = RequireSectionHeader(document.Sections[2], HeaderFooterValues.Default, "Section 2 default header");
+                var section3DefaultHeaderCreated = RequireSectionHeader(document.Sections[3], HeaderFooterValues.Default, "Section 3 default header");
+
+                Console.WriteLine("Section 0 - Text 0: " + section0DefaultHeaderCreated.Paragraphs[0].Text);
+                Console.WriteLine("Section 1 - Text 0: " + section1DefaultHeaderCreated.Paragraphs[0].Text);
+                Console.WriteLine("Section 2 - Text 0: " + section2DefaultHeaderCreated.Paragraphs[0].Text);
+                Console.WriteLine("Section 3 - Text 0: " + section3DefaultHeaderCreated.Paragraphs[0].Text);
                 document.Save(false);
             }
 
@@ -91,13 +108,19 @@ namespace OfficeIMO.Examples.Word {
                 Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Paragraphs[0].Text);
                 Console.WriteLine("Section 2 - Text 1: " + document.Sections[2].Paragraphs[1].Text);
                 Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Paragraphs[0].Text);
-                Console.WriteLine("Section 0 - Text 0: " + document.Sections[0].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 1 - Text 0: " + document.Sections[1].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 2 - Text 0: " + document.Sections[2].Header!.Default.Paragraphs[0].Text);
-                Console.WriteLine("Section 3 - Text 0: " + document.Sections[3].Header!.Default.Paragraphs[0].Text);
+                var section0DefaultHeaderLoaded = RequireSectionHeader(document.Sections[0], HeaderFooterValues.Default, "Section 0 default header");
+                var section1DefaultHeaderLoaded = RequireSectionHeader(document.Sections[1], HeaderFooterValues.Default, "Section 1 default header");
+                var section2DefaultHeaderLoaded = RequireSectionHeader(document.Sections[2], HeaderFooterValues.Default, "Section 2 default header");
+                var section3DefaultHeaderLoaded = RequireSectionHeader(document.Sections[3], HeaderFooterValues.Default, "Section 3 default header");
+
+                Console.WriteLine("Section 0 - Text 0: " + section0DefaultHeaderLoaded.Paragraphs[0].Text);
+                Console.WriteLine("Section 1 - Text 0: " + section1DefaultHeaderLoaded.Paragraphs[0].Text);
+                Console.WriteLine("Section 2 - Text 0: " + section2DefaultHeaderLoaded.Paragraphs[0].Text);
+                Console.WriteLine("Section 3 - Text 0: " + section3DefaultHeaderLoaded.Paragraphs[0].Text);
                 Console.WriteLine("-----");
-                document.Sections[1].Header!.Default.AddParagraph().SetText("Test Section 1 - Header-Par1");
-                Console.WriteLine("Section 1 - Text 1: " + document.Sections[1].Header!.Default.Paragraphs[1].Text);
+                var section1DefaultHeaderAfterLoad = RequireSectionHeader(document.Sections[1], HeaderFooterValues.Default, "Section 1 default header");
+                section1DefaultHeaderAfterLoad.AddParagraph().SetText("Test Section 1 - Header-Par1");
+                Console.WriteLine("Section 1 - Text 1: " + section1DefaultHeaderAfterLoad.Paragraphs[1].Text);
                 document.Save(openWord);
             }
         }

--- a/OfficeIMO.Examples/Word/Shapes/Shapes.SectionAndHeader.cs
+++ b/OfficeIMO.Examples/Word/Shapes/Shapes.SectionAndHeader.cs
@@ -15,12 +15,35 @@ namespace OfficeIMO.Examples.Word {
                 section.AddShapeDrawing(ShapeType.Ellipse, 40, 40);
 
                 section.AddHeadersAndFooters();
-                section.Header!.Default.AddShape(ShapeType.Rectangle, 30, 20, Color.Blue, Color.Black);
-                section.Header!.Default.AddShape(ShapeType.RoundedRectangle, 25, 15, Color.Green, Color.Black, 1, arcSize: 0.3);
-                section.Header!.Default.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
+                var defaultHeader = RequireDefaultSectionHeader(section, "Section 0 default header");
+                defaultHeader.AddShape(ShapeType.Rectangle, 30, 20, Color.Blue, Color.Black);
+                defaultHeader.AddShape(ShapeType.RoundedRectangle, 25, 15, Color.Green, Color.Black, 1, arcSize: 0.3);
+                defaultHeader.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
 
                 document.Save(openWord);
             }
+        }
+
+        private static WordHeader RequireDefaultSectionHeader(WordSection section, string description) {
+            if (section == null) {
+                throw new ArgumentNullException(nameof(section));
+            }
+
+            if (section.Header == null) {
+                section.AddHeadersAndFooters();
+            }
+
+            var headers = section.Header;
+            if (headers == null) {
+                throw new InvalidOperationException($"{description} headers are not available.");
+            }
+
+            var header = headers.Default;
+            if (header == null) {
+                throw new InvalidOperationException($"{description} is not available.");
+            }
+
+            return header;
         }
     }
 }

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Helpers.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Helpers.cs
@@ -1,6 +1,5 @@
 using System;
 using DocumentFormat.OpenXml.Wordprocessing;
-using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -14,23 +13,36 @@ namespace OfficeIMO.Examples.Word {
                 throw new ArgumentNullException(nameof(section));
             }
 
-            WordHeader? header;
+            if (section.Header == null) {
+                section.AddHeadersAndFooters();
+            }
+
+            var headers = section.Header;
+            if (headers == null) {
+                throw new InvalidOperationException("Headers are not available after attempting to add them.");
+            }
+
             string description;
+            WordHeader? header;
 
             if (type == HeaderFooterValues.Default) {
-                header = section.Header.Default;
                 description = "default";
+                header = headers.Default;
             } else if (type == HeaderFooterValues.Even) {
-                header = section.Header.Even;
                 description = "even";
+                header = headers.Even;
             } else if (type == HeaderFooterValues.First) {
-                header = section.Header.First;
                 description = "first";
+                header = headers.First;
             } else {
                 throw new ArgumentOutOfRangeException(nameof(type), type, "Unsupported header type.");
             }
 
-            return Guard.NotNull(header, $"Call AddHeadersAndFooters before accessing the {description} header.");
+            if (header == null) {
+                throw new InvalidOperationException($"The {description} header is not available.");
+            }
+
+            return header;
         }
     }
 }

--- a/OfficeIMO.Examples/Word/Watermark/Watermark.Sample1.cs
+++ b/OfficeIMO.Examples/Word/Watermark/Watermark.Sample1.cs
@@ -71,8 +71,8 @@ namespace OfficeIMO.Examples.Word {
                 section1.Margins.Type = WordMargin.Narrow;
                 Console.WriteLine("----");
 
-                Console.WriteLine("Section 0 - Paragraphs Count: " + document.Sections[0].Header!.Default.Paragraphs.Count);
-                Console.WriteLine("Section 1 - Paragraphs Count: " + document.Sections[1].Header!.Default.Paragraphs.Count);
+                Console.WriteLine("Section 0 - Paragraphs Count: " + section0Header.Paragraphs.Count);
+                Console.WriteLine("Section 1 - Paragraphs Count: " + section1Header.Paragraphs.Count);
 
                 Console.WriteLine("----");
                 section1.AddParagraph("Test");
@@ -91,17 +91,21 @@ namespace OfficeIMO.Examples.Word {
 
                 Console.WriteLine("----");
 
-                Console.WriteLine("Watermarks in default header: " + document.Header!.Default.Watermarks.Count);
+                var documentHeaders = document.Header ?? throw new InvalidOperationException("Document headers must exist when inspecting watermarks.");
+                var documentDefaultHeader = documentHeaders.Default ?? throw new InvalidOperationException("The default document header must exist when inspecting watermarks.");
+                Console.WriteLine("Watermarks in default header: " + documentDefaultHeader.Watermarks.Count);
 
-                Console.WriteLine("Watermarks in default footer: " + document.Footer!.Default.Watermarks.Count);
+                var documentFooters = document.Footer ?? throw new InvalidOperationException("Document footers must exist when inspecting watermarks.");
+                var documentDefaultFooter = documentFooters.Default ?? throw new InvalidOperationException("The default document footer must exist when inspecting watermarks.");
+                Console.WriteLine("Watermarks in default footer: " + documentDefaultFooter.Watermarks.Count);
 
                 Console.WriteLine("Watermarks in section 0: " + document.Sections[0].Watermarks.Count);
-                Console.WriteLine("Watermarks in section 0 (header): " + document.Sections[0].Header!.Default.Watermarks.Count);
-                Console.WriteLine("Paragraphs in section 0 (header): " + document.Sections[0].Header!.Default.Paragraphs.Count);
+                Console.WriteLine("Watermarks in section 0 (header): " + section0Header.Watermarks.Count);
+                Console.WriteLine("Paragraphs in section 0 (header): " + section0Header.Paragraphs.Count);
 
                 Console.WriteLine("Watermarks in section 1: " + document.Sections[1].Watermarks.Count);
-                Console.WriteLine("Watermarks in section 1 (header): " + document.Sections[1].Header!.Default.Watermarks.Count);
-                Console.WriteLine("Paragraphs in section 1 (header): " + document.Sections[1].Header!.Default.Paragraphs.Count);
+                Console.WriteLine("Watermarks in section 1 (header): " + section1Header.Watermarks.Count);
+                Console.WriteLine("Paragraphs in section 1 (header): " + section1Header.Paragraphs.Count);
 
                 Console.WriteLine("Watermarks in document: " + document.Watermarks.Count);
 


### PR DESCRIPTION
## Summary
- add helper methods to the section-based Word examples so headers and footers are created before use
- replace direct section header/footer dereferences with the helpers and throw informative exceptions when data is missing
- update the watermark helpers to initialize headers automatically and safeguard document-level header/footer inspection

## Testing
- dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cb1d169708832ea97c59c399cf8d53