### PR TITLE
Ensure Markdown slugs stay unique across renders

### DIFF
--- a/OfficeIMO.Markdown/Utilities/MarkdownSlug.cs
+++ b/OfficeIMO.Markdown/Utilities/MarkdownSlug.cs
@@ -1,21 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
 namespace OfficeIMO.Markdown;
 
 /// <summary>
 /// Slug utilities for generating anchor ids compatible with GitHub-like platforms.
 /// </summary>
 internal static class MarkdownSlug {
-    public static string GitHub(string text) {
-        if (string.IsNullOrEmpty(text)) return string.Empty;
+    /// <summary>
+    /// Creates a registry that tracks generated slugs to ensure uniqueness within a document render.
+    /// </summary>
+    public static Dictionary<string, int> CreateRegistry() => new(StringComparer.Ordinal);
+
+    public static string GitHub(string text) => GitHub(text, registry: null);
+
+    /// <summary>
+    /// Generates a GitHub-style slug and ensures uniqueness using the provided registry when supplied.
+    /// </summary>
+    public static string GitHub(string text, IDictionary<string, int>? registry) {
+        if (string.IsNullOrEmpty(text)) {
+            return EnsureUnique(string.Empty, registry);
+        }
+
         var sb = new StringBuilder(text.Length);
         bool prevHyphen = false;
         foreach (char ch in text.ToLowerInvariant()) {
-            if ((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')) { sb.Append(ch); prevHyphen = false; } else if (ch == ' ' || ch == '-' || ch == '_') { if (!prevHyphen) { sb.Append('-'); prevHyphen = true; } } else {
+            if ((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')) {
+                sb.Append(ch);
+                prevHyphen = false;
+            } else if (ch == ' ' || ch == '-' || ch == '_') {
+                if (!prevHyphen) {
+                    sb.Append('-');
+                    prevHyphen = true;
+                }
+            } else {
                 // skip punctuation
             }
         }
-        // trim trailing hyphen
+
         var result = sb.ToString().Trim('-');
-        return result;
+        return EnsureUnique(result, registry);
+    }
+
+    private static string EnsureUnique(string slug, IDictionary<string, int>? registry) {
+        if (registry is null) return slug;
+
+        if (!registry.TryGetValue(slug, out var count)) {
+            registry[slug] = 0;
+            return slug;
+        }
+
+        int next = count + 1;
+        string candidate;
+        do {
+            candidate = string.IsNullOrEmpty(slug)
+                ? $"-{next.ToString(CultureInfo.InvariantCulture)}"
+                : $"{slug}-{next.ToString(CultureInfo.InvariantCulture)}";
+            if (!registry.ContainsKey(candidate)) {
+                registry[slug] = next;
+                registry[candidate] = 0;
+                return candidate;
+            }
+            next++;
+        } while (true);
     }
 }
-

--- a/OfficeIMO.Tests/Markdown.DuplicateHeadings.cs
+++ b/OfficeIMO.Tests/Markdown.DuplicateHeadings.cs
@@ -1,0 +1,29 @@
+using OfficeIMO.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Markdown {
+        [Fact]
+        public void Markdown_DuplicateHeadingsProduceUniqueAnchors() {
+            var doc = MarkdownDoc.Create()
+                .Toc(opts => { opts.IncludeTitle = false; opts.MinLevel = 2; opts.MaxLevel = 3; }, placeAtTop: true)
+                .H1("Intro")
+                .H2("Repeat me")
+                .H2("Repeat me")
+                .H2("Repeat me");
+
+            string markdown = doc.ToMarkdown();
+            Assert.Contains("- [Repeat me](#repeat-me)", markdown);
+            Assert.Contains("- [Repeat me](#repeat-me-1)", markdown);
+            Assert.Contains("- [Repeat me](#repeat-me-2)", markdown);
+
+            string html = doc.ToHtmlFragment();
+            Assert.Contains("<h2 id=\"repeat-me\"", html);
+            Assert.Contains("<h2 id=\"repeat-me-1\"", html);
+            Assert.Contains("<h2 id=\"repeat-me-2\"", html);
+            Assert.Contains("href=\"#repeat-me\"", html);
+            Assert.Contains("href=\"#repeat-me-1\"", html);
+            Assert.Contains("href=\"#repeat-me-2\"", html);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend the Markdown slug helper with a registry that issues GitHub-style suffixes for duplicate headings
- propagate slug tracking through MarkdownDoc and HtmlRenderer so TOC entries and heading ids remain aligned
- add a regression test that renders duplicate headings and verifies unique anchors in both Markdown and HTML

## Testing
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_690332b3395c832e8fed8c91d44ac01d