### PR TITLE
Refine PowerPoint picture image type handling

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/UpdatePicturePowerPoint.cs
+++ b/OfficeIMO.Examples/PowerPoint/UpdatePicturePowerPoint.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.PowerPoint;
 
 namespace OfficeIMO.Examples.PowerPoint {

--- a/OfficeIMO.PowerPoint/ImagePartType.cs
+++ b/OfficeIMO.PowerPoint/ImagePartType.cs
@@ -1,0 +1,15 @@
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    /// Supported image part formats for PowerPoint operations.
+    /// </summary>
+    public enum ImagePartType {
+        /// <summary>Portable Network Graphics image.</summary>
+        Png,
+        /// <summary>JPEG image.</summary>
+        Jpeg,
+        /// <summary>Graphics Interchange Format image.</summary>
+        Gif,
+        /// <summary>Bitmap image.</summary>
+        Bmp,
+    }
+}

--- a/OfficeIMO.PowerPoint/ImagePartTypeExtensions.cs
+++ b/OfficeIMO.PowerPoint/ImagePartTypeExtensions.cs
@@ -1,0 +1,15 @@
+using System;
+using DocumentFormat.OpenXml.Packaging;
+using OpenXmlImagePartType = DocumentFormat.OpenXml.Packaging.ImagePartType;
+
+namespace OfficeIMO.PowerPoint {
+    internal static class ImagePartTypeExtensions {
+        public static PartTypeInfo ToPartTypeInfo(this ImagePartType type) => type switch {
+            ImagePartType.Png => OpenXmlImagePartType.Png,
+            ImagePartType.Jpeg => OpenXmlImagePartType.Jpeg,
+            ImagePartType.Gif => OpenXmlImagePartType.Gif,
+            ImagePartType.Bmp => OpenXmlImagePartType.Bmp,
+            _ => throw new NotSupportedException($"Image type {type} is not supported."),
+        };
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointPicture.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPicture.cs
@@ -34,17 +34,12 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         /// <param name="newImage">Stream containing the new image data.</param>
         /// <param name="type">Image format of the new image.</param>
-        public void UpdateImage(Stream newImage, PartTypeInfo type) {
+        public void UpdateImage(Stream newImage, ImagePartType type) {
             if (newImage == null) {
                 throw new ArgumentNullException(nameof(newImage));
             }
 
-            if (type != ImagePartType.Png &&
-                type != ImagePartType.Jpeg &&
-                type != ImagePartType.Gif &&
-                type != ImagePartType.Bmp) {
-                throw new NotSupportedException($"Image type {type} is not supported.");
-            }
+            PartTypeInfo partTypeInfo = type.ToPartTypeInfo();
 
             Picture picture = (Picture)Element;
             A.Blip blip = picture.BlipFill?.Blip ?? throw new InvalidOperationException("Picture has no image");
@@ -56,7 +51,7 @@ namespace OfficeIMO.PowerPoint {
                 }
             }
 
-            ImagePart imagePart = _slidePart.AddImagePart(type);
+            ImagePart imagePart = _slidePart.AddImagePart(partTypeInfo);
             newImage.Position = 0;
             imagePart.FeedData(newImage);
             string relId = _slidePart.GetIdOfPart(imagePart);

--- a/OfficeIMO.PowerPoint/PowerPointSlide.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.cs
@@ -324,7 +324,7 @@ namespace OfficeIMO.PowerPoint {
                 throw new FileNotFoundException("Image file not found.", imagePath);
             }
 
-            ImagePart imagePart = _slidePart.AddImagePart(ImagePartType.Png);
+            ImagePart imagePart = _slidePart.AddImagePart(ImagePartType.Png.ToPartTypeInfo());
             using FileStream stream = new(imagePath, FileMode.Open, FileAccess.Read);
             imagePart.FeedData(stream);
             string relationshipId = _slidePart.GetIdOfPart(imagePart);

--- a/OfficeIMO.Tests/PowerPoint.PictureUpdate.cs
+++ b/OfficeIMO.Tests/PowerPoint.PictureUpdate.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.PowerPoint;
 using Xunit;
 
@@ -16,7 +15,7 @@ namespace OfficeIMO.Tests {
 
         [Theory]
         [MemberData(nameof(ImageData))]
-        public void CanUpdatePicture(string newImage, PartTypeInfo type, string expectedContentType) {
+        public void CanUpdatePicture(string newImage, ImagePartType type, string expectedContentType) {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
             string originalImage = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", "BackgroundImage.png");
             string newImagePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", newImage);


### PR DESCRIPTION
## Summary
- add a PowerPoint-focused `ImagePartType` enum and conversion helper to map to Open XML part types
- update picture replacement logic and slide default picture creation to use the new enum values
- exercise multiple image formats in the PowerPoint picture update test

## Testing
- dotnet test OfficeIMO.Tests --filter PowerPointPictureUpdate

------
https://chatgpt.com/codex/tasks/task_e_68d54c7724e4832e835fc01f22808a10