### PR TITLE
Allow clearing PDF metadata values

### DIFF
--- a/OfficeIMO.Pdf/Core/PdfDoc.Meta.cs
+++ b/OfficeIMO.Pdf/Core/PdfDoc.Meta.cs
@@ -30,6 +30,7 @@ public sealed partial class PdfDoc {
 
     /// <summary>
     /// Sets PDF metadata. Only values provided are updated; missing parameters keep previous values.
+    /// Pass an empty string to clear a previously assigned value.
     /// </summary>
     /// <param name="title">Document title metadata.</param>
     /// <param name="author">Document author metadata.</param>
@@ -37,10 +38,21 @@ public sealed partial class PdfDoc {
     /// <param name="keywords">Document keywords metadata.</param>
     /// <returns>This <see cref="PdfDoc"/> for chaining.</returns>
     public PdfDoc Meta(string? title = null, string? author = null, string? subject = null, string? keywords = null) {
-        _title = title ?? _title;
-        _author = author ?? _author;
-        _subject = subject ?? _subject;
-        _keywords = keywords ?? _keywords;
+        if (title != null) {
+            _title = title.Length == 0 ? null : title;
+        }
+
+        if (author != null) {
+            _author = author.Length == 0 ? null : author;
+        }
+
+        if (subject != null) {
+            _subject = subject.Length == 0 ? null : subject;
+        }
+
+        if (keywords != null) {
+            _keywords = keywords.Length == 0 ? null : keywords;
+        }
         return this;
     }
 

--- a/OfficeIMO.Tests/Pdf/PdfDocMetadataTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocMetadataTests.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using OfficeIMO.Pdf;
+using UglyToad.PdfPig;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public class PdfDocMetadataTests {
+    [Fact]
+    public void Meta_CanClearPreviouslySetFields() {
+        var doc = PdfDoc.Create()
+            .Meta(title: "Initial Title", author: "Initial Author", subject: "Initial Subject", keywords: "alpha, beta");
+
+        doc.Meta(title: string.Empty, author: string.Empty, subject: string.Empty, keywords: string.Empty);
+
+        byte[] bytes = doc.ToBytes();
+
+        using var pdf = PdfDocument.Open(new MemoryStream(bytes));
+        var info = pdf.Information;
+
+        Assert.Null(info.Title);
+        Assert.Null(info.Author);
+        Assert.Null(info.Subject);
+        Assert.Null(info.Keywords);
+    }
+
+    [Fact]
+    public void Meta_ClearingSingleFieldRetainsOtherMetadata() {
+        var doc = PdfDoc.Create()
+            .Meta(title: "Retained Title", author: "Author To Clear");
+
+        doc.Meta(author: string.Empty);
+
+        byte[] bytes = doc.ToBytes();
+
+        using var pdf = PdfDocument.Open(new MemoryStream(bytes));
+        var info = pdf.Information;
+
+        Assert.Equal("Retained Title", info.Title);
+        Assert.Null(info.Author);
+    }
+}


### PR DESCRIPTION
## Summary
- allow PdfDoc.Meta to interpret empty strings as clearing metadata values and update the XML doc comment
- add unit tests covering metadata clearing scenarios and verifying values are omitted when cleared

## Testing
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d7efeb3654832e8bbd2a33584a8f86