### PR TITLE
Prevent duplicate Excel hyperlink entries

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.Hyperlinks.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Hyperlinks.cs
@@ -25,6 +25,7 @@ namespace OfficeIMO.Excel {
                 // Avoid nested locks: write value using core method
                 CellValueCore(row, column, text);
 
+                var reference = GetColumnName(column) + row.ToString(System.Globalization.CultureInfo.InvariantCulture);
                 // Ensure Hyperlinks container exists
                 var ws = _worksheetPart.Worksheet;
                 var hyperlinks = ws.Elements<Hyperlinks>().FirstOrDefault();
@@ -33,11 +34,12 @@ namespace OfficeIMO.Excel {
                     // place near the end but before TableParts per schema order
                     var tableParts = ws.Elements<TableParts>().FirstOrDefault();
                     if (tableParts != null) ws.InsertBefore(hyperlinks, tableParts); else ws.Append(hyperlinks);
+                } else {
+                    RemoveHyperlinksByReference(hyperlinks, reference);
                 }
 
                 // Add external relationship
                 var rel = _worksheetPart.AddHyperlinkRelationship(new Uri(url), true);
-                var reference = GetColumnName(column) + row.ToString(System.Globalization.CultureInfo.InvariantCulture);
                 var hl = new Hyperlink { Reference = reference, Id = rel.Id };
                 hyperlinks.Append(hl);
                 if (style) ApplyHyperlinkStyle(cell);
@@ -76,14 +78,16 @@ namespace OfficeIMO.Excel {
             WriteLock(() => {
                 string text = string.IsNullOrEmpty(display) ? location : display!;
                 CellValueCore(row, column, text);
+                var reference = GetColumnName(column) + row.ToString(System.Globalization.CultureInfo.InvariantCulture);
                 var ws = _worksheetPart.Worksheet;
                 var hyperlinks = ws.Elements<Hyperlinks>().FirstOrDefault();
                 if (hyperlinks == null) {
                     hyperlinks = new Hyperlinks();
                     var tableParts = ws.Elements<TableParts>().FirstOrDefault();
                     if (tableParts != null) ws.InsertBefore(hyperlinks, tableParts); else ws.Append(hyperlinks);
+                } else {
+                    RemoveHyperlinksByReference(hyperlinks, reference);
                 }
-                var reference = GetColumnName(column) + row.ToString(System.Globalization.CultureInfo.InvariantCulture);
                 var hl = new Hyperlink { Reference = reference, Location = location };
                 hyperlinks.Append(hl);
                 // Defer save to caller; final document Save() will persist
@@ -182,6 +186,24 @@ namespace OfficeIMO.Excel {
             }
 
             cell.StyleIndex = (uint)hyperlinkFormatIndex;
+        }
+
+        private void RemoveHyperlinksByReference(Hyperlinks hyperlinks, string reference) {
+            var matches = hyperlinks.Elements<Hyperlink>()
+                .Where(h => string.Equals(h.Reference?.Value, reference, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (matches.Count == 0) return;
+
+            foreach (var existing in matches) {
+                var relId = existing.Id?.Value;
+                if (!string.IsNullOrEmpty(relId)) {
+                    var rel = _worksheetPart.HyperlinkRelationships.FirstOrDefault(r => r.Id == relId);
+                    if (rel != null) {
+                        _worksheetPart.DeleteReferenceRelationship(rel);
+                    }
+                }
+                existing.Remove();
+            }
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.Hyperlinks.cs
+++ b/OfficeIMO.Tests/Excel.Hyperlinks.cs
@@ -1,0 +1,70 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        [Trait("Category", "ExcelLinks")]
+        public void Excel_SetHyperlink_ReplacesExistingEntry() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelHyperlinkReplace.xlsx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Links");
+                sheet.SetHyperlink(1, 1, "https://initial.example/", display: "First");
+                sheet.SetHyperlink(1, 1, "https://final.example/", display: "Second");
+                document.Save(false);
+            }
+
+            using (var package = SpreadsheetDocument.Open(filePath, false)) {
+                var workbookPart = package.WorkbookPart!;
+                var sheetRef = workbookPart.Workbook.Sheets!.Elements<Sheet>().First(s => s.Name!.Value == "Links");
+                var worksheetPart = (WorksheetPart)workbookPart.GetPartById(sheetRef.Id!);
+                var hyperlinks = worksheetPart.Worksheet.Elements<Hyperlinks>().FirstOrDefault();
+                Assert.NotNull(hyperlinks);
+                var items = hyperlinks!.Elements<Hyperlink>().ToList();
+                Assert.Single(items);
+                var hyperlink = items[0];
+                Assert.Equal("A1", hyperlink.Reference!.Value);
+                var relationships = worksheetPart.HyperlinkRelationships.ToList();
+                Assert.Single(relationships);
+                Assert.Equal("https://final.example/", relationships[0].Uri.ToString());
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "ExcelLinks")]
+        public void Excel_SetInternalLink_ReplacesExistingEntry() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelInternalLinkReplace.xlsx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Links");
+                var target1 = document.AddWorkSheet("Target1");
+                var target2 = document.AddWorkSheet("Target2");
+                sheet.SetInternalLink(2, 1, target1, "A1", display: "First");
+                sheet.SetInternalLink(2, 1, target2, "B5", display: "Second");
+                document.Save(false);
+            }
+
+            using (var package = SpreadsheetDocument.Open(filePath, false)) {
+                var workbookPart = package.WorkbookPart!;
+                var sheetRef = workbookPart.Workbook.Sheets!.Elements<Sheet>().First(s => s.Name!.Value == "Links");
+                var worksheetPart = (WorksheetPart)workbookPart.GetPartById(sheetRef.Id!);
+                var hyperlinks = worksheetPart.Worksheet.Elements<Hyperlinks>().FirstOrDefault();
+                Assert.NotNull(hyperlinks);
+                var items = hyperlinks!.Elements<Hyperlink>().ToList();
+                Assert.Single(items);
+                var hyperlink = items[0];
+                Assert.Equal("A2", hyperlink.Reference!.Value);
+                Assert.Equal("'Target2'!B5", hyperlink.Location!.Value);
+                Assert.Null(hyperlink.Id);
+                Assert.Empty(worksheetPart.HyperlinkRelationships);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove existing hyperlink entries before appending new ones for Excel external and internal links
- delete old hyperlink relationships when replacing entries and keep styling flow intact
- add regression tests that ensure duplicate hyperlinks are not created when resetting links

## Testing
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d02e297974832e9806edb582d330aa