### PR TITLE
Ensure tests use header/footer helper accessors

### DIFF
--- a/OfficeIMO.Tests/Word.CultureInvariant.cs
+++ b/OfficeIMO.Tests/Word.CultureInvariant.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using Xunit;
 
@@ -31,8 +32,8 @@ namespace OfficeIMO.Tests {
                 using var document = WordDocument.Create();
                 document.AddParagraph("Section 0");
                 document.AddHeadersAndFooters();
-
-                var watermark = document.Sections[0].Header!.Default.AddWatermark(WordWatermarkStyle.Text, "Watermark");
+                var header = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+                var watermark = header.AddWatermark(WordWatermarkStyle.Text, "Watermark");
 
                 Assert.Equal(90, watermark.Rotation);
 

--- a/OfficeIMO.Tests/Word.ListItemsEnumerator.cs
+++ b/OfficeIMO.Tests/Word.ListItemsEnumerator.cs
@@ -27,11 +27,13 @@ namespace OfficeIMO.Tests {
                 tableList.AddItem("Table2");
 
                 document.AddHeadersAndFooters();
-                var headerList = document.Header!.Default.AddList(WordListStyle.Bulleted);
+                var header = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+                var headerList = header.AddList(WordListStyle.Bulleted);
                 headerList.AddItem("Header1");
                 headerList.AddItem("Header2");
 
-                var footerList = document.Footer!.Default.AddList(WordListStyle.Bulleted);
+                var footer = RequireSectionFooter(document, 0, HeaderFooterValues.Default);
+                var footerList = footer.AddList(WordListStyle.Bulleted);
                 footerList.AddItem("Footer1");
                 footerList.AddItem("Footer2");
 

--- a/OfficeIMO.Tests/Word.Sections.cs
+++ b/OfficeIMO.Tests/Word.Sections.cs
@@ -506,19 +506,22 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "RemoveSection.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
-                document.Header!.Default.AddParagraph().SetText("Header 0");
+                var header0 = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+                header0.AddParagraph().SetText("Header 0");
                 var p0 = document.AddParagraph("Section0");
                 p0.AddList(WordListStyle.Bulleted).AddItem("0");
 
                 var section1 = document.AddSection();
                 section1.AddHeadersAndFooters();
-                section1.Header!.Default.AddParagraph().SetText("Header 1");
+                var header1 = RequireSectionHeader(document, 1, HeaderFooterValues.Default);
+                header1.AddParagraph().SetText("Header 1");
                 var p1 = section1.AddParagraph("Section1");
                 p1.AddList(WordListStyle.Bulleted).AddItem("1");
 
                 var section2 = document.AddSection();
                 section2.AddHeadersAndFooters();
-                section2.Header!.Default.AddParagraph().SetText("Header 2");
+                var header2 = RequireSectionHeader(document, 2, HeaderFooterValues.Default);
+                header2.AddParagraph().SetText("Header 2");
                 var p2 = section2.AddParagraph("Section2");
                 p2.AddList(WordListStyle.Bulleted).AddItem("2");
 
@@ -533,8 +536,10 @@ namespace OfficeIMO.Tests {
 
                 Assert.Equal(2, document.Sections.Count);
                 Assert.Equal(2, document.Lists.Count);
-                Assert.Equal("Header 0", document.Sections[0].Header!.Default.Paragraphs[0].Text);
-                Assert.Equal("Header 2", document.Sections[1].Header!.Default.Paragraphs[0].Text);
+                var remainingHeader0 = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+                var remainingHeader1 = RequireSectionHeader(document, 1, HeaderFooterValues.Default);
+                Assert.Equal("Header 0", remainingHeader0.Paragraphs[0].Text);
+                Assert.Equal("Header 2", remainingHeader1.Paragraphs[0].Text);
 
                 document.Save();
             }
@@ -542,8 +547,10 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.Equal(2, document.Sections.Count);
                 Assert.Equal(2, document.Lists.Count);
-                Assert.Equal("Header 0", document.Sections[0].Header!.Default.Paragraphs[0].Text);
-                Assert.Equal("Header 2", document.Sections[1].Header!.Default.Paragraphs[0].Text);
+                var loadedHeader0 = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+                var loadedHeader1 = RequireSectionHeader(document, 1, HeaderFooterValues.Default);
+                Assert.Equal("Header 0", loadedHeader0.Paragraphs[0].Text);
+                Assert.Equal("Header 2", loadedHeader1.Paragraphs[0].Text);
             }
         }
 


### PR DESCRIPTION
## Summary
- retrieve headers in section removal test through RequireSectionHeader to avoid null dereferences during creation and load
- update list enumerator test to build header and footer lists from helper-fetched instances
- fetch the default header via RequireSectionHeader before adding watermark in the culture invariant test

## Testing
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68cbb19c5ef8832e9bb5e4efe0e2fa8f