### PR TITLE
Format TimeSpan cells with duration number format

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -35,6 +35,12 @@ namespace OfficeIMO.Excel {
                 ApplyBuiltInNumberFormat(row, column, 14);  // Built-in format 14 is short date
             }
 
+            if (value is TimeSpan)
+            {
+                // Built-in format 46 renders durations using the invariant [h]:mm:ss pattern
+                ApplyBuiltInNumberFormat(row, column, 46);
+            }
+
             // Enable wrap text when value contains new lines so Excel renders multiple lines correctly
             if (value is string s && (s.Contains("\n") || s.Contains("\r")))
             {

--- a/OfficeIMO.Tests/Excel.CellValues.Additional.cs
+++ b/OfficeIMO.Tests/Excel.CellValues.Additional.cs
@@ -114,6 +114,51 @@ namespace OfficeIMO.Tests {
 #endif
             }
         }
+
+        [Fact]
+        public void Test_CellValues_TimeSpanFormatting() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesTimeSpanFormat.xlsx");
+            var duration = new TimeSpan(1, 2, 3, 4);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, duration);
+                sheet.CellValue(2, 1, (TimeSpan?)duration);
+                document.Save();
+            }
+
+            SpreadsheetDocument spreadsheet = null!;
+            Exception? ex = Record.Exception(() => spreadsheet = SpreadsheetDocument.Open(filePath, false));
+            Assert.Null(ex);
+
+            using (spreadsheet) {
+                ValidateSpreadsheetDocument(filePath, spreadsheet);
+
+                var workbookPart = spreadsheet.WorkbookPart!;
+                Assert.NotNull(workbookPart.WorkbookStylesPart);
+
+                WorksheetPart wsPart = workbookPart.WorksheetParts.First();
+                var cells = wsPart.Worksheet.Descendants<Cell>().ToList();
+
+                Cell cellDuration = cells.First(c => c.CellReference == "A1");
+                Assert.Equal(CellValues.Number, cellDuration.DataType!.Value);
+                Assert.Equal(duration.TotalDays.ToString(CultureInfo.InvariantCulture), cellDuration.CellValue!.Text);
+                Assert.NotNull(cellDuration.StyleIndex);
+
+                var styles = workbookPart.WorkbookStylesPart!.Stylesheet!;
+                Assert.NotNull(styles.CellFormats);
+                var cellFormats = styles.CellFormats!.Elements<CellFormat>().ToList();
+                var cellFormat = cellFormats[(int)cellDuration.StyleIndex!.Value];
+                Assert.NotNull(cellFormat.NumberFormatId);
+                Assert.Equal(46U, cellFormat.NumberFormatId!.Value);
+                Assert.True(cellFormat.ApplyNumberFormat?.Value ?? false);
+
+                Cell cellNullable = cells.First(c => c.CellReference == "A2");
+                Assert.Equal(duration.TotalDays.ToString(CultureInfo.InvariantCulture), cellNullable.CellValue!.Text);
+                Assert.NotNull(cellNullable.StyleIndex);
+                Assert.Equal(cellDuration.StyleIndex!.Value, cellNullable.StyleIndex!.Value);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure TimeSpan values written to cells automatically receive Excel's duration number format
- add regression coverage that reopens the workbook and checks the built-in format is applied to direct and nullable TimeSpan values

## Testing
- dotnet build OfficeImo.sln
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d02e10fa84832ebed4b7c04ed5e15e