### PR TITLE
Ensure SetTableTotals matches headers case-insensitively

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Tables.cs
@@ -27,6 +27,13 @@ namespace OfficeIMO.Excel {
         public void SetTableTotals(string range, System.Collections.Generic.Dictionary<string, DocumentFormat.OpenXml.Spreadsheet.TotalsRowFunctionValues> byHeader)
         {
             if (string.IsNullOrWhiteSpace(range)) throw new System.ArgumentNullException(nameof(range));
+            if (byHeader == null) throw new System.ArgumentNullException(nameof(byHeader));
+
+            var totalsByHeader = new System.Collections.Generic.Dictionary<string, DocumentFormat.OpenXml.Spreadsheet.TotalsRowFunctionValues>(byHeader.Count, System.StringComparer.OrdinalIgnoreCase);
+            foreach (var pair in byHeader)
+            {
+                totalsByHeader[pair.Key] = pair.Value;
+            }
             WriteLock(() =>
             {
                 foreach (var tdp in _worksheetPart.TableDefinitionParts)
@@ -39,7 +46,7 @@ namespace OfficeIMO.Excel {
                     foreach (var tc in table.TableColumns!.Elements<TableColumn>())
                     {
                         var name = headerNames[idx++];
-                        if (byHeader.TryGetValue(name, out var fn))
+                        if (totalsByHeader.TryGetValue(name, out var fn))
                         {
                             tc.TotalsRowFunction = fn;
                         }


### PR DESCRIPTION
## Summary
- ensure SetTableTotals builds a case-insensitive totals lookup before updating tables
- add a regression test covering totals header lookups with different casing

## Testing
- dotnet build OfficeImo.sln
- dotnet test OfficeImo.sln --filter "Test_SetTableTotalsMatchesHeadersCaseInsensitive"


------
https://chatgpt.com/codex/tasks/task_e_68d02e351ddc832e9428609643355ac2