### PR TITLE
Add stream-based overloads for ExcelDocument loading

### DIFF
--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -533,6 +533,21 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        private static bool ShouldCopyBackToSource(bool readOnly, bool autoSave, OpenSettings? openSettings)
+        {
+            if (readOnly)
+            {
+                return false;
+            }
+
+            if (autoSave)
+            {
+                return true;
+            }
+
+            return openSettings?.AutoSave == true;
+        }
+
         /// <summary>
         /// Loads an existing Excel document.
         /// </summary>
@@ -568,7 +583,7 @@ namespace OfficeIMO.Excel {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (!stream.CanRead) throw new ArgumentException("Stream must be readable.", nameof(stream));
 
-            bool shouldCopyBack = autoSave && !readOnly;
+            bool shouldCopyBack = ShouldCopyBackToSource(readOnly, autoSave, openSettings);
             if (shouldCopyBack)
             {
                 if (!stream.CanWrite)
@@ -655,7 +670,7 @@ namespace OfficeIMO.Excel {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (!stream.CanRead) throw new ArgumentException("Stream must be readable.", nameof(stream));
 
-            bool shouldCopyBack = autoSave && !readOnly;
+            bool shouldCopyBack = ShouldCopyBackToSource(readOnly, autoSave, openSettings);
             if (shouldCopyBack)
             {
                 if (!stream.CanWrite)

--- a/OfficeIMO.Tests/Excel.LoadExceptions.cs
+++ b/OfficeIMO.Tests/Excel.LoadExceptions.cs
@@ -32,7 +32,7 @@ namespace OfficeIMO.Tests {
         [Fact]
         public async Task Test_LoadAsyncNullPath_ThrowsArgumentNullException() {
             var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => ExcelDocument.LoadAsync((string)null!));
-            Assert.Equal("path", ex.ParamName);
+            Assert.Equal("filePath", ex.ParamName);
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Excel.LoadExceptions.cs
+++ b/OfficeIMO.Tests/Excel.LoadExceptions.cs
@@ -18,7 +18,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void Test_LoadNullPath_ThrowsArgumentNullException() {
-            var ex = Assert.Throws<ArgumentNullException>(() => ExcelDocument.Load(null!));
+            var ex = Assert.Throws<ArgumentNullException>(() => ExcelDocument.Load((string)null!));
             Assert.Equal("filePath", ex.ParamName);
         }
 
@@ -31,7 +31,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public async Task Test_LoadAsyncNullPath_ThrowsArgumentNullException() {
-            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => ExcelDocument.LoadAsync(null!));
+            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => ExcelDocument.LoadAsync((string)null!));
             Assert.Equal("path", ex.ParamName);
         }
 

--- a/OfficeIMO.Tests/Excel.LoadFromStream.cs
+++ b/OfficeIMO.Tests/Excel.LoadFromStream.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -101,7 +102,7 @@ namespace OfficeIMO.Tests
                         .ToArray();
                 }
 
-                await using var memory = new MemoryStream(File.ReadAllBytes(filePath));
+                using var memory = new MemoryStream(File.ReadAllBytes(filePath));
                 await using var fromStream = await ExcelDocument.LoadAsync(memory);
 
                 Assert.Equal("Async Stream Title", fromStream.BuiltinDocumentProperties.Title);
@@ -117,6 +118,138 @@ namespace OfficeIMO.Tests
                     .ToArray();
 
                 Assert.Equal(expectedShared, actualShared);
+            }
+            finally
+            {
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Load_FromMemoryStream_WithAutoSave_PersistsChanges()
+        {
+            string filePath = Path.Combine(_directoryWithFiles, "LoadFromStreamAutoSave.xlsx");
+
+            try
+            {
+                using (var document = ExcelDocument.Create(filePath))
+                {
+                    var sheet = document.AddWorkSheet("AutoSave");
+                    sheet.CellValue(1, 1, "Original");
+                    document.Save();
+                }
+
+                var bytes = File.ReadAllBytes(filePath);
+                using var memory = new MemoryStream();
+                memory.Write(bytes, 0, bytes.Length);
+                memory.Seek(0, SeekOrigin.Begin);
+
+                using (var document = ExcelDocument.Load(memory, readOnly: false, autoSave: true))
+                {
+                    var sheet = document.Sheets[0];
+                    sheet.CellValue(1, 1, "Updated");
+                }
+
+                memory.Seek(0, SeekOrigin.Begin);
+                using var reloaded = ExcelDocument.Load(memory);
+                var reloadedSheet = reloaded.Sheets[0];
+                Assert.True(reloadedSheet.TryGetCellText(1, 1, out var text));
+                Assert.Equal("Updated", text);
+            }
+            finally
+            {
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task LoadAsync_FromMemoryStream_WithAutoSave_PersistsChanges()
+        {
+            string filePath = Path.Combine(_directoryWithFiles, "LoadFromStreamAutoSaveAsync.xlsx");
+
+            try
+            {
+                using (var document = ExcelDocument.Create(filePath))
+                {
+                    var sheet = document.AddWorkSheet("AutoSave");
+                    sheet.CellValue(1, 1, "Original Async");
+                    document.Save();
+                }
+
+                var bytes = File.ReadAllBytes(filePath);
+                using var memory = new MemoryStream();
+                memory.Write(bytes, 0, bytes.Length);
+                memory.Seek(0, SeekOrigin.Begin);
+
+                await using (var document = await ExcelDocument.LoadAsync(memory, readOnly: false, autoSave: true))
+                {
+                    var sheet = document.Sheets[0];
+                    sheet.CellValue(1, 1, "Updated Async");
+                }
+
+                memory.Seek(0, SeekOrigin.Begin);
+                using var reloaded = ExcelDocument.Load(memory);
+                var reloadedSheet = reloaded.Sheets[0];
+                Assert.True(reloadedSheet.TryGetCellText(1, 1, out var text));
+                Assert.Equal("Updated Async", text);
+            }
+            finally
+            {
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Load_FromReadOnlyStream_WithAutoSave_Throws()
+        {
+            string filePath = Path.Combine(_directoryWithFiles, "LoadFromStreamReadOnly.xlsx");
+
+            try
+            {
+                using (var document = ExcelDocument.Create(filePath))
+                {
+                    document.AddWorkSheet("Readonly");
+                    document.Save();
+                }
+
+                using var readOnlyStream = new MemoryStream(File.ReadAllBytes(filePath), writable: false);
+                var ex = Assert.Throws<ArgumentException>(() => ExcelDocument.Load(readOnlyStream, readOnly: false, autoSave: true));
+                Assert.Equal("stream", ex.ParamName);
+            }
+            finally
+            {
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task LoadAsync_FromReadOnlyStream_WithAutoSave_Throws()
+        {
+            string filePath = Path.Combine(_directoryWithFiles, "LoadFromStreamReadOnlyAsync.xlsx");
+
+            try
+            {
+                using (var document = ExcelDocument.Create(filePath))
+                {
+                    document.AddWorkSheet("Readonly");
+                    document.Save();
+                }
+
+                using var readOnlyStream = new MemoryStream(File.ReadAllBytes(filePath), writable: false);
+                var ex = await Assert.ThrowsAsync<ArgumentException>(() => ExcelDocument.LoadAsync(readOnlyStream, readOnly: false, autoSave: true));
+                Assert.Equal("stream", ex.ParamName);
             }
             finally
             {

--- a/OfficeIMO.Tests/Excel.LoadFromStream.cs
+++ b/OfficeIMO.Tests/Excel.LoadFromStream.cs
@@ -1,0 +1,131 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests
+{
+    public partial class Excel
+    {
+        [Fact]
+        public void Load_FromMemoryStream_PreservesSharedStringsAndProperties()
+        {
+            string filePath = Path.Combine(_directoryWithFiles, "LoadFromStream.xlsx");
+
+            try
+            {
+                using (var document = ExcelDocument.Create(filePath))
+                {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Alpha");
+                    sheet.CellValue(2, 1, "Beta");
+                    sheet.CellValue(3, 1, "Gamma");
+
+                    document.BuiltinDocumentProperties.Title = "Stream Title";
+                    document.BuiltinDocumentProperties.Creator = "Stream Creator";
+                    document.ApplicationProperties.Company = "Stream Company";
+                    document.ApplicationProperties.Manager = "Stream Manager";
+
+                    document.Save();
+                }
+
+                string[] expectedShared;
+                using (var fromFile = ExcelDocument.Load(filePath))
+                {
+                    expectedShared = fromFile._spreadSheetDocument.WorkbookPart!
+                        .SharedStringTablePart!
+                        .SharedStringTable!
+                        .Elements<SharedStringItem>()
+                        .Select(item => item.InnerText)
+                        .ToArray();
+                }
+
+                using var memory = new MemoryStream(File.ReadAllBytes(filePath));
+                using var fromStream = ExcelDocument.Load(memory);
+
+                Assert.Equal("Stream Title", fromStream.BuiltinDocumentProperties.Title);
+                Assert.Equal("Stream Creator", fromStream.BuiltinDocumentProperties.Creator);
+                Assert.Equal("Stream Company", fromStream.ApplicationProperties.Company);
+                Assert.Equal("Stream Manager", fromStream.ApplicationProperties.Manager);
+
+                var actualShared = fromStream._spreadSheetDocument.WorkbookPart!
+                    .SharedStringTablePart!
+                    .SharedStringTable!
+                    .Elements<SharedStringItem>()
+                    .Select(item => item.InnerText)
+                    .ToArray();
+
+                Assert.Equal(expectedShared, actualShared);
+            }
+            finally
+            {
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task LoadAsync_FromMemoryStream_PreservesSharedStringsAndProperties()
+        {
+            string filePath = Path.Combine(_directoryWithFiles, "LoadFromStreamAsync.xlsx");
+
+            try
+            {
+                using (var document = ExcelDocument.Create(filePath))
+                {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Delta");
+                    sheet.CellValue(2, 1, "Epsilon");
+                    sheet.CellValue(3, 1, "Zeta");
+
+                    document.BuiltinDocumentProperties.Title = "Async Stream Title";
+                    document.BuiltinDocumentProperties.Creator = "Async Stream Creator";
+                    document.ApplicationProperties.Company = "Async Stream Company";
+                    document.ApplicationProperties.Manager = "Async Stream Manager";
+
+                    document.Save();
+                }
+
+                string[] expectedShared;
+                using (var fromFile = ExcelDocument.Load(filePath))
+                {
+                    expectedShared = fromFile._spreadSheetDocument.WorkbookPart!
+                        .SharedStringTablePart!
+                        .SharedStringTable!
+                        .Elements<SharedStringItem>()
+                        .Select(item => item.InnerText)
+                        .ToArray();
+                }
+
+                await using var memory = new MemoryStream(File.ReadAllBytes(filePath));
+                await using var fromStream = await ExcelDocument.LoadAsync(memory);
+
+                Assert.Equal("Async Stream Title", fromStream.BuiltinDocumentProperties.Title);
+                Assert.Equal("Async Stream Creator", fromStream.BuiltinDocumentProperties.Creator);
+                Assert.Equal("Async Stream Company", fromStream.ApplicationProperties.Company);
+                Assert.Equal("Async Stream Manager", fromStream.ApplicationProperties.Manager);
+
+                var actualShared = fromStream._spreadSheetDocument.WorkbookPart!
+                    .SharedStringTablePart!
+                    .SharedStringTable!
+                    .Elements<SharedStringItem>()
+                    .Select(item => item.InnerText)
+                    .ToArray();
+
+                Assert.Equal(expectedShared, actualShared);
+            }
+            finally
+            {
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a shared stream-loading pipeline for ExcelDocument and reuse it for the file-path overloads
- expose new Load(Stream, ...) and LoadAsync(Stream, ...) entry points
- add coverage that opens workbooks from MemoryStream and verifies shared string and property helpers

## Testing
- dotnet build OfficeImo.sln
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d4092879d4832e819e2fd2304a36d8