### PR TITLE
Improve ExcelDocument.Load error diagnostics

### DIFF
--- a/OfficeIMO.Tests/Excel.LoadExceptions.cs
+++ b/OfficeIMO.Tests/Excel.LoadExceptions.cs
@@ -1,6 +1,9 @@
 using System;
 using System.IO;
+using System.IO.Compression;
 using System.Threading.Tasks;
+using System.Text;
+using System.Xml;
 using OfficeIMO.Excel;
 using Xunit;
 
@@ -30,6 +33,37 @@ namespace OfficeIMO.Tests {
         public async Task Test_LoadAsyncNullPath_ThrowsArgumentNullException() {
             var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => ExcelDocument.LoadAsync(null!));
             Assert.Equal("path", ex.ParamName);
+        }
+
+        [Fact]
+        public void Test_LoadInvalidAppPropsContentType_ThrowsHelpfulIOException()
+        {
+            string sourcePath = Path.Combine(_directoryDocuments, "BasicExcel.xlsx");
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            File.Copy(sourcePath, filePath, overwrite: true);
+
+            using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            using (var archive = new ZipArchive(fileStream, ZipArchiveMode.Update, leaveOpen: false))
+            {
+                Assert.NotNull(archive.GetEntry("docProps/app.xml"));
+                var contentTypes = archive.GetEntry("[Content_Types].xml") ?? throw new InvalidOperationException("Missing content types.");
+                contentTypes.Delete();
+                var replacement = archive.CreateEntry("[Content_Types].xml", CompressionLevel.NoCompression);
+                using var replacementStream = replacement.Open();
+                using var writer = new StreamWriter(replacementStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                writer.Write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+                writer.Write("<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">\n");
+                writer.Write("  <Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>\n");
+                writer.Write("  <Default Extension=\"xml\" ContentType=\"application/xml\"/>\n");
+                writer.Write("  <Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>\n");
+                writer.Write("  <Override PartName=\"/docProps/core.xml\" ContentType=\"application/vnd.openxmlformats-package.core-properties+xml\"/>\n");
+                writer.Write("  <Override PartName=\"/docProps/app.xml\" ContentType=\"application/xml\">");
+                // Intentionally omit the closing tag to mimic a corrupted declaration that still references /docProps/app.xml
+            }
+
+            var exception = Assert.Throws<IOException>(() => ExcelDocument.Load(filePath));
+            Assert.Contains("invalid content type for '/docProps/app.xml'", exception.Message);
+            Assert.IsType<XmlException>(exception.InnerException);
         }
     }
 }


### PR DESCRIPTION
## Summary
- capture content-type normalization failures inside `ExcelDocument.Load`, log them via an optional callback, and surface an `IOException` with docProps context
- add an Excel regression test that corrupts `/docProps/app.xml` content type to ensure the new exception message is emitted

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68ce9f410118832e96dd123ed63ea302