### PR TITLE
Update Visio validator namespace and add 2012 validation tests

### DIFF
--- a/OfficeIMO.Tests/Visio.VsdxPackageValidatorTests.cs
+++ b/OfficeIMO.Tests/Visio.VsdxPackageValidatorTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioVsdxPackageValidatorTests {
+        private static string CreateSampleVisioDocument() {
+            string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = VisioDocument.Create(path);
+            VisioPage page = document.AddPage("Page-1", 8.5, 11, VisioMeasurementUnit.Inches);
+            page.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "Sample"));
+            document.Save();
+
+            return path;
+        }
+
+        [Fact]
+        public void ValidateFile_FlagsMissingPagesOverride_In2012Package() {
+            string tempPath = CreateSampleVisioDocument();
+            try {
+                var validator = new VsdxPackageValidator();
+                bool result = validator.ValidateFile(tempPath);
+
+                Assert.False(result);
+                Assert.Contains("Missing override for /visio/pages/pages.xml", validator.Errors);
+            } finally {
+                if (File.Exists(tempPath)) {
+                    File.Delete(tempPath);
+                }
+            }
+        }
+
+        [Fact]
+        public void ValidateFileStreaming_Passes_On2012Package() {
+            string tempPath = CreateSampleVisioDocument();
+            try {
+                var validator = new VsdxPackageValidator();
+                bool result = validator.ValidateFileStreaming(tempPath);
+
+                Assert.True(result, string.Join(Environment.NewLine, validator.Errors));
+                Assert.Empty(validator.Errors);
+            } finally {
+                if (File.Exists(tempPath)) {
+                    File.Delete(tempPath);
+                }
+            }
+        }
+
+        [Fact]
+        public void FixFile_CreatesCorrectedPackage_For2012Document() {
+            string inputPath = CreateSampleVisioDocument();
+            string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            try {
+                var validator = new VsdxPackageValidator();
+                bool fixedResult = validator.FixFile(inputPath, outputPath);
+
+                Assert.True(fixedResult);
+                Assert.True(File.Exists(outputPath));
+
+                var postValidator = new VsdxPackageValidator();
+                bool postResult = postValidator.ValidateFile(outputPath);
+                Assert.True(postResult, string.Join(Environment.NewLine, postValidator.Errors));
+                Assert.Empty(postValidator.Errors);
+            } finally {
+                if (File.Exists(inputPath)) {
+                    File.Delete(inputPath);
+                }
+                if (File.Exists(outputPath)) {
+                    File.Delete(outputPath);
+                }
+            }
+        }
+    }
+}
+

--- a/OfficeIMO.Visio/VsdxPackageValidator.cs
+++ b/OfficeIMO.Visio/VsdxPackageValidator.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Visio {
     /// Validates and optionally fixes Visio VSDX packages for common structural issues.
     /// </summary>
     public partial class VsdxPackageValidator {
-        private static readonly XNamespace nsCore = "http://schemas.microsoft.com/office/visio/2011/1/core";
+        private static readonly XNamespace nsCore = "http://schemas.microsoft.com/office/visio/2012/main";
         private static readonly XNamespace nsPkgRel = "http://schemas.openxmlformats.org/package/2006/relationships";
         private static readonly XNamespace nsDocRel = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
         private static readonly XNamespace nsCT = "http://schemas.openxmlformats.org/package/2006/content-types";
@@ -202,8 +202,8 @@ namespace OfficeIMO.Visio {
             var pagesDoc = LoadZipXml(zip, "visio/pages/pages.xml");
             if (pagesDoc?.Root == null) { _errors.Add("Missing or malformed /visio/pages/pages.xml"); return; }
 
-            XNamespace vNs = "http://schemas.microsoft.com/office/visio/2012/main";
-            XNamespace rNs = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+            XNamespace vNs = nsCore;
+            XNamespace rNs = nsDocRel;
 
             var pages = pagesDoc.Root.Elements(vNs + "Page").ToList();
             if (pages.Count == 0) {


### PR DESCRIPTION
## Summary
- align `VsdxPackageValidator` with the Visio 2012 namespace and reuse the shared namespace constants inside streaming validation
- add focused tests that exercise validator paths (validate, streaming, fix) against generated Visio 2012 packages

## Testing
- dotnet build OfficeImo.sln
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~VisioVsdxPackageValidatorTests"

------
https://chatgpt.com/codex/tasks/task_e_68d54e210d48832e9782b5756785f638