### PR TITLE
Add validation and normalization for PDF row columns

### DIFF
--- a/OfficeIMO.Pdf/Compose/PdfRowCompose.cs
+++ b/OfficeIMO.Pdf/Compose/PdfRowCompose.cs
@@ -1,18 +1,82 @@
 namespace OfficeIMO.Pdf;
 
+using System;
+using System.Linq;
+
 /// <summary>Row builder with percentage-based columns.</summary>
 public class PdfRowCompose {
+    private const double WidthTolerance = 0.0001;
     private readonly PdfDoc _doc;
     private readonly RowBlock _row = new RowBlock();
+    private double _allocatedWidth;
+
     internal PdfRowCompose(PdfDoc doc) { _doc = doc; }
+
     /// <summary>Adds a column with the given width percentage.</summary>
     public PdfRowCompose Column(double widthPercent, System.Action<PdfRowColumnCompose> build) {
+        Guard.NotNull(build, nameof(build));
+
+        ValidateWidth(widthPercent);
+        EnsureTotalWithinBounds(widthPercent);
+
         var col = new RowColumn(widthPercent);
         var cc = new PdfRowColumnCompose(col);
         build(cc);
         _row.Columns.Add(col);
+        _allocatedWidth += widthPercent;
         return this;
     }
-    internal void Commit() { _doc.AddRow(_row); }
+
+    internal void Commit() {
+        NormalizeColumnWidthsIfNeeded();
+        _doc.AddRow(_row);
+    }
+
+    private static void ValidateWidth(double widthPercent) {
+        if (widthPercent <= 0)
+            throw new ArgumentOutOfRangeException(nameof(widthPercent), widthPercent, "Column width must be greater than 0%.");
+
+        if (widthPercent > 100)
+            throw new ArgumentOutOfRangeException(nameof(widthPercent), widthPercent, "Column width cannot exceed 100%.");
+    }
+
+    private void EnsureTotalWithinBounds(double widthPercent) {
+        var prospectiveTotal = _allocatedWidth + widthPercent;
+        if (prospectiveTotal > 100 + WidthTolerance)
+            throw new InvalidOperationException($"Column widths cannot exceed 100%. Current total {_allocatedWidth:F2}% + {widthPercent:F2}%.");
+    }
+
+    private void NormalizeColumnWidthsIfNeeded() {
+        if (_row.Columns.Count == 0)
+            return;
+
+        var total = _row.Columns.Sum(static c => c.WidthPercent);
+        if (total <= 0)
+            return;
+
+        if (total > 100 + WidthTolerance)
+            throw new InvalidOperationException("Row columns exceed 100% total width after composition.");
+
+        if (total >= 100 - WidthTolerance) {
+            _allocatedWidth = total;
+            return;
+        }
+
+        var scale = 100.0 / total;
+        double accumulated = 0;
+        for (int i = 0; i < _row.Columns.Count; i++) {
+            double newWidth;
+            if (i == _row.Columns.Count - 1) {
+                newWidth = 100 - accumulated;
+            } else {
+                newWidth = _row.Columns[i].WidthPercent * scale;
+                accumulated += newWidth;
+            }
+
+            _row.Columns[i].WidthPercent = newWidth;
+        }
+
+        _allocatedWidth = _row.Columns.Sum(static c => c.WidthPercent);
+    }
 }
 

--- a/OfficeIMO.Pdf/Model/RowColumn.cs
+++ b/OfficeIMO.Pdf/Model/RowColumn.cs
@@ -1,7 +1,7 @@
 namespace OfficeIMO.Pdf;
 
 internal sealed class RowColumn {
-    public double WidthPercent { get; }
+    public double WidthPercent { get; internal set; }
     public System.Collections.Generic.List<IPdfBlock> Blocks { get; } = new();
     public RowColumn(double widthPercent) { WidthPercent = widthPercent; }
 }

--- a/OfficeIMO.Tests/Pdf/PdfRowComposeTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfRowComposeTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf {
+    public class PdfRowComposeTests {
+        [Fact]
+        public void ColumnRejectsNonPositiveWidth() {
+            var doc = PdfDoc.Create();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                doc.Compose(compose =>
+                    compose.Page(page =>
+                        page.Content(content =>
+                            content.Row(row =>
+                                row.Column(0, _ => { }))))));
+        }
+
+        [Fact]
+        public void ColumnRejectsWidthOverOneHundred() {
+            var doc = PdfDoc.Create();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                doc.Compose(compose =>
+                    compose.Page(page =>
+                        page.Content(content =>
+                            content.Row(row =>
+                                row.Column(150, _ => { }))))));
+        }
+
+        [Fact]
+        public void ColumnRejectsWhenTotalWouldExceedOneHundred() {
+            var doc = PdfDoc.Create();
+
+            Assert.Throws<InvalidOperationException>(() =>
+                doc.Compose(compose =>
+                    compose.Page(page =>
+                        page.Content(content =>
+                            content.Row(row => {
+                                row.Column(60, _ => { });
+                                row.Column(50, _ => { });
+                            })))));
+        }
+
+        [Fact]
+        public void ColumnsAreNormalizedWhenTotalLessThanOneHundred() {
+            var doc = PdfDoc.Create();
+
+            doc.Compose(compose =>
+                compose.Page(page =>
+                    page.Content(content =>
+                        content.Row(row => {
+                            row.Column(30, _ => { });
+                            row.Column(20, _ => { });
+                        }))));
+
+            var page = Assert.IsType<PageBlock>(Assert.Single(doc.Blocks));
+            var row = Assert.IsType<RowBlock>(Assert.Single(page.Blocks));
+            Assert.Equal(2, row.Columns.Count);
+
+            var widths = row.Columns.Select(c => c.WidthPercent).ToArray();
+            Assert.InRange(widths[0], 59.9, 60.1);
+            Assert.InRange(widths[1], 39.9, 40.1);
+            var total = widths.Sum();
+            Assert.InRange(total, 99.99, 100.01);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- validate PdfRowCompose column widths and enforce a 100% cap
- normalize remaining width across columns when the total is below 100%
- add unit tests covering the new PdfRowCompose validation and normalization behaviors

## Testing
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d02e4b1ccc832e9f636bfd5dcdd639