### PR TITLE
Ensure notes master part is created and linked to notes slides

### DIFF
--- a/OfficeIMO.Tests/PowerPoint.BasicDocument.cs
+++ b/OfficeIMO.Tests/PowerPoint.BasicDocument.cs
@@ -76,6 +76,13 @@ namespace OfficeIMO.Tests {
                 }
 
                 using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    PresentationPart presentationPart = document.PresentationPart!;
+                    NotesMasterPart notesMasterPart = presentationPart.NotesMasterPart!;
+                    NotesSlidePart notesSlidePart = presentationPart.SlideParts.First().NotesSlidePart!;
+
+                    Assert.Contains(notesSlidePart.Parts,
+                        pair => ReferenceEquals(pair.OpenXmlPart, notesMasterPart));
+
                     OpenXmlValidator validator = new();
                     var errors = validator.Validate(document).ToList();
                     Assert.True(errors.Count == 0,


### PR DESCRIPTION
## Summary
- ensure notes slides always create or hydrate a NotesSlidePart and attach it to the presentation's NotesMasterPart when required
- fall back to generating a default notes slide structure when an existing part is empty
- extend the PowerPoint basic document test to confirm the notes master relationship and validate the package with OpenXmlValidator

## Testing
- dotnet test OfficeIMO.Tests --filter PowerPointBasicDocument

------
https://chatgpt.com/codex/tasks/task_e_68d5388aba0c832e833a6fd686620ca8