### PR TITLE
Ensure Excel saves create missing directories

### DIFF
--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -786,13 +786,12 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
-            DirectoryInfo directoryInfo;
-            if (Directory.Exists(directory)) {
-                directoryInfo = new DirectoryInfo(directory);
-            } else {
-                directoryInfo = Directory.CreateDirectory(directory);
+            if (!Directory.Exists(directory)) {
+                Directory.CreateDirectory(directory);
+                return;
             }
 
+            var directoryInfo = new DirectoryInfo(directory);
             if (directoryInfo.Attributes.HasFlag(FileAttributes.ReadOnly)) {
                 throw new IOException($"Failed to save to '{path}'. The directory is read-only.");
             }

--- a/OfficeIMO.Tests/Excel.SaveMissingDirectory.cs
+++ b/OfficeIMO.Tests/Excel.SaveMissingDirectory.cs
@@ -16,12 +16,21 @@ namespace OfficeIMO.Tests {
             if (Directory.Exists(destinationDirectory)) Directory.Delete(destinationDirectory, recursive: true);
 
             using (var document = ExcelDocument.Create(sourcePath)) {
-                document.AddWorkSheet("Sheet1");
+                const string expectedSheetName = "Sheet1";
+                const string expectedCellValue = "Directory save";
+                var sheet = document.AddWorkSheet(expectedSheetName);
+                sheet.CellValue(1, 1, expectedCellValue);
 
                 document.Save(destinationPath, openExcel: false);
 
                 Assert.True(Directory.Exists(destinationDirectory));
                 Assert.True(File.Exists(destinationPath));
+
+                using (var reloaded = ExcelDocument.Load(destinationPath, readOnly: true)) {
+                    Assert.Equal(expectedSheetName, reloaded.Sheets[0].Name);
+                    Assert.True(reloaded.Sheets[0].TryGetCellText(1, 1, out var actualValue));
+                    Assert.Equal(expectedCellValue, actualValue);
+                }
             }
 
             if (File.Exists(sourcePath)) File.Delete(sourcePath);
@@ -39,12 +48,21 @@ namespace OfficeIMO.Tests {
             if (Directory.Exists(destinationDirectory)) Directory.Delete(destinationDirectory, recursive: true);
 
             await using (var document = ExcelDocument.Create(sourcePath)) {
-                document.AddWorkSheet("Sheet1");
+                const string expectedSheetName = "AsyncSheet";
+                const string expectedCellValue = "Async directory save";
+                var sheet = document.AddWorkSheet(expectedSheetName);
+                sheet.CellValue(1, 1, expectedCellValue);
 
                 await document.SaveAsync(destinationPath, openExcel: false);
 
                 Assert.True(Directory.Exists(destinationDirectory));
                 Assert.True(File.Exists(destinationPath));
+
+                using (var reloaded = ExcelDocument.Load(destinationPath, readOnly: true)) {
+                    Assert.Equal(expectedSheetName, reloaded.Sheets[0].Name);
+                    Assert.True(reloaded.Sheets[0].TryGetCellText(1, 1, out var actualValue));
+                    Assert.Equal(expectedCellValue, actualValue);
+                }
             }
 
             if (File.Exists(sourcePath)) File.Delete(sourcePath);


### PR DESCRIPTION
## Summary
- ensure Excel saves create the destination folder when missing before writing the workbook
- expand Save/SaveAsync tests to verify saving into non-existent subdirectories produces readable workbooks

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d53ae67be4832ea18e12526d05418d