### PR TITLE
Handle missing Excel headers without throwing

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.Headers.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.cs
@@ -65,18 +65,8 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
-        /// Returns a 1-based column index for a given header; throws when not found.
-        /// </summary>
-        public int ColumnIndexByHeader(string header, ExcelReadOptions? options = null) {
-            if (string.IsNullOrWhiteSpace(header)) throw new ArgumentNullException(nameof(header));
-            var map = GetHeaderMap(options);
-            if (!map.TryGetValue(header, out var idx))
-                throw new KeyNotFoundException($"Header '{header}' not found.");
-            return idx;
-        }
-
-        /// <summary>
-        /// Tries to resolve a 1-based column index for a given header. Returns false without throwing when the header cannot be found.
+        /// Tries to resolve a 1-based column index for a given header.
+        /// Returns false without throwing when the header cannot be found or the input is invalid.
         /// </summary>
         public bool TryGetColumnIndexByHeader(string header, out int columnIndex, ExcelReadOptions? options = null) {
             if (string.IsNullOrWhiteSpace(header)) {

--- a/OfficeIMO.Tests/Excel.HeaderLookup.BlankSheet.cs
+++ b/OfficeIMO.Tests/Excel.HeaderLookup.BlankSheet.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using OfficeIMO.Excel;
 using Xunit;
 
@@ -30,12 +29,17 @@ namespace OfficeIMO.Tests
                 var headers = sheet.GetHeaderMap();
                 Assert.Empty(headers);
 
-                Assert.Throws<KeyNotFoundException>(() => sheet.ColumnIndexByHeader("Missing"));
-
                 Assert.False(sheet.TryGetColumnIndexByHeader("Missing", out var columnIndex));
                 Assert.Equal(0, columnIndex);
 
                 Assert.False(sheet.TryGetColumnIndexByHeader("Column1", out _));
+
+                Assert.Null(Record.Exception(() => sheet.SetByHeader(2, "Missing", "Value")));
+                Assert.Null(Record.Exception(() => sheet.LinkByHeaderToInternalSheets("Missing")));
+                Assert.False(sheet.TryLinkByHeaderToInternalSheets("Missing"));
+                Assert.Null(Record.Exception(() => sheet.AutoFilterByHeaderEquals("Missing", new[] { "v" })));
+                Assert.Null(Record.Exception(() => sheet.AutoFilterByHeaderContains("Missing", "v")));
+                Assert.Null(Record.Exception(() => sheet.AutoFilterByHeadersEquals(("Missing", new[] { "v" }))));
             }
             finally
             {


### PR DESCRIPTION
## Summary
- remove the throwing `ColumnIndexByHeader` helper and document the non-throwing `TryGetColumnIndexByHeader`
- expand blank sheet tests to cover header-based helpers gracefully skipping missing headers

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d54cbe5a48832e8a4e8a9041436682