### PR TITLE
Ensure Excel save creates destination directories

### DIFF
--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -631,10 +631,14 @@ namespace OfficeIMO.Excel {
                 throw new IOException($"Failed to save to '{path}'. The file is read-only.");
             }
             var directory = Path.GetDirectoryName(Path.GetFullPath(path));
-            if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory)) {
-                var dirInfo = new DirectoryInfo(directory);
-                if (dirInfo.Attributes.HasFlag(FileAttributes.ReadOnly)) {
-                    throw new IOException($"Failed to save to '{path}'. The directory is read-only.");
+            if (!string.IsNullOrEmpty(directory)) {
+                if (!Directory.Exists(directory)) {
+                    Directory.CreateDirectory(directory);
+                } else {
+                    var dirInfo = new DirectoryInfo(directory);
+                    if (dirInfo.Attributes.HasFlag(FileAttributes.ReadOnly)) {
+                        throw new IOException($"Failed to save to '{path}'. The directory is read-only.");
+                    }
                 }
             }
 
@@ -745,10 +749,14 @@ namespace OfficeIMO.Excel {
                 throw new IOException($"Failed to save to '{target}'. The file is read-only.");
             }
             var directory = Path.GetDirectoryName(Path.GetFullPath(target));
-            if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory)) {
-                var dirInfo = new DirectoryInfo(directory);
-                if (dirInfo.Attributes.HasFlag(FileAttributes.ReadOnly)) {
-                    throw new IOException($"Failed to save to '{target}'. The directory is read-only.");
+            if (!string.IsNullOrEmpty(directory)) {
+                if (!Directory.Exists(directory)) {
+                    Directory.CreateDirectory(directory);
+                } else {
+                    var dirInfo = new DirectoryInfo(directory);
+                    if (dirInfo.Attributes.HasFlag(FileAttributes.ReadOnly)) {
+                        throw new IOException($"Failed to save to '{target}'. The directory is read-only.");
+                    }
                 }
             }
 

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -608,6 +608,28 @@ namespace OfficeIMO.Excel {
             this._spreadSheetDocument.Dispose();
         }
 
+        private static void EnsureDirectoryWritable(string path) {
+            if (string.IsNullOrWhiteSpace(path)) {
+                return;
+            }
+
+            var directory = Path.GetDirectoryName(Path.GetFullPath(path));
+            if (string.IsNullOrEmpty(directory)) {
+                return;
+            }
+
+            DirectoryInfo directoryInfo;
+            if (Directory.Exists(directory)) {
+                directoryInfo = new DirectoryInfo(directory);
+            } else {
+                directoryInfo = Directory.CreateDirectory(directory);
+            }
+
+            if (directoryInfo.Attributes.HasFlag(FileAttributes.ReadOnly)) {
+                throw new IOException($"Failed to save to '{path}'. The directory is read-only.");
+            }
+        }
+
         /// <summary>
         /// Saves the document and optionally opens it.
         /// </summary>
@@ -630,17 +652,7 @@ namespace OfficeIMO.Excel {
             if (File.Exists(path) && new FileInfo(path).IsReadOnly) {
                 throw new IOException($"Failed to save to '{path}'. The file is read-only.");
             }
-            var directory = Path.GetDirectoryName(Path.GetFullPath(path));
-            if (!string.IsNullOrEmpty(directory)) {
-                if (!Directory.Exists(directory)) {
-                    Directory.CreateDirectory(directory);
-                } else {
-                    var dirInfo = new DirectoryInfo(directory);
-                    if (dirInfo.Attributes.HasFlag(FileAttributes.ReadOnly)) {
-                        throw new IOException($"Failed to save to '{path}'. The directory is read-only.");
-                    }
-                }
-            }
+            EnsureDirectoryWritable(path);
 
             var payload = PreparePackageForSave(options);
 
@@ -748,17 +760,7 @@ namespace OfficeIMO.Excel {
             if (File.Exists(target) && new FileInfo(target).IsReadOnly) {
                 throw new IOException($"Failed to save to '{target}'. The file is read-only.");
             }
-            var directory = Path.GetDirectoryName(Path.GetFullPath(target));
-            if (!string.IsNullOrEmpty(directory)) {
-                if (!Directory.Exists(directory)) {
-                    Directory.CreateDirectory(directory);
-                } else {
-                    var dirInfo = new DirectoryInfo(directory);
-                    if (dirInfo.Attributes.HasFlag(FileAttributes.ReadOnly)) {
-                        throw new IOException($"Failed to save to '{target}'. The directory is read-only.");
-                    }
-                }
-            }
+            EnsureDirectoryWritable(target);
 
             var payload = PreparePackageForSave(options);
 

--- a/OfficeIMO.Tests/Excel.SaveMissingDirectory.cs
+++ b/OfficeIMO.Tests/Excel.SaveMissingDirectory.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_Save_CreatesMissingDirectory() {
+            var sourcePath = Path.Combine(_directoryWithFiles, $"Source_{Guid.NewGuid():N}.xlsx");
+            var destinationDirectory = Path.Combine(_directoryWithFiles, "Missing", Guid.NewGuid().ToString("N"));
+            var destinationPath = Path.Combine(destinationDirectory, "Created.xlsx");
+
+            if (File.Exists(sourcePath)) File.Delete(sourcePath);
+            if (Directory.Exists(destinationDirectory)) Directory.Delete(destinationDirectory, recursive: true);
+
+            using (var document = ExcelDocument.Create(sourcePath)) {
+                document.AddWorkSheet("Sheet1");
+
+                document.Save(destinationPath, openExcel: false);
+
+                Assert.True(Directory.Exists(destinationDirectory));
+                Assert.True(File.Exists(destinationPath));
+            }
+
+            if (File.Exists(sourcePath)) File.Delete(sourcePath);
+            if (File.Exists(destinationPath)) File.Delete(destinationPath);
+            if (Directory.Exists(destinationDirectory)) Directory.Delete(destinationDirectory, recursive: true);
+        }
+
+        [Fact]
+        public async Task Test_SaveAsync_CreatesMissingDirectory() {
+            var sourcePath = Path.Combine(_directoryWithFiles, $"AsyncSource_{Guid.NewGuid():N}.xlsx");
+            var destinationDirectory = Path.Combine(_directoryWithFiles, "MissingAsync", Guid.NewGuid().ToString("N"));
+            var destinationPath = Path.Combine(destinationDirectory, "Created.xlsx");
+
+            if (File.Exists(sourcePath)) File.Delete(sourcePath);
+            if (Directory.Exists(destinationDirectory)) Directory.Delete(destinationDirectory, recursive: true);
+
+            await using (var document = ExcelDocument.Create(sourcePath)) {
+                document.AddWorkSheet("Sheet1");
+
+                await document.SaveAsync(destinationPath, openExcel: false);
+
+                Assert.True(Directory.Exists(destinationDirectory));
+                Assert.True(File.Exists(destinationPath));
+            }
+
+            if (File.Exists(sourcePath)) File.Delete(sourcePath);
+            if (File.Exists(destinationPath)) File.Delete(destinationPath);
+            if (Directory.Exists(destinationDirectory)) Directory.Delete(destinationDirectory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create any missing destination directories before saving Excel workbooks synchronously or asynchronously
- add regression tests that save to new subfolders to verify workbook persistence

## Testing
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "Test_Save_CreatesMissingDirectory|Test_SaveAsync_CreatesMissingDirectory"


------
https://chatgpt.com/codex/tasks/task_e_68d02df67338832e83d74543eb971e45