### PR TITLE
Add Markdown quote builder and tests

### DIFF
--- a/OfficeIMO.Examples/Markdown/Markdown01_Builder_Basics.cs
+++ b/OfficeIMO.Examples/Markdown/Markdown01_Builder_Basics.cs
@@ -28,6 +28,13 @@ namespace OfficeIMO.Examples.Markdown {
                     .Item("TLS/SSL tests and cipher hints")
                     .Item("WHOIS, MX, PTR, DNSSEC, BIMI")
                     .Item("Exports: Word, HTML, PDF, Markdown"))
+                .H2("Testimonials")
+                .Quote(q => q
+                    .Line("OfficeIMO.Markdown keeps our release notes consistent.")
+                    .Quote(inner => inner
+                        .Line("Nested quotes help us show conversation context.")
+                        .Line("Great for highlighting support threads."))
+                    .P(p => p.Text("— Docs Team")))
                 .Hr()
                 .H2("Links")
                 .Ul(ul => ul

--- a/OfficeIMO.Markdown/Builders/QuoteBuilder.cs
+++ b/OfficeIMO.Markdown/Builders/QuoteBuilder.cs
@@ -1,0 +1,127 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Builder for block quotes supporting raw lines or nested blocks.
+/// </summary>
+public sealed class QuoteBuilder {
+    private readonly System.Collections.Generic.List<Entry> _entries = new();
+
+    /// <summary>Adds a raw text line to the quote.</summary>
+    public QuoteBuilder Line(string text) {
+        _entries.Add(new Entry(text ?? string.Empty));
+        return this;
+    }
+
+    /// <summary>Adds multiple raw lines to the quote.</summary>
+    public QuoteBuilder Lines(System.Collections.Generic.IEnumerable<string> lines) {
+        if (lines == null) return this;
+        foreach (var line in lines) Line(line ?? string.Empty);
+        return this;
+    }
+
+    /// <summary>Adds a paragraph with the specified text.</summary>
+    public QuoteBuilder P(string text) {
+        return Block(new ParagraphBlock(new InlineSequence().Text(text ?? string.Empty)));
+    }
+
+    /// <summary>Adds a paragraph built via <see cref="ParagraphBuilder"/>.</summary>
+    public QuoteBuilder P(System.Action<ParagraphBuilder> build) {
+        if (build == null) return this;
+        ParagraphBuilder builder = new ParagraphBuilder();
+        build(builder);
+        return Block(new ParagraphBlock(builder.Inlines));
+    }
+
+    /// <summary>Adds a nested block quote.</summary>
+    public QuoteBuilder Quote(System.Action<QuoteBuilder> build) {
+        if (build == null) return this;
+        QuoteBuilder nested = new QuoteBuilder();
+        build(nested);
+        return Block(nested.Build());
+    }
+
+    /// <summary>Adds an arbitrary markdown block inside the quote.</summary>
+    public QuoteBuilder Block(IMarkdownBlock block) {
+        if (block == null) throw new System.ArgumentNullException(nameof(block));
+        _entries.Add(new Entry(block));
+        return this;
+    }
+
+    internal QuoteBlock Build() {
+        bool hasBlocks = false;
+        foreach (var entry in _entries) {
+            if (entry.Block != null) { hasBlocks = true; break; }
+        }
+
+        QuoteBlock quote = new QuoteBlock();
+        if (!hasBlocks) {
+            foreach (var entry in _entries) quote.Lines.AddRange(SplitLines(entry.Line));
+            return quote;
+        }
+
+        System.Collections.Generic.List<string> buffer = new();
+        foreach (var entry in _entries) {
+            if (entry.Block != null) {
+                FlushBuffer(buffer, quote);
+                quote.Children.Add(entry.Block);
+            } else {
+                foreach (var part in SplitLines(entry.Line)) buffer.Add(part);
+            }
+        }
+        FlushBuffer(buffer, quote);
+        return quote;
+    }
+
+    private static System.Collections.Generic.IEnumerable<string> SplitLines(string? value) {
+        if (value == null) yield break;
+        string normalized = value.Replace("\r\n", "\n").Replace('\r', '\n');
+        int start = 0;
+        for (int i = 0; i < normalized.Length; i++) {
+            if (normalized[i] == '\n') {
+                yield return normalized.Substring(start, i - start);
+                start = i + 1;
+            }
+        }
+        if (start <= normalized.Length) yield return normalized.Substring(start);
+    }
+
+    private static void FlushBuffer(System.Collections.Generic.List<string> buffer, QuoteBlock quote) {
+        if (buffer.Count == 0) return;
+        foreach (var paragraph in BuildParagraphs(buffer)) quote.Children.Add(paragraph);
+        buffer.Clear();
+    }
+
+    private static System.Collections.Generic.IEnumerable<ParagraphBlock> BuildParagraphs(System.Collections.Generic.List<string> lines) {
+        System.Collections.Generic.List<string> current = new();
+        foreach (var line in lines) {
+            if (line.Length == 0) {
+                if (current.Count > 0) {
+                    yield return CreateParagraph(current);
+                    current.Clear();
+                }
+                continue;
+            }
+            current.Add(line);
+        }
+        if (current.Count > 0) {
+            yield return CreateParagraph(current);
+            current.Clear();
+        }
+    }
+
+    private static ParagraphBlock CreateParagraph(System.Collections.Generic.List<string> lines) {
+        InlineSequence sequence = new InlineSequence();
+        for (int i = 0; i < lines.Count; i++) {
+            if (i > 0) sequence.HardBreak();
+            sequence.Text(lines[i]);
+        }
+        return new ParagraphBlock(sequence);
+    }
+
+    private readonly struct Entry {
+        public string? Line { get; }
+        public IMarkdownBlock? Block { get; }
+        public Entry(string line) { Line = line; Block = null; }
+        public Entry(IMarkdownBlock block) { Line = null; Block = block; }
+    }
+}

--- a/OfficeIMO.Markdown/Core/MarkdownDoc.cs
+++ b/OfficeIMO.Markdown/Core/MarkdownDoc.cs
@@ -61,6 +61,16 @@ public class MarkdownDoc {
         return Add(new ParagraphBlock(builder.Inlines));
     }
 
+    /// <summary>Adds a simple block quote with a single line of text.</summary>
+    public MarkdownDoc Quote(string text) => Add(new QuoteBlock(new[] { text ?? string.Empty }));
+
+    /// <summary>Adds a block quote composed via <see cref="QuoteBuilder"/>.</summary>
+    public MarkdownDoc Quote(Action<QuoteBuilder> build) {
+        QuoteBuilder builder = new QuoteBuilder();
+        build(builder);
+        return Add(builder.Build());
+    }
+
     /// <summary>Adds a horizontal rule.</summary>
     public MarkdownDoc Hr() => Add(new HorizontalRuleBlock());
 

--- a/OfficeIMO.Tests/Markdown/Markdown_Builder_Quote_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_Builder_Quote_Tests.cs
@@ -1,0 +1,43 @@
+using OfficeIMO.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests.MarkdownSuite {
+    public class Markdown_Builder_Quote_Tests {
+        private static string Normalize(string value) => value.Replace("\r\n", "\n");
+
+        [Fact]
+        public void QuoteBuilder_Renders_Simple_Lines() {
+            var doc = MarkdownDoc.Create().Quote(q => q.Line("Line 1").Line("Line 2"));
+
+            string markdown = Normalize(doc.ToMarkdown());
+            Assert.Equal("> Line 1\n> Line 2\n", markdown);
+
+            string html = doc.Blocks[0].RenderHtml();
+            Assert.Equal("<blockquote><p>Line 1<br/>Line 2</p></blockquote>", html);
+
+            var singleLine = MarkdownDoc.Create().Quote("Single line");
+            string singleMarkdown = Normalize(singleLine.ToMarkdown());
+            Assert.Equal("> Single line\n", singleMarkdown);
+            Assert.Equal("<blockquote><p>Single line</p></blockquote>", singleLine.Blocks[0].RenderHtml());
+        }
+
+        [Fact]
+        public void QuoteBuilder_Renders_Nested_Blocks() {
+            var doc = MarkdownDoc.Create().Quote(q => q
+                .Line("Intro")
+                .Quote(inner => inner.Line("Inner line 1").Line("Inner line 2"))
+                .P(p => p.Text("Conclusion section"))
+                .Line("Closing note"));
+
+            string markdown = Normalize(doc.ToMarkdown());
+            Assert.Equal(
+                "> Intro\n> \n> > Inner line 1\n> > Inner line 2\n> \n> Conclusion section\n> \n> Closing note\n",
+                markdown);
+
+            string html = doc.Blocks[0].RenderHtml();
+            Assert.Equal(
+                "<blockquote><p>Intro</p><blockquote><p>Inner line 1<br/>Inner line 2</p></blockquote><p>Conclusion section</p><p>Closing note</p></blockquote>",
+                html);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Quote(Action<QuoteBuilder>) helper to MarkdownDoc and a reusable QuoteBuilder for composing nested blockquotes
- cover simple and nested quotes with markdown/html tests and extend the builder basics example with a nested quote section

## Testing
- dotnet build OfficeImo.sln
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d02e7ce224832e8df6930a1a2a09a5