### PR TITLE
Add defensive checks for cross-document paragraph insertions

### DIFF
--- a/OfficeIMO.Tests/Word.ParagraphGuards.cs
+++ b/OfficeIMO.Tests/Word.ParagraphGuards.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void ParagraphInsertionRejectsForeignDocumentParagraphs() {
+            string filePath1 = Path.Combine(_directoryWithFiles, "ParagraphGuard_Document1.docx");
+            string filePath2 = Path.Combine(_directoryWithFiles, "ParagraphGuard_Document2.docx");
+
+            using var document1 = WordDocument.Create(filePath1);
+            using var document2 = WordDocument.Create(filePath2);
+
+            var hostParagraph = document1.AddParagraph("Host");
+            var foreignParagraph = document2.AddParagraph("Foreign");
+
+            var paragraphException = Assert.Throws<InvalidOperationException>(() => hostParagraph.AddParagraph(foreignParagraph));
+            Assert.Contains("different document", paragraphException.Message, StringComparison.OrdinalIgnoreCase);
+
+            var documentException = Assert.Throws<InvalidOperationException>(() => document1.AddParagraph(foreignParagraph));
+            Assert.Contains("different document", documentException.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void TableCellRejectsParagraphsFromOtherDocuments() {
+            string hostPath = Path.Combine(_directoryWithFiles, "ParagraphGuard_TableHost.docx");
+            string foreignPath = Path.Combine(_directoryWithFiles, "ParagraphGuard_TableForeign.docx");
+
+            using var hostDocument = WordDocument.Create(hostPath);
+            using var foreignDocument = WordDocument.Create(foreignPath);
+
+            var table = hostDocument.AddTable(1, 1);
+            var hostCell = table.Rows[0].Cells[0];
+            var foreignParagraph = foreignDocument.AddParagraph("Foreign paragraph");
+
+            var exception = Assert.Throws<InvalidOperationException>(() => hostCell.AddParagraph(foreignParagraph));
+            Assert.Contains("different document", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void ParagraphInsertionRequiresMatchingSections() {
+            string filePath = Path.Combine(_directoryWithFiles, "ParagraphGuard_Sections.docx");
+
+            using var document = WordDocument.Create(filePath);
+            var firstSectionParagraph = document.AddParagraph("Section 1 paragraph");
+            var secondSection = document.AddSection();
+            var secondSectionParagraph = secondSection.AddParagraph("Section 2 paragraph");
+
+            var exception = Assert.Throws<InvalidOperationException>(() => secondSectionParagraph.AddParagraph(firstSectionParagraph));
+            Assert.Contains("different section", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -20,6 +20,9 @@ namespace OfficeIMO.Word {
 
             var body = _wordprocessingDocument?.MainDocumentPart?.Document?.Body
                 ?? throw new InvalidOperationException("Document body is missing.");
+
+            WordParagraph.EnsureParagraphCanBeInserted(this, body, wordParagraph,
+                "append a paragraph to the document body");
             body.AppendChild(wordParagraph._paragraph);
             return wordParagraph;
         }

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -124,6 +124,8 @@ namespace OfficeIMO.Word {
             if (paragraph == null) {
                 paragraph = new WordParagraph(this._document);
             }
+            WordParagraph.EnsureParagraphCanBeInserted(this._document, _tableCell, paragraph,
+                "append a paragraph to the table cell");
             _tableCell.Append(paragraph._paragraph);
             return paragraph;
         }


### PR DESCRIPTION
## Summary
- enforce document and section compatibility when inserting existing `WordParagraph` instances
- guard table cell paragraph insertion against foreign document content
- add unit tests verifying cross-document and cross-section paragraph rejection

## Testing
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter FullyQualifiedName~ParagraphInsertion
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter TableCellRejectsParagraphsFromOtherDocuments

------
https://chatgpt.com/codex/tasks/task_e_68d7f43a1648832ea5c931ef0bebed16