### PR TITLE
Use header/footer helpers in PDF and HTML tests

### DIFF
--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Sections.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Sections.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Pdf;
 using System.IO;
@@ -13,14 +14,18 @@ public partial class Word {
 
         using (WordDocument document = WordDocument.Create(docPath)) {
             document.AddHeadersAndFooters();
-            document.Header!.Default.AddParagraph("Header1");
-            document.Footer!.Default.AddParagraph("Footer1");
+            var defaultHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+            var defaultFooter = RequireSectionFooter(document, 0, HeaderFooterValues.Default);
+            defaultHeader.AddParagraph("Header1");
+            defaultFooter.AddParagraph("Footer1");
             document.AddParagraph("Section1 Paragraph");
 
             WordSection section2 = document.AddSection();
             section2.AddHeadersAndFooters();
-            section2.Header!.Default.AddParagraph("Header2");
-            section2.Footer!.Default.AddParagraph("Footer2");
+            var section2Header = RequireSectionHeader(document, 1, HeaderFooterValues.Default);
+            var section2Footer = RequireSectionFooter(document, 1, HeaderFooterValues.Default);
+            section2Header.AddParagraph("Header2");
+            section2Footer.AddParagraph("Footer2");
             document.AddParagraph("Section2 Paragraph");
 
             document.Save();
@@ -37,8 +42,10 @@ public partial class Word {
 
         using (WordDocument document = WordDocument.Create(docPath)) {
             document.AddHeadersAndFooters();
-            document.Header!.Default.AddParagraph("DefaultHeader");
-            document.Footer!.Default.AddParagraph("DefaultFooter");
+            var header = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+            var footer = RequireSectionFooter(document, 0, HeaderFooterValues.Default);
+            header.AddParagraph("DefaultHeader");
+            footer.AddParagraph("DefaultFooter");
 
             for (int i = 0; i < 100; i++) {
                 document.AddParagraph($"Paragraph {i}");

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
@@ -19,11 +19,13 @@ public partial class Word {
 
         using (WordDocument document = WordDocument.Create(docPath)) {
             document.AddHeadersAndFooters();
-            document.Header!.Default.AddParagraph("Sample Header");
-            WordTable headerTable = document.Header!.Default.AddTable(1, 1);
+            var defaultHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+            var defaultFooter = RequireSectionFooter(document, 0, HeaderFooterValues.Default);
+            defaultHeader.AddParagraph("Sample Header");
+            WordTable headerTable = defaultHeader.AddTable(1, 1);
             headerTable.Rows[0].Cells[0].Paragraphs[0].Text = "H1";
-            document.Footer!.Default.AddParagraph("Sample Footer");
-            WordTable footerTable = document.Footer!.Default.AddTable(1, 1);
+            defaultFooter.AddParagraph("Sample Footer");
+            WordTable footerTable = defaultFooter.AddTable(1, 1);
             footerTable.Rows[0].Cells[0].Paragraphs[0].Text = "F1";
 
             WordParagraph heading = document.AddParagraph("Heading One");
@@ -65,8 +67,10 @@ public partial class Word {
 
         using (WordDocument document = WordDocument.Create(docPath)) {
             document.AddHeadersAndFooters();
-            document.Header!.Default.AddParagraph().AddImage(imagePath, 20, 20);
-            document.Footer!.Default.AddParagraph().AddImage(imagePath, 400, 400);
+            var header = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+            var footer = RequireSectionFooter(document, 0, HeaderFooterValues.Default);
+            header.AddParagraph().AddImage(imagePath, 20, 20);
+            footer.AddParagraph().AddImage(imagePath, 400, 400);
             document.Save();
             document.SaveAsPdf(pdfPath);
         }


### PR DESCRIPTION
## Summary
- obtain section headers and footers with RequireSectionHeader/RequireSectionFooter before writing PDF test content
- add header/footer helper usage to async HTML header/footer assertions and share helper methods to avoid nullable access
- capture footer part ids before resolving footer parts when reading saved HTML output

## Testing
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68cbb797b828832e8f2262b9b355af77