### PR TITLE
Render bullets with hanging indent in PDF lists

### DIFF
--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.cs
@@ -186,7 +186,7 @@ internal static partial class PdfWriter {
                     double indent = bulletWidth + spaceAdvance;
                     double rawTextWidth = width - indent;
                     double availableWidth = Math.Max(rawTextWidth, size * glyphWidthEm * 2);
-                    double alignmentWidth = rawTextWidth > 0 ? rawTextWidth : availableWidth;
+                    double alignmentWidth = Math.Max(0, rawTextWidth);
                     foreach (var text in bl.Items) {
                         var lines = WrapMonospace(text, availableWidth, size, glyphWidthEm);
                         double needed = lines.Count * leading + leading * 0.15;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.cs
@@ -184,7 +184,9 @@ internal static partial class PdfWriter {
                     double bulletWidth = bulletGlyph.Length * size * glyphWidthEm;
                     double spaceAdvance = size * glyphWidthEm;
                     double indent = bulletWidth + spaceAdvance;
-                    double availableWidth = Math.Max(width - indent, size * glyphWidthEm * 2);
+                    double rawTextWidth = width - indent;
+                    double availableWidth = Math.Max(rawTextWidth, size * glyphWidthEm * 2);
+                    double alignmentWidth = rawTextWidth > 0 ? rawTextWidth : availableWidth;
                     foreach (var text in bl.Items) {
                         var lines = WrapMonospace(text, availableWidth, size, glyphWidthEm);
                         double needed = lines.Count * leading + leading * 0.15;
@@ -192,12 +194,12 @@ internal static partial class PdfWriter {
 
                         double firstLineWidth = lines.Count > 0 ? lines[0].Length * size * glyphWidthEm : 0;
                         double firstLineDx = 0;
-                        if (bl.Align == PdfAlign.Center) firstLineDx = Math.Max(0, (width - firstLineWidth) / 2);
-                        else if (bl.Align == PdfAlign.Right) firstLineDx = Math.Max(0, width - firstLineWidth);
+                        if (bl.Align == PdfAlign.Center) firstLineDx = Math.Max(0, (alignmentWidth - firstLineWidth) / 2);
+                        else if (bl.Align == PdfAlign.Right) firstLineDx = Math.Max(0, alignmentWidth - firstLineWidth);
 
                         var bulletLines = new System.Collections.Generic.List<string>(1) { bulletGlyph };
                         WriteLinesInternal("F1", size, leading, currentOpts.MarginLeft + firstLineDx, indent, y, bulletLines, PdfAlign.Left, bl.Color, applyBaselineTweak: true);
-                        WriteLinesInternal("F1", size, leading, currentOpts.MarginLeft + indent, width, y, lines, bl.Align, bl.Color, applyBaselineTweak: true);
+                        WriteLinesInternal("F1", size, leading, currentOpts.MarginLeft + indent, alignmentWidth, y, lines, bl.Align, bl.Color, applyBaselineTweak: true);
                         y -= needed;
                     }
                 } else if (block is TableBlock tb) {

--- a/OfficeIMO.Tests/Pdf/PdfDocBulletListTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocBulletListTests.cs
@@ -1,4 +1,9 @@
+using System;
+using System.IO;
+using System.Linq;
 using OfficeIMO.Pdf;
+using UglyToad.PdfPig;
+using UglyToad.PdfPig.Content;
 using Xunit;
 
 namespace OfficeIMO.Tests.Pdf;
@@ -12,5 +17,87 @@ public class PdfDocBulletListTests {
 
         Assert.Equal("items", exception.ParamName);
         Assert.Contains("Parameter 'items' cannot be null.", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Bullets_RenderGlyphsWithHangingIndent() {
+        var doc = PdfDoc.Create();
+        doc.Bullets(new[] {
+            "Short bullet",
+            "This bullet contains enough text to wrap across multiple lines so that we can validate hanging indentation in the generated PDF output."
+        });
+
+        var bytes = doc.ToBytes();
+        Assert.NotEmpty(bytes);
+
+        using var pdf = PdfDocument.Open(new MemoryStream(bytes));
+        var page = pdf.GetPage(1);
+        var lineGroups = page.Letters
+            .Where(letter => !string.IsNullOrWhiteSpace(letter.Value))
+            .GroupBy(letter => Math.Round(letter.StartBaseLine.Y, 1))
+            .OrderByDescending(group => group.Key)
+            .ToList();
+
+        var bulletIndices = lineGroups
+            .Select((group, index) => (group, index))
+            .Where(tuple => tuple.group.Any(letter => letter.Value == "•"))
+            .ToList();
+
+        Assert.Equal(2, bulletIndices.Count);
+
+        var firstLine = lineGroups[bulletIndices[0].index].OrderBy(letter => letter.StartBaseLine.X).ToList();
+        Assert.Equal("•", firstLine[0].Value);
+        double firstTextX = firstLine.First(letter => letter.Value != "•").StartBaseLine.X;
+        double firstBulletX = firstLine[0].StartBaseLine.X;
+        Assert.True(firstTextX - firstBulletX > 4);
+
+        var secondLine = lineGroups[bulletIndices[1].index].OrderBy(letter => letter.StartBaseLine.X).ToList();
+        Assert.Equal("•", secondLine[0].Value);
+        double secondTextX = secondLine.First(letter => letter.Value != "•").StartBaseLine.X;
+        double secondBulletX = secondLine[0].StartBaseLine.X;
+        Assert.True(secondTextX - secondBulletX > 4);
+
+        var wrapLine = lineGroups
+            .Skip(bulletIndices[1].index + 1)
+            .Select(group => group.OrderBy(letter => letter.StartBaseLine.X).ToList())
+            .First();
+        Assert.DoesNotContain(wrapLine, letter => letter.Value == "•");
+        double wrapTextX = wrapLine[0].StartBaseLine.X;
+        Assert.InRange(wrapTextX, secondTextX - 1, secondTextX + 1);
+    }
+
+    [Fact]
+    public void Bullets_RespectAlignmentOptions() {
+        var doc = PdfDoc.Create();
+        doc.Bullets(new[] { "Left aligned" }, PdfAlign.Left);
+        doc.Bullets(new[] { "Centered bullet" }, PdfAlign.Center);
+
+        var bytes = doc.ToBytes();
+        Assert.NotEmpty(bytes);
+
+        using var pdf = PdfDocument.Open(new MemoryStream(bytes));
+        var page = pdf.GetPage(1);
+        var bulletLines = page.Letters
+            .Where(letter => !string.IsNullOrWhiteSpace(letter.Value))
+            .GroupBy(letter => Math.Round(letter.StartBaseLine.Y, 1))
+            .OrderByDescending(group => group.Key)
+            .Select(group => group.OrderBy(letter => letter.StartBaseLine.X).ToList())
+            .Where(line => line.Any(letter => letter.Value == "•"))
+            .ToList();
+
+        Assert.Equal(2, bulletLines.Count);
+
+        var leftLine = bulletLines[0];
+        var centerLine = bulletLines[1];
+
+        double leftBulletX = leftLine.First(letter => letter.Value == "•").StartBaseLine.X;
+        double leftTextX = leftLine.First(letter => letter.Value != "•").StartBaseLine.X;
+        double centerBulletX = centerLine.First(letter => letter.Value == "•").StartBaseLine.X;
+        double centerTextX = centerLine.First(letter => letter.Value != "•").StartBaseLine.X;
+
+        Assert.True(centerBulletX > leftBulletX + 10);
+        double leftGap = leftTextX - leftBulletX;
+        double centerGap = centerTextX - centerBulletX;
+        Assert.InRange(centerGap, leftGap - 1, leftGap + 1);
     }
 }


### PR DESCRIPTION
## Summary
- Render bullet list items with an explicit bullet glyph, hanging indent, and wrapped text alignment in the PDF writer
- Ensure list alignment and color options continue to flow through the bullet rendering path
- Add PDF regression tests that inspect generated pages to confirm bullet glyph placement and alignment

## Testing
- dotnet build OfficeImo.sln
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PdfDocBulletListTests"

------
https://chatgpt.com/codex/tasks/task_e_68d7efb46230832e8549873cc3ab5245