### PR TITLE
Handle DataTable nulls as explicit blanks

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -7,7 +7,7 @@ namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
 
         // Core implementation: single source of truth (no locks here)
-        private void CellValueCore(int row, int column, object value) {
+        private void CellValueCore(int row, int column, object? value) {
             var (cellValue, dataType) = CoerceForCell(value);
             bool wroteNumber = dataType?.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.Number;
 
@@ -33,7 +33,7 @@ namespace OfficeIMO.Excel {
         }
 
         // Core coercion logic shared between sequential and parallel operations
-        private (CellValue cellValue, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues> dataType) CoerceForCell(object value) {
+        private (CellValue cellValue, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues> dataType) CoerceForCell(object? value) {
             var dateTimeOffsetStrategy = _excelDocument.DateTimeOffsetWriteStrategy;
             var (cellValue, cellType) = CoerceValueHelper.Coerce(
                 value,
@@ -682,7 +682,7 @@ namespace OfficeIMO.Excel {
         /// <param name="row">The 1-based row index.</param>
         /// <param name="column">The 1-based column index.</param>
         /// <param name="value">The value to assign.</param>
-        public void CellValue(int row, int column, object value) {
+        public void CellValue(int row, int column, object? value) {
             WriteLockConditional(() => CellValueCore(row, column, value));
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -74,7 +74,7 @@ namespace OfficeIMO.Excel {
         /// Compute-only coercion for parallel scenarios. Does not mutate DOM.
         /// Uses <see cref="SharedStringPlanner"/> for string values.
         /// </summary>
-        private (CellValue cellValue, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues> dataType) CoerceForCellNoDom(object value, SharedStringPlanner planner) {
+        private (CellValue cellValue, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues> dataType) CoerceForCellNoDom(object? value, SharedStringPlanner planner) {
             var dateTimeOffsetStrategy = _excelDocument.DateTimeOffsetWriteStrategy;
             var (cellValue, cellType) = CoerceValueHelper.Coerce(
                 value,

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.cs
@@ -24,7 +24,7 @@ namespace OfficeIMO.Excel {
             if (startColumn < 1) throw new ArgumentOutOfRangeException(nameof(startColumn));
 
             // Prepare a flat list of cells and optional number formats
-            var cells = new List<(int Row, int Col, object Val, string? NumFmt)>(
+            var cells = new List<(int Row, int Col, object? Val, string? NumFmt)>(
                 (table.Rows.Count + (includeHeaders ? 1 : 0)) * Math.Max(1, table.Columns.Count));
 
             int row = startRow;
@@ -38,7 +38,7 @@ namespace OfficeIMO.Excel {
             foreach (DataRow dr in table.Rows) {
                 for (int c = 0; c < table.Columns.Count; c++) {
                     var col = table.Columns[c];
-                    object value = dr.IsNull(c) ? string.Empty : dr[c];
+                    object? value = dr.IsNull(c) ? null : dr[c];
                     string? fmt = null;
                     var t = col.DataType;
                     if (t == typeof(DateTime) || t == typeof(DateTimeOffset)) {

--- a/OfficeIMO.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Tests/Excel.DataTableInsert.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Data;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    /// <summary>
+    /// Tests for inserting DataTable content with mixed null values.
+    /// </summary>
+    public partial class Excel {
+        [Fact]
+        public void Test_InsertDataTable_BlanksMaintainNumericAndDateTypes() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableNulls.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+
+                var table = new DataTable();
+                table.Columns.Add("Id", typeof(int));
+                table.Columns.Add("Amount", typeof(double));
+                table.Columns.Add("Date", typeof(DateTime));
+
+                table.Rows.Add(1, 10.5, new DateTime(2024, 1, 1));
+
+                var second = table.NewRow();
+                second["Id"] = 2;
+                second["Amount"] = DBNull.Value;
+                second["Date"] = new DateTime(2024, 1, 2);
+                table.Rows.Add(second);
+
+                var third = table.NewRow();
+                third["Id"] = 3;
+                third["Amount"] = 5.75;
+                third["Date"] = DBNull.Value;
+                table.Rows.Add(third);
+
+                sheet.InsertDataTable(table, includeHeaders: true);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                var cells = worksheetPart.Worksheet.Descendants<Cell>().ToList();
+
+                Cell GetCell(string reference) {
+                    return cells.First(c => c.CellReference == reference);
+                }
+
+                var amountRow2 = GetCell("B2");
+                Assert.Equal(CellValues.Number, amountRow2.DataType!.Value);
+                Assert.Equal(10.5.ToString(CultureInfo.InvariantCulture), amountRow2.CellValue!.Text);
+
+                var dateRow2 = GetCell("C2");
+                Assert.Equal(CellValues.Number, dateRow2.DataType!.Value);
+                Assert.Equal(new DateTime(2024, 1, 1).ToOADate().ToString(CultureInfo.InvariantCulture), dateRow2.CellValue!.Text);
+
+                var amountRow3 = GetCell("B3");
+                Assert.Equal(CellValues.String, amountRow3.DataType!.Value);
+                Assert.True(string.IsNullOrEmpty(amountRow3.CellValue!.Text));
+
+                var dateRow3 = GetCell("C3");
+                Assert.Equal(CellValues.Number, dateRow3.DataType!.Value);
+                Assert.Equal(new DateTime(2024, 1, 2).ToOADate().ToString(CultureInfo.InvariantCulture), dateRow3.CellValue!.Text);
+
+                var amountRow4 = GetCell("B4");
+                Assert.Equal(CellValues.Number, amountRow4.DataType!.Value);
+                Assert.Equal(5.75.ToString(CultureInfo.InvariantCulture), amountRow4.CellValue!.Text);
+
+                var dateRow4 = GetCell("C4");
+                Assert.Equal(CellValues.String, dateRow4.DataType!.Value);
+                Assert.True(string.IsNullOrEmpty(dateRow4.CellValue!.Text));
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure DataTable insertion pushes nulls so blank cells are written instead of shared strings
- allow cell coercion helpers to accept nullable values when writing
- add regression coverage confirming numeric and date columns keep number typing alongside nulls

## Testing
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d54caf62d0832eb2f355c729f3b3e0