### PR TITLE
Ensure cloned Word tables assign new SDT identifiers

### DIFF
--- a/OfficeIMO.Word/WordTable.Methods.cs
+++ b/OfficeIMO.Word/WordTable.Methods.cs
@@ -148,6 +148,7 @@ namespace OfficeIMO.Word {
 
             // Clone the row to avoid the "part of a tree" error
             var clonedRow = (TableRow)row._tableRow.CloneNode(true);
+            _document.AssignNewSdtIds(clonedRow);
 
             // Insert the new row after the last row
             var insertedRow = lastRow.InsertAfterSelf(clonedRow);
@@ -637,6 +638,7 @@ namespace OfficeIMO.Word {
         /// </example>
         public WordTable CloneAfterSelf() {
             var clonedTable = (Table)_table.CloneNode(true);
+            _document.AssignNewSdtIds(clonedTable);
             _table.InsertAfterSelf(clonedTable);
             return new WordTable(_document, clonedTable);
         }
@@ -652,6 +654,7 @@ namespace OfficeIMO.Word {
         /// </example>
         public WordTable CloneBeforeSelf() {
             var clonedTable = (Table)_table.CloneNode(true);
+            _document.AssignNewSdtIds(clonedTable);
             _table.InsertBeforeSelf(clonedTable);
             return new WordTable(_document, clonedTable);
         }
@@ -669,6 +672,7 @@ namespace OfficeIMO.Word {
         /// </example>
         public WordTable Clone(WordParagraph paragraph, bool after = true) {
             var clonedTable = (Table)_table.CloneNode(true);
+            _document.AssignNewSdtIds(clonedTable);
             if (after) {
                 paragraph._paragraph.InsertAfterSelf(clonedTable);
             } else {
@@ -690,6 +694,7 @@ namespace OfficeIMO.Word {
         /// </example>
         public WordTable Clone(WordTable table, bool after = true) {
             var clonedTable = (Table)_table.CloneNode(true);
+            _document.AssignNewSdtIds(clonedTable);
             if (after) {
                 table._table.InsertAfterSelf(clonedTable);
             } else {


### PR DESCRIPTION
## Summary
- ensure WordTable.CopyRow and all clone helpers assign new SDT identifiers before inserting duplicates so content controls remain unique
- add a regression test that exercises CopyRow and each clone helper with structured document tags to assert positive, unique SdtIds

## Testing
- dotnet test OfficeImo.sln

------
https://chatgpt.com/codex/tasks/task_e_690c3d62741c832ebce9e080595e88e7