### PR TITLE
Ensure notes master for generated notes

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointNotes.cs
+++ b/OfficeIMO.PowerPoint/PowerPointNotes.cs
@@ -35,14 +35,20 @@ namespace OfficeIMO.PowerPoint {
                     
                     NotesSlidePart notesPart = _slidePart.AddNewPart<NotesSlidePart>(notesRelId);
                     PresentationPart? presentationPart = _slidePart.GetParentParts().OfType<PresentationPart>().FirstOrDefault();
-                    if (presentationPart?.NotesMasterPart != null) {
-                        notesPart.AddPart(presentationPart.NotesMasterPart);
+                    if (presentationPart != null) {
+                        NotesMasterPart notesMasterPart = PowerPointUtils.EnsureNotesMasterPart(presentationPart);
+                        notesPart.AddPart(notesMasterPart);
                     }
                     notesPart.NotesSlide = new NotesSlide(
                         new CommonSlideData(new ShapeTree(
+                            new NonVisualGroupShapeProperties(
+                                new NonVisualDrawingProperties { Id = 1U, Name = string.Empty },
+                                new NonVisualGroupShapeDrawingProperties(),
+                                new ApplicationNonVisualDrawingProperties()),
+                            new GroupShapeProperties(new A.TransformGroup()),
                             new Shape(
                                 new NonVisualShapeProperties(
-                                    new NonVisualDrawingProperties { Id = 1U, Name = "Notes Placeholder" },
+                                    new NonVisualDrawingProperties { Id = 2U, Name = "Notes Placeholder" },
                                     new NonVisualShapeDrawingProperties(),
                                     new ApplicationNonVisualDrawingProperties(new PlaceholderShape())
                                 ),

--- a/OfficeIMO.PowerPoint/PowerPointUtils.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Drawing;
 using DocumentFormat.OpenXml.Packaging;
@@ -46,6 +47,97 @@ namespace OfficeIMO.PowerPoint {
             slideMasterPart1.AddPart(slideLayoutPart1, "rId1");
             presentationPart.AddPart(slideMasterPart1, "rId1");
             presentationPart.AddPart(themePart1, "rId5");
+        }
+
+        internal static NotesMasterPart EnsureNotesMasterPart(PresentationPart presentationPart) {
+            NotesMasterPart notesMasterPart = presentationPart.NotesMasterPart ?? presentationPart.AddNewPart<NotesMasterPart>();
+
+            if (notesMasterPart.NotesMaster == null) {
+                notesMasterPart.NotesMaster = CreateDefaultNotesMaster();
+            }
+
+            Presentation presentation = presentationPart.Presentation ??= new Presentation();
+            NotesMasterIdList notesMasterIdList = presentation.NotesMasterIdList ??= new NotesMasterIdList();
+
+            string relationshipId = presentationPart.GetIdOfPart(notesMasterPart);
+            bool hasEntry = notesMasterIdList.Elements<NotesMasterId>().Any(existing =>
+                existing.GetAttributes().Any(attribute => attribute.LocalName == "id" &&
+                                                           attribute.NamespaceUri == "http://schemas.openxmlformats.org/officeDocument/2006/relationships" &&
+                                                           attribute.Value == relationshipId));
+            if (!hasEntry) {
+                NotesMasterId notesMasterId = new NotesMasterId();
+                notesMasterId.SetAttribute(new OpenXmlAttribute("r", "id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships", relationshipId));
+                notesMasterIdList.AppendChild(notesMasterId);
+            }
+
+            return notesMasterPart;
+        }
+
+        private static NotesMaster CreateDefaultNotesMaster() {
+            ShapeTree shapeTree = new ShapeTree();
+            shapeTree.Append(
+                new P.NonVisualGroupShapeProperties(
+                    new P.NonVisualDrawingProperties { Id = 1U, Name = string.Empty },
+                    new P.NonVisualGroupShapeDrawingProperties(),
+                    new ApplicationNonVisualDrawingProperties()),
+                new P.GroupShapeProperties(new D.TransformGroup()));
+
+            shapeTree.Append(
+                CreatePlaceholderShape(2U, "Notes Placeholder", PlaceholderValues.Body, 1U, includeEndParagraph: true),
+                CreatePlaceholderShape(3U, "Slide Image Placeholder", PlaceholderValues.SlideImage, 2U, includeEndParagraph: false),
+                CreatePlaceholderShape(4U, "Date Placeholder", PlaceholderValues.DateAndTime, 3U, includeEndParagraph: true),
+                CreatePlaceholderShape(5U, "Slide Number Placeholder", PlaceholderValues.SlideNumber, 4U, includeEndParagraph: true),
+                CreatePlaceholderShape(6U, "Footer Placeholder", PlaceholderValues.Footer, 5U, includeEndParagraph: true));
+
+            Background background = new Background(new BackgroundProperties(new D.NoFill()));
+
+            return new NotesMaster(
+                new CommonSlideData(background, shapeTree),
+                new P.ColorMap {
+                    Background1 = D.ColorSchemeIndexValues.Light1,
+                    Text1 = D.ColorSchemeIndexValues.Dark1,
+                    Background2 = D.ColorSchemeIndexValues.Light2,
+                    Text2 = D.ColorSchemeIndexValues.Dark2,
+                    Accent1 = D.ColorSchemeIndexValues.Accent1,
+                    Accent2 = D.ColorSchemeIndexValues.Accent2,
+                    Accent3 = D.ColorSchemeIndexValues.Accent3,
+                    Accent4 = D.ColorSchemeIndexValues.Accent4,
+                    Accent5 = D.ColorSchemeIndexValues.Accent5,
+                    Accent6 = D.ColorSchemeIndexValues.Accent6,
+                    Hyperlink = D.ColorSchemeIndexValues.Hyperlink,
+                    FollowedHyperlink = D.ColorSchemeIndexValues.FollowedHyperlink
+                },
+                new NotesStyle(
+                    new D.Level1ParagraphProperties(new D.DefaultRunProperties { Language = "en-US" }),
+                    new D.Level2ParagraphProperties(new D.DefaultRunProperties { Language = "en-US" }),
+                    new D.Level3ParagraphProperties(new D.DefaultRunProperties { Language = "en-US" }),
+                    new D.Level4ParagraphProperties(new D.DefaultRunProperties { Language = "en-US" }),
+                    new D.Level5ParagraphProperties(new D.DefaultRunProperties { Language = "en-US" }),
+                    new D.Level6ParagraphProperties(new D.DefaultRunProperties { Language = "en-US" }),
+                    new D.Level7ParagraphProperties(new D.DefaultRunProperties { Language = "en-US" }),
+                    new D.Level8ParagraphProperties(new D.DefaultRunProperties { Language = "en-US" }),
+                    new D.Level9ParagraphProperties(new D.DefaultRunProperties { Language = "en-US" }))
+            );
+        }
+
+        private static P.Shape CreatePlaceholderShape(uint id, string name, PlaceholderValues type, uint index, bool includeEndParagraph) {
+            P.Shape shape = new P.Shape(
+                new P.NonVisualShapeProperties(
+                    new P.NonVisualDrawingProperties { Id = id, Name = name },
+                    new P.NonVisualShapeDrawingProperties(),
+                    new ApplicationNonVisualDrawingProperties(new PlaceholderShape { Type = type, Index = index })),
+                new P.ShapeProperties(),
+                new P.TextBody(
+                    new D.BodyProperties(),
+                    new D.ListStyle()));
+
+            D.Paragraph paragraph = new D.Paragraph();
+            if (includeEndParagraph) {
+                paragraph.Append(new D.EndParagraphRunProperties { Language = "en-US" });
+            }
+
+            shape.TextBody!.Append(paragraph);
+            return shape;
         }
 
         private static SlidePart CreateSlidePart(PresentationPart presentationPart) {


### PR DESCRIPTION
## Summary
- ensure notes slide creation wires up a notes master, generating a default definition when missing
- build a default notes master shape tree with placeholders and color map to satisfy Open XML validation
- add a regression test that writes notes to a new presentation and validates the package with OpenXmlValidator

## Testing
- dotnet test OfficeIMO.Tests --filter PowerPointBasicDocument

------
https://chatgpt.com/codex/tasks/task_e_68d403b3f344832e9e3a5617ead37444