### PR TITLE
Refine cross-platform targeting and builds

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -27,6 +27,36 @@ env:
   SUMMARIZE_FAILURES: true # set to 'false' to disable summarizing failing tests
 
 jobs:
+  build-matrix:
+    name: 'Cross-platform build'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore dependencies
+        run: dotnet restore OfficeImo.sln
+
+      - name: Build solution
+        run: dotnet build OfficeImo.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+
   test-windows:
     name: 'Windows'
     runs-on: windows-latest

--- a/OfficeIMO.Excel/OfficeIMO.Excel.csproj
+++ b/OfficeIMO.Excel/OfficeIMO.Excel.csproj
@@ -7,11 +7,9 @@
         <AssemblyTitle>OfficeIMO.Excel</AssemblyTitle>
 
         <VersionPrefix>0.4.0</VersionPrefix>
+        <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
-            netstandard2.0;net472;net48;net8.0;net9.0</TargetFrameworks>
-        <TargetFrameworks
-            Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
-            net8.0;net9.0</TargetFrameworks>
+            $(TargetFrameworks);net472</TargetFrameworks>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 
         <Company>Evotec</Company>
@@ -19,7 +17,7 @@
 
         <PackageId>OfficeIMO.Excel</PackageId>
         <PackageTags>
-            docx;net60;excel;office;openxml;net472;net48;net50;netstandard;netstandard2.0,netstandard2.1;net70</PackageTags>
+            docx;net60;excel;office;openxml;net472;net50;netstandard;netstandard2.0,netstandard2.1;net70</PackageTags>
         <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <DelaySign>False</DelaySign>
@@ -42,11 +40,11 @@
     </ItemGroup>
 
     <ItemGroup
-        Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net48'">
+        Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net48'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />

--- a/OfficeIMO.Markdown/OfficeIMO.Markdown.csproj
+++ b/OfficeIMO.Markdown/OfficeIMO.Markdown.csproj
@@ -5,8 +5,8 @@
     <AssemblyName>OfficeIMO.Markdown</AssemblyName>
     <AssemblyTitle>OfficeIMO.Markdown</AssemblyTitle>
     <VersionPrefix>0.3.0</VersionPrefix>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;netstandard2.0;net8.0;net9.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/OfficeIMO.Pdf/OfficeIMO.Pdf.csproj
+++ b/OfficeIMO.Pdf/OfficeIMO.Pdf.csproj
@@ -5,8 +5,8 @@
     <AssemblyName>OfficeIMO.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Pdf</AssemblyTitle>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;netstandard2.0;net8.0;net9.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj
+++ b/OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj
@@ -7,11 +7,9 @@
         <AssemblyTitle>OfficeIMO.PowerPoint</AssemblyTitle>
 
         <VersionPrefix>1.0.7</VersionPrefix>
+        <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
-            netstandard2.0;net472;net8.0;net9.0
-        </TargetFrameworks>
-        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
-            net8.0
+            $(TargetFrameworks);net472
         </TargetFrameworks>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <Company>Evotec</Company>
@@ -19,7 +17,7 @@
 
         <PackageId>OfficeIMO.PowerPoint</PackageId>
         <PackageTags>
-            pptx;powerpoint;office;openxml;net472;net48;net50;netstandard;netstandard2.0,netstandard2.1;net70
+            pptx;powerpoint;office;openxml;net472;net50;netstandard;netstandard2.0,netstandard2.1;net70
         </PackageTags>
         <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/OfficeIMO.Tests/OfficeIMO.Tests.csproj
+++ b/OfficeIMO.Tests/OfficeIMO.Tests.csproj
@@ -1,11 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
-            net472;net8.0;net9.0
-        </TargetFrameworks>
-        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
-            net8.0;net9.0
+            $(TargetFrameworks);net472
         </TargetFrameworks>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>

--- a/OfficeIMO.Visio/OfficeIMO.Visio.csproj
+++ b/OfficeIMO.Visio/OfficeIMO.Visio.csproj
@@ -7,17 +7,16 @@
         <AssemblyTitle>OfficeIMO.Visio</AssemblyTitle>
 
         <VersionPrefix>1.0.7</VersionPrefix>
+        <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
-            netstandard2.0;net472;net8.0;net9.0</TargetFrameworks>
-        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
-            net8.0</TargetFrameworks>
+            $(TargetFrameworks);net472</TargetFrameworks>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
 
         <PackageId>OfficeIMO.Visio</PackageId>
         <PackageTags>
-            vsdx;visio;office;openxml;net472;net48;net50;netstandard;netstandard2.0,netstandard2.1;net70</PackageTags>
+            vsdx;visio;office;openxml;net472;net50;netstandard;netstandard2.0,netstandard2.1;net70</PackageTags>
         <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <DelaySign>False</DelaySign>

--- a/OfficeIMO.Word.Html/OfficeIMO.Word.Html.csproj
+++ b/OfficeIMO.Word.Html/OfficeIMO.Word.Html.csproj
@@ -6,11 +6,9 @@
         <AssemblyTitle>OfficeIMO.Word.Html</AssemblyTitle>
 
         <VersionPrefix>1.0.7</VersionPrefix>
+        <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
-            netstandard2.0;net472;net8.0;net9.0
-        </TargetFrameworks>
-        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
-            net8.0;net9.0
+            $(TargetFrameworks);net472
         </TargetFrameworks>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <Company>Evotec</Company>

--- a/OfficeIMO.Word.Markdown/OfficeIMO.Word.Markdown.csproj
+++ b/OfficeIMO.Word.Markdown/OfficeIMO.Word.Markdown.csproj
@@ -4,8 +4,8 @@
     <AssemblyName>OfficeIMO.Word.Markdown</AssemblyName>
     <AssemblyTitle>OfficeIMO.Word.Markdown</AssemblyTitle>
     <VersionPrefix>1.0.7</VersionPrefix>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">netstandard2.0;net472;net8.0;net9.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/OfficeIMO.Word.Pdf/OfficeIMO.Word.Pdf.csproj
+++ b/OfficeIMO.Word.Pdf/OfficeIMO.Word.Pdf.csproj
@@ -5,8 +5,8 @@
     <AssemblyName>OfficeIMO.Word.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Word.Pdf</AssemblyTitle>
     <VersionPrefix>1.0.7</VersionPrefix>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">netstandard2.0;net472;net8.0;net9.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>Latest</LangVersion>

--- a/OfficeIMO.Word/OfficeIMO.Word.csproj
+++ b/OfficeIMO.Word/OfficeIMO.Word.csproj
@@ -7,17 +7,16 @@
         <AssemblyTitle>OfficeIMO.Word</AssemblyTitle>
 
         <VersionPrefix>1.0.9</VersionPrefix>
+        <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
-            netstandard2.0;net472;net8.0;net9.0</TargetFrameworks>
-        <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
-            net8.0</TargetFrameworks>
+            $(TargetFrameworks);net472</TargetFrameworks>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
 
         <PackageId>OfficeIMO.Word</PackageId>
         <PackageTags>
-            docx;net60;word;office;openxml;net472;net48;net50;netstandard;netstandard2.0,netstandard2.1;net70</PackageTags>
+            docx;net60;word;office;openxml;net472;net50;netstandard;netstandard2.0,netstandard2.1;net70</PackageTags>
         <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <DelaySign>False</DelaySign>


### PR DESCRIPTION
## Summary
- refactor the multi-targeting configuration so projects always target netstandard2.0, net8.0, and net9.0 while adding net472 only on Windows
- align supporting metadata and conditional references with the new target framework layout
- add a dedicated CI build matrix that exercises `dotnet build` on Windows and Linux runners

## Testing
- dotnet build OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d62e276b48832e972189be682d5ed4