### PR TITLE
Add guards for header/footer usage in examples

### DIFF
--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.HeaderFooterImages.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.HeaderFooterImages.cs
@@ -1,3 +1,4 @@
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word.Pdf;
 using OfficeIMO.Word;
 using System;
@@ -13,8 +14,13 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Create(docPath)) {
                 document.AddHeadersAndFooters();
-                document.Header!.Default.AddParagraph().AddImage(imagePath, 50, 50);
-                document.Footer!.Default.AddParagraph().AddImage(imagePath, 300, 300);
+                var headers = Guard.NotNull(document.Header, "Document headers must exist after enabling headers.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+                defaultHeader.AddParagraph().AddImage(imagePath, 50, 50);
+
+                var footers = Guard.NotNull(document.Footer, "Document footers must exist after enabling headers.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist after enabling headers.");
+                defaultFooter.AddParagraph().AddImage(imagePath, 300, 300);
                 document.Save();
                 document.SaveAsPdf(pdfPath);
             }

--- a/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdf.cs
+++ b/OfficeIMO.Examples/Converters/Pdf/Pdf.SaveAsPdf.cs
@@ -1,3 +1,4 @@
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word.Pdf;
 using OfficeIMO.Word;
 using QuestPDF.Helpers;
@@ -22,11 +23,15 @@ namespace OfficeIMO.Examples.Word {
 
             using (WordDocument document = WordDocument.Create(docPath)) {
                 document.AddHeadersAndFooters();
-                document.Header!.Default.AddParagraph("Example Header");
-                WordTable headerTable = document.Header!.Default.AddTable(1, 1);
+                var headers = Guard.NotNull(document.Header, "Document headers must exist after enabling headers.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+                defaultHeader.AddParagraph("Example Header");
+                WordTable headerTable = defaultHeader.AddTable(1, 1);
                 headerTable.Rows[0].Cells[0].Paragraphs[0].Text = "H1";
-                document.Footer!.Default.AddParagraph("Example Footer");
-                WordTable footerTable = document.Footer!.Default.AddTable(1, 1);
+                var footers = Guard.NotNull(document.Footer, "Document footers must exist after enabling headers.");
+                var defaultFooter = Guard.NotNull(footers.Default, "Default footer must exist after enabling headers.");
+                defaultFooter.AddParagraph("Example Footer");
+                WordTable footerTable = defaultFooter.AddTable(1, 1);
                 footerTable.Rows[0].Cells[0].Paragraphs[0].Text = "F1";
 
                 WordParagraph heading = document.AddParagraph("Sample Heading");

--- a/OfficeIMO.Examples/Word/Fields/Fields.CustomFormat.cs
+++ b/OfficeIMO.Examples/Word/Fields/Fields.CustomFormat.cs
@@ -1,4 +1,5 @@
 using System;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -26,7 +27,9 @@ namespace OfficeIMO.Examples.Word {
             string filePath = System.IO.Path.Combine(folderPath, "CustomFormattedHeaderDate.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                document.Header!.Default.AddField(WordFieldType.Date, customFormat: "yyyy-MM-dd", advanced: true);
+                var headers = Guard.NotNull(document.Header, "Document headers must exist after enabling headers.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+                defaultHeader.AddField(WordFieldType.Date, customFormat: "yyyy-MM-dd", advanced: true);
                 document.AddParagraph("Body paragraph");
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/Fields/Fields02.cs
+++ b/OfficeIMO.Examples/Word/Fields/Fields02.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -27,7 +28,9 @@ namespace OfficeIMO.Examples.Word {
                 document.AddField(WordFieldType.GreetingLine);
 
                 // added page number using dedicated way
-                var pageNumber = document.Header!.Default.AddPageNumber(WordPageNumberStyle.Roman);
+                var headers = Guard.NotNull(document.Header, "Document headers must exist after enabling headers.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+                var pageNumber = defaultHeader.AddPageNumber(WordPageNumberStyle.Roman);
 
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/Images/Images.InTable.cs
+++ b/OfficeIMO.Examples/Word/Images/Images.InTable.cs
@@ -1,5 +1,6 @@
 using System;
 using DocumentFormat.OpenXml.Drawing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -20,7 +21,9 @@ namespace OfficeIMO.Examples.Word {
 
             document.AddHeadersAndFooters();
 
-            var tableInHeader = document.Header!.Default.AddTable(2, 2);
+            var headers = Guard.NotNull(document.Header, "Document headers must exist after enabling headers.");
+            var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+            var tableInHeader = defaultHeader.AddTable(2, 2);
             tableInHeader.Rows[0].Cells[0].Paragraphs[0].AddImage(System.IO.Path.Combine(imagePaths, "PrzemyslawKlysAndKulkozaurr.jpg"), 200, 200);
 
             // not really nessessary to add new paragraph since one is already there by default

--- a/OfficeIMO.Examples/Word/Lists/Lists.NumberingDefinition.cs
+++ b/OfficeIMO.Examples/Word/Lists/Lists.NumberingDefinition.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -9,7 +10,7 @@ namespace OfficeIMO.Examples.Word {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var numbering = document.CreateNumberingDefinition();
                 numbering.AddLevel(new WordListLevel(WordListLevelKind.Decimal));
-                var retrieved = document.GetNumberingDefinition(numbering.AbstractNumberId);
+                var retrieved = Guard.NotNull(document.GetNumberingDefinition(numbering.AbstractNumberId), "Numbering definition should be retrievable after creation.");
                 Console.WriteLine("Numbering levels: " + retrieved.Levels.Count);
                 document.Save(openWord);
             }

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample3.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample3.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -13,7 +14,9 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddHeadersAndFooters();
 
-                var textBox = document.Header!.Default.AddTextBox("My textbox on the left");
+                var headers = Guard.NotNull(document.Header, "Document headers must exist after enabling headers.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+                var textBox = defaultHeader.AddTextBox("My textbox on the left");
 
                 textBox.HorizontalPositionRelativeFrom = HorizontalRelativePositionValues.Page;
                 // horizontal alignment overwrites the horizontal position offset so only one will work

--- a/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample4.cs
+++ b/OfficeIMO.Examples/Word/WordTextBox/WordTextBox.Sample4.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
+using OfficeIMO.Examples.Utils;
 using OfficeIMO.Word;
 
 namespace OfficeIMO.Examples.Word {
@@ -13,7 +14,9 @@ namespace OfficeIMO.Examples.Word {
 
                 document.AddHeadersAndFooters();
 
-                var textBox = document.Header!.Default.AddTextBox("My textbox in header");
+                var headers = Guard.NotNull(document.Header, "Document headers must exist after enabling headers.");
+                var defaultHeader = Guard.NotNull(headers.Default, "Default header must exist after enabling headers.");
+                var textBox = defaultHeader.AddTextBox("My textbox in header");
 
                 Console.WriteLine("Textbox (header) wraptext: " + textBox.WrapText);
 


### PR DESCRIPTION
## Summary
- add guard helpers before accessing header and footer content in PDF and Word examples
- guard numbering definition lookups to avoid null dereferences in examples

## Testing
- dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cb23e837fc832ebb4d8e57b62e0160