### PR TITLE
Enable modular reader package publishing and trim target deps

### DIFF
--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -4,6 +4,7 @@
   "ExpectedVersion": null,
   "ExpectedVersionMap": {
     "OfficeIMO.CSV": "0.1.X",
+    "OfficeIMO.Epub": "0.0.X",
     "OfficeIMO.Excel": "0.6.X",
     "OfficeIMO.Markdown": "0.6.X",
     "OfficeIMO.Markdown.Html": "0.1.X",
@@ -12,22 +13,24 @@
     "OfficeIMO.Pdf": "0.1.X",
     "OfficeIMO.PowerPoint": "1.0.X",
     "OfficeIMO.Reader": "0.1.X",
+    "OfficeIMO.Reader.Csv": "0.0.X",
+    "OfficeIMO.Reader.Epub": "0.0.X",
+    "OfficeIMO.Reader.Html": "0.0.X",
+    "OfficeIMO.Reader.Json": "0.0.X",
+    "OfficeIMO.Reader.Text": "0.0.X",
+    "OfficeIMO.Reader.Xml": "0.0.X",
+    "OfficeIMO.Reader.Zip": "0.0.X",
     "OfficeIMO.Word": "1.0.X",
     "OfficeIMO.Word.Html": "1.0.X",
     "OfficeIMO.Word.Markdown": "1.0.X",
-    "OfficeIMO.Word.Pdf": "1.0.X"
+    "OfficeIMO.Word.Pdf": "1.0.X",
+    "OfficeIMO.Zip": "0.0.X"
   },
   "ExpectedVersionMapAsInclude": true,
   "ExpectedVersionMapUseWildcards": false,
   "ExcludeProjects": [
     "OfficeIMO.Visio",
-    "OfficeIMO.Project",
-    "OfficeIMO.Zip",
-    "OfficeIMO.Epub",
-    "OfficeIMO.Reader.Zip",
-    "OfficeIMO.Reader.Epub",
-    "OfficeIMO.Reader.Text",
-    "OfficeIMO.Reader.Html"
+    "OfficeIMO.Project"
   ],
   "NugetSource": [],
   "IncludePrerelease": false,

--- a/Docs/officeimo.reader.modular-roadmap.md
+++ b/Docs/officeimo.reader.modular-roadmap.md
@@ -19,7 +19,7 @@ The goal is clean IntelligenceX integration without forcing one large dependency
 - `OfficeIMO.Reader.Text`
 - `OfficeIMO.Reader.Html`
 
-All scaffolded packages are currently excluded from publishing.
+These scaffolded packages are now wired into the publishing pipeline.
 
 ## Delivery Order (Low -> High Effort)
 

--- a/OfficeIMO.CSV.Tests/OfficeIMO.CSV.Tests.csproj
+++ b/OfficeIMO.CSV.Tests/OfficeIMO.CSV.Tests.csproj
@@ -17,6 +17,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
   </ItemGroup>
 

--- a/OfficeIMO.CSV/OfficeIMO.CSV.csproj
+++ b/OfficeIMO.CSV/OfficeIMO.CSV.csproj
@@ -51,7 +51,7 @@
     <Using Include="System.Text" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
   </ItemGroup>
 

--- a/OfficeIMO.Epub/OfficeIMO.Epub.csproj
+++ b/OfficeIMO.Epub/OfficeIMO.Epub.csproj
@@ -7,8 +7,8 @@
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
 
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/OfficeIMO.Excel.GoogleSheets/OfficeIMO.Excel.GoogleSheets.csproj
+++ b/OfficeIMO.Excel.GoogleSheets/OfficeIMO.Excel.GoogleSheets.csproj
@@ -46,7 +46,7 @@
         <ProjectReference Include="..\OfficeIMO.Excel\OfficeIMO.Excel.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
         <PackageReference Include="System.Text.Json" Version="[8.0.5,9.0.0)" />
     </ItemGroup>
 

--- a/OfficeIMO.GoogleWorkspace/OfficeIMO.GoogleWorkspace.csproj
+++ b/OfficeIMO.GoogleWorkspace/OfficeIMO.GoogleWorkspace.csproj
@@ -45,7 +45,7 @@
         <Reference Include="System.Net.Http" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
         <PackageReference Include="System.Text.Json" Version="[8.0.5,9.0.0)" />
     </ItemGroup>
 

--- a/OfficeIMO.MarkdownRenderer.SamplePlugin/OfficeIMO.MarkdownRenderer.SamplePlugin.csproj
+++ b/OfficeIMO.MarkdownRenderer.SamplePlugin/OfficeIMO.MarkdownRenderer.SamplePlugin.csproj
@@ -32,7 +32,7 @@
     <ProjectReference Include="..\OfficeIMO.Markdown.Html\OfficeIMO.Markdown.Html.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
     <PackageReference Include="System.Text.Json" Version="[8.0.5,9.0.0)" />
   </ItemGroup>
 

--- a/OfficeIMO.MarkdownRenderer/OfficeIMO.MarkdownRenderer.csproj
+++ b/OfficeIMO.MarkdownRenderer/OfficeIMO.MarkdownRenderer.csproj
@@ -33,7 +33,7 @@
     <ProjectReference Include="..\OfficeIMO.Markdown.Html\OfficeIMO.Markdown.Html.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
     <PackageReference Include="System.Text.Json" Version="[8.0.5,9.0.0)" />
   </ItemGroup>
 

--- a/OfficeIMO.Reader.Csv/OfficeIMO.Reader.Csv.csproj
+++ b/OfficeIMO.Reader.Csv/OfficeIMO.Reader.Csv.csproj
@@ -7,8 +7,8 @@
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
 
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/OfficeIMO.Reader.Epub/OfficeIMO.Reader.Epub.csproj
+++ b/OfficeIMO.Reader.Epub/OfficeIMO.Reader.Epub.csproj
@@ -7,8 +7,8 @@
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
 
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/OfficeIMO.Reader.Html/OfficeIMO.Reader.Html.csproj
+++ b/OfficeIMO.Reader.Html/OfficeIMO.Reader.Html.csproj
@@ -7,8 +7,8 @@
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
 
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/OfficeIMO.Reader.Json/OfficeIMO.Reader.Json.csproj
+++ b/OfficeIMO.Reader.Json/OfficeIMO.Reader.Json.csproj
@@ -7,8 +7,8 @@
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
 
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/OfficeIMO.Reader.Text/OfficeIMO.Reader.Text.csproj
+++ b/OfficeIMO.Reader.Text/OfficeIMO.Reader.Text.csproj
@@ -7,8 +7,8 @@
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
 
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/OfficeIMO.Reader.Xml/OfficeIMO.Reader.Xml.csproj
+++ b/OfficeIMO.Reader.Xml/OfficeIMO.Reader.Xml.csproj
@@ -7,8 +7,8 @@
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
 
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/OfficeIMO.Reader.Zip/OfficeIMO.Reader.Zip.csproj
+++ b/OfficeIMO.Reader.Zip/OfficeIMO.Reader.Zip.csproj
@@ -7,8 +7,8 @@
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
 
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/OfficeIMO.Reader/OfficeIMO.Reader.csproj
+++ b/OfficeIMO.Reader/OfficeIMO.Reader.csproj
@@ -31,7 +31,7 @@
     <ProjectReference Include="..\OfficeIMO.Pdf\OfficeIMO.Pdf.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
     <PackageReference Include="System.Text.Json" Version="[8.0.5,9.0.0)" />
   </ItemGroup>
 

--- a/OfficeIMO.Tests/PackageDependencyGuardrails.cs
+++ b/OfficeIMO.Tests/PackageDependencyGuardrails.cs
@@ -1,0 +1,83 @@
+using System.Xml.Linq;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class PackageDependencyGuardrailTests {
+    [Theory]
+    [InlineData("OfficeIMO.Reader/OfficeIMO.Reader.csproj")]
+    [InlineData("OfficeIMO.Reader.Json/OfficeIMO.Reader.Json.csproj")]
+    [InlineData("OfficeIMO.MarkdownRenderer/OfficeIMO.MarkdownRenderer.csproj")]
+    [InlineData("OfficeIMO.MarkdownRenderer.SamplePlugin/OfficeIMO.MarkdownRenderer.SamplePlugin.csproj")]
+    [InlineData("OfficeIMO.GoogleWorkspace/OfficeIMO.GoogleWorkspace.csproj")]
+    [InlineData("OfficeIMO.Excel.GoogleSheets/OfficeIMO.Excel.GoogleSheets.csproj")]
+    [InlineData("OfficeIMO.Word.GoogleDocs/OfficeIMO.Word.GoogleDocs.csproj")]
+    public void SystemTextJsonPackageReference_IsLimitedToNonInboxTargets(string relativeProjectPath) {
+        var projectPath = Path.Combine(GetRepositoryRoot(), relativeProjectPath.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(projectPath), "Project file is missing: " + projectPath);
+
+        var document = XDocument.Load(projectPath);
+        var ns = document.Root?.Name.Namespace ?? XNamespace.None;
+
+        var references = document
+            .Descendants(ns + "PackageReference")
+            .Where(static e => string.Equals((string?)e.Attribute("Include"), "System.Text.Json", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Single(references);
+
+        var parentItemGroup = references[0].Parent;
+        Assert.NotNull(parentItemGroup);
+
+        var condition = (string?)parentItemGroup!.Attribute("Condition");
+        Assert.False(string.IsNullOrWhiteSpace(condition));
+        Assert.Contains("netstandard2.0", condition!, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("net472", condition!, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("net8.0", condition!, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("net10.0", condition!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("OfficeIMO.CSV/OfficeIMO.CSV.csproj")]
+    [InlineData("OfficeIMO.CSV.Tests/OfficeIMO.CSV.Tests.csproj")]
+    public void NetFrameworkReferenceAssemblies_AreLimitedToNet472(string relativeProjectPath) {
+        var projectPath = Path.Combine(GetRepositoryRoot(), relativeProjectPath.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(projectPath), "Project file is missing: " + projectPath);
+
+        var document = XDocument.Load(projectPath);
+        var ns = document.Root?.Name.Namespace ?? XNamespace.None;
+
+        var references = document
+            .Descendants(ns + "PackageReference")
+            .Where(static e => string.Equals((string?)e.Attribute("Include"), "Microsoft.NETFramework.ReferenceAssemblies", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Single(references);
+
+        var parentItemGroup = references[0].Parent;
+        Assert.NotNull(parentItemGroup);
+
+        var condition = (string?)parentItemGroup!.Attribute("Condition");
+        Assert.False(string.IsNullOrWhiteSpace(condition));
+        Assert.Contains("net472", condition!, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("net8.0", condition!, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("net10.0", condition!, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("netstandard2.0", condition!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetRepositoryRoot() {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null) {
+            if (
+                File.Exists(Path.Combine(directory.FullName, "OfficeIMO.sln")) ||
+                File.Exists(Path.Combine(directory.FullName, "OfficeImo.sln"))
+            ) {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate OfficeIMO repository root from test runtime base directory.");
+    }
+}

--- a/OfficeIMO.Tests/Reader.PackagingGuardrails.cs
+++ b/OfficeIMO.Tests/Reader.PackagingGuardrails.cs
@@ -5,6 +5,8 @@ namespace OfficeIMO.Tests;
 
 public sealed class ReaderPackagingGuardrailTests {
     [Theory]
+    [InlineData("OfficeIMO.Zip/OfficeIMO.Zip.csproj")]
+    [InlineData("OfficeIMO.Epub/OfficeIMO.Epub.csproj")]
     [InlineData("OfficeIMO.Reader.Zip/OfficeIMO.Reader.Zip.csproj")]
     [InlineData("OfficeIMO.Reader.Epub/OfficeIMO.Reader.Epub.csproj")]
     [InlineData("OfficeIMO.Reader.Html/OfficeIMO.Reader.Html.csproj")]
@@ -12,7 +14,7 @@ public sealed class ReaderPackagingGuardrailTests {
     [InlineData("OfficeIMO.Reader.Csv/OfficeIMO.Reader.Csv.csproj")]
     [InlineData("OfficeIMO.Reader.Json/OfficeIMO.Reader.Json.csproj")]
     [InlineData("OfficeIMO.Reader.Xml/OfficeIMO.Reader.Xml.csproj")]
-    public void ModularReaderProjects_RemainNonPackableAndNonPublishable(string relativeProjectPath) {
+    public void ModularReaderProjects_RemainPackableAndPublishable(string relativeProjectPath) {
         var projectPath = Path.Combine(GetRepositoryRoot(), relativeProjectPath.Replace('/', Path.DirectorySeparatorChar));
         Assert.True(File.Exists(projectPath), "Project file is missing: " + projectPath);
 
@@ -26,8 +28,8 @@ public sealed class ReaderPackagingGuardrailTests {
             .Select(static e => (e.Value ?? string.Empty).Trim())
             .ToArray();
 
-        Assert.Contains(isPackableValues, static value => string.Equals(value, "false", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(isPublishableValues, static value => string.Equals(value, "false", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(isPackableValues, static value => string.Equals(value, "true", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(isPublishableValues, static value => string.Equals(value, "true", StringComparison.OrdinalIgnoreCase));
     }
 
     private static string GetRepositoryRoot() {

--- a/OfficeIMO.Word.GoogleDocs/OfficeIMO.Word.GoogleDocs.csproj
+++ b/OfficeIMO.Word.GoogleDocs/OfficeIMO.Word.GoogleDocs.csproj
@@ -46,7 +46,7 @@
         <ProjectReference Include="..\OfficeIMO.Word\OfficeIMO.Word.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
         <PackageReference Include="System.Text.Json" Version="[8.0.5,9.0.0)" />
     </ItemGroup>
 

--- a/OfficeIMO.Zip/OfficeIMO.Zip.csproj
+++ b/OfficeIMO.Zip/OfficeIMO.Zip.csproj
@@ -7,8 +7,8 @@
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
 
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>


### PR DESCRIPTION
## Summary
- include the modular reader packages and their reusable zip/epub dependencies in the build publishing pipeline
- make the new reader packages packable/publishable and update guardrail tests to protect that release path
- trim unnecessary package metadata for modern target frameworks by scoping compatibility-only dependencies to netstandard2.0 and net472

## Why
The reader adapters were implemented and documented but still excluded from the publish flow, and several multi-targeted packages were advertising inbox dependencies like System.Text.Json for net8.0 and net10.0.

## Validation
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PackageDependencyGuardrailTests|FullyQualifiedName~ReaderPackagingGuardrailTests"
- dotnet test OfficeIMO.CSV.Tests\OfficeIMO.CSV.Tests.csproj
- dotnet pack OfficeIMO.Reader\OfficeIMO.Reader.csproj -c Release -o .tmp\pack-reader
- dotnet pack OfficeIMO.GoogleWorkspace\OfficeIMO.GoogleWorkspace.csproj -c Release -o .tmp\pack-gw
- dotnet pack OfficeIMO.Excel.GoogleSheets\OfficeIMO.Excel.GoogleSheets.csproj -c Release -o .tmp\pack-sheets
- dotnet pack OfficeIMO.Word.GoogleDocs\OfficeIMO.Word.GoogleDocs.csproj -c Release -o .tmp\pack-docs
- dotnet pack OfficeIMO.MarkdownRenderer\OfficeIMO.MarkdownRenderer.csproj -c Release -o .tmp\pack-renderer
- dotnet pack OfficeIMO.CSV\OfficeIMO.CSV.csproj -c Release -o .tmp\pack-csv
- dotnet pack OfficeIMO.Visio\OfficeIMO.Visio.csproj -c Release -o .tmp\pack-visio
