### PR TITLE
Guard PowerPoint table indices and add tests

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointTable.cs
+++ b/OfficeIMO.PowerPoint/PowerPointTable.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using DocumentFormat.OpenXml.Presentation;
 using A = DocumentFormat.OpenXml.Drawing;
 
@@ -29,8 +31,24 @@ namespace OfficeIMO.PowerPoint {
         /// <param name="column">Zero-based column index.</param>
         public PowerPointTableCell GetCell(int row, int column) {
             A.Table table = Frame.Graphic!.GraphicData!.GetFirstChild<A.Table>()!;
-            A.TableRow tableRow = table.Elements<A.TableRow>().ElementAt(row);
-            A.TableCell cell = tableRow.Elements<A.TableCell>().ElementAt(column);
+            List<A.TableRow> tableRows = table.Elements<A.TableRow>().ToList();
+            int rowCount = tableRows.Count;
+
+            if (row < 0 || row >= rowCount) {
+                throw new ArgumentOutOfRangeException(nameof(row),
+                    $"Row index {row} is out of range. The table contains {rowCount} row{(rowCount == 1 ? string.Empty : "s")}.");
+            }
+
+            A.TableRow tableRow = tableRows[row];
+            List<A.TableCell> tableCells = tableRow.Elements<A.TableCell>().ToList();
+            int columnCount = tableCells.Count;
+
+            if (column < 0 || column >= columnCount) {
+                throw new ArgumentOutOfRangeException(nameof(column),
+                    $"Column index {column} is out of range. The table contains {columnCount} column{(columnCount == 1 ? string.Empty : "s")}.");
+            }
+
+            A.TableCell cell = tableCells[column];
             return new PowerPointTableCell(cell);
         }
 
@@ -65,8 +83,14 @@ namespace OfficeIMO.PowerPoint {
         /// <param name="index">Zero-based index of the row to remove.</param>
         public void RemoveRow(int index) {
             A.Table table = Frame.Graphic!.GraphicData!.GetFirstChild<A.Table>()!;
-            A.TableRow row = table.Elements<A.TableRow>().ElementAt(index);
-            row.Remove();
+            List<A.TableRow> rows = table.Elements<A.TableRow>().ToList();
+
+            if (index < 0 || index >= rows.Count) {
+                throw new ArgumentOutOfRangeException(nameof(index),
+                    $"Row index {index} is out of range. The table contains {rows.Count} row{(rows.Count == 1 ? string.Empty : "s")}.");
+            }
+
+            rows[index].Remove();
         }
 
         /// <summary>
@@ -108,9 +132,17 @@ namespace OfficeIMO.PowerPoint {
         public void RemoveColumn(int index) {
             A.Table table = Frame.Graphic!.GraphicData!.GetFirstChild<A.Table>()!;
             A.TableGrid grid = table.TableGrid!;
-            grid.Elements<A.GridColumn>().ElementAt(index).Remove();
+            List<A.GridColumn> columns = grid.Elements<A.GridColumn>().ToList();
+
+            if (index < 0 || index >= columns.Count) {
+                throw new ArgumentOutOfRangeException(nameof(index),
+                    $"Column index {index} is out of range. The table contains {columns.Count} column{(columns.Count == 1 ? string.Empty : "s")}.");
+            }
+
+            columns[index].Remove();
             foreach (A.TableRow row in table.Elements<A.TableRow>()) {
-                row.Elements<A.TableCell>().ElementAt(index).Remove();
+                List<A.TableCell> cells = row.Elements<A.TableCell>().ToList();
+                cells[index].Remove();
             }
         }
     }

--- a/OfficeIMO.Tests/PowerPoint.Tables.cs
+++ b/OfficeIMO.Tests/PowerPoint.Tables.cs
@@ -1,39 +1,39 @@
-        public void CanManipulateTableCellsAndPreserveStyle() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using A = DocumentFormat.OpenXml.Drawing;
+using OfficeIMO.PowerPoint;
+using Xunit;
 
-            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
-                PowerPointSlide slide = presentation.AddSlide();
-                PowerPointTable table = slide.AddTable(2, 2);
-            File.Delete(filePath);
-        }
-
-        [Theory]
-        [InlineData(-1)]
-        [InlineData(2)]
-        public void GetCellInvalidRowThrowsArgumentOutOfRangeException(int row) {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
-
-            try {
-                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
-                    PowerPointSlide slide = presentation.AddSlide();
-                    PowerPointTable table = slide.AddTable(2, 2);
-
-                    ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() => table.GetCell(row, 0));
-                    Assert.StartsWith($"Row index {row} is out of range.", exception.Message);
-                    Assert.EndsWith("(Parameter 'row')", exception.Message);
-                }
-            } finally {
-                if (File.Exists(filePath)) {
-                    File.Delete(filePath);
-                }
+namespace OfficeIMO.Tests {
+    public class PowerPointTables {
+        [Fact]
+                PowerPointTableCell cell = table.GetCell(0, 0);
+                cell.Text = "Test";
+                cell.FillColor = "FF0000";
+                cell.Merge = (1, 2);
+                table.AddRow();
+                table.AddColumn();
+                table.RemoveRow(2);
+                table.RemoveColumn(2);
+                presentation.Save();
             }
-        }
 
-        [Theory]
-        [InlineData(-1)]
-        [InlineData(2)]
-        public void GetCellInvalidColumnThrowsArgumentOutOfRangeException(int column) {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                PowerPointTable table = presentation.Slides[0].Tables.First();
+                Assert.Equal(2, table.Rows);
+                Assert.Equal(2, table.Columns);
+                PowerPointTableCell cell = table.GetCell(0, 0);
+                Assert.Equal("Test", cell.Text);
+                Assert.Equal((1, 2), cell.Merge);
+            }
+
+            using (PresentationDocument doc = PresentationDocument.Open(filePath, false)) {
+                A.Table table = doc.PresentationPart!.SlideParts.First().Slide.Descendants<A.Table>().First();
+                string? styleId = table.TableProperties?.GetFirstChild<A.TableStyleId>()?.Text;
+                Assert.Equal("{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}", styleId);
+            }
 
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
@@ -101,7 +101,7 @@ using Xunit;
 namespace OfficeIMO.Tests {
     public class PowerPointTables {
         [Fact]
-        public void CanManipulateTableCellsAndPreserveStyle() {
+        public void CanManipulateTableCellsAndPreserveStyle() {}
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
 
             using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
@@ -136,4 +136,4 @@ namespace OfficeIMO.Tests {
             File.Delete(filePath);
         }
     }
-}
+}

--- a/OfficeIMO.Tests/PowerPoint.Tables.cs
+++ b/OfficeIMO.Tests/PowerPoint.Tables.cs
@@ -1,9 +1,101 @@
-using System;
-using System.IO;
-using System.Linq;
-using DocumentFormat.OpenXml.Packaging;
-using A = DocumentFormat.OpenXml.Drawing;
-using OfficeIMO.PowerPoint;
+        public void CanManipulateTableCellsAndPreserveStyle() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                PowerPointSlide slide = presentation.AddSlide();
+                PowerPointTable table = slide.AddTable(2, 2);
+            File.Delete(filePath);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(2)]
+        public void GetCellInvalidRowThrowsArgumentOutOfRangeException(int row) {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    PowerPointTable table = slide.AddTable(2, 2);
+
+                    ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() => table.GetCell(row, 0));
+                    Assert.StartsWith($"Row index {row} is out of range.", exception.Message);
+                    Assert.EndsWith("(Parameter 'row')", exception.Message);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(2)]
+        public void GetCellInvalidColumnThrowsArgumentOutOfRangeException(int column) {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    PowerPointTable table = slide.AddTable(2, 2);
+
+                    ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() => table.GetCell(0, column));
+                    Assert.StartsWith($"Column index {column} is out of range.", exception.Message);
+                    Assert.EndsWith("(Parameter 'column')", exception.Message);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(2)]
+        public void RemoveRowInvalidIndexThrowsArgumentOutOfRangeException(int rowIndex) {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    PowerPointTable table = slide.AddTable(2, 2);
+
+                    ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() => table.RemoveRow(rowIndex));
+                    Assert.StartsWith($"Row index {rowIndex} is out of range.", exception.Message);
+                    Assert.EndsWith("(Parameter 'index')", exception.Message);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(2)]
+        public void RemoveColumnInvalidIndexThrowsArgumentOutOfRangeException(int columnIndex) {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    PowerPointTable table = slide.AddTable(2, 2);
+
+                    ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() => table.RemoveColumn(columnIndex));
+                    Assert.StartsWith($"Column index {columnIndex} is out of range.", exception.Message);
+                    Assert.EndsWith("(Parameter 'index')", exception.Message);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+    }
+}
 using Xunit;
 
 namespace OfficeIMO.Tests {


### PR DESCRIPTION
## Summary
- guard PowerPoint table cell, row, and column access with descriptive ArgumentOutOfRangeException messages
- add table tests that cover invalid row and column access scenarios

## Testing
- dotnet test OfficeIMO.Tests --filter PowerPointTables

------
https://chatgpt.com/codex/tasks/task_e_68d455ff4d80832e9abeed512dfaf14b