### PR TITLE
Handle blank sheet header lookups

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.Headers.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.cs
@@ -23,16 +23,16 @@ namespace OfficeIMO.Excel {
                 var sh = rdr.GetSheet(this.Name);
                 var values = sh.ReadRange(a1Used);
 
-                int rows = values.GetLength(0);
-                int cols = values.GetLength(1);
-                var map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-                if (rows == 0 || cols == 0) {
-                    _headerMapCache = map;
+                if (values.GetLength(0) == 0 || values.GetLength(1) == 0) {
+                    var empty = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                    _headerMapCache = empty;
                     _headerMapSourceA1 = a1Used;
                     _headerMapNormalize = opt.NormalizeHeaders;
                     return new Dictionary<string, int>(_headerMapCache, StringComparer.OrdinalIgnoreCase);
                 }
 
+                int cols = values.GetLength(1);
+                var map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
                 var (_, c1, _, _) = A1.ParseRange(a1Used);
                 var headers = new string?[cols];
                 bool anyHeader = false;

--- a/OfficeIMO.Tests/Excel.HeaderLookup.BlankSheet.cs
+++ b/OfficeIMO.Tests/Excel.HeaderLookup.BlankSheet.cs
@@ -31,11 +31,13 @@ namespace OfficeIMO.Tests
                 Assert.Empty(headers);
 
                 Assert.Throws<KeyNotFoundException>(() => sheet.ColumnIndexByHeader("Missing"));
+                Assert.Throws<KeyNotFoundException>(() => sheet.ColumnIndexByHeader("Column1"));
 
                 Assert.False(sheet.TryGetColumnIndexByHeader("Missing", out var columnIndex));
                 Assert.Equal(0, columnIndex);
 
-                Assert.False(sheet.TryGetColumnIndexByHeader("Column1", out _));
+                Assert.False(sheet.TryGetColumnIndexByHeader("Column1", out var column1Index));
+                Assert.Equal(0, column1Index);
             }
             finally
             {


### PR DESCRIPTION
## Summary
- guard header map creation when the used range has no rows or columns
- add blank sheet coverage for ColumnIndexByHeader and TryGetColumnIndexByHeader

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d53adedeb4832eba3256e76d98c66a