### PR TITLE
Propagate cancellation during Excel column autofit

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.ColumnsRows.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ColumnsRows.cs
@@ -76,6 +76,8 @@ namespace OfficeIMO.Excel {
                     }, i => {
                         try {
                             computed[i] = CalculateColumnWidth(columnsList[i]);
+                        } catch (OperationCanceledException) {
+                            throw;
                         } catch {
                             failures.Add(i);
                         }


### PR DESCRIPTION
## Summary
- ensure the parallel column auto-fit path rethrows `OperationCanceledException` so cancellation bubbles to callers
- add a regression test that verifies `AutoFitColumns` propagates cancellation tokens

## Testing
- dotnet test OfficeImo.sln --filter FullyQualifiedName~Test_AutoFitColumns_CancellationPropagates

------
https://chatgpt.com/codex/tasks/task_e_68d633583098832e996b46c7ecfc5df7