### PR TITLE
Handle empty rows when reading ranges

### DIFF
--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Rows.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Rows.cs
@@ -13,6 +13,12 @@ namespace OfficeIMO.Excel {
         /// <param name="a1Range">Inclusive A1 range (e.g., "A1:C100").</param>
         /// <param name="ct">Cancellation token.</param>
         /// <returns>Sequence of rows as object?[] with fixed width equal to the range width. Rows without any cells yield null.</returns>
+        /// <remarks>
+        /// A <c>null</c> row is emitted when the worksheet row is missing from the requested range or when it
+        /// contains no cells within the specified bounds. Consumers that require dense data can call
+        /// <see cref="ReadRowsAs{T}(string, Func{object, T}?, CancellationToken)"/> which throws an
+        /// <see cref="InvalidOperationException"/> when an empty worksheet row is encountered.
+        /// </remarks>
         public IEnumerable<object?[]?> ReadRows(string a1Range, CancellationToken ct = default) {
             var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
             if (r1 > r2 || c1 > c2) yield break;

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Typed.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Typed.cs
@@ -37,11 +37,13 @@ namespace OfficeIMO.Excel {
         /// <param name="ct">Cancellation token.</param>
         public IEnumerable<T[]> ReadRowsAs<T>(string a1Range, Func<object, T>? convert = null, CancellationToken ct = default) {
             var (r1, _, _, _) = A1.ParseRange(a1Range);
-            int currentRow = r1;
+            int offset = 0;
             foreach (var row in ReadRows(a1Range, ct)) {
                 if (ct.IsCancellationRequested) yield break;
+                int rowIndex = r1 + offset;
+                offset++;
                 if (row is null) {
-                    throw new InvalidOperationException($"Row {currentRow} in range '{a1Range}' on sheet '{Name}' contains no cells.");
+                    throw new InvalidOperationException($"Row {rowIndex} in range '{a1Range}' on sheet '{Name}' contains no cells.");
                 }
                 var result = new T[row.Length];
                 for (int i = 0; i < row.Length; i++) {
@@ -58,7 +60,6 @@ namespace OfficeIMO.Excel {
                     }
                 }
                 yield return result;
-                currentRow++;
             }
         }
 

--- a/OfficeIMO.Tests/Excel.ReadRowsEmptyRows.cs
+++ b/OfficeIMO.Tests/Excel.ReadRowsEmptyRows.cs
@@ -9,40 +9,52 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void ReadRows_ReturnsNullForRowsWithoutCells() {
             string filePath = Path.Combine(_directoryWithFiles, "ReadRowsEmptyRows.xlsx");
-            using (var document = ExcelDocument.Create(filePath)) {
-                var sheet = document.AddWorkSheet("Data");
-                sheet.CellValue(1, 1, "Header");
-                sheet.CellValue(3, 1, "Value");
-                document.Save();
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Header");
+                    sheet.CellValue(3, 1, "Value");
+                    document.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                var rows = reader.GetSheet("Data").ReadRows("A1:A3").ToList();
+
+                Assert.Equal(3, rows.Count);
+                Assert.NotNull(rows[0]);
+                Assert.Equal("Header", rows[0]![0]);
+                Assert.Null(rows[1]);
+                Assert.NotNull(rows[2]);
+                Assert.Equal("Value", rows[2]![0]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
             }
-
-            using var reader = ExcelDocumentReader.Open(filePath);
-            var rows = reader.GetSheet("Data").ReadRows("A1:A3").ToList();
-
-            Assert.Equal(3, rows.Count);
-            Assert.NotNull(rows[0]);
-            Assert.Equal("Header", rows[0]![0]);
-            Assert.Null(rows[1]);
-            Assert.NotNull(rows[2]);
-            Assert.Equal("Value", rows[2]![0]);
         }
 
         [Fact]
         public void ReadRowsAs_ThrowsForRowsWithoutCells() {
             string filePath = Path.Combine(_directoryWithFiles, "ReadRowsAsEmptyRows.xlsx");
-            using (var document = ExcelDocument.Create(filePath)) {
-                var sheet = document.AddWorkSheet("Data");
-                sheet.CellValue(1, 1, "Header");
-                sheet.CellValue(3, 1, "Value");
-                document.Save();
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Header");
+                    sheet.CellValue(3, 1, "Value");
+                    document.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                var sheetReader = reader.GetSheet("Data");
+
+                var ex = Assert.Throws<InvalidOperationException>(() => sheetReader.ReadRowsAs<string>("A1:A3").ToList());
+                Assert.Contains("Row 2", ex.Message);
+                Assert.Contains("contains no cells", ex.Message);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
             }
-
-            using var reader = ExcelDocumentReader.Open(filePath);
-            var sheetReader = reader.GetSheet("Data");
-
-            var ex = Assert.Throws<InvalidOperationException>(() => sheetReader.ReadRowsAs<string>("A1:A3").ToList());
-            Assert.Contains("Row 2", ex.Message);
-            Assert.Contains("contains no cells", ex.Message);
         }
     }
 }


### PR DESCRIPTION
## Summary
- return null for worksheet rows that have no cells when streaming ranges
- throw a descriptive exception from the typed row reader when an empty row is encountered
- add regression tests covering empty row reads and typed reader behavior

## Testing
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d7f42e293c832ebd756896b6dccad9