### PR TITLE
Cache PowerPoint validation results and add tests

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointChart.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml.Presentation;
 
 namespace OfficeIMO.PowerPoint {
@@ -5,7 +6,7 @@ namespace OfficeIMO.PowerPoint {
     ///     Represents a chart on a slide.
     /// </summary>
     public class PowerPointChart : PowerPointShape {
-        internal PowerPointChart(GraphicFrame frame) : base(frame) {
+        internal PowerPointChart(GraphicFrame frame, Action onChanged) : base(frame, onChanged) {
         }
     }
 }

--- a/OfficeIMO.PowerPoint/PowerPointNotes.cs
+++ b/OfficeIMO.PowerPoint/PowerPointNotes.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
@@ -10,9 +11,11 @@ namespace OfficeIMO.PowerPoint {
     /// </summary>
     public class PowerPointNotes {
         private readonly SlidePart _slidePart;
+        private readonly Action _onChanged;
 
-        internal PowerPointNotes(SlidePart slidePart) {
+        internal PowerPointNotes(SlidePart slidePart, Action onChanged) {
             _slidePart = slidePart;
+            _onChanged = onChanged;
         }
 
         private NotesSlide NotesSlide {
@@ -52,6 +55,7 @@ namespace OfficeIMO.PowerPoint {
                             )
                         )),
                         new ColorMapOverride(new A.MasterColorMapping()));
+                    _onChanged();
                 }
 
                 return _slidePart.NotesSlidePart!.NotesSlide;
@@ -91,6 +95,7 @@ namespace OfficeIMO.PowerPoint {
                 A.Run run = paragraph.GetFirstChild<A.Run>() ?? paragraph.AppendChild(new A.Run());
                 A.Text text = run.GetFirstChild<A.Text>() ?? run.AppendChild(new A.Text());
                 text.Text = value;
+                _onChanged();
             }
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointPicture.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPicture.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using A = DocumentFormat.OpenXml.Drawing;
@@ -9,7 +10,7 @@ namespace OfficeIMO.PowerPoint {
     public class PowerPointPicture : PowerPointShape {
         private readonly SlidePart _slidePart;
 
-        internal PowerPointPicture(Picture picture, SlidePart slidePart) : base(picture) {
+        internal PowerPointPicture(Picture picture, SlidePart slidePart, Action onChanged) : base(picture, onChanged) {
             _slidePart = slidePart;
         }
 
@@ -61,6 +62,7 @@ namespace OfficeIMO.PowerPoint {
             imagePart.FeedData(newImage);
             string relId = _slidePart.GetIdOfPart(imagePart);
             blip.Embed = relId;
+            NotifyChanged();
         }
     }
 }

--- a/OfficeIMO.PowerPoint/PowerPointShape.cs
+++ b/OfficeIMO.PowerPoint/PowerPointShape.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml.Presentation;
 using A = DocumentFormat.OpenXml.Drawing;
 
@@ -6,11 +7,26 @@ namespace OfficeIMO.PowerPoint {
     ///     Base class for shapes used on PowerPoint slides.
     /// </summary>
     public abstract class PowerPointShape {
-        internal PowerPointShape(OpenXmlElement element) {
+        private readonly Action? _onChanged;
+
+        internal PowerPointShape(OpenXmlElement element, Action? onChanged = null) {
             Element = element;
+            _onChanged = onChanged;
         }
 
         internal OpenXmlElement Element { get; }
+
+        /// <summary>
+        ///     Gets the callback invoked when the underlying Open XML element changes.
+        /// </summary>
+        protected Action? ChangeHandler => _onChanged;
+
+        /// <summary>
+        ///     Notifies the owning presentation that the shape's underlying Open XML element has changed.
+        /// </summary>
+        protected void NotifyChanged() {
+            _onChanged?.Invoke();
+        }
 
         /// <summary>
         ///     Name assigned to the shape.
@@ -49,6 +65,7 @@ namespace OfficeIMO.PowerPoint {
                     if (value != null) {
                         shape.ShapeProperties.Append(new A.SolidFill(new A.RgbColorModelHex { Val = value }));
                     }
+                    NotifyChanged();
                 }
             }
         }
@@ -58,7 +75,10 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public long Left {
             get => GetOffset().X?.Value ?? 0L;
-            set => GetOffset().X = value;
+            set {
+                GetOffset().X = value;
+                NotifyChanged();
+            }
         }
 
         /// <summary>
@@ -66,7 +86,10 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public long Top {
             get => GetOffset().Y?.Value ?? 0L;
-            set => GetOffset().Y = value;
+            set {
+                GetOffset().Y = value;
+                NotifyChanged();
+            }
         }
 
         /// <summary>
@@ -74,7 +97,10 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public long Width {
             get => GetExtents().Cx?.Value ?? 0L;
-            set => GetExtents().Cx = value;
+            set {
+                GetExtents().Cx = value;
+                NotifyChanged();
+            }
         }
 
         /// <summary>
@@ -82,7 +108,10 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public long Height {
             get => GetExtents().Cy?.Value ?? 0L;
-            set => GetExtents().Cy = value;
+            set {
+                GetExtents().Cy = value;
+                NotifyChanged();
+            }
         }
 
         private A.Offset GetOffset() {

--- a/OfficeIMO.PowerPoint/PowerPointTable.cs
+++ b/OfficeIMO.PowerPoint/PowerPointTable.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml.Presentation;
 using A = DocumentFormat.OpenXml.Drawing;
 
@@ -6,7 +7,7 @@ namespace OfficeIMO.PowerPoint {
     ///     Represents a table on a slide.
     /// </summary>
     public class PowerPointTable : PowerPointShape {
-        internal PowerPointTable(GraphicFrame frame) : base(frame) {
+        internal PowerPointTable(GraphicFrame frame, Action onChanged) : base(frame, onChanged) {
         }
 
         private GraphicFrame Frame => (GraphicFrame)Element;
@@ -31,7 +32,7 @@ namespace OfficeIMO.PowerPoint {
             A.Table table = Frame.Graphic!.GraphicData!.GetFirstChild<A.Table>()!;
             A.TableRow tableRow = table.Elements<A.TableRow>().ElementAt(row);
             A.TableCell cell = tableRow.Elements<A.TableCell>().ElementAt(column);
-            return new PowerPointTableCell(cell);
+            return new PowerPointTableCell(cell, ChangeHandler);
         }
 
         /// <summary>
@@ -57,6 +58,7 @@ namespace OfficeIMO.PowerPoint {
             } else {
                 table.Append(row);
             }
+            NotifyChanged();
         }
 
         /// <summary>
@@ -67,6 +69,7 @@ namespace OfficeIMO.PowerPoint {
             A.Table table = Frame.Graphic!.GraphicData!.GetFirstChild<A.Table>()!;
             A.TableRow row = table.Elements<A.TableRow>().ElementAt(index);
             row.Remove();
+            NotifyChanged();
         }
 
         /// <summary>
@@ -99,6 +102,7 @@ namespace OfficeIMO.PowerPoint {
                     row.Append(cell);
                 }
             }
+            NotifyChanged();
         }
 
         /// <summary>
@@ -112,6 +116,7 @@ namespace OfficeIMO.PowerPoint {
             foreach (A.TableRow row in table.Elements<A.TableRow>()) {
                 row.Elements<A.TableCell>().ElementAt(index).Remove();
             }
+            NotifyChanged();
         }
     }
 }

--- a/OfficeIMO.PowerPoint/PowerPointTableCell.cs
+++ b/OfficeIMO.PowerPoint/PowerPointTableCell.cs
@@ -1,12 +1,17 @@
 using DocumentFormat.OpenXml.Drawing;
 
+using System;
+
 namespace OfficeIMO.PowerPoint {
     /// <summary>
     ///     Represents a cell within a PowerPoint table.
     /// </summary>
     public class PowerPointTableCell {
-        internal PowerPointTableCell(TableCell cell) {
+        private readonly Action? _onChanged;
+
+        internal PowerPointTableCell(TableCell cell, Action? onChanged) {
             Cell = cell;
+            _onChanged = onChanged;
         }
 
         internal TableCell Cell { get; }
@@ -25,6 +30,7 @@ namespace OfficeIMO.PowerPoint {
                 paragraph.RemoveAllChildren<Run>();
                 paragraph.Append(new Run(new Text(value ?? string.Empty)));
                 Cell.TextBody.Append(paragraph);
+                _onChanged?.Invoke();
             }
         }
 
@@ -51,6 +57,7 @@ namespace OfficeIMO.PowerPoint {
                 } else {
                     Cell.GridSpan = value.columns;
                 }
+                _onChanged?.Invoke();
             }
         }
 
@@ -71,6 +78,7 @@ namespace OfficeIMO.PowerPoint {
                 if (value != null) {
                     Cell.TableCellProperties.Append(new SolidFill(new RgbColorModelHex { Val = value }));
                 }
+                _onChanged?.Invoke();
             }
         }
     }

--- a/OfficeIMO.PowerPoint/PowerPointTextBox.cs
+++ b/OfficeIMO.PowerPoint/PowerPointTextBox.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml.Presentation;
 using A = DocumentFormat.OpenXml.Drawing;
 
@@ -6,7 +7,7 @@ namespace OfficeIMO.PowerPoint {
     ///     Represents a textbox shape.
     /// </summary>
     public class PowerPointTextBox : PowerPointShape {
-        internal PowerPointTextBox(Shape shape) : base(shape) {
+        internal PowerPointTextBox(Shape shape, Action onChanged) : base(shape, onChanged) {
         }
 
         private Shape Shape => (Shape)Element;
@@ -26,6 +27,7 @@ namespace OfficeIMO.PowerPoint {
                 A.Run run = Shape.TextBody!.GetFirstChild<A.Paragraph>()!.GetFirstChild<A.Run>()!;
                 A.Text text = run.GetFirstChild<A.Text>()!;
                 text.Text = value;
+                NotifyChanged();
             }
         }
 
@@ -42,6 +44,7 @@ namespace OfficeIMO.PowerPoint {
                     A.RunProperties runProps = run.RunProperties ??= new A.RunProperties();
                     runProps.Bold = value ? true : null;
                 }
+                NotifyChanged();
             }
         }
 
@@ -58,6 +61,7 @@ namespace OfficeIMO.PowerPoint {
                     A.RunProperties runProps = run.RunProperties ??= new A.RunProperties();
                     runProps.Italic = value ? true : null;
                 }
+                NotifyChanged();
             }
         }
 
@@ -75,6 +79,7 @@ namespace OfficeIMO.PowerPoint {
                     A.RunProperties runProps = run.RunProperties ??= new A.RunProperties();
                     runProps.FontSize = value != null ? value * 100 : null;
                 }
+                NotifyChanged();
             }
         }
 
@@ -94,6 +99,7 @@ namespace OfficeIMO.PowerPoint {
                         runProps.Append(new A.LatinFont { Typeface = value });
                     }
                 }
+                NotifyChanged();
             }
         }
 
@@ -113,6 +119,7 @@ namespace OfficeIMO.PowerPoint {
                         runProps.Append(new A.SolidFill(new A.RgbColorModelHex { Val = value }));
                     }
                 }
+                NotifyChanged();
             }
         }
 
@@ -131,6 +138,7 @@ namespace OfficeIMO.PowerPoint {
                 run
             );
             Shape.TextBody!.AppendChild(paragraph);
+            NotifyChanged();
         }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.ValidateDocument.cs
+++ b/OfficeIMO.Tests/PowerPoint.ValidateDocument.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Validation;
 using OfficeIMO.PowerPoint;
 using Xunit;
@@ -26,6 +27,64 @@ namespace OfficeIMO.Tests {
             }
 
             File.Delete(filePath);
+        }
+
+        [Fact]
+        public void DocumentValidationErrors_IsCachedUntilInvalidated() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            int factoryCalls = 0;
+            Func<FileFormatVersions, OpenXmlValidator> originalFactory = PowerPointPresentation.ValidatorFactory;
+
+            try {
+                PowerPointPresentation.ValidatorFactory = version => {
+                    factoryCalls++;
+                    return new OpenXmlValidator(version);
+                };
+
+                using (var presentation = PowerPointPresentation.Create(filePath)) {
+                    Assert.Empty(presentation.DocumentValidationErrors);
+                    Assert.Empty(presentation.DocumentValidationErrors);
+                    Assert.Equal(1, factoryCalls);
+
+                    presentation.Slides[0].AddTextBox("Cached validation");
+
+                    Assert.Empty(presentation.DocumentValidationErrors);
+                    Assert.Equal(2, factoryCalls);
+
+                    Assert.Empty(presentation.ValidateDocument(forceRefresh: true));
+                    Assert.Equal(3, factoryCalls);
+                }
+            } finally {
+                PowerPointPresentation.ValidatorFactory = originalFactory;
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DocumentIsValid_UsesCachedValidationResults() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            int factoryCalls = 0;
+            Func<FileFormatVersions, OpenXmlValidator> originalFactory = PowerPointPresentation.ValidatorFactory;
+
+            try {
+                PowerPointPresentation.ValidatorFactory = version => {
+                    factoryCalls++;
+                    return new OpenXmlValidator(version);
+                };
+
+                using (var presentation = PowerPointPresentation.Create(filePath)) {
+                    Assert.True(presentation.DocumentIsValid);
+                    Assert.True(presentation.DocumentIsValid);
+                    Assert.Equal(1, factoryCalls);
+                }
+            } finally {
+                PowerPointPresentation.ValidatorFactory = originalFactory;
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
         }
 
         private static string FormatValidationErrors(IEnumerable<ValidationErrorInfo> errors) {


### PR DESCRIPTION
## Summary
- cache validation results in `PowerPointPresentation`, including a validator factory hook and force-refresh option
- propagate document change notifications from slides, shapes, notes, and tables so the cache is invalidated when content changes
- add unit tests that ensure validation is cached until explicitly refreshed or the document changes

## Testing
- dotnet build OfficeImo.sln
- dotnet test OfficeIMO.Tests --filter PowerPointValidateDocument

------
https://chatgpt.com/codex/tasks/task_e_68d403db0de8832e870f9507a1f54b17