### PR TITLE
Guard SetCellValues against null inputs

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -12,6 +12,7 @@ namespace OfficeIMO.Excel {
         /// <param name="mode">Optional execution mode override.</param>
         /// <param name="ct">Cancellation token.</param>
         public void SetCellValues(IEnumerable<(int Row, int Column, object Value)> cells, ExecutionMode? mode = null, CancellationToken ct = default) {
+            ArgumentNullException.ThrowIfNull(cells);
             var list = cells as IList<(int Row, int Column, object Value)> ?? cells.ToList();
             if (list.Count == 0) return;
 

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -12,7 +12,9 @@ namespace OfficeIMO.Excel {
         /// <param name="mode">Optional execution mode override.</param>
         /// <param name="ct">Cancellation token.</param>
         public void SetCellValues(IEnumerable<(int Row, int Column, object Value)> cells, ExecutionMode? mode = null, CancellationToken ct = default) {
-            ArgumentNullException.ThrowIfNull(cells);
+            if (cells is null) {
+                throw new ArgumentNullException(nameof(cells));
+            }
             var list = cells as IList<(int Row, int Column, object Value)> ?? cells.ToList();
             if (list.Count == 0) return;
 

--- a/OfficeIMO.Tests/Excel.SetCellValuesParallel.cs
+++ b/OfficeIMO.Tests/Excel.SetCellValuesParallel.cs
@@ -113,6 +113,17 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_SetCellValuesThrowsOnNullCells() {
+            string filePath = Path.Combine(_directoryWithFiles, "SetCellValuesNull.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+
+                Assert.Throws<ArgumentNullException>(() => sheet.SetCellValues(null!));
+            }
+        }
+
+        [Fact]
         public void Test_SetCellValuesParallelSanitizesControlCharacters() {
             string filePath = Path.Combine(_directoryWithFiles, "SetCellValuesParallelSanitizedControls.xlsx");
 


### PR DESCRIPTION
## Summary
- throw an ArgumentNullException when SetCellValues is called with a null cells collection
- add a regression test to ensure the null argument is rejected

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d6333488b0832eb35ded1da351c35a