### PR TITLE
Add parent accessors for Word table rows and cells

### DIFF
--- a/OfficeIMO.Examples/Word/Tables/Tables.ParentAccess.cs
+++ b/OfficeIMO.Examples/Word/Tables/Tables.ParentAccess.cs
@@ -1,0 +1,26 @@
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Examples.Word {
+    internal static partial class Tables {
+        internal static void Example_TablesParentAccess(string folderPath, bool openWord) {
+            Console.WriteLine("[*] Accessing table row information from a cell");
+            string filePath = System.IO.Path.Combine(folderPath, "Document with Table Parent Access.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(1, 2, WordTableStyle.TableGrid);
+                table.Rows[0].Height = 480;
+
+                WordTableCell firstCell = table.Rows[0].Cells[0];
+                firstCell.Paragraphs[0].Text = "Row height:";
+
+                int? heightFromCell = firstCell.Parent.Height;
+                firstCell.AddParagraph(heightFromCell?.ToString() ?? "not set");
+
+                Console.WriteLine($"Row height read from cell: {heightFromCell}");
+                Console.WriteLine($"Cell belongs to table style: {firstCell.ParentTable.Style}");
+
+                document.Save(openWord);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.Tables.cs
+++ b/OfficeIMO.Tests/Word.Tables.cs
@@ -134,6 +134,25 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_TableRowAndCellParentAccessors() {
+            string filePath = Path.Combine(_directoryWithFiles, "TableParentAccessors.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordTable table = document.AddTable(1, 1);
+                table.Rows[0].Height = 400;
+
+                var row = table.Rows[0];
+                Assert.Same(table, row.Parent);
+
+                var cell = row.Cells[0];
+                Assert.Same(row, cell.Parent);
+                Assert.Same(table, cell.ParentTable);
+                Assert.Equal(row.Height, cell.Parent.Height);
+
+                document.Save(false);
+            }
+        }
+
+        [Fact]
         public void Test_CreatingWordDocumentWithTablesAddRows() {
             string filePath = Path.Combine(_directoryWithFiles, "CreatedDocumentWithTables.docx");
             using (WordDocument document = WordDocument.Create(filePath)) {

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -23,6 +23,16 @@ namespace OfficeIMO.Word {
         private readonly WordDocument _document;
 
         /// <summary>
+        /// Gets the row that owns this cell.
+        /// </summary>
+        public WordTableRow Parent => _wordTableRow;
+
+        /// <summary>
+        /// Gets the table that owns this cell.
+        /// </summary>
+        public WordTable ParentTable => _wordTable;
+
+        /// <summary>
         /// Gets or Sets Horizontal Merge for a Table Cell
         /// </summary>
         public MergedCellValues? HorizontalMerge {

--- a/OfficeIMO.Word/WordTableRow.cs
+++ b/OfficeIMO.Word/WordTableRow.cs
@@ -140,6 +140,11 @@ namespace OfficeIMO.Word {
         private readonly WordDocument _document;
 
         /// <summary>
+        /// Gets the table that owns this row.
+        /// </summary>
+        public WordTable Parent => _wordTable;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="WordTableRow"/> class and creates an empty row.
         /// </summary>
         /// <param name="document">The parent <see cref="WordDocument"/>.</param>


### PR DESCRIPTION
## Summary
- expose the owning table on `WordTableRow` and the owning row/table on `WordTableCell`
- cover the new parent chain with a unit test in `Word.Tables`
- document the feature with a table example that reads a row property from a cell

## Testing
- dotnet build
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fb24ef97a4832eb58b14258a375cbf