### PR TITLE
Refactor tests to use header/footer helper accessors

### DIFF
--- a/OfficeIMO.Tests/Word.ImageLocation.cs
+++ b/OfficeIMO.Tests/Word.ImageLocation.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
+using HeaderFooterValues = DocumentFormat.OpenXml.Wordprocessing.HeaderFooterValues;
 using OfficeIMO.Word;
 using Xunit;
 
@@ -29,7 +30,9 @@ namespace OfficeIMO.Tests {
             using var document = WordDocument.Create(filePath);
             document.AddHeadersAndFooters();
 
-            var paragraph = document.Header!.Default.AddParagraph();
+            var defaultHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+            var defaultFooter = RequireSectionFooter(document, 0, HeaderFooterValues.Default);
+            var paragraph = defaultHeader.AddParagraph();
             paragraph.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 50, 50);
 
             var mainPart = document._wordprocessingDocument.MainDocumentPart!;
@@ -37,6 +40,7 @@ namespace OfficeIMO.Tests {
 
             Assert.Single(headerPart.ImageParts);
             Assert.Empty(mainPart.ImageParts);
+            Assert.Empty(defaultFooter.Images);
             Assert.Empty(mainPart.FooterParts.First().ImageParts);
 
             document.Save(false);
@@ -48,7 +52,9 @@ namespace OfficeIMO.Tests {
             using var document = WordDocument.Create(filePath);
             document.AddHeadersAndFooters();
 
-            var paragraph = document.Footer!.Default.AddParagraph();
+            var defaultFooter = RequireSectionFooter(document, 0, HeaderFooterValues.Default);
+            var defaultHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+            var paragraph = defaultFooter.AddParagraph();
             paragraph.AddImage(Path.Combine(_directoryWithImages, "Kulek.jpg"), 50, 50);
 
             var mainPart = document._wordprocessingDocument.MainDocumentPart!;
@@ -56,6 +62,7 @@ namespace OfficeIMO.Tests {
 
             Assert.Single(footerPart.ImageParts);
             Assert.Empty(mainPart.ImageParts);
+            Assert.Empty(defaultHeader.Images);
             Assert.Empty(mainPart.HeaderParts.First().ImageParts);
 
             document.Save(false);

--- a/OfficeIMO.Tests/Word.Images.cs
+++ b/OfficeIMO.Tests/Word.Images.cs
@@ -3,6 +3,7 @@ using System.IO;
 using DocumentFormat.OpenXml.Drawing;
 using DocumentFormat.OpenXml.Drawing.Wordprocessing;
 using DocumentFormat.OpenXml.Packaging;
+using HeaderFooterValues = DocumentFormat.OpenXml.Wordprocessing.HeaderFooterValues;
 using OfficeIMO.Word;
 using Xunit;
 
@@ -114,26 +115,29 @@ namespace OfficeIMO.Tests {
             document.AddHeadersAndFooters();
             document.DifferentOddAndEvenPages = true;
 
-            Assert.True(document.Header!.Default.Images.Count == 0);
-            Assert.True(document.Header!.Even.Images.Count == 0);
+            var defaultHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+            var evenHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Even);
+            var defaultFooter = RequireSectionFooter(document, 0, HeaderFooterValues.Default);
+            var evenFooter = RequireSectionFooter(document, 0, HeaderFooterValues.Even);
+
+            Assert.True(defaultHeader.Images.Count == 0);
+            Assert.True(evenHeader.Images.Count == 0);
             Assert.True(document.Images.Count == 0);
-            Assert.True(document.Footer!.Default.Images.Count == 0);
-            Assert.True(document.Footer!.Even.Images.Count == 0);
+            Assert.True(defaultFooter.Images.Count == 0);
+            Assert.True(evenFooter.Images.Count == 0);
 
 
-            var header = document.Header!.Default;
             // add image to header, directly to paragraph
-            header.AddParagraph().AddImage(image, 100, 100);
+            defaultHeader.AddParagraph().AddImage(image, 100, 100);
 
-            var footer = document.Footer!.Default;
             // add image to footer, directly to paragraph
-            footer.AddParagraph().AddImage(image, 200, 200);
+            defaultFooter.AddParagraph().AddImage(image, 200, 200);
 
-            Assert.True(document.Header!.Default.Images.Count == 1);
-            Assert.True(document.Header!.Even.Images.Count == 0);
+            Assert.True(defaultHeader.Images.Count == 1);
+            Assert.True(evenHeader.Images.Count == 0);
             Assert.True(document.Images.Count == 0);
-            Assert.True(document.Footer!.Default.Images.Count == 1);
-            Assert.True(document.Footer!.Even.Images.Count == 0);
+            Assert.True(defaultFooter.Images.Count == 1);
+            Assert.True(evenFooter.Images.Count == 0);
 
             const string fileNameImage = "Kulek.jpg";
             var filePathImage = System.IO.Path.Combine(imagePaths, fileNameImage);
@@ -141,12 +145,12 @@ namespace OfficeIMO.Tests {
             using (var imageStream = System.IO.File.OpenRead(filePathImage)) {
                 paragraph.AddImage(imageStream, fileNameImage, 300, 300);
             }
-            Assert.True(document.Header!.Default.Images.Count == 1);
-            Assert.True(document.Header!.Even.Images.Count == 0);
+            Assert.True(defaultHeader.Images.Count == 1);
+            Assert.True(evenHeader.Images.Count == 0);
 
             Assert.True(document.Images.Count == 1);
-            Assert.True(document.Footer!.Default.Images.Count == 1);
-            Assert.True(document.Footer!.Even.Images.Count == 0);
+            Assert.True(defaultFooter.Images.Count == 1);
+            Assert.True(evenFooter.Images.Count == 0);
 
             Assert.True(document.Images[0].FileName == fileNameImage);
             Assert.True(document.Images[0].Rotation == null);
@@ -155,7 +159,7 @@ namespace OfficeIMO.Tests {
 
             const string fileNameImageEvotec = "EvotecLogo.png";
             var filePathImageEvotec = System.IO.Path.Combine(imagePaths, fileNameImageEvotec);
-            var paragraphHeader = document.Header!.Even.AddParagraph();
+            var paragraphHeader = evenHeader.AddParagraph();
             using (var imageStream = System.IO.File.OpenRead(filePathImageEvotec)) {
                 paragraphHeader.AddImage(imageStream, fileNameImageEvotec, 300, 300, WrapTextImage.InLineWithText, "This is a test");
                 var headerImage = paragraphHeader.Image;
@@ -163,12 +167,12 @@ namespace OfficeIMO.Tests {
                 Assert.True(headerImage!.CompressionQuality == BlipCompressionValues.Print);
             }
 
-            Assert.True(document.Header!.Default.Images.Count == 1);
-            Assert.True(document.Header!.Even.Images.Count == 1);
-            Assert.True(document.Header!.Even.Images[0].FileName == fileNameImageEvotec);
-            Assert.True(document.Header!.Even.Images[0].Description == "This is a test");
+            Assert.True(defaultHeader.Images.Count == 1);
+            Assert.True(evenHeader.Images.Count == 1);
+            Assert.True(evenHeader.Images[0].FileName == fileNameImageEvotec);
+            Assert.True(evenHeader.Images[0].Description == "This is a test");
 
-            var headerEvenImage = document.Header!.Even.Images[0];
+            var headerEvenImage = evenHeader.Images[0];
             Assert.NotNull(headerEvenImage);
             headerEvenImage!.Description = "Different description";
             Assert.True(headerEvenImage.VerticalFlip == null);
@@ -195,14 +199,16 @@ namespace OfficeIMO.Tests {
             using (var document = WordDocument.Load(filePath)) {
                 Assert.True(document.Paragraphs.Count == 36);
                 Assert.True(document.Images.Count == 4);
-                Assert.True(document.Header!.Default.Images.Count == 1);
-                Assert.True(document.Footer!.Default.Images.Count == 0);
+                var defaultHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+                var defaultFooter = RequireSectionFooter(document, 0, HeaderFooterValues.Default);
+                Assert.True(defaultHeader.Images.Count == 1);
+                Assert.True(defaultFooter.Images.Count == 0);
 
                 Assert.True(document.Images[0].WrapText == WrapTextImage.InLineWithText);
                 Assert.True(document.Images[1].WrapText == WrapTextImage.Square);
                 Assert.True(document.Images[2].WrapText == WrapTextImage.InFrontOfText);
                 Assert.True(document.Images[3].WrapText == WrapTextImage.BehindText);
-                Assert.True(document.Header!.Default.Images[0].WrapText == WrapTextImage.InLineWithText);
+                Assert.True(defaultHeader.Images[0].WrapText == WrapTextImage.InLineWithText);
 
                 Assert.NotNull(document.Images[0].Shape);
                 Assert.NotNull(document.Images[1].Shape);
@@ -356,7 +362,8 @@ namespace OfficeIMO.Tests {
 
             document.AddHeadersAndFooters();
 
-            var tableInHeader = document.Header!.Default.AddTable(2, 2);
+            var defaultHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+            var tableInHeader = defaultHeader.AddTable(2, 2);
             tableInHeader.Rows[0].Cells[0].Paragraphs[0].AddImage(filePathImage, 200, 200);
 
             // not really necessary to add new paragraph since one is already there by default
@@ -367,7 +374,7 @@ namespace OfficeIMO.Tests {
             Assert.True(document.Tables[0].Rows.Count == 2);
             Assert.True(document.Tables[0].Rows[0].Cells.Count == 2);
 
-            Assert.True(document.Header!.Default.Tables.Count == 1);
+            Assert.True(defaultHeader.Tables.Count == 1);
 
             document.Save(false);
 

--- a/OfficeIMO.Tests/Word.Shapes.cs
+++ b/OfficeIMO.Tests/Word.Shapes.cs
@@ -2,6 +2,7 @@ using System.IO;
 using OfficeIMO.Word;
 using SixLabors.ImageSharp;
 using Xunit;
+using HeaderFooterValues = DocumentFormat.OpenXml.Wordprocessing.HeaderFooterValues;
 
 namespace OfficeIMO.Tests {
     public partial class Word {
@@ -140,9 +141,10 @@ namespace OfficeIMO.Tests {
                 section.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
 
                 section.AddHeadersAndFooters();
-                section.Header!.Default.AddShape(ShapeType.Rectangle, 30, 15, Color.Blue, Color.Black);
-                section.Header!.Default.AddShape(ShapeType.RoundedRectangle, 25, 15, Color.Green, Color.Black, 1, arcSize: 0.3);
-                section.Header!.Default.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
+                var defaultHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+                defaultHeader.AddShape(ShapeType.Rectangle, 30, 15, Color.Blue, Color.Black);
+                defaultHeader.AddShape(ShapeType.RoundedRectangle, 25, 15, Color.Green, Color.Black, 1, arcSize: 0.3);
+                defaultHeader.AddShapeDrawing(ShapeType.Ellipse, 20, 20);
 
                 document.Save(false);
             }
@@ -151,9 +153,7 @@ namespace OfficeIMO.Tests {
                 var section = document.Sections[0];
                 Assert.Equal(3, document.Shapes.Count);
                 Assert.Equal(3, section.Shapes.Count);
-                Assert.NotNull(section.Header);
-                Assert.NotNull(section.Header!.Default);
-                var headerDefault = section.Header!.Default!;
+                var headerDefault = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
                 Assert.True(headerDefault.Paragraphs[0].IsShape);
                 Assert.True(headerDefault.Paragraphs[1].IsShape);
                 Assert.True(headerDefault.Paragraphs[2].IsShape);

--- a/OfficeIMO.Tests/Word.TextBox.cs
+++ b/OfficeIMO.Tests/Word.TextBox.cs
@@ -2,6 +2,7 @@ using DocumentFormat.OpenXml.Drawing.Wordprocessing;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using Xunit;
+using HeaderFooterValues = DocumentFormat.OpenXml.Wordprocessing.HeaderFooterValues;
 using Color = SixLabors.ImageSharp.Color;
 
 namespace OfficeIMO.Tests {
@@ -478,14 +479,16 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "HeaderTextBoxWithHyperlink.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                var textBox = document.Sections[0].Header!.Default.AddTextBox("Header hyperlink test");
+                var defaultHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+                var textBox = defaultHeader.AddTextBox("Header hyperlink test");
 
                 textBox.Paragraphs[0].AddHyperLink(" to website?", new Uri("https://evotec.xyz"), addStyle: true);
 
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
-                Assert.Contains(document.Sections[0].Header!.Default.Paragraphs, p => p.IsTextBox);
+                var defaultHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+                Assert.Contains(defaultHeader.Paragraphs, p => p.IsTextBox);
 
             }
         }


### PR DESCRIPTION
## Summary
- reuse RequireSectionHeader/RequireSectionFooter in image-related header/footer tests
- update image location, text box, and shape tests to avoid direct header/footer dereferences

## Testing
- dotnet build OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68cba4f3ec48832e86c3f9d5046d100c