### PR TITLE
Fix checkbox rendering and add combo box defaults

### DIFF
--- a/OfficeIMO.Examples/Word/ComboBoxes/ComboBoxes.Basic.cs
+++ b/OfficeIMO.Examples/Word/ComboBoxes/ComboBoxes.Basic.cs
@@ -9,7 +9,7 @@ namespace OfficeIMO.Examples.Word {
             string filePath = Path.Combine(folderPath, "DocumentWithComboBox.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var items = new[] { "One", "Two", "Three" };
-                document.AddParagraph("Choose:").AddComboBox(items, "Combo", "ComboTag");
+                document.AddParagraph("Choose:").AddComboBox(items, "Combo", "ComboTag", defaultValue: "Two");
                 document.Save(openWord);
             }
         }

--- a/OfficeIMO.Tests/Word.ComboBox.cs
+++ b/OfficeIMO.Tests/Word.ComboBox.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using Xunit;
 
@@ -13,12 +15,13 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "DocumentWithComboBox.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {
                 var items = new List<string> { "One", "Two" };
-                var cb = document.AddParagraph("Select:").AddComboBox(items, "CB", "CBTag");
+                var cb = document.AddParagraph("Select:").AddComboBox(items, "CB", "CBTag", defaultValue: "Two");
 
                 Assert.Single(document.ComboBoxes);
                 Assert.Equal(2, cb.Items.Count);
                 Assert.Equal("CB", cb.Alias);
                 Assert.Equal("CBTag", cb.Tag);
+                Assert.Equal("Two", cb.SelectedValue);
 
                 document.Save(false);
                 Assert.False(HasUnexpectedElements(document), "Document has unexpected elements. Order of elements matters!");
@@ -29,7 +32,14 @@ namespace OfficeIMO.Tests {
                 var list = document.GetComboBoxByAlias("CB");
                 Assert.NotNull(list);
                 Assert.Equal("CBTag", document.GetComboBoxByTag("CBTag")?.Tag);
+                Assert.Equal("Two", list!.SelectedValue);
                 document.Save(false);
+            }
+
+            using (WordprocessingDocument wordDoc = WordprocessingDocument.Open(filePath, false)) {
+                var runText = wordDoc.MainDocumentPart!.Document.Body!.Descendants<SdtRun>()
+                    .Single().SdtContentRun!.Descendants<Text>().SingleOrDefault()?.Text;
+                Assert.Equal("Two", runText);
             }
 
             using (WordDocument document = WordDocument.Load(filePath)) {
@@ -39,6 +49,33 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Load(filePath)) {
                 Assert.Empty(document.ComboBoxes);
+            }
+        }
+
+        [Fact]
+        public void Test_ComboBoxDefaultsToFirstItemWhenNoneSpecified() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithComboBoxDefault.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var items = new List<string> { "Alpha", "Beta", "Gamma" };
+                var combo = document.AddParagraph("Choose:").AddComboBox(items, "Combo", "ComboTag");
+                Assert.Equal("Alpha", combo.SelectedValue);
+                document.Save(false);
+            }
+
+            using (WordprocessingDocument wordDoc = WordprocessingDocument.Open(filePath, false)) {
+                var runText = wordDoc.MainDocumentPart!.Document.Body!.Descendants<SdtRun>()
+                    .Single().SdtContentRun!.Descendants<Text>().SingleOrDefault()?.Text;
+                Assert.Equal("Alpha", runText);
+            }
+        }
+
+        [Fact]
+        public void Test_ComboBoxThrowsWhenDefaultMissingFromItems() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithComboBoxInvalidDefault.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var items = new List<string> { "Red", "Green" };
+                var paragraph = document.AddParagraph("Pick:");
+                Assert.Throws<ArgumentException>(() => paragraph.AddComboBox(items, "Combo", "ComboTag", defaultValue: "Blue"));
             }
         }
     }

--- a/OfficeIMO.Word/WordCheckBox.cs
+++ b/OfficeIMO.Word/WordCheckBox.cs
@@ -6,6 +6,12 @@ namespace OfficeIMO.Word {
     /// Represents a checkbox content control within a paragraph.
     /// </summary>
     public class WordCheckBox : WordElement {
+        internal const string SymbolFont = "MS Gothic";
+        internal const string CheckedSymbol = "\u2611";
+        internal const string UncheckedSymbol = "\u2610";
+        internal const string CheckedStateValue = "2611";
+        internal const string UncheckedStateValue = "2610";
+
         private readonly WordDocument _document;
         private readonly Paragraph _paragraph;
         internal readonly SdtRun _sdtRun;
@@ -35,6 +41,8 @@ namespace OfficeIMO.Word {
                     }
                     ch.Val = value ? W14.OnOffValues.One : W14.OnOffValues.Zero;
                 }
+
+                UpdateSymbol(value);
             }
         }
 
@@ -73,6 +81,41 @@ namespace OfficeIMO.Word {
         /// </summary>
         public void Remove() {
             _sdtRun.Remove();
+        }
+
+        private void UpdateSymbol(bool isChecked) {
+            var content = _sdtRun.SdtContentRun;
+            if (content == null) {
+                content = new SdtContentRun();
+                _sdtRun.Append(content);
+            }
+
+            var run = content.Elements<Run>().FirstOrDefault();
+            if (run == null) {
+                run = new Run();
+                content.Append(run);
+            }
+
+            var runProperties = run.RunProperties ?? (run.RunProperties = new RunProperties());
+            var fonts = runProperties.Elements<RunFonts>().FirstOrDefault();
+            if (fonts == null) {
+                fonts = new RunFonts();
+                runProperties.Append(fonts);
+            }
+
+            fonts.Ascii = SymbolFont;
+            fonts.HighAnsi = SymbolFont;
+            fonts.EastAsia = SymbolFont;
+            fonts.ComplexScript = SymbolFont;
+
+            var text = run.Elements<Text>().FirstOrDefault();
+            if (text == null) {
+                text = new Text();
+                run.Append(text);
+            }
+
+            text.Text = isChecked ? CheckedSymbol : UncheckedSymbol;
+            text.Space = SpaceProcessingModeValues.Preserve;
         }
     }
 }

--- a/OfficeIMO.Word/WordComboBox.cs
+++ b/OfficeIMO.Word/WordComboBox.cs
@@ -31,6 +31,38 @@ namespace OfficeIMO.Word {
         }
 
         /// <summary>
+        /// Gets or sets the currently selected value displayed by the combo box.
+        /// </summary>
+        public string? SelectedValue {
+            get {
+                var text = _sdtRun.SdtContentRun?.Descendants<Text>().FirstOrDefault();
+                return text?.Text;
+            }
+            set {
+                var content = _sdtRun.SdtContentRun;
+                if (content == null) {
+                    content = new SdtContentRun();
+                    _sdtRun.Append(content);
+                }
+
+                var run = content.Elements<Run>().FirstOrDefault();
+                if (run == null) {
+                    run = new Run();
+                    content.Append(run);
+                }
+
+                var text = run.Elements<Text>().FirstOrDefault();
+                if (text == null) {
+                    text = new Text();
+                    run.Append(text);
+                }
+
+                text.Text = value ?? string.Empty;
+                text.Space = SpaceProcessingModeValues.Preserve;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the tag value for this combo box control.
         /// </summary>
         public string? Tag {


### PR DESCRIPTION
## Summary
- ensure checkbox content controls include visible symbols and update when toggled
- support default selections for combo boxes and expose the selected value
- add regression tests and update the combo box example to cover new behavior

## Testing
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d6e0f193f0832e8fbec1e7b00977a9