### PR TITLE
Ensure positive Visio view scale defaults

### DIFF
--- a/OfficeIMO.Tests/Visio.AssetPagesOnly.cs
+++ b/OfficeIMO.Tests/Visio.AssetPagesOnly.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
 using OfficeIMO.Visio;
 using Xunit;
@@ -36,7 +37,14 @@ namespace OfficeIMO.Tests {
             XNamespace v = "http://schemas.microsoft.com/office/visio/2012/main";
             var ePage = exp.Root!.Element(v + "Page")!;
             var aPage = act.Root!.Element(v + "Page")!;
-            Assert.Equal((string?)ePage.Attribute("ViewScale"), (string?)aPage.Attribute("ViewScale"));
+            string? expectedViewScaleAttr = ePage.Attribute("ViewScale")?.Value;
+            string? actualViewScaleAttr = aPage.Attribute("ViewScale")?.Value;
+            double expectedViewScale = expectedViewScaleAttr != null ? XmlConvert.ToDouble(expectedViewScaleAttr) : 1;
+            double actualViewScale = actualViewScaleAttr != null ? XmlConvert.ToDouble(actualViewScaleAttr) : 1;
+            if (double.IsNaN(expectedViewScale) || double.IsInfinity(expectedViewScale) || expectedViewScale <= 0) {
+                expectedViewScale = 1;
+            }
+            Assert.Equal(expectedViewScale, actualViewScale);
             Assert.Equal((string?)ePage.Attribute("ViewCenterX"), (string?)aPage.Attribute("ViewCenterX"));
             Assert.Equal((string?)ePage.Attribute("ViewCenterY"), (string?)aPage.Attribute("ViewCenterY"));
             var eCells = ePage.Element(v + "PageSheet")!.Elements(v + "Cell").ToDictionary(c => (string)c.Attribute("N")!, c => (val: (string?)c.Attribute("V"), unit: (string?)c.Attribute("U")));
@@ -71,7 +79,11 @@ namespace OfficeIMO.Tests {
             XNamespace v = "http://schemas.microsoft.com/office/visio/2012/main";
             var ePage = exp.Root!.Element(v + "Page")!;
             var aPage = act.Root!.Element(v + "Page")!;
-            Assert.Equal((string?)ePage.Attribute("ViewScale"), (string?)aPage.Attribute("ViewScale"));
+            string? expectedViewScaleAttr = ePage.Attribute("ViewScale")?.Value;
+            string? actualViewScaleAttr = aPage.Attribute("ViewScale")?.Value;
+            Assert.NotNull(expectedViewScaleAttr);
+            Assert.NotNull(actualViewScaleAttr);
+            Assert.Equal(XmlConvert.ToDouble(expectedViewScaleAttr), XmlConvert.ToDouble(actualViewScaleAttr));
             Assert.Equal((string?)ePage.Attribute("ViewCenterX"), (string?)aPage.Attribute("ViewCenterX"));
             Assert.Equal((string?)ePage.Attribute("ViewCenterY"), (string?)aPage.Attribute("ViewCenterY"));
             var eCells = ePage.Element(v + "PageSheet")!.Elements(v + "Cell").ToDictionary(c => (string)c.Attribute("N")!, c => (val: (string?)c.Attribute("V"), unit: (string?)c.Attribute("U")));

--- a/OfficeIMO.Visio/VisioDocument.LoadCore.cs
+++ b/OfficeIMO.Visio/VisioDocument.LoadCore.cs
@@ -80,7 +80,13 @@ namespace OfficeIMO.Visio {
                 int pageId = int.TryParse(pageRef.Attribute("ID")?.Value, out int tmp) ? tmp : document.Pages.Count;
                 VisioPage page = document.AddPage(name, id: pageId);
                 page.NameU = pageRef.Attribute("NameU")?.Value ?? name;
-                page.ViewScale = ParseDouble(pageRef.Attribute("ViewScale")?.Value);
+                string? viewScaleValue = pageRef.Attribute("ViewScale")?.Value;
+                double parsedViewScale = ParseDouble(viewScaleValue);
+                if (double.IsNaN(parsedViewScale) || double.IsInfinity(parsedViewScale) || parsedViewScale <= 0) {
+                    page.ViewScale = 1;
+                } else {
+                    page.ViewScale = parsedViewScale;
+                }
                 page.ViewCenterX = ParseDouble(pageRef.Attribute("ViewCenterX")?.Value);
                 page.ViewCenterY = ParseDouble(pageRef.Attribute("ViewCenterY")?.Value);
 

--- a/OfficeIMO.Visio/VisioDocument.SaveCore.cs
+++ b/OfficeIMO.Visio/VisioDocument.SaveCore.cs
@@ -316,7 +316,11 @@ namespace OfficeIMO.Visio {
                         writer.WriteAttributeString("ID", XmlConvert.ToString(page.Id));
                         writer.WriteAttributeString("Name", page.Name);
                         writer.WriteAttributeString("NameU", page.Name);
-                        writer.WriteAttributeString("ViewScale", XmlConvert.ToString(page.ViewScale));
+                        double viewScale = page.ViewScale;
+                        if (double.IsNaN(viewScale) || double.IsInfinity(viewScale) || viewScale <= 0) {
+                            viewScale = 1;
+                        }
+                        writer.WriteAttributeString("ViewScale", XmlConvert.ToString(viewScale));
                         writer.WriteAttributeString("ViewCenterX", XmlConvert.ToString(page.ViewCenterX));
                         writer.WriteAttributeString("ViewCenterY", XmlConvert.ToString(page.ViewCenterY));
 

--- a/OfficeIMO.Visio/VisioPage.cs
+++ b/OfficeIMO.Visio/VisioPage.cs
@@ -12,6 +12,7 @@ namespace OfficeIMO.Visio {
         private bool _gridVisible;
         private bool _snap = true;
         private VisioMeasurementUnit _defaultUnit = VisioMeasurementUnit.Inches;
+        private double _viewScale = 1;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VisioPage"/> class with default A4 size.
@@ -31,7 +32,6 @@ namespace OfficeIMO.Visio {
             NameU = name;
             _width = widthInches;
             _height = heightInches;
-            ViewScale = -1;
             ViewCenterX = widthInches / 2;
             ViewCenterY = heightInches / 2;
         }
@@ -54,7 +54,16 @@ namespace OfficeIMO.Visio {
         /// <summary>
         /// Gets or sets the view scale of the page.
         /// </summary>
-        public double ViewScale { get; set; }
+        public double ViewScale {
+            get => _viewScale;
+            set {
+                if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0) {
+                    _viewScale = 1;
+                } else {
+                    _viewScale = value;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets or sets the horizontal center of the view.


### PR DESCRIPTION
## Summary
- ensure `VisioPage` clamps invalid view scales to a positive default
- guard Visio save/load routines so only valid view scales are written or restored
- add and update tests covering default view metadata and asset comparisons

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d54e321630832e8e27ed214c690405