### PR TITLE
Extend Excel preflight cleanup for empty containers

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.Preflight.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Preflight.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.Excel {
@@ -19,6 +20,41 @@ namespace OfficeIMO.Excel {
                 var merges = ws.Elements<MergeCells>().FirstOrDefault();
                 if (merges != null && !merges.Elements<MergeCell>().Any()) {
                     ws.RemoveChild(merges);
+                }
+
+                // Remove empty DataValidations containers
+                var dataValidations = ws.Elements<DataValidations>().FirstOrDefault();
+                if (dataValidations != null) {
+                    var validationCount = dataValidations.Elements<DataValidation>().Count();
+                    if (validationCount == 0) {
+                        ws.RemoveChild(dataValidations);
+                    } else {
+                        dataValidations.SetAttribute(new OpenXmlAttribute("count", string.Empty, validationCount.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+                    }
+                }
+
+                // Remove empty IgnoredErrors containers
+                var ignoredErrors = ws.Elements<IgnoredErrors>().FirstOrDefault();
+                if (ignoredErrors != null) {
+                    var errorCount = ignoredErrors.Elements<IgnoredError>().Count();
+                    if (errorCount == 0) {
+                        ws.RemoveChild(ignoredErrors);
+                    } else {
+                        ignoredErrors.SetAttribute(new OpenXmlAttribute("count", string.Empty, errorCount.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+                    }
+                }
+
+                // Remove empty CustomSheetViews containers
+                var customSheetViews = ws.Elements<CustomSheetViews>().FirstOrDefault();
+                if (customSheetViews != null && !customSheetViews.Elements<CustomSheetView>().Any()) {
+                    ws.RemoveChild(customSheetViews);
+                }
+
+                // Remove empty ConditionalFormatting entries
+                foreach (var conditional in ws.Elements<ConditionalFormatting>().ToList()) {
+                    if (!conditional.Elements<ConditionalFormattingRule>().Any()) {
+                        conditional.Remove();
+                    }
                 }
 
                 // Drop orphaned Drawing reference


### PR DESCRIPTION
## Summary
- remove empty DataValidations, IgnoredErrors, CustomSheetViews, and ConditionalFormatting entries during worksheet preflight
- synchronize DataValidations/IgnoredErrors counts when children remain
- add regression coverage ensuring empty containers are stripped before save

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d538c1a204832eb0ca6dac434738ac