### PR TITLE
Handle inline markdown formatting inside definitions

### DIFF
--- a/OfficeIMO.Markdown/Blocks/DefinitionListBlock.cs
+++ b/OfficeIMO.Markdown/Blocks/DefinitionListBlock.cs
@@ -24,7 +24,12 @@ public sealed class DefinitionListBlock : IMarkdownBlock {
         sb.Append("<dl>");
         foreach (var (term, def) in Items) {
             sb.Append("<dt>" + System.Net.WebUtility.HtmlEncode(term) + "</dt>");
-            sb.Append("<dd>" + System.Net.WebUtility.HtmlEncode(def) + "</dd>");
+            sb.Append("<dd>");
+            if (!string.IsNullOrEmpty(def)) {
+                var inlines = MarkdownReader.ParseInlineText(def);
+                sb.Append(inlines.RenderHtml());
+            }
+            sb.Append("</dd>");
         }
         sb.Append("</dl>");
         return sb.ToString();

--- a/OfficeIMO.Tests/Markdown/Markdown_DefinitionList_Html_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_DefinitionList_Html_Tests.cs
@@ -1,0 +1,26 @@
+using System;
+using OfficeIMO.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests.MarkdownSuite {
+    public class Markdown_DefinitionList_Html_Tests {
+        [Theory]
+        [InlineData("Term: Definition with *emphasis* inside.", "<em>emphasis</em>")]
+        [InlineData("Term: Includes a [link](https://example.com).", "<a href=\"https://example.com\">link</a>")]
+        public void DefinitionList_Renders_Inline_Markup(string markdown, string expectedFragment) {
+            var doc = MarkdownReader.Parse(markdown);
+            var html = doc.ToHtml();
+
+            Assert.Contains("<dl>", html);
+
+            int ddStart = html.IndexOf("<dd>", StringComparison.OrdinalIgnoreCase);
+            Assert.True(ddStart >= 0, "Definition element not found in HTML output.");
+
+            int ddEnd = html.IndexOf("</dd>", ddStart, StringComparison.OrdinalIgnoreCase);
+            Assert.True(ddEnd > ddStart, "Closing definition tag not found in HTML output.");
+
+            var inner = html.Substring(ddStart + 4, ddEnd - (ddStart + 4));
+            Assert.Contains(expectedFragment, inner);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- render definition list definitions through the inline markdown parser before emitting HTML
- add coverage to ensure emphasis and links inside definition lists render as HTML markup

## Testing
- dotnet build OfficeImo.sln
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d02e99423c832ea7e9f68d4a532010