### PR TITLE
Refresh website workflows to latest PowerForge

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -35,7 +35,7 @@ jobs:
 
   website-deploy:
     needs: resolve-post-deploy
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@4a8c9b3a69e505dab381db94b602cd3d70406cae
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -44,7 +44,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 4a8c9b3a69e505dab381db94b602cd3d70406cae
+      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -16,12 +16,12 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@4a8c9b3a69e505dab381db94b602cd3d70406cae
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 4a8c9b3a69e505dab381db94b602cd3d70406cae
+      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -15,12 +15,12 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@4a8c9b3a69e505dab381db94b602cd3d70406cae
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 4a8c9b3a69e505dab381db94b602cd3d70406cae
+      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/themes/officeimo/theme.manifest.json
+++ b/Website/themes/officeimo/theme.manifest.json
@@ -21,7 +21,7 @@
   },
   "featureContracts": {
     "apiDocs": {
-      "requiredPartials": ["api-header", "api-footer"],
+      "requiredPartials": ["api-header", "api-footer", "theme-tokens"],
       "cssHrefs": ["/css/app.css", "/css/api.css"],
       "requiredCssSelectors": [
         ".api-layout",


### PR DESCRIPTION
## Summary
- update website CI, deploy, and maintenance workflows to the current PSPublishModule reusable workflow SHA 263eb3ccc4e6948132a5bdd3df9a084501291f68
- move package-mode website runs to PowerForgeWeb-v1.0.0-preview-202603311925
- keep website automation aligned with the newer PowerForge bits before the Magick bump becomes a blocker

## Notes
- this is scoped to website pipeline targeting only