### PR TITLE
Use header/footer helpers in fluent headers footers test

### DIFF
--- a/OfficeIMO.Tests/Word.Fluent.HeadersFooters.cs
+++ b/OfficeIMO.Tests/Word.Fluent.HeadersFooters.cs
@@ -35,17 +35,23 @@ namespace OfficeIMO.Tests {
             using var loaded = WordDocument.Load(filePath);
             Assert.Equal(2, loaded.Sections.Count);
 
-            var defaultHeader = loaded.Sections[1].Header!.Default;
+            var defaultHeader = RequireSectionHeader(loaded, 1, HeaderFooterValues.Default);
+            var firstHeader = RequireSectionHeader(loaded, 1, HeaderFooterValues.First);
+            var evenHeader = RequireSectionHeader(loaded, 1, HeaderFooterValues.Even);
             Assert.Equal(3, defaultHeader.Paragraphs.Count);
             Assert.Single(defaultHeader.Tables);
             Assert.Single(defaultHeader.ParagraphsImages);
 
-            Assert.Equal("First header", loaded.Sections[1].Header!.First.Paragraphs[0].Text);
-            Assert.Equal("Even header", loaded.Sections[1].Header!.Even.Paragraphs[0].Text);
+            Assert.Equal("First header", firstHeader.Paragraphs[0].Text);
+            Assert.Equal("Even header", evenHeader.Paragraphs[0].Text);
 
-            Assert.Equal("Default footer", loaded.Sections[1].Footer!.Default.Paragraphs[0].Text);
-            Assert.Equal("First footer", loaded.Sections[1].Footer!.First.Paragraphs[0].Text);
-            Assert.Equal("Even footer", loaded.Sections[1].Footer!.Even.Paragraphs[0].Text);
+            var defaultFooter = RequireSectionFooter(loaded, 1, HeaderFooterValues.Default);
+            var firstFooter = RequireSectionFooter(loaded, 1, HeaderFooterValues.First);
+            var evenFooter = RequireSectionFooter(loaded, 1, HeaderFooterValues.Even);
+
+            Assert.Equal("Default footer", defaultFooter.Paragraphs[0].Text);
+            Assert.Equal("First footer", firstFooter.Paragraphs[0].Text);
+            Assert.Equal("Even footer", evenFooter.Paragraphs[0].Text);
 
             Assert.Null(loaded.Sections[0].Header!.Default);
             Assert.Null(loaded.Sections[0].Footer!.Default);


### PR DESCRIPTION
## Summary
- resolve nullability access in the fluent headers/footers persistence test by using helper methods
- assert header and footer content via helper-returned references instead of direct section chains

## Testing
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68cbb79dbf9c832ea8748004b81abff7