### PR TITLE
Prevent removing last slide and add regression tests

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -223,6 +223,10 @@ namespace OfficeIMO.PowerPoint {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
 
+            if (_slides.Count == 1) {
+                throw new InvalidOperationException("Cannot remove the last slide from the presentation.");
+            }
+
             SlideIdList? slideIdList = _presentationPart.Presentation.SlideIdList;
             if (slideIdList == null) {
                 throw new InvalidOperationException("Presentation has no slides.");

--- a/OfficeIMO.Tests/PowerPoint.SlidesManagement.cs
+++ b/OfficeIMO.Tests/PowerPoint.SlidesManagement.cs
@@ -34,6 +34,32 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void RemovingSlidesDownToOneKeepsPresentationValid() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                presentation.AddSlide().AddTextBox("Slide 1");
+                presentation.AddSlide().AddTextBox("Slide 2");
+                presentation.AddSlide().AddTextBox("Slide 3");
+
+                presentation.RemoveSlide(2);
+                presentation.RemoveSlide(1);
+
+                Assert.Single(presentation.Slides);
+                Assert.True(presentation.DocumentIsValid);
+
+                presentation.Save();
+            }
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                Assert.Single(presentation.Slides);
+                Assert.True(presentation.DocumentIsValid);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void CanMoveSlide() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
 
@@ -65,6 +91,14 @@ namespace OfficeIMO.Tests {
         public void RemovingInvalidSlideThrows() {
             using PowerPointPresentation presentation = PowerPointPresentation.Create(Path.GetTempFileName());
             Assert.Throws<ArgumentOutOfRangeException>(() => presentation.RemoveSlide(0));
+        }
+
+        [Fact]
+        public void RemovingLastSlideThrows() {
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(Path.GetTempFileName());
+            presentation.AddSlide();
+
+            Assert.Throws<InvalidOperationException>(() => presentation.RemoveSlide(0));
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- prevent removing the final slide in a presentation to maintain package validity
- add tests covering removal down to one slide and guarding against deleting the last slide

## Testing
- dotnet test OfficeIMO.Tests --filter PowerPointSlidesManagement

------
https://chatgpt.com/codex/tasks/task_e_68d53893f0a8832e88f853e8dd2e85bd