### PR TITLE
Improve PDF reader and SaveAsPdf compatibility

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.cs
@@ -53,13 +53,12 @@ public sealed class PdfReadDocument {
                 var kids = ResolveArray(pagesNode.Items.TryGetValue("Kids", out var kidsObj) ? kidsObj : null);
                 int kidCount = kids?.Items.Count ?? 0;
                 var visited = new HashSet<int>();
-                var contentKeys = new HashSet<string>(StringComparer.Ordinal);
                 int? target = null;
                 var cnt = pagesNode.Get<PdfNumber>("Count");
                 if (cnt is not null) {
                     int cc = (int)cnt.Value; if (cc > 0) target = cc;
                 }
-                TraversePagesNodeDeepLimited(pagesNode, visited, contentKeys, result, target);
+                TraversePagesNodeDeepLimited(pagesNode, visited, result, target);
                 if (result.Count == 0 && kidCount > 0) {
                     // Build a reachable candidate set from Kids only
                     var reachable = CollectReachableLeafCandidates(pagesNode);
@@ -128,16 +127,13 @@ public sealed class PdfReadDocument {
         return !hasKids && hasContents && (hasRes || hasMedia);
     }
 
-    private void TraversePagesNodeDeepLimited(PdfDictionary node, HashSet<int> visited, HashSet<string> contentKeys, List<PdfReadPage> outList, int? limit) {
+    private void TraversePagesNodeDeepLimited(PdfDictionary node, HashSet<int> visited, List<PdfReadPage> outList, int? limit) {
         var type = node.Get<PdfName>("Type")?.Name;
         if (type == "Page" || (type is null && IsLikelyPage(node))) {
             int objNum = FindObjectNumberFor(node);
             if (objNum > 0 && visited.Add(objNum)) {
                 if (type == "Page" || HasMedia(node) || HasInheritedValue(node, "MediaBox") || HasInheritedValue(node, "CropBox")) {
-                    var key = ContentsKey(node);
-                    if (key is null || contentKeys.Add(key)) {
-                        outList.Add(new PdfReadPage(objNum, node, _objects));
-                    }
+                    outList.Add(new PdfReadPage(objNum, node, _objects));
                 }
             }
             return;
@@ -149,16 +145,13 @@ public sealed class PdfReadDocument {
             var d = ResolveDict(kid);
             if (d is null) { continue; }
             var t = d.Get<PdfName>("Type")?.Name;
-            if (t == "Pages" || (t is null && ResolveArray(d.Items.TryGetValue("Kids", out var dKidsObj) ? dKidsObj : null) is not null)) TraversePagesNodeDeepLimited(d, visited, contentKeys, outList, limit);
+            if (t == "Pages" || (t is null && ResolveArray(d.Items.TryGetValue("Kids", out var dKidsObj) ? dKidsObj : null) is not null)) TraversePagesNodeDeepLimited(d, visited, outList, limit);
             else if ((t == "Page" || IsLikelyPage(d) || IsLeafPageByParent(d)) &&
                      (t == "Page" || HasMedia(d) || HasInheritedValue(d, "MediaBox") || HasInheritedValue(d, "CropBox"))) {
                 int on = FindObjectNumberFor(d);
                 if (on > 0 && visited.Add(on)) {
-                    var key = ContentsKey(d);
-                    if (key is null || contentKeys.Add(key)) {
-                        outList.Add(new PdfReadPage(on, d, _objects));
-                        if (limit.HasValue && outList.Count >= limit.Value) return;
-                    }
+                    outList.Add(new PdfReadPage(on, d, _objects));
+                    if (limit.HasValue && outList.Count >= limit.Value) return;
                 }
             }
         }
@@ -226,30 +219,6 @@ public sealed class PdfReadDocument {
     }
 
     private static bool HasMedia(PdfDictionary d) => d.Items.ContainsKey("MediaBox") || d.Items.ContainsKey("CropBox");
-    private string? ContentsKey(PdfDictionary d) {
-        if (!d.Items.TryGetValue("Contents", out var c)) return null;
-        if (c is PdfReference r) {
-            if (_objects.TryGetValue(r.ObjectNumber, out var ind) && ind.Value is PdfArray referencedArray) {
-                return ContentsArrayKey(referencedArray);
-            }
-            return $"ref:{r.ObjectNumber}";
-        }
-        if (c is PdfStream) return "stream:direct";
-        if (c is PdfArray arr) {
-            return ContentsArrayKey(arr);
-        }
-        return null;
-    }
-
-    private static string ContentsArrayKey(PdfArray arr) {
-        var sb = new System.Text.StringBuilder();
-        sb.Append("arr:");
-        foreach (var it in arr.Items) {
-            if (it is PdfReference rr) sb.Append(rr.ObjectNumber).Append(',');
-        }
-        return sb.ToString();
-    }
-
     private int FindObjectNumberFor(PdfDictionary dict) {
         foreach (var kv in _objects) if (ReferenceEquals(kv.Value.Value, dict)) return kv.Key;
         // As a fallback when dictionary was re-parsed separately, match by identity via a simple scan of Page objects

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.cs
@@ -50,7 +50,7 @@ public sealed class PdfReadDocument {
         if (catalogId is int cat && _objects.TryGetValue(cat, out var catObj) && catObj.Value is PdfDictionary catalog) {
             var pagesNode = ResolveDict(catalog.Items.TryGetValue("Pages", out var v) ? v : null);
             if (pagesNode is not null) {
-                var kids = pagesNode.Get<PdfArray>("Kids");
+                var kids = ResolveArray(pagesNode.Items.TryGetValue("Kids", out var kidsObj) ? kidsObj : null);
                 int kidCount = kids?.Items.Count ?? 0;
                 var visited = new HashSet<int>();
                 var contentKeys = new HashSet<string>(StringComparer.Ordinal);
@@ -92,6 +92,13 @@ public sealed class PdfReadDocument {
         return null;
     }
 
+    private PdfArray? ResolveArray(PdfObject? obj) {
+        if (obj is null) return null;
+        if (obj is PdfArray a) return a;
+        if (obj is PdfReference r && _objects.TryGetValue(r.ObjectNumber, out var ind) && ind.Value is PdfArray aa) return aa;
+        return null;
+    }
+
     private void TraversePagesNode(PdfDictionary node, List<PdfReadPage> outList) {
         var type = node.Get<PdfName>("Type")?.Name;
         if (type == "Page" || (type is null && IsLikelyPage(node))) {
@@ -100,8 +107,9 @@ public sealed class PdfReadDocument {
             outList.Add(new PdfReadPage(objNum, node, _objects));
             return;
         }
-        if (type == "Pages" || (type is null && node.Get<PdfArray>("Kids") is not null)) {
-            var kids = node.Get<PdfArray>("Kids");
+        var kidsObj = node.Items.TryGetValue("Kids", out var kidsValue) ? kidsValue : null;
+        if (type == "Pages" || (type is null && ResolveArray(kidsObj) is not null)) {
+            var kids = ResolveArray(kidsObj);
             if (kids is null) return;
             foreach (var kid in kids.Items) {
                 var d = ResolveDict(kid);
@@ -111,12 +119,12 @@ public sealed class PdfReadDocument {
         }
     }
 
-    private static bool IsLikelyPage(PdfDictionary d) {
-        // Heuristic when /Type is missing: leaf node has Contents, and either its own Resources or MediaBox.
+    private bool IsLikelyPage(PdfDictionary d) {
+        // Heuristic when /Type is missing: leaf node has Contents, and page data can come from itself or inherited /Pages nodes.
         bool hasContents = d.Items.ContainsKey("Contents");
-        bool hasRes = d.Items.ContainsKey("Resources");
-        bool hasMedia = d.Items.ContainsKey("MediaBox") || d.Items.ContainsKey("CropBox");
-        bool hasKids = d.Items.ContainsKey("Kids");
+        bool hasRes = d.Items.ContainsKey("Resources") || HasInheritedValue(d, "Resources");
+        bool hasMedia = HasMedia(d) || HasInheritedValue(d, "MediaBox") || HasInheritedValue(d, "CropBox");
+        bool hasKids = ResolveArray(d.Items.TryGetValue("Kids", out var kidsObj) ? kidsObj : null) is not null;
         return !hasKids && hasContents && (hasRes || hasMedia);
     }
 
@@ -125,7 +133,7 @@ public sealed class PdfReadDocument {
         if (type == "Page" || (type is null && IsLikelyPage(node))) {
             int objNum = FindObjectNumberFor(node);
             if (objNum > 0 && visited.Add(objNum)) {
-                if (HasMedia(node)) {
+                if (type == "Page" || HasMedia(node) || HasInheritedValue(node, "MediaBox") || HasInheritedValue(node, "CropBox")) {
                     var key = ContentsKey(node);
                     if (key is null || contentKeys.Add(key)) {
                         outList.Add(new PdfReadPage(objNum, node, _objects));
@@ -134,15 +142,16 @@ public sealed class PdfReadDocument {
             }
             return;
         }
-        var kids = node.Get<PdfArray>("Kids");
+        var kids = ResolveArray(node.Items.TryGetValue("Kids", out var kidsObj) ? kidsObj : null);
         if (kids is null) return;
         foreach (var kid in kids.Items) {
             if (limit.HasValue && outList.Count >= limit.Value) return;
             var d = ResolveDict(kid);
             if (d is null) { continue; }
             var t = d.Get<PdfName>("Type")?.Name;
-            if (t == "Pages" || (t is null && d.Get<PdfArray>("Kids") is not null)) TraversePagesNodeDeepLimited(d, visited, contentKeys, outList, limit);
-            else if ((t == "Page" || IsLikelyPage(d) || IsLeafPageByParent(d)) && HasMedia(d)) {
+            if (t == "Pages" || (t is null && ResolveArray(d.Items.TryGetValue("Kids", out var dKidsObj) ? dKidsObj : null) is not null)) TraversePagesNodeDeepLimited(d, visited, contentKeys, outList, limit);
+            else if ((t == "Page" || IsLikelyPage(d) || IsLeafPageByParent(d)) &&
+                     (t == "Page" || HasMedia(d) || HasInheritedValue(d, "MediaBox") || HasInheritedValue(d, "CropBox"))) {
                 int on = FindObjectNumberFor(d);
                 if (on > 0 && visited.Add(on)) {
                     var key = ContentsKey(d);
@@ -162,13 +171,13 @@ public sealed class PdfReadDocument {
         int guard = 0;
         while (stack.Count > 0 && guard++ < 10000) {
             var cur = stack.Pop();
-            var kids = cur.Get<PdfArray>("Kids");
+            var kids = ResolveArray(cur.Items.TryGetValue("Kids", out var kidsObj) ? kidsObj : null);
             if (kids is null) continue;
             foreach (var k in kids.Items) {
                 var d = ResolveDict(k);
                 if (d is null) continue;
                 var t = d.Get<PdfName>("Type")?.Name;
-                if (t == "Pages" || (t is null && d.Get<PdfArray>("Kids") is not null)) stack.Push(d);
+                if (t == "Pages" || (t is null && ResolveArray(d.Items.TryGetValue("Kids", out var dKidsObj) ? dKidsObj : null) is not null)) stack.Push(d);
                 else if (IsLikelyPage(d) || IsLeafPageByParent(d)) {
                     int on = FindObjectNumberFor(d);
                     if (on > 0) set.Add(on);
@@ -193,17 +202,52 @@ public sealed class PdfReadDocument {
         return false;
     }
 
+    private bool HasInheritedValue(PdfDictionary start, string key) {
+        PdfDictionary? current = start;
+        int guard = 0;
+        while (current is not null && guard++ < 100) {
+            if (current.Items.ContainsKey(key)) {
+                return true;
+            }
+
+            if (!current.Items.TryGetValue("Parent", out var parentObj)) {
+                break;
+            }
+
+            var parent = ResolveDict(parentObj);
+            if (parent is null) {
+                break;
+            }
+
+            current = parent;
+        }
+
+        return false;
+    }
+
     private static bool HasMedia(PdfDictionary d) => d.Items.ContainsKey("MediaBox") || d.Items.ContainsKey("CropBox");
-    private static string? ContentsKey(PdfDictionary d) {
+    private string? ContentsKey(PdfDictionary d) {
         if (!d.Items.TryGetValue("Contents", out var c)) return null;
-        if (c is PdfReference r) return $"ref:{r.ObjectNumber}";
+        if (c is PdfReference r) {
+            if (_objects.TryGetValue(r.ObjectNumber, out var ind) && ind.Value is PdfArray referencedArray) {
+                return ContentsArrayKey(referencedArray);
+            }
+            return $"ref:{r.ObjectNumber}";
+        }
+        if (c is PdfStream) return "stream:direct";
         if (c is PdfArray arr) {
-            var sb = new System.Text.StringBuilder();
-            sb.Append("arr:");
-            foreach (var it in arr.Items) if (it is PdfReference rr) sb.Append(rr.ObjectNumber).Append(',');
-            return sb.ToString();
+            return ContentsArrayKey(arr);
         }
         return null;
+    }
+
+    private static string ContentsArrayKey(PdfArray arr) {
+        var sb = new System.Text.StringBuilder();
+        sb.Append("arr:");
+        foreach (var it in arr.Items) {
+            if (it is PdfReference rr) sb.Append(rr.ObjectNumber).Append(',');
+        }
+        return sb.ToString();
     }
 
     private int FindObjectNumberFor(PdfDictionary dict) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
@@ -43,7 +43,7 @@ public sealed class PdfReadPage {
         var pageResources = ResolveDictionary(GetInheritedValue("Resources"));
         var pageDecoders = ResourceResolver.GetFontDecoders(_pageDict, _objects);
         var pageWidthProviders = ResourceResolver.GetFontWidthProviders(_pageDict, _objects);
-        var activeForms = new HashSet<int>();
+        var activeForms = new HashSet<PdfStream>();
 
         foreach (var stream in GetContentStreams()) {
             CollectTextAndForms(
@@ -64,7 +64,7 @@ public sealed class PdfReadPage {
         Dictionary<string, Func<byte[], string>> decoders,
         Dictionary<string, Func<byte[], double>> widthProviders,
         List<PdfTextSpan> spans,
-        HashSet<int> activeForms) {
+        HashSet<PdfStream> activeForms) {
         string DecodeWithFont(string fontRes, byte[] bytes) =>
             decoders.TryGetValue(fontRes, out var dec) ? dec(bytes) : PdfWinAnsiEncoding.Decode(bytes);
         double SumWidth1000(string fontRes, byte[] bytes) =>
@@ -73,12 +73,11 @@ public sealed class PdfReadPage {
         spans.AddRange(TextContentParser.Parse(content, DecodeWithFont, SumWidth1000));
 
         foreach (var invocation in TextContentParser.ExtractFormInvocations(content)) {
-            if (!TryGetFormStream(resources, invocation.Name, out var formStream, out int formObjectNumber)) {
+            if (!TryGetFormStream(resources, invocation.Name, out var formStream)) {
                 continue;
             }
 
-            bool trackRecursion = formObjectNumber > 0;
-            if (trackRecursion && !activeForms.Add(formObjectNumber)) {
+            if (!activeForms.Add(formStream)) {
                 continue;
             }
 
@@ -92,24 +91,20 @@ public sealed class PdfReadPage {
 
                 CollectTextAndForms(formContent, formResources, formDecoders, formWidths, spans, activeForms);
             } finally {
-                if (trackRecursion) {
-                    activeForms.Remove(formObjectNumber);
-                }
+                activeForms.Remove(formStream);
             }
         }
     }
 
-    private bool TryGetFormStream(PdfDictionary? resources, string name, out PdfStream formStream, out int objectNumber) {
+    private bool TryGetFormStream(PdfDictionary? resources, string name, out PdfStream formStream) {
         if (resources is null || !resources.Items.TryGetValue("XObject", out var xoObj)) {
             formStream = null!;
-            objectNumber = 0;
             return false;
         }
 
         var xoDict = ResolveDictionary(xoObj);
         if (xoDict is null || !xoDict.Items.TryGetValue(name, out var formObj)) {
             formStream = null!;
-            objectNumber = 0;
             return false;
         }
 
@@ -118,19 +113,16 @@ public sealed class PdfReadPage {
             indirectForm.Value is PdfStream stream &&
             string.Equals(stream.Dictionary.Get<PdfName>("Subtype")?.Name, "Form", StringComparison.Ordinal)) {
             formStream = stream;
-            objectNumber = formRef.ObjectNumber;
             return true;
         }
 
         if (formObj is PdfStream directStream &&
             string.Equals(directStream.Dictionary.Get<PdfName>("Subtype")?.Name, "Form", StringComparison.Ordinal)) {
             formStream = directStream;
-            objectNumber = 0;
             return true;
         }
 
         formStream = null!;
-        objectNumber = 0;
         return false;
     }
 

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
@@ -24,80 +24,237 @@ public sealed class PdfReadPage {
     }
 
     /// <summary>
-    /// Attempts to read page size from MediaBox (or CropBox) and returns width/height in points.
+    /// Attempts to read page size from CropBox (or MediaBox) and returns width/height in points.
     /// Falls back to 612x792 (US Letter) when not present or malformed.
     /// </summary>
     public (double Width, double Height) GetPageSize() {
-        static (double, double) ParseBox(PdfObject? box) {
-            if (box is PdfArray arr && arr.Items.Count >= 4 &&
-                arr.Items[0] is PdfNumber llx && arr.Items[1] is PdfNumber lly &&
-                arr.Items[2] is PdfNumber urx && arr.Items[3] is PdfNumber ury) {
-                double w = urx.Value - llx.Value;
-                double h = ury.Value - lly.Value;
-                if (w > 0 && h > 0) return (w, h);
-            }
-            return (612, 792); // default Letter
-        }
-        if (_pageDict.Items.TryGetValue("MediaBox", out var media)) return ParseBox(media);
-        if (_pageDict.Items.TryGetValue("CropBox", out var crop)) return ParseBox(crop);
+        var crop = GetInheritedValue("CropBox");
+        if (TryParseBox(crop, out var cropSize)) return cropSize;
+
+        var media = GetInheritedValue("MediaBox");
+        if (TryParseBox(media, out var mediaSize)) return mediaSize;
+
         return (612, 792);
     }
 
     /// <summary>Gets text spans (text with position and font info) from this page.</summary>
     public IReadOnlyList<PdfTextSpan> GetTextSpans() {
         var spans = new List<PdfTextSpan>();
-        var streams = GetContentStreams();
-        var decoders = ResourceResolver.GetFontDecoders(_pageDict, _objects);
-        var widthProviders = ResourceResolver.GetFontWidthProviders(_pageDict, _objects);
-        string DecodeWithFont(string fontRes, byte[] bytes) =>
-            decoders.TryGetValue(fontRes, out var dec) ? dec(bytes) : PdfWinAnsiEncoding.Decode(bytes);
-        double SumWidth1000(string fontRes, byte[] bytes) => widthProviders.TryGetValue(fontRes, out var wp) ? wp(bytes) : (bytes?.Length ?? 0) * 500.0;
-        foreach (var s in streams) {
-            var content = PdfEncoding.Latin1GetString(s);
-            spans.AddRange(TextContentParser.Parse(content, DecodeWithFont, SumWidth1000));
+        var pageResources = ResolveDictionary(GetInheritedValue("Resources"));
+        var pageDecoders = ResourceResolver.GetFontDecoders(_pageDict, _objects);
+        var pageWidthProviders = ResourceResolver.GetFontWidthProviders(_pageDict, _objects);
+        var activeForms = new HashSet<int>();
+
+        foreach (var stream in GetContentStreams()) {
+            CollectTextAndForms(
+                PdfEncoding.Latin1GetString(stream),
+                pageResources,
+                pageDecoders,
+                pageWidthProviders,
+                spans,
+                activeForms);
         }
-        // Additionally parse Form XObjects referenced via /Resources/XObject
-        var formStreams = ResourceResolver.GetFormXObjectStreams(_pageDict, _objects);
-        foreach (var kv in formStreams) {
-            var formName = kv.Key;
-            var bytes = kv.Value;
-            var content = PdfEncoding.Latin1GetString(bytes);
-            // Build decoders using the form's own resources if present
-            var formDict = GetFormDict(formName);
-            var formDecoders = ResourceResolver.GetFontDecodersForForm(formDict, _objects);
-            var formWidths = ResourceResolver.GetFontWidthProviders(formDict, _objects);
-            string DecodeWithFormFont(string fontRes, byte[] input) => formDecoders.TryGetValue(fontRes, out var dec) ? dec(input) : DecodeWithFont(fontRes, input);
-            double SumWidth1000Form(string fontRes, byte[] input) => formWidths.TryGetValue(fontRes, out var wp) ? wp(input) : SumWidth1000(fontRes, input);
-            // If the form has a /Matrix, inject it as a cm operator to apply CTM correctly
-            if (formDict is not null && formDict.Items.TryGetValue("Matrix", out var mObj) && mObj is PdfArray arr && arr.Items.Count >= 6) {
-                double A() => (arr.Items[0] as PdfNumber)?.Value ?? 1;
-                double B() => (arr.Items[1] as PdfNumber)?.Value ?? 0;
-                double C() => (arr.Items[2] as PdfNumber)?.Value ?? 0;
-                double D() => (arr.Items[3] as PdfNumber)?.Value ?? 1;
-                double E() => (arr.Items[4] as PdfNumber)?.Value ?? 0;
-                double F() => (arr.Items[5] as PdfNumber)?.Value ?? 0;
-                string prefix = $"q {A().ToString(System.Globalization.CultureInfo.InvariantCulture)} {B().ToString(System.Globalization.CultureInfo.InvariantCulture)} {C().ToString(System.Globalization.CultureInfo.InvariantCulture)} {D().ToString(System.Globalization.CultureInfo.InvariantCulture)} {E().ToString(System.Globalization.CultureInfo.InvariantCulture)} {F().ToString(System.Globalization.CultureInfo.InvariantCulture)} cm ";
-                content = prefix + content + " Q";
-            }
-            spans.AddRange(TextContentParser.Parse(content, DecodeWithFormFont, SumWidth1000Form));
-        }
+
         return spans;
     }
 
-    private PdfDictionary GetFormDict(string name) {
-        if (_pageDict.Items.TryGetValue("Resources", out var resObj) && resObj is PdfReference rr && _objects.TryGetValue(rr.ObjectNumber, out var indr) && indr.Value is PdfDictionary res) {
-            if (res.Items.TryGetValue("XObject", out var xoObj)) {
-                PdfDictionary? xoDict = null;
-                if (xoObj is PdfReference xref && _objects.TryGetValue(xref.ObjectNumber, out var indxo) && indxo.Value is PdfDictionary xod) xoDict = xod;
-                if (xoObj is PdfDictionary d) xoDict = d;
-                if (xoDict is not null && xoDict.Items.TryGetValue(name, out var formObj)) {
-                    if (formObj is PdfReference fr && _objects.TryGetValue(fr.ObjectNumber, out var indForm) && indForm.Value is PdfStream s && s.Dictionary is not null) {
-                        return s.Dictionary;
-                    }
+    private void CollectTextAndForms(
+        string content,
+        PdfDictionary? resources,
+        Dictionary<string, Func<byte[], string>> decoders,
+        Dictionary<string, Func<byte[], double>> widthProviders,
+        List<PdfTextSpan> spans,
+        HashSet<int> activeForms) {
+        string DecodeWithFont(string fontRes, byte[] bytes) =>
+            decoders.TryGetValue(fontRes, out var dec) ? dec(bytes) : PdfWinAnsiEncoding.Decode(bytes);
+        double SumWidth1000(string fontRes, byte[] bytes) =>
+            widthProviders.TryGetValue(fontRes, out var wp) ? wp(bytes) : (bytes?.Length ?? 0) * 500.0;
+
+        spans.AddRange(TextContentParser.Parse(content, DecodeWithFont, SumWidth1000));
+
+        foreach (var invocation in TextContentParser.ExtractFormInvocations(content)) {
+            if (!TryGetFormStream(resources, invocation.Name, out var formStream, out int formObjectNumber)) {
+                continue;
+            }
+
+            bool trackRecursion = formObjectNumber > 0;
+            if (trackRecursion && !activeForms.Add(formObjectNumber)) {
+                continue;
+            }
+
+            try {
+                var formDict = formStream.Dictionary;
+                var formResources = ResolveDictionary(formDict.Items.TryGetValue("Resources", out var resObj) ? resObj : null) ?? resources;
+                var formDecoders = MergeDecoders(decoders, ResourceResolver.GetFontDecodersForForm(formDict, _objects));
+                var formWidths = MergeWidthProviders(widthProviders, ResourceResolver.GetFontWidthProviders(formDict, _objects));
+                var combinedTransform = ApplyFormMatrix(invocation.Transform, formDict);
+                var formContent = WrapContentWithTransform(PdfEncoding.Latin1GetString(DecodeIfNeeded(formStream)), combinedTransform);
+
+                CollectTextAndForms(formContent, formResources, formDecoders, formWidths, spans, activeForms);
+            } finally {
+                if (trackRecursion) {
+                    activeForms.Remove(formObjectNumber);
                 }
             }
         }
-        return _pageDict;
+    }
+
+    private bool TryGetFormStream(PdfDictionary? resources, string name, out PdfStream formStream, out int objectNumber) {
+        if (resources is null || !resources.Items.TryGetValue("XObject", out var xoObj)) {
+            formStream = null!;
+            objectNumber = 0;
+            return false;
+        }
+
+        var xoDict = ResolveDictionary(xoObj);
+        if (xoDict is null || !xoDict.Items.TryGetValue(name, out var formObj)) {
+            formStream = null!;
+            objectNumber = 0;
+            return false;
+        }
+
+        if (formObj is PdfReference formRef &&
+            _objects.TryGetValue(formRef.ObjectNumber, out var indirectForm) &&
+            indirectForm.Value is PdfStream stream &&
+            string.Equals(stream.Dictionary.Get<PdfName>("Subtype")?.Name, "Form", StringComparison.Ordinal)) {
+            formStream = stream;
+            objectNumber = formRef.ObjectNumber;
+            return true;
+        }
+
+        if (formObj is PdfStream directStream &&
+            string.Equals(directStream.Dictionary.Get<PdfName>("Subtype")?.Name, "Form", StringComparison.Ordinal)) {
+            formStream = directStream;
+            objectNumber = 0;
+            return true;
+        }
+
+        formStream = null!;
+        objectNumber = 0;
+        return false;
+    }
+
+    private static Dictionary<string, Func<byte[], string>> MergeDecoders(
+        Dictionary<string, Func<byte[], string>> parent,
+        Dictionary<string, Func<byte[], string>> local) {
+        var merged = new Dictionary<string, Func<byte[], string>>(parent, StringComparer.Ordinal);
+        foreach (var entry in local) {
+            merged[entry.Key] = entry.Value;
+        }
+
+        return merged;
+    }
+
+    private static Dictionary<string, Func<byte[], double>> MergeWidthProviders(
+        Dictionary<string, Func<byte[], double>> parent,
+        Dictionary<string, Func<byte[], double>> local) {
+        var merged = new Dictionary<string, Func<byte[], double>>(parent, StringComparer.Ordinal);
+        foreach (var entry in local) {
+            merged[entry.Key] = entry.Value;
+        }
+
+        return merged;
+    }
+
+    private static string WrapContentWithTransform(string content, Matrix2D transform) {
+        string prefix = string.Format(
+            System.Globalization.CultureInfo.InvariantCulture,
+            "q {0} {1} {2} {3} {4} {5} cm ",
+            transform.A,
+            transform.B,
+            transform.C,
+            transform.D,
+            transform.E,
+            transform.F);
+        return prefix + content + " Q";
+    }
+
+    private static Matrix2D ApplyFormMatrix(Matrix2D invocationTransform, PdfDictionary? formDict) {
+        if (formDict is null ||
+            !formDict.Items.TryGetValue("Matrix", out var matrixObj) ||
+            matrixObj is not PdfArray arr ||
+            arr.Items.Count < 6) {
+            return invocationTransform;
+        }
+
+        var formMatrix = new Matrix2D(
+            (arr.Items[0] as PdfNumber)?.Value ?? 1,
+            (arr.Items[1] as PdfNumber)?.Value ?? 0,
+            (arr.Items[2] as PdfNumber)?.Value ?? 0,
+            (arr.Items[3] as PdfNumber)?.Value ?? 1,
+            (arr.Items[4] as PdfNumber)?.Value ?? 0,
+            (arr.Items[5] as PdfNumber)?.Value ?? 0);
+
+        return Matrix2D.Multiply(invocationTransform, formMatrix);
+    }
+
+    private PdfObject? GetInheritedValue(string key) {
+        PdfDictionary? current = _pageDict;
+        int guard = 0;
+        while (current is not null && guard++ < 100) {
+            if (current.Items.TryGetValue(key, out var value)) {
+                return value;
+            }
+
+            if (!current.Items.TryGetValue("Parent", out var parentObj) ||
+                parentObj is not PdfReference parentRef ||
+                !_objects.TryGetValue(parentRef.ObjectNumber, out var parentIndirect) ||
+                parentIndirect.Value is not PdfDictionary parentDict) {
+                break;
+            }
+
+            current = parentDict;
+        }
+
+        return null;
+    }
+
+    private PdfDictionary? ResolveDictionary(PdfObject? obj) {
+        if (obj is PdfDictionary dictionary) {
+            return dictionary;
+        }
+
+        if (obj is PdfReference reference &&
+            _objects.TryGetValue(reference.ObjectNumber, out var indirect) &&
+            indirect.Value is PdfDictionary referencedDictionary) {
+            return referencedDictionary;
+        }
+
+        return null;
+    }
+
+    private PdfArray? ResolveArray(PdfObject? obj) {
+        if (obj is PdfArray array) {
+            return array;
+        }
+
+        if (obj is PdfReference reference &&
+            _objects.TryGetValue(reference.ObjectNumber, out var indirect) &&
+            indirect.Value is PdfArray referencedArray) {
+            return referencedArray;
+        }
+
+        return null;
+    }
+
+    private bool TryParseBox(PdfObject? box, out (double Width, double Height) size) {
+        var arr = ResolveArray(box);
+        if (arr is not null &&
+            arr.Items.Count >= 4 &&
+            arr.Items[0] is PdfNumber llx &&
+            arr.Items[1] is PdfNumber lly &&
+            arr.Items[2] is PdfNumber urx &&
+            arr.Items[3] is PdfNumber ury) {
+            double width = urx.Value - llx.Value;
+            double height = ury.Value - lly.Value;
+            if (width > 0 && height > 0) {
+                size = (width, height);
+                return true;
+            }
+        }
+
+        size = default;
+        return false;
     }
 
     private static double GlyphWidthEmForBase(string baseFont) {
@@ -123,21 +280,31 @@ public sealed class PdfReadPage {
         var result = new List<byte[]>();
         var contents = _pageDict.Items.TryGetValue("Contents", out var obj) ? obj : null;
         if (contents is PdfReference r) {
-            if (_objects.TryGetValue(r.ObjectNumber, out var ind) && ind.Value is PdfStream s) result.Add(DecodeIfNeeded(s));
-        } else if (contents is PdfArray arr) {
-            foreach (var item in arr.Items) {
-                if (item is PdfReference rr) {
-                    if (_objects.TryGetValue(rr.ObjectNumber, out var ind2) && ind2.Value is PdfStream s2) result.Add(DecodeIfNeeded(s2));
-                }
+            if (_objects.TryGetValue(r.ObjectNumber, out var ind) && ind.Value is PdfStream s) {
+                result.Add(DecodeIfNeeded(s));
+                return result;
             }
         }
+
+        var contentArray = ResolveArray(contents);
+        if (contentArray is null) {
+            return result;
+        }
+
+        foreach (var item in contentArray.Items) {
+            if (item is PdfReference rr &&
+                _objects.TryGetValue(rr.ObjectNumber, out var ind2) &&
+                ind2.Value is PdfStream s2) {
+                result.Add(DecodeIfNeeded(s2));
+            } else if (item is PdfStream directStream) {
+                result.Add(DecodeIfNeeded(directStream));
+            }
+        }
+
         return result;
     }
 
-    private static byte[] DecodeIfNeeded(PdfStream s) {
-        if (PdfSyntax.HasFlateDecode(s.Dictionary)) {
-            try { return Filters.FlateDecoder.Decode(s.Data); } catch { return s.Data; }
-        }
-        return s.Data;
+    private byte[] DecodeIfNeeded(PdfStream s) {
+        return Filters.StreamDecoder.Decode(s.Dictionary, s.Data, _objects);
     }
 }

--- a/OfficeIMO.Pdf/Reading/Core/PdfStringParser.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfStringParser.cs
@@ -19,6 +19,11 @@ internal static class PdfStringParser {
                     case '(': bytes.Add((byte)'('); break;
                     case ')': bytes.Add((byte)')'); break;
                     case '\n': /* line continuation */ break;
+                    case '\r':
+                        if (i + 1 < inner.Length && inner[i + 1] == '\n') {
+                            i++;
+                        }
+                        break;
                     default:
                         if (IsOctalDigit(n)) {
                             int v = n - '0';

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
@@ -20,6 +20,7 @@ internal static class PdfSyntax {
             int id = int.Parse(matches[i].Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
             int gen = int.Parse(matches[i].Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture);
             int start = matches[i].Index;
+            int bodyStart = matches[i].Index + matches[i].Length;
             int end = FindObjectEnd(text, start);
             if (end < 0) end = (i + 1 < matches.Count) ? matches[i + 1].Index : text.Length;
 
@@ -68,6 +69,19 @@ internal static class PdfSyntax {
                     map[id] = new PdfIndirectObject(id, gen, dict);
                 }
             }
+
+            if (!map.ContainsKey(id)) {
+                int bodyEnd = end;
+                if (bodyEnd - 6 >= bodyStart && string.Equals(text.Substring(bodyEnd - 6, 6), "endobj", StringComparison.Ordinal)) {
+                    bodyEnd -= 6;
+                }
+
+                string body = SafeSlice(text, bodyStart, bodyEnd - bodyStart, 1_000_000).Trim();
+                var parsed = ParseTopLevelObject(body);
+                if (parsed is not null) {
+                    map[id] = new PdfIndirectObject(id, gen, parsed);
+                }
+            }
         }
         // Expand object streams (/Type /ObjStm) to populate embedded objects (pages and resources often live there)
         ExpandObjectStreams(map, pdf);
@@ -86,7 +100,7 @@ internal static class PdfSyntax {
             if (!string.Equals(type, "ObjStm", StringComparison.Ordinal)) continue;
 
             // Decode object stream bytes (flate only for now)
-            var data = HasFlateDecode(s.Dictionary) ? Filters.FlateDecoder.Decode(s.Data) : s.Data;
+            var data = Filters.StreamDecoder.Decode(s.Dictionary, s.Data, map);
             int n = (int)(s.Dictionary.Get<PdfNumber>("N")?.Value ?? 0);
             int first = (int)(s.Dictionary.Get<PdfNumber>("First")?.Value ?? 0);
             if (n <= 0 || first <= 0 || first > data.Length) continue;
@@ -159,6 +173,11 @@ internal static class PdfSyntax {
             string inner = end > 1 ? s.Substring(1, end - 1) : s.Substring(1);
             return new PdfStringObj(Unescape(inner));
         }
+        if (s.Length > 0 && s[0] == '<' && (s.Length == 1 || s[1] != '<')) {
+            int end = s.IndexOf('>');
+            string inner = end > 1 ? s.Substring(1, end - 1) : s.Substring(1);
+            return new PdfStringObj(DecodeHexString(inner));
+        }
         // number or name fallbacks
         var tokens = Tokenize(s);
         if (tokens.Count > 0) {
@@ -182,7 +201,7 @@ internal static class PdfSyntax {
         var tokens = Tokenize(dict);
         for (int i = 0; i < tokens.Count; i++) {
             if (tokens[i].Length > 0 && tokens[i][0] == '/') {
-                string key = tokens[i].Substring(1);
+                string key = DecodeName(tokens[i].Substring(1));
                 if (i + 1 < tokens.Count) {
                     var (obj, consumed) = ParseObject(tokens, i + 1);
                     d.Items[key] = obj;
@@ -196,6 +215,24 @@ internal static class PdfSyntax {
     private static (PdfObject Obj, int Consumed) ParseObject(List<string> tokens, int i) {
         if (i < 0 || i >= tokens.Count) return (new PdfName(""), 0);
         string tok = tokens[i] ?? string.Empty;
+        if (tok == "<<") {
+            var dict = new PdfDictionary();
+            int j = i + 1;
+            while (j < tokens.Count && tokens[j] != ">>") {
+                string keyToken = tokens[j] ?? string.Empty;
+                if (keyToken.Length > 0 && keyToken[0] == '/') {
+                    string key = DecodeName(keyToken.Substring(1));
+                    if (j + 1 < tokens.Count) {
+                        var (obj, consumed) = ParseObject(tokens, j + 1);
+                        dict.Items[key] = obj;
+                        j += consumed + 2;
+                        continue;
+                    }
+                }
+                j++;
+            }
+            return (dict, j - i);
+        }
         if (tok == "[") {
             var arr = new PdfArray(); int j = i + 1;
             while (j < tokens.Count && tokens[j] != "]") {
@@ -205,8 +242,11 @@ internal static class PdfSyntax {
             }
             return (arr, j - i);
         }
-        if (tok.Length > 0 && tok[0] == '/') return (new PdfName(tok.Substring(1)), 0);
+        if (tok.Length > 0 && tok[0] == '/') return (new PdfName(DecodeName(tok.Substring(1))), 0);
         if (tok.Length > 0 && tok[0] == '(') return (new PdfStringObj(Unescape(tok.Substring(1, tok.Length - 2))), 0);
+        if (tok.Length > 1 && tok[0] == '<' && tok[tok.Length - 1] == '>' && (tok.Length == 2 || tok[1] != '<')) {
+            return (new PdfStringObj(DecodeHexString(tok.Substring(1, tok.Length - 2))), 0);
+        }
         if (tok.Length > 0 && (char.IsDigit(tok[0]) || tok[0] == '-' || tok[0] == '+')) {
             // reference (obj gen R) or number
             if (i + 2 < tokens.Count && tokens[i + 2] == "R" && int.TryParse(tokens[i], out int obj) && int.TryParse(tokens[i + 1], out int gen)) {
@@ -227,16 +267,28 @@ internal static class PdfSyntax {
         while (i < s.Length) {
             char c = s[i];
             if (char.IsWhiteSpace(c)) { i++; continue; }
+            if (c == '%') {
+                i++;
+                while (i < s.Length && s[i] != '\n' && s[i] != '\r') i++;
+                continue;
+            }
             if (c == '<' && i + 1 < s.Length && s[i + 1] == '<') { tokens.Add("<<"); i += 2; continue; }
             if (c == '>' && i + 1 < s.Length && s[i + 1] == '>') { tokens.Add(">>"); i += 2; continue; }
             if (c == '[' || c == ']') { tokens.Add(c.ToString()); i++; continue; }
+            if (c == '<') {
+                int start = i++;
+                while (i < s.Length && s[i] != '>') i++;
+                if (i < s.Length && s[i] == '>') i++;
+                tokens.Add(s.Substring(start, i - start));
+                continue;
+            }
             if (c == '(') {
                 int start = i; i++;
                 int depth = 1; bool esc = false;
                 var sb = new StringBuilder();
                 while (i < s.Length && depth > 0) {
                     char ch = s[i++];
-                    if (esc) { sb.Append(ch); esc = false; } else if (ch == '\\') esc = true;
+                    if (esc) { sb.Append(ch); esc = false; } else if (ch == '\\') { sb.Append(ch); esc = true; }
                     else if (ch == '(') { depth++; sb.Append(ch); } else if (ch == ')') { depth--; if (depth > 0) sb.Append(ch); } else sb.Append(ch);
                 }
                 tokens.Add("(" + sb.ToString() + ")");
@@ -244,10 +296,10 @@ internal static class PdfSyntax {
             }
             // name, number, keyword
             int j = i;
-            while (j < s.Length && !char.IsWhiteSpace(s[j]) && s[j] != '/' && s[j] != '[' && s[j] != ']' && s[j] != '<' && s[j] != '>' && s[j] != '(' && s[j] != ')') j++;
+            while (j < s.Length && !char.IsWhiteSpace(s[j]) && s[j] != '%' && s[j] != '/' && s[j] != '[' && s[j] != ']' && s[j] != '<' && s[j] != '>' && s[j] != '(' && s[j] != ')') j++;
             string tok = s.Substring(i, j - i);
             if (tok.Length == 0 && s[i] == '/') { // name starting here
-                j = i + 1; while (j < s.Length && !char.IsWhiteSpace(s[j]) && s[j] != '/' && s[j] != '[' && s[j] != ']' && s[j] != '<' && s[j] != '>' && s[j] != '(' && s[j] != ')') j++;
+                j = i + 1; while (j < s.Length && !char.IsWhiteSpace(s[j]) && s[j] != '%' && s[j] != '/' && s[j] != '[' && s[j] != ']' && s[j] != '<' && s[j] != '>' && s[j] != '(' && s[j] != ')') j++;
                 tok = s.Substring(i, j - i);
             }
             tokens.Add(tok);
@@ -258,6 +310,85 @@ internal static class PdfSyntax {
     }
 
     private static string Unescape(string s) => PdfTextExtractor.UnescapePdfLiteral(s);
+
+    internal static string DecodeName(string raw) {
+        if (string.IsNullOrEmpty(raw) || raw.IndexOf('#') < 0) {
+            return raw;
+        }
+
+        var sb = new StringBuilder(raw.Length);
+        for (int i = 0; i < raw.Length; i++) {
+            char ch = raw[i];
+            if (ch == '#' && i + 2 < raw.Length && TryHexNibble(raw[i + 1], out int hi) && TryHexNibble(raw[i + 2], out int lo)) {
+                sb.Append(PdfEncoding.Latin1GetString(new[] { (byte)((hi << 4) | lo) }));
+                i += 2;
+                continue;
+            }
+
+            sb.Append(ch);
+        }
+
+        return sb.ToString();
+    }
+
+    private static string DecodeHexString(string raw) {
+        var bytes = DecodeHexBytes(raw);
+        if (bytes.Length >= 2) {
+            if (bytes[0] == 0xFE && bytes[1] == 0xFF) {
+                return Encoding.BigEndianUnicode.GetString(bytes, 2, bytes.Length - 2);
+            }
+
+            if (bytes[0] == 0xFF && bytes[1] == 0xFE) {
+                return Encoding.Unicode.GetString(bytes, 2, bytes.Length - 2);
+            }
+        }
+
+        return PdfWinAnsiEncoding.Decode(bytes);
+    }
+
+    private static byte[] DecodeHexBytes(string raw) {
+        var hex = new StringBuilder(raw.Length);
+        for (int i = 0; i < raw.Length; i++) {
+            char ch = raw[i];
+            if (!char.IsWhiteSpace(ch)) hex.Append(ch);
+        }
+
+        if ((hex.Length & 1) == 1) hex.Append('0');
+
+        var bytes = new byte[hex.Length / 2];
+        for (int i = 0; i < bytes.Length; i++) {
+            int hi = HexNibble(hex[i * 2]);
+            int lo = HexNibble(hex[i * 2 + 1]);
+            bytes[i] = (byte)((hi << 4) | lo);
+        }
+
+        return bytes;
+    }
+
+    private static int HexNibble(char c) {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+        if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+        throw new FormatException($"Invalid hex character '{c}'.");
+    }
+
+    private static bool TryHexNibble(char c, out int value) {
+        if (c >= '0' && c <= '9') {
+            value = c - '0';
+            return true;
+        }
+        if (c >= 'a' && c <= 'f') {
+            value = 10 + (c - 'a');
+            return true;
+        }
+        if (c >= 'A' && c <= 'F') {
+            value = 10 + (c - 'A');
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
 
     private static int FindObjectEnd(string text, int start) {
         int idx = text.IndexOf("endobj", start, StringComparison.Ordinal);

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
@@ -510,7 +510,7 @@ internal static class PdfSyntax {
         }
 
         char c = text[idx];
-        return char.IsWhiteSpace(c) || c is '/' or '<' or '>' or '[' or ']' or '(' or ')' or '%';
+        return char.IsWhiteSpace(c) || c is '<' or '>' or '[' or ']' or '%';
     }
 
     private static int SkipEOL(string text, int idx, int limit) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
@@ -179,6 +179,9 @@ internal static class PdfSyntax {
     private static PdfObject? ParseTopLevelObject(string body) {
         if (string.IsNullOrWhiteSpace(body)) return null;
         var s = body.TrimStart();
+        if (string.Equals(s, "true", StringComparison.Ordinal)) return new PdfBoolean(true);
+        if (string.Equals(s, "false", StringComparison.Ordinal)) return new PdfBoolean(false);
+        if (string.Equals(s, "null", StringComparison.Ordinal)) return PdfNull.Instance;
         if (s.StartsWith("<<", System.StringComparison.Ordinal)) {
             // Find matching >> and parse inside
             int dictStart = body.IndexOf("<<", StringComparison.Ordinal);
@@ -276,6 +279,9 @@ internal static class PdfSyntax {
         if (tok.Length > 1 && tok[0] == '<' && tok[tok.Length - 1] == '>' && (tok.Length == 2 || tok[1] != '<')) {
             return (new PdfStringObj(DecodeHexString(tok.Substring(1, tok.Length - 2))), 0);
         }
+        if (string.Equals(tok, "true", StringComparison.Ordinal)) return (new PdfBoolean(true), 0);
+        if (string.Equals(tok, "false", StringComparison.Ordinal)) return (new PdfBoolean(false), 0);
+        if (string.Equals(tok, "null", StringComparison.Ordinal)) return (PdfNull.Instance, 0);
         if (tok.Length > 0 && (char.IsDigit(tok[0]) || tok[0] == '-' || tok[0] == '+')) {
             // reference (obj gen R) or number
             if (i + 2 < tokens.Count && tokens[i + 2] == "R" && int.TryParse(tokens[i], out int obj) && int.TryParse(tokens[i + 1], out int gen)) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
@@ -482,9 +482,35 @@ internal static class PdfSyntax {
     }
 
     private static int IndexOfKeyword(string text, string keyword, int start, int limit) {
-        if (start < 0) start = 0; if (limit > text.Length) limit = text.Length;
-        int idx = text.IndexOf(keyword, start, StringComparison.Ordinal);
-        return (idx >= 0 && idx < limit) ? idx : -1;
+        if (start < 0) start = 0;
+        if (limit > text.Length) limit = text.Length;
+
+        int searchFrom = start;
+        while (searchFrom < limit) {
+            int idx = text.IndexOf(keyword, searchFrom, StringComparison.Ordinal);
+            if (idx < 0 || idx >= limit) {
+                return -1;
+            }
+
+            int end = idx + keyword.Length;
+            if (HasKeywordBoundary(text, idx - 1, start, limit) &&
+                HasKeywordBoundary(text, end, start, limit)) {
+                return idx;
+            }
+
+            searchFrom = idx + 1;
+        }
+
+        return -1;
+    }
+
+    private static bool HasKeywordBoundary(string text, int idx, int start, int limit) {
+        if (idx < start || idx >= limit) {
+            return true;
+        }
+
+        char c = text[idx];
+        return char.IsWhiteSpace(c) || c is '/' or '<' or '>' or '[' or ']' or '(' or ')' or '%';
     }
 
     private static int SkipEOL(string text, int idx, int limit) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
@@ -15,6 +15,7 @@ internal static class PdfSyntax {
     internal static (Dictionary<int, PdfIndirectObject> Map, string TrailerRaw) ParseObjects(byte[] pdf) {
         string text = PdfEncoding.Latin1GetString(pdf);
         var map = new Dictionary<int, PdfIndirectObject>();
+        var streamLocations = new List<(int Id, int Generation, int DataStart)>();
         var matches = ObjRegex.Matches(text);
         for (int i = 0; i < matches.Count; i++) {
             int id = int.Parse(matches[i].Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
@@ -38,14 +39,11 @@ internal static class PdfSyntax {
                     int streamKw = IndexOfKeyword(text, "stream", dictEnd, end);
                     if (streamKw >= 0) {
                         int dataStart = SkipEOL(text, streamKw + 6, end);
+                        streamLocations.Add((id, gen, dataStart));
                         // Try /Length first (inline number only)
                         int byteStart = dataStart;
                         int byteLen = -1;
-                        var lenNum = dict.Get<PdfNumber>("Length");
-                        if (lenNum is not null) {
-                            int L = (int)Math.Max(0, Math.Min(int.MaxValue, lenNum.Value));
-                            if (byteStart >= 0 && byteStart + L <= pdf.Length) byteLen = L;
-                        }
+                        TryGetResolvedLength(dict, map, out byteLen);
                         if (byteLen < 0) {
                             int endStream = IndexOfKeyword(text, "endstream", dataStart, end);
                             if (endStream > dataStart) byteLen = endStream - dataStart;
@@ -83,11 +81,42 @@ internal static class PdfSyntax {
                 }
             }
         }
+        ResolveIndirectStreamLengths(map, pdf, streamLocations);
         // Expand object streams (/Type /ObjStm) to populate embedded objects (pages and resources often live there)
         ExpandObjectStreams(map, pdf);
         int trailerIdx = text.LastIndexOf("trailer", StringComparison.OrdinalIgnoreCase);
         string trailerRaw = trailerIdx >= 0 ? text.Substring(trailerIdx) : string.Empty;
         return (map, trailerRaw);
+    }
+
+    private static void ResolveIndirectStreamLengths(Dictionary<int, PdfIndirectObject> map, byte[] pdf, List<(int Id, int Generation, int DataStart)> streamLocations) {
+        foreach (var streamLocation in streamLocations) {
+            if (!map.TryGetValue(streamLocation.Id, out var indirect) || indirect.Value is not PdfStream stream) {
+                continue;
+            }
+
+            if (!TryGetResolvedLength(stream.Dictionary, map, out int byteLen)) {
+                continue;
+            }
+
+            bool isImage = (stream.Dictionary.Get<PdfName>("Subtype")?.Name == "Image") || (stream.Dictionary.Get<PdfName>("Type")?.Name == "XObject" && stream.Dictionary.Get<PdfName>("Subtype")?.Name == "Image");
+            if (isImage) {
+                continue;
+            }
+
+            int byteStart = streamLocation.DataStart;
+            if (byteStart < 0 || byteLen < 0 || byteStart + byteLen > pdf.Length) {
+                continue;
+            }
+
+            if (stream.Data.Length == byteLen) {
+                continue;
+            }
+
+            var data = new byte[byteLen];
+            Buffer.BlockCopy(pdf, byteStart, data, 0, byteLen);
+            map[streamLocation.Id] = new PdfIndirectObject(streamLocation.Id, streamLocation.Generation, new PdfStream(stream.Dictionary, data, stream.DecodingFailed, stream.DecodingError));
+        }
     }
 
     private static void ExpandObjectStreams(Dictionary<int, PdfIndirectObject> map, byte[] pdf) {
@@ -307,6 +336,26 @@ internal static class PdfSyntax {
             i = j;
         }
         return tokens;
+    }
+
+    private static bool TryGetResolvedLength(PdfDictionary dict, Dictionary<int, PdfIndirectObject> map, out int length) {
+        length = -1;
+
+        if (dict.Get<PdfNumber>("Length") is PdfNumber lenNum) {
+            int resolved = (int)Math.Max(0, Math.Min(int.MaxValue, lenNum.Value));
+            length = resolved;
+            return true;
+        }
+
+        if (dict.Get<PdfReference>("Length") is PdfReference lenRef &&
+            map.TryGetValue(lenRef.ObjectNumber, out var indirectLength) &&
+            indirectLength.Value is PdfNumber referencedLength) {
+            int resolved = (int)Math.Max(0, Math.Min(int.MaxValue, referencedLength.Value));
+            length = resolved;
+            return true;
+        }
+
+        return false;
     }
 
     private static string Unescape(string s) => PdfTextExtractor.UnescapePdfLiteral(s);

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
@@ -446,8 +446,29 @@ internal static class PdfSyntax {
     }
 
     private static int FindObjectEnd(string text, int start) {
-        int idx = text.IndexOf("endobj", start, StringComparison.Ordinal);
-        return idx >= 0 ? idx + 6 : -1;
+        int searchFrom = start;
+        while (searchFrom >= 0 && searchFrom < text.Length) {
+            int streamIdx = IndexOfKeyword(text, "stream", searchFrom, text.Length);
+            int endObjIdx = IndexOfKeyword(text, "endobj", searchFrom, text.Length);
+
+            if (endObjIdx < 0) {
+                return -1;
+            }
+
+            if (streamIdx < 0 || endObjIdx < streamIdx) {
+                return endObjIdx + 6;
+            }
+
+            int afterStream = SkipEOL(text, streamIdx + 6, text.Length);
+            int endStreamIdx = IndexOfKeyword(text, "endstream", afterStream, text.Length);
+            if (endStreamIdx < 0) {
+                return -1;
+            }
+
+            searchFrom = endStreamIdx + 9;
+        }
+
+        return -1;
     }
 
     private static int FindDictEnd(string text, int dictStart, int limit) {

--- a/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
+++ b/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
@@ -17,7 +17,7 @@ internal static class ResourceResolver {
             ToUnicodeCMap? cmap = null;
             if (hasToUnicode) {
                 if (fontVal.Items.TryGetValue("ToUnicode", out var tu) && tu is PdfReference r && objects.TryGetValue(r.ObjectNumber, out var ind) && ind.Value is PdfStream s) {
-                    var data = PdfSyntax.HasFlateDecode(s.Dictionary) ? Filters.FlateDecoder.Decode(s.Data) : s.Data;
+                    var data = Filters.StreamDecoder.Decode(s.Dictionary, s.Data, objects);
                     if (!ToUnicodeCMap.TryParse(data, out cmap)) cmap = null;
                 }
             }
@@ -151,7 +151,7 @@ internal static class ResourceResolver {
             ToUnicodeCMap? cmap = null;
             if (hasToUnicode) {
                 if (fontVal.Items.TryGetValue("ToUnicode", out var tu) && tu is PdfReference r && objects.TryGetValue(r.ObjectNumber, out var ind) && ind.Value is PdfStream s) {
-                    var data = PdfSyntax.HasFlateDecode(s.Dictionary) ? Filters.FlateDecoder.Decode(s.Data) : s.Data;
+                    var data = Filters.StreamDecoder.Decode(s.Dictionary, s.Data, objects);
                     if (!ToUnicodeCMap.TryParse(data, out cmap)) cmap = null;
                 }
             }
@@ -173,7 +173,7 @@ internal static class ResourceResolver {
             if (kv.Value is PdfReference r && objects.TryGetValue(r.ObjectNumber, out var ind) && ind.Value is PdfStream s) {
                 var subtype = s.Dictionary.Get<PdfName>("Subtype")?.Name;
                 if (string.Equals(subtype, "Form", System.StringComparison.Ordinal)) {
-                    var data = PdfSyntax.HasFlateDecode(s.Dictionary) ? Filters.FlateDecoder.Decode(s.Data) : s.Data;
+                    var data = Filters.StreamDecoder.Decode(s.Dictionary, s.Data, objects);
                     result[kv.Key] = data;
                 }
             }

--- a/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
+++ b/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
@@ -10,6 +10,16 @@ internal static class TextContentParser {
         "er", "ers", "ed", "ly", "ology", "ologies"
     };
 
+    internal readonly struct FormInvocation {
+        public string Name { get; }
+        public Matrix2D Transform { get; }
+
+        public FormInvocation(string name, Matrix2D transform) {
+            Name = name;
+            Transform = transform;
+        }
+    }
+
     public static List<PdfTextSpan> Parse(
         string content,
         System.Func<string, byte[], string> decodeWithFont,
@@ -177,8 +187,8 @@ internal static class TextContentParser {
 
         string ReadName() {
             i++; int start = i;
-            while (i < n) { char ch = content[i]; if (char.IsWhiteSpace(ch) || ch == '/' || ch == '[' || ch == ']' || ch == '(' || ch == ')' || ch == '<' || ch == '>') break; i++; }
-            return content.Substring(start, i - start);
+            while (i < n) { char ch = content[i]; if (char.IsWhiteSpace(ch) || ch == '%' || ch == '/' || ch == '[' || ch == ']' || ch == '(' || ch == ')' || ch == '<' || ch == '>') break; i++; }
+            return PdfSyntax.DecodeName(content.Substring(start, i - start));
         }
 
         byte[] ReadLiteralStringBytes() {
@@ -238,7 +248,7 @@ internal static class TextContentParser {
             if (ch == '\'' || ch == '"') return ch.ToString();
             while (i < n) {
                 char c2 = content[i];
-                if (char.IsWhiteSpace(c2) || c2 == '(' || c2 == '[' || c2 == '/' || c2 == '<' || c2 == '>') break;
+                if (char.IsWhiteSpace(c2) || c2 == '%' || c2 == '(' || c2 == '[' || c2 == '/' || c2 == '<' || c2 == '>') break;
                 i++;
             }
             return content.Substring(start, i - start);
@@ -295,5 +305,159 @@ internal static class TextContentParser {
             }
             return joined;
         }
+    }
+
+    public static List<FormInvocation> ExtractFormInvocations(string content) {
+        var invocations = new List<FormInvocation>();
+        Matrix2D ctm = Matrix2D.Identity;
+        var gstack = new Stack<Matrix2D>();
+        var args = new List<object>(8);
+        int i = 0;
+        int n = content.Length;
+
+        while (i < n) {
+            SkipWs();
+            if (i >= n) break;
+
+            char c = content[i];
+            if (c == '%') {
+                while (i < n && content[i] != '\n' && content[i] != '\r') i++;
+                continue;
+            }
+
+            if (c == '/') { args.Add(ReadName()); continue; }
+            if (c == '(') { ReadLiteralStringBytes(); continue; }
+            if (c == '<') {
+                if (i + 1 < n && content[i + 1] == '<') { i += 2; continue; }
+                ReadHexStringBytes();
+                continue;
+            }
+            if (c == '[') { ReadArray(); continue; }
+            if (c == ']' || c == '>') { i++; continue; }
+            if (IsNumberStart(c)) { args.Add(ReadNumber()); continue; }
+
+            string op = ReadOperator();
+            if (op.Length == 0) { i++; continue; }
+
+            switch (op) {
+                case "q":
+                    gstack.Push(ctm);
+                    args.Clear();
+                    break;
+                case "Q":
+                    ctm = gstack.Count > 0 ? gstack.Pop() : Matrix2D.Identity;
+                    args.Clear();
+                    break;
+                case "cm":
+                    if (args.Count >= 6) {
+                        var m2 = new Matrix2D(
+                            ToDouble(args[args.Count - 6]),
+                            ToDouble(args[args.Count - 5]),
+                            ToDouble(args[args.Count - 4]),
+                            ToDouble(args[args.Count - 3]),
+                            ToDouble(args[args.Count - 2]),
+                            ToDouble(args[args.Count - 1]));
+                        ctm = Matrix2D.Multiply(ctm, m2);
+                    }
+                    args.Clear();
+                    break;
+                case "Do":
+                    if (args.Count >= 1) {
+                        string name = ToName(args[args.Count - 1]);
+                        if (!string.IsNullOrEmpty(name)) {
+                            invocations.Add(new FormInvocation(name, ctm));
+                        }
+                    }
+                    args.Clear();
+                    break;
+                default:
+                    args.Clear();
+                    break;
+            }
+        }
+
+        return invocations;
+
+        void SkipWs() { while (i < n && char.IsWhiteSpace(content[i])) i++; }
+        static bool IsDigit(char ch) => ch >= '0' && ch <= '9';
+        bool IsNumberStart(char ch) => ch == '-' || ch == '+' || ch == '.' || IsDigit(ch);
+
+        double ReadNumber() {
+            int start = i;
+            i++;
+            while (i < n) {
+                char ch = content[i];
+                if (!(IsDigit(ch) || ch == '.' || ch == 'E' || ch == 'e' || ch == '-' || ch == '+')) break;
+                i++;
+            }
+            var s = content.Substring(start, i - start);
+            if (!double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var v)) v = 0;
+            return v;
+        }
+
+        string ReadName() {
+            i++;
+            int start = i;
+            while (i < n) {
+                char ch = content[i];
+                if (char.IsWhiteSpace(ch) || ch == '%' || ch == '/' || ch == '[' || ch == ']' || ch == '(' || ch == ')' || ch == '<' || ch == '>') break;
+                i++;
+            }
+            return PdfSyntax.DecodeName(content.Substring(start, i - start));
+        }
+
+        void ReadLiteralStringBytes() {
+            i++;
+            int depth = 1;
+            bool esc = false;
+            while (i < n && depth > 0) {
+                char ch = content[i++];
+                if (esc) esc = false;
+                else if (ch == '\\') esc = true;
+                else if (ch == '(') depth++;
+                else if (ch == ')') depth--;
+            }
+        }
+
+        void ReadHexStringBytes() {
+            i++;
+            while (i < n && content[i] != '>') i++;
+            if (i < n && content[i] == '>') i++;
+        }
+
+        void ReadArray() {
+            i++;
+            while (i < n) {
+                SkipWs();
+                if (i >= n) break;
+                char ch = content[i];
+                if (ch == ']') { i++; break; }
+                if (ch == '(') { ReadLiteralStringBytes(); continue; }
+                if (ch == '<') {
+                    if (i + 1 < n && content[i + 1] == '<') { i += 2; continue; }
+                    ReadHexStringBytes();
+                    continue;
+                }
+                if (IsNumberStart(ch)) { ReadNumber(); continue; }
+                if (ch == '/') { ReadName(); continue; }
+                if (ch == '[') { i++; continue; }
+                ReadOperator();
+            }
+        }
+
+        string ReadOperator() {
+            int start = i;
+            char ch = content[i++];
+            if (ch == '\'' || ch == '"') return ch.ToString();
+            while (i < n) {
+                char c2 = content[i];
+                if (char.IsWhiteSpace(c2) || c2 == '%' || c2 == '(' || c2 == '[' || c2 == '/' || c2 == '<' || c2 == '>') break;
+                i++;
+            }
+            return content.Substring(start, i - start);
+        }
+
+        static double ToDouble(object o) => o is double d ? d : 0.0;
+        static string ToName(object o) => o as string ?? string.Empty;
     }
 }

--- a/OfficeIMO.Pdf/Reading/Filters/Ascii85Decoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/Ascii85Decoder.cs
@@ -1,0 +1,71 @@
+namespace OfficeIMO.Pdf.Filters;
+
+internal static class Ascii85Decoder {
+    public static byte[] Decode(byte[] data) {
+        if (data == null || data.Length == 0) {
+            return Array.Empty<byte>();
+        }
+
+        using var output = new MemoryStream();
+        uint value = 0;
+        int count = 0;
+
+        for (int i = 0; i < data.Length; i++) {
+            byte b = data[i];
+            if (IsWhitespace(b)) {
+                continue;
+            }
+
+            if (b == (byte)'~') {
+                break;
+            }
+
+            if (b == (byte)'z') {
+                if (count != 0) {
+                    throw new FormatException("Invalid 'z' inside partial ASCII85 group.");
+                }
+
+                output.WriteByte(0);
+                output.WriteByte(0);
+                output.WriteByte(0);
+                output.WriteByte(0);
+                continue;
+            }
+
+            if (b < (byte)'!' || b > (byte)'u') {
+                throw new FormatException($"Invalid ASCII85 character '{(char)b}'.");
+            }
+
+            value = checked(value * 85 + (uint)(b - (byte)'!'));
+            count++;
+
+            if (count == 5) {
+                WriteTuple(output, value, 4);
+                value = 0;
+                count = 0;
+            }
+        }
+
+        if (count > 1) {
+            for (int i = count; i < 5; i++) {
+                value = checked(value * 85 + 84);
+            }
+
+            WriteTuple(output, value, count - 1);
+        }
+
+        return output.ToArray();
+    }
+
+    private static bool IsWhitespace(byte value) =>
+        value == (byte)' ' || value == (byte)'\t' || value == (byte)'\r' || value == (byte)'\n' || value == (byte)'\f' || value == 0;
+
+    private static void WriteTuple(Stream output, uint value, int bytesToWrite) {
+        byte[] tuple = new byte[4];
+        tuple[0] = (byte)(value >> 24);
+        tuple[1] = (byte)(value >> 16);
+        tuple[2] = (byte)(value >> 8);
+        tuple[3] = (byte)value;
+        output.Write(tuple, 0, bytesToWrite);
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Filters/AsciiHexDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/AsciiHexDecoder.cs
@@ -1,0 +1,49 @@
+using System.Text;
+
+namespace OfficeIMO.Pdf.Filters;
+
+internal static class AsciiHexDecoder {
+    public static byte[] Decode(byte[] data) {
+        if (data == null || data.Length == 0) {
+            return Array.Empty<byte>();
+        }
+
+        var hex = new StringBuilder(data.Length);
+        for (int i = 0; i < data.Length; i++) {
+            char ch = (char)data[i];
+            if (char.IsWhiteSpace(ch)) {
+                continue;
+            }
+
+            if (ch == '>') {
+                break;
+            }
+
+            hex.Append(ch);
+        }
+
+        if (hex.Length == 0) {
+            return Array.Empty<byte>();
+        }
+
+        if ((hex.Length & 1) == 1) {
+            hex.Append('0');
+        }
+
+        var bytes = new byte[hex.Length / 2];
+        for (int i = 0; i < bytes.Length; i++) {
+            int hi = HexNibble(hex[i * 2]);
+            int lo = HexNibble(hex[i * 2 + 1]);
+            bytes[i] = (byte)((hi << 4) | lo);
+        }
+
+        return bytes;
+    }
+
+    private static int HexNibble(char c) {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+        if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+        throw new FormatException($"Invalid ASCIIHex character '{c}'.");
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Filters/PngPredictorDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/PngPredictorDecoder.cs
@@ -1,0 +1,93 @@
+namespace OfficeIMO.Pdf.Filters;
+
+internal static class PngPredictorDecoder {
+    public static byte[] Decode(byte[] data, int columns, int colors = 1, int bitsPerComponent = 8) {
+        if (data == null || data.Length == 0) {
+            return Array.Empty<byte>();
+        }
+
+        colors = Math.Max(1, colors);
+        bitsPerComponent = Math.Max(1, bitsPerComponent);
+        columns = Math.Max(1, columns);
+
+        int bytesPerPixel = Math.Max(1, (colors * bitsPerComponent + 7) / 8);
+        int rowLength = (columns * colors * bitsPerComponent + 7) / 8;
+        if (rowLength <= 0) {
+            return data;
+        }
+
+        var output = new byte[(data.Length / (rowLength + 1) + 1) * rowLength];
+        int outputOffset = 0;
+        int inputOffset = 0;
+        var previousRow = new byte[rowLength];
+        var currentRow = new byte[rowLength];
+
+        while (inputOffset < data.Length) {
+            int filterType = data[inputOffset++];
+            if (inputOffset + rowLength > data.Length) {
+                throw new FormatException("PNG predictor row exceeds decoded stream length.");
+            }
+
+            Buffer.BlockCopy(data, inputOffset, currentRow, 0, rowLength);
+            inputOffset += rowLength;
+
+            switch (filterType) {
+                case 0:
+                    break;
+                case 1:
+                    for (int i = 0; i < rowLength; i++) {
+                        int left = i >= bytesPerPixel ? currentRow[i - bytesPerPixel] : 0;
+                        currentRow[i] = unchecked((byte)(currentRow[i] + left));
+                    }
+                    break;
+                case 2:
+                    for (int i = 0; i < rowLength; i++) {
+                        currentRow[i] = unchecked((byte)(currentRow[i] + previousRow[i]));
+                    }
+                    break;
+                case 3:
+                    for (int i = 0; i < rowLength; i++) {
+                        int left = i >= bytesPerPixel ? currentRow[i - bytesPerPixel] : 0;
+                        int up = previousRow[i];
+                        currentRow[i] = unchecked((byte)(currentRow[i] + ((left + up) / 2)));
+                    }
+                    break;
+                case 4:
+                    for (int i = 0; i < rowLength; i++) {
+                        int left = i >= bytesPerPixel ? currentRow[i - bytesPerPixel] : 0;
+                        int up = previousRow[i];
+                        int upLeft = i >= bytesPerPixel ? previousRow[i - bytesPerPixel] : 0;
+                        currentRow[i] = unchecked((byte)(currentRow[i] + PaethPredictor(left, up, upLeft)));
+                    }
+                    break;
+                default:
+                    throw new FormatException($"Unsupported PNG predictor filter type '{filterType}'.");
+            }
+
+            Buffer.BlockCopy(currentRow, 0, output, outputOffset, rowLength);
+            outputOffset += rowLength;
+            Buffer.BlockCopy(currentRow, 0, previousRow, 0, rowLength);
+        }
+
+        if (outputOffset == output.Length) {
+            return output;
+        }
+
+        var trimmed = new byte[outputOffset];
+        Buffer.BlockCopy(output, 0, trimmed, 0, outputOffset);
+        return trimmed;
+    }
+
+    private static int PaethPredictor(int left, int up, int upLeft) {
+        int prediction = left + up - upLeft;
+        int distanceLeft = Math.Abs(prediction - left);
+        int distanceUp = Math.Abs(prediction - up);
+        int distanceUpLeft = Math.Abs(prediction - upLeft);
+
+        if (distanceLeft <= distanceUp && distanceLeft <= distanceUpLeft) {
+            return left;
+        }
+
+        return distanceUp <= distanceUpLeft ? up : upLeft;
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Filters/RunLengthDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/RunLengthDecoder.cs
@@ -1,0 +1,41 @@
+namespace OfficeIMO.Pdf.Filters;
+
+internal static class RunLengthDecoder {
+    public static byte[] Decode(byte[] data) {
+        if (data == null || data.Length == 0) {
+            return Array.Empty<byte>();
+        }
+
+        using var output = new MemoryStream();
+        int i = 0;
+        while (i < data.Length) {
+            byte length = data[i++];
+            if (length == 128) {
+                break;
+            }
+
+            if (length <= 127) {
+                int literalCount = length + 1;
+                if (i + literalCount > data.Length) {
+                    throw new FormatException("RunLengthDecode literal run exceeds input length.");
+                }
+
+                output.Write(data, i, literalCount);
+                i += literalCount;
+                continue;
+            }
+
+            int repeatCount = 257 - length;
+            if (i >= data.Length) {
+                throw new FormatException("RunLengthDecode repeat run is missing a byte.");
+            }
+
+            byte value = data[i++];
+            for (int j = 0; j < repeatCount; j++) {
+                output.WriteByte(value);
+            }
+        }
+
+        return output.ToArray();
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -51,13 +51,21 @@ internal static class StreamDecoder {
         }
 
         int predictor = (int)(decodeParms.Get<PdfNumber>("Predictor")?.Value ?? 1);
-        if (predictor < 10) {
+        if (predictor <= 1) {
             return data;
         }
 
         int columns = (int)(decodeParms.Get<PdfNumber>("Columns")?.Value ?? 1);
         int colors = (int)(decodeParms.Get<PdfNumber>("Colors")?.Value ?? 1);
         int bitsPerComponent = (int)(decodeParms.Get<PdfNumber>("BitsPerComponent")?.Value ?? 8);
+        if (predictor == 2) {
+            return TiffPredictorDecoder.Decode(data, columns, colors, bitsPerComponent);
+        }
+
+        if (predictor < 10) {
+            return data;
+        }
+
         return PngPredictorDecoder.Decode(data, columns, colors, bitsPerComponent);
     }
 

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -11,7 +11,7 @@ internal static class StreamDecoder {
         byte[] original = data;
         byte[] current = data;
         int filterIndex = 0;
-        foreach (string filterName in EnumerateFilters(filterObj)) {
+        foreach (string filterName in EnumerateFilters(filterObj, objects)) {
             try {
                 switch (filterName) {
                     case "FlateDecode":
@@ -74,11 +74,13 @@ internal static class StreamDecoder {
             return null;
         }
 
-        if (ResolveDictionary(decodeParmsObj, objects) is PdfDictionary directDict) {
+        PdfObject? resolvedDecodeParms = ResolveObject(decodeParmsObj, objects);
+
+        if (resolvedDecodeParms is PdfDictionary directDict) {
             return filterIndex == 0 ? directDict : null;
         }
 
-        if (decodeParmsObj is PdfArray decodeParmsArray &&
+        if (resolvedDecodeParms is PdfArray decodeParmsArray &&
             filterIndex >= 0 &&
             filterIndex < decodeParmsArray.Items.Count &&
             ResolveDictionary(decodeParmsArray.Items[filterIndex], objects) is PdfDictionary indexedDict) {
@@ -89,29 +91,33 @@ internal static class StreamDecoder {
     }
 
     private static PdfDictionary? ResolveDictionary(PdfObject? obj, Dictionary<int, PdfIndirectObject>? objects) {
-        if (obj is PdfDictionary directDictionary) {
+        if (ResolveObject(obj, objects) is PdfDictionary directDictionary) {
             return directDictionary;
-        }
-
-        if (obj is PdfReference reference &&
-            objects is not null &&
-            objects.TryGetValue(reference.ObjectNumber, out var indirect) &&
-            indirect.Value is PdfDictionary referencedDictionary) {
-            return referencedDictionary;
         }
 
         return null;
     }
 
-    private static IEnumerable<string> EnumerateFilters(PdfObject filterObj) {
-        if (filterObj is PdfName filterName) {
+    private static PdfObject? ResolveObject(PdfObject? obj, Dictionary<int, PdfIndirectObject>? objects) {
+        if (obj is PdfReference reference &&
+            objects is not null &&
+            objects.TryGetValue(reference.ObjectNumber, out var indirect) &&
+            indirect.Value is PdfObject resolvedObject) {
+            return resolvedObject;
+        }
+
+        return obj;
+    }
+
+    private static IEnumerable<string> EnumerateFilters(PdfObject filterObj, Dictionary<int, PdfIndirectObject>? objects) {
+        if (ResolveObject(filterObj, objects) is PdfName filterName) {
             yield return filterName.Name;
             yield break;
         }
 
-        if (filterObj is PdfArray filterArray) {
+        if (ResolveObject(filterObj, objects) is PdfArray filterArray) {
             foreach (var item in filterArray.Items) {
-                if (item is PdfName arrayFilterName) {
+                if (ResolveObject(item, objects) is PdfName arrayFilterName) {
                     yield return arrayFilterName.Name;
                 }
             }

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -1,0 +1,112 @@
+using OfficeIMO.Pdf;
+
+namespace OfficeIMO.Pdf.Filters;
+
+internal static class StreamDecoder {
+    public static byte[] Decode(PdfDictionary dict, byte[] data, Dictionary<int, PdfIndirectObject>? objects = null) {
+        if (data == null || data.Length == 0 || !dict.Items.TryGetValue("Filter", out var filterObj)) {
+            return data ?? Array.Empty<byte>();
+        }
+
+        byte[] original = data;
+        byte[] current = data;
+        int filterIndex = 0;
+        foreach (string filterName in EnumerateFilters(filterObj)) {
+            try {
+                switch (filterName) {
+                    case "FlateDecode":
+                    case "Fl":
+                        current = FlateDecoder.Decode(current);
+                        current = ApplyDecodeParms(dict, filterIndex, current, objects);
+                        break;
+                    case "ASCIIHexDecode":
+                    case "AHx":
+                        current = AsciiHexDecoder.Decode(current);
+                        break;
+                    case "ASCII85Decode":
+                    case "A85":
+                        current = Ascii85Decoder.Decode(current);
+                        break;
+                    case "RunLengthDecode":
+                    case "RL":
+                        current = RunLengthDecoder.Decode(current);
+                        break;
+                    default:
+                        return original;
+                }
+            } catch {
+                return original;
+            }
+
+            filterIndex++;
+        }
+
+        return current;
+    }
+
+    private static byte[] ApplyDecodeParms(PdfDictionary dict, int filterIndex, byte[] data, Dictionary<int, PdfIndirectObject>? objects) {
+        var decodeParms = GetDecodeParms(dict, filterIndex, objects);
+        if (decodeParms is null) {
+            return data;
+        }
+
+        int predictor = (int)(decodeParms.Get<PdfNumber>("Predictor")?.Value ?? 1);
+        if (predictor < 10) {
+            return data;
+        }
+
+        int columns = (int)(decodeParms.Get<PdfNumber>("Columns")?.Value ?? 1);
+        int colors = (int)(decodeParms.Get<PdfNumber>("Colors")?.Value ?? 1);
+        int bitsPerComponent = (int)(decodeParms.Get<PdfNumber>("BitsPerComponent")?.Value ?? 8);
+        return PngPredictorDecoder.Decode(data, columns, colors, bitsPerComponent);
+    }
+
+    private static PdfDictionary? GetDecodeParms(PdfDictionary dict, int filterIndex, Dictionary<int, PdfIndirectObject>? objects) {
+        if (!dict.Items.TryGetValue("DecodeParms", out var decodeParmsObj)) {
+            return null;
+        }
+
+        if (ResolveDictionary(decodeParmsObj, objects) is PdfDictionary directDict) {
+            return filterIndex == 0 ? directDict : null;
+        }
+
+        if (decodeParmsObj is PdfArray decodeParmsArray &&
+            filterIndex >= 0 &&
+            filterIndex < decodeParmsArray.Items.Count &&
+            ResolveDictionary(decodeParmsArray.Items[filterIndex], objects) is PdfDictionary indexedDict) {
+            return indexedDict;
+        }
+
+        return null;
+    }
+
+    private static PdfDictionary? ResolveDictionary(PdfObject? obj, Dictionary<int, PdfIndirectObject>? objects) {
+        if (obj is PdfDictionary directDictionary) {
+            return directDictionary;
+        }
+
+        if (obj is PdfReference reference &&
+            objects is not null &&
+            objects.TryGetValue(reference.ObjectNumber, out var indirect) &&
+            indirect.Value is PdfDictionary referencedDictionary) {
+            return referencedDictionary;
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> EnumerateFilters(PdfObject filterObj) {
+        if (filterObj is PdfName filterName) {
+            yield return filterName.Name;
+            yield break;
+        }
+
+        if (filterObj is PdfArray filterArray) {
+            foreach (var item in filterArray.Items) {
+                if (item is PdfName arrayFilterName) {
+                    yield return arrayFilterName.Name;
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Filters/TiffPredictorDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/TiffPredictorDecoder.cs
@@ -1,0 +1,32 @@
+namespace OfficeIMO.Pdf.Filters;
+
+internal static class TiffPredictorDecoder {
+    public static byte[] Decode(byte[] data, int columns, int colors = 1, int bitsPerComponent = 8) {
+        if (data == null || data.Length == 0) {
+            return Array.Empty<byte>();
+        }
+
+        colors = Math.Max(1, colors);
+        columns = Math.Max(1, columns);
+        bitsPerComponent = Math.Max(1, bitsPerComponent);
+
+        if (bitsPerComponent != 8) {
+            return data;
+        }
+
+        int rowLength = columns * colors;
+        if (rowLength <= 0 || data.Length % rowLength != 0) {
+            return data;
+        }
+
+        var output = new byte[data.Length];
+        for (int rowOffset = 0; rowOffset < data.Length; rowOffset += rowLength) {
+            for (int i = 0; i < rowLength; i++) {
+                int left = i >= colors ? output[rowOffset + i - colors] : 0;
+                output[rowOffset + i] = unchecked((byte)(data[rowOffset + i] + left));
+            }
+        }
+
+        return output;
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Objects/PdfObject.cs
+++ b/OfficeIMO.Pdf/Reading/Objects/PdfObject.cs
@@ -9,6 +9,13 @@ internal sealed class PdfNumber : PdfObject {
     public override string ToString() => Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
 }
 
+/// <summary>PDF boolean value.</summary>
+internal sealed class PdfBoolean : PdfObject {
+    public bool Value { get; }
+    public PdfBoolean(bool value) { Value = value; }
+    public override string ToString() => Value ? "true" : "false";
+}
+
 /// <summary>PDF name object (e.g. /Type, /Font).</summary>
 internal sealed class PdfName : PdfObject {
     public string Name { get; }
@@ -26,6 +33,13 @@ internal sealed class PdfStringObj : PdfObject {
 /// <summary>PDF array object.</summary>
 internal sealed class PdfArray : PdfObject {
     public System.Collections.Generic.List<PdfObject> Items { get; } = new();
+}
+
+/// <summary>PDF null object.</summary>
+internal sealed class PdfNull : PdfObject {
+    private PdfNull() { }
+    public static PdfNull Instance { get; } = new PdfNull();
+    public override string ToString() => "null";
 }
 
 /// <summary>PDF dictionary object.</summary>

--- a/OfficeIMO.Pdf/Reading/PdfTextExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/PdfTextExtractor.cs
@@ -4,23 +4,36 @@ namespace OfficeIMO.Pdf;
 
 /// <summary>
 /// Minimal, zero-dependency text extractor for simple PDFs produced by OfficeIMO.Pdf
-/// (uncompressed streams, literal Tj strings, line breaks via T*).
+/// and common external PDFs with basic text operators and FlateDecode content streams.
 /// Not a general-purpose PDF parser; designed as a pragmatic starting point.
 /// </summary>
 public static class PdfTextExtractor {
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
+    private static readonly char[] SpaceSplitChars = new[] { ' ' };
 #if NET8_0_OR_GREATER
     private static readonly Regex ObjRegex = new Regex(@"(\d+)\s+0\s+obj", RegexOptions.Compiled | RegexOptions.NonBacktracking, RegexTimeout);
     private static readonly Regex InfoRefRegex = new Regex(@"/Info\s+(\d+)\s+0\s+R", RegexOptions.Compiled | RegexOptions.NonBacktracking, RegexTimeout);
-    private static readonly Regex PageObjRegex = new Regex(@"<<(?:.*?)/Type\s*/Page(?:.*?)/Contents\s+(\d+)\s+0\s+R(?:.*?)/?>>", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.NonBacktracking, RegexTimeout);
+    private static readonly Regex PageObjRegex = new Regex(@"<<(?:.*?)/Type\s*/Page\b(?:.*?)/Contents\s+(?:(?<single>\d+)\s+0\s+R|\[(?<array>[^\]]*)\])(?:.*?)/?>>", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.NonBacktracking, RegexTimeout);
+    private static readonly Regex RefRegex = new Regex(@"(\d+)\s+0\s+R", RegexOptions.Compiled | RegexOptions.NonBacktracking, RegexTimeout);
     private static readonly Regex StreamRegex = new Regex(@"stream\r?\n([\s\S]*?)\r?\nendstream", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.NonBacktracking, RegexTimeout);
     private static readonly Regex TjRegex = new Regex(@"\((?<txt>(?:\\.|[^\\\)])*)\)\s*Tj", RegexOptions.Compiled | RegexOptions.NonBacktracking, RegexTimeout);
+    private static readonly Regex HexTjRegex = new Regex(@"<(?<txt>[0-9A-Fa-f\s]+)>\s*Tj", RegexOptions.Compiled | RegexOptions.NonBacktracking, RegexTimeout);
+    private static readonly Regex QuoteLiteralRegex = new Regex(@"\((?<txt>(?:\\.|[^\\\)])*)\)\s*'", RegexOptions.Compiled | RegexOptions.NonBacktracking, RegexTimeout);
+    private static readonly Regex QuoteHexRegex = new Regex(@"<(?<txt>[0-9A-Fa-f\s]+)>\s*'", RegexOptions.Compiled | RegexOptions.NonBacktracking, RegexTimeout);
+    private static readonly Regex DoubleQuoteLiteralRegex = new Regex(@"(?<ws>[+-]?\d*\.?\d+)\s+(?<cs>[+-]?\d*\.?\d+)\s+\((?<txt>(?:\\.|[^\\\)])*)\)\s*""", RegexOptions.Compiled | RegexOptions.NonBacktracking, RegexTimeout);
+    private static readonly Regex DoubleQuoteHexRegex = new Regex(@"(?<ws>[+-]?\d*\.?\d+)\s+(?<cs>[+-]?\d*\.?\d+)\s+<(?<txt>[0-9A-Fa-f\s]+)>\s*""", RegexOptions.Compiled | RegexOptions.NonBacktracking, RegexTimeout);
 #else
     private static readonly Regex ObjRegex = new Regex(@"(\d+)\s+0\s+obj", RegexOptions.Compiled, RegexTimeout);
     private static readonly Regex InfoRefRegex = new Regex(@"/Info\s+(\d+)\s+0\s+R", RegexOptions.Compiled, RegexTimeout);
-    private static readonly Regex PageObjRegex = new Regex(@"<<(?:.|\n|\r)*?/Type\s*/Page(?:.|\n|\r)*?/Contents\s+(\d+)\s+0\s+R(?:.|\n|\r)*?>>", RegexOptions.Compiled, RegexTimeout);
+    private static readonly Regex PageObjRegex = new Regex(@"<<(?:.|\n|\r)*?/Type\s*/Page\b(?:.|\n|\r)*?/Contents\s+(?:(?<single>\d+)\s+0\s+R|\[(?<array>[^\]]*)\])(?:.|\n|\r)*?>>", RegexOptions.Compiled, RegexTimeout);
+    private static readonly Regex RefRegex = new Regex(@"(\d+)\s+0\s+R", RegexOptions.Compiled, RegexTimeout);
     private static readonly Regex StreamRegex = new Regex(@"stream\r?\n([\s\S]*?)\r?\nendstream", RegexOptions.Compiled, RegexTimeout);
     private static readonly Regex TjRegex = new Regex(@"\((?<txt>(?:\\.|[^\\\)])*)\)\s*Tj", RegexOptions.Compiled, RegexTimeout);
+    private static readonly Regex HexTjRegex = new Regex(@"<(?<txt>[0-9A-Fa-f\s]+)>\s*Tj", RegexOptions.Compiled, RegexTimeout);
+    private static readonly Regex QuoteLiteralRegex = new Regex(@"\((?<txt>(?:\\.|[^\\\)])*)\)\s*'", RegexOptions.Compiled, RegexTimeout);
+    private static readonly Regex QuoteHexRegex = new Regex(@"<(?<txt>[0-9A-Fa-f\s]+)>\s*'", RegexOptions.Compiled, RegexTimeout);
+    private static readonly Regex DoubleQuoteLiteralRegex = new Regex(@"(?<ws>[+-]?\d*\.?\d+)\s+(?<cs>[+-]?\d*\.?\d+)\s+\((?<txt>(?:\\.|[^\\\)])*)\)\s*""", RegexOptions.Compiled, RegexTimeout);
+    private static readonly Regex DoubleQuoteHexRegex = new Regex(@"(?<ws>[+-]?\d*\.?\d+)\s+(?<cs>[+-]?\d*\.?\d+)\s+<(?<txt>[0-9A-Fa-f\s]+)>\s*""", RegexOptions.Compiled, RegexTimeout);
 #endif
 
     /// <summary>Extracts plain text from all pages, concatenated with blank lines between pages.</summary>
@@ -31,19 +44,83 @@ public static class PdfTextExtractor {
 
     /// <summary>Extracts plain text from all pages, concatenated with blank lines between pages.</summary>
     public static string ExtractAllText(byte[] pdf) {
+        var (parsedObjects, _) = PdfSyntax.ParseObjects(pdf);
         var map = BuildObjectMap(pdf, out _);
-        var pageContents = FindPageContentIds(pdf);
+        var pages = CollectPages(parsedObjects);
         var sb = new StringBuilder();
-        for (int i = 0; i < pageContents.Count; i++) {
-            if (map.TryGetValue(pageContents[i], out var obj)) {
-                var m = StreamRegex.Match(obj);
-                if (m.Success) {
-                    if (i > 0) sb.AppendLine();
-                    sb.Append(ExtractTextFromContentStream(m.Groups[1].Value));
+
+        if (pages.Count > 0) {
+            for (int i = 0; i < pages.Count; i++) {
+                string pageText = ExtractTextFromPage(pages[i], parsedObjects, map);
+                if (string.IsNullOrWhiteSpace(pageText)) {
+                    continue;
                 }
+
+                if (sb.Length > 0) {
+                    sb.AppendLine();
+                }
+                sb.Append(pageText);
+            }
+
+            if (sb.Length > 0) {
+                return sb.ToString();
             }
         }
+
+        var pageContents = FindPageContentIds(pdf);
+        for (int i = 0; i < pageContents.Count; i++) {
+            var pageText = new StringBuilder();
+            foreach (int contentId in pageContents[i]) {
+                if (TryGetContentStreamContent(parsedObjects, map, contentId, out string content)) {
+                    pageText.Append(ExtractTextFromContentStream(content));
+                }
+            }
+
+            if (pageText.Length == 0) {
+                continue;
+            }
+
+            if (sb.Length > 0) {
+                sb.AppendLine();
+            }
+            sb.Append(pageText);
+        }
         return sb.ToString();
+    }
+
+    private static string ExtractTextFromPage(PdfDictionary page, Dictionary<int, PdfIndirectObject> parsedObjects, Dictionary<int, string> rawObjects) {
+        var pageText = new StringBuilder();
+        var resources = ResolveDict(GetInheritedValue(page, "Resources", parsedObjects), parsedObjects);
+        var activeForms = new HashSet<int>();
+
+        foreach (int contentId in GetContentIds(page, parsedObjects)) {
+            if (TryGetContentStreamContent(parsedObjects, rawObjects, contentId, out string content)) {
+                pageText.Append(ExtractTextFromContentStream(content, resources, parsedObjects, rawObjects, activeForms));
+            }
+        }
+
+        return pageText.ToString();
+    }
+
+    private static bool TryGetContentStreamContent(Dictionary<int, PdfIndirectObject> parsedObjects, Dictionary<int, string> rawObjects, int contentId, out string content) {
+        if (parsedObjects.TryGetValue(contentId, out var parsedObject) &&
+            parsedObject.Value is PdfStream stream) {
+            byte[] streamBytes = Filters.StreamDecoder.Decode(stream.Dictionary, stream.Data, parsedObjects);
+
+            content = PdfEncoding.Latin1GetString(streamBytes);
+            return true;
+        }
+
+        if (rawObjects.TryGetValue(contentId, out var obj)) {
+            var match = StreamRegex.Match(obj);
+            if (match.Success) {
+                content = match.Groups[1].Value;
+                return true;
+            }
+        }
+
+        content = string.Empty;
+        return false;
     }
 
     /// <summary>Gets document metadata (Title/Author/Subject/Keywords) if present; null when absent.</summary>
@@ -53,10 +130,10 @@ public static class PdfTextExtractor {
         if (!m.Success) return (null, null, null, null);
         int infoId = int.Parse(m.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
         if (!map.TryGetValue(infoId, out var obj)) return (null, null, null, null);
-        string? title = ExtractLiteral(obj, "/Title");
-        string? author = ExtractLiteral(obj, "/Author");
-        string? subject = ExtractLiteral(obj, "/Subject");
-        string? keywords = ExtractLiteral(obj, "/Keywords");
+        string? title = ExtractStringValue(obj, "/Title");
+        string? author = ExtractStringValue(obj, "/Author");
+        string? subject = ExtractStringValue(obj, "/Subject");
+        string? keywords = ExtractStringValue(obj, "/Keywords");
         return (title, author, subject, keywords);
     }
 
@@ -81,34 +158,401 @@ public static class PdfTextExtractor {
         return dict;
     }
 
-    private static List<int> FindPageContentIds(byte[] pdf) {
+    private static List<List<int>> FindPageContentIds(byte[] pdf) {
         string text = PdfEncoding.Latin1GetString(pdf);
-        var ids = new List<int>();
+        var ids = new List<List<int>>();
         foreach (Match m in PageObjRegex.Matches(text)) {
-            if (int.TryParse(m.Groups[1].Value, out int id)) ids.Add(id);
+            if (m.Groups["single"].Success && int.TryParse(m.Groups["single"].Value, out int singleId)) {
+                ids.Add(new List<int> { singleId });
+                continue;
+            }
+
+            if (!m.Groups["array"].Success) {
+                continue;
+            }
+
+            var pageIds = new List<int>();
+            foreach (Match refMatch in RefRegex.Matches(m.Groups["array"].Value)) {
+                if (int.TryParse(refMatch.Groups[1].Value, out int id)) {
+                    pageIds.Add(id);
+                }
+            }
+
+            if (pageIds.Count > 0) {
+                ids.Add(pageIds);
+            }
         }
         return ids;
     }
 
-    private static string ExtractTextFromContentStream(string content) {
+    private static string ExtractTextFromContentStream(
+        string content,
+        PdfDictionary? resources = null,
+        Dictionary<int, PdfIndirectObject>? parsedObjects = null,
+        Dictionary<int, string>? rawObjects = null,
+        HashSet<int>? activeForms = null) {
         var sb = new StringBuilder();
         bool inText = false;
-        using StringReader sr = new StringReader(content);
-        string? line;
-        while ((line = sr.ReadLine()) is not null) {
-            if (line.Contains(" BT")) { inText = true; continue; }
-            if (line.Contains(" ET")) { inText = false; continue; }
-            if (!inText) continue;
+        bool pendingSpace = false;
+        double currentFontSize = 12;
+        double currentHorizontalScale = 1.0;
+        var args = new List<object>(8);
+        int i = 0;
+        int n = content.Length;
+        while (i < n) {
+            SkipWs();
+            if (i >= n) break;
 
-            // Handle T* as newline
-            if (line.Trim() == "T*") { sb.AppendLine(); continue; }
+            char c = content[i];
+            if (c == '%') {
+                while (i < n && content[i] != '\n' && content[i] != '\r') i++;
+                continue;
+            }
 
-            foreach (Match tj in TjRegex.Matches(line)) {
-                var raw = tj.Groups["txt"].Value;
-                sb.Append(UnescapePdfLiteral(raw));
+            if (c == '/') { args.Add(ReadName()); continue; }
+            if (c == '(') { args.Add(ReadLiteralString()); continue; }
+            if (c == '<') {
+                if (i + 1 < n && content[i + 1] == '<') { i += 2; continue; }
+                args.Add(ReadHexString());
+                continue;
+            }
+            if (c == '[') { args.Add(ReadArray()); continue; }
+            if (c == ']' || c == '>') { i++; continue; }
+            if (IsNumberStart(c)) { args.Add(ReadNumber()); continue; }
+
+            string op = ReadOperator();
+            if (op.Length == 0) {
+                i++;
+                continue;
+            }
+
+            switch (op) {
+                case "BT":
+                    inText = true;
+                    pendingSpace = false;
+                    args.Clear();
+                    break;
+                case "ET":
+                    inText = false;
+                    pendingSpace = false;
+                    args.Clear();
+                    break;
+                case "T*":
+                    if (inText) {
+                        sb.AppendLine();
+                        pendingSpace = false;
+                    }
+                    args.Clear();
+                    break;
+                case "Tf":
+                    if (args.Count >= 2) {
+                        currentFontSize = ToDouble(args[args.Count - 1]);
+                    }
+                    args.Clear();
+                    break;
+                case "Tz":
+                    if (args.Count >= 1) {
+                        currentHorizontalScale = ToDouble(args[args.Count - 1]) / 100.0;
+                    }
+                    args.Clear();
+                    break;
+                case "Td":
+                    if (inText && args.Count >= 2) {
+                        double advanceX = ToDouble(args[args.Count - 2]);
+                        double advanceY = ToDouble(args[args.Count - 1]);
+                        if (advanceY == 0 && advanceX > 0.1) {
+                            pendingSpace = true;
+                        }
+                    }
+                    args.Clear();
+                    break;
+                case "Tj":
+                    if (inText && args.Count >= 1) {
+                        AppendTextRun(ToText(args[args.Count - 1]));
+                    }
+                    args.Clear();
+                    break;
+                case "TJ":
+                    if (inText && args.Count >= 1) {
+                        AppendTextArray(args[args.Count - 1]);
+                    }
+                    args.Clear();
+                    break;
+                case "'":
+                    if (inText && args.Count >= 1) {
+                        RequestSpace();
+                        AppendTextRun(ToText(args[args.Count - 1]));
+                    }
+                    args.Clear();
+                    break;
+                case "\"":
+                    if (inText && args.Count >= 3) {
+                        RequestSpace();
+                        AppendTextRun(ToText(args[args.Count - 1]));
+                    }
+                    args.Clear();
+                    break;
+                case "Do":
+                    if (resources is not null && parsedObjects is not null && rawObjects is not null && args.Count >= 1) {
+                        string formText = ExtractInvokedFormText(ToName(args[args.Count - 1]), resources, parsedObjects, rawObjects, activeForms ?? new HashSet<int>());
+                        if (!string.IsNullOrEmpty(formText)) {
+                            AppendTextRun(formText);
+                        }
+                    }
+                    args.Clear();
+                    break;
+                default:
+                    args.Clear();
+                    break;
             }
         }
+
         return sb.ToString();
+
+        void AppendTextRun(string value) {
+            if (string.IsNullOrEmpty(value)) return;
+            if (pendingSpace &&
+                sb.Length > 0 &&
+                !char.IsWhiteSpace(sb[sb.Length - 1]) &&
+                !char.IsWhiteSpace(value[0])) {
+                sb.Append(' ');
+            }
+            sb.Append(value);
+            pendingSpace = false;
+        }
+
+        void RequestSpace() {
+            pendingSpace = true;
+        }
+
+        void AppendTextArray(object arrayObject) {
+            if (arrayObject is not List<object> list) {
+                return;
+            }
+
+            foreach (var item in list) {
+                if (item is string text) {
+                    AppendTextRun(text);
+                } else if (item is double adjustment &&
+                           (-adjustment / 1000.0 * currentFontSize * currentHorizontalScale) > Math.Max(1.5, currentFontSize * 0.24)) {
+                    RequestSpace();
+                }
+            }
+        }
+
+        void SkipWs() {
+            while (i < n && char.IsWhiteSpace(content[i])) i++;
+        }
+
+        double ReadNumber() {
+            int start = i;
+            i++;
+            while (i < n) {
+                char ch = content[i];
+                if (!(char.IsDigit(ch) || ch == '.' || ch == 'E' || ch == 'e' || ch == '-' || ch == '+')) break;
+                i++;
+            }
+
+            var s = content.Substring(start, i - start);
+            if (!double.TryParse(s, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v)) v = 0;
+            return v;
+        }
+
+        string ReadName() {
+            i++;
+            int start = i;
+            while (i < n) {
+                char ch = content[i];
+                if (char.IsWhiteSpace(ch) || ch == '%' || ch == '/' || ch == '[' || ch == ']' || ch == '(' || ch == ')' || ch == '<' || ch == '>') break;
+                i++;
+            }
+            return PdfSyntax.DecodeName(content.Substring(start, i - start));
+        }
+
+        string ReadLiteralString() {
+            i++;
+            int depth = 1;
+            bool escaped = false;
+            var raw = new StringBuilder();
+            while (i < n && depth > 0) {
+                char ch = content[i++];
+                if (escaped) {
+                    raw.Append(ch);
+                    escaped = false;
+                    continue;
+                }
+
+                if (ch == '\\') {
+                    raw.Append(ch);
+                    escaped = true;
+                    continue;
+                }
+
+                if (ch == '(') {
+                    depth++;
+                    raw.Append(ch);
+                    continue;
+                }
+
+                if (ch == ')') {
+                    depth--;
+                    if (depth > 0) {
+                        raw.Append(ch);
+                    }
+                    continue;
+                }
+
+                raw.Append(ch);
+            }
+
+            return UnescapePdfLiteral(raw.ToString());
+        }
+
+        string ReadHexString() {
+            i++;
+            var raw = new StringBuilder();
+            while (i < n && content[i] != '>') {
+                raw.Append(content[i]);
+                i++;
+            }
+
+            if (i < n && content[i] == '>') {
+                i++;
+            }
+
+            return DecodeHexPdfString(raw.ToString());
+        }
+
+        List<object> ReadArray() {
+            var list = new List<object>();
+            i++;
+            while (i < n) {
+                SkipWs();
+                if (i >= n) break;
+                char ch = content[i];
+                if (ch == ']') {
+                    i++;
+                    break;
+                }
+
+                if (ch == '(') {
+                    list.Add(ReadLiteralString());
+                    continue;
+                }
+
+                if (ch == '<') {
+                    if (i + 1 < n && content[i + 1] == '<') {
+                        i += 2;
+                        continue;
+                    }
+                    list.Add(ReadHexString());
+                    continue;
+                }
+
+                if (IsNumberStart(ch)) {
+                    list.Add(ReadNumber());
+                    continue;
+                }
+
+                if (ch == '/') {
+                    list.Add(ReadName());
+                    continue;
+                }
+
+                if (ch == '[') {
+                    i++;
+                    continue;
+                }
+
+                ReadOperator();
+            }
+
+            return list;
+        }
+
+        string ReadOperator() {
+            int start = i;
+            char ch = content[i++];
+            if (ch == '\'' || ch == '"') return ch.ToString();
+            while (i < n) {
+                char current = content[i];
+                if (char.IsWhiteSpace(current) || current == '%' || current == '(' || current == '[' || current == '/' || current == '<' || current == '>') break;
+                i++;
+            }
+            return content.Substring(start, i - start);
+        }
+
+        static bool IsNumberStart(char ch) => ch == '+' || ch == '-' || ch == '.' || char.IsDigit(ch);
+        static double ToDouble(object o) => o is double d ? d : 0.0;
+        static string ToText(object o) => o as string ?? string.Empty;
+        static string ToName(object o) => o as string ?? string.Empty;
+    }
+
+    private static string ExtractInvokedFormText(
+        string formName,
+        PdfDictionary resources,
+        Dictionary<int, PdfIndirectObject> parsedObjects,
+        Dictionary<int, string> rawObjects,
+        HashSet<int> activeForms) {
+        if (!TryGetFormStream(resources, formName, parsedObjects, out var formStream, out int formObjectNumber)) {
+            return string.Empty;
+        }
+
+        bool trackRecursion = formObjectNumber > 0;
+        if (trackRecursion && !activeForms.Add(formObjectNumber)) {
+            return string.Empty;
+        }
+
+        try {
+            string content = DecodeStreamContent(formStream, parsedObjects);
+            var formResources = ResolveDict(formStream.Dictionary.Items.TryGetValue("Resources", out var resObj) ? resObj : null, parsedObjects) ?? resources;
+            return ExtractTextFromContentStream(content, formResources, parsedObjects, rawObjects, activeForms);
+        } finally {
+            if (trackRecursion) {
+                activeForms.Remove(formObjectNumber);
+            }
+        }
+    }
+
+    private static bool TryGetFormStream(
+        PdfDictionary resources,
+        string name,
+        Dictionary<int, PdfIndirectObject> parsedObjects,
+        out PdfStream formStream,
+        out int objectNumber) {
+        formStream = null!;
+        objectNumber = 0;
+
+        if (!resources.Items.TryGetValue("XObject", out var xObjectObj)) {
+            return false;
+        }
+
+        var xObjectDict = ResolveDict(xObjectObj, parsedObjects);
+        if (xObjectDict is null || !xObjectDict.Items.TryGetValue(name, out var formObj)) {
+            return false;
+        }
+
+        if (formObj is PdfReference formRef &&
+            parsedObjects.TryGetValue(formRef.ObjectNumber, out var indirectForm) &&
+            indirectForm.Value is PdfStream referencedStream &&
+            string.Equals(referencedStream.Dictionary.Get<PdfName>("Subtype")?.Name, "Form", StringComparison.Ordinal)) {
+            formStream = referencedStream;
+            objectNumber = formRef.ObjectNumber;
+            return true;
+        }
+
+        if (formObj is PdfStream directStream &&
+            string.Equals(directStream.Dictionary.Get<PdfName>("Subtype")?.Name, "Form", StringComparison.Ordinal)) {
+            formStream = directStream;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string DecodeStreamContent(PdfStream stream, Dictionary<int, PdfIndirectObject>? parsedObjects = null) {
+        byte[] bytes = Filters.StreamDecoder.Decode(stream.Dictionary, stream.Data, parsedObjects);
+        return PdfEncoding.Latin1GetString(bytes);
     }
 
     internal static string UnescapePdfLiteral(string s) {
@@ -117,6 +561,28 @@ public static class PdfTextExtractor {
             char c = s[i];
             if (c == '\\' && i + 1 < s.Length) {
                 char n = s[++i];
+                if (n >= '0' && n <= '7') {
+                    int value = n - '0';
+                    int digits = 1;
+                    while (digits < 3 && i + 1 < s.Length && s[i + 1] >= '0' && s[i + 1] <= '7') {
+                        value = (value * 8) + (s[++i] - '0');
+                        digits++;
+                    }
+                    sb.Append((char)value);
+                    continue;
+                }
+
+                if (n == '\r') {
+                    if (i + 1 < s.Length && s[i + 1] == '\n') {
+                        i++;
+                    }
+                    continue;
+                }
+
+                if (n == '\n') {
+                    continue;
+                }
+
                 sb.Append(n switch {
                     'n' => '\n',
                     'r' => '\r',
@@ -133,15 +599,61 @@ public static class PdfTextExtractor {
         return sb.ToString();
     }
 
-    private static string? ExtractLiteral(string obj, string key) {
+    internal static string DecodeHexPdfString(string s) {
+        if (string.IsNullOrWhiteSpace(s)) return string.Empty;
+
+        var hex = new StringBuilder(s.Length);
+        for (int i = 0; i < s.Length; i++) {
+            char ch = s[i];
+            if (!char.IsWhiteSpace(ch)) hex.Append(ch);
+        }
+
+        if (hex.Length % 2 == 1) hex.Append('0');
+
+        var bytes = new byte[hex.Length / 2];
+        for (int i = 0; i < bytes.Length; i++) {
+            int hi = HexNibble(hex[i * 2]);
+            int lo = HexNibble(hex[i * 2 + 1]);
+            bytes[i] = (byte)((hi << 4) | lo);
+        }
+
+        return PdfWinAnsiEncoding.Decode(bytes);
+
+        static int HexNibble(char c) {
+            if (c >= '0' && c <= '9') return c - '0';
+            if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+            if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+            throw new FormatException($"Invalid hex character '{c}'.");
+        }
+    }
+
+    private static string? ExtractStringValue(string obj, string key) {
         int idx = obj.IndexOf(key, StringComparison.Ordinal);
         if (idx < 0) return null;
-        int open = obj.IndexOf('(', idx);
-        if (open < 0) return null;
-        int close = FindCloseParen(obj, open);
-        if (close < 0) return null;
-        string raw = obj.Substring(open + 1, close - open - 1);
-        return UnescapePdfLiteral(raw);
+        int valueStart = idx + key.Length;
+        while (valueStart < obj.Length && char.IsWhiteSpace(obj[valueStart])) {
+            valueStart++;
+        }
+
+        if (valueStart >= obj.Length) {
+            return null;
+        }
+
+        if (obj[valueStart] == '(') {
+            int close = FindCloseParen(obj, valueStart);
+            if (close < 0) return null;
+            string raw = obj.Substring(valueStart + 1, close - valueStart - 1);
+            return UnescapePdfLiteral(raw);
+        }
+
+        if (obj[valueStart] == '<' && (valueStart + 1 >= obj.Length || obj[valueStart + 1] != '<')) {
+            int close = obj.IndexOf('>', valueStart + 1);
+            if (close < 0) return null;
+            string raw = obj.Substring(valueStart + 1, close - valueStart - 1);
+            return DecodeMetadataHexString(raw);
+        }
+
+        return null;
     }
 
     private static int FindCloseParen(string s, int start) {
@@ -153,5 +665,408 @@ public static class PdfTextExtractor {
             else if (c == ')') { depth--; if (depth == 0) return i; }
         }
         return -1;
+    }
+
+    private static bool TryReadTextAdvance(string line, out double advanceX, out double advanceY) {
+        advanceX = 0;
+        advanceY = 0;
+
+        if (!line.EndsWith(" Td", StringComparison.Ordinal) && line != "Td") {
+            return false;
+        }
+
+        var parts = line.Split(SpaceSplitChars, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 3 || !string.Equals(parts[parts.Length - 1], "Td", StringComparison.Ordinal)) {
+            return false;
+        }
+
+        return double.TryParse(parts[parts.Length - 3], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out advanceX) &&
+               double.TryParse(parts[parts.Length - 2], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out advanceY);
+    }
+
+    private static bool TryReadFontSize(string line, out double fontSize) {
+        fontSize = 0;
+        var parts = line.Split(SpaceSplitChars, StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length >= 3 &&
+               string.Equals(parts[parts.Length - 1], "Tf", StringComparison.Ordinal) &&
+               double.TryParse(parts[parts.Length - 2], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out fontSize);
+    }
+
+    private static bool TryReadHorizontalScale(string line, out double horizontalScale) {
+        horizontalScale = 0;
+        var parts = line.Split(SpaceSplitChars, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 2 ||
+            !string.Equals(parts[parts.Length - 1], "Tz", StringComparison.Ordinal) ||
+            !double.TryParse(parts[parts.Length - 2], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out double percent)) {
+            return false;
+        }
+
+        horizontalScale = percent / 100.0;
+        return true;
+    }
+
+    private static bool TryAppendTextArray(string line, double fontSize, double horizontalScale, Action<string> appendText, Action requestSpace) {
+        int operatorIndex = line.LastIndexOf("TJ", StringComparison.Ordinal);
+        if (operatorIndex < 0) {
+            return false;
+        }
+
+        int arrayStart = line.IndexOf('[');
+        int arrayEnd = line.LastIndexOf(']');
+        if (arrayStart < 0 || arrayEnd < arrayStart || arrayEnd > operatorIndex) {
+            return false;
+        }
+
+        string items = line.Substring(arrayStart + 1, arrayEnd - arrayStart - 1);
+        int i = 0;
+        while (i < items.Length) {
+            while (i < items.Length && char.IsWhiteSpace(items[i])) {
+                i++;
+            }
+
+            if (i >= items.Length) {
+                break;
+            }
+
+            char ch = items[i];
+            if (ch == '(') {
+                appendText(ReadLiteral(items, ref i));
+                continue;
+            }
+
+            if (ch == '<') {
+                appendText(ReadHex(items, ref i));
+                continue;
+            }
+
+            if (IsNumberStart(ch)) {
+                if (TryReadNumber(items, ref i, out double adjustment) &&
+                    ToVisualAdvance(adjustment, fontSize, horizontalScale) > Math.Max(1.5, fontSize * 0.24)) {
+                    requestSpace();
+                }
+                continue;
+            }
+
+            i++;
+        }
+
+        return true;
+
+        static string ReadLiteral(string s, ref int index) {
+            index++; // skip (
+            int depth = 1;
+            bool escaped = false;
+            var raw = new StringBuilder();
+            while (index < s.Length && depth > 0) {
+                char current = s[index++];
+                if (escaped) {
+                    raw.Append(current);
+                    escaped = false;
+                    continue;
+                }
+
+                if (current == '\\') {
+                    raw.Append(current);
+                    escaped = true;
+                    continue;
+                }
+
+                if (current == '(') {
+                    depth++;
+                    raw.Append(current);
+                    continue;
+                }
+
+                if (current == ')') {
+                    depth--;
+                    if (depth > 0) {
+                        raw.Append(current);
+                    }
+                    continue;
+                }
+
+                raw.Append(current);
+            }
+
+            return UnescapePdfLiteral(raw.ToString());
+        }
+
+        static string ReadHex(string s, ref int index) {
+            index++; // skip <
+            var raw = new StringBuilder();
+            while (index < s.Length && s[index] != '>') {
+                raw.Append(s[index]);
+                index++;
+            }
+
+            if (index < s.Length && s[index] == '>') {
+                index++;
+            }
+
+            return DecodeHexPdfString(raw.ToString());
+        }
+
+        static bool TryReadNumber(string s, ref int index, out double value) {
+            int start = index;
+            if (s[index] == '+' || s[index] == '-') {
+                index++;
+            }
+
+            while (index < s.Length && (char.IsDigit(s[index]) || s[index] == '.')) {
+                index++;
+            }
+
+#if NET8_0_OR_GREATER
+            return double.TryParse(s.AsSpan(start, index - start), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out value);
+#else
+            return double.TryParse(s.Substring(start, index - start), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out value);
+#endif
+        }
+
+        static bool IsNumberStart(char ch) => ch == '+' || ch == '-' || ch == '.' || char.IsDigit(ch);
+        static double ToVisualAdvance(double tjAdjustment, double currentFontSize, double currentHorizontalScale) => -tjAdjustment / 1000.0 * currentFontSize * currentHorizontalScale;
+    }
+
+    private static bool TryAppendNextLineShowText(string line, Action<string> appendText, Action requestSpace) {
+        Match literalQuote = QuoteLiteralRegex.Match(line);
+        if (literalQuote.Success) {
+            requestSpace();
+            appendText(UnescapePdfLiteral(literalQuote.Groups["txt"].Value));
+            return true;
+        }
+
+        Match hexQuote = QuoteHexRegex.Match(line);
+        if (hexQuote.Success) {
+            requestSpace();
+            appendText(DecodeHexPdfString(hexQuote.Groups["txt"].Value));
+            return true;
+        }
+
+        Match literalDoubleQuote = DoubleQuoteLiteralRegex.Match(line);
+        if (literalDoubleQuote.Success) {
+            requestSpace();
+            appendText(UnescapePdfLiteral(literalDoubleQuote.Groups["txt"].Value));
+            return true;
+        }
+
+        Match hexDoubleQuote = DoubleQuoteHexRegex.Match(line);
+        if (hexDoubleQuote.Success) {
+            requestSpace();
+            appendText(DecodeHexPdfString(hexDoubleQuote.Groups["txt"].Value));
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string DecodeMetadataHexString(string raw) {
+        if (string.IsNullOrWhiteSpace(raw)) {
+            return string.Empty;
+        }
+
+        var bytes = DecodeHexBytes(raw);
+        if (bytes.Length >= 2) {
+            if (bytes[0] == 0xFE && bytes[1] == 0xFF) {
+                return Encoding.BigEndianUnicode.GetString(bytes, 2, bytes.Length - 2);
+            }
+
+            if (bytes[0] == 0xFF && bytes[1] == 0xFE) {
+                return Encoding.Unicode.GetString(bytes, 2, bytes.Length - 2);
+            }
+        }
+
+        return PdfWinAnsiEncoding.Decode(bytes);
+    }
+
+    private static byte[] DecodeHexBytes(string s) {
+        var hex = new StringBuilder(s.Length);
+        for (int i = 0; i < s.Length; i++) {
+            char ch = s[i];
+            if (!char.IsWhiteSpace(ch)) hex.Append(ch);
+        }
+
+        if (hex.Length % 2 == 1) hex.Append('0');
+
+        var bytes = new byte[hex.Length / 2];
+        for (int i = 0; i < bytes.Length; i++) {
+            int hi = HexNibble(hex[i * 2]);
+            int lo = HexNibble(hex[i * 2 + 1]);
+            bytes[i] = (byte)((hi << 4) | lo);
+        }
+
+        return bytes;
+
+        static int HexNibble(char c) {
+            if (c >= '0' && c <= '9') return c - '0';
+            if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+            if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+            throw new FormatException($"Invalid hex character '{c}'.");
+        }
+    }
+
+    private static List<PdfDictionary> CollectPages(Dictionary<int, PdfIndirectObject> objects) {
+        var result = new List<PdfDictionary>();
+        int? catalogId = null;
+        foreach (var kv in objects) {
+            if (kv.Value.Value is PdfDictionary dict && dict.Get<PdfName>("Type")?.Name == "Catalog") {
+                catalogId = kv.Key;
+                break;
+            }
+        }
+
+        if (catalogId is int cat &&
+            objects.TryGetValue(cat, out var catalogObject) &&
+            catalogObject.Value is PdfDictionary catalog &&
+            ResolveDict(catalog.Items.TryGetValue("Pages", out var pagesObj) ? pagesObj : null, objects) is PdfDictionary pagesRoot) {
+            TraversePagesNode(pagesRoot, objects, result, new HashSet<int>());
+        }
+
+        if (result.Count > 0) {
+            return result;
+        }
+
+        foreach (var kv in objects.OrderBy(k => k.Key)) {
+            if (kv.Value.Value is PdfDictionary dict && IsLeafPage(dict, objects)) {
+                result.Add(dict);
+            }
+        }
+
+        return result;
+    }
+
+    private static void TraversePagesNode(
+        PdfDictionary node,
+        Dictionary<int, PdfIndirectObject> objects,
+        List<PdfDictionary> result,
+        HashSet<int> visited) {
+        string? type = node.Get<PdfName>("Type")?.Name;
+        if (type == "Page" || (type is null && IsLeafPage(node, objects))) {
+            int objectNumber = FindObjectNumberFor(node, objects);
+            if (objectNumber <= 0 || visited.Add(objectNumber)) {
+                result.Add(node);
+            }
+            return;
+        }
+
+        var kids = ResolveArray(node.Items.TryGetValue("Kids", out var kidsObj) ? kidsObj : null, objects);
+        if (kids is null) {
+            return;
+        }
+
+        foreach (var kid in kids.Items) {
+            var child = ResolveDict(kid, objects);
+            if (child is not null) {
+                TraversePagesNode(child, objects, result, visited);
+            }
+        }
+    }
+
+    private static bool IsLeafPage(PdfDictionary page, Dictionary<int, PdfIndirectObject> objects) {
+        if (ResolveArray(page.Items.TryGetValue("Kids", out var kidsObj) ? kidsObj : null, objects) is not null) {
+            return false;
+        }
+
+        if (!page.Items.ContainsKey("Contents")) {
+            return false;
+        }
+
+        string? type = page.Get<PdfName>("Type")?.Name;
+        if (type == "Page") {
+            return true;
+        }
+
+        return type is null &&
+               (page.Items.ContainsKey("Resources") || GetInheritedValue(page, "Resources", objects) is not null) &&
+               (page.Items.ContainsKey("MediaBox") ||
+                page.Items.ContainsKey("CropBox") ||
+                GetInheritedValue(page, "MediaBox", objects) is not null ||
+                GetInheritedValue(page, "CropBox", objects) is not null);
+    }
+
+    private static List<int> GetContentIds(PdfDictionary page, Dictionary<int, PdfIndirectObject> objects) {
+        var ids = new List<int>();
+        if (!page.Items.TryGetValue("Contents", out var contents)) {
+            return ids;
+        }
+
+        if (contents is PdfReference reference) {
+            if (objects.TryGetValue(reference.ObjectNumber, out var indirect) &&
+                indirect.Value is PdfArray referencedArray) {
+                AppendContentIds(referencedArray, ids);
+            } else {
+                ids.Add(reference.ObjectNumber);
+            }
+            return ids;
+        }
+
+        if (contents is PdfArray arr) {
+            AppendContentIds(arr, ids);
+        }
+
+        return ids;
+    }
+
+    private static PdfObject? GetInheritedValue(PdfDictionary start, string key, Dictionary<int, PdfIndirectObject> objects) {
+        PdfDictionary? current = start;
+        int guard = 0;
+        while (current is not null && guard++ < 100) {
+            if (current.Items.TryGetValue(key, out var value)) {
+                return value;
+            }
+
+            if (!current.Items.TryGetValue("Parent", out var parentObj)) {
+                break;
+            }
+
+            current = ResolveDict(parentObj, objects);
+        }
+
+        return null;
+    }
+
+    private static PdfDictionary? ResolveDict(PdfObject? obj, Dictionary<int, PdfIndirectObject> objects) {
+        if (obj is PdfDictionary dict) {
+            return dict;
+        }
+
+        if (obj is PdfReference reference &&
+            objects.TryGetValue(reference.ObjectNumber, out var indirect) &&
+            indirect.Value is PdfDictionary referencedDict) {
+            return referencedDict;
+        }
+
+        return null;
+    }
+
+    private static PdfArray? ResolveArray(PdfObject? obj, Dictionary<int, PdfIndirectObject> objects) {
+        if (obj is PdfArray arr) {
+            return arr;
+        }
+
+        if (obj is PdfReference reference &&
+            objects.TryGetValue(reference.ObjectNumber, out var indirect) &&
+            indirect.Value is PdfArray referencedArray) {
+            return referencedArray;
+        }
+
+        return null;
+    }
+
+    private static void AppendContentIds(PdfArray contentArray, List<int> ids) {
+        foreach (var item in contentArray.Items) {
+            if (item is PdfReference itemReference) {
+                ids.Add(itemReference.ObjectNumber);
+            }
+        }
+    }
+
+    private static int FindObjectNumberFor(PdfDictionary dict, Dictionary<int, PdfIndirectObject> objects) {
+        foreach (var kv in objects) {
+            if (ReferenceEquals(kv.Value.Value, dict)) {
+                return kv.Key;
+            }
+        }
+
+        return 0;
     }
 }

--- a/OfficeIMO.Pdf/Reading/PdfTextExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/PdfTextExtractor.cs
@@ -91,7 +91,7 @@ public static class PdfTextExtractor {
     private static string ExtractTextFromPage(PdfDictionary page, Dictionary<int, PdfIndirectObject> parsedObjects, Dictionary<int, string> rawObjects) {
         var pageText = new StringBuilder();
         var resources = ResolveDict(GetInheritedValue(page, "Resources", parsedObjects), parsedObjects);
-        var activeForms = new HashSet<int>();
+        var activeForms = new HashSet<PdfStream>();
 
         foreach (int contentId in GetContentIds(page, parsedObjects)) {
             if (TryGetContentStreamContent(parsedObjects, rawObjects, contentId, out string content)) {
@@ -190,7 +190,7 @@ public static class PdfTextExtractor {
         PdfDictionary? resources = null,
         Dictionary<int, PdfIndirectObject>? parsedObjects = null,
         Dictionary<int, string>? rawObjects = null,
-        HashSet<int>? activeForms = null) {
+        HashSet<PdfStream>? activeForms = null) {
         var sb = new StringBuilder();
         bool inText = false;
         bool pendingSpace = false;
@@ -294,7 +294,7 @@ public static class PdfTextExtractor {
                     break;
                 case "Do":
                     if (resources is not null && parsedObjects is not null && rawObjects is not null && args.Count >= 1) {
-                        string formText = ExtractInvokedFormText(ToName(args[args.Count - 1]), resources, parsedObjects, rawObjects, activeForms ?? new HashSet<int>());
+                        string formText = ExtractInvokedFormText(ToName(args[args.Count - 1]), resources, parsedObjects, rawObjects, activeForms ?? new HashSet<PdfStream>());
                         if (!string.IsNullOrEmpty(formText)) {
                             AppendTextRun(formText);
                         }
@@ -493,13 +493,12 @@ public static class PdfTextExtractor {
         PdfDictionary resources,
         Dictionary<int, PdfIndirectObject> parsedObjects,
         Dictionary<int, string> rawObjects,
-        HashSet<int> activeForms) {
-        if (!TryGetFormStream(resources, formName, parsedObjects, out var formStream, out int formObjectNumber)) {
+        HashSet<PdfStream> activeForms) {
+        if (!TryGetFormStream(resources, formName, parsedObjects, out var formStream)) {
             return string.Empty;
         }
 
-        bool trackRecursion = formObjectNumber > 0;
-        if (trackRecursion && !activeForms.Add(formObjectNumber)) {
+        if (!activeForms.Add(formStream)) {
             return string.Empty;
         }
 
@@ -508,9 +507,7 @@ public static class PdfTextExtractor {
             var formResources = ResolveDict(formStream.Dictionary.Items.TryGetValue("Resources", out var resObj) ? resObj : null, parsedObjects) ?? resources;
             return ExtractTextFromContentStream(content, formResources, parsedObjects, rawObjects, activeForms);
         } finally {
-            if (trackRecursion) {
-                activeForms.Remove(formObjectNumber);
-            }
+            activeForms.Remove(formStream);
         }
     }
 
@@ -518,10 +515,8 @@ public static class PdfTextExtractor {
         PdfDictionary resources,
         string name,
         Dictionary<int, PdfIndirectObject> parsedObjects,
-        out PdfStream formStream,
-        out int objectNumber) {
+        out PdfStream formStream) {
         formStream = null!;
-        objectNumber = 0;
 
         if (!resources.Items.TryGetValue("XObject", out var xObjectObj)) {
             return false;
@@ -537,7 +532,6 @@ public static class PdfTextExtractor {
             indirectForm.Value is PdfStream referencedStream &&
             string.Equals(referencedStream.Dictionary.Get<PdfName>("Subtype")?.Name, "Form", StringComparison.Ordinal)) {
             formStream = referencedStream;
-            objectNumber = formRef.ObjectNumber;
             return true;
         }
 

--- a/OfficeIMO.Pdf/Reading/PdfTextExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/PdfTextExtractor.cs
@@ -939,12 +939,14 @@ public static class PdfTextExtractor {
         Dictionary<int, PdfIndirectObject> objects,
         List<PdfDictionary> result,
         HashSet<int> visited) {
+        int objectNumber = FindObjectNumberFor(node, objects);
+        if (objectNumber > 0 && !visited.Add(objectNumber)) {
+            return;
+        }
+
         string? type = node.Get<PdfName>("Type")?.Name;
         if (type == "Page" || (type is null && IsLeafPage(node, objects))) {
-            int objectNumber = FindObjectNumberFor(node, objects);
-            if (objectNumber <= 0 || visited.Add(objectNumber)) {
-                result.Add(node);
-            }
+            result.Add(node);
             return;
         }
 

--- a/OfficeIMO.Pdf/Rendering/PdfWriter.cs
+++ b/OfficeIMO.Pdf/Rendering/PdfWriter.cs
@@ -31,22 +31,43 @@ internal static partial class PdfWriter {
             var page = layout.Pages[pageIndex];
             // Make a resources dict that references the fonts we declared
             var pageOpts = page.Options ?? opts;
+            var pageFontResources = new Dictionary<PdfStandardFont, string>();
+            string EnsurePageFontResource(PdfStandardFont font, string preferredAlias) {
+                if (pageFontResources.TryGetValue(font, out string? existingAlias)) {
+                    return existingAlias;
+                }
+
+                string alias = preferredAlias;
+                int aliasIndex = pageFontResources.Count + 1;
+                while (pageFontResources.Values.Contains(alias, StringComparer.Ordinal)) {
+                    alias = "F" + aliasIndex.ToString(CultureInfo.InvariantCulture);
+                    aliasIndex++;
+                }
+
+                pageFontResources[font] = alias;
+                EnsureFont(font);
+                return alias;
+            }
+
             var normalFont = ChooseNormal(pageOpts.DefaultFont);
-            int normalFontId = EnsureFont(normalFont);
-            var fontParts = new List<string> { $"/F1 {normalFontId} 0 R" };
+            _ = EnsurePageFontResource(normalFont, "F1");
             if (page.UsedBold) {
                 var boldFont = ChooseBold(normalFont);
-                fontParts.Add($"/F2 {EnsureFont(boldFont)} 0 R");
+                EnsurePageFontResource(boldFont, "F2");
             }
             if (page.UsedItalic) {
                 var italicFont = ChooseItalic(normalFont);
-                fontParts.Add($"/F3 {EnsureFont(italicFont)} 0 R");
+                EnsurePageFontResource(italicFont, "F3");
             }
             if (page.UsedBoldItalic) {
                 var biFont = ChooseBoldItalic(normalFont);
-                fontParts.Add($"/F4 {EnsureFont(biFont)} 0 R");
+                EnsurePageFontResource(biFont, "F4");
             }
-            string fontDict = $"<< {string.Join(" ", fontParts)} >>";
+            string footerFontAlias = EnsurePageFontResource(pageOpts.FooterFont, "F5");
+            string fontDict = "<< " + string.Join(" ",
+                pageFontResources
+                    .OrderBy(kvp => kvp.Value, StringComparer.Ordinal)
+                    .Select(kvp => "/" + kvp.Value + " " + EnsureFont(kvp.Key).ToString(CultureInfo.InvariantCulture) + " 0 R")) + " >>";
 
             // Content stream (append image draw commands at end)
             string contentStr = page.Content;
@@ -78,7 +99,7 @@ internal static partial class PdfWriter {
                 contentStr += sbImgs.ToString();
             }
             if (pageOpts.ShowPageNumbers) {
-                string footer = BuildFooter(pageOpts, pageIndex + 1, totalPages);
+                string footer = BuildFooter(pageOpts, pageIndex + 1, totalPages, pageOpts.FooterFont, footerFontAlias);
                 contentStr += footer;
             }
             byte[] content = Encoding.ASCII.GetBytes(contentStr);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.cs
@@ -9,7 +9,7 @@ internal static partial class PdfWriter {
     private sealed class ColHead : ColItem { public HeadingBlock Block = null!; public System.Collections.Generic.List<string> Lines = null!; public double Leading; public double Size; public ColHead() { Kind = "H"; } }
     private sealed class ColRule : ColItem { public HorizontalRuleBlock Block = null!; public ColRule() { Kind = "R"; } }
     private sealed class ColImg : ColItem { public ImageBlock Block = null!; public ColImg() { Kind = "I"; } }
-    private static string BuildFooter(PdfOptions opts, int page, int pages) {
+    private static string BuildFooter(PdfOptions opts, int page, int pages, PdfStandardFont footerFont, string footerFontResource) {
         string text;
         if (opts.FooterSegments != null && opts.FooterSegments.Count > 0) {
             var sbFooter = new StringBuilder();
@@ -25,7 +25,7 @@ internal static partial class PdfWriter {
             text = opts.FooterFormat.Replace("{page}", page.ToString(CultureInfo.InvariantCulture)).Replace("{pages}", pages.ToString(CultureInfo.InvariantCulture));
         }
         double width = opts.PageWidth - opts.MarginLeft - opts.MarginRight;
-        double em = GlyphWidthEmFor(ChooseNormal(opts.FooterFont));
+        double em = GlyphWidthEmFor(footerFont);
         double textWidth = text.Length * opts.FooterFontSize * em;
         double x = opts.MarginLeft;
         if (opts.FooterAlign == PdfAlign.Center) x = opts.MarginLeft + Math.Max(0, (width - textWidth) / 2);
@@ -33,9 +33,9 @@ internal static partial class PdfWriter {
         double y = opts.MarginBottom - opts.FooterOffsetY;
         var sb = new StringBuilder();
         sb.Append("BT\n");
-        sb.Append("/F1 ").Append(F(opts.FooterFontSize)).Append(" Tf\n");
+        sb.Append('/').Append(footerFontResource).Append(' ').Append(F(opts.FooterFontSize)).Append(" Tf\n");
         sb.Append("1 0 0 1 ").Append(F(x)).Append(' ').Append(F(y)).Append(" Tm\n");
-        sb.Append('(').Append(EscapeText(text)).Append(") Tj\n");
+        sb.Append('<').Append(EncodeWinAnsiHex(text)).Append("> Tj\n");
         sb.Append("ET\n");
         return sb.ToString();
     }

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -145,6 +145,15 @@ public class PdfReaderAndFooterRegressionTests {
     }
 
     [Fact]
+    public void PdfTextExtractor_ExtractAllText_IgnoresCyclicKidsReferences() {
+        byte[] bytes = BuildPdfWithCyclicKidsReferences();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello cyclic kids", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PdfTextExtractor_ExtractAllText_ReadsPagesWithIndirectContentArrayObjects() {
         byte[] bytes = BuildPdfWithIndirectContentArrayObject();
 
@@ -875,6 +884,41 @@ public class PdfReaderAndFooterRegressionTests {
             "endobj",
             "6 0 obj",
             "[3 0 R]",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithCyclicKidsReferences() {
+        const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(Hello cyclic kids) Tj\nET\n";
+        int streamLength = Encoding.ASCII.GetByteCount(streamContent);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 612 792] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Pages /Parent 2 0 R /Kids [2 0 R 4 0 R] >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Page /Parent 3 0 R /Resources << /Font << /F1 5 0 R >> >> /Contents 6 0 R >>",
+            "endobj",
+            "5 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "6 0 obj",
+            $"<< /Length {streamLength} >>",
+            "stream",
+            streamContent.TrimEnd('\n'),
+            "endstream",
             "endobj",
             "trailer",
             "<< /Root 1 0 R >>",

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -11,6 +11,34 @@ namespace OfficeIMO.Tests.Pdf;
 
 public class PdfReaderAndFooterRegressionTests {
     [Fact]
+    public void PdfSyntax_ParseObjects_ReadsBooleanAndNullObjects() {
+        byte[] bytes = BuildPdfWithBooleanAndNullObjects();
+
+        var (map, _) = PdfSyntax.ParseObjects(bytes);
+
+        Assert.True(map[3].Value is PdfBoolean boolTrue && boolTrue.Value);
+        Assert.True(map[4].Value is PdfBoolean boolFalse && !boolFalse.Value);
+        Assert.Same(PdfNull.Instance, map[5].Value);
+    }
+
+    [Fact]
+    public void PdfSyntax_ParseObjects_ReadsBooleanAndNullDictionaryValues() {
+        byte[] bytes = BuildPdfWithBooleanAndNullObjects();
+
+        var (map, _) = PdfSyntax.ParseObjects(bytes);
+
+        var metadata = Assert.IsType<PdfDictionary>(map[6].Value);
+        Assert.True(metadata.Get<PdfBoolean>("IsTagged")?.Value);
+        Assert.False(metadata.Get<PdfBoolean>("NeedsRendering")?.Value ?? true);
+        Assert.IsType<PdfNull>(metadata.Items["OptionalContent"]);
+
+        var flags = Assert.IsType<PdfArray>(metadata.Items["Flags"]);
+        Assert.True(Assert.IsType<PdfBoolean>(flags.Items[0]).Value);
+        Assert.False(Assert.IsType<PdfBoolean>(flags.Items[1]).Value);
+        Assert.IsType<PdfNull>(flags.Items[2]);
+    }
+
+    [Fact]
     public void PdfReadPage_GetPageSize_InheritsMediaBoxFromPagesNode() {
         byte[] pdfBytes = BuildPdfWithInheritedMediaBox(500, 700);
 
@@ -618,6 +646,35 @@ public class PdfReaderAndFooterRegressionTests {
             "stream",
             streamContent.TrimEnd('\n'),
             "endstream",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithBooleanAndNullObjects() {
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R /Metadata 6 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 0 /Kids [ ] >>",
+            "endobj",
+            "3 0 obj",
+            "true",
+            "endobj",
+            "4 0 obj",
+            "false",
+            "endobj",
+            "5 0 obj",
+            "null",
+            "endobj",
+            "6 0 obj",
+            "<< /IsTagged true /NeedsRendering false /OptionalContent null /Flags [true false null] >>",
             "endobj",
             "trailer",
             "<< /Root 1 0 R >>",

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -258,6 +258,16 @@ public class PdfReaderAndFooterRegressionTests {
     }
 
     [Fact]
+    public void PdfReadDocument_Metadata_ReadsLiteralStringsContainingStandaloneParserKeywords() {
+        byte[] bytes = BuildPdfWithLiteralMetadata("(stream title)", "(endobj author)");
+
+        var document = PdfReadDocument.Load(bytes);
+
+        Assert.Equal("stream title", document.Metadata.Title);
+        Assert.Equal("endobj author", document.Metadata.Author);
+    }
+
+    [Fact]
     public void PdfTextExtractor_ExtractAllText_ReadsFlateCompressedContentStreams() {
         byte[] bytes = BuildPdfWithFlateCompressedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello flate) Tj\nET\n");
 

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -145,6 +145,27 @@ public class PdfReaderAndFooterRegressionTests {
     }
 
     [Fact]
+    public void PdfReadDocument_Load_PreservesPagesWithDirectContentStreams() {
+        byte[] bytes = BuildPdfWithTwoDirectContentPages();
+
+        var document = PdfReadDocument.Load(bytes);
+
+        Assert.Equal(2, document.Pages.Count);
+        Assert.NotEqual(document.Pages[0].ObjectNumber, document.Pages[1].ObjectNumber);
+    }
+
+    [Fact]
+    public void PdfReadDocument_Load_PreservesPagesWithDistinctReferencedContentArrays() {
+        byte[] bytes = BuildPdfWithDistinctReferencedContentArrays();
+
+        var document = PdfReadDocument.Load(bytes);
+
+        Assert.Equal(2, document.Pages.Count);
+        Assert.Contains("Shared stream page", document.Pages[0].ExtractText(), StringComparison.Ordinal);
+        Assert.Contains("Shared stream page", document.Pages[1].ExtractText(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PdfTextExtractor_ExtractAllText_IgnoresCyclicKidsReferences() {
         byte[] bytes = BuildPdfWithCyclicKidsReferences();
 
@@ -1628,6 +1649,88 @@ public class PdfReaderAndFooterRegressionTests {
             "endobj",
             "13 0 obj",
             "<< /F1 4 0 R >>",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithTwoDirectContentPages() {
+        const string pageOne = "BT\n/F1 12 Tf\n72 720 Td\n(Direct page one) Tj\nET\n";
+        const string pageTwo = "BT\n/F1 12 Tf\n72 720 Td\n(Direct page two) Tj\nET\n";
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 2 /Kids [3 0 R 4 0 R] /MediaBox [0 0 612 792] /Resources 5 0 R >>",
+            "endobj",
+            "3 0 obj",
+            $"<< /Type /Page /Parent 2 0 R /Contents << /Length {Encoding.ASCII.GetByteCount(pageOne)} >>\nstream\n{pageOne.TrimEnd('\n')}\nendstream >>",
+            "endobj",
+            "4 0 obj",
+            $"<< /Type /Page /Parent 2 0 R /Contents << /Length {Encoding.ASCII.GetByteCount(pageTwo)} >>\nstream\n{pageTwo.TrimEnd('\n')}\nendstream >>",
+            "endobj",
+            "5 0 obj",
+            "<< /Font 6 0 R >>",
+            "endobj",
+            "6 0 obj",
+            "<< /F1 7 0 R >>",
+            "endobj",
+            "7 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithDistinctReferencedContentArrays() {
+        const string sharedStream = "BT\n/F1 12 Tf\n72 720 Td\n(Shared stream page) Tj\nET\n";
+        int sharedLength = Encoding.ASCII.GetByteCount(sharedStream);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 2 /Kids [3 0 R 4 0 R] /MediaBox [0 0 612 792] /Resources 8 0 R >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /Contents 5 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Page /Parent 2 0 R /Contents 6 0 R >>",
+            "endobj",
+            "5 0 obj",
+            "[7 0 R]",
+            "endobj",
+            "6 0 obj",
+            "[7 0 R]",
+            "endobj",
+            "7 0 obj",
+            $"<< /Length {sharedLength} >>",
+            "stream",
+            sharedStream.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "8 0 obj",
+            "<< /Font 9 0 R >>",
+            "endobj",
+            "9 0 obj",
+            "<< /F1 10 0 R >>",
+            "endobj",
+            "10 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
             "endobj",
             "trailer",
             "<< /Root 1 0 R >>",

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -515,6 +515,26 @@ public class PdfReaderAndFooterRegressionTests {
         Assert.Equal("Hello predictor indirect chain", span.Text);
     }
 
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsFlateStreamsWithTiffPredictorDecodeParms() {
+        byte[] bytes = BuildPdfWithTiffPredictorEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello TIFF predictor) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello TIFF predictor", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsFlateStreamsWithTiffPredictorDecodeParms() {
+        byte[] bytes = BuildPdfWithTiffPredictorEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello TIFF predictor) Tj\nET\n");
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans());
+        Assert.Equal("Hello TIFF predictor", span.Text);
+    }
+
     private static byte[] BuildPdfWithInheritedMediaBox(int width, int height) {
         const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(Hi) Tj\nET\n";
         int streamLength = Encoding.ASCII.GetByteCount(streamContent);
@@ -890,6 +910,13 @@ public class PdfReaderAndFooterRegressionTests {
             "endobj");
     }
 
+    private static byte[] BuildPdfWithTiffPredictorEncodedStream(string streamContent) {
+        byte[] streamBytes = Encoding.ASCII.GetBytes(streamContent);
+        byte[] predictedBytes = EncodeTiffPredictedRows(streamBytes);
+        byte[] compressedBytes = CompressWithDeflate(predictedBytes);
+        return BuildSingleStreamPdf(compressedBytes, $"/Filter /FlateDecode /DecodeParms << /Predictor 2 /Columns {streamBytes.Length} >>");
+    }
+
     private static byte[] BuildPdfWithTjArraySpacing() {
         const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n[(Hello) -600 (world)] TJ\nET\n";
         int streamLength = Encoding.ASCII.GetByteCount(streamContent);
@@ -1074,6 +1101,20 @@ public class PdfReaderAndFooterRegressionTests {
         var output = new byte[input.Length + 1];
         output[0] = 2;
         Buffer.BlockCopy(input, 0, output, 1, input.Length);
+        return output;
+    }
+
+    private static byte[] EncodeTiffPredictedRows(byte[] input) {
+        if (input.Length == 0) {
+            return Array.Empty<byte>();
+        }
+
+        var output = new byte[input.Length];
+        output[0] = input[0];
+        for (int i = 1; i < input.Length; i++) {
+            output[i] = unchecked((byte)(input[i] - input[i - 1]));
+        }
+
         return output;
     }
 

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -172,6 +173,31 @@ public class PdfReaderAndFooterRegressionTests {
         string text = PdfTextExtractor.ExtractAllText(bytes);
 
         Assert.Contains("Hello cyclic kids", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_IgnoresDirectFormCycles() {
+        var page = CreatePdfReadPageWithDirectFormCycle();
+
+        var spans = page.GetTextSpans();
+
+        Assert.Empty(spans);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_InternalExtractor_IgnoresDirectFormCycles() {
+        var state = BuildDirectFormCycleState();
+        var method = typeof(PdfTextExtractor).GetMethod("ExtractTextFromContentStream", BindingFlags.NonPublic | BindingFlags.Static);
+
+        string text = Assert.IsType<string>(method!.Invoke(null, new object?[] {
+            "/Fx Do",
+            state.Resources,
+            state.Objects,
+            new Dictionary<int, string>(),
+            new HashSet<PdfStream>()
+        }));
+
+        Assert.Equal(string.Empty, text);
     }
 
     [Fact]
@@ -1790,6 +1816,40 @@ public class PdfReaderAndFooterRegressionTests {
         }) + "\n";
 
         return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static PdfReadPage CreatePdfReadPageWithDirectFormCycle() {
+        var state = BuildDirectFormCycleState();
+        var pageDict = new PdfDictionary();
+        pageDict.Items["Type"] = new PdfName("Page");
+        pageDict.Items["Resources"] = state.Resources;
+
+        var contents = new PdfArray();
+        contents.Items.Add(new PdfStream(new PdfDictionary(), Encoding.ASCII.GetBytes("/Fx Do")));
+        pageDict.Items["Contents"] = contents;
+
+        var ctor = typeof(PdfReadPage).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            new[] { typeof(int), typeof(PdfDictionary), typeof(Dictionary<int, PdfIndirectObject>) },
+            modifiers: null);
+
+        return Assert.IsType<PdfReadPage>(ctor!.Invoke(new object[] { 1, pageDict, state.Objects }));
+    }
+
+    private static (PdfDictionary Resources, Dictionary<int, PdfIndirectObject> Objects) BuildDirectFormCycleState() {
+        var xObjects = new PdfDictionary();
+        var resources = new PdfDictionary();
+        resources.Items["XObject"] = xObjects;
+
+        var formDict = new PdfDictionary();
+        formDict.Items["Subtype"] = new PdfName("Form");
+        formDict.Items["Resources"] = resources;
+
+        var formStream = new PdfStream(formDict, Encoding.ASCII.GetBytes("/Fx Do"));
+        xObjects.Items["Fx"] = formStream;
+
+        return (resources, new Dictionary<int, PdfIndirectObject>());
     }
 
     private static string EncodeUtf16BeHex(string value) {

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -1,0 +1,1423 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using OfficeIMO.Pdf;
+using UglyToad.PdfPig;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public class PdfReaderAndFooterRegressionTests {
+    [Fact]
+    public void PdfReadPage_GetPageSize_InheritsMediaBoxFromPagesNode() {
+        byte[] pdfBytes = BuildPdfWithInheritedMediaBox(500, 700);
+
+        var doc = PdfReadDocument.Load(pdfBytes);
+
+        Assert.Single(doc.Pages);
+        var (width, height) = doc.Pages[0].GetPageSize();
+        Assert.Equal(500, width);
+        Assert.Equal(700, height);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetPageSize_PrefersCropBoxOverMediaBox() {
+        byte[] pdfBytes = BuildPdfWithMediaAndCropBoxes(500, 700, 300, 400);
+
+        var doc = PdfReadDocument.Load(pdfBytes);
+
+        Assert.Single(doc.Pages);
+        var (width, height) = doc.Pages[0].GetPageSize();
+        Assert.Equal(300, width);
+        Assert.Equal(400, height);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetPageSize_ReadsInheritedIndirectMediaBoxArrays() {
+        byte[] pdfBytes = BuildPdfWithInheritedIndirectMediaBox(520, 710);
+
+        var doc = PdfReadDocument.Load(pdfBytes);
+
+        Assert.Single(doc.Pages);
+        var (width, height) = doc.Pages[0].GetPageSize();
+        Assert.Equal(520, width);
+        Assert.Equal(710, height);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetPageSize_PrefersInheritedIndirectCropBoxArrays() {
+        byte[] pdfBytes = BuildPdfWithInheritedIndirectCropBox(520, 710, 320, 410);
+
+        var doc = PdfReadDocument.Load(pdfBytes);
+
+        Assert.Single(doc.Pages);
+        var (width, height) = doc.Pages[0].GetPageSize();
+        Assert.Equal(320, width);
+        Assert.Equal(410, height);
+    }
+
+    [Fact]
+    public void Footer_UsesConfiguredFooterFont() {
+        var options = new PdfOptions {
+            DefaultFont = PdfStandardFont.TimesRoman,
+            ShowPageNumbers = true,
+            FooterFormat = "Footer check",
+            FooterFont = PdfStandardFont.HelveticaBold,
+            FooterAlign = PdfAlign.Left
+        };
+
+        byte[] bytes = PdfDoc.Create(options)
+            .Paragraph(p => p.Text("Body text only."))
+            .ToBytes();
+
+        using var pdf = PdfDocument.Open(new MemoryStream(bytes));
+        var footerLine = pdf.GetPage(1).Letters
+            .Where(letter => !string.IsNullOrWhiteSpace(letter.Value))
+            .GroupBy(letter => Math.Round(letter.StartBaseLine.Y, 1))
+            .OrderBy(group => group.Key)
+            .First()
+            .OrderBy(letter => letter.StartBaseLine.X)
+            .ToList();
+
+        string footerText = new string(string.Concat(footerLine.Select(letter => letter.Value)).Where(c => !char.IsWhiteSpace(c)).ToArray());
+        Assert.Equal("Footercheck", footerText);
+        Assert.Contains(footerLine, letter => letter.FontName != null && letter.FontName.Contains("Helvetica-Bold", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(footerLine, letter => letter.FontName != null && letter.FontName.Contains("Times", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsLibraryGeneratedHexText() {
+        byte[] bytes = PdfDoc.Create()
+            .Paragraph(p => p.Text("Hello extractor"))
+            .ToBytes();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello extractor", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsPagesWithContentStreamArrays() {
+        byte[] bytes = BuildPdfWithContentStreamArray();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello world", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsPagesWithIndirectKidsArrayObjects() {
+        byte[] bytes = BuildPdfWithIndirectKidsArrayObject();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello indirect kids", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsPagesWithIndirectContentArrayObjects() {
+        byte[] bytes = BuildPdfWithIndirectContentArrayObject();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello world", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsTJArrays() {
+        byte[] bytes = BuildPdfWithTjArraySpacing();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello world", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsSingleQuoteOperator() {
+        byte[] bytes = BuildPdfWithSingleQuoteOperator();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello world", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsDoubleQuoteOperator() {
+        byte[] bytes = BuildPdfWithDoubleQuoteOperator();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello world", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_GetMetadata_ReadsHexUtf16InfoStrings() {
+        byte[] bytes = BuildPdfWithHexMetadata("Hello metadata", "OfficeIMO");
+
+        var metadata = PdfTextExtractor.GetMetadata(bytes);
+
+        Assert.Equal("Hello metadata", metadata.Title);
+        Assert.Equal("OfficeIMO", metadata.Author);
+    }
+
+    [Fact]
+    public void PdfReadDocument_Metadata_ReadsHexUtf16InfoStrings() {
+        byte[] bytes = BuildPdfWithHexMetadata("Hello metadata", "OfficeIMO");
+
+        var document = PdfReadDocument.Load(bytes);
+
+        Assert.Equal("Hello metadata", document.Metadata.Title);
+        Assert.Equal("OfficeIMO", document.Metadata.Author);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsOctalEscapedLiteralStrings() {
+        byte[] bytes = BuildSingleStreamPdf("BT\n/F1 12 Tf\n72 720 Td\n(Hello\\040octal\\041) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello octal!", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsLineContinuedLiteralStrings() {
+        byte[] bytes = BuildSingleStreamPdf("BT\n/F1 12 Tf\n72 720 Td\n(Hello\\\r\nworld) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Helloworld", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_GetMetadata_ReadsOctalEscapedLiteralInfoStrings() {
+        byte[] bytes = BuildPdfWithLiteralMetadata("(Hello\\040meta\\041)", "(OfficeIMO\\\r\nTeam)");
+
+        var metadata = PdfTextExtractor.GetMetadata(bytes);
+
+        Assert.Equal("Hello meta!", metadata.Title);
+        Assert.Equal("OfficeIMOTeam", metadata.Author);
+    }
+
+    [Fact]
+    public void PdfReadDocument_Metadata_ReadsOctalEscapedLiteralInfoStrings() {
+        byte[] bytes = BuildPdfWithLiteralMetadata("(Hello\\040meta\\041)", "(OfficeIMO\\\r\nTeam)");
+
+        var document = PdfReadDocument.Load(bytes);
+
+        Assert.Equal("Hello meta!", document.Metadata.Title);
+        Assert.Equal("OfficeIMOTeam", document.Metadata.Author);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsFlateCompressedContentStreams() {
+        byte[] bytes = BuildPdfWithFlateCompressedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello flate) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello flate", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsAsciiHexEncodedContentStreams() {
+        byte[] bytes = BuildPdfWithAsciiHexEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello hex) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello hex", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsAscii85EncodedContentStreams() {
+        byte[] bytes = BuildPdfWithAscii85EncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello ascii85) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello ascii85", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsChainedAscii85AndFlateContentStreams() {
+        byte[] bytes = BuildPdfWithAscii85AndFlateEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello chained) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello chained", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsChainedAsciiHexAndFlateContentStreamsWithAliases() {
+        byte[] bytes = BuildPdfWithAsciiHexAndFlateEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello aliases) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello aliases", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsRunLengthEncodedContentStreams() {
+        byte[] bytes = BuildPdfWithRunLengthEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello runlength) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello runlength", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsChainedAscii85AndRunLengthContentStreamsWithAliases() {
+        byte[] bytes = BuildPdfWithAscii85AndRunLengthEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello runlength chain) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello runlength chain", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsInlineNestedFormResourceDictionaries() {
+        byte[] bytes = BuildPdfWithInlineNestedFormResources();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Inline form", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsNestedFormXObjects() {
+        byte[] bytes = BuildPdfWithNestedFormInvocations();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Nested form", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_PreservesInlineFormOrdering() {
+        byte[] bytes = BuildPdfWithInlineFormTextOrdering();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Before middle after", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_UsesInheritedResourcesForFormXObjects() {
+        byte[] bytes = BuildPdfWithInheritedFormResources();
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans(), s => s.Text == "Form hello");
+        Assert.Equal(110, span.X, 3);
+        Assert.Equal(220, span.Y, 3);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_TracksRepeatedFormInvocations() {
+        byte[] bytes = BuildPdfWithRepeatedFormInvocations();
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var spans = doc.Pages[0].GetTextSpans().Where(s => s.Text == "Repeated form").OrderBy(s => s.X).ToList();
+        Assert.Equal(2, spans.Count);
+        Assert.Equal(10, spans[0].X, 3);
+        Assert.Equal(110, spans[1].X, 3);
+        Assert.Equal(20, spans[0].Y, 3);
+        Assert.Equal(20, spans[1].Y, 3);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_TracksNestedFormInvocations() {
+        byte[] bytes = BuildPdfWithNestedFormInvocations();
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans(), s => s.Text == "Nested form");
+        Assert.Equal(120, span.X, 3);
+        Assert.Equal(232, span.Y, 3);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsInlineNestedFormResourceDictionaries() {
+        byte[] bytes = BuildPdfWithInlineNestedFormResources();
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans(), s => s.Text == "Inline form");
+        Assert.Equal(10, span.X, 3);
+        Assert.Equal(20, span.Y, 3);
+    }
+
+    [Fact]
+    public void PdfReadDocument_CollectPages_ReadsIndirectKidsArrayObjects() {
+        byte[] bytes = BuildPdfWithIndirectKidsArrayObject();
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        Assert.Contains("Hello indirect kids", doc.Pages[0].ExtractText(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsIndirectContentArrayObjects() {
+        byte[] bytes = BuildPdfWithIndirectContentArrayObject();
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        string joinedText = string.Concat(doc.Pages[0].GetTextSpans().Select(s => s.Text));
+        Assert.Contains("Hello", joinedText, StringComparison.Ordinal);
+        Assert.Contains("world", joinedText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsPageDictionariesWithInlineComments() {
+        byte[] bytes = BuildPdfWithCommentedPageDictionary();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello comments", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsPageDictionariesWithInlineComments() {
+        byte[] bytes = BuildPdfWithCommentedPageDictionary();
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans());
+        Assert.Equal("Hello comments", span.Text);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsFormResourcesWithEscapedNames() {
+        byte[] bytes = BuildPdfWithFormResourceNameEscapes(dictionaryUsesEscapedName: true, contentUsesEscapedName: false);
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Escaped form", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsFormInvocationsWithEscapedNames() {
+        byte[] bytes = BuildPdfWithFormResourceNameEscapes(dictionaryUsesEscapedName: false, contentUsesEscapedName: true);
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Escaped form", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsFormResourcesWithEscapedNames() {
+        byte[] bytes = BuildPdfWithFormResourceNameEscapes(dictionaryUsesEscapedName: true, contentUsesEscapedName: false);
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans(), s => s.Text == "Escaped form");
+        Assert.Equal(10, span.X, 3);
+        Assert.Equal(20, span.Y, 3);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsFormInvocationsWithEscapedNames() {
+        byte[] bytes = BuildPdfWithFormResourceNameEscapes(dictionaryUsesEscapedName: false, contentUsesEscapedName: true);
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans(), s => s.Text == "Escaped form");
+        Assert.Equal(10, span.X, 3);
+        Assert.Equal(20, span.Y, 3);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsFlateStreamsWithPredictorDecodeParms() {
+        byte[] bytes = BuildPdfWithPredictorEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello predictor) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello predictor", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsFlateStreamsWithPredictorDecodeParms() {
+        byte[] bytes = BuildPdfWithPredictorEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello predictor) Tj\nET\n");
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans());
+        Assert.Equal("Hello predictor", span.Text);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsChainedFiltersWithDecodeParmsArrays() {
+        byte[] bytes = BuildPdfWithAscii85AndPredictorEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello predictor chain) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello predictor chain", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsChainedFiltersWithDecodeParmsArrays() {
+        byte[] bytes = BuildPdfWithAscii85AndPredictorEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello predictor chain) Tj\nET\n");
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans());
+        Assert.Equal("Hello predictor chain", span.Text);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsIndirectDecodeParmsDictionaries() {
+        byte[] bytes = BuildPdfWithIndirectPredictorEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello predictor indirect) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello predictor indirect", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsIndirectDecodeParmsDictionaries() {
+        byte[] bytes = BuildPdfWithIndirectPredictorEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello predictor indirect) Tj\nET\n");
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans());
+        Assert.Equal("Hello predictor indirect", span.Text);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsIndirectDecodeParmsArrayEntries() {
+        byte[] bytes = BuildPdfWithAscii85AndIndirectPredictorEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello predictor indirect chain) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello predictor indirect chain", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsIndirectDecodeParmsArrayEntries() {
+        byte[] bytes = BuildPdfWithAscii85AndIndirectPredictorEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello predictor indirect chain) Tj\nET\n");
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans());
+        Assert.Equal("Hello predictor indirect chain", span.Text);
+    }
+
+    private static byte[] BuildPdfWithInheritedMediaBox(int width, int height) {
+        const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(Hi) Tj\nET\n";
+        int streamLength = Encoding.ASCII.GetByteCount(streamContent);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            $"<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 {width} {height}] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "5 0 obj",
+            $"<< /Length {streamLength} >>",
+            "stream",
+            streamContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithMediaAndCropBoxes(int mediaWidth, int mediaHeight, int cropWidth, int cropHeight) {
+        const string streamContent = "BT\n/F1 12 Tf\n72 360 Td\n(Hi) Tj\nET\n";
+        int streamLength = Encoding.ASCII.GetByteCount(streamContent);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "endobj",
+            "3 0 obj",
+            $"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {mediaWidth} {mediaHeight}] /CropBox [0 0 {cropWidth} {cropHeight}] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "5 0 obj",
+            $"<< /Length {streamLength} >>",
+            "stream",
+            streamContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithInheritedIndirectMediaBox(int width, int height) {
+        const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(Hi) Tj\nET\n";
+        int streamLength = Encoding.ASCII.GetByteCount(streamContent);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox 6 0 R >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "5 0 obj",
+            $"<< /Length {streamLength} >>",
+            "stream",
+            streamContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "6 0 obj",
+            $"[0 0 {width} {height}]",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithInheritedIndirectCropBox(int mediaWidth, int mediaHeight, int cropWidth, int cropHeight) {
+        const string streamContent = "BT\n/F1 12 Tf\n72 360 Td\n(Hi) Tj\nET\n";
+        int streamLength = Encoding.ASCII.GetByteCount(streamContent);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox 6 0 R /CropBox 7 0 R >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "5 0 obj",
+            $"<< /Length {streamLength} >>",
+            "stream",
+            streamContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "6 0 obj",
+            $"[0 0 {mediaWidth} {mediaHeight}]",
+            "endobj",
+            "7 0 obj",
+            $"[0 0 {cropWidth} {cropHeight}]",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithContentStreamArray() {
+        const string streamOne = "BT\n/F1 12 Tf\n72 720 Td\n(Hello) Tj\nET\n";
+        const string streamTwo = "BT\n/F1 12 Tf\n72 720 Td\n( world) Tj\nET\n";
+        int streamOneLength = Encoding.ASCII.GetByteCount(streamOne);
+        int streamTwoLength = Encoding.ASCII.GetByteCount(streamTwo);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 612 792] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /Contents [5 0 R 6 0 R] >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "5 0 obj",
+            $"<< /Length {streamOneLength} >>",
+            "stream",
+            streamOne.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "6 0 obj",
+            $"<< /Length {streamTwoLength} >>",
+            "stream",
+            streamTwo.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithIndirectKidsArrayObject() {
+        const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(Hello indirect kids) Tj\nET\n";
+        int streamLength = Encoding.ASCII.GetByteCount(streamContent);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids 6 0 R /MediaBox [0 0 612 792] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "5 0 obj",
+            $"<< /Length {streamLength} >>",
+            "stream",
+            streamContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "6 0 obj",
+            "[3 0 R]",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithIndirectContentArrayObject() {
+        const string streamOne = "BT\n/F1 12 Tf\n72 720 Td\n(Hello) Tj\nET\n";
+        const string streamTwo = "BT\n/F1 12 Tf\n72 720 Td\n( world) Tj\nET\n";
+        int streamOneLength = Encoding.ASCII.GetByteCount(streamOne);
+        int streamTwoLength = Encoding.ASCII.GetByteCount(streamTwo);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 612 792] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /Contents 7 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "5 0 obj",
+            $"<< /Length {streamOneLength} >>",
+            "stream",
+            streamOne.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "6 0 obj",
+            $"<< /Length {streamTwoLength} >>",
+            "stream",
+            streamTwo.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "7 0 obj",
+            "[5 0 R 6 0 R]",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithCommentedPageDictionary() {
+        const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(Hello comments) Tj\nET\n";
+        int streamLength = Encoding.ASCII.GetByteCount(streamContent);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 612 792] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page",
+            "/Parent 2 0 R",
+            "/Resources % resources comment",
+            "<< /Font << /F1 4 0 R >> >>",
+            "/Contents % contents comment",
+            "5 0 R",
+            ">>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "5 0 obj",
+            $"<< /Length {streamLength} >>",
+            "stream",
+            streamContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithFormResourceNameEscapes(bool dictionaryUsesEscapedName, bool contentUsesEscapedName) {
+        const string formContent = "BT\n/F1 12 Tf\n10 20 Td\n(Escaped form) Tj\nET\n";
+        string pageContentName = contentUsesEscapedName ? "/Fm#31" : "/Fm1";
+        string resourceName = dictionaryUsesEscapedName ? "/Fm#31" : "/Fm1";
+        string pageContent = $"q\n{pageContentName} Do\nQ\n";
+        int pageStreamLength = Encoding.ASCII.GetByteCount(pageContent);
+        int formStreamLength = Encoding.ASCII.GetByteCount(formContent);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 612 792] >>",
+            "endobj",
+            "3 0 obj",
+            $"<< /Type /Page /Parent 2 0 R /Resources << /XObject << {resourceName} 5 0 R >> >> /Contents 6 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "5 0 obj",
+            $"<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] /Resources << /Font << /F1 4 0 R >> >> /Length {formStreamLength} >>",
+            "stream",
+            formContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "6 0 obj",
+            $"<< /Length {pageStreamLength} >>",
+            "stream",
+            pageContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithPredictorEncodedStream(string streamContent) {
+        byte[] streamBytes = Encoding.ASCII.GetBytes(streamContent);
+        byte[] predictedBytes = EncodeUpPredictedRows(streamBytes);
+        byte[] compressedBytes = CompressWithDeflate(predictedBytes);
+        return BuildSingleStreamPdf(compressedBytes, $"/Filter /FlateDecode /DecodeParms << /Predictor 12 /Columns {streamBytes.Length} >>");
+    }
+
+    private static byte[] BuildPdfWithAscii85AndPredictorEncodedStream(string streamContent) {
+        byte[] streamBytes = Encoding.ASCII.GetBytes(streamContent);
+        byte[] predictedBytes = EncodeUpPredictedRows(streamBytes);
+        byte[] compressedBytes = CompressWithDeflate(predictedBytes);
+        byte[] encodedBytes = Encoding.ASCII.GetBytes(EncodeAscii85(compressedBytes));
+        return BuildSingleStreamPdf(encodedBytes, $"/Filter [/ASCII85Decode /FlateDecode] /DecodeParms [null << /Predictor 12 /Columns {streamBytes.Length} >>]");
+    }
+
+    private static byte[] BuildPdfWithIndirectPredictorEncodedStream(string streamContent) {
+        byte[] streamBytes = Encoding.ASCII.GetBytes(streamContent);
+        byte[] predictedBytes = EncodeUpPredictedRows(streamBytes);
+        byte[] compressedBytes = CompressWithDeflate(predictedBytes);
+        return BuildSingleStreamPdfWithExtraObjects(
+            compressedBytes,
+            "/Filter /FlateDecode /DecodeParms 6 0 R",
+            "6 0 obj",
+            $"<< /Predictor 12 /Columns {streamBytes.Length} >>",
+            "endobj");
+    }
+
+    private static byte[] BuildPdfWithAscii85AndIndirectPredictorEncodedStream(string streamContent) {
+        byte[] streamBytes = Encoding.ASCII.GetBytes(streamContent);
+        byte[] predictedBytes = EncodeUpPredictedRows(streamBytes);
+        byte[] compressedBytes = CompressWithDeflate(predictedBytes);
+        byte[] encodedBytes = Encoding.ASCII.GetBytes(EncodeAscii85(compressedBytes));
+        return BuildSingleStreamPdfWithExtraObjects(
+            encodedBytes,
+            "/Filter [/ASCII85Decode /FlateDecode] /DecodeParms [null 6 0 R]",
+            "6 0 obj",
+            $"<< /Predictor 12 /Columns {streamBytes.Length} >>",
+            "endobj");
+    }
+
+    private static byte[] BuildPdfWithTjArraySpacing() {
+        const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n[(Hello) -600 (world)] TJ\nET\n";
+        int streamLength = Encoding.ASCII.GetByteCount(streamContent);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 612 792] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "5 0 obj",
+            $"<< /Length {streamLength} >>",
+            "stream",
+            streamContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithSingleQuoteOperator() {
+        const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(Hello) Tj\n( world) '\nET\n";
+        return BuildSingleStreamPdf(streamContent);
+    }
+
+    private static byte[] BuildPdfWithDoubleQuoteOperator() {
+        const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(Hello) Tj\n0 0 ( world) \"\nET\n";
+        return BuildSingleStreamPdf(streamContent);
+    }
+
+    private static byte[] BuildPdfWithFlateCompressedStream(string streamContent) {
+        byte[] compressedBytes = CompressWithDeflate(Encoding.ASCII.GetBytes(streamContent));
+        return BuildSingleStreamPdf(compressedBytes, "/Filter /FlateDecode");
+    }
+
+    private static byte[] BuildPdfWithAsciiHexEncodedStream(string streamContent) {
+        byte[] encodedBytes = Encoding.ASCII.GetBytes(EncodeAsciiHex(Encoding.ASCII.GetBytes(streamContent)));
+        return BuildSingleStreamPdf(encodedBytes, "/Filter /ASCIIHexDecode");
+    }
+
+    private static byte[] BuildPdfWithAscii85EncodedStream(string streamContent) {
+        byte[] encodedBytes = Encoding.ASCII.GetBytes(EncodeAscii85(Encoding.ASCII.GetBytes(streamContent)));
+        return BuildSingleStreamPdf(encodedBytes, "/Filter /ASCII85Decode");
+    }
+
+    private static byte[] BuildPdfWithAscii85AndFlateEncodedStream(string streamContent) {
+        byte[] flatedBytes = CompressWithDeflate(Encoding.ASCII.GetBytes(streamContent));
+        byte[] encodedBytes = Encoding.ASCII.GetBytes(EncodeAscii85(flatedBytes));
+        return BuildSingleStreamPdf(encodedBytes, "/Filter [/ASCII85Decode /FlateDecode]");
+    }
+
+    private static byte[] BuildPdfWithAsciiHexAndFlateEncodedStream(string streamContent) {
+        byte[] flatedBytes = CompressWithDeflate(Encoding.ASCII.GetBytes(streamContent));
+        byte[] encodedBytes = Encoding.ASCII.GetBytes(EncodeAsciiHex(flatedBytes));
+        return BuildSingleStreamPdf(encodedBytes, "/Filter [/AHx /Fl]");
+    }
+
+    private static byte[] BuildPdfWithRunLengthEncodedStream(string streamContent) {
+        byte[] encodedBytes = EncodeRunLength(Encoding.ASCII.GetBytes(streamContent));
+        return BuildSingleStreamPdf(encodedBytes, "/Filter /RunLengthDecode");
+    }
+
+    private static byte[] BuildPdfWithAscii85AndRunLengthEncodedStream(string streamContent) {
+        byte[] runLengthBytes = EncodeRunLength(Encoding.ASCII.GetBytes(streamContent));
+        byte[] encodedBytes = Encoding.ASCII.GetBytes(EncodeAscii85(runLengthBytes));
+        return BuildSingleStreamPdf(encodedBytes, "/Filter [/A85 /RL]");
+    }
+
+    private static byte[] BuildPdfWithInlineNestedFormResources() {
+        const string pageContent = "q\n/Fx Do\nQ\n";
+        const string formContent = "BT\n/F1 12 Tf\n10 20 Td\n(Inline form) Tj\nET\n";
+        int pageStreamLength = Encoding.ASCII.GetByteCount(pageContent);
+        int formStreamLength = Encoding.ASCII.GetByteCount(formContent);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 612 792] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /Resources << /XObject << /Fx 5 0 R >> >> /Contents 6 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "5 0 obj",
+            $"<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] /Resources << /Font << /F1 4 0 R >> >> /Length {formStreamLength} >>",
+            "stream",
+            formContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "6 0 obj",
+            $"<< /Length {pageStreamLength} >>",
+            "stream",
+            pageContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildSingleStreamPdf(string streamContent) {
+        return BuildSingleStreamPdf(Encoding.ASCII.GetBytes(streamContent.TrimEnd('\n')));
+    }
+
+    private static byte[] BuildSingleStreamPdf(byte[] streamBytes, string extraStreamDictionaryEntries = "") {
+        return BuildSingleStreamPdfWithExtraObjects(streamBytes, extraStreamDictionaryEntries);
+    }
+
+    private static byte[] BuildSingleStreamPdfWithExtraObjects(byte[] streamBytes, string extraStreamDictionaryEntries = "", params string[] extraObjects) {
+        using var ms = new MemoryStream();
+        using var writer = new StreamWriter(ms, Encoding.ASCII, 1024, leaveOpen: true);
+
+        writer.WriteLine("%PDF-1.4");
+        writer.WriteLine("1 0 obj");
+        writer.WriteLine("<< /Type /Catalog /Pages 2 0 R >>");
+        writer.WriteLine("endobj");
+        writer.WriteLine("2 0 obj");
+        writer.WriteLine("<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 612 792] >>");
+        writer.WriteLine("endobj");
+        writer.WriteLine("3 0 obj");
+        writer.WriteLine("<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>");
+        writer.WriteLine("endobj");
+        writer.WriteLine("4 0 obj");
+        writer.WriteLine("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>");
+        writer.WriteLine("endobj");
+        writer.WriteLine("5 0 obj");
+        writer.Write("<< /Length ");
+        writer.Write(streamBytes.Length);
+        if (!string.IsNullOrWhiteSpace(extraStreamDictionaryEntries)) {
+            writer.Write(' ');
+            writer.Write(extraStreamDictionaryEntries.Trim());
+        }
+        writer.WriteLine(" >>");
+        writer.WriteLine("stream");
+        writer.Flush();
+
+        ms.Write(streamBytes, 0, streamBytes.Length);
+
+        writer.WriteLine();
+        writer.WriteLine("endstream");
+        writer.WriteLine("endobj");
+        foreach (string extraObject in extraObjects) {
+            writer.WriteLine(extraObject);
+        }
+        writer.WriteLine("trailer");
+        writer.WriteLine("<< /Root 1 0 R >>");
+        writer.WriteLine("%%EOF");
+        writer.Flush();
+        return ms.ToArray();
+    }
+
+    private static byte[] CompressWithDeflate(byte[] input) {
+        using var output = new MemoryStream();
+        using (var deflate = new DeflateStream(output, CompressionLevel.Optimal, leaveOpen: true)) {
+            deflate.Write(input, 0, input.Length);
+        }
+
+        return output.ToArray();
+    }
+
+    private static byte[] EncodeUpPredictedRows(byte[] input) {
+        var output = new byte[input.Length + 1];
+        output[0] = 2;
+        Buffer.BlockCopy(input, 0, output, 1, input.Length);
+        return output;
+    }
+
+    private static byte[] EncodeRunLength(byte[] input) {
+        using var output = new MemoryStream();
+        int index = 0;
+        while (index < input.Length) {
+            int chunkLength = Math.Min(128, input.Length - index);
+            output.WriteByte((byte)(chunkLength - 1));
+            output.Write(input, index, chunkLength);
+            index += chunkLength;
+        }
+
+        output.WriteByte(128);
+        return output.ToArray();
+    }
+
+    private static string EncodeAsciiHex(byte[] input) {
+        var sb = new StringBuilder(input.Length * 2 + 1);
+        for (int i = 0; i < input.Length; i++) {
+            sb.Append(input[i].ToString("X2"));
+        }
+        sb.Append('>');
+        return sb.ToString();
+    }
+
+    private static string EncodeAscii85(byte[] input) {
+        var sb = new StringBuilder((input.Length * 5 / 4) + 4);
+        int index = 0;
+        while (index + 4 <= input.Length) {
+            uint value =
+                ((uint)input[index] << 24) |
+                ((uint)input[index + 1] << 16) |
+                ((uint)input[index + 2] << 8) |
+                input[index + 3];
+
+            if (value == 0) {
+                sb.Append('z');
+            } else {
+                AppendAscii85Tuple(sb, value, 5);
+            }
+
+            index += 4;
+        }
+
+        int remaining = input.Length - index;
+        if (remaining > 0) {
+            uint value = 0;
+            for (int i = 0; i < remaining; i++) {
+                value |= (uint)input[index + i] << (24 - (8 * i));
+            }
+
+            AppendAscii85Tuple(sb, value, remaining + 1);
+        }
+
+        sb.Append("~>");
+        return sb.ToString();
+    }
+
+    private static void AppendAscii85Tuple(StringBuilder sb, uint value, int count) {
+        char[] encoded = new char[5];
+        for (int i = 4; i >= 0; i--) {
+            encoded[i] = (char)((value % 85) + '!');
+            value /= 85;
+        }
+
+        for (int i = 0; i < count; i++) {
+            sb.Append(encoded[i]);
+        }
+    }
+
+    private static byte[] BuildPdfWithHexMetadata(string title, string author) {
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 0 /Kids [ ] >>",
+            "endobj",
+            "3 0 obj",
+            $"<< /Title <{EncodeUtf16BeHex(title)}> /Author <{EncodeUtf16BeHex(author)}> >>",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R /Info 3 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithLiteralMetadata(string titleLiteral, string authorLiteral) {
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 0 /Kids [ ] >>",
+            "endobj",
+            "3 0 obj",
+            $"<< /Title {titleLiteral} /Author {authorLiteral} >>",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R /Info 3 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithInheritedFormResources() {
+        const string pageContent = "q\n/Fx Do\nQ\n";
+        const string formContent = "BT\n/F1 12 Tf\n10 20 Td\n(Form hello) Tj\nET\n";
+        int pageStreamLength = Encoding.ASCII.GetByteCount(pageContent);
+        int formStreamLength = Encoding.ASCII.GetByteCount(formContent);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 612 792] /Resources 7 0 R >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /Contents 6 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "5 0 obj",
+            $"<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] /Matrix [1 0 0 1 100 200] /Resources 9 0 R /Length {formStreamLength} >>",
+            "stream",
+            formContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "6 0 obj",
+            $"<< /Length {pageStreamLength} >>",
+            "stream",
+            pageContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "7 0 obj",
+            "<< /XObject 8 0 R >>",
+            "endobj",
+            "8 0 obj",
+            "<< /Fx 5 0 R >>",
+            "endobj",
+            "9 0 obj",
+            "<< /Font 10 0 R >>",
+            "endobj",
+            "10 0 obj",
+            "<< /F1 4 0 R >>",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithRepeatedFormInvocations() {
+        const string pageContent = "q\n1 0 0 1 0 0 cm\n/Fx Do\nQ\nq\n1 0 0 1 100 0 cm\n/Fx Do\nQ\n";
+        const string formContent = "BT\n/F1 12 Tf\n10 20 Td\n(Repeated form) Tj\nET\n";
+        int pageStreamLength = Encoding.ASCII.GetByteCount(pageContent);
+        int formStreamLength = Encoding.ASCII.GetByteCount(formContent);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 612 792] /Resources 7 0 R >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /Contents 6 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "5 0 obj",
+            $"<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] /Resources 9 0 R /Length {formStreamLength} >>",
+            "stream",
+            formContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "6 0 obj",
+            $"<< /Length {pageStreamLength} >>",
+            "stream",
+            pageContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "7 0 obj",
+            "<< /XObject 8 0 R >>",
+            "endobj",
+            "8 0 obj",
+            "<< /Fx 5 0 R >>",
+            "endobj",
+            "9 0 obj",
+            "<< /Font 10 0 R >>",
+            "endobj",
+            "10 0 obj",
+            "<< /F1 4 0 R >>",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithNestedFormInvocations() {
+        const string pageContent = "q\n1 0 0 1 100 200 cm\n/FxOuter Do\nQ\n";
+        const string outerFormContent = "q\n1 0 0 1 15 25 cm\n/FxInner Do\nQ\n";
+        const string innerFormContent = "BT\n/F1 12 Tf\n5 7 Td\n(Nested form) Tj\nET\n";
+        int pageStreamLength = Encoding.ASCII.GetByteCount(pageContent);
+        int outerFormLength = Encoding.ASCII.GetByteCount(outerFormContent);
+        int innerFormLength = Encoding.ASCII.GetByteCount(innerFormContent);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 612 792] /Resources 7 0 R >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /Contents 8 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "5 0 obj",
+            $"<< /Type /XObject /Subtype /Form /BBox [0 0 200 200] /Resources 9 0 R /Length {outerFormLength} >>",
+            "stream",
+            outerFormContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "6 0 obj",
+            $"<< /Type /XObject /Subtype /Form /BBox [0 0 50 50] /Resources 11 0 R /Length {innerFormLength} >>",
+            "stream",
+            innerFormContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "7 0 obj",
+            "<< /XObject 10 0 R >>",
+            "endobj",
+            "8 0 obj",
+            $"<< /Length {pageStreamLength} >>",
+            "stream",
+            pageContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "9 0 obj",
+            "<< /XObject 12 0 R >>",
+            "endobj",
+            "10 0 obj",
+            "<< /FxOuter 5 0 R >>",
+            "endobj",
+            "11 0 obj",
+            "<< /Font 13 0 R >>",
+            "endobj",
+            "12 0 obj",
+            "<< /FxInner 6 0 R >>",
+            "endobj",
+            "13 0 obj",
+            "<< /F1 4 0 R >>",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildPdfWithInlineFormTextOrdering() {
+        const string pageContent = "BT /F1 12 Tf (Before ) Tj /Fx Do ( after) Tj ET\n";
+        const string formContent = "BT /F1 12 Tf (middle) Tj ET\n";
+        int pageStreamLength = Encoding.ASCII.GetByteCount(pageContent);
+        int formStreamLength = Encoding.ASCII.GetByteCount(formContent);
+
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] /MediaBox [0 0 612 792] /Resources 7 0 R >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /Contents 5 0 R >>",
+            "endobj",
+            "4 0 obj",
+            $"<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] /Resources 8 0 R /Length {formStreamLength} >>",
+            "stream",
+            formContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "5 0 obj",
+            $"<< /Length {pageStreamLength} >>",
+            "stream",
+            pageContent.TrimEnd('\n'),
+            "endstream",
+            "endobj",
+            "7 0 obj",
+            "<< /Font 9 0 R /XObject 10 0 R >>",
+            "endobj",
+            "8 0 obj",
+            "<< /Font 9 0 R >>",
+            "endobj",
+            "9 0 obj",
+            "<< /F1 6 0 R >>",
+            "endobj",
+            "10 0 obj",
+            "<< /Fx 4 0 R >>",
+            "endobj",
+            "6 0 obj",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R >>",
+            "%%EOF"
+        }) + "\n";
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static string EncodeUtf16BeHex(string value) {
+        byte[] bom = new byte[] { 0xFE, 0xFF };
+        byte[] textBytes = Encoding.BigEndianUnicode.GetBytes(value);
+        byte[] bytes = new byte[bom.Length + textBytes.Length];
+        Buffer.BlockCopy(bom, 0, bytes, 0, bom.Length);
+        Buffer.BlockCopy(textBytes, 0, bytes, bom.Length, textBytes.Length);
+
+        var sb = new StringBuilder(bytes.Length * 2);
+        for (int i = 0; i < bytes.Length; i++) {
+            sb.Append(bytes[i].ToString("X2"));
+        }
+        return sb.ToString();
+    }
+}

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -248,6 +248,16 @@ public class PdfReaderAndFooterRegressionTests {
     }
 
     [Fact]
+    public void PdfReadDocument_Metadata_ReadsLiteralStringsContainingStreamSubstrings() {
+        byte[] bytes = BuildPdfWithLiteralMetadata("(mainstream title)", "(upstream author)");
+
+        var document = PdfReadDocument.Load(bytes);
+
+        Assert.Equal("mainstream title", document.Metadata.Title);
+        Assert.Equal("upstream author", document.Metadata.Author);
+    }
+
+    [Fact]
     public void PdfTextExtractor_ExtractAllText_ReadsFlateCompressedContentStreams() {
         byte[] bytes = BuildPdfWithFlateCompressedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello flate) Tj\nET\n");
 

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -535,6 +535,46 @@ public class PdfReaderAndFooterRegressionTests {
         Assert.Equal("Hello TIFF predictor", span.Text);
     }
 
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsIndirectFilterNameObjects() {
+        byte[] bytes = BuildPdfWithIndirectFilterNameEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello indirect filter) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello indirect filter", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsIndirectFilterNameObjects() {
+        byte[] bytes = BuildPdfWithIndirectFilterNameEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello indirect filter) Tj\nET\n");
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans());
+        Assert.Equal("Hello indirect filter", span.Text);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsIndirectFilterAndDecodeParmsArrayObjects() {
+        byte[] bytes = BuildPdfWithIndirectFilterAndDecodeParmsArrayObjects("BT\n/F1 12 Tf\n72 720 Td\n(Hello indirect arrays) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello indirect arrays", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsIndirectFilterAndDecodeParmsArrayObjects() {
+        byte[] bytes = BuildPdfWithIndirectFilterAndDecodeParmsArrayObjects("BT\n/F1 12 Tf\n72 720 Td\n(Hello indirect arrays) Tj\nET\n");
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans());
+        Assert.Equal("Hello indirect arrays", span.Text);
+    }
+
     private static byte[] BuildPdfWithInheritedMediaBox(int width, int height) {
         const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(Hi) Tj\nET\n";
         int streamLength = Encoding.ASCII.GetByteCount(streamContent);
@@ -915,6 +955,35 @@ public class PdfReaderAndFooterRegressionTests {
         byte[] predictedBytes = EncodeTiffPredictedRows(streamBytes);
         byte[] compressedBytes = CompressWithDeflate(predictedBytes);
         return BuildSingleStreamPdf(compressedBytes, $"/Filter /FlateDecode /DecodeParms << /Predictor 2 /Columns {streamBytes.Length} >>");
+    }
+
+    private static byte[] BuildPdfWithIndirectFilterNameEncodedStream(string streamContent) {
+        byte[] compressedBytes = CompressWithDeflate(Encoding.ASCII.GetBytes(streamContent));
+        return BuildSingleStreamPdfWithExtraObjects(
+            compressedBytes,
+            "/Filter 6 0 R",
+            "6 0 obj",
+            "/FlateDecode",
+            "endobj");
+    }
+
+    private static byte[] BuildPdfWithIndirectFilterAndDecodeParmsArrayObjects(string streamContent) {
+        byte[] streamBytes = Encoding.ASCII.GetBytes(streamContent);
+        byte[] predictedBytes = EncodeUpPredictedRows(streamBytes);
+        byte[] compressedBytes = CompressWithDeflate(predictedBytes);
+        byte[] encodedBytes = Encoding.ASCII.GetBytes(EncodeAscii85(compressedBytes));
+        return BuildSingleStreamPdfWithExtraObjects(
+            encodedBytes,
+            "/Filter 6 0 R /DecodeParms 7 0 R",
+            "6 0 obj",
+            "[/ASCII85Decode /FlateDecode]",
+            "endobj",
+            "7 0 obj",
+            "[null 8 0 R]",
+            "endobj",
+            "8 0 obj",
+            $"<< /Predictor 12 /Columns {streamBytes.Length} >>",
+            "endobj");
     }
 
     private static byte[] BuildPdfWithTjArraySpacing() {

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -623,6 +623,26 @@ public class PdfReaderAndFooterRegressionTests {
         Assert.Equal("Hello endstream marker", span.Text);
     }
 
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsStreamsContainingEndobjLiterals() {
+        byte[] bytes = BuildSingleStreamPdf("BT\n/F1 12 Tf\n72 720 Td\n(Hello endobj marker) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello endobj marker", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsStreamsContainingEndobjLiterals() {
+        byte[] bytes = BuildSingleStreamPdf("BT\n/F1 12 Tf\n72 720 Td\n(Hello endobj marker) Tj\nET\n");
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans());
+        Assert.Equal("Hello endobj marker", span.Text);
+    }
+
     private static byte[] BuildPdfWithInheritedMediaBox(int width, int height) {
         const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(Hi) Tj\nET\n";
         int streamLength = Encoding.ASCII.GetByteCount(streamContent);

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -575,6 +575,26 @@ public class PdfReaderAndFooterRegressionTests {
         Assert.Equal("Hello indirect arrays", span.Text);
     }
 
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsStreamsWithIndirectLengthObjects() {
+        byte[] bytes = BuildPdfWithIndirectLengthStreamContainingEndstreamLiteral();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello endstream marker", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsStreamsWithIndirectLengthObjects() {
+        byte[] bytes = BuildPdfWithIndirectLengthStreamContainingEndstreamLiteral();
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans());
+        Assert.Equal("Hello endstream marker", span.Text);
+    }
+
     private static byte[] BuildPdfWithInheritedMediaBox(int width, int height) {
         const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(Hi) Tj\nET\n";
         int streamLength = Encoding.ASCII.GetByteCount(streamContent);
@@ -983,6 +1003,17 @@ public class PdfReaderAndFooterRegressionTests {
             "endobj",
             "8 0 obj",
             $"<< /Predictor 12 /Columns {streamBytes.Length} >>",
+            "endobj");
+    }
+
+    private static byte[] BuildPdfWithIndirectLengthStreamContainingEndstreamLiteral() {
+        const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(Hello endstream marker) Tj\nET\n";
+        byte[] streamBytes = Encoding.ASCII.GetBytes(streamContent);
+        return BuildSingleStreamPdfWithExtraObjects(
+            streamBytes,
+            "/Length 6 0 R",
+            "6 0 obj",
+            streamBytes.Length.ToString(System.Globalization.CultureInfo.InvariantCulture),
             "endobj");
     }
 

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Async.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Async.cs
@@ -52,6 +52,19 @@ public partial class Word {
     }
 
     [Fact]
+    public async Task Test_WordDocument_SaveAsPdfAsync_DirectoryPath_Throws() {
+        var docPath = Path.Combine(_directoryWithFiles, "PdfAsyncDirectoryPath.docx");
+
+        using (var document = WordDocument.Create(docPath)) {
+            document.AddParagraph("Hello World");
+            document.Save();
+
+            var ex = await Assert.ThrowsAsync<ArgumentException>(() => document.SaveAsPdfAsync(_directoryWithFiles, cancellationToken: CancellationToken.None));
+            Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
     public async Task Test_WordDocument_SaveAsPdfAsync_CanceledToken_Throws() {
         var docPath = Path.Combine(_directoryWithFiles, "PdfAsyncCanceled.docx");
         var pdfPath = Path.Combine(_directoryWithFiles, "PdfAsyncCanceled.pdf");

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.CustomFonts.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.CustomFonts.cs
@@ -64,5 +64,57 @@ namespace OfficeIMO.Tests {
                 }
             }
         }
+
+        [Fact]
+        public void Test_WordDocument_SaveAsPdf_CustomFontFile_CanRetryAfterMissingPath() {
+            string fontPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Fonts), "arial.ttf")
+                : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                    ? "/System/Library/Fonts/Supplemental/Arial.ttf"
+                    : "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
+            string expectedFont = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+                                   RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                ? "Arial"
+                : "DejaVuSans";
+            string docPath = Path.Combine(_directoryWithFiles, "PdfFontRetry.docx");
+            string fontAlias = "RetryFont" + Guid.NewGuid().ToString("N");
+            string missingPath = Path.Combine(_directoryWithFiles, "missing-font-file.ttf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddParagraph("Hello from retried file font").FontFamily = fontAlias;
+                document.Save();
+
+                byte[] firstPdf = document.SaveAsPdf(new PdfSaveOptions {
+                    FontFilePaths = new Dictionary<string, string> { { fontAlias, missingPath } }
+                });
+                Assert.NotEmpty(firstPdf);
+
+                byte[] secondPdf = document.SaveAsPdf(new PdfSaveOptions {
+                    FontFilePaths = new Dictionary<string, string> { { fontAlias, fontPath } }
+                });
+
+                using (PdfDocument pdfDoc = PdfDocument.Open(new MemoryStream(secondPdf))) {
+                    var fonts = pdfDoc.GetPage(1).Letters.Select(l => l.FontName).Distinct();
+                    Assert.Contains(fonts, f => f != null && f.Contains(expectedFont));
+                }
+            }
+        }
+
+        [Fact]
+        public void Test_WordDocument_SaveAsPdf_CustomFontStream_RewindsSourceAfterFailure() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfFontStreamFailure.docx");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.AddParagraph("Hello from invalid stream font").FontFamily = "BrokenStreamFont";
+                document.Save();
+
+                using MemoryStream invalidFontStream = new MemoryStream(new byte[] { 1, 2, 3, 4 });
+                Assert.ThrowsAny<Exception>(() => document.SaveAsPdf(new PdfSaveOptions {
+                    FontStreams = new Dictionary<string, Stream> { { "BrokenStreamFont", invalidFontStream } }
+                }));
+
+                Assert.Equal(0, invalidFontStream.Position);
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.CustomFonts.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.CustomFonts.cs
@@ -32,7 +32,7 @@ namespace OfficeIMO.Tests {
                 byte[] pdf = document.SaveAsPdf(options);
                 using (PdfDocument pdfDoc = PdfDocument.Open(new MemoryStream(pdf))) {
                     var fonts = pdfDoc.GetPage(1).Letters.Select(l => l.FontName).Distinct();
-                    Assert.Contains(fonts, f => f != null && f.Contains(expectedFont));
+                    Assert.Contains(fonts, f => FontNameMatches(f, expectedFont));
                 }
             }
         }
@@ -60,7 +60,7 @@ namespace OfficeIMO.Tests {
                 byte[] pdf = document.SaveAsPdf(options);
                 using (PdfDocument pdfDoc = PdfDocument.Open(new MemoryStream(pdf))) {
                     var fonts = pdfDoc.GetPage(1).Letters.Select(l => l.FontName).Distinct();
-                    Assert.Contains(fonts, f => f != null && f.Contains(expectedFont));
+                    Assert.Contains(fonts, f => FontNameMatches(f, expectedFont));
                 }
             }
         }
@@ -95,7 +95,7 @@ namespace OfficeIMO.Tests {
 
                 using (PdfDocument pdfDoc = PdfDocument.Open(new MemoryStream(secondPdf))) {
                     var fonts = pdfDoc.GetPage(1).Letters.Select(l => l.FontName).Distinct();
-                    Assert.Contains(fonts, f => f != null && f.Contains(expectedFont));
+                    Assert.Contains(fonts, f => FontNameMatches(f, expectedFont));
                 }
             }
         }
@@ -115,6 +115,22 @@ namespace OfficeIMO.Tests {
 
                 Assert.Equal(0, invalidFontStream.Position);
             }
+        }
+
+        private static bool FontNameMatches(string? actualFontName, string expectedFont) {
+            if (string.IsNullOrWhiteSpace(actualFontName)) {
+                return false;
+            }
+
+            string normalizedExpected = NormalizeFontName(expectedFont);
+            string normalizedActual = NormalizeFontName(actualFontName!);
+            return normalizedActual.Contains(normalizedExpected, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string NormalizeFontName(string fontName) {
+            int subsetSeparator = fontName.IndexOf('+');
+            string trimmed = subsetSeparator >= 0 ? fontName.Substring(subsetSeparator + 1) : fontName;
+            return string.Concat(trimmed.Where(char.IsLetterOrDigit));
         }
     }
 }

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.License.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.License.cs
@@ -2,6 +2,7 @@ using OfficeIMO.Word;
 using OfficeIMO.Word.Pdf;
 using QuestPDF.Infrastructure;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -91,6 +92,54 @@ namespace OfficeIMO.Tests {
                     }, CancellationToken.None);
 
                     Assert.NotEmpty(bytes);
+                }
+
+                Assert.Null(QuestPDF.Settings.License);
+            } finally {
+                QuestPDF.Settings.License = null;
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsPdfAsync_Path_RestoresUnsetLicense_WhenDocumentCreationFails() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfAsyncLicensePathFailure.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfAsyncLicensePathFailure.pdf");
+
+            QuestPDF.Settings.License = null;
+            try {
+                using (WordDocument document = WordDocument.Create(docPath)) {
+                    document.AddParagraph("Hello World");
+                    document.Save();
+
+                    using MemoryStream invalidFontStream = new MemoryStream(new byte[] { 1, 2, 3, 4 });
+                    await Assert.ThrowsAnyAsync<Exception>(() => document.SaveAsPdfAsync(pdfPath, new PdfSaveOptions {
+                        QuestPdfLicenseType = LicenseType.Community,
+                        FontStreams = new Dictionary<string, Stream> { { "BrokenFont", invalidFontStream } }
+                    }, CancellationToken.None));
+                }
+
+                Assert.Null(QuestPDF.Settings.License);
+            } finally {
+                QuestPDF.Settings.License = null;
+            }
+        }
+
+        [Fact]
+        public async Task SaveAsPdfAsync_Stream_RestoresUnsetLicense_WhenDocumentCreationFails() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfAsyncLicenseStreamFailure.docx");
+
+            QuestPDF.Settings.License = null;
+            try {
+                using (WordDocument document = WordDocument.Create(docPath)) {
+                    document.AddParagraph("Hello World");
+                    document.Save();
+
+                    using MemoryStream output = new MemoryStream();
+                    using MemoryStream invalidFontStream = new MemoryStream(new byte[] { 1, 2, 3, 4 });
+                    await Assert.ThrowsAnyAsync<Exception>(() => document.SaveAsPdfAsync(output, new PdfSaveOptions {
+                        QuestPdfLicenseType = LicenseType.Community,
+                        FontStreams = new Dictionary<string, Stream> { { "BrokenFont", invalidFontStream } }
+                    }, CancellationToken.None));
                 }
 
                 Assert.Null(QuestPDF.Settings.License);

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
@@ -172,6 +172,19 @@ public partial class Word {
     }
 
     [Fact]
+    public void Test_WordDocument_SaveAsPdf_DirectoryPath_Throws() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfDirectoryPath.docx");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            document.AddParagraph("Hello World");
+            document.Save();
+
+            var ex = Assert.Throws<ArgumentException>(() => document.SaveAsPdf(_directoryWithFiles));
+            Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
     public void Test_WordDocument_SaveAsPdf_NullDocument_Throws() {
         Assert.Throws<ArgumentNullException>(() => WordPdfConverterExtensions.SaveAsPdf(null!, "file.pdf"));
     }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
@@ -257,8 +257,12 @@ namespace OfficeIMO.Word.Pdf {
                     options.FontFilePaths.TryGetValue(fontName, out string? path) &&
                     !string.IsNullOrWhiteSpace(path) &&
                     File.Exists(path)) {
-                    using SKTypeface? typeface = SKTypeface.FromFile(path);
-                    string? familyName = typeface?.FamilyName;
+                    string? familyName = null;
+                    try {
+                        familyName = TryReadFontFamily(path, File.ReadAllBytes(path));
+                    } catch {
+                    }
+
                     if (!string.IsNullOrWhiteSpace(familyName)) {
                         return familyName;
                     }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
@@ -6,6 +6,7 @@ using SkiaSharp;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text;
 using W = DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word.Pdf {
@@ -22,7 +23,7 @@ namespace OfficeIMO.Word.Pdf {
             try {
                 bool registered = false;
                 using SKTypeface? typeface = SKTypeface.FromFamilyName(fontFamily);
-                using SKStreamAsset? skStream = typeface?.OpenStream();
+                using SKStreamAsset? skStream = MatchesRequestedFamily(typeface, fontFamily!) ? typeface?.OpenStream() : null;
                 if (skStream != null) {
                     using MemoryStream ms = new();
                     if (skStream.HasLength) {
@@ -56,6 +57,29 @@ namespace OfficeIMO.Word.Pdf {
                 }
             } catch {
             }
+        }
+
+        static bool MatchesRequestedFamily(SKTypeface? typeface, string requestedFamily) {
+            if (typeface == null || string.IsNullOrWhiteSpace(typeface.FamilyName)) {
+                return false;
+            }
+
+            string resolved = NormalizeFontFamily(typeface.FamilyName);
+            string requested = NormalizeFontFamily(requestedFamily);
+            return resolved.Equals(requested, StringComparison.OrdinalIgnoreCase) ||
+                   resolved.StartsWith(requested, StringComparison.OrdinalIgnoreCase) ||
+                   requested.StartsWith(resolved, StringComparison.OrdinalIgnoreCase);
+        }
+
+        static string NormalizeFontFamily(string family) {
+            var sb = new StringBuilder(family.Length);
+            foreach (char c in family) {
+                if (char.IsLetterOrDigit(c)) {
+                    sb.Append(c);
+                }
+            }
+
+            return sb.ToString();
         }
 
         static string? TryResolveSystemFontFile(string family) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
@@ -246,24 +246,20 @@ namespace OfficeIMO.Word.Pdf {
             return container;
 
             string? ResolveRegisteredFamily(string? name) {
-                try {
-                    if (!string.IsNullOrWhiteSpace(name)) {
-                        if (options?.FontFilePaths != null && options.FontFilePaths.TryGetValue(name!, out var path) && File.Exists(path)) {
-                            using var tf = SKTypeface.FromFile(path);
-                            return tf?.FamilyName ?? name;
-                        }
-                        if (options?.FontStreams != null && options.FontStreams.TryGetValue(name!, out var s) && s != null) {
-                            Stream src = s;
-                            if (src.CanSeek) src.Position = 0;
-                            using MemoryStream ms = new();
-                            src.CopyTo(ms);
-                            ms.Position = 0;
-                            using var tf = SKTypeface.FromStream(new SKManagedStream(ms));
-                            if (src.CanSeek) src.Position = 0;
-                            return tf?.FamilyName ?? name;
-                        }
+                if (!string.IsNullOrWhiteSpace(name)) {
+                    if (options?.FontFilePaths != null &&
+                        options.FontFilePaths.TryGetValue(name!, out var path) &&
+                        !string.IsNullOrWhiteSpace(path)) {
+                        return name;
                     }
-                } catch { }
+
+                    if (options?.FontStreams != null &&
+                        options.FontStreams.TryGetValue(name!, out var stream) &&
+                        stream != null) {
+                        return name;
+                    }
+                }
+
                 return name;
             }
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
@@ -342,12 +342,9 @@ namespace OfficeIMO.Word.Pdf {
                 if (run.VerticalTextAlignment == W.VerticalPositionValues.Subscript) span = span.Subscript();
                 // Inline hyperlink on text spans is not supported by QuestPDF directly.
                 // Paragraph-level hyperlinks are applied earlier; skip span-level link here.
-                // Choose run font: explicit run font, otherwise platform monospace, otherwise PdfSaveOptions.FontFamily
-                string? mono = null;
-                if (!string.IsNullOrEmpty(run.FontFamily)) mono = run.FontFamily;
-                mono ??= FontResolver.Resolve("monospace") ?? opt?.FontFamily;
-                if (!string.IsNullOrEmpty(mono)) {
-                    var fam = ResolveRegisteredFamily(mono)!;
+                // Preserve paragraph/default fonts unless the run explicitly overrides them.
+                if (!string.IsNullOrEmpty(run.FontFamily)) {
+                    var fam = ResolveRegisteredFamily(run.FontFamily)!;
                     EmbedFont(fam);
                     span = span.FontFamily(fam);
                 }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
@@ -246,21 +246,7 @@ namespace OfficeIMO.Word.Pdf {
             return container;
 
             string? ResolveRegisteredFamily(string? name) {
-                if (!string.IsNullOrWhiteSpace(name)) {
-                    if (options?.FontFilePaths != null &&
-                        options.FontFilePaths.TryGetValue(name!, out var path) &&
-                        !string.IsNullOrWhiteSpace(path)) {
-                        return name;
-                    }
-
-                    if (options?.FontStreams != null &&
-                        options.FontStreams.TryGetValue(name!, out var stream) &&
-                        stream != null) {
-                        return name;
-                    }
-                }
-
-                return name;
+                return ResolveRegisteredFontFamily(name);
             }
 
             void ApplyFormatting(TextSpanDescriptor span) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
@@ -246,7 +246,25 @@ namespace OfficeIMO.Word.Pdf {
             return container;
 
             string? ResolveRegisteredFamily(string? name) {
-                return ResolveRegisteredFontFamily(name);
+                string? resolved = ResolveRegisteredFontFamily(name);
+                if (!string.Equals(resolved, name, StringComparison.Ordinal) || string.IsNullOrWhiteSpace(name)) {
+                    return resolved;
+                }
+
+                string fontName = name ?? string.Empty;
+                if (fontName.Length > 0 &&
+                    options?.FontFilePaths != null &&
+                    options.FontFilePaths.TryGetValue(fontName, out string? path) &&
+                    !string.IsNullOrWhiteSpace(path) &&
+                    File.Exists(path)) {
+                    using SKTypeface? typeface = SKTypeface.FromFile(path);
+                    string? familyName = typeface?.FamilyName;
+                    if (!string.IsNullOrWhiteSpace(familyName)) {
+                        return familyName;
+                    }
+                }
+
+                return resolved;
             }
 
             void ApplyFormatting(TextSpanDescriptor span) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Rendering.cs
@@ -16,10 +16,11 @@ namespace OfficeIMO.Word.Pdf {
             if (string.IsNullOrWhiteSpace(fontFamily)) {
                 return;
             }
-            if (!_embeddedFonts.Add(fontFamily!)) {
+            if (_embeddedFonts.Contains(fontFamily!)) {
                 return;
             }
             try {
+                bool registered = false;
                 using SKTypeface? typeface = SKTypeface.FromFamilyName(fontFamily);
                 using SKStreamAsset? skStream = typeface?.OpenStream();
                 if (skStream != null) {
@@ -37,6 +38,8 @@ namespace OfficeIMO.Word.Pdf {
                     }
                     ms.Position = 0;
                     FontManager.RegisterFontWithCustomName(fontFamily!, ms);
+                    registered = true;
+                    _embeddedFonts.Add(fontFamily!);
                     return;
                 }
 
@@ -45,6 +48,11 @@ namespace OfficeIMO.Word.Pdf {
                 if (!string.IsNullOrEmpty(path) && File.Exists(path)) {
                     using var fs = File.OpenRead(path);
                     FontManager.RegisterFontWithCustomName(fontFamily!, fs);
+                    registered = true;
+                }
+
+                if (registered) {
+                    _embeddedFonts.Add(fontFamily!);
                 }
             } catch {
             }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -583,7 +583,7 @@ namespace OfficeIMO.Word.Pdf {
                     }
 
                     using var stream = File.OpenRead(kvp.Value);
-                    TryRegisterFontWithAliases(kvp.Key, stream);
+                    TryRegisterFontWithAliases(kvp.Key, stream, kvp.Value);
                 }
             }
 
@@ -611,7 +611,7 @@ namespace OfficeIMO.Word.Pdf {
             }
         }
 
-        private static void TryRegisterFontWithAliases(string alias, Stream stream) {
+        private static void TryRegisterFontWithAliases(string alias, Stream stream, string? sourcePath = null) {
             byte[] bytes;
             using (MemoryStream ms = new()) {
                 stream.CopyTo(ms);
@@ -624,7 +624,7 @@ namespace OfficeIMO.Word.Pdf {
 
             RegisterFontData(alias, bytes);
 
-            string? family = TryReadFontFamily(bytes);
+            string? family = TryReadFontFamily(sourcePath, bytes);
             if (string.IsNullOrWhiteSpace(family)) {
                 return;
             }
@@ -668,8 +668,16 @@ namespace OfficeIMO.Word.Pdf {
             return key;
         }
 
-        private static string? TryReadFontFamily(byte[] bytes) {
+        private static string? TryReadFontFamily(string? sourcePath, byte[] bytes) {
             try {
+                if (!string.IsNullOrWhiteSpace(sourcePath) && File.Exists(sourcePath)) {
+                    using SKTypeface? fileTypeface = SKTypeface.FromFile(sourcePath);
+                    string? familyName = fileTypeface?.FamilyName;
+                    if (!string.IsNullOrWhiteSpace(familyName)) {
+                        return familyName;
+                    }
+                }
+
                 using MemoryStream ms = new(bytes, writable: false);
                 using SKManagedStream skStream = new(ms);
                 using SKTypeface? typeface = SKTypeface.FromStream(skStream);

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -37,7 +37,8 @@ namespace OfficeIMO.Word.Pdf {
                 throw new ArgumentException("Path cannot be empty or whitespace.", nameof(path));
             }
 
-            string? directory = Path.GetDirectoryName(path);
+            string fullPath = ValidateOutputPath(path, nameof(path));
+            string? directory = Path.GetDirectoryName(fullPath);
             if (!string.IsNullOrEmpty(directory)) {
                 Directory.CreateDirectory(directory);
             }
@@ -45,7 +46,7 @@ namespace OfficeIMO.Word.Pdf {
             var originalLicense = QuestPdfLicenseUtil.GetEffectiveLicenseValue();
             try {
                 Document pdf = CreatePdfDocument(document, options);
-                pdf.GeneratePdf(path);
+                pdf.GeneratePdf(fullPath);
             } finally {
                 // Restore whatever license was set before conversion across all loaded QuestPDF TFMs
                 RestoreQuestPdfLicense(originalLicense);
@@ -141,7 +142,7 @@ namespace OfficeIMO.Word.Pdf {
         /// <param name="options">Optional PDF configuration.</param>
         /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public static Task SaveAsPdfAsync(this WordDocument document, string path, PdfSaveOptions? options = null, CancellationToken cancellationToken = default) {
+        public static async Task SaveAsPdfAsync(this WordDocument document, string path, PdfSaveOptions? options = null, CancellationToken cancellationToken = default) {
             if (document == null) {
                 throw new ArgumentNullException(nameof(document));
             }
@@ -154,21 +155,20 @@ namespace OfficeIMO.Word.Pdf {
                 throw new ArgumentException("Path cannot be empty or whitespace.", nameof(path));
             }
 
-            string? directory = Path.GetDirectoryName(path);
+            string fullPath = ValidateOutputPath(path, nameof(path));
+            string? directory = Path.GetDirectoryName(fullPath);
             cancellationToken.ThrowIfCancellationRequested();
             if (!string.IsNullOrEmpty(directory)) {
                 Directory.CreateDirectory(directory);
             }
 
             var originalLicense = QuestPdfLicenseUtil.GetEffectiveLicenseValue();
-            Document pdf = CreatePdfDocument(document, options);
-            return Task.Run(() => {
-                try {
-                    pdf.GeneratePdf(path);
-                } finally {
-                    RestoreQuestPdfLicense(originalLicense);
-                }
-            }, cancellationToken);
+            try {
+                Document pdf = CreatePdfDocument(document, options);
+                await Task.Run(() => pdf.GeneratePdf(fullPath), cancellationToken).ConfigureAwait(false);
+            } finally {
+                RestoreQuestPdfLicense(originalLicense);
+            }
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace OfficeIMO.Word.Pdf {
         /// <param name="options">Optional PDF configuration.</param>
         /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public static Task SaveAsPdfAsync(this WordDocument document, Stream stream, PdfSaveOptions? options = null, CancellationToken cancellationToken = default) {
+        public static async Task SaveAsPdfAsync(this WordDocument document, Stream stream, PdfSaveOptions? options = null, CancellationToken cancellationToken = default) {
             if (document == null) {
                 throw new ArgumentNullException(nameof(document));
             }
@@ -195,22 +195,44 @@ namespace OfficeIMO.Word.Pdf {
             }
 
             var originalLicense = QuestPdfLicenseUtil.GetEffectiveLicenseValue();
-            Document pdf = CreatePdfDocument(document, options);
-            return Task.Run(() => {
-                try {
-                    pdf.GeneratePdf(stream);
-                    if (stream.CanSeek) {
-                        stream.Position = 0;
-                    }
-                } finally {
-                    RestoreQuestPdfLicense(originalLicense);
+            try {
+                Document pdf = CreatePdfDocument(document, options);
+                await Task.Run(() => pdf.GeneratePdf(stream), cancellationToken).ConfigureAwait(false);
+                if (stream.CanSeek) {
+                    stream.Position = 0;
                 }
-            }, cancellationToken);
+            } finally {
+                RestoreQuestPdfLicense(originalLicense);
+            }
         }
 
         private static void RestoreQuestPdfLicense(int? originalLicense) {
             QuestPdfLicenseUtil.SetLicenseForAll(originalLicense);
             QuestPDF.Settings.License = originalLicense.HasValue ? (LicenseType?) (LicenseType)originalLicense.Value : null;
+        }
+
+        private static string ValidateOutputPath(string path, string paramName) {
+            string fullPath;
+            try {
+                fullPath = Path.GetFullPath(path);
+            } catch (Exception ex) {
+                throw new ArgumentException("Path is invalid.", paramName, ex);
+            }
+
+            if (Directory.Exists(fullPath) && (File.GetAttributes(fullPath) & FileAttributes.Directory) == FileAttributes.Directory) {
+                throw new ArgumentException("Path refers to a directory; a file path is required.", paramName);
+            }
+
+            string fileName = Path.GetFileName(fullPath);
+            if (string.IsNullOrEmpty(fileName)) {
+                throw new ArgumentException("Path must include a file name.", paramName);
+            }
+
+            if (fileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0) {
+                throw new ArgumentException("Path contains invalid file name characters.", paramName);
+            }
+
+            return fullPath;
         }
 
         private static Document CreatePdfDocument(WordDocument document, PdfSaveOptions? options) {
@@ -553,14 +575,13 @@ namespace OfficeIMO.Word.Pdf {
                     if (string.IsNullOrWhiteSpace(kvp.Key) || string.IsNullOrWhiteSpace(kvp.Value)) {
                         continue;
                     }
-                    if (!_embeddedFonts.Add(kvp.Key)) {
+                    if (_embeddedFonts.Contains(kvp.Key) || !File.Exists(kvp.Value)) {
                         continue;
                     }
-                    if (!File.Exists(kvp.Value)) {
-                        continue;
-                    }
+
                     using var stream = File.OpenRead(kvp.Value);
                     FontManager.RegisterFontWithCustomName(kvp.Key, stream);
+                    _embeddedFonts.Add(kvp.Key);
                 }
             }
 
@@ -569,19 +590,24 @@ namespace OfficeIMO.Word.Pdf {
                     if (string.IsNullOrWhiteSpace(kvp.Key) || kvp.Value == null) {
                         continue;
                     }
-                    if (!_embeddedFonts.Add(kvp.Key)) {
+                    if (_embeddedFonts.Contains(kvp.Key)) {
                         continue;
                     }
+
                     Stream stream = kvp.Value;
-                    if (stream.CanSeek) {
-                        stream.Position = 0;
-                    }
-                    using MemoryStream ms = new();
-                    stream.CopyTo(ms);
-                    ms.Position = 0;
-                    FontManager.RegisterFontWithCustomName(kvp.Key, ms);
-                    if (stream.CanSeek) {
-                        stream.Position = 0;
+                    try {
+                        if (stream.CanSeek) {
+                            stream.Position = 0;
+                        }
+                        using MemoryStream ms = new();
+                        stream.CopyTo(ms);
+                        ms.Position = 0;
+                        FontManager.RegisterFontWithCustomName(kvp.Key, ms);
+                        _embeddedFonts.Add(kvp.Key);
+                    } finally {
+                        if (stream.CanSeek) {
+                            stream.Position = 0;
+                        }
                     }
                 }
             }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -681,10 +681,23 @@ namespace OfficeIMO.Word.Pdf {
                 using MemoryStream ms = new(bytes, writable: false);
                 using SKManagedStream skStream = new(ms);
                 using SKTypeface? typeface = SKTypeface.FromStream(skStream);
-                return typeface?.FamilyName;
+                string? streamFamilyName = typeface?.FamilyName;
+                if (!string.IsNullOrWhiteSpace(streamFamilyName)) {
+                    return streamFamilyName;
+                }
             } catch {
+            }
+
+            return DeriveFontFamilyFromPath(sourcePath);
+        }
+
+        private static string? DeriveFontFamilyFromPath(string? sourcePath) {
+            if (string.IsNullOrWhiteSpace(sourcePath)) {
                 return null;
             }
+
+            string familyName = Path.GetFileNameWithoutExtension(sourcePath);
+            return string.IsNullOrWhiteSpace(familyName) ? null : familyName;
         }
 
     }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.cs
@@ -2,6 +2,7 @@ using QuestPDF.Drawing;
 using QuestPDF.Fluent;
 using QuestPDF.Helpers;
 using QuestPDF.Infrastructure;
+using SkiaSharp;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -18,6 +19,8 @@ namespace OfficeIMO.Word.Pdf {
     /// Provides extension methods for converting <see cref="WordDocument"/> instances to PDF files.
     /// </summary>
     public static partial class WordPdfConverterExtensions {
+        static readonly Dictionary<string, string> _registeredCustomFontFamilies = new(StringComparer.OrdinalIgnoreCase);
+
         /// <summary>
         /// Saves the specified <see cref="WordDocument"/> as a PDF at the given <paramref name="path"/>.
         /// </summary>
@@ -575,13 +578,12 @@ namespace OfficeIMO.Word.Pdf {
                     if (string.IsNullOrWhiteSpace(kvp.Key) || string.IsNullOrWhiteSpace(kvp.Value)) {
                         continue;
                     }
-                    if (_embeddedFonts.Contains(kvp.Key) || !File.Exists(kvp.Value)) {
+                    if (!File.Exists(kvp.Value)) {
                         continue;
                     }
 
                     using var stream = File.OpenRead(kvp.Value);
-                    FontManager.RegisterFontWithCustomName(kvp.Key, stream);
-                    _embeddedFonts.Add(kvp.Key);
+                    TryRegisterFontWithAliases(kvp.Key, stream);
                 }
             }
 
@@ -599,17 +601,81 @@ namespace OfficeIMO.Word.Pdf {
                         if (stream.CanSeek) {
                             stream.Position = 0;
                         }
-                        using MemoryStream ms = new();
-                        stream.CopyTo(ms);
-                        ms.Position = 0;
-                        FontManager.RegisterFontWithCustomName(kvp.Key, ms);
-                        _embeddedFonts.Add(kvp.Key);
+                        TryRegisterFontWithAliases(kvp.Key, stream);
                     } finally {
                         if (stream.CanSeek) {
                             stream.Position = 0;
                         }
                     }
                 }
+            }
+        }
+
+        private static void TryRegisterFontWithAliases(string alias, Stream stream) {
+            byte[] bytes;
+            using (MemoryStream ms = new()) {
+                stream.CopyTo(ms);
+                bytes = ms.ToArray();
+            }
+
+            if (bytes.Length == 0) {
+                return;
+            }
+
+            RegisterFontData(alias, bytes);
+
+            string? family = TryReadFontFamily(bytes);
+            if (string.IsNullOrWhiteSpace(family)) {
+                return;
+            }
+
+            string familyName = family ?? string.Empty;
+            if (familyName.Length == 0) {
+                return;
+            }
+
+            _registeredCustomFontFamilies[alias] = familyName;
+            if (!string.Equals(alias, familyName, StringComparison.OrdinalIgnoreCase)) {
+                RegisterFontData(familyName, bytes);
+            }
+        }
+
+        private static void RegisterFontData(string fontName, byte[] bytes) {
+            if (string.IsNullOrWhiteSpace(fontName) || _embeddedFonts.Contains(fontName)) {
+                return;
+            }
+
+            using MemoryStream ms = new(bytes, writable: false);
+            FontManager.RegisterFontWithCustomName(fontName, ms);
+            _embeddedFonts.Add(fontName);
+        }
+
+        private static string? ResolveRegisteredFontFamily(string? fontName) {
+            if (string.IsNullOrWhiteSpace(fontName)) {
+                return fontName;
+            }
+
+            string key = fontName ?? string.Empty;
+            if (key.Length == 0) {
+                return fontName;
+            }
+
+            if (_registeredCustomFontFamilies.TryGetValue(key, out var family) &&
+                !string.IsNullOrWhiteSpace(family)) {
+                return family;
+            }
+
+            return key;
+        }
+
+        private static string? TryReadFontFamily(byte[] bytes) {
+            try {
+                using MemoryStream ms = new(bytes, writable: false);
+                using SKManagedStream skStream = new(ms);
+                using SKTypeface? typeface = SKTypeface.FromStream(skStream);
+                return typeface?.FamilyName;
+            } catch {
+                return null;
             }
         }
 


### PR DESCRIPTION
## Summary
- improve PDF writer and Word-to-PDF robustness around footer rendering, output path validation, QuestPDF license restoration, and custom font registration retries
- expand PDF reader and lightweight extractor compatibility for inherited page metadata/resources, nested forms, content arrays, compressed and filtered streams, inline dictionaries, escaped names, comments, string decoding, and predictor-based DecodeParms
- add broad regression coverage for PDF reader/extractor and SaveAsPdf edge cases

## Root cause
The PDF projects handled the library's own output well, but several external-PDF shapes and a few SaveAsPdf failure paths still relied on narrow assumptions around page inheritance, stream filters, string parsing, and cleanup behavior.

## Validation
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PdfReaderAndFooterRegressionTests"`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~Pdf"`

Regression results were green on `net8.0`, `net10.0`, and `net472`.
