### PR TITLE
Handle sections without matching properties

### DIFF
--- a/OfficeIMO.Tests/Word.SectionProperties.cs
+++ b/OfficeIMO.Tests/Word.SectionProperties.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using Xunit;
@@ -76,6 +77,61 @@ namespace OfficeIMO.Tests {
                 Assert.False(document.Sections[0].RtlGutter);
                 Assert.False(document.Sections[1].RtlGutter);
             }
+        }
+
+        [Fact]
+        public void Test_SectionParagraphsReturnEmptyWhenSectionPropertiesMissing() {
+            string filePath = Path.Combine(_directoryWithFiles, "SectionParagraphsNoSectionProps.docx");
+            using WordDocument document = WordDocument.Create(filePath);
+
+            document.AddParagraph("Section zero paragraph");
+
+            var section = document.Sections[0];
+            section._sectionProperties = new SectionProperties();
+
+            var paragraphs = section.Paragraphs;
+
+            var texts = paragraphs.Select(p => p.Text).ToList();
+            Assert.Single(paragraphs);
+            Assert.Contains("Section zero paragraph", texts);
+        }
+
+        [Fact]
+        public void Test_SectionParagraphsWhenBodyHasNoSectionProperties() {
+            string filePath = Path.Combine(_directoryWithFiles, "SectionParagraphsDetachedProps.docx");
+            using WordDocument document = WordDocument.Create(filePath);
+
+            document.AddParagraph("First section paragraph");
+            var secondSection = document.AddSection();
+            secondSection.AddParagraph("Second section paragraph");
+
+            var body = document._wordprocessingDocument.MainDocumentPart!.Document.Body!;
+            foreach (var paragraph in body.Elements<Paragraph>().ToList()) {
+                if (paragraph.ParagraphProperties != null) {
+                    paragraph.ParagraphProperties.RemoveAllChildren<SectionProperties>();
+                    if (!paragraph.ParagraphProperties.ChildElements.Any()) {
+                        paragraph.ParagraphProperties.Remove();
+                    }
+                }
+            }
+
+            var sectionPropertiesNodes = body.Elements<SectionProperties>().ToList();
+            if (sectionPropertiesNodes.Count > 1) {
+                // Keep a single trailing SectionProperties to mimic documents that only store
+                // section metadata at the body level, removing any earlier matches.
+                foreach (var node in sectionPropertiesNodes.Take(sectionPropertiesNodes.Count - 1)) {
+                    node.Remove();
+                }
+            }
+
+            var bodyParagraphs = body.Elements<Paragraph>().ToList();
+            var firstSectionParagraphs = document.Sections[0].Paragraphs;
+            var secondSectionParagraphs = document.Sections[1].Paragraphs;
+
+            Assert.Equal(bodyParagraphs.Count, firstSectionParagraphs.Count);
+            Assert.Equal(bodyParagraphs.Count, secondSectionParagraphs.Count);
+            Assert.Contains("First section paragraph", firstSectionParagraphs.Select(p => p.Text));
+            Assert.Contains("Second section paragraph", secondSectionParagraphs.Select(p => p.Text));
         }
     }
 }

--- a/OfficeIMO.Word/WordSection.PrivateMethods.cs
+++ b/OfficeIMO.Word/WordSection.PrivateMethods.cs
@@ -275,6 +275,10 @@ namespace OfficeIMO.Word {
                             } else {
                                 dataSections[count].Add(paragraph);
                             }
+                        } else if (element is SectionProperties sectionPropertiesElement) {
+                            if (AreSectionPropertiesEqual(sectionPropertiesElement, _sectionProperties)) {
+                                foundCount = count;
+                            }
                         }
                     }
 
@@ -287,7 +291,19 @@ namespace OfficeIMO.Word {
                 }
             }
 
-            return ConvertParagraphsToWordParagraphs(_document, dataSections[foundCount]);
+            if (foundCount < 0) {
+                if (dataSections.Count == 1 && dataSections.TryGetValue(0, out var singleSectionParagraphs)) {
+                    return ConvertParagraphsToWordParagraphs(_document, singleSectionParagraphs);
+                }
+
+                return new List<WordParagraph>();
+            }
+
+            if (!dataSections.TryGetValue(foundCount, out var paragraphsForSection)) {
+                return new List<WordParagraph>();
+            }
+
+            return ConvertParagraphsToWordParagraphs(_document, paragraphsForSection);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- make WordSection paragraph retrieval resilient when no section properties match a body paragraph
- cover scenarios where section properties live outside body paragraphs to ensure paragraph access remains safe

## Testing
- dotnet build
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "SectionParagraphs"

------
https://chatgpt.com/codex/tasks/task_e_68d7f3fdaff8832eafd405ee0f6f04ae