### PR TITLE
Write integer cell values without double coercion

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -82,27 +82,27 @@ namespace OfficeIMO.Excel {
 
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, uint value) {
-            CellValue(row, column, (double)value);
+            WriteLockConditional(() => CellValueCore(row, column, value));
         }
 
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, ulong value) {
-            CellValue(row, column, (double)value);
+            WriteLockConditional(() => CellValueCore(row, column, value));
         }
 
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, ushort value) {
-            CellValue(row, column, (double)value);
+            WriteLockConditional(() => CellValueCore(row, column, value));
         }
 
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, byte value) {
-            CellValue(row, column, (double)value);
+            WriteLockConditional(() => CellValueCore(row, column, value));
         }
 
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, sbyte value) {
-            CellValue(row, column, (double)value);
+            WriteLockConditional(() => CellValueCore(row, column, value));
         }
 
         /// <inheritdoc cref="CellValue(int,int,object)" />


### PR DESCRIPTION
## Summary
- update the integer Excel cell-value overloads to invoke `CellValueCore` directly and avoid double conversions
- add a regression test to ensure large signed and unsigned integers serialize without precision loss

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d54ccafaf0832e95129b0e1852914e