### PR TITLE
Optimize InsertObjects header tracking and add large graph test

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.cs
@@ -26,13 +26,14 @@ namespace OfficeIMO.Excel {
 
             var flattenedItems = new List<Dictionary<string, object?>>();
             List<string> headers = new List<string>();
+            HashSet<string> headerSet = new HashSet<string>();
 
             foreach (var item in list) {
                 var dict = new Dictionary<string, object?>();
                 FlattenObject(item, null, dict);
                 flattenedItems.Add(dict);
                 foreach (var key in dict.Keys) {
-                    if (!headers.Contains(key)) {
+                    if (headerSet.Add(key)) {
                         headers.Add(key);
                     }
                 }
@@ -49,7 +50,7 @@ namespace OfficeIMO.Excel {
 
             foreach (var dict in flattenedItems) {
                 for (int c = 0; c < headers.Count; c++) {
-                    object value = dict.ContainsKey(headers[c]) ? dict[headers[c]] ?? string.Empty : string.Empty;
+                    object value = dict.TryGetValue(headers[c], out var entry) ? entry ?? string.Empty : string.Empty;
                     cells.Add((row, c + 1, value));
                 }
                 row++;


### PR DESCRIPTION
## Summary
- replace InsertObjects header tracking with a HashSet to avoid repeated linear scans while preserving ordering
- extend Excel InsertObjects tests with complex graph coverage to confirm header stability

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d78af4886c832e9ade4de8299e0f3c