### PR TITLE
Retarget website workflows to latest PowerForgeWeb preview

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -35,7 +35,7 @@ jobs:
 
   website-deploy:
     needs: resolve-post-deploy
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@d2f478c85c5141c255554505d5d536c0fd4b8222
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@7ebebd771b3e99fd590babfd1c905b21df89243e
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -44,7 +44,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: d2f478c85c5141c255554505d5d536c0fd4b8222
+      powerforge_ref: 7ebebd771b3e99fd590babfd1c905b21df89243e
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -44,7 +44,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
+      powerforge_ref: d2f478c85c5141c255554505d5d536c0fd4b8222
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -35,7 +35,7 @@ jobs:
 
   website-deploy:
     needs: resolve-post-deploy
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@d2f478c85c5141c255554505d5d536c0fd4b8222
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,5 +23,5 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
+      powerforge_ref: d2f478c85c5141c255554505d5d536c0fd4b8222
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@d2f478c85c5141c255554505d5d536c0fd4b8222
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -16,12 +16,12 @@ permissions:
 
 jobs:
   website-build:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@d2f478c85c5141c255554505d5d536c0fd4b8222
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@7ebebd771b3e99fd590babfd1c905b21df89243e
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: d2f478c85c5141c255554505d5d536c0fd4b8222
+      powerforge_ref: 7ebebd771b3e99fd590babfd1c905b21df89243e
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@d2f478c85c5141c255554505d5d536c0fd4b8222
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -15,12 +15,12 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@d2f478c85c5141c255554505d5d536c0fd4b8222
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@7ebebd771b3e99fd590babfd1c905b21df89243e
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: d2f478c85c5141c255554505d5d536c0fd4b8222
+      powerforge_ref: 7ebebd771b3e99fd590babfd1c905b21df89243e
       report_artifact_name: powerforge-website-maintenance-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -22,5 +22,5 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
+      powerforge_ref: d2f478c85c5141c255554505d5d536c0fd4b8222
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/static/css/api.css
+++ b/Website/static/css/api.css
@@ -248,8 +248,49 @@
   line-height: 1.5;
 }
 
+.pf-api-docs .type-usage,
+.pf-api-docs .type-related-content,
+.pf-api-docs .type-parameters,
+.pf-api-docs .type-examples,
+.pf-api-docs .type-see-also {
+  margin: 0.9rem 0;
+}
+
+.pf-api-docs .type-usage-summary {
+  margin: 0 0 0.85rem;
+  color: var(--imo-text-muted);
+  line-height: 1.6;
+}
+
+.pf-api-docs .usage-group {
+  margin-top: 0.9rem;
+  padding: 0.9rem 1rem;
+  background: rgba(10, 22, 40, 0.6);
+  border: 1px solid var(--imo-glass-border);
+  border-radius: var(--imo-radius);
+}
+
+.pf-api-docs .usage-group h3 {
+  margin: 0 0 0.65rem;
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+}
+
+.pf-api-docs .usage-list {
+  display: grid;
+  gap: 0.55rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 [data-theme="light"] .pf-api-docs .example-media-meta {
   color: #64748b;
+}
+
+[data-theme="light"] .pf-api-docs .usage-group {
+  background: rgba(255, 255, 255, 0.92);
+  border-color: rgba(148, 163, 184, 0.45);
 }
 
 [data-theme="light"] .pf-api-docs .example-origin-badge.example-origin-authored {


### PR DESCRIPTION
## Summary
- retarget website workflows to PSPublishModule commit d2f478c85c5141c255554505d5d536c0fd4b8222
- refresh the website workflow source pin to the merged engine commit
- keep the scope to workflow pins only

## Why
This picks up the merged Magick.NET-Q8-AnyCPU 14.12.0 engine fix from PSPublishModule PR #316 for the source-driven website workflows.
