### PR TITLE
Mark TOC fields dirty when auto-updating

### DIFF
--- a/OfficeIMO.Word/WordTableOfContent.cs
+++ b/OfficeIMO.Word/WordTableOfContent.cs
@@ -149,6 +149,17 @@ namespace OfficeIMO.Word {
         /// </summary>
         public void Update() {
             this._document.Settings.UpdateFieldsOnOpen = true;
+            if (_sdtBlock == null) {
+                return;
+            }
+
+            foreach (var simpleField in _sdtBlock.Descendants<SimpleField>()) {
+                simpleField.Dirty = true;
+            }
+
+            foreach (var fieldChar in _sdtBlock.Descendants<FieldChar>()) {
+                fieldChar.Dirty = true;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- mark table of contents simple fields and nested field characters as dirty whenever Update is called so Word refreshes them on open
- add a regression test that saves a document with AutoUpdateToc to a byte array and confirms the TOC fields remain dirty after reload

## Testing
- dotnet build OfficeImo.sln
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e7fbc8c7b4832e8725f8ebbaf345fd