### PR TITLE
Clamp TOC levels during HTML rendering

### DIFF
--- a/OfficeIMO.Tests/Markdown/Markdown_TocHtml_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_TocHtml_Tests.cs
@@ -20,6 +20,43 @@ namespace OfficeIMO.Tests.MarkdownSuite {
             // Broken structure must not occur: closing </li> immediately followed by nested <ul>
             Assert.DoesNotContain("</li><ul>", normalized);
         }
+
+        [Fact]
+        public void Toc_Html_Clamps_OutOfRange_Level_Settings() {
+            var md = MarkdownDoc.Create()
+                .TocHere(o => {
+                    o.IncludeTitle = true;
+                    o.Title = "Contents";
+                    o.MinLevel = 0;
+                    o.MaxLevel = 99;
+                    o.TitleLevel = 9;
+                })
+                .H1("Intro")
+                .H6("Deep");
+
+            var html = md.ToHtmlFragment(new HtmlOptions { Style = HtmlStyle.Clean });
+
+            Assert.Contains("<h6>Contents</h6>", html);
+            Assert.DoesNotContain("<h9", html);
+            Assert.Contains("href=\"#intro\">Intro</a>", html);
+            Assert.Contains("href=\"#deep\">Deep</a>", html);
+        }
+
+        [Fact]
+        public void Toc_Html_Normalizes_OutOfRange_MinAndMaxLevels() {
+            var md = MarkdownDoc.Create()
+                .TocHere(o => {
+                    o.IncludeTitle = false;
+                    o.MinLevel = 8;
+                    o.MaxLevel = 9;
+                    o.RequireTopLevel = false;
+                })
+                .H6("Deep");
+
+            var html = md.ToHtmlFragment(new HtmlOptions { Style = HtmlStyle.Clean });
+
+            Assert.Contains("href=\"#deep\">Deep</a>", html);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- clamp TOC option levels to the valid 1-6 range before building HTML
- reuse the clamped values when scoping headings and rendering legacy TOC titles
- add regression tests that verify out-of-range TOC options are normalized in the HTML output

## Testing
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d02ea38234832e9fb098af2fa8a8db