### PR TITLE
Add optional OpenSettings parameters to Load APIs

### DIFF
--- a/OfficeIMO.Tests/Excel.OpenSettings.cs
+++ b/OfficeIMO.Tests/Excel.OpenSettings.cs
@@ -1,0 +1,56 @@
+using System.IO;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_ExcelLoad_CustomOpenSettingsAreApplied() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelCustomOpenSettings.xlsx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.Save();
+            }
+
+            var settings = new OpenSettings {
+                MarkupCompatibilityProcessSettings = new MarkupCompatibilityProcessSettings(MarkupCompatibilityProcessMode.ProcessAllParts, FileFormatVersions.Office2016)
+            };
+
+            using (var document = ExcelDocument.Load(filePath, openSettings: settings)) {
+                var mcSettings = document._spreadSheetDocument.MarkupCompatibilityProcessSettings;
+                Assert.NotNull(mcSettings);
+                Assert.Equal(MarkupCompatibilityProcessMode.ProcessAllParts, mcSettings.ProcessMode);
+                Assert.Equal(FileFormatVersions.Office2016, mcSettings.TargetFileFormatVersions);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public async Task Test_ExcelLoadAsync_CustomOpenSettingsAreApplied() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelCustomOpenSettingsAsync.xlsx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.Save();
+            }
+
+            var settings = new OpenSettings {
+                MarkupCompatibilityProcessSettings = new MarkupCompatibilityProcessSettings(MarkupCompatibilityProcessMode.ProcessAllParts, FileFormatVersions.Office2007)
+            };
+
+            await using (var document = await ExcelDocument.LoadAsync(filePath, openSettings: settings)) {
+                var mcSettings = document._spreadSheetDocument.MarkupCompatibilityProcessSettings;
+                Assert.NotNull(mcSettings);
+                Assert.Equal(MarkupCompatibilityProcessMode.ProcessAllParts, mcSettings.ProcessMode);
+                Assert.Equal(FileFormatVersions.Office2007, mcSettings.TargetFileFormatVersions);
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.OpenSettings.cs
+++ b/OfficeIMO.Tests/Word.OpenSettings.cs
@@ -1,0 +1,59 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_WordLoad_CustomOpenSettingsAreApplied() {
+            var filePath = Path.Combine(_directoryWithFiles, "WordCustomOpenSettings.docx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+
+            using (var document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Custom settings");
+                document.Save();
+            }
+
+            var settings = new OpenSettings {
+                MarkupCompatibilityProcessSettings = new MarkupCompatibilityProcessSettings(MarkupCompatibilityProcessMode.ProcessAllParts, FileFormatVersions.Office2010)
+            };
+
+            using (var document = WordDocument.Load(filePath, openSettings: settings)) {
+                var mcSettings = document._wordprocessingDocument.MarkupCompatibilityProcessSettings;
+                Assert.NotNull(mcSettings);
+                Assert.Equal(MarkupCompatibilityProcessMode.ProcessAllParts, mcSettings.ProcessMode);
+                Assert.Equal(FileFormatVersions.Office2010, mcSettings.TargetFileFormatVersions);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public async Task Test_WordLoadAsync_CustomOpenSettingsAreApplied() {
+            var filePath = Path.Combine(_directoryWithFiles, "WordCustomOpenSettingsAsync.docx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+
+            using (var document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Custom settings async");
+                document.Save();
+            }
+
+            var settings = new OpenSettings {
+                MarkupCompatibilityProcessSettings = new MarkupCompatibilityProcessSettings(MarkupCompatibilityProcessMode.ProcessAllParts, FileFormatVersions.Office2013)
+            };
+
+            await using (var document = await WordDocument.LoadAsync(filePath, openSettings: settings, cancellationToken: CancellationToken.None)) {
+                var mcSettings = document._wordprocessingDocument.MarkupCompatibilityProcessSettings;
+                Assert.NotNull(mcSettings);
+                Assert.Equal(MarkupCompatibilityProcessMode.ProcessAllParts, mcSettings.ProcessMode);
+                Assert.Equal(FileFormatVersions.Office2013, mcSettings.TargetFileFormatVersions);
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow `ExcelDocument.Load`/`LoadAsync` to accept optional `OpenSettings` and merge caller settings with existing autosave defaults
- allow `WordDocument` load overloads to accept optional `OpenSettings` while keeping initialization logic intact
- add Excel and Word tests verifying that custom `MarkupCompatibilityProcessSettings` are honored for synchronous and async load paths

## Testing
- dotnet build
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d02df01858832e99dcd33044383adb