### PR TITLE
Handle empty header maps on blank sheets

### DIFF
--- a/OfficeIMO.Tests/Excel.HeaderLookup.BlankSheet.cs
+++ b/OfficeIMO.Tests/Excel.HeaderLookup.BlankSheet.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests
+{
+    public partial class Excel
+    {
+        [Fact]
+        public void Test_BlankSheetHeaderLookups()
+        {
+            var filePath = Path.Combine(_directoryWithFiles, "BlankSheetHeaderLookups.xlsx");
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+
+            using (var document = ExcelDocument.Create(filePath))
+            {
+                document.AddWorkSheet("Empty");
+                document.Save();
+            }
+
+            try
+            {
+                using var document = ExcelDocument.Load(filePath);
+                var sheet = document.Sheets[0];
+
+                var headers = sheet.GetHeaderMap();
+                Assert.Empty(headers);
+
+                Assert.Throws<KeyNotFoundException>(() => sheet.ColumnIndexByHeader("Missing"));
+
+                Assert.False(sheet.TryGetColumnIndexByHeader("Missing", out var columnIndex));
+                Assert.Equal(0, columnIndex);
+
+                Assert.False(sheet.TryGetColumnIndexByHeader("Column1", out _));
+            }
+            finally
+            {
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- guard header-map construction against empty ranges and skip generating headers when the first row has no values
- ensure blank worksheets return an empty header map rather than synthesized column names
- cover the blank-sheet scenario with a regression test for ColumnIndexByHeader/TryGetColumnIndexByHeader

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d409601368832e9a273e8616a08fee