### PR TITLE
Ensure Word comparer cleans up temporary results

### DIFF
--- a/OfficeIMO.Tests/Word.CompareDocuments.cs
+++ b/OfficeIMO.Tests/Word.CompareDocuments.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Linq;
-using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using Xunit;
@@ -21,15 +20,12 @@ namespace OfficeIMO.Tests {
                 doc.Save(false);
             }
 
-            string resultPath;
-            using (WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath)) {
-                resultPath = result.FilePath;
-            }
-
-            using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-              InsertedRun? ins = word.MainDocumentPart!.Document!.Body!.Descendants<InsertedRun>().FirstOrDefault();
-              Assert.NotNull(ins);
-              Assert.Equal(" World", ins!.InnerText);
+            using WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath);
+            Body body = result._wordprocessingDocument.MainDocumentPart!.Document!.Body!;
+            InsertedRun? ins = body.Descendants<InsertedRun>().FirstOrDefault();
+            Assert.NotNull(ins);
+            Assert.Equal(" World", ins!.InnerText);
+            AssertNoTempArtifact(result);
         }
 
         [Fact]
@@ -46,15 +42,12 @@ namespace OfficeIMO.Tests {
                 doc.Save(false);
             }
 
-            string resultPath;
-            using (WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath)) {
-                resultPath = result.FilePath;
-            }
-
-            using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-              DeletedRun? del = word.MainDocumentPart!.Document!.Body!.Descendants<DeletedRun>().FirstOrDefault();
-              Assert.NotNull(del);
-              Assert.Equal(" World", del!.InnerText);
+            using WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath);
+            Body body = result._wordprocessingDocument.MainDocumentPart!.Document!.Body!;
+            DeletedRun? del = body.Descendants<DeletedRun>().FirstOrDefault();
+            Assert.NotNull(del);
+            Assert.Equal(" World", del!.InnerText);
+            AssertNoTempArtifact(result);
         }
 
         [Fact]
@@ -72,15 +65,12 @@ namespace OfficeIMO.Tests {
                 doc.Save(false);
             }
 
-            string resultPath;
-            using (WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath)) {
-                resultPath = result.FilePath;
-            }
-
-            using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-              Run run = word.MainDocumentPart!.Document!.Body!.Descendants<Run>().First();
-              Assert.NotNull(run.RunProperties);
-              Assert.NotNull(run.RunProperties!.RunPropertiesChange);
+            using WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath);
+            Body body = result._wordprocessingDocument.MainDocumentPart!.Document!.Body!;
+            Run run = body.Descendants<Run>().First();
+            Assert.NotNull(run.RunProperties);
+            Assert.NotNull(run.RunProperties!.RunPropertiesChange);
+            AssertNoTempArtifact(result);
         }
 
         [Fact]
@@ -100,14 +90,11 @@ namespace OfficeIMO.Tests {
                 doc.Save(false);
             }
 
-            string resultPath;
-            using (WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath)) {
-                resultPath = result.FilePath;
-            }
-
-            using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-              InsertedRun? ins = word.MainDocumentPart!.Document!.Body!.Descendants<InsertedRun>().FirstOrDefault(r => r.InnerText == "Row2");
-              Assert.NotNull(ins);
+            using WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath);
+            Body body = result._wordprocessingDocument.MainDocumentPart!.Document!.Body!;
+            InsertedRun? ins = body.Descendants<InsertedRun>().FirstOrDefault(r => r.InnerText == "Row2");
+            Assert.NotNull(ins);
+            AssertNoTempArtifact(result);
         }
 
         [Fact]
@@ -127,14 +114,11 @@ namespace OfficeIMO.Tests {
                 doc.Save(false);
             }
 
-            string resultPath;
-            using (WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath)) {
-                resultPath = result.FilePath;
-            }
-
-            using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-              DeletedRun? del = word.MainDocumentPart!.Document!.Body!.Descendants<DeletedRun>().FirstOrDefault(r => r.InnerText == "Row2");
-              Assert.NotNull(del);
+            using WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath);
+            Body body = result._wordprocessingDocument.MainDocumentPart!.Document!.Body!;
+            DeletedRun? del = body.Descendants<DeletedRun>().FirstOrDefault(r => r.InnerText == "Row2");
+            Assert.NotNull(del);
+            AssertNoTempArtifact(result);
         }
 
         [Fact]
@@ -151,17 +135,20 @@ namespace OfficeIMO.Tests {
                 doc.Save(false);
             }
 
-            string resultPath;
-            using (WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath)) {
-                resultPath = result.FilePath;
-            }
-
-            using WordprocessingDocument word = WordprocessingDocument.Open(resultPath, false);
-              InsertedRun? ins = word.MainDocumentPart!.Document!.Body!.Descendants<InsertedRun>().FirstOrDefault(r => r.InnerText == "[Image]");
-              DeletedRun? del = word.MainDocumentPart!.Document!.Body!.Descendants<DeletedRun>().FirstOrDefault(r => r.InnerText == "[Image]");
-              Assert.NotNull(ins);
-              Assert.NotNull(del);
+            using WordDocument result = WordDocumentComparer.Compare(sourcePath, targetPath);
+            Body body = result._wordprocessingDocument.MainDocumentPart!.Document!.Body!;
+            InsertedRun? ins = body.Descendants<InsertedRun>().FirstOrDefault(r => r.InnerText == "[Image]");
+            DeletedRun? del = body.Descendants<DeletedRun>().FirstOrDefault(r => r.InnerText == "[Image]");
+            Assert.NotNull(ins);
+            Assert.NotNull(del);
+            AssertNoTempArtifact(result);
         }
 
+        private static void AssertNoTempArtifact(WordDocument document) {
+            string artifactPath = document.FilePath;
+            Assert.False(File.Exists(artifactPath));
+            string fileName = Path.GetFileName(artifactPath);
+            Assert.Empty(Directory.GetFiles(Path.GetTempPath(), fileName));
+        }
     }
 }

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.cs
@@ -16,17 +16,32 @@ namespace OfficeIMO.Word {
             string resultPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".docx");
             File.Copy(sourcePath, resultPath, true);
 
-            using (WordDocument source = WordDocument.Load(sourcePath))
-            using (WordDocument target = WordDocument.Load(targetPath))
-            using (WordDocument result = WordDocument.Load(resultPath)) {
-                CompareParagraphs(source, target, result);
-                CompareTables(source, target, result);
-                CompareImages(source, target, result);
+            WordDocument finalResult;
+            try {
+                using (WordDocument source = WordDocument.Load(sourcePath))
+                using (WordDocument target = WordDocument.Load(targetPath))
+                using (WordDocument result = WordDocument.Load(resultPath)) {
+                    CompareParagraphs(source, target, result);
+                    CompareTables(source, target, result);
+                    CompareImages(source, target, result);
 
-                result.Save(false);
+                    result.Save(false);
+                }
+
+                finalResult = WordDocument.Load(resultPath);
+            } finally {
+                if (File.Exists(resultPath)) {
+                    try {
+                        File.Delete(resultPath);
+                    } catch (IOException) {
+                        // Ignore cleanup failures.
+                    } catch (UnauthorizedAccessException) {
+                        // Ignore cleanup failures.
+                    }
+                }
             }
 
-            return WordDocument.Load(resultPath);
+            return finalResult;
         }
     }
 }


### PR DESCRIPTION
## Summary
- load the comparer result into memory and delete the temporary file before returning
- update compare tests to validate revision output and assert that no temporary artifacts remain

## Testing
- dotnet build OfficeImo.sln
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter Word.CompareDetects

------
https://chatgpt.com/codex/tasks/task_e_68d7f41e0238832ebbf2791fcdfe0597