### PR TITLE
Guard against inverted Excel table ranges

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Tables.cs
@@ -203,6 +203,10 @@ namespace OfficeIMO.Excel {
                 int startRowIndex = GetRowIndex(startRef);
                 int endRowIndex = GetRowIndex(endRef);
 
+                if (startColumnIndex > endColumnIndex || startRowIndex > endRowIndex) {
+                    throw new ArgumentException($"Invalid range '{range}'. The start cell must be the top-left cell and the end cell must be the bottom-right cell.", nameof(range));
+                }
+
                 uint columnsCount = (uint)(endColumnIndex - startColumnIndex + 1);
 
                 foreach (var existingPart in _worksheetPart.TableDefinitionParts) {

--- a/OfficeIMO.Tests/Excel.Tables.cs
+++ b/OfficeIMO.Tests/Excel.Tables.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -101,6 +102,21 @@ namespace OfficeIMO.Tests {
                 WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 Assert.Single(wsPart.TableDefinitionParts);
                   Assert.Equal("A1:B3", wsPart.TableDefinitionParts.First().Table.Reference!.Value);
+            }
+        }
+
+        [Theory]
+        [InlineData("B1:A2")]
+        [InlineData("A3:A1")]
+        [InlineData("B3:A1")]
+        public void Test_AddTableInvertedRangeThrows(string range) {
+            string safeRange = range.Replace(':', '_');
+            string filePath = Path.Combine(_directoryWithFiles, $"Table.Inverted.{safeRange}.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+
+                Assert.Throws<ArgumentException>(() =>
+                    sheet.AddTable(range, true, "MyTable", TableStyle.TableStyleMedium9));
             }
         }
 


### PR DESCRIPTION
## Summary
- validate Excel table ranges to require the start cell to be the top-left corner
- add unit coverage that inverted ranges throw an ArgumentException

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d53ad4611c832ea9daa4dc1bd4f2be