### PR TITLE
Add default slide layouts and extend theme tests

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointUtils.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.cs
@@ -310,7 +310,17 @@ namespace OfficeIMO.PowerPoint {
                     new D.Paragraph(new D.EndParagraphRunProperties { Language = "en-US" }))); 
         }
 
-        private readonly record struct SlideLayoutDefinition(string RelationshipId, uint LayoutId, Func<SlideLayout> CreateLayout);
+        private readonly struct SlideLayoutDefinition {
+            public SlideLayoutDefinition(string relationshipId, uint layoutId, Func<SlideLayout> createLayout) {
+                RelationshipId = relationshipId;
+                LayoutId = layoutId;
+                CreateLayout = createLayout;
+            }
+
+            public string RelationshipId { get; }
+            public uint LayoutId { get; }
+            public Func<SlideLayout> CreateLayout { get; }
+        }
 
         private static void CreatePresentationPropertiesPart(PresentationPart presentationPart) {
             PresentationPropertiesPart part = presentationPart.PresentationPropertiesPart ?? presentationPart.AddNewPart<PresentationPropertiesPart>("rId3");

--- a/OfficeIMO.PowerPoint/PowerPointUtils.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.cs
@@ -1,6 +1,9 @@
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Xml.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Drawing;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
@@ -52,6 +55,7 @@ namespace OfficeIMO.PowerPoint {
             themePart1 = CreateTheme(slideMasterPart1);
 
             slideMasterPart1.AddPart(slideLayoutPart1, "rId1");
+            CreateAdditionalSlideLayouts(slideMasterPart1, slideLayoutPart1);
 
             CreatePresentationPropertiesPart(presentationPart);
             CreateViewPropertiesPart(presentationPart);
@@ -180,15 +184,7 @@ namespace OfficeIMO.PowerPoint {
 
         private static SlideLayoutPart CreateSlideLayoutPart(SlidePart slidePart1) {
             SlideLayoutPart slideLayoutPart1 = slidePart1.AddNewPart<SlideLayoutPart>("rId1");
-            SlideLayout slideLayout = new SlideLayout(
-            new CommonSlideData(new ShapeTree(
-              new P.NonVisualGroupShapeProperties(
-              new P.NonVisualDrawingProperties() { Id = (UInt32Value)1U, Name = "" },
-              new P.NonVisualGroupShapeDrawingProperties(),
-              new ApplicationNonVisualDrawingProperties()),
-              new GroupShapeProperties(new TransformGroup()))),
-            new ColorMapOverride(new MasterColorMapping()));
-            slideLayoutPart1.SlideLayout = slideLayout;
+            slideLayoutPart1.SlideLayout = CreateTitleSlideLayout();
             return slideLayoutPart1;
         }
 
@@ -208,6 +204,113 @@ namespace OfficeIMO.PowerPoint {
 
             return slideMasterPart1;
         }
+
+        private static void CreateAdditionalSlideLayouts(SlideMasterPart slideMasterPart, SlideLayoutPart initialLayoutPart) {
+            List<(SlideLayoutPart Part, string RelationshipId, uint LayoutId)> layoutEntries = new();
+
+            string initialRelationshipId = slideMasterPart.GetIdOfPart(initialLayoutPart);
+            layoutEntries.Add((initialLayoutPart, initialRelationshipId, 2147483649U));
+
+            foreach (SlideLayoutDefinition definition in GetDefaultSlideLayoutDefinitions()) {
+                SlideLayoutPart layoutPart = slideMasterPart.AddNewPart<SlideLayoutPart>(definition.RelationshipId);
+                layoutPart.SlideLayout = definition.CreateLayout();
+                layoutEntries.Add((layoutPart, definition.RelationshipId, definition.LayoutId));
+            }
+
+            SlideLayoutIdList slideLayoutIdList = slideMasterPart.SlideMaster.SlideLayoutIdList ?? new SlideLayoutIdList();
+            slideLayoutIdList.RemoveAllChildren<SlideLayoutId>();
+
+            foreach ((SlideLayoutPart Part, string RelationshipId, uint LayoutId) entry in layoutEntries) {
+                slideLayoutIdList.Append(new SlideLayoutId() { Id = (UInt32Value)entry.LayoutId, RelationshipId = entry.RelationshipId });
+            }
+
+            slideMasterPart.SlideMaster.SlideLayoutIdList = slideLayoutIdList;
+        }
+
+        private static IEnumerable<SlideLayoutDefinition> GetDefaultSlideLayoutDefinitions() {
+            yield return new SlideLayoutDefinition("rId2", 2147483650U, CreateTitleAndContentLayout);
+            yield return new SlideLayoutDefinition("rId3", 2147483651U, CreateSectionHeaderLayout);
+            yield return new SlideLayoutDefinition("rId4", 2147483652U, CreateTwoContentLayout);
+            yield return new SlideLayoutDefinition("rId6", 2147483653U, CreateTitleOnlyLayout);
+            yield return new SlideLayoutDefinition("rId7", 2147483654U, CreateBlankLayout);
+        }
+
+        private static SlideLayout CreateTitleSlideLayout() {
+            P.Shape titleShape = CreateLayoutPlaceholderShape(2U, "Title Placeholder 1", PlaceholderValues.Title, 0U, 838200L, 365125L, 7772400L, 1470025L);
+            P.Shape subtitleShape = CreateLayoutPlaceholderShape(3U, "Subtitle Placeholder 2", PlaceholderValues.SubTitle, 1U, 838200L, 2174875L, 7772400L, 1470025L);
+
+            return CreateSlideLayout("Title Slide", SlideLayoutValues.Title, titleShape, subtitleShape);
+        }
+
+        private static SlideLayout CreateTitleAndContentLayout() {
+            P.Shape titleShape = CreateLayoutPlaceholderShape(2U, "Title Placeholder 1", PlaceholderValues.Title, 0U, 838200L, 365125L, 7772400L, 1470025L);
+            P.Shape contentShape = CreateLayoutPlaceholderShape(3U, "Content Placeholder 2", PlaceholderValues.Body, 1U, 838200L, 2174875L, 7772400L, 3962400L);
+
+            return CreateSlideLayout("Title and Content", SlideLayoutValues.Text, titleShape, contentShape);
+        }
+
+        private static SlideLayout CreateSectionHeaderLayout() {
+            P.Shape titleShape = CreateLayoutPlaceholderShape(2U, "Section Header Title 1", PlaceholderValues.CenteredTitle, 0U, 838200L, 365125L, 7772400L, 1470025L);
+            P.Shape contentShape = CreateLayoutPlaceholderShape(3U, "Section Header Text 2", PlaceholderValues.Body, 1U, 838200L, 2174875L, 7772400L, 1470025L);
+
+            return CreateSlideLayout("Section Header", SlideLayoutValues.SectionHeader, titleShape, contentShape);
+        }
+
+        private static SlideLayout CreateTwoContentLayout() {
+            P.Shape titleShape = CreateLayoutPlaceholderShape(2U, "Two Content Title 1", PlaceholderValues.Title, 0U, 838200L, 365125L, 7772400L, 1470025L);
+            P.Shape leftContent = CreateLayoutPlaceholderShape(3U, "Content Placeholder 2", PlaceholderValues.Body, 1U, 685800L, 2174875L, 3657600L, 3962400L);
+            P.Shape rightContent = CreateLayoutPlaceholderShape(4U, "Content Placeholder 3", PlaceholderValues.Body, 2U, 4127500L, 2174875L, 3657600L, 3962400L);
+
+            return CreateSlideLayout("Two Content", SlideLayoutValues.TwoColumnText, titleShape, leftContent, rightContent);
+        }
+
+        private static SlideLayout CreateTitleOnlyLayout() {
+            P.Shape titleShape = CreateLayoutPlaceholderShape(2U, "Title Placeholder 1", PlaceholderValues.Title, 0U, 838200L, 365125L, 7772400L, 1470025L);
+
+            return CreateSlideLayout("Title Only", SlideLayoutValues.TitleOnly, titleShape);
+        }
+
+        private static SlideLayout CreateBlankLayout() {
+            return CreateSlideLayout("Blank", SlideLayoutValues.Blank);
+        }
+
+        private static SlideLayout CreateSlideLayout(string name, SlideLayoutValues layoutType, params OpenXmlElement[] shapes) {
+            P.ShapeTree shapeTree = new(
+                new P.NonVisualGroupShapeProperties(
+                    new P.NonVisualDrawingProperties() { Id = 1U, Name = "" },
+                    new P.NonVisualGroupShapeDrawingProperties(),
+                    new ApplicationNonVisualDrawingProperties()),
+                new P.GroupShapeProperties(new D.TransformGroup()));
+
+            foreach (OpenXmlElement shape in shapes) {
+                shapeTree.Append(shape);
+            }
+
+            return new SlideLayout(
+                new CommonSlideData(shapeTree) { Name = name },
+                new ColorMapOverride(new MasterColorMapping())) { Type = layoutType };
+        }
+
+        private static P.Shape CreateLayoutPlaceholderShape(uint id, string name, PlaceholderValues type, uint index, long left, long top, long width, long height) {
+            PlaceholderShape placeholderShape = new() { Type = type, Index = index };
+
+            return new P.Shape(
+                new P.NonVisualShapeProperties(
+                    new P.NonVisualDrawingProperties { Id = id, Name = name },
+                    new P.NonVisualShapeDrawingProperties(new D.ShapeLocks { NoGrouping = true }),
+                    new ApplicationNonVisualDrawingProperties(placeholderShape)),
+                new P.ShapeProperties(
+                    new D.Transform2D(
+                        new D.Offset { X = left, Y = top },
+                        new D.Extents { Cx = width, Cy = height }),
+                    new D.PresetGeometry(new D.AdjustValueList()) { Preset = D.ShapeTypeValues.Rectangle }),
+                new P.TextBody(
+                    new D.BodyProperties(),
+                    new D.ListStyle(),
+                    new D.Paragraph(new D.EndParagraphRunProperties { Language = "en-US" }))); 
+        }
+
+        private readonly record struct SlideLayoutDefinition(string RelationshipId, uint LayoutId, Func<SlideLayout> CreateLayout);
 
         private static void CreatePresentationPropertiesPart(PresentationPart presentationPart) {
             PresentationPropertiesPart part = presentationPart.PresentationPropertiesPart ?? presentationPart.AddNewPart<PresentationPropertiesPart>("rId3");

--- a/OfficeIMO.Tests/PowerPoint.ThemeAndLayout.cs
+++ b/OfficeIMO.Tests/PowerPoint.ThemeAndLayout.cs
@@ -1,27 +1,65 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
 using OfficeIMO.PowerPoint;
 using Xunit;
 
 namespace OfficeIMO.Tests {
     public class PowerPointThemeAndLayout {
-        [Fact(Skip = "Doesn't work after changes to PowerPoint")]
+        [Fact]
         public void CanSetThemeAndSelectLayout() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            List<SlideLayoutValues> expectedLayouts = new() {
+                SlideLayoutValues.Title,
+                SlideLayoutValues.Text,
+                SlideLayoutValues.SectionHeader,
+                SlideLayoutValues.TwoColumnText,
+                SlideLayoutValues.TitleOnly,
+                SlideLayoutValues.Blank
+            };
 
             using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
                 Assert.Equal("Office Theme", presentation.ThemeName);
                 presentation.ThemeName = "My Theme";
+                Assert.Single(presentation.Slides);
+                Assert.Equal(0, presentation.Slides[0].LayoutIndex);
+
+                // Consume the initial slide so subsequent calls create new slides.
                 presentation.AddSlide();
-                presentation.AddSlide(layoutIndex: 1);
+
+                for (int i = 1; i < expectedLayouts.Count; i++) {
+                    PowerPointSlide slide = presentation.AddSlide(layoutIndex: i);
+                    Assert.Equal(i, slide.LayoutIndex);
+                }
+
+                Assert.Equal(expectedLayouts.Count, presentation.Slides.Count);
                 presentation.Save();
             }
 
             using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
                 Assert.Equal("My Theme", presentation.ThemeName);
-                Assert.Equal(2, presentation.Slides.Count);
-                Assert.Equal(0, presentation.Slides[0].LayoutIndex);
-                Assert.Equal(1, presentation.Slides[1].LayoutIndex);
+                Assert.Equal(expectedLayouts.Count, presentation.Slides.Count);
+
+                for (int i = 0; i < presentation.Slides.Count; i++) {
+                    Assert.Equal(i, presentation.Slides[i].LayoutIndex);
+                }
+            }
+
+            using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                SlideMasterPart masterPart = document.PresentationPart!.SlideMasterParts.First();
+                SlideLayoutPart[] layoutParts = masterPart.SlideLayoutParts.ToArray();
+
+                Assert.Equal(expectedLayouts.Count, layoutParts.Length);
+
+                SlideLayoutIdList layoutIdList = masterPart.SlideMaster.SlideLayoutIdList!;
+                for (int i = 0; i < layoutParts.Length; i++) {
+                    Assert.Equal(expectedLayouts[i], layoutParts[i].SlideLayout.Type?.Value);
+                    string relId = masterPart.GetIdOfPart(layoutParts[i]);
+                    Assert.Contains(layoutIdList.Elements<SlideLayoutId>(), id => id.RelationshipId == relId);
+                }
             }
 
             File.Delete(filePath);


### PR DESCRIPTION
## Summary
- add default slide layouts to the slide master and register their IDs
- create reusable helpers for generating placeholder shapes in the default layouts
- extend the PowerPoint theme and layout test to cover all default layouts

## Testing
- dotnet test OfficeIMO.Tests --filter PowerPointThemeAndLayout
- dotnet build OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d54c7cb744832eaa8b8e00a2847441