### PR TITLE
Fix break paragraph insertion for section tracking

### DIFF
--- a/OfficeIMO.Tests/Word.AddBreak.cs
+++ b/OfficeIMO.Tests/Word.AddBreak.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using OfficeIMO.Word;
 using Xunit;
 
@@ -14,6 +15,22 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(paragraphCount + 1, document.Paragraphs.Count);
                 Assert.Equal(paragraphCount + 1, document.Sections[0].Paragraphs.Count);
                 Assert.Single(document.Breaks);
+                document.Save(false);
+            }
+        }
+
+        [Fact]
+        public void SectionParagraphsIncludeBreakAfterDocumentAddBreak() {
+            string filePath = Path.Combine(_directoryWithFiles, "SectionParagraphsIncludeBreakAfterDocumentAddBreak.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                var section = document.Sections[0];
+                int initialParagraphCount = section.Paragraphs.Count;
+
+                document.AddBreak();
+
+                var sectionParagraphs = section.Paragraphs;
+                Assert.Equal(initialParagraphCount + 1, sectionParagraphs.Count);
+                Assert.True(sectionParagraphs.Last().IsPageBreak);
                 document.Save(false);
             }
         }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -70,10 +70,13 @@ namespace OfficeIMO.Word {
             };
             newWordParagraph._paragraph = new Paragraph(newWordParagraph._run);
 
-            var body = _document.Body ?? throw new InvalidOperationException("Document body is missing.");
-            body.Append(newWordParagraph._paragraph);
             var currentSection = this.Sections.LastOrDefault();
-            currentSection?.Paragraphs.Add(newWordParagraph);
+            if (currentSection != null) {
+                currentSection.AppendParagraphToSection(newWordParagraph);
+            } else {
+                var body = _document.Body ?? throw new InvalidOperationException("Document body is missing.");
+                body.Append(newWordParagraph._paragraph);
+            }
             return newWordParagraph;
         }
 


### PR DESCRIPTION
## Summary
- ensure `WordDocument.AddBreak` delegates to the owning section so break paragraphs are inserted before the section boundary
- add a section helper that places new paragraphs within the correct body region
- add a regression test that confirms `Section.Paragraphs` contains the break returned by `WordDocument.AddBreak`

## Testing
- `dotnet test OfficeImo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68d7f3f6ed58832eb7181e1260837dc7