### PR TITLE
Refine header/footer test helpers

### DIFF
--- a/OfficeIMO.Tests/Word.CleanupHeadersFooters.cs
+++ b/OfficeIMO.Tests/Word.CleanupHeadersFooters.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using Xunit;
 
@@ -11,41 +12,45 @@ namespace OfficeIMO.Tests {
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddHeadersAndFooters();
 
-                var headerParagraph = document.Header!.Default.AddParagraph("Header ");
+                var defaultHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+                var headerParagraph = defaultHeader.AddParagraph("Header ");
                 headerParagraph.AddText("clutter ");
                 headerParagraph.AddText("text");
-                document.Header!.Default.AddParagraph();
+                defaultHeader.AddParagraph();
 
-                var footerParagraph = document.Footer!.Default.AddParagraph("Footer ");
+                var defaultFooter = RequireSectionFooter(document, 0, HeaderFooterValues.Default);
+                var footerParagraph = defaultFooter.AddParagraph("Footer ");
                 footerParagraph.AddText("clutter ");
                 footerParagraph.AddText("text");
-                document.Footer!.Default.AddParagraph();
+                defaultFooter.AddParagraph();
 
-                Assert.True(document.Header!.Default.Paragraphs.Count > 1);
+                Assert.True(defaultHeader.Paragraphs.Count > 1);
                 Assert.True(headerParagraph.GetRuns().Count() > 1);
-                Assert.True(document.Footer!.Default.Paragraphs.Count > 1);
+                Assert.True(defaultFooter.Paragraphs.Count > 1);
                 Assert.True(footerParagraph.GetRuns().Count() > 1);
 
                 document.CleanupDocument();
 
-                Assert.True(document.Header!.Default.Paragraphs.Count == 1);
-                Assert.True(document.Header!.Default.Paragraphs[0].GetRuns().Count() == 1);
-                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Header clutter text");
+                Assert.True(defaultHeader.Paragraphs.Count == 1);
+                Assert.True(defaultHeader.Paragraphs[0].GetRuns().Count() == 1);
+                Assert.True(defaultHeader.Paragraphs[0].Text == "Header clutter text");
 
-                Assert.True(document.Footer!.Default.Paragraphs.Count == 1);
-                Assert.True(document.Footer!.Default.Paragraphs[0].GetRuns().Count() == 1);
-                Assert.True(document.Footer!.Default.Paragraphs[0].Text == "Footer clutter text");
+                Assert.True(defaultFooter.Paragraphs.Count == 1);
+                Assert.True(defaultFooter.Paragraphs[0].GetRuns().Count() == 1);
+                Assert.True(defaultFooter.Paragraphs[0].Text == "Footer clutter text");
 
                 document.Save(false);
             }
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CleanupHeadersAndFooters.docx"))) {
-                Assert.True(document.Header!.Default.Paragraphs.Count == 1);
-                Assert.True(document.Header!.Default.Paragraphs[0].GetRuns().Count() == 1);
-                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Header clutter text");
+                var reloadedHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+                Assert.True(reloadedHeader.Paragraphs.Count == 1);
+                Assert.True(reloadedHeader.Paragraphs[0].GetRuns().Count() == 1);
+                Assert.True(reloadedHeader.Paragraphs[0].Text == "Header clutter text");
 
-                Assert.True(document.Footer!.Default.Paragraphs.Count == 1);
-                Assert.True(document.Footer!.Default.Paragraphs[0].GetRuns().Count() == 1);
-                Assert.True(document.Footer!.Default.Paragraphs[0].Text == "Footer clutter text");
+                var reloadedFooter = RequireSectionFooter(document, 0, HeaderFooterValues.Default);
+                Assert.True(reloadedFooter.Paragraphs.Count == 1);
+                Assert.True(reloadedFooter.Paragraphs[0].GetRuns().Count() == 1);
+                Assert.True(reloadedFooter.Paragraphs[0].Text == "Footer clutter text");
             }
         }
     }

--- a/OfficeIMO.Tests/Word.HeadersAndFooter.cs
+++ b/OfficeIMO.Tests/Word.HeadersAndFooter.cs
@@ -341,29 +341,37 @@ namespace OfficeIMO.Tests {
                 document.AddParagraph("Test Section0");
                 document.AddHeadersAndFooters();
 
-                document.Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
-                document.Footer!.Default.AddParagraph().SetText("Test Section 0 - Footer");
+                var section0DefaultHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Default);
+                var section0DefaultFooter = RequireSectionFooter(document, 0, HeaderFooterValues.Default);
+
+                section0DefaultHeader.AddParagraph().SetText("Test Section 0 - Header");
+                section0DefaultFooter.AddParagraph().SetText("Test Section 0 - Footer");
 
                 Assert.True(document.Header!.First == null);
                 Assert.True(document.Footer!.First == null);
 
                 document.DifferentFirstPage = true;
 
-                Assert.True(document.Header!.First != null);
-                Assert.True(document.Footer!.First != null);
-                document.Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
-                document.Footer!.First.AddParagraph().SetText("Test Section 0 - First Footer");
+                var section0FirstHeader = RequireSectionHeader(document, 0, HeaderFooterValues.First);
+                var section0FirstFooter = RequireSectionFooter(document, 0, HeaderFooterValues.First);
+
+                Assert.NotNull(section0FirstHeader);
+                Assert.NotNull(section0FirstFooter);
+                section0FirstHeader.AddParagraph().SetText("Test Section 0 - First Header");
+                section0FirstFooter.AddParagraph().SetText("Test Section 0 - First Footer");
 
                 Assert.True(document.Header!.Even == null);
                 Assert.True(document.Footer!.Even == null);
 
                 document.DifferentOddAndEvenPages = true;
 
-                Assert.True(document.Header!.Even != null);
-                Assert.True(document.Footer!.Even != null);
+                var section0EvenHeader = RequireSectionHeader(document, 0, HeaderFooterValues.Even);
+                var section0EvenFooter = RequireSectionFooter(document, 0, HeaderFooterValues.Even);
 
-                document.Header!.Even.AddParagraph().SetText("Test Section 0 - Header Even");
-                document.Footer!.Even.AddParagraph().SetText("Test Section 0 - Footer Even");
+                Assert.NotNull(section0EvenHeader);
+                Assert.NotNull(section0EvenFooter);
+                section0EvenHeader.AddParagraph().SetText("Test Section 0 - Header Even");
+                section0EvenFooter.AddParagraph().SetText("Test Section 0 - Footer Even");
 
 
                 var section1 = document.AddSection();
@@ -371,27 +379,35 @@ namespace OfficeIMO.Tests {
                 section1.DifferentFirstPage = true;
                 section1.DifferentOddAndEvenPages = true;
 
-                section1.Header!.Default.AddParagraph().SetText("Test Section 0 - Header");
-                section1.Footer!.Default.AddParagraph().SetText("Test Section 0 - Footer");
-                section1.Header!.First.AddParagraph().SetText("Test Section 0 - First Header");
-                section1.Footer!.First.AddParagraph().SetText("Test Section 0 - First Footer");
-                section1.Header!.Even.AddParagraph().SetText("Test Section 0 - Header Even");
-                section1.Footer!.Even.AddParagraph().SetText("Test Section 0 - Footer Even");
+                var section1DefaultHeader = RequireSectionHeader(document, 1, HeaderFooterValues.Default);
+                var section1DefaultFooter = RequireSectionFooter(document, 1, HeaderFooterValues.Default);
+                section1DefaultHeader.AddParagraph().SetText("Test Section 0 - Header");
+                section1DefaultFooter.AddParagraph().SetText("Test Section 0 - Footer");
+
+                var section1FirstHeader = RequireSectionHeader(document, 1, HeaderFooterValues.First);
+                var section1FirstFooter = RequireSectionFooter(document, 1, HeaderFooterValues.First);
+                section1FirstHeader.AddParagraph().SetText("Test Section 0 - First Header");
+                section1FirstFooter.AddParagraph().SetText("Test Section 0 - First Footer");
+
+                var section1EvenHeader = RequireSectionHeader(document, 1, HeaderFooterValues.Even);
+                var section1EvenFooter = RequireSectionFooter(document, 1, HeaderFooterValues.Even);
+                section1EvenHeader.AddParagraph().SetText("Test Section 0 - Header Even");
+                section1EvenFooter.AddParagraph().SetText("Test Section 0 - Footer Even");
 
 
-                Assert.True(document.Header!.Default.Paragraphs[0].Text == "Test Section 0 - Header");
-                Assert.True(document.Footer!.Default.Paragraphs[0].Text == "Test Section 0 - Footer");
-                Assert.True(document.Header!.First.Paragraphs[0].Text == "Test Section 0 - First Header");
-                Assert.True(document.Footer!.First.Paragraphs[0].Text == "Test Section 0 - First Footer");
-                Assert.True(document.Header!.Even.Paragraphs[0].Text == "Test Section 0 - Header Even");
-                Assert.True(document.Footer!.Even.Paragraphs[0].Text == "Test Section 0 - Footer Even");
+                Assert.True(section0DefaultHeader.Paragraphs[0].Text == "Test Section 0 - Header");
+                Assert.True(section0DefaultFooter.Paragraphs[0].Text == "Test Section 0 - Footer");
+                Assert.True(section0FirstHeader.Paragraphs[0].Text == "Test Section 0 - First Header");
+                Assert.True(section0FirstFooter.Paragraphs[0].Text == "Test Section 0 - First Footer");
+                Assert.True(section0EvenHeader.Paragraphs[0].Text == "Test Section 0 - Header Even");
+                Assert.True(section0EvenFooter.Paragraphs[0].Text == "Test Section 0 - Footer Even");
 
-                Assert.True(document.Header!.Default.Paragraphs.Count == 1);
-                Assert.True(document.Footer!.Default.Paragraphs.Count == 1);
-                Assert.True(document.Header!.First.Paragraphs.Count == 1);
-                Assert.True(document.Footer!.First.Paragraphs.Count == 1);
-                Assert.True(document.Header!.Even.Paragraphs.Count == 1);
-                Assert.True(document.Footer!.Even.Paragraphs.Count == 1);
+                Assert.True(section0DefaultHeader.Paragraphs.Count == 1);
+                Assert.True(section0DefaultFooter.Paragraphs.Count == 1);
+                Assert.True(section0FirstHeader.Paragraphs.Count == 1);
+                Assert.True(section0FirstFooter.Paragraphs.Count == 1);
+                Assert.True(section0EvenHeader.Paragraphs.Count == 1);
+                Assert.True(section0EvenFooter.Paragraphs.Count == 1);
 
                 Assert.True(document.Paragraphs.Count == 1, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 0, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);
@@ -406,19 +422,29 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(Path.Combine(_directoryWithFiles, "CreatedDocumentWithHeadersAndRemoveThem.docx"))) {
 
-                Assert.True(document.Header!.Default == null);
-                Assert.True(document.Footer!.Default == null);
-                Assert.True(document.Header!.First == null);
-                Assert.True(document.Footer!.First == null);
-                Assert.True(document.Header!.Even == null);
-                Assert.True(document.Footer!.Even == null);
+                var section0Headers = document.Header;
+                Assert.NotNull(section0Headers);
+                Assert.Null(section0Headers.Default);
+                Assert.Null(section0Headers.First);
+                Assert.Null(section0Headers.Even);
 
-                Assert.True(document.Sections[1].Header!.Default == null);
-                Assert.True(document.Sections[1].Footer!.Default == null);
-                Assert.True(document.Sections[1].Header!.First == null);
-                Assert.True(document.Sections[1].Footer!.First == null);
-                Assert.True(document.Sections[1].Header!.Even == null);
-                Assert.True(document.Sections[1].Footer!.Even == null);
+                var section0Footers = document.Footer;
+                Assert.NotNull(section0Footers);
+                Assert.Null(section0Footers.Default);
+                Assert.Null(section0Footers.First);
+                Assert.Null(section0Footers.Even);
+
+                var section1Headers = document.Sections[1].Header;
+                Assert.NotNull(section1Headers);
+                Assert.Null(section1Headers.Default);
+                Assert.Null(section1Headers.First);
+                Assert.Null(section1Headers.Even);
+
+                var section1Footers = document.Sections[1].Footer;
+                Assert.NotNull(section1Footers);
+                Assert.Null(section1Footers.Default);
+                Assert.Null(section1Footers.First);
+                Assert.Null(section1Footers.Even);
 
                 Assert.True(document.Paragraphs.Count == 1, "Number of paragraphs during creation is wrong. Current: " + document.Paragraphs.Count);
                 Assert.True(document.PageBreaks.Count == 0, "Number of page breaks during creation is wrong. Current: " + document.PageBreaks.Count);


### PR DESCRIPTION
## Summary
- use RequireSectionHeader/RequireSectionFooter when populating headers and footers in the delete test
- validate removed header and footer states through local references before examining header/footer variants
- obtain WordHeader and WordFooter instances via helpers in cleanup tests for mutation and verification

## Testing
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68cbb788f354832e905a6fcf266dfb46