### PR TITLE
Enhance Visio validator coverage for multi-page packages

### DIFF
--- a/OfficeIMO.Tests/Visio.Validation.cs
+++ b/OfficeIMO.Tests/Visio.Validation.cs
@@ -62,7 +62,10 @@ namespace OfficeIMO.Tests {
             }
 
             var issues = VisioValidator.Validate(filePath);
-            Assert.Contains(issues, issue => issue.Contains("Page ID 1 (Page-2)") && issue.Contains("page2.xml") && issue.Contains("missing", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(issues, issue =>
+                issue.Contains("Page ID 1 (Page-2)") &&
+                issue.Contains("page2.xml") &&
+                issue.IndexOf("missing", StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
         [Fact]
@@ -98,7 +101,9 @@ namespace OfficeIMO.Tests {
             }
 
             var issues = VisioValidator.Validate(filePath);
-            Assert.Contains(issues, issue => issue.Contains("Page ID 1 (Page-2)") && issue.Contains("Missing Override", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(issues, issue =>
+                issue.Contains("Page ID 1 (Page-2)") &&
+                issue.IndexOf("Missing Override", StringComparison.OrdinalIgnoreCase) >= 0);
             Assert.DoesNotContain(issues, issue => issue.Contains("Page ID 0 (Page-1)"));
         }
     }

--- a/OfficeIMO.Tests/Visio.Validation.cs
+++ b/OfficeIMO.Tests/Visio.Validation.cs
@@ -1,5 +1,8 @@
 using System;
 using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
 using OfficeIMO.Visio;
 using Xunit;
 
@@ -19,6 +22,84 @@ namespace OfficeIMO.Tests {
 
             VisioDocument loaded = VisioDocument.Load(filePath);
             Assert.Single(loaded.Pages);
+        }
+
+        [Fact]
+        public void MultiPageDocumentValidatesAndLoads() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = VisioDocument.Create(filePath);
+            VisioPage page1 = document.AddPage("Page-1");
+            page1.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "Rectangle"));
+
+            VisioPage page2 = document.AddPage("Page-2");
+            page2.Shapes.Add(new VisioShape("2", 2, 2, 1.5, 1, "Ellipse"));
+            document.Save();
+
+            var issues = VisioValidator.Validate(filePath);
+            Assert.Empty(issues);
+
+            VisioDocument loaded = VisioDocument.Load(filePath);
+            Assert.Equal(2, loaded.Pages.Count);
+        }
+
+        [Fact]
+        public void ValidatorDetectsMissingPagePartInMultiPagePackage() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = VisioDocument.Create(filePath);
+            VisioPage first = document.AddPage("Page-1");
+            first.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "Start"));
+            VisioPage second = document.AddPage("Page-2");
+            second.Shapes.Add(new VisioShape("2", 2, 2, 1, 1, "End"));
+            document.Save();
+
+            using (FileStream stream = new(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            using (ZipArchive archive = new(stream, ZipArchiveMode.Update)) {
+                ZipArchiveEntry? page2Entry = archive.GetEntry("visio/pages/page2.xml");
+                Assert.NotNull(page2Entry);
+                page2Entry!.Delete();
+            }
+
+            var issues = VisioValidator.Validate(filePath);
+            Assert.Contains(issues, issue => issue.Contains("Page ID 1 (Page-2)") && issue.Contains("page2.xml") && issue.Contains("missing", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public void ValidatorDetectsMissingPageOverrideInMultiPagePackage() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = VisioDocument.Create(filePath);
+            VisioPage page1 = document.AddPage("Page-1");
+            page1.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "Start"));
+            VisioPage page2 = document.AddPage("Page-2");
+            page2.Shapes.Add(new VisioShape("2", 2, 2, 1, 1, "End"));
+            document.Save();
+
+            using (FileStream stream = new(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            using (ZipArchive archive = new(stream, ZipArchiveMode.Update)) {
+                ZipArchiveEntry? entry = archive.GetEntry("[Content_Types].xml");
+                Assert.NotNull(entry);
+                XDocument contentTypes;
+                using (Stream entryStream = entry!.Open()) {
+                    contentTypes = XDocument.Load(entryStream);
+                }
+
+                entry.Delete();
+                XNamespace ct = "http://schemas.openxmlformats.org/package/2006/content-types";
+                contentTypes.Root!
+                    .Elements(ct + "Override")
+                    .Where(e => string.Equals((string?)e.Attribute("PartName"), "/visio/pages/page2.xml", StringComparison.OrdinalIgnoreCase))
+                    .Remove();
+
+                ZipArchiveEntry newEntry = archive.CreateEntry("[Content_Types].xml");
+                using Stream newEntryStream = newEntry.Open();
+                contentTypes.Save(newEntryStream);
+            }
+
+            var issues = VisioValidator.Validate(filePath);
+            Assert.Contains(issues, issue => issue.Contains("Page ID 1 (Page-2)") && issue.Contains("Missing Override", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(issues, issue => issue.Contains("Page ID 0 (Page-1)"));
         }
     }
 }


### PR DESCRIPTION
## Summary
- iterate through all Visio pages to validate relationship targets, part existence, overrides, and shape ids with per-page context
- add Visio validator tests covering multi-page success cases and failures when page parts or overrides are missing

## Testing
- dotnet build OfficeImo.sln
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d62deb99d0832ebdfb5231fde3e03e