### PR TITLE
Guard PDF bullet lists against null inputs

### DIFF
--- a/OfficeIMO.Pdf/Core/PdfDoc.Blocks.cs
+++ b/OfficeIMO.Pdf/Core/PdfDoc.Blocks.cs
@@ -19,6 +19,7 @@ public sealed partial class PdfDoc {
 
     /// <summary>Adds a simple bullet list.</summary>
     public PdfDoc Bullets(System.Collections.Generic.IEnumerable<string> items, PdfAlign align = PdfAlign.Left, PdfColor? color = null) {
+        Guard.NotNull(items, nameof(items));
         AddBlock(new BulletListBlock(items, align, color));
         return this;
     }

--- a/OfficeIMO.Pdf/Model/BulletListBlock.cs
+++ b/OfficeIMO.Pdf/Model/BulletListBlock.cs
@@ -4,5 +4,10 @@ internal sealed class BulletListBlock : IPdfBlock {
     public System.Collections.Generic.List<string> Items { get; } = new();
     public PdfAlign Align { get; }
     public PdfColor? Color { get; }
-    public BulletListBlock(System.Collections.Generic.IEnumerable<string> items, PdfAlign align, PdfColor? color) { Align = align; Color = color; Items.AddRange(items); }
+    public BulletListBlock(System.Collections.Generic.IEnumerable<string> items, PdfAlign align, PdfColor? color) {
+        Guard.NotNull(items, nameof(items));
+        Align = align;
+        Color = color;
+        Items.AddRange(items.Where(item => item is not null));
+    }
 }

--- a/OfficeIMO.Tests/Pdf/PdfDocBulletListTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocBulletListTests.cs
@@ -1,0 +1,16 @@
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public class PdfDocBulletListTests {
+    [Fact]
+    public void Bullets_WithNullItems_ThrowsArgumentNullException() {
+        var doc = PdfDoc.Create();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => doc.Bullets(null!));
+
+        Assert.Equal("items", exception.ParamName);
+        Assert.Contains("Parameter 'items' cannot be null.", exception.Message, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- guard `PdfDoc.Bullets` against null collections and sanitize bullet content
- ensure `BulletListBlock` filters null entries before storing items
- add a unit test that verifies a helpful exception when null is passed to `Bullets`

## Testing
- dotnet build OfficeImo.sln
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d02e6666c4832e8b2e88a228d61859