### PR TITLE
Add MarkdownDoc Hr helper and tests

### DIFF
--- a/OfficeIMO.Examples/Markdown/Markdown01_Builder_Basics.cs
+++ b/OfficeIMO.Examples/Markdown/Markdown01_Builder_Basics.cs
@@ -28,6 +28,7 @@ namespace OfficeIMO.Examples.Markdown {
                     .Item("TLS/SSL tests and cipher hints")
                     .Item("WHOIS, MX, PTR, DNSSEC, BIMI")
                     .Item("Exports: Word, HTML, PDF, Markdown"))
+                .Hr()
                 .H2("Links")
                 .Ul(ul => ul
                     .ItemLink("Docs", "https://evotec.xyz/hub/")

--- a/OfficeIMO.Markdown/Core/MarkdownDoc.cs
+++ b/OfficeIMO.Markdown/Core/MarkdownDoc.cs
@@ -61,6 +61,9 @@ public class MarkdownDoc {
         return Add(new ParagraphBlock(builder.Inlines));
     }
 
+    /// <summary>Adds a horizontal rule.</summary>
+    public MarkdownDoc Hr() => Add(new HorizontalRuleBlock());
+
     /// <summary>Adds a callout/admonition block (Docs-style).</summary>
     public MarkdownDoc Callout(string kind, string title, string body) => Add(new CalloutBlock(kind, title, body));
 

--- a/OfficeIMO.Tests/Markdown/Markdown_Html_Render_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_Html_Render_Tests.cs
@@ -106,7 +106,8 @@ namespace OfficeIMO.Tests.MarkdownSuite {
                 .P("After the break.");
 
             string markdown = doc.ToMarkdown();
-            Assert.Contains("\n---\n", markdown, StringComparison.Ordinal);
+            string normalizedMarkdown = markdown.Replace("\r\n", "\n");
+            Assert.Contains("\n---\n", normalizedMarkdown, StringComparison.Ordinal);
 
             string html = doc.ToHtmlFragment();
             Assert.Contains("<hr />", html, StringComparison.Ordinal);

--- a/OfficeIMO.Tests/Markdown/Markdown_Html_Render_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_Html_Render_Tests.cs
@@ -97,5 +97,19 @@ namespace OfficeIMO.Tests.MarkdownSuite {
             Assert.Contains("data-asset-id=\"prism-core\"", merged.headLinks);
             Assert.Contains("prefers-color-scheme: dark", merged.headLinks);
         }
+
+        [Fact]
+        public void HorizontalRule_Renders_In_Markdown_And_Html() {
+            var doc = MarkdownDoc.Create()
+                .P("Before the break.")
+                .Hr()
+                .P("After the break.");
+
+            string markdown = doc.ToMarkdown();
+            Assert.Contains("\n---\n", markdown, StringComparison.Ordinal);
+
+            string html = doc.ToHtmlFragment();
+            Assert.Contains("<hr />", html, StringComparison.Ordinal);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a `Hr()` convenience to `MarkdownDoc` so horizontal rules can be chained fluently
- exercise the new helper in HTML/Markdown rendering tests to ensure both outputs contain the rule
- demonstrate the helper in the Markdown builder basics example

## Testing
- dotnet test OfficeIMO.Tests

------
https://chatgpt.com/codex/tasks/task_e_68ce9f572634832e88d722ecda493eed