### PR TITLE
Use local DateTimeOffset values when writing Excel cells

### DIFF
--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -53,6 +53,18 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public ExecutionPolicy Execution { get; } = new();
 
+        private Func<DateTimeOffset, DateTime> _dateTimeOffsetWriteStrategy = static dto => dto.LocalDateTime;
+
+        /// <summary>
+        /// Controls how <see cref="DateTimeOffset"/> values are converted to <see cref="DateTime"/>
+        /// before being written to worksheet cells. Defaults to <see cref="DateTimeOffset.LocalDateTime"/>.
+        /// </summary>
+        public Func<DateTimeOffset, DateTime> DateTimeOffsetWriteStrategy
+        {
+            get => _dateTimeOffsetWriteStrategy;
+            set => _dateTimeOffsetWriteStrategy = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
         internal ReaderWriterLockSlim EnsureLock()
             => _lock ??= new ReaderWriterLockSlim(); // default: NoRecursion
 

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -57,7 +57,8 @@ namespace OfficeIMO.Excel {
                 {
                     int idx = _excelDocument.GetSharedStringIndex(s);
                     return new CellValue(idx.ToString(CultureInfo.InvariantCulture));
-                });
+                },
+                _excelDocument.DateTimeOffsetWriteStrategy);
             return (cellValue, new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(cellType));
         }
 
@@ -88,7 +89,7 @@ namespace OfficeIMO.Excel {
 
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, DateTimeOffset value) {
-            CellValue(row, column, value.UtcDateTime);
+            WriteLockConditional(() => CellValueCore(row, column, value));
         }
 
         /// <inheritdoc cref="CellValue(int,int,object)" />

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -99,7 +99,8 @@ namespace OfficeIMO.Excel
                 {
                     planner.Note(s);
                     return new CellValue(s);
-                });
+                },
+                _excelDocument.DateTimeOffsetWriteStrategy);
             return (cellValue, new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(cellType));
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.cs
@@ -201,7 +201,8 @@ namespace OfficeIMO.Excel {
                 case DateTime dt:
                     return new CellUpdate(row, column, dt.ToOADate().ToString(CultureInfo.InvariantCulture), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number, false);
                 case DateTimeOffset dto:
-                    return new CellUpdate(row, column, dto.UtcDateTime.ToOADate().ToString(CultureInfo.InvariantCulture), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number, false);
+                    var local = _excelDocument.DateTimeOffsetWriteStrategy(dto).ToOADate().ToString(CultureInfo.InvariantCulture);
+                    return new CellUpdate(row, column, local, DocumentFormat.OpenXml.Spreadsheet.CellValues.Number, false);
                 case TimeSpan ts:
                     return new CellUpdate(row, column, ts.TotalDays.ToString(CultureInfo.InvariantCulture), DocumentFormat.OpenXml.Spreadsheet.CellValues.Number, false);
                 case bool b:

--- a/OfficeIMO.Tests/Excel.CoerceValueHelper.cs
+++ b/OfficeIMO.Tests/Excel.CoerceValueHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
@@ -100,6 +101,30 @@ public class ExcelCoerceValueHelper
         Assert.Equal(CellValues.SharedString, uriType);
         Assert.Equal("IDX", uriValue.Text);
         Assert.Equal(uri.ToString(), uriCaptured);
+    }
+
+    [Fact]
+    public void Coerce_DateTimeOffset_UsesLocalStrategyByDefault()
+    {
+        var offset = new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.FromHours(5));
+        var expected = offset.LocalDateTime.ToOADate().ToString(CultureInfo.InvariantCulture);
+
+        var (value, type) = CoerceValueHelper.Coerce(offset, s => new CellValue(s));
+
+        Assert.Equal(CellValues.Number, type);
+        Assert.Equal(expected, value.Text);
+    }
+
+    [Fact]
+    public void Coerce_DateTimeOffset_AllowsCustomStrategy()
+    {
+        var offset = new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.FromHours(-3));
+        var expected = offset.UtcDateTime.ToOADate().ToString(CultureInfo.InvariantCulture);
+
+        var (value, type) = CoerceValueHelper.Coerce(offset, s => new CellValue(s), dto => dto.UtcDateTime);
+
+        Assert.Equal(CellValues.Number, type);
+        Assert.Equal(expected, value.Text);
     }
 
 #if NET6_0_OR_GREATER


### PR DESCRIPTION
## Summary
- convert DateTimeOffset coercion to use the local date/time before writing Excel numbers
- expose a configurable DateTimeOffset write strategy on ExcelDocument and apply it across sheet helpers
- add regression tests covering positive and negative offsets as well as custom strategies

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d409505a68832eb59256b093f7024f