### PR TITLE
Fix nullable warnings in markdown and excel helpers

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.Core.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Core.cs
@@ -195,12 +195,10 @@ namespace OfficeIMO.Excel {
             Cell? insertAfterCell = null;
             int targetColumnIndex = column;
             foreach (Cell c in rowElement.Elements<Cell>()) {
-                var existingRef = c.CellReference?.Value;
-                if (string.IsNullOrEmpty(existingRef)) {
+                if (c.CellReference?.Value is not string existingRefValue || existingRefValue.Length == 0) {
                     continue;
                 }
 
-                string existingRefValue = existingRef;
                 int existingColumnIndex = GetColumnIndex(existingRefValue);
                 if (existingColumnIndex == targetColumnIndex) {
                     cell = c;
@@ -222,9 +220,7 @@ namespace OfficeIMO.Excel {
                     // Insert at beginning or append when row is empty or existing first cell has larger column index
                     var firstCell = rowElement.Elements<Cell>().FirstOrDefault();
                     if (firstCell != null) {
-                        var firstRef = firstCell.CellReference?.Value;
-                        if (!string.IsNullOrEmpty(firstRef)) {
-                            string firstRefValue = firstRef;
+                        if (firstCell.CellReference?.Value is string firstRefValue && firstRefValue.Length > 0) {
                             if (GetColumnIndex(firstRefValue) > targetColumnIndex) {
                                 rowElement.InsertBefore(cell, firstCell);
                             } else {

--- a/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
+++ b/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
@@ -498,8 +498,8 @@ internal static class HtmlRenderer {
     }
 
     internal static string ScopeCss(string? css, string? scopeSelector) {
-        string? cssText = css;
-        if (string.IsNullOrEmpty(cssText)) return string.Empty;
+        string cssText = css ?? string.Empty;
+        if (cssText.Length == 0) return string.Empty;
         string scope = NormalizeScope(scopeSelector);
         // Naive scoping: prefix common selectors with the scope to avoid global bleed.
         // This is intentionally conservative.
@@ -512,7 +512,7 @@ internal static class HtmlRenderer {
     }
 
     private static string NormalizeScope(string? scopeSelector) {
-        var selector = scopeSelector;
+        string selector = scopeSelector ?? string.Empty;
         if (string.IsNullOrWhiteSpace(selector)) return "body";
         return selector.Trim();
     }


### PR DESCRIPTION
## Summary
- guard CSS scoping helpers against null values before performing replacements
- tighten Excel cell lookup logic to only process non-empty cell references

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68cbc3cb7828832eb104204a563f5e58