### PR TITLE
Ensure compatibility fixer rewinds streams

### DIFF
--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1460,6 +1460,7 @@ namespace OfficeIMO.Word {
                     using (var clone = this._wordprocessingDocument.Clone(fs)) {
                         CopyPackageProperties(_wordprocessingDocument.PackageProperties, clone.PackageProperties);
                     }
+                    fs.Seek(0, SeekOrigin.Begin);
                     Helpers.MakeOpenOfficeCompatible(fs);
                     fs.Flush();
                     FilePath = filePath;
@@ -1533,6 +1534,7 @@ namespace OfficeIMO.Word {
                 using (var clone = _wordprocessingDocument.Clone(fs)) {
                     CopyPackageProperties(_wordprocessingDocument.PackageProperties, clone.PackageProperties);
                 }
+                fs.Seek(0, SeekOrigin.Begin);
                 Helpers.MakeOpenOfficeCompatible(fs);
                 fs.Flush();
             } catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException) {
@@ -1569,6 +1571,7 @@ namespace OfficeIMO.Word {
                     CopyPackageProperties(_wordprocessingDocument.PackageProperties, clone.PackageProperties);
                 }
 
+                memoryStream.Seek(0, SeekOrigin.Begin);
                 Helpers.MakeOpenOfficeCompatible(memoryStream);
                 memoryStream.Flush();
 
@@ -1647,6 +1650,7 @@ namespace OfficeIMO.Word {
                         using (var clone = this._wordprocessingDocument.Clone(fs)) {
                             CopyPackageProperties(_wordprocessingDocument.PackageProperties, clone.PackageProperties);
                         }
+                        fs.Seek(0, SeekOrigin.Begin);
                         Helpers.MakeOpenOfficeCompatible(fs);
                         await fs.FlushAsync(cancellationToken);
                     }


### PR DESCRIPTION
## Summary
- seek file and memory streams to the beginning before running the OpenOffice compatibility fixer in synchronous and asynchronous save flows
- add regression tests that verify the compatibility fixer trims `/word/` prefixes and that the saved artifacts remain readable

## Testing
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d7f3ed4604832eb86acba6fc648977