### PR TITLE
Preserve relationships when appending Word documents

### DIFF
--- a/OfficeIMO.Word/WordDocument.Merge.cs
+++ b/OfficeIMO.Word/WordDocument.Merge.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 
@@ -17,6 +21,9 @@ namespace OfficeIMO.Word {
             var srcMain = source._wordprocessingDocument.MainDocumentPart;
             var destMain = this._wordprocessingDocument.MainDocumentPart;
             if (srcMain == null || destMain == null) return;
+
+            Dictionary<string, string> relationshipIdMap = new();
+            Dictionary<OpenXmlPart, OpenXmlPart> partMap = new();
 
             Numbering destNumbering;
             if (destMain.NumberingDefinitionsPart == null) {
@@ -77,6 +84,7 @@ namespace OfficeIMO.Word {
                         numId.Val = mapped;
                     }
                 }
+                RemapRelationshipIds(clone, srcMain, destMain, relationshipIdMap, partMap);
                 destMain.Document.Body.Append(clone);
             }
         }
@@ -93,6 +101,94 @@ namespace OfficeIMO.Word {
                 .Select(n => (int)(n.NumberID?.Value ?? 0))
                 .ToList();
             return ids.Count > 0 ? ids.Max() + 1 : 1;
+        }
+
+        private static void RemapRelationshipIds(OpenXmlElement element, OpenXmlPartContainer sourceContainer, OpenXmlPartContainer destinationContainer,
+            Dictionary<string, string> relationshipIdMap, Dictionary<OpenXmlPart, OpenXmlPart> partMap) {
+            const string relationshipNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+            foreach (var attribute in element.GetAttributes()) {
+                if (!string.Equals(attribute.NamespaceUri, relationshipNamespace, StringComparison.Ordinal) || string.IsNullOrEmpty(attribute.Value)) {
+                    continue;
+                }
+
+                var newId = EnsureRelationship(attribute.Value, sourceContainer, destinationContainer, relationshipIdMap, partMap);
+                if (!string.Equals(newId, attribute.Value, StringComparison.Ordinal)) {
+                    element.SetAttribute(new OpenXmlAttribute(attribute.Prefix, attribute.LocalName, attribute.NamespaceUri, newId));
+                }
+            }
+
+            foreach (var child in element.ChildElements) {
+                RemapRelationshipIds(child, sourceContainer, destinationContainer, relationshipIdMap, partMap);
+            }
+        }
+
+        private static string EnsureRelationship(string relationshipId, OpenXmlPartContainer sourceContainer, OpenXmlPartContainer destinationContainer,
+            Dictionary<string, string> relationshipIdMap, Dictionary<OpenXmlPart, OpenXmlPart> partMap) {
+            if (relationshipIdMap.TryGetValue(relationshipId, out var mapped)) {
+                return mapped;
+            }
+
+            OpenXmlPart? sourcePart = TryGetPartById(sourceContainer, relationshipId);
+            if (sourcePart != null) {
+                var destinationPart = ClonePartRecursive(sourcePart, destinationContainer, partMap);
+                var newId = destinationContainer.GetIdOfPart(destinationPart);
+                if (string.IsNullOrEmpty(newId)) {
+                    newId = destinationContainer.GetIdOfPart(destinationPart);
+                }
+                relationshipIdMap[relationshipId] = newId!;
+                return newId!;
+            }
+
+            var hyperlink = sourceContainer.HyperlinkRelationships.FirstOrDefault(h => h.Id == relationshipId);
+            if (hyperlink != null) {
+                var newId = $"rId{Guid.NewGuid():N}";
+                destinationContainer.AddHyperlinkRelationship(hyperlink.Uri, hyperlink.IsExternal, newId);
+                relationshipIdMap[relationshipId] = newId;
+                return newId;
+            }
+
+            var external = sourceContainer.ExternalRelationships.FirstOrDefault(e => e.Id == relationshipId);
+            if (external != null) {
+                var newId = $"rId{Guid.NewGuid():N}";
+                destinationContainer.AddExternalRelationship(external.RelationshipType, external.Uri, newId);
+                relationshipIdMap[relationshipId] = newId;
+                return newId;
+            }
+
+            relationshipIdMap[relationshipId] = relationshipId;
+            return relationshipId;
+        }
+
+        private static OpenXmlPart ClonePartRecursive(OpenXmlPart sourcePart, OpenXmlPartContainer destinationContainer, Dictionary<OpenXmlPart, OpenXmlPart> partMap) {
+            if (partMap.TryGetValue(sourcePart, out var existingPart)) {
+                return existingPart;
+            }
+
+            var clonedPart = destinationContainer.AddPart(sourcePart);
+            partMap[sourcePart] = clonedPart;
+
+            foreach (var external in sourcePart.ExternalRelationships) {
+                clonedPart.AddExternalRelationship(external.RelationshipType, external.Uri);
+            }
+
+            foreach (var hyperlink in sourcePart.HyperlinkRelationships) {
+                clonedPart.AddHyperlinkRelationship(hyperlink.Uri, hyperlink.IsExternal);
+            }
+
+            foreach (var child in sourcePart.Parts) {
+                ClonePartRecursive(child.OpenXmlPart, clonedPart, partMap);
+            }
+
+            return clonedPart;
+        }
+
+        private static OpenXmlPart? TryGetPartById(OpenXmlPartContainer container, string relationshipId) {
+            try {
+                return container.GetPartById(relationshipId);
+            } catch (ArgumentOutOfRangeException) {
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure `WordDocument.AppendDocument` remaps relationship ids and copies related parts when merging
- add a regression test that verifies images, hyperlinks, and embedded objects survive after append

## Testing
- dotnet test OfficeImo.sln --filter FullyQualifiedName~OfficeIMO.Tests.Word.Test_MergingDocumentsPreservesRelationships
- dotnet build OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d7f4164b18832e96b0000f6bb37882