### PR TITLE
Add section validation to Word header and footer helpers

### DIFF
--- a/OfficeIMO.Tests/Word.HeadersAndFooters.DefaultSectionCreation.cs
+++ b/OfficeIMO.Tests/Word.HeadersAndFooters.DefaultSectionCreation.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void HeaderAndFooterAccessors_CreateSectionWhenMissing() {
+            using var stream = new MemoryStream();
+            using var document = WordDocument.Create(stream);
+
+            document.Sections.Clear();
+
+            var header = document.HeaderDefaultOrCreate;
+            Assert.NotNull(header);
+            Assert.Single(document.Sections);
+
+            var footer = document.FooterDefaultOrCreate;
+            Assert.NotNull(footer);
+            Assert.Single(document.Sections);
+
+            Assert.False(document.DifferentFirstPage);
+            Assert.Single(document.Sections);
+
+            document.DifferentFirstPage = true;
+            Assert.True(document.DifferentFirstPage);
+
+            Assert.False(document.DifferentOddAndEvenPages);
+
+            document.DifferentOddAndEvenPages = true;
+            Assert.True(document.DifferentOddAndEvenPages);
+        }
+
+        [Fact]
+        public void HeaderAndFooterProperties_ThrowWhenSectionMissing() {
+            using var stream = new MemoryStream();
+            using var document = WordDocument.Create(stream);
+
+            document.Sections.Clear();
+
+            Assert.Throws<InvalidOperationException>(() => _ = document.Header);
+            Assert.Throws<InvalidOperationException>(() => _ = document.Footer);
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.HeadersAndFooters.cs
+++ b/OfficeIMO.Word/WordDocument.HeadersAndFooters.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml.Wordprocessing;
+using System;
 using System.Diagnostics;
 
 namespace OfficeIMO.Word {
@@ -21,16 +22,25 @@ namespace OfficeIMO.Word {
             }
         }
 
+        private WordSection GetFirstSectionOrThrow(string propertyName, bool createIfMissing) {
+            if (this.Sections.Count > 0) {
+                return this.Sections[0];
+            }
+
+            if (!createIfMissing) {
+                throw new InvalidOperationException($"Cannot access '{propertyName}' because the document does not contain any sections. Call AddSection() before using this property.");
+            }
+
+            return new WordSection(this, sectionProperties: null, paragraph: null);
+        }
+
         /// <summary>
         /// Gets the headers of the first section.
         /// </summary>
         public WordHeaders? Header {
             get {
-                if (this.Sections.Count == 0) {
-                    return null;
-                }
                 WarnIfMultipleSections(nameof(Header));
-                return this.Sections[0].Header;
+                return GetFirstSectionOrThrow(nameof(Header), false).Header;
             }
         }
         /// <summary>
@@ -38,11 +48,8 @@ namespace OfficeIMO.Word {
         /// </summary>
         public WordFooters? Footer {
             get {
-                if (this.Sections.Count == 0) {
-                    return null;
-                }
                 WarnIfMultipleSections(nameof(Footer));
-                return this.Sections[0].Footer;
+                return GetFirstSectionOrThrow(nameof(Footer), false).Footer;
             }
         }
 
@@ -53,7 +60,7 @@ namespace OfficeIMO.Word {
         public WordHeader HeaderDefaultOrCreate {
             get {
                 WarnIfMultipleSections(nameof(HeaderDefaultOrCreate));
-                return this.Sections[0].GetOrCreateHeader(HeaderFooterValues.Default);
+                return GetFirstSectionOrThrow(nameof(HeaderDefaultOrCreate), true).GetOrCreateHeader(HeaderFooterValues.Default);
             }
         }
 
@@ -64,7 +71,7 @@ namespace OfficeIMO.Word {
         public WordHeader HeaderFirstOrCreate {
             get {
                 WarnIfMultipleSections(nameof(HeaderFirstOrCreate));
-                return this.Sections[0].GetOrCreateHeader(HeaderFooterValues.First);
+                return GetFirstSectionOrThrow(nameof(HeaderFirstOrCreate), true).GetOrCreateHeader(HeaderFooterValues.First);
             }
         }
 
@@ -75,7 +82,7 @@ namespace OfficeIMO.Word {
         public WordHeader HeaderEvenOrCreate {
             get {
                 WarnIfMultipleSections(nameof(HeaderEvenOrCreate));
-                return this.Sections[0].GetOrCreateHeader(HeaderFooterValues.Even);
+                return GetFirstSectionOrThrow(nameof(HeaderEvenOrCreate), true).GetOrCreateHeader(HeaderFooterValues.Even);
             }
         }
 
@@ -86,7 +93,7 @@ namespace OfficeIMO.Word {
         public WordFooter FooterDefaultOrCreate {
             get {
                 WarnIfMultipleSections(nameof(FooterDefaultOrCreate));
-                return this.Sections[0].GetOrCreateFooter(HeaderFooterValues.Default);
+                return GetFirstSectionOrThrow(nameof(FooterDefaultOrCreate), true).GetOrCreateFooter(HeaderFooterValues.Default);
             }
         }
 
@@ -97,7 +104,7 @@ namespace OfficeIMO.Word {
         public WordFooter FooterFirstOrCreate {
             get {
                 WarnIfMultipleSections(nameof(FooterFirstOrCreate));
-                return this.Sections[0].GetOrCreateFooter(HeaderFooterValues.First);
+                return GetFirstSectionOrThrow(nameof(FooterFirstOrCreate), true).GetOrCreateFooter(HeaderFooterValues.First);
             }
         }
 
@@ -108,7 +115,7 @@ namespace OfficeIMO.Word {
         public WordFooter FooterEvenOrCreate {
             get {
                 WarnIfMultipleSections(nameof(FooterEvenOrCreate));
-                return this.Sections[0].GetOrCreateFooter(HeaderFooterValues.Even);
+                return GetFirstSectionOrThrow(nameof(FooterEvenOrCreate), true).GetOrCreateFooter(HeaderFooterValues.Even);
             }
         }
 
@@ -118,10 +125,10 @@ namespace OfficeIMO.Word {
         public bool DifferentFirstPage {
             get {
                 WarnIfMultipleSections(nameof(DifferentFirstPage));
-                return this.Sections[0].DifferentFirstPage;
+                return GetFirstSectionOrThrow(nameof(DifferentFirstPage), true).DifferentFirstPage;
             }
             set {
-                this.Sections[0].DifferentFirstPage = value;
+                GetFirstSectionOrThrow(nameof(DifferentFirstPage), true).DifferentFirstPage = value;
             }
 
         }
@@ -131,10 +138,10 @@ namespace OfficeIMO.Word {
         public bool DifferentOddAndEvenPages {
             get {
                 WarnIfMultipleSections(nameof(DifferentOddAndEvenPages));
-                return this.Sections[0].DifferentOddAndEvenPages;
+                return GetFirstSectionOrThrow(nameof(DifferentOddAndEvenPages), true).DifferentOddAndEvenPages;
             }
             set {
-                this.Sections[0].DifferentOddAndEvenPages = value;
+                GetFirstSectionOrThrow(nameof(DifferentOddAndEvenPages), true).DifferentOddAndEvenPages = value;
             }
         }
 


### PR DESCRIPTION
## Summary
- add a helper that ensures the first section exists or throws a clear InvalidOperationException when headers and footers are accessed
- update the header/footer accessors and page-difference flags to use the helper so a section is created on demand when appropriate
- add regression tests that exercise the new creation and exception paths on a fresh document

## Testing
- dotnet build
- dotnet test --filter HeaderAndFooterAccessors_CreateSectionWhenMissing


------
https://chatgpt.com/codex/tasks/task_e_68d7f40530cc832e81bfe6a853ca974b