### PR TITLE
Add guards for PDF image input validation

### DIFF
--- a/OfficeIMO.Pdf/Compose/PdfItemCompose.cs
+++ b/OfficeIMO.Pdf/Compose/PdfItemCompose.cs
@@ -42,5 +42,12 @@ public class PdfItemCompose {
     /// <param name="width">Target width in points.</param>
     /// <param name="height">Target height in points.</param>
     /// <param name="align">Image alignment inside content width.</param>
-    public PdfItemCompose Image(byte[] jpegBytes, double width, double height, PdfAlign align = PdfAlign.Left) { _doc.Image(jpegBytes, width, height, align); return this; }
+    public PdfItemCompose Image(byte[] jpegBytes, double width, double height, PdfAlign align = PdfAlign.Left) {
+        Guard.NotNullOrEmpty(jpegBytes, nameof(jpegBytes));
+        Guard.Positive(width, nameof(width));
+        Guard.Positive(height, nameof(height));
+
+        _doc.Image(jpegBytes, width, height, align);
+        return this;
+    }
 }

--- a/OfficeIMO.Pdf/Compose/PdfRowColumnCompose.cs
+++ b/OfficeIMO.Pdf/Compose/PdfRowColumnCompose.cs
@@ -23,5 +23,14 @@ public class PdfRowColumnCompose {
     /// <summary>Adds a horizontal rule in the column.</summary>
     public PdfRowColumnCompose HR(double thickness = 0.5, PdfColor? color = null, double spacingBefore = 6, double spacingAfter = 6) { _col.Blocks.Add(new HorizontalRuleBlock(thickness, color ?? PdfColor.Gray, spacingBefore, spacingAfter)); return this; }
     /// <summary>Adds a JPEG image in the column.</summary>
-    public PdfRowColumnCompose Image(byte[] jpegBytes, double width, double height, PdfAlign align = PdfAlign.Left) { _col.Blocks.Add(new ImageBlock(jpegBytes, width, height, align)); return this; }
+    public PdfRowColumnCompose Image(byte[] jpegBytes, double width, double height, PdfAlign align = PdfAlign.Left) {
+        Guard.NotNullOrEmpty(jpegBytes, nameof(jpegBytes));
+        Guard.Positive(width, nameof(width));
+        Guard.Positive(height, nameof(height));
+
+        PdfDoc.WarnIfBytesNotJpeg(jpegBytes);
+
+        _col.Blocks.Add(new ImageBlock(jpegBytes, width, height, align));
+        return this;
+    }
 }

--- a/OfficeIMO.Pdf/Core/PdfDoc.Blocks.cs
+++ b/OfficeIMO.Pdf/Core/PdfDoc.Blocks.cs
@@ -68,6 +68,12 @@ public sealed partial class PdfDoc {
 
     /// <summary>Adds a JPEG image at the current flow position.</summary>
     public PdfDoc Image(byte[] jpegBytes, double width, double height, PdfAlign align = PdfAlign.Left) {
+        Guard.NotNullOrEmpty(jpegBytes, nameof(jpegBytes));
+        Guard.Positive(width, nameof(width));
+        Guard.Positive(height, nameof(height));
+
+        WarnIfBytesNotJpeg(jpegBytes);
+
         AddBlock(new ImageBlock(jpegBytes, width, height, align));
         return this;
     }
@@ -89,6 +95,20 @@ public sealed partial class PdfDoc {
         if (links != null) foreach (var kv in links) tb.Links[kv.Key] = kv.Value;
         AddBlock(tb);
         return this;
+    }
+}
+
+public sealed partial class PdfDoc {
+    internal static void WarnIfBytesNotJpeg(byte[] data) {
+        if (!LooksLikeJpeg(data))
+            System.Diagnostics.Trace.TraceWarning("PdfDoc.Image: Provided bytes do not appear to be JPEG encoded.");
+    }
+
+    private static bool LooksLikeJpeg(byte[] data) {
+        if (data.Length < 4)
+            return false;
+
+        return data[0] == 0xFF && data[1] == 0xD8 && data[data.Length - 2] == 0xFF && data[data.Length - 1] == 0xD9;
     }
 }
 

--- a/OfficeIMO.Pdf/Utilities/Guard.cs
+++ b/OfficeIMO.Pdf/Utilities/Guard.cs
@@ -7,4 +7,19 @@ internal static class Guard {
     public static void NotNull<T>(T? value, string paramName) where T : class {
         if (value is null) throw new System.ArgumentNullException(paramName, $"Parameter '{paramName}' cannot be null.");
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void NotNullOrEmpty(byte[]? value, string paramName) {
+        if (value is null)
+            throw new System.ArgumentNullException(paramName, $"Parameter '{paramName}' cannot be null.");
+
+        if (value.Length == 0)
+            throw new System.ArgumentException($"Parameter '{paramName}' cannot be empty.", paramName);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Positive(double value, string paramName) {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0)
+            throw new System.ArgumentOutOfRangeException(paramName, value, $"Parameter '{paramName}' must be a finite positive number.");
+    }
 }

--- a/OfficeIMO.Tests/Pdf/PdfDocImageValidationTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocImageValidationTests.cs
@@ -1,0 +1,181 @@
+using System;
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public class PdfDocImageValidationTests {
+    [Fact]
+    public void Image_WithNullBytes_ThrowsArgumentNullException() {
+        var doc = PdfDoc.Create();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => doc.Image(null!, 24, 24));
+
+        Assert.Equal("jpegBytes", exception.ParamName);
+        Assert.Contains("Parameter 'jpegBytes' cannot be null.", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Image_WithEmptyBytes_ThrowsArgumentException() {
+        var doc = PdfDoc.Create();
+
+        var exception = Assert.Throws<ArgumentException>(() => doc.Image(Array.Empty<byte>(), 24, 24));
+
+        Assert.Equal("jpegBytes", exception.ParamName);
+        Assert.Contains("Parameter 'jpegBytes' cannot be empty.", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void Image_WithInvalidWidth_ThrowsArgumentOutOfRangeException(double invalidWidth) {
+        var doc = PdfDoc.Create();
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => doc.Image(new byte[] { 0xFF, 0xD8, 0xFF, 0xD9 }, invalidWidth, 10));
+
+        Assert.Equal("width", exception.ParamName);
+        Assert.Contains("Parameter 'width' must be a finite positive number.", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void Image_WithInvalidHeight_ThrowsArgumentOutOfRangeException(double invalidHeight) {
+        var doc = PdfDoc.Create();
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => doc.Image(new byte[] { 0xFF, 0xD8, 0xFF, 0xD9 }, 10, invalidHeight));
+
+        Assert.Equal("height", exception.ParamName);
+        Assert.Contains("Parameter 'height' must be a finite positive number.", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RowColumnImage_WithNullBytes_ThrowsArgumentNullException() {
+        var doc = PdfDoc.Create();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            doc.Compose(compose =>
+                compose.Page(page =>
+                    page.Content(content =>
+                        content.Row(row =>
+                            row.Column(100, column =>
+                                column.Image(null!, 24, 24)))))));
+
+        Assert.Equal("jpegBytes", exception.ParamName);
+    }
+
+    [Fact]
+    public void RowColumnImage_WithEmptyBytes_ThrowsArgumentException() {
+        var doc = PdfDoc.Create();
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            doc.Compose(compose =>
+                compose.Page(page =>
+                    page.Content(content =>
+                        content.Row(row =>
+                            row.Column(100, column =>
+                                column.Image(Array.Empty<byte>(), 24, 24)))))));
+
+        Assert.Equal("jpegBytes", exception.ParamName);
+        Assert.Contains("Parameter 'jpegBytes' cannot be empty.", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void RowColumnImage_WithNonPositiveWidth_ThrowsArgumentOutOfRangeException(double invalidWidth) {
+        var doc = PdfDoc.Create();
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            doc.Compose(compose =>
+                compose.Page(page =>
+                    page.Content(content =>
+                        content.Row(row =>
+                            row.Column(100, column =>
+                                column.Image(new byte[] { 0xFF, 0xD8, 0xFF, 0xD9 }, invalidWidth, 24)))))));
+
+        Assert.Equal("width", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void RowColumnImage_WithNonPositiveHeight_ThrowsArgumentOutOfRangeException(double invalidHeight) {
+        var doc = PdfDoc.Create();
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            doc.Compose(compose =>
+                compose.Page(page =>
+                    page.Content(content =>
+                        content.Row(row =>
+                            row.Column(100, column =>
+                                column.Image(new byte[] { 0xFF, 0xD8, 0xFF, 0xD9 }, 24, invalidHeight)))))));
+
+        Assert.Equal("height", exception.ParamName);
+    }
+
+    [Fact]
+    public void ItemComposeImage_WithNullBytes_ThrowsArgumentNullException() {
+        var doc = PdfDoc.Create();
+
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            doc.Compose(compose =>
+                compose.Page(page =>
+                    page.Content(content =>
+                        content.Column(column =>
+                            column.Item().Image(null!, 24, 24))))));
+
+        Assert.Equal("jpegBytes", exception.ParamName);
+    }
+
+    [Fact]
+    public void ItemComposeImage_WithEmptyBytes_ThrowsArgumentException() {
+        var doc = PdfDoc.Create();
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            doc.Compose(compose =>
+                compose.Page(page =>
+                    page.Content(content =>
+                        content.Column(column =>
+                            column.Item().Image(Array.Empty<byte>(), 24, 24))))));
+
+        Assert.Equal("jpegBytes", exception.ParamName);
+        Assert.Contains("Parameter 'jpegBytes' cannot be empty.", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-2)]
+    public void ItemComposeImage_WithNonPositiveWidth_ThrowsArgumentOutOfRangeException(double invalidWidth) {
+        var doc = PdfDoc.Create();
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            doc.Compose(compose =>
+                compose.Page(page =>
+                    page.Content(content =>
+                        content.Column(column =>
+                            column.Item().Image(new byte[] { 0xFF, 0xD8, 0xFF, 0xD9 }, invalidWidth, 24))))));
+
+        Assert.Equal("width", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-2)]
+    public void ItemComposeImage_WithNonPositiveHeight_ThrowsArgumentOutOfRangeException(double invalidHeight) {
+        var doc = PdfDoc.Create();
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            doc.Compose(compose =>
+                compose.Page(page =>
+                    page.Content(content =>
+                        content.Column(column =>
+                            column.Item().Image(new byte[] { 0xFF, 0xD8, 0xFF, 0xD9 }, 24, invalidHeight))))));
+
+        Assert.Equal("height", exception.ParamName);
+    }
+}


### PR DESCRIPTION
## Summary
- add guard helpers for byte-array emptiness and positive numeric validation used by PDF image entry points
- validate PDF image creation APIs and emit a diagnostic warning when data does not resemble JPEG encoding
- add PDF unit tests that assert the image helpers throw for null, empty, and non-positive arguments across compose surfaces

## Testing
- dotnet test OfficeImo.sln --filter PdfDocImageValidationTests

------
https://chatgpt.com/codex/tasks/task_e_68d7efbf16d8832e8b92f69806dc6697