### PR TITLE
Fix WordDocument dispose deadlock

### DIFF
--- a/OfficeIMO.Tests/Word.Dispose.cs
+++ b/OfficeIMO.Tests/Word.Dispose.cs
@@ -1,5 +1,7 @@
+using System;
 using System.IO;
 using OfficeIMO.Word;
+using System.Threading;
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -19,6 +21,37 @@ namespace OfficeIMO.Tests {
             document.Dispose();
 
             Assert.False(filePath.IsFileLocked());
+        }
+
+        [Fact]
+        public void Test_DisposeDoesNotCaptureSynchronizationContext() {
+            var filePath = Path.Combine(_directoryWithFiles, "DisposeTestingSynchronizationContext.docx");
+            File.Delete(filePath);
+
+            var document = WordDocument.Create(filePath, autoSave: true);
+            document.AddParagraph("This is my test");
+
+            var originalContext = SynchronizationContext.Current;
+            var context = new ThrowingSynchronizationContext();
+
+            try {
+                SynchronizationContext.SetSynchronizationContext(context);
+                document.Dispose();
+            } finally {
+                SynchronizationContext.SetSynchronizationContext(originalContext);
+            }
+
+            Assert.Equal(0, context.PostCount);
+            Assert.False(filePath.IsFileLocked());
+        }
+
+        private sealed class ThrowingSynchronizationContext : SynchronizationContext {
+            public int PostCount { get; private set; }
+
+            public override void Post(SendOrPostCallback d, object? state) {
+                PostCount++;
+                throw new InvalidOperationException("Asynchronous continuations are not expected during synchronous disposal.");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- avoid synchronously awaiting DisposeAsync by giving WordDocument a synchronous disposal path
- keep asynchronous disposal from capturing the current synchronization context
- add a regression test that verifies disposing under a custom SynchronizationContext completes

## Testing
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName=OfficeIMO.Tests.Word.Test_DisposeDoesNotCaptureSynchronizationContext"

------
https://chatgpt.com/codex/tasks/task_e_68df6a175b68832eadc5844fbc6f69ae