### PR TITLE
Fix PowerPoint validation ordering and add modern deck example

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/ModernPowerPointDeck.cs
+++ b/OfficeIMO.Examples/PowerPoint/ModernPowerPointDeck.cs
@@ -50,6 +50,9 @@ namespace OfficeIMO.Examples.PowerPoint {
                 minorComplexScript: "Arial"));
 
             AddCoverSlide(presentation, backgroundImagePath);
+            AddAgendaSlide(presentation);
+            AddCapabilitiesSlide(presentation);
+            AddProcessSlide(presentation);
             AddPerformanceSlide(presentation);
             AddChannelMixSlide(presentation);
             AddGrowthSlide(presentation);
@@ -112,11 +115,127 @@ namespace OfficeIMO.Examples.PowerPoint {
             pill.OutlineColor = Linen;
             pill.SetSoftEdges(1.2);
 
-            PowerPointTextBox footer = slide.AddTextBoxCm("Validated PPTX output", 22.7, 13.45, 7.8, 0.45);
+            PowerPointTextBox footer = slide.AddTextBoxCm("Composable layout system", 22.7, 13.45, 7.8, 0.45);
             footer.FontSize = 11;
             footer.Color = Ink;
             footer.TextVerticalAlignment = A.TextAnchoringTypeValues.Center;
             slide.Notes.Text = "Opening slide introduces the feature set demonstrated by this deck.";
+        }
+
+        private static void AddAgendaSlide(PowerPointPresentation presentation) {
+            PowerPointSlide slide = presentation.AddSlide();
+            slide.BackgroundColor = Paper;
+            slide.Transition = SlideTransition.Fade;
+            AddSlideTitle(slide, "Agenda", "Lists, layout grids, charts, tables, and guided placement.");
+
+            PowerPointAutoShape rail = slide.AddRectangleCm(1.25, 4.05, 0.18, 8.7, "Agenda Rail");
+            rail.FillColor = Teal;
+            rail.OutlineColor = Teal;
+
+            PowerPointTextBox list = slide.AddTextBox("",
+                PowerPointLayoutBox.FromCentimeters(2.25, 4.25, 13.4, 5.4));
+            list.SetBullets(new[] {
+                "Build a reusable visual system",
+                "Use grids for predictable placement",
+                "Validate rich slides with real content"
+            }, configure: paragraph => {
+                paragraph.SetFontSize(25)
+                    .SetColor(Ink)
+                    .SetFontName("Aptos Display")
+                    .SetHangingPoints(22)
+                    .SetSpaceAfterPoints(14)
+                    .SetBulletSizePercent(72);
+            });
+            list.SetTextMarginsCm(0, 0, 0, 0);
+            list.TextAutoFit = PowerPointTextAutoFit.Normal;
+
+            PowerPointAutoShape note = AddPanel(slide, 2.25, 10.6, 11.8, 1.8, "Agenda Note");
+            note.FillColor = Linen;
+            note.OutlineColor = Linen;
+            AddBody(slide, "The main lesson: charts and tables are only useful when the surrounding layout makes the story obvious.", 2.75, 11.05, 10.7, 0.75, 12);
+
+            PowerPointLayoutBox[,] cards = PowerPointLayoutBox
+                .FromCentimeters(17.0, 4.15, 13.6, 8.15)
+                .SplitGridCm(3, 1, 0.55, 0);
+            AddNumberedAgendaCard(slide, cards[0, 0], "01", "Composition", "Shared margins and rhythm");
+            AddNumberedAgendaCard(slide, cards[1, 0], "02", "Content blocks", "Lists, cards, tables, and notes");
+            AddNumberedAgendaCard(slide, cards[2, 0], "03", "Native charts", "Readable visuals that stay editable");
+
+            slide.Notes.Text = "Agenda slide demonstrates styled bullet lists, numbered cards, and a consistent placement grid.";
+        }
+
+        private static void AddCapabilitiesSlide(PowerPointPresentation presentation) {
+            PowerPointSlide slide = presentation.AddSlide();
+            slide.BackgroundColor = Paper;
+            slide.Transition = SlideTransition.Fade;
+            AddSlideTitle(slide, "Layout building blocks", "Cards, lists, and aligned sections from one grid.");
+
+            AddLabel(slide, "Reusable sections", 2.1, 3.25, 7.5, 0.55, Teal, 16, bold: true);
+            AddBody(slide, "The same grid can drive service cards, checklist panels, logos, and table-adjacent commentary without hand tuning every element.", 2.1, 4.0, 15.0, 1.0, 13);
+
+            PowerPointLayoutBox[,] serviceGrid = PowerPointLayoutBox
+                .FromCentimeters(2.1, 6.0, 28.3, 4.5)
+                .SplitGridCm(1, 4, 0, 0.55);
+            AddServiceCard(slide, serviceGrid[0, 0], "Device Management", Teal,
+                new[] { "Microsoft Intune", "Autopilot", "SCCM / MECM" });
+            AddServiceCard(slide, serviceGrid[0, 1], "Microsoft Ecosystem", Indigo,
+                new[] { "Entra ID", "Conditional Access", "Identity guardrails" });
+            AddServiceCard(slide, serviceGrid[0, 2], "Security", "12B8C9",
+                new[] { "Defender", "Security baselines", "Compliance policies" });
+            AddServiceCard(slide, serviceGrid[0, 3], "Apple", Orange,
+                new[] { "macOS", "Jamf Pro", "Apple Business Manager" });
+
+            PowerPointAutoShape band = AddPanel(slide, 2.1, 11.55, 28.3, 3.8, "Additional Areas");
+            band.FillColor = "FFFFFF";
+            band.OutlineColor = "D8DDE3";
+            AddLabel(slide, "Additional areas we can model", 2.7, 12.0, 9.0, 0.55, Ink, 15, bold: true);
+
+            PowerPointLayoutBox[,] pillGrid = PowerPointLayoutBox
+                .FromCentimeters(2.7, 13.0, 26.8, 1.7)
+                .SplitGridCm(2, 3, 0.35, 0.55);
+            string[] pills = {
+                "Application Packaging",
+                "OS / application patching",
+                "Reporting",
+                "Onboarding / offboarding",
+                "Modern roadmap",
+                "Compliance review"
+            };
+            for (int index = 0; index < pills.Length; index++) {
+                int row = index / 3;
+                int column = index % 3;
+                AddPill(slide, pillGrid[row, column], pills[index]);
+            }
+
+            slide.Notes.Text = "Capabilities slide exercises card grids, bulleted text inside cards, and pill-style supporting sections.";
+        }
+
+        private static void AddProcessSlide(PowerPointPresentation presentation) {
+            PowerPointSlide slide = presentation.AddSlide();
+            slide.BackgroundColor = Teal;
+            slide.Transition = SlideTransition.Fade;
+            AddDarkSlideChrome(slide);
+
+            AddLabel(slide, "Commercial snapshot", 1.85, 1.25, 8.0, 0.45, "D7F3FA", 10, bold: false);
+            AddLabel(slide, "From data to decision", 1.85, 2.2, 18.0, 1.1, "FFFFFF", 31, bold: true);
+            AddBodyOnDark(slide, "A process layout with aligned cards, arrows, captions, and slide-level brand rhythm.", 1.9, 3.35, 18.0, 0.7, 13);
+
+            PowerPointAutoShape wash = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, 10.0, 0.0, 11.0, 19.05, "Dark Process Wash");
+            wash.FillColor = "0B5475";
+            wash.FillTransparency = 42;
+            wash.OutlineColor = "0B5475";
+
+            PowerPointLayoutBox[,] steps = PowerPointLayoutBox
+                .FromCentimeters(2.0, 7.0, 28.5, 5.2)
+                .SplitGridCm(1, 3, 0, 1.2);
+            AddProcessStep(slide, steps[0, 0], "1.", "Collect", new[] { "Source data", "Inventory", "Baseline" });
+            AddProcessStep(slide, steps[0, 1], "2.", "Analyze", new[] { "Risk signals", "Gaps", "Priorities" });
+            AddProcessStep(slide, steps[0, 2], "3.", "Act", new[] { "Roadmap", "Owners", "Controls" });
+            AddArrowBetween(slide, steps[0, 0], steps[0, 1]);
+            AddArrowBetween(slide, steps[0, 1], steps[0, 2]);
+
+            AddBodyOnDark(slide, "Use this pattern when the audience needs sequence first and details second.", 2.0, 15.55, 18.0, 0.65, 13);
+            slide.Notes.Text = "Process slide demonstrates dark backgrounds, arrows, large numbers, grouped step content, and bottom captions.";
         }
 
         private static void AddPerformanceSlide(PowerPointPresentation presentation) {
@@ -254,7 +373,127 @@ namespace OfficeIMO.Examples.PowerPoint {
             slide.Notes.Text = "Growth slide: this intentionally uses a line chart because the month-to-month sequence matters.";
         }
 
+        private static void AddNumberedAgendaCard(PowerPointSlide slide, PowerPointLayoutBox box, string number,
+            string title, string detail) {
+            PowerPointAutoShape card = AddPanel(slide, box.LeftCm, box.TopCm, box.WidthCm, box.HeightCm, title + " Agenda Card");
+            card.FillColor = "FFFFFF";
+            card.OutlineColor = Linen;
+            card.SetShadow("000000", blurPoints: 5, distancePoints: 1, angleDegrees: 90, transparencyPercent: 88);
+
+            AddLabel(slide, number, box.LeftCm + 0.55, box.TopCm + 0.36, 2.0, 0.8, Orange, 20, bold: true);
+            AddLabel(slide, title, box.LeftCm + 2.25, box.TopCm + 0.38, 6.5, 0.5, Ink, 14, bold: true);
+            AddBody(slide, detail, box.LeftCm + 2.25, box.TopCm + 1.02, 9.8, 0.45, 10);
+        }
+
+        private static void AddServiceCard(PowerPointSlide slide, PowerPointLayoutBox box, string title, string color,
+            IEnumerable<string> bullets) {
+            PowerPointAutoShape card = AddPanel(slide, box.LeftCm, box.TopCm, box.WidthCm, box.HeightCm, title + " Service Card");
+            card.FillColor = "FFFFFF";
+            card.OutlineColor = "D8DDE3";
+            card.OutlineWidthPoints = 1.0;
+
+            PowerPointAutoShape accent = slide.AddRectangleCm(box.LeftCm, box.TopCm, box.WidthCm, 0.18, title + " Accent");
+            accent.FillColor = color;
+            accent.OutlineColor = color;
+
+            AddLabel(slide, title, box.LeftCm + 0.45, box.TopCm + 0.65, box.WidthCm - 0.9, 0.55, color, 14, bold: true);
+            PowerPointTextBox list = slide.AddTextBox("",
+                PowerPointLayoutBox.FromCentimeters(box.LeftCm + 0.55, box.TopCm + 1.55, box.WidthCm - 0.95, box.HeightCm - 1.9));
+            list.SetBullets(bullets, configure: paragraph => {
+                paragraph.SetFontSize(10)
+                    .SetColor("626B75")
+                    .SetHangingPoints(12)
+                    .SetSpaceAfterPoints(3)
+                    .SetBulletSizePercent(72);
+            });
+            list.SetTextMarginsCm(0, 0, 0, 0);
+            list.TextAutoFit = PowerPointTextAutoFit.Normal;
+        }
+
+        private static void AddPill(PowerPointSlide slide, PowerPointLayoutBox box, string text) {
+            PowerPointAutoShape pill = AddPanel(slide, box.LeftCm, box.TopCm, box.WidthCm, box.HeightCm, text + " Pill");
+            pill.FillColor = "FDFBF7";
+            pill.OutlineColor = "D8DDE3";
+
+            PowerPointTextBox label = AddLabel(slide, text, box.LeftCm + 0.25, box.TopCm + 0.17, box.WidthCm - 0.5,
+                box.HeightCm - 0.3, "4A4F55", 10, bold: false);
+            label.TextVerticalAlignment = A.TextAnchoringTypeValues.Center;
+            foreach (PowerPointParagraph paragraph in label.Paragraphs) {
+                paragraph.Alignment = A.TextAlignmentTypeValues.Center;
+            }
+        }
+
+        private static void AddProcessStep(PowerPointSlide slide, PowerPointLayoutBox box, string number, string title,
+            IEnumerable<string> bullets) {
+            AddLabel(slide, number, box.LeftCm, box.TopCm, 3.0, 1.4, "FFFFFF", 39, bold: true);
+            AddLabel(slide, title, box.LeftCm, box.TopCm + 2.0, box.WidthCm, 0.6, "FFFFFF", 15, bold: true);
+            PowerPointTextBox list = slide.AddTextBox("",
+                PowerPointLayoutBox.FromCentimeters(box.LeftCm, box.TopCm + 2.85, box.WidthCm, 1.7));
+            list.SetParagraphs(bullets, paragraph => {
+                paragraph.SetFontSize(11)
+                    .SetColor("D7F3FA")
+                    .SetFontName("Aptos")
+                    .SetSpaceAfterPoints(4);
+            });
+            list.SetTextMarginsCm(0, 0, 0, 0);
+        }
+
+        private static void AddArrowBetween(PowerPointSlide slide, PowerPointLayoutBox left, PowerPointLayoutBox right) {
+            double y = left.TopCm + 2.42;
+            PowerPointAutoShape arrow = slide.AddLineCm(left.RightCm + 0.25, y, right.LeftCm - 0.45, y, "Process Arrow");
+            arrow.OutlineColor = "FFFFFF";
+            arrow.OutlineWidthPoints = 2.0;
+            arrow.SetLineEnds(null, A.LineEndValues.Triangle, A.LineEndWidthValues.Medium, A.LineEndLengthValues.Medium);
+        }
+
+        private static void AddLightSlideChrome(PowerPointSlide slide) {
+            PowerPointAutoShape diagonal = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, 11.2, -2.2, 9.5, 23.5,
+                "Subtle Diagonal Wash");
+            diagonal.FillColor = Linen;
+            diagonal.FillTransparency = 58;
+            diagonal.OutlineColor = Linen;
+
+            PowerPointTextBox brand = slide.AddTextBoxCm("OfficeIMO.PowerPoint", 1.3, 17.4, 7.0, 0.35);
+            brand.FontSize = 8;
+            brand.Color = Teal;
+            brand.SetTextMarginsCm(0, 0, 0, 0);
+
+            PowerPointTextBox marker = slide.AddTextBoxCm("layout system", 27.6, 17.4, 4.3, 0.35);
+            marker.FontSize = 8;
+            marker.Color = "8B847C";
+            marker.SetTextMarginsCm(0, 0, 0, 0);
+        }
+
+        private static void AddDarkSlideChrome(PowerPointSlide slide) {
+            PowerPointAutoShape bottom = slide.AddRectangleCm(0, 15.1, 33.87, 3.95, "Dark Footer Wash");
+            bottom.FillColor = "0B415A";
+            bottom.FillTransparency = 35;
+            bottom.OutlineColor = "0B415A";
+
+            PowerPointTextBox brand = slide.AddTextBoxCm("OfficeIMO.PowerPoint", 1.85, 17.1, 7.0, 0.35);
+            brand.FontSize = 8;
+            brand.Color = "D7F3FA";
+            brand.SetTextMarginsCm(0, 0, 0, 0);
+
+            PowerPointTextBox marker = slide.AddTextBoxCm("modern layouts", 27.0, 17.1, 4.8, 0.35);
+            marker.FontSize = 8;
+            marker.Color = "D7F3FA";
+            marker.SetTextMarginsCm(0, 0, 0, 0);
+        }
+
+        private static PowerPointTextBox AddBodyOnDark(PowerPointSlide slide, string text, double leftCm, double topCm,
+            double widthCm, double heightCm, int fontSize) {
+            PowerPointTextBox box = slide.AddTextBoxCm(text, leftCm, topCm, widthCm, heightCm);
+            box.FontSize = fontSize;
+            box.Color = "D7F3FA";
+            box.TextAutoFit = PowerPointTextAutoFit.Normal;
+            box.SetTextMarginsCm(0, 0, 0, 0);
+            return box;
+        }
+
         private static void AddSlideTitle(PowerPointSlide slide, string title, string subtitle) {
+            AddLightSlideChrome(slide);
+
             PowerPointTextBox titleBox = slide.AddTextBoxCm(title, 1.3, 0.85, 17.5, 0.95);
             titleBox.FontSize = 23;
             titleBox.Color = Ink;

--- a/OfficeIMO.Examples/PowerPoint/ModernPowerPointDeck.cs
+++ b/OfficeIMO.Examples/PowerPoint/ModernPowerPointDeck.cs
@@ -23,9 +23,9 @@ namespace OfficeIMO.Examples.PowerPoint {
 
         public static void Example_ModernPowerPointDeck(string folderPath, bool openPowerPoint) {
             Console.WriteLine("[*] PowerPoint - Modern themed deck");
-            string filePath = Path.Combine(folderPath, Path.GetFileName("Modern PowerPoint Deck.pptx"));
-            string imagesDirectory = Path.Combine(AppContext.BaseDirectory, "Images");
-            string backgroundImagePath = Path.Combine(imagesDirectory, "BackgroundImage.png");
+            string filePath = AppendPathSegment(folderPath, "Modern PowerPoint Deck.pptx");
+            string imagesDirectory = AppendPathSegment(AppContext.BaseDirectory, "Images");
+            string backgroundImagePath = AppendPathSegment(imagesDirectory, "BackgroundImage.png");
 
             using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
             presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
@@ -615,6 +615,12 @@ namespace OfficeIMO.Examples.PowerPoint {
             wash.FillColor = Paper;
             wash.FillTransparency = 6;
             wash.OutlineColor = Paper;
+        }
+
+        private static string AppendPathSegment(string directoryPath, string childName) {
+            string normalizedDirectory = Path.GetFullPath(directoryPath)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            return normalizedDirectory + Path.DirectorySeparatorChar + childName;
         }
 
         private sealed class KpiRow {

--- a/OfficeIMO.Examples/PowerPoint/ModernPowerPointDeck.cs
+++ b/OfficeIMO.Examples/PowerPoint/ModernPowerPointDeck.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OfficeIMO.PowerPoint;
+using A = DocumentFormat.OpenXml.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace OfficeIMO.Examples.PowerPoint {
+    /// <summary>
+    /// Demonstrates a modern PowerPoint deck with theme colors, theme fonts, backgrounds, transitions,
+    /// effects, charts, a table, notes, and validation.
+    /// </summary>
+    public static class ModernPowerPointDeck {
+        private const string Ink = "161411";
+        private const string Paper = "F8F5EF";
+        private const string Linen = "EFE8DA";
+        private const string Teal = "156082";
+        private const string Orange = "F26A3D";
+        private const string Sage = "8CB369";
+        private const string Indigo = "6B6EA8";
+        private const string Gold = "D6A84F";
+
+        public static void Example_ModernPowerPointDeck(string folderPath, bool openPowerPoint) {
+            Console.WriteLine("[*] PowerPoint - Modern themed deck");
+            string filePath = Path.Combine(folderPath, "Modern PowerPoint Deck.pptx");
+            string backgroundImagePath = Path.Combine(AppContext.BaseDirectory, "Images", "BackgroundImage.png");
+
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+            presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+            presentation.ThemeName = "OfficeIMO Modern";
+            presentation.SetThemeColorsForAllMasters(new Dictionary<PowerPointThemeColor, string> {
+                [PowerPointThemeColor.Dark1] = Ink,
+                [PowerPointThemeColor.Light1] = Paper,
+                [PowerPointThemeColor.Dark2] = "253746",
+                [PowerPointThemeColor.Light2] = Linen,
+                [PowerPointThemeColor.Accent1] = Teal,
+                [PowerPointThemeColor.Accent2] = Orange,
+                [PowerPointThemeColor.Accent3] = Sage,
+                [PowerPointThemeColor.Accent4] = Indigo,
+                [PowerPointThemeColor.Accent5] = Gold,
+                [PowerPointThemeColor.Accent6] = "6C8EAD"
+            });
+            presentation.SetThemeFontsForAllMasters(new PowerPointThemeFontSet(
+                majorLatin: "Aptos Display",
+                minorLatin: "Aptos",
+                majorEastAsian: "Yu Gothic",
+                minorEastAsian: "Yu Gothic",
+                majorComplexScript: "Arial",
+                minorComplexScript: "Arial"));
+
+            AddCoverSlide(presentation, backgroundImagePath);
+            AddPerformanceSlide(presentation);
+            AddChannelMixSlide(presentation);
+            AddGrowthSlide(presentation);
+
+            presentation.Save();
+            List<DocumentFormat.OpenXml.Validation.ValidationErrorInfo> errors = presentation.ValidateDocument();
+            if (errors.Count > 0) {
+                string details = string.Join(Environment.NewLine, errors.Take(5).Select(error => error.Description));
+                throw new InvalidOperationException($"PowerPoint validation failed with {errors.Count} error(s).{Environment.NewLine}{details}");
+            }
+
+            Console.WriteLine($"    Saved: {filePath}");
+            Console.WriteLine("    Validation: no Open XML errors found.");
+            Helpers.Open(filePath, openPowerPoint);
+        }
+
+        private static void AddCoverSlide(PowerPointPresentation presentation, string backgroundImagePath) {
+            PowerPointSlide slide = presentation.AddSlide();
+            slide.BackgroundColor = Paper;
+            slide.Transition = SlideTransition.Morph;
+            ApplyBackgroundImage(slide, backgroundImagePath);
+            AddWash(slide);
+
+            PowerPointAutoShape rail = slide.AddRectangleCm(1.0, 1.1, 0.18, 10.8, "Accent Rail");
+            rail.FillColor = Teal;
+            rail.OutlineColor = Teal;
+
+            PowerPointTextBox eyebrow = slide.AddTextBoxCm("Commercial snapshot", 1.5, 1.1, 9.0, 0.6);
+            eyebrow.FontSize = 11;
+            eyebrow.Color = Teal;
+
+            PowerPointTextBox title = slide.AddTextBoxCm("Modern decks with OfficeIMO.PowerPoint", 1.5, 2.1, 17.5, 2.5);
+            title.FontSize = 34;
+            title.Color = Ink;
+            title.TextAutoFit = PowerPointTextAutoFit.Normal;
+            title.SetTextMarginsCm(0, 0, 0, 0);
+
+            PowerPointAutoShape card = slide.AddRectangleCm(1.5, 5.6, 15.8, 3.5, "Hero Story Card");
+            card.FillColor = Teal;
+            card.FillTransparency = 8;
+            card.OutlineColor = Teal;
+            card.SetShadow("000000", blurPoints: 10, distancePoints: 4, angleDegrees: 90, transparencyPercent: 72);
+
+            PowerPointTextBox story = slide.AddTextBoxCm(
+                "Themes, backgrounds, effects, editable charts, tables, notes, and transitions in one generated presentation.",
+                2.1, 6.35, 14.4, 1.5);
+            story.FontSize = 19;
+            story.Color = "FFFFFF";
+            story.TextAutoFit = PowerPointTextAutoFit.Normal;
+
+            PowerPointAutoShape glow = slide.AddEllipseCm(24.4, 1.0, 4.5, 4.5, "Glow Accent");
+            glow.FillColor = Orange;
+            glow.FillTransparency = 18;
+            glow.OutlineColor = Orange;
+            glow.SetGlow(Orange, radiusPoints: 8, transparencyPercent: 28);
+
+            PowerPointAutoShape pill = slide.AddRectangleCm(22.2, 13.2, 8.8, 1.1, "Footer Pill");
+            pill.FillColor = Linen;
+            pill.FillTransparency = 0;
+            pill.OutlineColor = Linen;
+            pill.SetSoftEdges(1.2);
+
+            PowerPointTextBox footer = slide.AddTextBoxCm("Validated PPTX output", 22.7, 13.45, 7.8, 0.45);
+            footer.FontSize = 11;
+            footer.Color = Ink;
+            footer.TextVerticalAlignment = A.TextAnchoringTypeValues.Center;
+            slide.Notes.Text = "Opening slide introduces the feature set demonstrated by this deck.";
+        }
+
+        private static void AddPerformanceSlide(PowerPointPresentation presentation) {
+            PowerPointSlide slide = presentation.AddSlide();
+            slide.BackgroundColor = Paper;
+            slide.Transition = SlideTransition.Fade;
+            AddSlideTitle(slide, "Monthly performance", "Column chart, KPI table, shape effects, and speaker notes.");
+
+            PowerPointAutoShape chartPanel = AddPanel(slide, 1.3, 3.1, 16.2, 9.9, "Chart Surface");
+            chartPanel.SetShadow("000000", blurPoints: 7, distancePoints: 2, angleDegrees: 90, transparencyPercent: 84);
+
+            PowerPointChartData data = new(
+                new[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun" },
+                new[] {
+                    new PowerPointChartSeries("Sales", new[] { 10d, 12d, 16d, 19d, 24d, 27d }),
+                    new PowerPointChartSeries("Profit", new[] { 4d, 5d, 7d, 9d, 11d, 13d })
+                });
+            PowerPointChart chart = slide.AddChartCm(data, 1.8, 3.7, 15.1, 8.5);
+            chart.SetTitle("Sales vs Profit")
+                .SetLegend(C.LegendPositionValues.Bottom)
+                .SetChartAreaStyle(fillColor: "FFFFFF", lineColor: "FFFFFF")
+                .SetPlotAreaStyle(fillColor: "FFFFFF", lineColor: "FFFFFF")
+                .SetSeriesFillColor("Sales", Teal)
+                .SetSeriesFillColor("Profit", Orange)
+                .SetValueAxisGridlines(showMajor: true, lineColor: "D8D5CC", lineWidthPoints: 0.75)
+                .SetValueAxisLabelTextStyle(fontSizePoints: 9, color: "534F49", fontName: "Aptos")
+                .SetCategoryAxisLabelTextStyle(fontSizePoints: 9, color: "534F49", fontName: "Aptos");
+
+            PowerPointAutoShape takeawayCard = AddPanel(slide, 18.5, 3.1, 11.4, 3.6, "Takeaway Card");
+            takeawayCard.FillColor = Linen;
+            takeawayCard.OutlineColor = Orange;
+            takeawayCard.OutlineWidthPoints = 1.4;
+            takeawayCard.SetReflection(blurPoints: 2, distancePoints: 1, startOpacityPercent: 15, endOpacityPercent: 0);
+            AddLabel(slide, "Takeaway", 19.1, 3.55, 5.0, 0.55, Orange, 12, bold: true);
+            AddBody(slide, "Sales nearly triple from January to June while profit expands at a steadier pace.", 19.1, 4.45, 9.8, 1.5, 18);
+
+            PowerPointTable table = slide.AddTableCm(
+                new[] {
+                    new KpiRow { Metric = "Sales", Value = "27", Status = "up 170%" },
+                    new KpiRow { Metric = "Profit", Value = "13", Status = "up 225%" },
+                    new KpiRow { Metric = "Runway", Value = "Q3", Status = "healthy" }
+                },
+                options => {
+                    options.HeaderCase = HeaderCase.Title;
+                    options.PinFirst("Metric");
+                },
+                includeHeaders: true,
+                leftCm: 18.5,
+                topCm: 7.6,
+                widthCm: 11.4,
+                heightCm: 4.5);
+            table.ApplyStyle(PowerPointTableStylePreset.Default);
+            table.SetColumnWidthsPoints(105, 75, 125);
+            StyleTable(table);
+
+            slide.Notes.Text = "Performance slide: keep the conversation on the widening gap between revenue growth and profitability.";
+        }
+
+        private static void AddChannelMixSlide(PowerPointPresentation presentation) {
+            PowerPointSlide slide = presentation.AddSlide();
+            slide.BackgroundColor = Paper;
+            slide.Transition = SlideTransition.Fade;
+            AddSlideTitle(slide, "Channel mix", "Doughnut chart, modern cards, and soft visual hierarchy.");
+
+            PowerPointAutoShape chartPanel = AddPanel(slide, 1.3, 3.0, 15.3, 10.0, "Channel Chart Panel");
+            chartPanel.FillColor = "FFFFFF";
+            chartPanel.SetShadow("000000", blurPoints: 7, distancePoints: 2, angleDegrees: 90, transparencyPercent: 84);
+
+            PowerPointChartData data = new(
+                new[] { "Direct", "Partner", "Online", "Events" },
+                new[] { new PowerPointChartSeries("Share", new[] { 42d, 27d, 22d, 9d }) });
+            PowerPointChart chart = slide.AddDoughnutChartCm(data, 2.2, 3.9, 13.4, 7.8);
+            chart.SetTitle("Revenue Share by Channel")
+                .SetLegend(C.LegendPositionValues.Bottom)
+                .SetDataLabels(showPercent: true)
+                .SetDataLabelPosition(C.DataLabelPositionValues.BestFit)
+                .SetChartAreaStyle(fillColor: "FFFFFF", lineColor: "FFFFFF")
+                .SetSeriesFillColor(0, Teal);
+
+            AddMetricCard(slide, "42%", "Direct", "Primary engine", 18.2, 3.1, Teal);
+            AddMetricCard(slide, "27%", "Partner", "Strong co-sell base", 18.2, 6.1, Orange);
+            AddMetricCard(slide, "22%", "Online", "Efficient pipeline", 18.2, 9.1, Sage);
+
+            PowerPointAutoShape noteCard = AddPanel(slide, 25.2, 3.1, 5.1, 8.9, "Story Card");
+            noteCard.FillColor = Linen;
+            noteCard.OutlineColor = Indigo;
+            noteCard.OutlineWidthPoints = 1.2;
+            AddLabel(slide, "Story", 25.75, 3.75, 3.8, 0.5, Indigo, 12, bold: true);
+            AddBody(slide, "Enterprise remains anchor-led, but online demand now deserves a dedicated program.", 25.75, 4.75, 4.1, 4.0, 16);
+
+            slide.Notes.Text = "Channel slide: direct is still dominant, but online has enough share to justify deliberate investment.";
+        }
+
+        private static void AddGrowthSlide(PowerPointPresentation presentation) {
+            PowerPointSlide slide = presentation.AddSlide();
+            slide.BackgroundColor = Paper;
+            slide.Transition = SlideTransition.Fade;
+            AddSlideTitle(slide, "Growth trend", "Line chart with styled series, markers, gridlines, and an observation card.");
+
+            PowerPointAutoShape stripe = slide.AddRectangleCm(1.3, 4.2, 0.36, 8.8, "Accent Stripe");
+            stripe.FillColor = Orange;
+            stripe.OutlineColor = Orange;
+
+            PowerPointAutoShape chartPanel = AddPanel(slide, 2.2, 3.2, 20.7, 9.6, "Trend Chart Panel");
+            chartPanel.FillColor = "FFFFFF";
+            chartPanel.SetShadow("000000", blurPoints: 7, distancePoints: 2, angleDegrees: 90, transparencyPercent: 84);
+
+            PowerPointChartData data = new(
+                new[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun" },
+                new[] {
+                    new PowerPointChartSeries("Sales", new[] { 10d, 14d, 18d, 21d, 25d, 28d }),
+                    new PowerPointChartSeries("Profit", new[] { 4d, 6d, 8d, 10d, 12d, 14d })
+                });
+            PowerPointChart chart = slide.AddLineChartCm(data, 2.8, 3.8, 19.5, 8.4);
+            chart.SetTitle("Momentum Over Time")
+                .SetLegend(C.LegendPositionValues.Bottom)
+                .SetChartAreaStyle(fillColor: "FFFFFF", lineColor: "FFFFFF")
+                .SetPlotAreaStyle(fillColor: "FFFFFF", lineColor: "FFFFFF")
+                .SetSeriesLineColor("Sales", Teal, widthPoints: 2.75)
+                .SetSeriesLineColor("Profit", Orange, widthPoints: 2.75)
+                .SetSeriesMarker("Sales", C.MarkerStyleValues.Diamond, size: 8, fillColor: Teal, lineColor: Teal)
+                .SetSeriesMarker("Profit", C.MarkerStyleValues.Square, size: 8, fillColor: Orange, lineColor: Orange)
+                .SetValueAxisGridlines(showMajor: true, lineColor: "D8D5CC", lineWidthPoints: 0.75)
+                .SetValueAxisLabelTextStyle(fontSizePoints: 9, color: "534F49", fontName: "Aptos")
+                .SetCategoryAxisLabelTextStyle(fontSizePoints: 9, color: "534F49", fontName: "Aptos");
+
+            PowerPointAutoShape callout = AddPanel(slide, 24.2, 4.8, 7.4, 5.9, "Observation Card");
+            callout.FillColor = Linen;
+            callout.OutlineColor = Indigo;
+            callout.OutlineWidthPoints = 1.2;
+            callout.SetReflection(blurPoints: 2, distancePoints: 1, startOpacityPercent: 18, endOpacityPercent: 0);
+            AddLabel(slide, "Observation", 25.0, 5.45, 5.5, 0.55, Indigo, 13, bold: true);
+            AddBody(slide, "The slope stays healthy through Q2, which makes the line view easier to read than a scatter plot here.", 25.0, 6.6, 5.6, 3.0, 16);
+
+            slide.Notes.Text = "Growth slide: this intentionally uses a line chart because the month-to-month sequence matters.";
+        }
+
+        private static void AddSlideTitle(PowerPointSlide slide, string title, string subtitle) {
+            PowerPointTextBox titleBox = slide.AddTextBoxCm(title, 1.3, 0.85, 17.5, 0.95);
+            titleBox.FontSize = 23;
+            titleBox.Color = Ink;
+            titleBox.SetTextMarginsCm(0, 0, 0, 0);
+
+            PowerPointTextBox subtitleBox = slide.AddTextBoxCm(subtitle, 1.35, 1.85, 16.5, 0.5);
+            subtitleBox.FontSize = 10;
+            subtitleBox.Color = "6A625B";
+            subtitleBox.SetTextMarginsCm(0, 0, 0, 0);
+        }
+
+        private static PowerPointAutoShape AddPanel(PowerPointSlide slide, double leftCm, double topCm, double widthCm, double heightCm, string name) {
+            PowerPointAutoShape panel = slide.AddRectangleCm(leftCm, topCm, widthCm, heightCm, name);
+            panel.FillColor = "FFFFFF";
+            panel.FillTransparency = 0;
+            panel.OutlineColor = Linen;
+            panel.SetSoftEdges(0.9);
+            return panel;
+        }
+
+        private static void AddMetricCard(PowerPointSlide slide, string value, string label, string detail, double leftCm, double topCm, string color) {
+            PowerPointAutoShape card = AddPanel(slide, leftCm, topCm, 5.7, 2.25, label + " Card");
+            card.OutlineColor = color;
+            card.OutlineWidthPoints = 1.1;
+
+            PowerPointAutoShape chip = slide.AddEllipseCm(leftCm + 0.45, topCm + 0.42, 0.55, 0.55, label + " Chip");
+            chip.FillColor = color;
+            chip.OutlineColor = color;
+
+            AddLabel(slide, value, leftCm + 1.25, topCm + 0.25, 3.8, 0.65, Ink, 18, bold: true);
+            AddLabel(slide, label, leftCm + 1.25, topCm + 0.95, 3.8, 0.45, color, 11, bold: true);
+            AddBody(slide, detail, leftCm + 1.25, topCm + 1.45, 3.95, 0.45, 10);
+        }
+
+        private static PowerPointTextBox AddLabel(PowerPointSlide slide, string text, double leftCm, double topCm, double widthCm, double heightCm, string color, int fontSize, bool bold) {
+            PowerPointTextBox box = slide.AddTextBoxCm(text, leftCm, topCm, widthCm, heightCm);
+            box.FontSize = fontSize;
+            box.Color = color;
+            box.Bold = bold;
+            box.SetTextMarginsCm(0, 0, 0, 0);
+            return box;
+        }
+
+        private static PowerPointTextBox AddBody(PowerPointSlide slide, string text, double leftCm, double topCm, double widthCm, double heightCm, int fontSize) {
+            PowerPointTextBox box = slide.AddTextBoxCm(text, leftCm, topCm, widthCm, heightCm);
+            box.FontSize = fontSize;
+            box.Color = Ink;
+            box.TextAutoFit = PowerPointTextAutoFit.Normal;
+            box.SetTextMarginsCm(0, 0, 0, 0);
+            return box;
+        }
+
+        private static void StyleTable(PowerPointTable table) {
+            for (int c = 0; c < table.Columns; c++) {
+                PowerPointTableCell header = table.GetCell(0, c);
+                header.Bold = true;
+                header.HorizontalAlignment = A.TextAlignmentTypeValues.Center;
+                header.VerticalAlignment = A.TextAnchoringTypeValues.Center;
+            }
+        }
+
+        private static void ApplyBackgroundImage(PowerPointSlide slide, string imagePath) {
+            if (File.Exists(imagePath)) {
+                slide.SetBackgroundImage(imagePath);
+            }
+        }
+
+        private static void AddWash(PowerPointSlide slide) {
+            PowerPointAutoShape wash = slide.AddRectangleCm(0, 0, 33.87, 19.05, "Background Wash");
+            wash.FillColor = Paper;
+            wash.FillTransparency = 6;
+            wash.OutlineColor = Paper;
+        }
+
+        private sealed class KpiRow {
+            public string Metric { get; set; } = string.Empty;
+            public string Value { get; set; } = string.Empty;
+            public string Status { get; set; } = string.Empty;
+        }
+    }
+}

--- a/OfficeIMO.Examples/PowerPoint/ModernPowerPointDeck.cs
+++ b/OfficeIMO.Examples/PowerPoint/ModernPowerPointDeck.cs
@@ -214,27 +214,33 @@ namespace OfficeIMO.Examples.PowerPoint {
             PowerPointSlide slide = presentation.AddSlide();
             slide.BackgroundColor = Teal;
             slide.Transition = SlideTransition.Fade;
+
+            PowerPointAutoShape wash = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, 9.5, 0.0, 12.0, 19.05, "Dark Process Wash");
+            wash.FillColor = "0B5475";
+            wash.FillTransparency = 45;
+            wash.OutlineColor = "0B5475";
+
+            PowerPointAutoShape highlight = slide.AddRectangleCm(1.85, 5.35, 28.5, 0.04, "Process Divider");
+            highlight.FillColor = "D7F3FA";
+            highlight.FillTransparency = 74;
+            highlight.OutlineColor = "D7F3FA";
+
             AddDarkSlideChrome(slide);
 
             AddLabel(slide, "Commercial snapshot", 1.85, 1.25, 8.0, 0.45, "D7F3FA", 10, bold: false);
-            AddLabel(slide, "From data to decision", 1.85, 2.2, 18.0, 1.1, "FFFFFF", 31, bold: true);
-            AddBodyOnDark(slide, "A process layout with aligned cards, arrows, captions, and slide-level brand rhythm.", 1.9, 3.35, 18.0, 0.7, 13);
-
-            PowerPointAutoShape wash = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, 10.0, 0.0, 11.0, 19.05, "Dark Process Wash");
-            wash.FillColor = "0B5475";
-            wash.FillTransparency = 42;
-            wash.OutlineColor = "0B5475";
+            AddLabel(slide, "From data to decision", 1.85, 2.15, 18.0, 1.1, "FFFFFF", 31, bold: true);
+            AddBodyOnDark(slide, "Aligned steps, clear hierarchy, stronger arrows, and enough whitespace for the sequence to breathe.", 1.9, 3.3, 20.0, 0.7, 13);
 
             PowerPointLayoutBox[,] steps = PowerPointLayoutBox
-                .FromCentimeters(2.0, 7.0, 28.5, 5.2)
-                .SplitGridCm(1, 3, 0, 1.2);
-            AddProcessStep(slide, steps[0, 0], "1.", "Collect", new[] { "Source data", "Inventory", "Baseline" });
-            AddProcessStep(slide, steps[0, 1], "2.", "Analyze", new[] { "Risk signals", "Gaps", "Priorities" });
-            AddProcessStep(slide, steps[0, 2], "3.", "Act", new[] { "Roadmap", "Owners", "Controls" });
+                .FromCentimeters(2.0, 6.95, 28.5, 5.9)
+                .SplitGridCm(1, 3, 0, 1.0);
+            AddProcessStep(slide, steps[0, 0], "01", "Collect", new[] { "Source data", "Inventory", "Baseline" }, Teal);
+            AddProcessStep(slide, steps[0, 1], "02", "Analyze", new[] { "Risk signals", "Gaps", "Priorities" }, "0B5475");
+            AddProcessStep(slide, steps[0, 2], "03", "Act", new[] { "Roadmap", "Owners", "Controls" }, "0B415A");
             AddArrowBetween(slide, steps[0, 0], steps[0, 1]);
             AddArrowBetween(slide, steps[0, 1], steps[0, 2]);
 
-            AddBodyOnDark(slide, "Use this pattern when the audience needs sequence first and details second.", 2.0, 15.55, 18.0, 0.65, 13);
+            AddBodyOnDark(slide, "Use this pattern when the audience needs sequence first and details second.", 2.0, 15.55, 19.0, 0.65, 13);
             slide.Notes.Text = "Process slide demonstrates dark backgrounds, arrows, large numbers, grouped step content, and bottom captions.";
         }
 
@@ -402,8 +408,8 @@ namespace OfficeIMO.Examples.PowerPoint {
             list.SetBullets(bullets, configure: paragraph => {
                 paragraph.SetFontSize(10)
                     .SetColor("626B75")
-                    .SetHangingPoints(12)
-                    .SetSpaceAfterPoints(3)
+                    .SetHangingPoints(18)
+                    .SetSpaceAfterPoints(4)
                     .SetBulletSizePercent(72);
             });
             list.SetTextMarginsCm(0, 0, 0, 0);
@@ -424,11 +430,35 @@ namespace OfficeIMO.Examples.PowerPoint {
         }
 
         private static void AddProcessStep(PowerPointSlide slide, PowerPointLayoutBox box, string number, string title,
-            IEnumerable<string> bullets) {
-            AddLabel(slide, number, box.LeftCm, box.TopCm, 3.0, 1.4, "FFFFFF", 39, bold: true);
-            AddLabel(slide, title, box.LeftCm, box.TopCm + 2.0, box.WidthCm, 0.6, "FFFFFF", 15, bold: true);
+            IEnumerable<string> bullets, string accentColor) {
+            PowerPointAutoShape card = slide.AddRectangleCm(box.LeftCm - 0.28, box.TopCm - 0.2, box.WidthCm + 0.56,
+                box.HeightCm + 0.25, title + " Step Card");
+            card.FillColor = "FFFFFF";
+            card.FillTransparency = 92;
+            card.OutlineColor = "D7F3FA";
+            card.OutlineWidthPoints = 0.7;
+
+            PowerPointAutoShape accent = slide.AddRectangleCm(box.LeftCm - 0.28, box.TopCm - 0.2, box.WidthCm + 0.56,
+                0.16, title + " Step Accent");
+            accent.FillColor = accentColor;
+            accent.FillTransparency = 0;
+            accent.OutlineColor = accentColor;
+
+            PowerPointAutoShape badge = slide.AddEllipseCm(box.LeftCm, box.TopCm + 0.3, 1.35, 1.35, title + " Badge");
+            badge.FillColor = "FFFFFF";
+            badge.FillTransparency = 0;
+            badge.OutlineColor = "FFFFFF";
+
+            PowerPointTextBox numberBox = AddLabel(slide, number, box.LeftCm + 0.17, box.TopCm + 0.68, 1.0, 0.4,
+                accentColor, 11, bold: true);
+            numberBox.TextVerticalAlignment = A.TextAnchoringTypeValues.Center;
+            foreach (PowerPointParagraph paragraph in numberBox.Paragraphs) {
+                paragraph.Alignment = A.TextAlignmentTypeValues.Center;
+            }
+
+            AddLabel(slide, title, box.LeftCm, box.TopCm + 2.15, box.WidthCm, 0.6, "FFFFFF", 15, bold: true);
             PowerPointTextBox list = slide.AddTextBox("",
-                PowerPointLayoutBox.FromCentimeters(box.LeftCm, box.TopCm + 2.85, box.WidthCm, 1.7));
+                PowerPointLayoutBox.FromCentimeters(box.LeftCm, box.TopCm + 2.95, box.WidthCm, 1.7));
             list.SetParagraphs(bullets, paragraph => {
                 paragraph.SetFontSize(11)
                     .SetColor("D7F3FA")
@@ -439,18 +469,20 @@ namespace OfficeIMO.Examples.PowerPoint {
         }
 
         private static void AddArrowBetween(PowerPointSlide slide, PowerPointLayoutBox left, PowerPointLayoutBox right) {
-            double y = left.TopCm + 2.42;
-            PowerPointAutoShape arrow = slide.AddLineCm(left.RightCm + 0.25, y, right.LeftCm - 0.45, y, "Process Arrow");
-            arrow.OutlineColor = "FFFFFF";
-            arrow.OutlineWidthPoints = 2.0;
-            arrow.SetLineEnds(null, A.LineEndValues.Triangle, A.LineEndWidthValues.Medium, A.LineEndLengthValues.Medium);
+            double y = left.TopCm + 2.5;
+            PowerPointAutoShape arrow = slide.AddShapeCm(A.ShapeTypeValues.RightArrow, left.RightCm + 0.08, y,
+                Math.Max(0.7, right.LeftCm - left.RightCm - 0.42), 0.52, "Process Arrow");
+            arrow.FillColor = "D7F3FA";
+            arrow.FillTransparency = 16;
+            arrow.OutlineColor = "D7F3FA";
+            arrow.OutlineWidthPoints = 0.4;
         }
 
         private static void AddLightSlideChrome(PowerPointSlide slide) {
-            PowerPointAutoShape diagonal = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, 11.2, -2.2, 9.5, 23.5,
+            PowerPointAutoShape diagonal = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, 12.0, 0.0, 7.3, 19.05,
                 "Subtle Diagonal Wash");
             diagonal.FillColor = Linen;
-            diagonal.FillTransparency = 58;
+            diagonal.FillTransparency = 62;
             diagonal.OutlineColor = Linen;
 
             PowerPointTextBox brand = slide.AddTextBoxCm("OfficeIMO.PowerPoint", 1.3, 17.4, 7.0, 0.35);
@@ -475,7 +507,7 @@ namespace OfficeIMO.Examples.PowerPoint {
             brand.Color = "D7F3FA";
             brand.SetTextMarginsCm(0, 0, 0, 0);
 
-            PowerPointTextBox marker = slide.AddTextBoxCm("modern layouts", 27.0, 17.1, 4.8, 0.35);
+            PowerPointTextBox marker = slide.AddTextBoxCm("deck system", 27.0, 17.1, 4.8, 0.35);
             marker.FontSize = 8;
             marker.Color = "D7F3FA";
             marker.SetTextMarginsCm(0, 0, 0, 0);

--- a/OfficeIMO.Examples/PowerPoint/ModernPowerPointDeck.cs
+++ b/OfficeIMO.Examples/PowerPoint/ModernPowerPointDeck.cs
@@ -23,8 +23,9 @@ namespace OfficeIMO.Examples.PowerPoint {
 
         public static void Example_ModernPowerPointDeck(string folderPath, bool openPowerPoint) {
             Console.WriteLine("[*] PowerPoint - Modern themed deck");
-            string filePath = Path.Combine(folderPath, "Modern PowerPoint Deck.pptx");
-            string backgroundImagePath = Path.Combine(AppContext.BaseDirectory, "Images", "BackgroundImage.png");
+            string filePath = Path.Combine(folderPath, Path.GetFileName("Modern PowerPoint Deck.pptx"));
+            string imagesDirectory = Path.Combine(AppContext.BaseDirectory, "Images");
+            string backgroundImagePath = Path.Combine(imagesDirectory, "BackgroundImage.png");
 
             using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
             presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);

--- a/OfficeIMO.Examples/PowerPoint/ModernPowerPointDeck.cs
+++ b/OfficeIMO.Examples/PowerPoint/ModernPowerPointDeck.cs
@@ -215,33 +215,49 @@ namespace OfficeIMO.Examples.PowerPoint {
             slide.BackgroundColor = Teal;
             slide.Transition = SlideTransition.Fade;
 
-            PowerPointAutoShape wash = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, 9.5, 0.0, 12.0, 19.05, "Dark Process Wash");
-            wash.FillColor = "0B5475";
-            wash.FillTransparency = 45;
-            wash.OutlineColor = "0B5475";
+            PowerPointAutoShape leftPlane = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, -1.0, 0.0, 15.1, 19.05, "Process Left Plane");
+            leftPlane.FillColor = "176A8D";
+            leftPlane.FillTransparency = 18;
+            leftPlane.OutlineColor = "176A8D";
 
-            PowerPointAutoShape highlight = slide.AddRectangleCm(1.85, 5.35, 28.5, 0.04, "Process Divider");
-            highlight.FillColor = "D7F3FA";
-            highlight.FillTransparency = 74;
-            highlight.OutlineColor = "D7F3FA";
+            PowerPointAutoShape middlePlane = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, 11.0, 0.0, 10.7, 19.05, "Process Middle Plane");
+            middlePlane.FillColor = "0B5475";
+            middlePlane.FillTransparency = 26;
+            middlePlane.OutlineColor = "0B5475";
+
+            PowerPointAutoShape rightPlane = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, 21.0, 0.0, 13.4, 19.05, "Process Right Plane");
+            rightPlane.FillColor = "0B415A";
+            rightPlane.FillTransparency = 34;
+            rightPlane.OutlineColor = "0B415A";
+
+            AddArrowMotif(slide, 25.1, 1.75, 10, 0.42);
 
             AddDarkSlideChrome(slide);
 
             AddLabel(slide, "Commercial snapshot", 1.85, 1.25, 8.0, 0.45, "D7F3FA", 10, bold: false);
             AddLabel(slide, "From data to decision", 1.85, 2.15, 18.0, 1.1, "FFFFFF", 31, bold: true);
-            AddBodyOnDark(slide, "Aligned steps, clear hierarchy, stronger arrows, and enough whitespace for the sequence to breathe.", 1.9, 3.3, 20.0, 0.7, 13);
+            AddBodyOnDark(slide, "A process layout with scale, direction, and enough whitespace for the sequence to breathe.", 1.9, 3.3, 21.2, 0.7, 13);
+
+            PowerPointAutoShape titleRule = slide.AddRectangleCm(1.85, 5.25, 4.2, 0.06, "Process Title Rule");
+            titleRule.FillColor = "D7F3FA";
+            titleRule.OutlineColor = "D7F3FA";
 
             PowerPointLayoutBox[,] steps = PowerPointLayoutBox
-                .FromCentimeters(2.0, 6.95, 28.5, 5.9)
-                .SplitGridCm(1, 3, 0, 1.0);
-            AddProcessStep(slide, steps[0, 0], "01", "Collect", new[] { "Source data", "Inventory", "Baseline" }, Teal);
-            AddProcessStep(slide, steps[0, 1], "02", "Analyze", new[] { "Risk signals", "Gaps", "Priorities" }, "0B5475");
-            AddProcessStep(slide, steps[0, 2], "03", "Act", new[] { "Roadmap", "Owners", "Controls" }, "0B415A");
+                .FromCentimeters(2.0, 6.75, 29.0, 6.3)
+                .SplitGridCm(1, 3, 0, 1.65);
+
+            AddProcessLane(slide, steps[0, 0], "Process Collect Lane", "1B7194");
+            AddProcessLane(slide, steps[0, 1], "Process Analyze Lane", "0E5572");
+            AddProcessLane(slide, steps[0, 2], "Process Act Lane", "0B415A");
+
+            AddProcessStep(slide, steps[0, 0], "1.", "Collect", new[] { "Source data", "Inventory", "Baseline" }, Orange);
+            AddProcessStep(slide, steps[0, 1], "2.", "Analyze", new[] { "Risk signals", "Gaps", "Priorities" }, "D7F3FA");
+            AddProcessStep(slide, steps[0, 2], "3.", "Act", new[] { "Roadmap", "Owners", "Controls" }, Gold);
             AddArrowBetween(slide, steps[0, 0], steps[0, 1]);
             AddArrowBetween(slide, steps[0, 1], steps[0, 2]);
 
             AddBodyOnDark(slide, "Use this pattern when the audience needs sequence first and details second.", 2.0, 15.55, 19.0, 0.65, 13);
-            slide.Notes.Text = "Process slide demonstrates dark backgrounds, arrows, large numbers, grouped step content, and bottom captions.";
+            slide.Notes.Text = "Process slide demonstrates dark backgrounds, diagonal planes, arrow connectors, large numbers, grouped step content, and bottom captions.";
         }
 
         private static void AddPerformanceSlide(PowerPointPresentation presentation) {
@@ -429,36 +445,38 @@ namespace OfficeIMO.Examples.PowerPoint {
             }
         }
 
+        private static void AddProcessLane(PowerPointSlide slide, PowerPointLayoutBox box, string name, string fillColor) {
+            PowerPointAutoShape lane = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, box.LeftCm - 0.55, box.TopCm + 0.15,
+                box.WidthCm + 1.0, box.HeightCm + 0.8, name);
+            lane.FillColor = fillColor;
+            lane.FillTransparency = 72;
+            lane.OutlineColor = fillColor;
+            lane.OutlineWidthPoints = 0;
+        }
+
+        private static void AddArrowMotif(PowerPointSlide slide, double leftCm, double topCm, int count, double spacingCm) {
+            for (int index = 0; index < count; index++) {
+                PowerPointAutoShape arrow = slide.AddShapeCm(A.ShapeTypeValues.RightArrow, leftCm + index * spacingCm, topCm,
+                    0.26, 0.18, "Process Direction Motif " + (index + 1));
+                arrow.FillColor = "D7F3FA";
+                arrow.FillTransparency = Math.Min(65, 18 + index * 5);
+                arrow.OutlineColor = "D7F3FA";
+            }
+        }
+
         private static void AddProcessStep(PowerPointSlide slide, PowerPointLayoutBox box, string number, string title,
             IEnumerable<string> bullets, string accentColor) {
-            PowerPointAutoShape card = slide.AddRectangleCm(box.LeftCm - 0.28, box.TopCm - 0.2, box.WidthCm + 0.56,
-                box.HeightCm + 0.25, title + " Step Card");
-            card.FillColor = "FFFFFF";
-            card.FillTransparency = 92;
-            card.OutlineColor = "D7F3FA";
-            card.OutlineWidthPoints = 0.7;
-
-            PowerPointAutoShape accent = slide.AddRectangleCm(box.LeftCm - 0.28, box.TopCm - 0.2, box.WidthCm + 0.56,
-                0.16, title + " Step Accent");
+            PowerPointAutoShape accent = slide.AddRectangleCm(box.LeftCm, box.TopCm + 2.72, 1.45, 0.08, title + " Step Accent");
             accent.FillColor = accentColor;
-            accent.FillTransparency = 0;
             accent.OutlineColor = accentColor;
 
-            PowerPointAutoShape badge = slide.AddEllipseCm(box.LeftCm, box.TopCm + 0.3, 1.35, 1.35, title + " Badge");
-            badge.FillColor = "FFFFFF";
-            badge.FillTransparency = 0;
-            badge.OutlineColor = "FFFFFF";
+            PowerPointTextBox numberBox = AddLabel(slide, number, box.LeftCm, box.TopCm + 0.05, 3.25, 1.75,
+                "FFFFFF", 46, bold: true);
+            numberBox.TextAutoFit = PowerPointTextAutoFit.Normal;
 
-            PowerPointTextBox numberBox = AddLabel(slide, number, box.LeftCm + 0.17, box.TopCm + 0.68, 1.0, 0.4,
-                accentColor, 11, bold: true);
-            numberBox.TextVerticalAlignment = A.TextAnchoringTypeValues.Center;
-            foreach (PowerPointParagraph paragraph in numberBox.Paragraphs) {
-                paragraph.Alignment = A.TextAlignmentTypeValues.Center;
-            }
-
-            AddLabel(slide, title, box.LeftCm, box.TopCm + 2.15, box.WidthCm, 0.6, "FFFFFF", 15, bold: true);
+            AddLabel(slide, title, box.LeftCm, box.TopCm + 2.0, box.WidthCm, 0.6, "FFFFFF", 15, bold: true);
             PowerPointTextBox list = slide.AddTextBox("",
-                PowerPointLayoutBox.FromCentimeters(box.LeftCm, box.TopCm + 2.95, box.WidthCm, 1.7));
+                PowerPointLayoutBox.FromCentimeters(box.LeftCm, box.TopCm + 3.15, box.WidthCm, 1.85));
             list.SetParagraphs(bullets, paragraph => {
                 paragraph.SetFontSize(11)
                     .SetColor("D7F3FA")
@@ -469,13 +487,11 @@ namespace OfficeIMO.Examples.PowerPoint {
         }
 
         private static void AddArrowBetween(PowerPointSlide slide, PowerPointLayoutBox left, PowerPointLayoutBox right) {
-            double y = left.TopCm + 2.5;
-            PowerPointAutoShape arrow = slide.AddShapeCm(A.ShapeTypeValues.RightArrow, left.RightCm + 0.08, y,
-                Math.Max(0.7, right.LeftCm - left.RightCm - 0.42), 0.52, "Process Arrow");
-            arrow.FillColor = "D7F3FA";
-            arrow.FillTransparency = 16;
+            double y = left.TopCm + 1.15;
+            PowerPointAutoShape arrow = slide.AddLineCm(left.RightCm + 0.06, y, right.LeftCm - 0.22, y, "Process Arrow");
             arrow.OutlineColor = "D7F3FA";
-            arrow.OutlineWidthPoints = 0.4;
+            arrow.OutlineWidthPoints = 2.8;
+            arrow.SetLineEnds(null, A.LineEndValues.Triangle, A.LineEndWidthValues.Medium, A.LineEndLengthValues.Medium);
         }
 
         private static void AddLightSlideChrome(PowerPointSlide slide) {

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -15,6 +15,11 @@ namespace OfficeIMO.Examples {
             string templatesPath = Path.Combine(baseFolder, "Templates");
             string folderPath = Path.Combine(baseFolder, "Documents");
             Setup(folderPath);
+            if (Array.Exists(args, arg => string.Equals(arg, "--modern-powerpoint", StringComparison.OrdinalIgnoreCase))) {
+                PowerPoint.ModernPowerPointDeck.Example_ModernPowerPointDeck(folderPath, false);
+                return;
+            }
+
             // Visio - Core Examples
             // Visio.BasicVisioDocument.Example_BasicVisio(folderPath, false);
             // Visio.ConnectRectangles.Example_ConnectRectangles(folderPath, false);
@@ -114,6 +119,7 @@ namespace OfficeIMO.Examples {
             // // PowerPoint
             PowerPoint.BasicPowerPointDocument.Example_BasicPowerPoint(folderPath, false);
             PowerPoint.AdvancedPowerPoint.Example_AdvancedPowerPoint(folderPath, false);
+            PowerPoint.ModernPowerPointDeck.Example_ModernPowerPointDeck(folderPath, false);
             PowerPoint.FluentPowerPoint.Example_FluentPowerPoint(folderPath, false);
             PowerPoint.ShapesPowerPoint.Example_PowerPointShapes(folderPath, false);
             PowerPoint.SlidesManagementPowerPoint.Example_SlidesManagement(folderPath, false);

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace OfficeIMO.Examples {
     internal static class Program {
@@ -9,14 +11,75 @@ namespace OfficeIMO.Examples {
             }
         }
 
+        private static bool HasArgument(string[] args, string value) {
+            return Array.Exists(args, arg => string.Equals(arg, value, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static void RunPowerPointExamples(string folderPath) {
+            DateTime startedUtc = DateTime.UtcNow.AddSeconds(-2);
+
+            PowerPoint.BasicPowerPointDocument.Example_BasicPowerPoint(folderPath, false);
+            PowerPoint.AdvancedPowerPoint.Example_AdvancedPowerPoint(folderPath, false);
+            PowerPoint.ModernPowerPointDeck.Example_ModernPowerPointDeck(folderPath, false);
+            PowerPoint.FluentPowerPoint.Example_FluentPowerPoint(folderPath, false);
+            PowerPoint.ShapesPowerPoint.Example_PowerPointShapes(folderPath, false);
+            PowerPoint.SlidesManagementPowerPoint.Example_SlidesManagement(folderPath, false);
+            PowerPoint.SectionsWithoutRepairPowerPoint.Example_PowerPointSectionsWithoutRepair(folderPath, false);
+            PowerPoint.TablesPowerPoint.Example_PowerPointTables(folderPath, false);
+            PowerPoint.TextFormattingPowerPoint.Example_TextFormattingPowerPoint(folderPath, false);
+            PowerPoint.ThemeAndLayoutPowerPoint.Example_PowerPointThemeAndLayout(folderPath, false);
+            PowerPoint.TransitionsThemesPowerPoint.Example_TransitionsThemes(folderPath, false);
+            PowerPoint.UpdatePicturePowerPoint.Example_PowerPointUpdatePicture(folderPath, false);
+            PowerPoint.ValidateDocument.Example(folderPath, false);
+            PowerPoint.TestLazyInit.Example_TestLazyInit(folderPath, false);
+
+            ValidateGeneratedPowerPointDecks(folderPath, startedUtc);
+        }
+
+        private static void ValidateGeneratedPowerPointDecks(string folderPath, DateTime startedUtc) {
+            List<string> failures = new();
+            List<string> generatedFiles = Directory
+                .EnumerateFiles(folderPath, "*.pptx")
+                .Where(file => File.GetLastWriteTimeUtc(file) >= startedUtc)
+                .OrderBy(file => file, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            foreach (string filePath in generatedFiles) {
+                using global::OfficeIMO.PowerPoint.PowerPointPresentation presentation =
+                    global::OfficeIMO.PowerPoint.PowerPointPresentation.Open(filePath);
+                List<DocumentFormat.OpenXml.Validation.ValidationErrorInfo> errors =
+                    presentation.ValidateDocument().ToList();
+                if (errors.Count == 0) {
+                    continue;
+                }
+
+                string details = string.Join("; ", errors.Take(3).Select(error => error.Description));
+                failures.Add($"{Path.GetFileName(filePath)}: {errors.Count} validation error(s). {details}");
+            }
+
+            if (failures.Count > 0) {
+                throw new InvalidOperationException(
+                    "One or more PowerPoint examples generated invalid Open XML." +
+                    Environment.NewLine +
+                    string.Join(Environment.NewLine, failures));
+            }
+
+            Console.WriteLine($"    Validation: {generatedFiles.Count} generated PowerPoint deck(s) passed Open XML validation.");
+        }
+
         static void Main(string[] args) {
             string baseFolder = Path.TrimEndingDirectorySeparator(AppContext.BaseDirectory);
             Directory.SetCurrentDirectory(baseFolder);
             string templatesPath = Path.Combine(baseFolder, "Templates");
             string folderPath = Path.Combine(baseFolder, "Documents");
             Setup(folderPath);
-            if (Array.Exists(args, arg => string.Equals(arg, "--modern-powerpoint", StringComparison.OrdinalIgnoreCase))) {
+            if (HasArgument(args, "--modern-powerpoint")) {
                 PowerPoint.ModernPowerPointDeck.Example_ModernPowerPointDeck(folderPath, false);
+                return;
+            }
+
+            if (HasArgument(args, "--powerpoint")) {
+                RunPowerPointExamples(folderPath);
                 return;
             }
 

--- a/OfficeIMO.PowerPoint/PowerPointChart.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.cs
@@ -3536,9 +3536,20 @@ namespace OfficeIMO.PowerPoint {
 
         private static C.ChartShapeProperties EnsureChartShapeProperties(OpenXmlCompositeElement series) {
             C.ChartShapeProperties props = series.GetFirstChild<C.ChartShapeProperties>() ?? new C.ChartShapeProperties();
-            if (props.Parent == null) {
-                series.Append(props);
+            if (props.Parent != null) {
+                props.Remove();
             }
+
+            OpenXmlElement? insertAfter = series.GetFirstChild<C.SeriesText>();
+            insertAfter ??= series.GetFirstChild<C.Order>();
+            insertAfter ??= series.GetFirstChild<C.Index>();
+
+            if (insertAfter != null) {
+                series.InsertAfter(props, insertAfter);
+            } else {
+                series.PrependChild(props);
+            }
+
             return props;
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointChart.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.cs
@@ -330,27 +330,27 @@ namespace OfficeIMO.PowerPoint {
             }
 
             foreach (C.BarChart barChart in plotArea.Elements<C.BarChart>()) {
-                ReplaceChild(EnsureDataLabels(barChart), new C.DataLabelPosition { Val = position });
+                SetDataLabelPosition(EnsureDataLabels(barChart), position);
             }
 
             foreach (C.LineChart lineChart in plotArea.Elements<C.LineChart>()) {
-                ReplaceChild(EnsureDataLabels(lineChart), new C.DataLabelPosition { Val = position });
+                SetDataLabelPosition(EnsureDataLabels(lineChart), position);
             }
 
             foreach (C.AreaChart areaChart in plotArea.Elements<C.AreaChart>()) {
-                ReplaceChild(EnsureDataLabels(areaChart), new C.DataLabelPosition { Val = position });
+                SetDataLabelPosition(EnsureDataLabels(areaChart), position);
             }
 
             foreach (C.PieChart pieChart in plotArea.Elements<C.PieChart>()) {
-                ReplaceChild(EnsureDataLabels(pieChart), new C.DataLabelPosition { Val = position });
+                SetDataLabelPosition(EnsureDataLabels(pieChart), position);
             }
 
             foreach (C.DoughnutChart doughnutChart in plotArea.Elements<C.DoughnutChart>()) {
-                ReplaceChild(EnsureDataLabels(doughnutChart), new C.DataLabelPosition { Val = position });
+                SetDataLabelPosition(EnsureDataLabels(doughnutChart), position);
             }
 
             foreach (C.ScatterChart scatterChart in plotArea.Elements<C.ScatterChart>()) {
-                ReplaceChild(EnsureDataLabels(scatterChart), new C.DataLabelPosition { Val = position });
+                SetDataLabelPosition(EnsureDataLabels(scatterChart), position);
             }
 
             Save();
@@ -372,45 +372,27 @@ namespace OfficeIMO.PowerPoint {
             }
 
             foreach (C.BarChart barChart in plotArea.Elements<C.BarChart>()) {
-                ReplaceChild(EnsureDataLabels(barChart), new C.NumberingFormat {
-                    FormatCode = formatCode,
-                    SourceLinked = sourceLinked
-                });
+                SetDataLabelNumberFormat(EnsureDataLabels(barChart), formatCode, sourceLinked);
             }
 
             foreach (C.LineChart lineChart in plotArea.Elements<C.LineChart>()) {
-                ReplaceChild(EnsureDataLabels(lineChart), new C.NumberingFormat {
-                    FormatCode = formatCode,
-                    SourceLinked = sourceLinked
-                });
+                SetDataLabelNumberFormat(EnsureDataLabels(lineChart), formatCode, sourceLinked);
             }
 
             foreach (C.AreaChart areaChart in plotArea.Elements<C.AreaChart>()) {
-                ReplaceChild(EnsureDataLabels(areaChart), new C.NumberingFormat {
-                    FormatCode = formatCode,
-                    SourceLinked = sourceLinked
-                });
+                SetDataLabelNumberFormat(EnsureDataLabels(areaChart), formatCode, sourceLinked);
             }
 
             foreach (C.PieChart pieChart in plotArea.Elements<C.PieChart>()) {
-                ReplaceChild(EnsureDataLabels(pieChart), new C.NumberingFormat {
-                    FormatCode = formatCode,
-                    SourceLinked = sourceLinked
-                });
+                SetDataLabelNumberFormat(EnsureDataLabels(pieChart), formatCode, sourceLinked);
             }
 
             foreach (C.DoughnutChart doughnutChart in plotArea.Elements<C.DoughnutChart>()) {
-                ReplaceChild(EnsureDataLabels(doughnutChart), new C.NumberingFormat {
-                    FormatCode = formatCode,
-                    SourceLinked = sourceLinked
-                });
+                SetDataLabelNumberFormat(EnsureDataLabels(doughnutChart), formatCode, sourceLinked);
             }
 
             foreach (C.ScatterChart scatterChart in plotArea.Elements<C.ScatterChart>()) {
-                ReplaceChild(EnsureDataLabels(scatterChart), new C.NumberingFormat {
-                    FormatCode = formatCode,
-                    SourceLinked = sourceLinked
-                });
+                SetDataLabelNumberFormat(EnsureDataLabels(scatterChart), formatCode, sourceLinked);
             }
 
             Save();
@@ -2894,6 +2876,19 @@ namespace OfficeIMO.PowerPoint {
             ReplaceChild(labels, new C.ShowSeriesName { Val = showSeriesName });
             ReplaceChild(labels, new C.ShowPercent { Val = showPercent });
             ReplaceChild(labels, new C.ShowBubbleSize { Val = false });
+            NormalizeDataLabelsOrder(labels);
+        }
+
+        private static void SetDataLabelPosition(C.DataLabels labels, C.DataLabelPositionValues position) {
+            ReplaceChild(labels, new C.DataLabelPosition { Val = position });
+            NormalizeDataLabelsOrder(labels);
+        }
+
+        private static void SetDataLabelNumberFormat(C.DataLabels labels, string formatCode, bool sourceLinked) {
+            ReplaceChild(labels, new C.NumberingFormat {
+                FormatCode = formatCode,
+                SourceLinked = sourceLinked
+            });
             NormalizeDataLabelsOrder(labels);
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointChart.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.cs
@@ -342,11 +342,11 @@ namespace OfficeIMO.PowerPoint {
             }
 
             foreach (C.PieChart pieChart in plotArea.Elements<C.PieChart>()) {
-                SetDataLabelPosition(EnsureDataLabels(pieChart), position);
+                SetDataLabelPosition(EnsureDataLabels(pieChart), GetPowerPointCompatibleDataLabelPosition(pieChart, position));
             }
 
             foreach (C.DoughnutChart doughnutChart in plotArea.Elements<C.DoughnutChart>()) {
-                SetDataLabelPosition(EnsureDataLabels(doughnutChart), position);
+                SetDataLabelPosition(EnsureDataLabels(doughnutChart), GetPowerPointCompatibleDataLabelPosition(doughnutChart, position));
             }
 
             foreach (C.ScatterChart scatterChart in plotArea.Elements<C.ScatterChart>()) {
@@ -2879,9 +2879,23 @@ namespace OfficeIMO.PowerPoint {
             NormalizeDataLabelsOrder(labels);
         }
 
-        private static void SetDataLabelPosition(C.DataLabels labels, C.DataLabelPositionValues position) {
-            ReplaceChild(labels, new C.DataLabelPosition { Val = position });
+        private static void SetDataLabelPosition(C.DataLabels labels, C.DataLabelPositionValues? position) {
+            labels.GetFirstChild<C.DataLabelPosition>()?.Remove();
+            if (position != null) {
+                ReplaceChild(labels, new C.DataLabelPosition { Val = position.Value });
+            }
             NormalizeDataLabelsOrder(labels);
+        }
+
+        private static C.DataLabelPositionValues? GetPowerPointCompatibleDataLabelPosition(
+            OpenXmlElement chartElement,
+            C.DataLabelPositionValues position) {
+            if (chartElement is C.DoughnutChart && position == C.DataLabelPositionValues.BestFit) {
+                // PowerPoint repairs doughnut charts that explicitly serialize bestFit; omitting it keeps the default behavior.
+                return null;
+            }
+
+            return position;
         }
 
         private static void SetDataLabelNumberFormat(C.DataLabels labels, string formatCode, bool sourceLinked) {

--- a/OfficeIMO.PowerPoint/PowerPointLayoutBox.cs
+++ b/OfficeIMO.PowerPoint/PowerPointLayoutBox.cs
@@ -103,6 +103,16 @@ namespace OfficeIMO.PowerPoint {
         public double HeightCm => PowerPointUnits.ToCentimeters(Height);
 
         /// <summary>
+        ///     Right position in centimeters.
+        /// </summary>
+        public double RightCm => PowerPointUnits.ToCentimeters(Right);
+
+        /// <summary>
+        ///     Bottom position in centimeters.
+        /// </summary>
+        public double BottomCm => PowerPointUnits.ToCentimeters(Bottom);
+
+        /// <summary>
         ///     Left position in inches.
         /// </summary>
         public double LeftInches => PowerPointUnits.ToInches(Left);
@@ -123,6 +133,16 @@ namespace OfficeIMO.PowerPoint {
         public double HeightInches => PowerPointUnits.ToInches(Height);
 
         /// <summary>
+        ///     Right position in inches.
+        /// </summary>
+        public double RightInches => PowerPointUnits.ToInches(Right);
+
+        /// <summary>
+        ///     Bottom position in inches.
+        /// </summary>
+        public double BottomInches => PowerPointUnits.ToInches(Bottom);
+
+        /// <summary>
         ///     Left position in points.
         /// </summary>
         public double LeftPoints => PowerPointUnits.ToPoints(Left);
@@ -141,6 +161,16 @@ namespace OfficeIMO.PowerPoint {
         ///     Height in points.
         /// </summary>
         public double HeightPoints => PowerPointUnits.ToPoints(Height);
+
+        /// <summary>
+        ///     Right position in points.
+        /// </summary>
+        public double RightPoints => PowerPointUnits.ToPoints(Right);
+
+        /// <summary>
+        ///     Bottom position in points.
+        /// </summary>
+        public double BottomPoints => PowerPointUnits.ToPoints(Bottom);
 
         /// <summary>
         ///     Splits the layout box into equal columns (EMU units).
@@ -244,6 +274,64 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public PowerPointLayoutBox[] SplitRowsPoints(int rowCount, double gutterPoints) {
             return SplitRows(rowCount, PowerPointUnits.FromPoints(gutterPoints));
+        }
+
+        /// <summary>
+        ///     Splits the layout box into an equal row/column grid (EMU units).
+        /// </summary>
+        public PowerPointLayoutBox[,] SplitGrid(int rowCount, int columnCount, long rowGutterEmus, long columnGutterEmus) {
+            if (rowCount <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(rowCount));
+            }
+            if (columnCount <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(columnCount));
+            }
+            if (rowGutterEmus < 0) {
+                throw new ArgumentOutOfRangeException(nameof(rowGutterEmus));
+            }
+            if (columnGutterEmus < 0) {
+                throw new ArgumentOutOfRangeException(nameof(columnGutterEmus));
+            }
+
+            PowerPointLayoutBox[,] grid = new PowerPointLayoutBox[rowCount, columnCount];
+            PowerPointLayoutBox[] rows = SplitRows(rowCount, rowGutterEmus);
+            for (int row = 0; row < rowCount; row++) {
+                PowerPointLayoutBox[] columns = rows[row].SplitColumns(columnCount, columnGutterEmus);
+                for (int column = 0; column < columnCount; column++) {
+                    grid[row, column] = columns[column];
+                }
+            }
+
+            return grid;
+        }
+
+        /// <summary>
+        ///     Splits the layout box into an equal row/column grid in centimeters.
+        /// </summary>
+        public PowerPointLayoutBox[,] SplitGridCm(int rowCount, int columnCount, double rowGutterCm, double columnGutterCm) {
+            return SplitGrid(rowCount, columnCount,
+                PowerPointUnits.FromCentimeters(rowGutterCm),
+                PowerPointUnits.FromCentimeters(columnGutterCm));
+        }
+
+        /// <summary>
+        ///     Splits the layout box into an equal row/column grid in inches.
+        /// </summary>
+        public PowerPointLayoutBox[,] SplitGridInches(int rowCount, int columnCount, double rowGutterInches,
+            double columnGutterInches) {
+            return SplitGrid(rowCount, columnCount,
+                PowerPointUnits.FromInches(rowGutterInches),
+                PowerPointUnits.FromInches(columnGutterInches));
+        }
+
+        /// <summary>
+        ///     Splits the layout box into an equal row/column grid in points.
+        /// </summary>
+        public PowerPointLayoutBox[,] SplitGridPoints(int rowCount, int columnCount, double rowGutterPoints,
+            double columnGutterPoints) {
+            return SplitGrid(rowCount, columnCount,
+                PowerPointUnits.FromPoints(rowGutterPoints),
+                PowerPointUnits.FromPoints(columnGutterPoints));
         }
 
         /// <summary>

--- a/OfficeIMO.PowerPoint/PowerPointParagraph.cs
+++ b/OfficeIMO.PowerPoint/PowerPointParagraph.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Drawing;
 using DocumentFormat.OpenXml.Packaging;
 using A = DocumentFormat.OpenXml.Drawing;
@@ -412,7 +413,7 @@ namespace OfficeIMO.PowerPoint {
                 A.ParagraphProperties props = EnsureParagraphProperties();
                 props.RemoveAllChildren<A.BulletFont>();
                 if (!string.IsNullOrWhiteSpace(value)) {
-                    props.Append(new A.BulletFont { Typeface = value });
+                    InsertParagraphPropertyChild(props, new A.BulletFont { Typeface = value });
                 }
             }
         }
@@ -430,7 +431,7 @@ namespace OfficeIMO.PowerPoint {
                 props.RemoveAllChildren<A.BulletSizePoints>();
                 props.RemoveAllChildren<A.BulletSizePercentage>();
                 if (value != null) {
-                    props.Append(new A.BulletSizePoints { Val = value.Value * 100 });
+                    InsertParagraphPropertyChild(props, new A.BulletSizePoints { Val = value.Value * 100 });
                 }
             }
         }
@@ -448,7 +449,7 @@ namespace OfficeIMO.PowerPoint {
                 props.RemoveAllChildren<A.BulletSizePercentage>();
                 props.RemoveAllChildren<A.BulletSizePoints>();
                 if (value != null) {
-                    props.Append(new A.BulletSizePercentage { Val = value.Value * 1000 });
+                    InsertParagraphPropertyChild(props, new A.BulletSizePercentage { Val = value.Value * 1000 });
                 }
             }
         }
@@ -483,7 +484,7 @@ namespace OfficeIMO.PowerPoint {
         public void SetBullet(char bulletChar = '\u2022') {
             A.ParagraphProperties props = EnsureParagraphProperties();
             ClearBulletInternal(props);
-            props.Append(new A.CharacterBullet { Char = bulletChar.ToString() });
+            InsertParagraphPropertyChild(props, new A.CharacterBullet { Char = bulletChar.ToString() });
         }
 
         /// <summary>
@@ -492,7 +493,7 @@ namespace OfficeIMO.PowerPoint {
         public void SetNumbered(A.TextAutoNumberSchemeValues style, int startAt = 1) {
             A.ParagraphProperties props = EnsureParagraphProperties();
             ClearBulletInternal(props);
-            props.Append(new A.AutoNumberedBullet { Type = style, StartAt = startAt });
+            InsertParagraphPropertyChild(props, new A.AutoNumberedBullet { Type = style, StartAt = startAt });
         }
 
         /// <summary>
@@ -501,7 +502,7 @@ namespace OfficeIMO.PowerPoint {
         public void SetNumbered(A.TextAutoNumberSchemeValues style) {
             A.ParagraphProperties props = EnsureParagraphProperties();
             ClearBulletInternal(props);
-            props.Append(new A.AutoNumberedBullet { Type = style });
+            InsertParagraphPropertyChild(props, new A.AutoNumberedBullet { Type = style });
         }
 
         /// <summary>
@@ -517,7 +518,7 @@ namespace OfficeIMO.PowerPoint {
         public void ClearBullet() {
             A.ParagraphProperties props = EnsureParagraphProperties();
             ClearBulletInternal(props);
-            props.Append(new A.NoBullet());
+            InsertParagraphPropertyChild(props, new A.NoBullet());
         }
 
         private PowerPointTextRun GetDefaultRun() {
@@ -543,6 +544,40 @@ namespace OfficeIMO.PowerPoint {
             props.RemoveAllChildren<A.CharacterBullet>();
             props.RemoveAllChildren<A.AutoNumberedBullet>();
             props.RemoveAllChildren<A.NoBullet>();
+        }
+
+        private static void InsertParagraphPropertyChild(A.ParagraphProperties props, OpenXmlElement child) {
+            int childOrder = GetParagraphPropertyChildOrder(child);
+            OpenXmlElement? insertBefore = props.ChildElements
+                .FirstOrDefault(existing => GetParagraphPropertyChildOrder(existing) > childOrder);
+
+            if (insertBefore == null) {
+                props.Append(child);
+            } else {
+                props.InsertBefore(child, insertBefore);
+            }
+        }
+
+        private static int GetParagraphPropertyChildOrder(OpenXmlElement element) {
+            return element switch {
+                A.LineSpacing => 10,
+                A.SpaceBefore => 20,
+                A.SpaceAfter => 30,
+                A.BulletColorText => 40,
+                A.BulletColor => 50,
+                A.BulletSizeText => 60,
+                A.BulletSizePercentage => 70,
+                A.BulletSizePoints => 80,
+                A.BulletFontText => 90,
+                A.BulletFont => 100,
+                A.NoBullet => 110,
+                A.AutoNumberedBullet => 120,
+                A.CharacterBullet => 130,
+                A.TabStopList => 140,
+                A.DefaultRunProperties => 150,
+                A.ExtensionList => 160,
+                _ => 1000
+            };
         }
 
         private A.ParagraphProperties EnsureParagraphProperties() {

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -1680,25 +1680,38 @@ namespace OfficeIMO.PowerPoint {
 
         private static void SetThemeFont(OpenXmlCompositeElement parent, string? latin, string? eastAsian,
             string? complexScript, bool keepExistingWhenNull) {
-            SetThemeFontElement<A.LatinFont>(parent, latin, keepExistingWhenNull);
-            SetThemeFontElement<A.EastAsianFont>(parent, eastAsian, keepExistingWhenNull);
-            SetThemeFontElement<A.ComplexScriptFont>(parent, complexScript, keepExistingWhenNull);
+            string? resolvedLatin = ResolveThemeFontTypeface<A.LatinFont>(parent, latin, keepExistingWhenNull);
+            string? resolvedEastAsian =
+                ResolveThemeFontTypeface<A.EastAsianFont>(parent, eastAsian, keepExistingWhenNull);
+            string? resolvedComplexScript =
+                ResolveThemeFontTypeface<A.ComplexScriptFont>(parent, complexScript, keepExistingWhenNull);
+
+            parent.RemoveAllChildren<A.LatinFont>();
+            parent.RemoveAllChildren<A.EastAsianFont>();
+            parent.RemoveAllChildren<A.ComplexScriptFont>();
+
+            int insertIndex = 0;
+            if (resolvedLatin != null) {
+                parent.InsertAt(new A.LatinFont { Typeface = resolvedLatin }, insertIndex++);
+            }
+            if (resolvedEastAsian != null) {
+                parent.InsertAt(new A.EastAsianFont { Typeface = resolvedEastAsian }, insertIndex++);
+            }
+            if (resolvedComplexScript != null) {
+                parent.InsertAt(new A.ComplexScriptFont { Typeface = resolvedComplexScript }, insertIndex);
+            }
         }
 
-        private static void SetThemeFontElement<TFont>(OpenXmlCompositeElement parent, string? typeface,
-            bool keepExistingWhenNull) where TFont : A.TextFontType, new() {
+        private static string? ResolveThemeFontTypeface<TFont>(OpenXmlCompositeElement parent, string? typeface,
+            bool keepExistingWhenNull) where TFont : A.TextFontType {
             if (typeface == null) {
-                if (!keepExistingWhenNull) {
-                    parent.RemoveAllChildren<TFont>();
-                }
-                return;
+                return keepExistingWhenNull ? parent.GetFirstChild<TFont>()?.Typeface?.Value : null;
             }
             if (string.IsNullOrWhiteSpace(typeface)) {
                 throw new ArgumentException("Font name cannot be null or empty.", nameof(typeface));
             }
 
-            parent.RemoveAllChildren<TFont>();
-            parent.Append(new TFont { Typeface = typeface });
+            return typeface;
         }
 
         private static OpenXmlCompositeElement? GetColorElement(A.ColorScheme scheme, PowerPointThemeColor color) {

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -1680,11 +1680,11 @@ namespace OfficeIMO.PowerPoint {
 
         private static void SetThemeFont(OpenXmlCompositeElement parent, string? latin, string? eastAsian,
             string? complexScript, bool keepExistingWhenNull) {
-            string? resolvedLatin = ResolveThemeFontTypeface<A.LatinFont>(parent, latin, keepExistingWhenNull);
-            string? resolvedEastAsian =
-                ResolveThemeFontTypeface<A.EastAsianFont>(parent, eastAsian, keepExistingWhenNull);
-            string? resolvedComplexScript =
-                ResolveThemeFontTypeface<A.ComplexScriptFont>(parent, complexScript, keepExistingWhenNull);
+            A.LatinFont? resolvedLatin = ResolveThemeFont<A.LatinFont>(parent, latin, keepExistingWhenNull);
+            A.EastAsianFont? resolvedEastAsian =
+                ResolveThemeFont<A.EastAsianFont>(parent, eastAsian, keepExistingWhenNull);
+            A.ComplexScriptFont? resolvedComplexScript =
+                ResolveThemeFont<A.ComplexScriptFont>(parent, complexScript, keepExistingWhenNull);
 
             parent.RemoveAllChildren<A.LatinFont>();
             parent.RemoveAllChildren<A.EastAsianFont>();
@@ -1692,26 +1692,29 @@ namespace OfficeIMO.PowerPoint {
 
             int insertIndex = 0;
             if (resolvedLatin != null) {
-                parent.InsertAt(new A.LatinFont { Typeface = resolvedLatin }, insertIndex++);
+                parent.InsertAt(resolvedLatin, insertIndex++);
             }
             if (resolvedEastAsian != null) {
-                parent.InsertAt(new A.EastAsianFont { Typeface = resolvedEastAsian }, insertIndex++);
+                parent.InsertAt(resolvedEastAsian, insertIndex++);
             }
             if (resolvedComplexScript != null) {
-                parent.InsertAt(new A.ComplexScriptFont { Typeface = resolvedComplexScript }, insertIndex);
+                parent.InsertAt(resolvedComplexScript, insertIndex);
             }
         }
 
-        private static string? ResolveThemeFontTypeface<TFont>(OpenXmlCompositeElement parent, string? typeface,
-            bool keepExistingWhenNull) where TFont : A.TextFontType {
+        private static TFont? ResolveThemeFont<TFont>(OpenXmlCompositeElement parent, string? typeface,
+            bool keepExistingWhenNull) where TFont : A.TextFontType, new() {
+            TFont? existing = parent.GetFirstChild<TFont>()?.CloneNode(true) as TFont;
             if (typeface == null) {
-                return keepExistingWhenNull ? parent.GetFirstChild<TFont>()?.Typeface?.Value : null;
+                return keepExistingWhenNull ? existing : null;
             }
             if (string.IsNullOrWhiteSpace(typeface)) {
                 throw new ArgumentException("Font name cannot be null or empty.", nameof(typeface));
             }
 
-            return typeface;
+            TFont font = existing ?? new TFont();
+            font.Typeface = typeface;
+            return font;
         }
 
         private static OpenXmlCompositeElement? GetColorElement(A.ColorScheme scheme, PowerPointThemeColor color) {

--- a/OfficeIMO.PowerPoint/PowerPointShape.cs
+++ b/OfficeIMO.PowerPoint/PowerPointShape.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using DocumentFormat.OpenXml.Presentation;
 using A = DocumentFormat.OpenXml.Drawing;
 
@@ -52,7 +53,7 @@ namespace OfficeIMO.PowerPoint {
 
                 props.RemoveAllChildren<A.SolidFill>();
                 if (value != null) {
-                    props.Append(new A.SolidFill(new A.RgbColorModelHex { Val = value }));
+                    InsertShapePropertyChild(props, new A.SolidFill(new A.RgbColorModelHex { Val = value }));
                 }
             }
         }
@@ -815,7 +816,7 @@ namespace OfficeIMO.PowerPoint {
                         return;
                     }
                     solid = new A.SolidFill(new A.RgbColorModelHex { Val = "FFFFFF" });
-                    props.Append(solid);
+                    InsertShapePropertyChild(props, solid);
                 }
 
                 A.RgbColorModelHex? rgb = solid.RgbColorModelHex ?? new A.RgbColorModelHex { Val = "FFFFFF" };
@@ -980,7 +981,7 @@ namespace OfficeIMO.PowerPoint {
             A.Outline? outline = props.GetFirstChild<A.Outline>();
             if (outline == null && create) {
                 outline = new A.Outline();
-                props.Append(outline);
+                InsertShapePropertyChild(props, outline);
             }
 
             return outline;
@@ -995,7 +996,7 @@ namespace OfficeIMO.PowerPoint {
             A.EffectList? effectList = props.GetFirstChild<A.EffectList>();
             if (effectList == null && create) {
                 effectList = new A.EffectList();
-                props.Append(effectList);
+                InsertShapePropertyChild(props, effectList);
             }
 
             return effectList;
@@ -1010,7 +1011,7 @@ namespace OfficeIMO.PowerPoint {
             A.OuterShadow? shadow = effects.GetFirstChild<A.OuterShadow>();
             if (shadow == null && create) {
                 shadow = new A.OuterShadow();
-                effects.Append(shadow);
+                InsertEffectChild(effects, shadow);
             }
 
             return shadow;
@@ -1025,7 +1026,7 @@ namespace OfficeIMO.PowerPoint {
             A.Blur? blur = effects.GetFirstChild<A.Blur>();
             if (blur == null && create) {
                 blur = new A.Blur();
-                effects.Append(blur);
+                InsertEffectChild(effects, blur);
             }
 
             return blur;
@@ -1040,7 +1041,7 @@ namespace OfficeIMO.PowerPoint {
             A.Reflection? reflection = effects.GetFirstChild<A.Reflection>();
             if (reflection == null && create) {
                 reflection = new A.Reflection();
-                effects.Append(reflection);
+                InsertEffectChild(effects, reflection);
             }
 
             return reflection;
@@ -1055,7 +1056,7 @@ namespace OfficeIMO.PowerPoint {
             A.Glow? glow = effects.GetFirstChild<A.Glow>();
             if (glow == null && create) {
                 glow = new A.Glow();
-                effects.Append(glow);
+                InsertEffectChild(effects, glow);
             }
 
             return glow;
@@ -1070,10 +1071,66 @@ namespace OfficeIMO.PowerPoint {
             A.SoftEdge? softEdge = effects.GetFirstChild<A.SoftEdge>();
             if (softEdge == null && create) {
                 softEdge = new A.SoftEdge();
-                effects.Append(softEdge);
+                InsertEffectChild(effects, softEdge);
             }
 
             return softEdge;
+        }
+
+        private static void InsertShapePropertyChild(ShapeProperties properties, OpenXmlElement child) {
+            int childOrder = GetShapePropertyChildOrder(child);
+            OpenXmlElement? insertBefore = properties.ChildElements
+                .FirstOrDefault(existing => GetShapePropertyChildOrder(existing) > childOrder);
+
+            if (insertBefore != null) {
+                properties.InsertBefore(child, insertBefore);
+            } else {
+                properties.Append(child);
+            }
+        }
+
+        private static int GetShapePropertyChildOrder(OpenXmlElement child) {
+            return child switch {
+                A.Transform2D => 0,
+                A.CustomGeometry => 1,
+                A.PresetGeometry => 1,
+                A.NoFill => 2,
+                A.SolidFill => 2,
+                A.GradientFill => 2,
+                A.BlipFill => 2,
+                A.PatternFill => 2,
+                A.GroupFill => 2,
+                A.Outline => 3,
+                A.EffectList => 4,
+                A.EffectDag => 4,
+                _ => 100
+            };
+        }
+
+        private static void InsertEffectChild(A.EffectList effects, OpenXmlElement child) {
+            int childOrder = GetEffectChildOrder(child);
+            OpenXmlElement? insertBefore = effects.ChildElements
+                .FirstOrDefault(existing => GetEffectChildOrder(existing) > childOrder);
+
+            if (insertBefore != null) {
+                effects.InsertBefore(child, insertBefore);
+            } else {
+                effects.Append(child);
+            }
+        }
+
+        private static int GetEffectChildOrder(OpenXmlElement child) {
+            return child switch {
+                A.Blur => 0,
+                A.FillOverlay => 1,
+                A.Glow => 2,
+                A.InnerShadow => 3,
+                A.OuterShadow => 4,
+                A.PresetShadow => 5,
+                A.Reflection => 6,
+                A.SoftEdge => 7,
+                _ => 100
+            };
         }
 
         private static void RemoveShadowColors(A.OuterShadow shadow) {

--- a/OfficeIMO.PowerPoint/PowerPointShape.cs
+++ b/OfficeIMO.PowerPoint/PowerPointShape.cs
@@ -494,8 +494,8 @@ namespace OfficeIMO.PowerPoint {
                     return;
                 }
 
-                outline.RemoveAllChildren<A.SolidFill>();
-                outline.Append(new A.SolidFill(new A.RgbColorModelHex { Val = value }));
+                RemoveOutlineFillChildren(outline);
+                InsertOutlineChild(outline, new A.SolidFill(new A.RgbColorModelHex { Val = value }));
             }
         }
 
@@ -545,7 +545,7 @@ namespace OfficeIMO.PowerPoint {
                 A.PresetDash dash = outline.GetFirstChild<A.PresetDash>() ?? new A.PresetDash();
                 dash.Val = value.Value;
                 if (dash.Parent == null) {
-                    outline.Append(dash);
+                    InsertOutlineChild(outline, dash);
                 }
             }
         }
@@ -1107,6 +1107,38 @@ namespace OfficeIMO.PowerPoint {
             };
         }
 
+        private static void InsertOutlineChild(A.Outline outline, OpenXmlElement child) {
+            int childOrder = GetOutlineChildOrder(child);
+            OpenXmlElement? insertBefore = outline.ChildElements
+                .FirstOrDefault(existing => GetOutlineChildOrder(existing) > childOrder);
+
+            if (insertBefore != null) {
+                outline.InsertBefore(child, insertBefore);
+            } else {
+                outline.Append(child);
+            }
+        }
+
+        private static int GetOutlineChildOrder(OpenXmlElement child) {
+            return child switch {
+                A.NoFill => 0,
+                A.SolidFill => 0,
+                A.GradientFill => 0,
+                A.PatternFill => 0,
+                A.PresetDash => 1,
+                A.HeadEnd => 3,
+                A.TailEnd => 4,
+                _ => 100
+            };
+        }
+
+        private static void RemoveOutlineFillChildren(A.Outline outline) {
+            outline.RemoveAllChildren<A.NoFill>();
+            outline.RemoveAllChildren<A.SolidFill>();
+            outline.RemoveAllChildren<A.GradientFill>();
+            outline.RemoveAllChildren<A.PatternFill>();
+        }
+
         private static void InsertEffectChild(A.EffectList effects, OpenXmlElement child) {
             int childOrder = GetEffectChildOrder(child);
             OpenXmlElement? insertBefore = effects.ChildElements
@@ -1181,7 +1213,7 @@ namespace OfficeIMO.PowerPoint {
                     head.Length = length.Value;
                 }
                 if (head.Parent == null) {
-                    outline.Append(head);
+                    InsertOutlineChild(outline, head);
                 }
             } else {
                 A.TailEnd? tail = outline.GetFirstChild<A.TailEnd>();
@@ -1199,7 +1231,7 @@ namespace OfficeIMO.PowerPoint {
                     tail.Length = length.Value;
                 }
                 if (tail.Parent == null) {
-                    outline.Append(tail);
+                    InsertOutlineChild(outline, tail);
                 }
             }
         }

--- a/OfficeIMO.PowerPoint/PowerPointShape.cs
+++ b/OfficeIMO.PowerPoint/PowerPointShape.cs
@@ -1126,6 +1126,10 @@ namespace OfficeIMO.PowerPoint {
                 A.GradientFill => 0,
                 A.PatternFill => 0,
                 A.PresetDash => 1,
+                A.CustomDash => 1,
+                A.Round => 2,
+                A.Bevel => 2,
+                A.Miter => 2,
                 A.HeadEnd => 3,
                 A.TailEnd => 4,
                 _ => 100

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Grid.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Grid.cs
@@ -253,15 +253,7 @@ namespace OfficeIMO.PowerPoint {
 
         private static PowerPointLayoutBox[,] BuildGrid(PowerPointLayoutBox bounds, int columns, int rows,
             long gutterX, long gutterY) {
-            PowerPointLayoutBox[,] grid = new PowerPointLayoutBox[rows, columns];
-            PowerPointLayoutBox[] rowBoxes = bounds.SplitRows(rows, gutterY);
-            for (int r = 0; r < rows; r++) {
-                PowerPointLayoutBox[] colBoxes = rowBoxes[r].SplitColumns(columns, gutterX);
-                for (int c = 0; c < columns; c++) {
-                    grid[r, c] = colBoxes[c];
-                }
-            }
-            return grid;
+            return bounds.SplitGrid(rows, columns, gutterY, gutterX);
         }
 
         private static int GetAutoGridColumns(int count, PowerPointLayoutBox bounds, long gutterX, long gutterY,

--- a/OfficeIMO.PowerPoint/PowerPointSlide.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.cs
@@ -368,23 +368,20 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public bool Hidden {
             get {
-                SlideId slideId = GetSlideId();
-                OpenXmlAttribute? showAttribute = slideId.GetAttributes()
-                    .FirstOrDefault(attribute =>
-                        attribute.LocalName == "show" && string.IsNullOrEmpty(attribute.NamespaceUri));
-                if (showAttribute == null || string.IsNullOrEmpty(showAttribute.Value.Value)) {
-                    return false;
+                if (SlideRoot.Show?.Value != null) {
+                    return SlideRoot.Show.Value == false;
                 }
 
-                return string.Equals(showAttribute.Value.Value, "0", StringComparison.Ordinal) ||
-                       string.Equals(showAttribute.Value.Value, "false", StringComparison.OrdinalIgnoreCase);
+                return IsHiddenShowValue(GetLegacySlideIdShowValue(GetSlideId()));
             }
             set {
                 SlideId slideId = GetSlideId();
+                slideId.RemoveAttribute("show", string.Empty);
+
                 if (value) {
-                    slideId.SetAttribute(new OpenXmlAttribute("show", string.Empty, "0"));
+                    SlideRoot.Show = false;
                 } else {
-                    slideId.RemoveAttribute("show", string.Empty);
+                    SlideRoot.Show = null;
                 }
             }
         }
@@ -563,6 +560,32 @@ namespace OfficeIMO.PowerPoint {
             }
 
             return slideId;
+        }
+
+        private static string? GetLegacySlideIdShowValue(SlideId slideId) {
+            return slideId.GetAttributes()
+                .FirstOrDefault(attribute =>
+                    attribute.LocalName == "show" && string.IsNullOrEmpty(attribute.NamespaceUri))
+                .Value;
+        }
+
+        private static bool IsHiddenShowValue(string? showValue) {
+            if (string.IsNullOrEmpty(showValue)) {
+                return false;
+            }
+
+            return string.Equals(showValue, "0", StringComparison.Ordinal) ||
+                   string.Equals(showValue, "false", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void NormalizeHiddenSlideMarkup() {
+            SlideId slideId = GetSlideId();
+            string? legacyShowValue = GetLegacySlideIdShowValue(slideId);
+            if (SlideRoot.Show?.Value == null && IsHiddenShowValue(legacyShowValue)) {
+                SlideRoot.Show = false;
+            }
+
+            slideId.RemoveAttribute("show", string.Empty);
         }
 
         /// <summary>
@@ -865,6 +888,7 @@ namespace OfficeIMO.PowerPoint {
         }
 
         internal void Save() {
+            NormalizeHiddenSlideMarkup();
             SlideRoot.Save();
             _notes?.Save();
         }

--- a/OfficeIMO.PowerPoint/PowerPointSlide.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.cs
@@ -369,7 +369,7 @@ namespace OfficeIMO.PowerPoint {
         public bool Hidden {
             get {
                 if (SlideRoot.Show?.Value != null) {
-                    return SlideRoot.Show.Value == false;
+                    return !SlideRoot.Show.Value;
                 }
 
                 return IsHiddenShowValue(GetLegacySlideIdShowValue(GetSlideId()));

--- a/OfficeIMO.PowerPoint/PowerPointUtils.PresentationParts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.PresentationParts.cs
@@ -165,7 +165,7 @@ namespace OfficeIMO.PowerPoint {
                 presentationPart.TryGetPartById(relationshipId, out OpenXmlPart? part) &&
                 part is SlidePart slidePart &&
                 slidePart.Slide?.Show?.Value != null) {
-                return slidePart.Slide.Show.Value == false;
+                return !slidePart.Slide.Show.Value;
             }
 
             string? legacyShowValue = slideId.GetAttributes()

--- a/OfficeIMO.PowerPoint/PowerPointUtils.PresentationParts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointUtils.PresentationParts.cs
@@ -147,7 +147,8 @@ namespace OfficeIMO.PowerPoint {
             properties.Slides.Text = slideIds.Length.ToString(CultureInfo.InvariantCulture);
             properties.Notes.Text = presentationPart.SlideParts.Count(slidePart => slidePart.NotesSlidePart != null)
                 .ToString(CultureInfo.InvariantCulture);
-            properties.HiddenSlides.Text = slideIds.Count(IsHiddenSlide).ToString(CultureInfo.InvariantCulture);
+            properties.HiddenSlides.Text = slideIds.Count(slideId => IsHiddenSlide(presentationPart, slideId))
+                .ToString(CultureInfo.InvariantCulture);
             properties.PresentationFormat.Text = GetPresentationFormat(presentationPart.Presentation?.SlideSize);
 
             var packageProperties = presentationDocument.PackageProperties;
@@ -158,17 +159,25 @@ namespace OfficeIMO.PowerPoint {
             packageProperties.Modified = DateTime.UtcNow;
         }
 
-        private static bool IsHiddenSlide(SlideId slideId) {
-            string? showValue = slideId.GetAttributes()
+        private static bool IsHiddenSlide(PresentationPart presentationPart, SlideId slideId) {
+            string? relationshipId = slideId.RelationshipId?.Value;
+            if (relationshipId is { Length: > 0 } &&
+                presentationPart.TryGetPartById(relationshipId, out OpenXmlPart? part) &&
+                part is SlidePart slidePart &&
+                slidePart.Slide?.Show?.Value != null) {
+                return slidePart.Slide.Show.Value == false;
+            }
+
+            string? legacyShowValue = slideId.GetAttributes()
                 .FirstOrDefault(attribute =>
                     attribute.LocalName == "show" && string.IsNullOrEmpty(attribute.NamespaceUri))
                 .Value;
-            if (string.IsNullOrEmpty(showValue)) {
+            if (string.IsNullOrEmpty(legacyShowValue)) {
                 return false;
             }
 
-            return string.Equals(showValue, "0", StringComparison.Ordinal) ||
-                   string.Equals(showValue, "false", StringComparison.OrdinalIgnoreCase);
+            return string.Equals(legacyShowValue, "0", StringComparison.Ordinal) ||
+                   string.Equals(legacyShowValue, "false", StringComparison.OrdinalIgnoreCase);
         }
 
         private static string GetPresentationFormat(SlideSize? slideSize) {

--- a/OfficeIMO.PowerPoint/README.md
+++ b/OfficeIMO.PowerPoint/README.md
@@ -12,6 +12,18 @@ OfficeIMO.PowerPoint focuses on creating and editing .pptx presentations with Op
 
 See `OfficeIMO.Examples` for runnable samples. This README hosts PowerPoint‑specific usage and notes.
 
+## Runnable modern deck sample
+
+To generate the richer validation sample deck with theme colors, theme fonts, background image, transitions, shape effects,
+charts, a table, and speaker notes:
+
+```powershell
+dotnet run --project OfficeIMO.Examples/OfficeIMO.Examples.csproj -f net10.0 -- --modern-powerpoint
+```
+
+The sample writes `Modern PowerPoint Deck.pptx` to the examples `Documents` output folder and validates the generated Open
+XML package before reporting success.
+
 ## Install
 
 ```powershell

--- a/OfficeIMO.PowerPoint/README.md
+++ b/OfficeIMO.PowerPoint/README.md
@@ -24,6 +24,12 @@ dotnet run --project OfficeIMO.Examples/OfficeIMO.Examples.csproj -f net10.0 -- 
 The sample writes `Modern PowerPoint Deck.pptx` to the examples `Documents` output folder and validates the generated Open
 XML package before reporting success.
 
+To run the full PowerPoint examples set without opening PowerPoint and validate every generated deck:
+
+```powershell
+dotnet run --project OfficeIMO.Examples/OfficeIMO.Examples.csproj -f net10.0 -- --powerpoint
+```
+
 ## Install
 
 ```powershell

--- a/OfficeIMO.Tests/PowerPoint.AdvancedFeatures.cs
+++ b/OfficeIMO.Tests/PowerPoint.AdvancedFeatures.cs
@@ -119,6 +119,60 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void TransitionBackgroundAndNotesMutationsValidatePackage() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string imagePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", "BackgroundImage.png");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    slide.SetBackgroundImage(imagePath);
+                    slide.Transition = SlideTransition.Morph;
+                    slide.Notes.Text = "Initial morph notes";
+
+                    slide.Transition = SlideTransition.Flash;
+                    slide.BackgroundColor = "112233";
+                    slide.Notes.Text = "Updated notes";
+
+                    PowerPointSlide cleared = presentation.AddSlide();
+                    cleared.Transition = SlideTransition.Morph;
+                    cleared.Transition = SlideTransition.None;
+                    cleared.SetBackgroundImage(imagePath);
+                    cleared.ClearBackgroundImage();
+                    cleared.Notes.Text = "Cleared transition notes";
+
+                    presentation.Save();
+                    Assert.Empty(presentation.ValidateDocument());
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                    Assert.Equal(SlideTransition.Flash, presentation.Slides[0].Transition);
+                    Assert.Equal("112233", presentation.Slides[0].BackgroundColor);
+                    Assert.Equal("Updated notes", presentation.Slides[0].Notes.Text);
+                    Assert.Equal(SlideTransition.None, presentation.Slides[1].Transition);
+                    Assert.Equal("Cleared transition notes", presentation.Slides[1].Notes.Text);
+                    Assert.Empty(presentation.ValidateDocument());
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    OpenXmlValidator validator = new(FileFormatVersions.Microsoft365);
+                    Assert.Empty(validator.Validate(document));
+
+                    SlidePart[] slideParts = document.PresentationPart!.SlideParts.ToArray();
+                    Assert.DoesNotContain("AlternateContent", slideParts[0].Slide.OuterXml, StringComparison.Ordinal);
+                    Assert.Contains("flash", slideParts[0].Slide.OuterXml, StringComparison.OrdinalIgnoreCase);
+                    Assert.DoesNotContain("AlternateContent", slideParts[1].Slide.OuterXml, StringComparison.Ordinal);
+                    Assert.Null(slideParts[1].Slide.Transition);
+                    Assert.Empty(slideParts[1].ImageParts);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
         public void CanAddMultipleChartsWithUniqueAxisIds() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
 

--- a/OfficeIMO.Tests/PowerPoint.AdvancedFeatures.cs
+++ b/OfficeIMO.Tests/PowerPoint.AdvancedFeatures.cs
@@ -120,9 +120,9 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void TransitionBackgroundAndNotesMutationsValidatePackage() {
-            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
-            string imagesDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images");
-            string imagePath = Path.Combine(imagesDirectory, "BackgroundImage.png");
+            string filePath = CreateTempFilePath(".pptx");
+            string imagesDirectory = AppendPathSegment(AppDomain.CurrentDomain.BaseDirectory, "Images");
+            string imagePath = AppendPathSegment(imagesDirectory, "BackgroundImage.png");
 
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
@@ -455,6 +455,18 @@ namespace OfficeIMO.Tests {
             }
 
             return builder.ToString();
+        }
+
+        private static string CreateTempFilePath(string extension) {
+            string path = Path.GetTempFileName();
+            File.Delete(path);
+            return Path.ChangeExtension(path, extension);
+        }
+
+        private static string AppendPathSegment(string directoryPath, string childName) {
+            string normalizedDirectory = Path.GetFullPath(directoryPath)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            return normalizedDirectory + Path.DirectorySeparatorChar + childName;
         }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.AdvancedFeatures.cs
+++ b/OfficeIMO.Tests/PowerPoint.AdvancedFeatures.cs
@@ -120,8 +120,9 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void TransitionBackgroundAndNotesMutationsValidatePackage() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
-            string imagePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images", "BackgroundImage.png");
+            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
+            string imagesDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Images");
+            string imagePath = Path.Combine(imagesDirectory, "BackgroundImage.png");
 
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {

--- a/OfficeIMO.Tests/PowerPoint.ChartAxisFormat.cs
+++ b/OfficeIMO.Tests/PowerPoint.ChartAxisFormat.cs
@@ -1102,7 +1102,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void CombinedAxisMutationsValidateChartParts() {
-            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
+            string filePath = CreateTempFilePath(".pptx");
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
                     PowerPointSlide barSlide = presentation.AddSlide();
@@ -1169,6 +1169,12 @@ namespace OfficeIMO.Tests {
                     File.Delete(filePath);
                 }
             }
+        }
+
+        private static string CreateTempFilePath(string extension) {
+            string path = Path.GetTempFileName();
+            File.Delete(path);
+            return Path.ChangeExtension(path, extension);
         }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.ChartAxisFormat.cs
+++ b/OfficeIMO.Tests/PowerPoint.ChartAxisFormat.cs
@@ -1099,5 +1099,76 @@ namespace OfficeIMO.Tests {
                 }
             }
         }
+
+        [Fact]
+        public void CombinedAxisMutationsValidateChartParts() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide barSlide = presentation.AddSlide();
+                    PowerPointChart barChart = barSlide.AddChart();
+                    barChart.SetTitle("Axis Stress")
+                        .SetCategoryAxisTitle("Quarter")
+                        .SetCategoryAxisTitleTextStyle(fontSizePoints: 11, bold: true, color: "1F4E79", fontName: "Calibri")
+                        .SetCategoryAxisNumberFormat("0")
+                        .SetCategoryAxisLabelRotation(35)
+                        .SetCategoryAxisTickLabelPosition(C.TickLabelPositionValues.High)
+                        .SetCategoryAxisGridlines(showMajor: true, showMinor: false, lineColor: "D9D9D9", lineWidthPoints: 0.5)
+                        .SetCategoryAxisReverseOrder()
+                        .SetCategoryAxisCrossing(C.CrossesValues.Minimum)
+                        .SetValueAxisTitle("Revenue")
+                        .SetValueAxisTitleTextStyle(fontSizePoints: 10, italic: true, color: "C55A11", fontName: "Arial")
+                        .SetValueAxisNumberFormat("#,##0.00")
+                        .SetValueAxisLabelTextStyle(fontSizePoints: 10, color: "404040", fontName: "Aptos")
+                        .SetValueAxisGridlines(showMajor: true, showMinor: true, lineColor: "C0C0C0", lineWidthPoints: 0.75)
+                        .SetValueAxisScale(minimum: 0, maximum: 100, majorUnit: 25, minorUnit: 5)
+                        .SetValueAxisCrossing(C.CrossesValues.Maximum)
+                        .SetValueAxisCrossBetween(C.CrossBetweenValues.Between)
+                        .SetValueAxisDisplayUnits(C.BuiltInUnitValues.Thousands, "Thousands USD", showLabel: true);
+
+                    PowerPointSlide scatterSlide = presentation.AddSlide();
+                    PowerPointChart scatterChart = scatterSlide.AddScatterChart();
+                    scatterChart.SetScatterXAxisTitle("Month")
+                        .SetScatterXAxisTitleTextStyle(fontSizePoints: 11, bold: true, color: "1F4E79", fontName: "Calibri")
+                        .SetScatterXAxisNumberFormat("0.0")
+                        .SetScatterXAxisLabelTextStyle(fontSizePoints: 9, color: "404040", fontName: "Aptos")
+                        .SetScatterXAxisLabelRotation(45)
+                        .SetScatterXAxisTickLabelPosition(C.TickLabelPositionValues.Low)
+                        .SetScatterXAxisGridlines(showMajor: true, showMinor: false, lineColor: "D9D9D9", lineWidthPoints: 0.5)
+                        .SetScatterXAxisScale(minimum: 1, maximum: 10, majorUnit: 1)
+                        .SetScatterXAxisCrossing(C.CrossesValues.AutoZero, crossesAt: 2d)
+                        .SetScatterXAxisDisplayUnits(C.BuiltInUnitValues.Hundreds, "Hundreds X", showLabel: true)
+                        .SetScatterYAxisTitle("Revenue")
+                        .SetScatterYAxisTitleTextStyle(fontSizePoints: 10, italic: true, color: "C55A11", fontName: "Arial")
+                        .SetScatterYAxisNumberFormat("#,##0.00")
+                        .SetScatterYAxisLabelTextStyle(fontSizePoints: 10, color: "1F4E79", fontName: "Aptos")
+                        .SetScatterYAxisLabelRotation(-30)
+                        .SetScatterYAxisTickLabelPosition(C.TickLabelPositionValues.High)
+                        .SetScatterYAxisGridlines(showMajor: true, showMinor: true, lineColor: "C0C0C0", lineWidthPoints: 0.75)
+                        .SetScatterYAxisScale(minimum: 0, maximum: 6, majorUnit: 1)
+                        .SetScatterYAxisCrossing(crossesAt: 3d)
+                        .SetScatterYAxisDisplayUnits(1000d, "Thousands Y", showLabel: true);
+
+                    presentation.Save();
+                    Assert.Empty(presentation.ValidateDocument());
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    OpenXmlValidator validator = new OpenXmlValidator(FileFormatVersions.Microsoft365);
+                    ChartPart[] chartParts = document.PresentationPart!.SlideParts
+                        .SelectMany(slidePart => slidePart.ChartParts)
+                        .ToArray();
+
+                    Assert.Equal(2, chartParts.Length);
+                    foreach (ChartPart chartPart in chartParts) {
+                        Assert.Empty(validator.Validate(chartPart.ChartSpace));
+                    }
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.ChartAxisFormat.cs
+++ b/OfficeIMO.Tests/PowerPoint.ChartAxisFormat.cs
@@ -1102,7 +1102,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void CombinedAxisMutationsValidateChartParts() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
                     PowerPointSlide barSlide = presentation.AddSlide();

--- a/OfficeIMO.Tests/PowerPoint.ChartCreationParity.cs
+++ b/OfficeIMO.Tests/PowerPoint.ChartCreationParity.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
 using OfficeIMO.PowerPoint;
 using Xunit;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
@@ -42,6 +43,9 @@ namespace OfficeIMO.Tests {
 
                 using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
                     ChartPart chartPart = document.PresentationPart!.SlideParts.First().ChartParts.First();
+                    OpenXmlValidator validator = new OpenXmlValidator();
+                    Assert.Empty(validator.Validate(chartPart.ChartSpace!));
+
                     C.Chart chart = chartPart.ChartSpace!.GetFirstChild<C.Chart>()!;
                     C.PlotArea plotArea = chart.PlotArea!;
 
@@ -118,6 +122,9 @@ namespace OfficeIMO.Tests {
 
                 using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
                     ChartPart chartPart = document.PresentationPart!.SlideParts.First().ChartParts.First();
+                    OpenXmlValidator validator = new OpenXmlValidator();
+                    Assert.Empty(validator.Validate(chartPart.ChartSpace!));
+
                     C.Chart chart = chartPart.ChartSpace!.GetFirstChild<C.Chart>()!;
                     C.PlotArea plotArea = chart.PlotArea!;
 
@@ -202,6 +209,9 @@ namespace OfficeIMO.Tests {
 
                 using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
                     ChartPart chartPart = document.PresentationPart!.SlideParts.First().ChartParts.First();
+                    OpenXmlValidator validator = new OpenXmlValidator();
+                    Assert.Empty(validator.Validate(chartPart.ChartSpace!));
+
                     C.Chart chart = chartPart.ChartSpace!.GetFirstChild<C.Chart>()!;
                     C.PlotArea plotArea = chart.PlotArea!;
 

--- a/OfficeIMO.Tests/PowerPoint.ChartCreationParity.cs
+++ b/OfficeIMO.Tests/PowerPoint.ChartCreationParity.cs
@@ -81,8 +81,12 @@ namespace OfficeIMO.Tests {
                         .GetFirstChild<C.ShowPercent>()?
                         .Val?.Value;
                     Assert.True(showPercent);
-                    Assert.Equal(C.DataLabelPositionValues.BestFit,
-                        chartElement.GetFirstChild<C.DataLabels>()?.GetFirstChild<C.DataLabelPosition>()?.Val?.Value);
+                    C.DataLabelPosition? labelPosition = chartElement.GetFirstChild<C.DataLabels>()?.GetFirstChild<C.DataLabelPosition>();
+                    if (doughnut) {
+                        Assert.Null(labelPosition);
+                    } else {
+                        Assert.Equal(C.DataLabelPositionValues.BestFit, labelPosition?.Val?.Value);
+                    }
                     Assert.Equal("0.0%",
                         chartElement.GetFirstChild<C.DataLabels>()?.GetFirstChild<C.NumberingFormat>()?.FormatCode?.Value);
 

--- a/OfficeIMO.Tests/PowerPoint.ChartFormatting.cs
+++ b/OfficeIMO.Tests/PowerPoint.ChartFormatting.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
 using OfficeIMO.PowerPoint;
@@ -125,7 +126,7 @@ namespace OfficeIMO.Tests {
                         new[] { new PowerPointChartSeries("Share", new[] { 42d, 27d, 31d }) });
                     PowerPointChart chart = slide.AddDoughnutChart(data);
                     chart.SetDataLabels(showPercent: true)
-                        .SetDataLabelPosition(C.DataLabelPositionValues.BestFit);
+                        .SetDataLabelPosition(C.DataLabelPositionValues.OutsideEnd);
 
                     presentation.Save();
                     Assert.Empty(presentation.ValidateDocument());
@@ -145,6 +146,45 @@ namespace OfficeIMO.Tests {
                     int positionIndex = labelChildren.FindIndex(child => child is C.DataLabelPosition);
                     int showPercentIndex = labelChildren.FindIndex(child => child is C.ShowPercent);
                     Assert.True(positionIndex < showPercentIndex);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DoughnutBestFitDataLabelPositionIsOmittedForPowerPointCompatibility() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    PowerPointChartData data = new(
+                        new[] { "Direct", "Partner", "Online" },
+                        new[] { new PowerPointChartSeries("Share", new[] { 42d, 27d, 31d }) });
+                    PowerPointChart chart = slide.AddDoughnutChart(data);
+                    chart.SetDataLabels(showPercent: true)
+                        .SetDataLabelPosition(C.DataLabelPositionValues.OutsideEnd)
+                        .SetDataLabelPosition(C.DataLabelPositionValues.BestFit);
+
+                    presentation.Save();
+                    Assert.Empty(presentation.ValidateDocument());
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    ChartPart chartPart = document.PresentationPart!.SlideParts.First().ChartParts.First();
+                    OpenXmlValidator validator = new OpenXmlValidator(FileFormatVersions.Microsoft365);
+                    Assert.Empty(validator.Validate(chartPart.ChartSpace));
+
+                    C.DataLabels labels = chartPart.ChartSpace.GetFirstChild<C.Chart>()!
+                        .GetFirstChild<C.PlotArea>()!
+                        .GetFirstChild<C.DoughnutChart>()!
+                        .GetFirstChild<C.DataLabels>()!;
+
+                    Assert.Null(labels.GetFirstChild<C.DataLabelPosition>());
+                    Assert.True(labels.GetFirstChild<C.ShowPercent>()?.Val?.Value);
                 }
             } finally {
                 if (File.Exists(filePath)) {

--- a/OfficeIMO.Tests/PowerPoint.ChartFormatting.cs
+++ b/OfficeIMO.Tests/PowerPoint.ChartFormatting.cs
@@ -116,7 +116,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void ChartLevelDataLabelPositionValidatesAfterLabelFlags() {
-            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
+            string filePath = CreateTempFilePath(".pptx");
 
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
@@ -156,7 +156,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DoughnutBestFitDataLabelPositionIsOmittedForPowerPointCompatibility() {
-            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
+            string filePath = CreateTempFilePath(".pptx");
 
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
@@ -1141,6 +1141,12 @@ namespace OfficeIMO.Tests {
                     File.Delete(filePath);
                 }
             }
+        }
+
+        private static string CreateTempFilePath(string extension) {
+            string path = Path.GetTempFileName();
+            File.Delete(path);
+            return Path.ChangeExtension(path, extension);
         }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.ChartFormatting.cs
+++ b/OfficeIMO.Tests/PowerPoint.ChartFormatting.cs
@@ -77,6 +77,12 @@ namespace OfficeIMO.Tests {
                     Assert.Equal(C.DataLabelPositionValues.OutsideEnd, dataLabels?.GetFirstChild<C.DataLabelPosition>()?.Val?.Value);
                     Assert.Equal("#,##0.0", dataLabels?.GetFirstChild<C.NumberingFormat>()?.FormatCode?.Value);
                     Assert.False(dataLabels?.GetFirstChild<C.NumberingFormat>()?.SourceLinked?.Value);
+                    var labelChildren = dataLabels!.ChildElements.ToList();
+                    int positionIndex = labelChildren.FindIndex(child => child is C.DataLabelPosition);
+                    int numberFormatIndex = labelChildren.FindIndex(child => child is C.NumberingFormat);
+                    int showValueIndex = labelChildren.FindIndex(child => child is C.ShowValue);
+                    Assert.True(numberFormatIndex < positionIndex);
+                    Assert.True(positionIndex < showValueIndex);
 
                     string? categoryTitle = chart.PlotArea!
                         .GetFirstChild<C.CategoryAxis>()?
@@ -99,6 +105,46 @@ namespace OfficeIMO.Tests {
                         .GetFirstChild<A.Text>()?
                         .Text;
                     Assert.Equal("Revenue", valueTitle);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void ChartLevelDataLabelPositionValidatesAfterLabelFlags() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    PowerPointChartData data = new(
+                        new[] { "Direct", "Partner", "Online" },
+                        new[] { new PowerPointChartSeries("Share", new[] { 42d, 27d, 31d }) });
+                    PowerPointChart chart = slide.AddDoughnutChart(data);
+                    chart.SetDataLabels(showPercent: true)
+                        .SetDataLabelPosition(C.DataLabelPositionValues.BestFit);
+
+                    presentation.Save();
+                    Assert.Empty(presentation.ValidateDocument());
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    ChartPart chartPart = document.PresentationPart!.SlideParts.First().ChartParts.First();
+                    OpenXmlValidator validator = new OpenXmlValidator();
+                    Assert.Empty(validator.Validate(chartPart.ChartSpace));
+
+                    C.DataLabels labels = chartPart.ChartSpace.GetFirstChild<C.Chart>()!
+                        .GetFirstChild<C.PlotArea>()!
+                        .GetFirstChild<C.DoughnutChart>()!
+                        .GetFirstChild<C.DataLabels>()!;
+
+                    var labelChildren = labels.ChildElements.ToList();
+                    int positionIndex = labelChildren.FindIndex(child => child is C.DataLabelPosition);
+                    int showPercentIndex = labelChildren.FindIndex(child => child is C.ShowPercent);
+                    Assert.True(positionIndex < showPercentIndex);
                 }
             } finally {
                 if (File.Exists(filePath)) {

--- a/OfficeIMO.Tests/PowerPoint.ChartFormatting.cs
+++ b/OfficeIMO.Tests/PowerPoint.ChartFormatting.cs
@@ -116,7 +116,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void ChartLevelDataLabelPositionValidatesAfterLabelFlags() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
 
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
@@ -156,7 +156,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DoughnutBestFitDataLabelPositionIsOmittedForPowerPointCompatibility() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
 
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {

--- a/OfficeIMO.Tests/PowerPoint.FunctionalSmokeTests.cs
+++ b/OfficeIMO.Tests/PowerPoint.FunctionalSmokeTests.cs
@@ -9,6 +9,7 @@ using DocumentFormat.OpenXml.Validation;
 using OfficeIMO.PowerPoint;
 using Xunit;
 using A = DocumentFormat.OpenXml.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
 using PptImagePartType = OfficeIMO.PowerPoint.ImagePartType;
 
 namespace OfficeIMO.Tests {
@@ -83,6 +84,141 @@ namespace OfficeIMO.Tests {
             } finally {
                 if (File.Exists(filePath)) {
                     File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanBuildModernThemeDeckAndValidate() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string backgroundPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".png");
+
+            try {
+                File.WriteAllBytes(backgroundPath, OnePixelPng);
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+                    presentation.ThemeName = "OfficeIMO Modern Smoke";
+                    presentation.SetThemeColorsForAllMasters(new Dictionary<PowerPointThemeColor, string> {
+                        [PowerPointThemeColor.Dark1] = "161411",
+                        [PowerPointThemeColor.Light1] = "F8F5EF",
+                        [PowerPointThemeColor.Dark2] = "253746",
+                        [PowerPointThemeColor.Light2] = "EFE8DA",
+                        [PowerPointThemeColor.Accent1] = "156082",
+                        [PowerPointThemeColor.Accent2] = "F26A3D",
+                        [PowerPointThemeColor.Accent3] = "8CB369",
+                        [PowerPointThemeColor.Accent4] = "6B6EA8",
+                        [PowerPointThemeColor.Accent5] = "D6A84F",
+                        [PowerPointThemeColor.Accent6] = "6C8EAD"
+                    });
+                    presentation.SetThemeFontsForAllMasters(new PowerPointThemeFontSet(
+                        majorLatin: "Aptos Display",
+                        minorLatin: "Aptos",
+                        majorEastAsian: "Yu Gothic",
+                        minorEastAsian: "Yu Gothic",
+                        majorComplexScript: "Arial",
+                        minorComplexScript: "Arial"));
+
+                    PowerPointSlide cover = presentation.AddSlide(SlideLayoutValues.TitleOnly);
+                    cover.BackgroundColor = "F8F5EF";
+                    cover.Transition = SlideTransition.Morph;
+                    PowerPointTextBox title = cover.AddTitle("Commercial Snapshot",
+                        new PowerPointLayoutBox(PowerPointUnits.Cm(1.4), PowerPointUnits.Cm(1.0),
+                            PowerPointUnits.Cm(18.0), PowerPointUnits.Cm(1.2)));
+                    title.FontSize = 32;
+                    title.Color = "161411";
+
+                    PowerPointAutoShape hero = cover.AddRectangleCm(1.4, 3.0, 16.0, 3.0, "Hero Card");
+                    hero.FillColor = "156082";
+                    hero.FillTransparency = 8;
+                    hero.OutlineColor = "156082";
+                    hero.SetShadow("000000", blurPoints: 10, distancePoints: 4, angleDegrees: 90, transparencyPercent: 70);
+
+                    PowerPointTextBox insight = cover.AddTextBox("A clean, generated deck with theme colors, font scheme, background, effects, chart, and table.",
+                        new PowerPointLayoutBox(PowerPointUnits.Cm(2.0), PowerPointUnits.Cm(3.6),
+                            PowerPointUnits.Cm(14.8), PowerPointUnits.Cm(1.3)));
+                    insight.FontSize = 18;
+                    insight.Color = "FFFFFF";
+
+                    PowerPointAutoShape accent = cover.AddEllipseCm(17.8, 0.7, 2.5, 2.5, "Glow Accent");
+                    accent.FillColor = "F26A3D";
+                    accent.FillTransparency = 18;
+                    accent.OutlineColor = "F26A3D";
+                    accent.SetGlow("F26A3D", radiusPoints: 8, transparencyPercent: 30);
+
+                    PowerPointSlide dashboard = presentation.AddSlide(SlideLayoutValues.Blank);
+                    dashboard.SetBackgroundImage(backgroundPath);
+                    dashboard.Transition = SlideTransition.Fade;
+
+                    PowerPointAutoShape panel = dashboard.AddRectangleCm(0.9, 0.7, 24.0, 12.0, "Dashboard Surface");
+                    panel.FillColor = "F8F5EF";
+                    panel.FillTransparency = 3;
+                    panel.OutlineColor = "EFE8DA";
+                    panel.SetSoftEdges(1.5);
+
+                    PowerPointChartData data = new(
+                        new[] { "Jan", "Feb", "Mar", "Apr" },
+                        new[] {
+                            new PowerPointChartSeries("Revenue", new[] { 12d, 18d, 21d, 28d }),
+                            new PowerPointChartSeries("Profit", new[] { 4d, 7d, 9d, 13d })
+                        });
+                    PowerPointChart chart = dashboard.AddLineChartCm(data, 1.4, 1.3, 14.5, 7.0);
+                    chart.SetTitle("Momentum Over Time");
+                    chart.SetLegend(C.LegendPositionValues.Bottom);
+                    chart.SetChartAreaStyle(fillColor: "FFFFFF", lineColor: "EFE8DA");
+                    chart.SetPlotAreaStyle(fillColor: "FFFFFF", lineColor: "FFFFFF");
+                    chart.SetSeriesLineColor("Revenue", "156082", widthPoints: 2.5);
+                    chart.SetSeriesLineColor("Profit", "F26A3D", widthPoints: 2.5);
+                    chart.SetValueAxisGridlines(showMajor: true, lineColor: "D8D5CC", lineWidthPoints: 0.75);
+
+                    PowerPointTable table = dashboard.AddTable(rows: 3, columns: 2,
+                        styleName: presentation.TableStyles.First().Name,
+                        left: PowerPointUnits.Cm(16.8), top: PowerPointUnits.Cm(1.5),
+                        width: PowerPointUnits.Cm(7.0), height: PowerPointUnits.Cm(3.8),
+                        firstRow: true, bandedRows: true);
+                    table.GetCell(0, 0).Text = "Metric";
+                    table.GetCell(0, 1).Text = "Value";
+                    table.GetCell(1, 0).Text = "Revenue";
+                    table.GetCell(1, 1).Text = "28";
+                    table.GetCell(2, 0).Text = "Profit";
+                    table.GetCell(2, 1).Text = "13";
+
+                    PowerPointAutoShape callout = dashboard.AddRectangleCm(16.8, 6.1, 7.0, 3.1, "Observation Card");
+                    callout.FillColor = "EFE8DA";
+                    callout.FillTransparency = 0;
+                    callout.OutlineColor = "6B6EA8";
+                    callout.OutlineWidthPoints = 1.2;
+                    callout.SetReflection(blurPoints: 2, distancePoints: 1, startOpacityPercent: 20, endOpacityPercent: 0);
+
+                    PowerPointTextBox calloutText = dashboard.AddTextBox("Observation\nThe revenue trend stays healthy through Q2.",
+                        new PowerPointLayoutBox(PowerPointUnits.Cm(17.3), PowerPointUnits.Cm(6.5),
+                            PowerPointUnits.Cm(6.0), PowerPointUnits.Cm(2.2)));
+                    calloutText.FontSize = 16;
+                    calloutText.Color = "161411";
+
+                    dashboard.Notes.Text = "Modern deck smoke test validates theme, background, effects, chart and table.";
+                    presentation.Save();
+                    var packageErrors = presentation.ValidateDocument().ToList();
+                    Assert.True(packageErrors.Count == 0, FormatValidationErrors(packageErrors));
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    var validator = new OpenXmlValidator(FileFormatVersions.Microsoft365);
+                    var errors = validator.Validate(document).ToList();
+                    Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+
+                    PresentationPart part = document.PresentationPart!;
+                    Assert.Contains(part.SlideParts, slidePart => slidePart.ImageParts.Any());
+                    Assert.Contains(part.SlideParts, slidePart => slidePart.ChartParts.Any());
+                    Assert.Contains(part.SlideMasterParts, master =>
+                        master.ThemePart?.Theme?.Name?.Value == "OfficeIMO Modern Smoke");
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+                if (File.Exists(backgroundPath)) {
+                    File.Delete(backgroundPath);
                 }
             }
         }

--- a/OfficeIMO.Tests/PowerPoint.FunctionalSmokeTests.cs
+++ b/OfficeIMO.Tests/PowerPoint.FunctionalSmokeTests.cs
@@ -19,7 +19,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void CanBuildRichDeckAndValidate() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
                     presentation.SetThemeColorForAllMasters(PowerPointThemeColor.Accent1, "4472C4");
@@ -90,8 +90,8 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void CanBuildModernThemeDeckAndValidate() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
-            string backgroundPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".png");
+            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
+            string backgroundPath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".png"));
 
             try {
                 File.WriteAllBytes(backgroundPath, OnePixelPng);

--- a/OfficeIMO.Tests/PowerPoint.FunctionalSmokeTests.cs
+++ b/OfficeIMO.Tests/PowerPoint.FunctionalSmokeTests.cs
@@ -19,7 +19,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void CanBuildRichDeckAndValidate() {
-            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
+            string filePath = CreateTempFilePath(".pptx");
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
                     presentation.SetThemeColorForAllMasters(PowerPointThemeColor.Accent1, "4472C4");
@@ -90,8 +90,8 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void CanBuildModernThemeDeckAndValidate() {
-            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
-            string backgroundPath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".png"));
+            string filePath = CreateTempFilePath(".pptx");
+            string backgroundPath = CreateTempFilePath(".png");
 
             try {
                 File.WriteAllBytes(backgroundPath, OnePixelPng);
@@ -231,6 +231,12 @@ namespace OfficeIMO.Tests {
                     $"ErrorType: {error.ErrorType}\n" +
                     $"Part: {error.Part?.Uri}\n" +
                     $"Path: {error.Path?.XPath}"));
+        }
+
+        private static string CreateTempFilePath(string extension) {
+            string path = Path.GetTempFileName();
+            File.Delete(path);
+            return Path.ChangeExtension(path, extension);
         }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.LayoutThemeHelpers.cs
+++ b/OfficeIMO.Tests/PowerPoint.LayoutThemeHelpers.cs
@@ -63,7 +63,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void SetThemeLatinFontsPreservesExistingScriptFontAttributes() {
-            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
+            string filePath = CreateTempFilePath(".pptx");
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
                     presentation.SetThemeFonts(new PowerPointThemeFontSet(
@@ -179,6 +179,12 @@ namespace OfficeIMO.Tests {
                     File.Delete(filePath);
                 }
             }
+        }
+
+        private static string CreateTempFilePath(string extension) {
+            string path = Path.GetTempFileName();
+            File.Delete(path);
+            return Path.ChangeExtension(path, extension);
         }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.LayoutThemeHelpers.cs
+++ b/OfficeIMO.Tests/PowerPoint.LayoutThemeHelpers.cs
@@ -62,6 +62,66 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SetThemeLatinFontsPreservesExistingScriptFontAttributes() {
+            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.SetThemeFonts(new PowerPointThemeFontSet(
+                        majorLatin: "Major Latin",
+                        minorLatin: "Minor Latin",
+                        majorEastAsian: "Major East Asian",
+                        minorEastAsian: "Minor East Asian",
+                        majorComplexScript: "Major Complex",
+                        minorComplexScript: "Minor Complex"));
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, true)) {
+                    SlideMasterPart master = document.PresentationPart!.SlideMasterParts.First();
+                    A.FontScheme fontScheme = master.ThemePart!.Theme!.ThemeElements!.FontScheme!;
+                    A.EastAsianFont eastAsian = fontScheme.MajorFont!.EastAsianFont!;
+                    eastAsian.Panose = "020B0604020202020204";
+                    eastAsian.PitchFamily = 34;
+                    eastAsian.CharacterSet = 0;
+
+                    A.ComplexScriptFont complexScript = fontScheme.MajorFont.ComplexScriptFont!;
+                    complexScript.Panose = "020B0604020202020205";
+                    complexScript.PitchFamily = 18;
+                    complexScript.CharacterSet = 1;
+                    master.ThemePart.Theme.Save();
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                    presentation.SetThemeLatinFonts("Updated Major Latin", "Updated Minor Latin");
+                    presentation.Save();
+                    Assert.Empty(presentation.ValidateDocument());
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    SlideMasterPart master = document.PresentationPart!.SlideMasterParts.First();
+                    A.FontScheme fontScheme = master.ThemePart!.Theme!.ThemeElements!.FontScheme!;
+
+                    Assert.Equal("Updated Major Latin", fontScheme.MajorFont!.LatinFont!.Typeface);
+                    A.EastAsianFont eastAsian = fontScheme.MajorFont.EastAsianFont!;
+                    Assert.Equal("Major East Asian", eastAsian.Typeface);
+                    Assert.Equal("020B0604020202020204", eastAsian.Panose);
+                    Assert.Equal(34, eastAsian.PitchFamily);
+                    Assert.Equal(0, eastAsian.CharacterSet);
+
+                    A.ComplexScriptFont complexScript = fontScheme.MajorFont.ComplexScriptFont!;
+                    Assert.Equal("Major Complex", complexScript.Typeface);
+                    Assert.Equal("020B0604020202020205", complexScript.Panose);
+                    Assert.Equal(18, complexScript.PitchFamily);
+                    Assert.Equal(1, complexScript.CharacterSet);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
         public void DefaultThemeColors_IncludeSystemColorBackedEntries() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
             try {

--- a/OfficeIMO.Tests/PowerPoint.LayoutThemeHelpers.cs
+++ b/OfficeIMO.Tests/PowerPoint.LayoutThemeHelpers.cs
@@ -94,6 +94,7 @@ namespace OfficeIMO.Tests {
                         majorComplexScript: "Arial",
                         minorComplexScript: "Tahoma"));
                     presentation.Save();
+                    Assert.Empty(presentation.ValidateDocument());
                 }
 
                 using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
@@ -106,6 +107,12 @@ namespace OfficeIMO.Tests {
                     Assert.Equal("Yu Gothic", fontScheme.MinorFont?.EastAsianFont?.Typeface);
                     Assert.Equal("Arial", fontScheme.MajorFont?.ComplexScriptFont?.Typeface);
                     Assert.Equal("Tahoma", fontScheme.MinorFont?.ComplexScriptFont?.Typeface);
+                    Assert.IsType<A.LatinFont>(fontScheme.MajorFont!.ChildElements[0]);
+                    Assert.IsType<A.EastAsianFont>(fontScheme.MajorFont.ChildElements[1]);
+                    Assert.IsType<A.ComplexScriptFont>(fontScheme.MajorFont.ChildElements[2]);
+                    Assert.IsType<A.LatinFont>(fontScheme.MinorFont!.ChildElements[0]);
+                    Assert.IsType<A.EastAsianFont>(fontScheme.MinorFont.ChildElements[1]);
+                    Assert.IsType<A.ComplexScriptFont>(fontScheme.MinorFont.ChildElements[2]);
                 }
             } finally {
                 if (File.Exists(filePath)) {

--- a/OfficeIMO.Tests/PowerPoint.ShapeEffects.cs
+++ b/OfficeIMO.Tests/PowerPoint.ShapeEffects.cs
@@ -163,7 +163,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void ShapePropertiesStayInSchemaOrderWhenStylingAfterEffects() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempFilePath(".pptx");
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
                     PowerPointSlide slide = presentation.AddSlide();
@@ -217,6 +217,12 @@ namespace OfficeIMO.Tests {
                     File.Delete(filePath);
                 }
             }
+        }
+
+        private static string CreateTempFilePath(string extension) {
+            string path = Path.GetTempFileName();
+            File.Delete(path);
+            return Path.ChangeExtension(path, extension);
         }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.ShapeEffects.cs
+++ b/OfficeIMO.Tests/PowerPoint.ShapeEffects.cs
@@ -160,5 +160,63 @@ namespace OfficeIMO.Tests {
                 }
             }
         }
+
+        [Fact]
+        public void ShapePropertiesStayInSchemaOrderWhenStylingAfterEffects() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    PowerPointAutoShape shape = slide.AddRectangle(0, 0, 4000, 2000, "StyledAfterEffects");
+
+                    shape.SetSoftEdges(2);
+                    shape.SetReflection(blurPoints: 2, distancePoints: 1, startOpacityPercent: 20);
+                    shape.SetShadow("000000", blurPoints: 6, distancePoints: 3, transparencyPercent: 55);
+                    shape.SetGlow("F26A3D", radiusPoints: 3, transparencyPercent: 30);
+                    shape.FillColor = "EFE8DA";
+                    shape.FillTransparency = 8;
+                    shape.OutlineColor = "6B6EA8";
+                    shape.OutlineWidthPoints = 1.2;
+
+                    presentation.Save();
+                    Assert.Empty(presentation.ValidateDocument());
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    SlidePart slidePart = document.PresentationPart!.SlideParts.First();
+                    Shape shape = slidePart.Slide.CommonSlideData!.ShapeTree!.Elements<Shape>()
+                        .First(xmlShape => xmlShape.NonVisualShapeProperties?.NonVisualDrawingProperties?.Name?.Value == "StyledAfterEffects");
+
+                    var shapePropertyChildren = shape.ShapeProperties!.ChildElements.ToList();
+                    int fillIndex = shapePropertyChildren.FindIndex(child => child is A.SolidFill);
+                    int outlineIndex = shapePropertyChildren.FindIndex(child => child is A.Outline);
+                    int effectsIndex = shapePropertyChildren.FindIndex(child => child is A.EffectList);
+
+                    Assert.True(fillIndex >= 0);
+                    Assert.True(outlineIndex >= 0);
+                    Assert.True(effectsIndex >= 0);
+                    Assert.True(fillIndex < outlineIndex);
+                    Assert.True(outlineIndex < effectsIndex);
+
+                    var effectChildren = shape.ShapeProperties.GetFirstChild<A.EffectList>()!.ChildElements.ToList();
+                    int glowIndex = effectChildren.FindIndex(child => child is A.Glow);
+                    int shadowIndex = effectChildren.FindIndex(child => child is A.OuterShadow);
+                    int reflectionIndex = effectChildren.FindIndex(child => child is A.Reflection);
+                    int softEdgeIndex = effectChildren.FindIndex(child => child is A.SoftEdge);
+
+                    Assert.True(glowIndex >= 0);
+                    Assert.True(shadowIndex >= 0);
+                    Assert.True(reflectionIndex >= 0);
+                    Assert.True(softEdgeIndex >= 0);
+                    Assert.True(glowIndex < shadowIndex);
+                    Assert.True(shadowIndex < reflectionIndex);
+                    Assert.True(reflectionIndex < softEdgeIndex);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.ShapeGrid.cs
+++ b/OfficeIMO.Tests/PowerPoint.ShapeGrid.cs
@@ -68,6 +68,29 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SplitGrid_ReturnsAlignedCellsWithIndependentGutters() {
+            PowerPointLayoutBox bounds = new(100, 200, 6300, 4400);
+
+            PowerPointLayoutBox[,] grid = bounds.SplitGrid(2, 3, rowGutterEmus: 400, columnGutterEmus: 300);
+
+            Assert.Equal(2, grid.GetLength(0));
+            Assert.Equal(3, grid.GetLength(1));
+
+            Assert.Equal(100, grid[0, 0].Left);
+            Assert.Equal(200, grid[0, 0].Top);
+            Assert.Equal(1900, grid[0, 0].Width);
+            Assert.Equal(2000, grid[0, 0].Height);
+
+            Assert.Equal(2300, grid[0, 1].Left);
+            Assert.Equal(4500, grid[0, 2].Left);
+            Assert.Equal(2600, grid[1, 0].Top);
+            Assert.Equal(grid[0, 1].Width, grid[1, 1].Width);
+            Assert.Equal(grid[0, 1].Height, grid[1, 2].Height);
+            Assert.Equal(PowerPointUnits.ToCentimeters(grid[0, 0].Right), grid[0, 0].RightCm);
+            Assert.Equal(PowerPointUnits.ToCentimeters(grid[0, 0].Bottom), grid[0, 0].BottomCm);
+        }
+
+        [Fact]
         public void ArrangeShapesInGrid_DoesNotResizeWhenDisabled() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
             try {

--- a/OfficeIMO.Tests/PowerPoint.ShapeLineStyles.cs
+++ b/OfficeIMO.Tests/PowerPoint.ShapeLineStyles.cs
@@ -49,7 +49,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void LineEndsStayAfterExistingLineJoinNodes() {
-            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
+            string filePath = CreateTempFilePath(".pptx");
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
                     PowerPointSlide slide = presentation.AddSlide();
@@ -101,7 +101,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void OutlineChildrenStayInSchemaOrderWhenStylingAfterArrowheads() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempFilePath(".pptx");
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
                     PowerPointSlide slide = presentation.AddSlide();
@@ -144,6 +144,12 @@ namespace OfficeIMO.Tests {
                     File.Delete(filePath);
                 }
             }
+        }
+
+        private static string CreateTempFilePath(string extension) {
+            string path = Path.GetTempFileName();
+            File.Delete(path);
+            return Path.ChangeExtension(path, extension);
         }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.ShapeLineStyles.cs
+++ b/OfficeIMO.Tests/PowerPoint.ShapeLineStyles.cs
@@ -48,6 +48,58 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void LineEndsStayAfterExistingLineJoinNodes() {
+            string filePath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".pptx"));
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    PowerPointAutoShape line = slide.AddLine(0, 0, 4000, 0, "JoinedArrowLine");
+                    line.OutlineColor = "156082";
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, true)) {
+                    SlidePart slidePart = document.PresentationPart!.SlideParts.First();
+                    Shape lineShape = slidePart.Slide.CommonSlideData!.ShapeTree!
+                        .Elements<Shape>()
+                        .First(shape => shape.NonVisualShapeProperties?.NonVisualDrawingProperties?.Name?.Value == "JoinedArrowLine");
+                    A.Outline outline = lineShape.ShapeProperties!.GetFirstChild<A.Outline>()!;
+                    outline.Append(new A.Round());
+                    slidePart.Slide.Save();
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                    PowerPointShape line = presentation.Slides[0].GetShape("JoinedArrowLine")!;
+                    line.SetLineEnds(null, A.LineEndValues.Triangle, A.LineEndWidthValues.Medium, A.LineEndLengthValues.Medium);
+                    presentation.Save();
+                    Assert.Empty(presentation.ValidateDocument());
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    OpenXmlValidator validator = new(FileFormatVersions.Microsoft365);
+                    Assert.Empty(validator.Validate(document));
+
+                    SlidePart slidePart = document.PresentationPart!.SlideParts.First();
+                    Shape lineShape = slidePart.Slide.CommonSlideData!.ShapeTree!
+                        .Elements<Shape>()
+                        .First(shape => shape.NonVisualShapeProperties?.NonVisualDrawingProperties?.Name?.Value == "JoinedArrowLine");
+                    A.Outline outline = lineShape.ShapeProperties!.GetFirstChild<A.Outline>()!;
+                    var children = outline.ChildElements.ToList();
+                    int roundIndex = children.FindIndex(child => child is A.Round);
+                    int headIndex = children.FindIndex(child => child is A.HeadEnd);
+
+                    Assert.True(roundIndex >= 0);
+                    Assert.True(headIndex >= 0);
+                    Assert.True(roundIndex < headIndex);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
         public void OutlineChildrenStayInSchemaOrderWhenStylingAfterArrowheads() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
             try {

--- a/OfficeIMO.Tests/PowerPoint.ShapeLineStyles.cs
+++ b/OfficeIMO.Tests/PowerPoint.ShapeLineStyles.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
 using System.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
+using DocumentFormat.OpenXml.Validation;
 using OfficeIMO.PowerPoint;
 using Xunit;
 using A = DocumentFormat.OpenXml.Drawing;
@@ -37,6 +39,53 @@ namespace OfficeIMO.Tests {
                     Assert.Equal(A.LineEndValues.Stealth, tail?.Type?.Value);
                     Assert.Equal(A.LineEndWidthValues.Medium, head?.Width?.Value);
                     Assert.Equal(A.LineEndLengthValues.Medium, head?.Length?.Value);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void OutlineChildrenStayInSchemaOrderWhenStylingAfterArrowheads() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    PowerPointAutoShape line = slide.AddLine(0, 0, 4000, 0, "ReverseStyledArrowLine");
+
+                    line.SetLineEnds(A.LineEndValues.Triangle, A.LineEndValues.Stealth, A.LineEndWidthValues.Medium, A.LineEndLengthValues.Medium);
+                    line.OutlineColor = "156082";
+                    line.OutlineDash = A.PresetLineDashValues.DashDot;
+
+                    presentation.Save();
+                    Assert.Empty(presentation.ValidateDocument());
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    OpenXmlValidator validator = new(FileFormatVersions.Microsoft365);
+                    Assert.Empty(validator.Validate(document));
+
+                    SlidePart slidePart = document.PresentationPart!.SlideParts.First();
+                    Shape lineShape = slidePart.Slide.CommonSlideData!.ShapeTree!
+                        .Elements<Shape>()
+                        .First(shape => shape.NonVisualShapeProperties?.NonVisualDrawingProperties?.Name?.Value == "ReverseStyledArrowLine");
+
+                    A.Outline outline = lineShape.ShapeProperties!.GetFirstChild<A.Outline>()!;
+                    var children = outline.ChildElements.ToList();
+                    int fillIndex = children.FindIndex(child => child is A.SolidFill);
+                    int dashIndex = children.FindIndex(child => child is A.PresetDash);
+                    int headIndex = children.FindIndex(child => child is A.HeadEnd);
+                    int tailIndex = children.FindIndex(child => child is A.TailEnd);
+
+                    Assert.True(fillIndex >= 0);
+                    Assert.True(dashIndex >= 0);
+                    Assert.True(headIndex >= 0);
+                    Assert.True(tailIndex >= 0);
+                    Assert.True(fillIndex < dashIndex);
+                    Assert.True(dashIndex < headIndex);
+                    Assert.True(headIndex < tailIndex);
                 }
             } finally {
                 if (File.Exists(filePath)) {

--- a/OfficeIMO.Tests/PowerPoint.SlidesManagement.cs
+++ b/OfficeIMO.Tests/PowerPoint.SlidesManagement.cs
@@ -215,7 +215,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void HiddenSlideUsesSlideShowAttributeAndValidates() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempFilePath(".pptx");
 
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
@@ -309,6 +309,12 @@ namespace OfficeIMO.Tests {
                     File.Delete(targetPath);
                 }
             }
+        }
+
+        private static string CreateTempFilePath(string extension) {
+            string path = Path.GetTempFileName();
+            File.Delete(path);
+            return Path.ChangeExtension(path, extension);
         }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.SlidesManagement.cs
+++ b/OfficeIMO.Tests/PowerPoint.SlidesManagement.cs
@@ -134,6 +134,7 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Speaker notes", duplicate.Notes.Text);
 
                 presentation.Save();
+                Assert.Empty(presentation.ValidateDocument());
             }
 
             using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
@@ -184,6 +185,7 @@ namespace OfficeIMO.Tests {
                 sourceSlide.Notes.Text = "Imported notes";
                 sourceSlide.Hidden = true;
                 source.Save();
+                Assert.Empty(source.ValidateDocument());
 
                 using (PowerPointPresentation target = PowerPointPresentation.Create(targetPath)) {
                     PowerPointSlide imported = target.ImportSlide(source, 0);
@@ -195,6 +197,7 @@ namespace OfficeIMO.Tests {
                     Assert.Equal("Imported notes", imported.Notes.Text);
 
                     target.Save();
+                    Assert.Empty(target.ValidateDocument());
                 }
             }
 
@@ -208,6 +211,45 @@ namespace OfficeIMO.Tests {
 
             File.Delete(sourcePath);
             File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void HiddenSlideUsesSlideShowAttributeAndValidates() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.AddSlide().AddTextBox("Visible slide");
+                    PowerPointSlide hiddenSlide = presentation.AddSlide();
+                    hiddenSlide.AddTextBox("Hidden slide");
+                    hiddenSlide.Hide();
+
+                    presentation.Save();
+                    Assert.Empty(presentation.ValidateDocument());
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    OpenXmlValidator validator = new();
+                    Assert.Empty(validator.Validate(document));
+
+                    PresentationPart presentationPart = document.PresentationPart!;
+                    SlideId hiddenSlideId = presentationPart.Presentation!.SlideIdList!.Elements<SlideId>().Last();
+                    Assert.DoesNotContain(hiddenSlideId.GetAttributes(),
+                        attribute => attribute.LocalName == "show" && string.IsNullOrEmpty(attribute.NamespaceUri));
+
+                    SlidePart hiddenSlidePart = (SlidePart)presentationPart.GetPartById(hiddenSlideId.RelationshipId!);
+                    Assert.False(hiddenSlidePart.Slide!.Show!.Value);
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                    Assert.False(presentation.Slides[0].Hidden);
+                    Assert.True(presentation.Slides[1].Hidden);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
         }
 
         [Fact]

--- a/OfficeIMO.Tests/PowerPoint.Tables.cs
+++ b/OfficeIMO.Tests/PowerPoint.Tables.cs
@@ -4,7 +4,9 @@ using System.IO;
 
 using System.Linq;
 
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
 using A = DocumentFormat.OpenXml.Drawing;
 using OfficeIMO.PowerPoint;
 
@@ -308,6 +310,71 @@ namespace OfficeIMO.Tests {
             }
 
             File.Delete(filePath);
+        }
+
+        [Fact]
+        public void CombinedTableMutationsValidatePackage() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                var data = new[] {
+                    new SalesRow("Alpha", 12, 15),
+                    new SalesRow("Beta", 9, 11)
+                };
+
+                var columns = new[] {
+                    PowerPointTableColumn<SalesRow>.Create("Product", row => row.Product),
+                    PowerPointTableColumn<SalesRow>.Create("Q1", row => row.Q1)
+                };
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    PowerPointTable table = slide.AddTable(3, 3, left: 0L, top: 0L, width: 6000000L, height: 3000000L);
+
+                    table.ApplyStyle(new PowerPointTableStylePreset(firstRow: true, bandedRows: true, bandedColumns: true));
+                    table.LastRow = true;
+                    table.FirstColumn = true;
+                    table.SetColumnWidthsByRatio(2, 1, 1);
+                    table.SetRowHeightsByRatio(1, 1, 1);
+                    table.SetCellPaddingCm(0.15, 0.1, 0.15, 0.1);
+                    table.SetCellAlignment(A.TextAlignmentTypeValues.Center, A.TextAnchoringTypeValues.Center);
+                    table.SetCellBorders(TableCellBorders.All, "4472C4", widthPoints: 0.75, dash: A.PresetLineDashValues.Dash);
+
+                    PowerPointTableCell header = table.GetCell(0, 0);
+                    header.Text = "Header";
+                    header.FillColor = "1F4E79";
+                    header.Color = "FFFFFF";
+                    header.Bold = true;
+                    header.FontSize = 12;
+                    header.FontName = "Aptos";
+                    header.SetTextAutoFit(PowerPointTextAutoFit.Normal,
+                        new PowerPointTextAutoFitOptions(fontScalePercent: 90, lineSpaceReductionPercent: 5));
+
+                    table.AddRowFromTemplate(0, index: 1);
+                    table.AddColumnFromTemplate(0, index: 1);
+                    table.RemoveRow(table.Rows - 1);
+                    table.RemoveColumn(table.Columns - 1);
+                    table.Bind(data, columns, includeHeaders: true, startRow: 1, startColumn: 1);
+                    table.MergeCells(0, 0, 1, 1);
+
+                    presentation.Save();
+                    Assert.Empty(presentation.ValidateDocument());
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    OpenXmlValidator validator = new OpenXmlValidator(FileFormatVersions.Microsoft365);
+                    Assert.Empty(validator.Validate(document));
+
+                    A.Table table = document.PresentationPart!.SlideParts.First()
+                        .Slide.Descendants<A.Table>().First();
+                    Assert.Equal(4, table.Elements<A.TableRow>().Count());
+                    Assert.Equal(3, table.TableGrid!.Elements<A.GridColumn>().Count());
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
         }
 
         private sealed class SalesRow {

--- a/OfficeIMO.Tests/PowerPoint.Tables.cs
+++ b/OfficeIMO.Tests/PowerPoint.Tables.cs
@@ -314,7 +314,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void CombinedTableMutationsValidatePackage() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempFilePath(".pptx");
 
             try {
                 var data = new[] {
@@ -387,6 +387,12 @@ namespace OfficeIMO.Tests {
             public string Product { get; }
             public int Q1 { get; }
             public int Q2 { get; }
+        }
+
+        private static string CreateTempFilePath(string extension) {
+            string path = Path.GetTempFileName();
+            File.Delete(path);
+            return Path.ChangeExtension(path, extension);
         }
     }
 

--- a/OfficeIMO.Tests/PowerPoint.TextFormatting.cs
+++ b/OfficeIMO.Tests/PowerPoint.TextFormatting.cs
@@ -245,5 +245,48 @@ namespace OfficeIMO.Tests {
 
             File.Delete(filePath);
         }
+
+        [Fact]
+        public void BulletSizingAndFontStayInSchemaOrder() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                PowerPointSlide slide = presentation.AddSlide();
+                PowerPointTextBox box = slide.AddTextBox("Bullets");
+                box.SetBullets(new[] { "First", "Second" }, configure: paragraph => {
+                    paragraph.SetBulletSizePercent(72)
+                        .SetBulletFont("Aptos")
+                        .SetHangingPoints(16)
+                        .SetFontSize(18);
+                });
+
+                presentation.Save();
+
+                Assert.Empty(presentation.ValidateDocument());
+            }
+
+            using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                Shape shape = document.PresentationPart!.SlideParts.First().Slide.Descendants<Shape>().First();
+                A.ParagraphProperties props = shape.TextBody!.Elements<A.Paragraph>().First().ParagraphProperties!;
+                var children = props.ChildElements.ToList();
+
+                int sizeIndex = IndexOf<A.BulletSizePercentage>(children);
+                int fontIndex = IndexOf<A.BulletFont>(children);
+                int bulletIndex = IndexOf<A.CharacterBullet>(children);
+
+                Assert.NotEqual(-1, sizeIndex);
+                Assert.NotEqual(-1, fontIndex);
+                Assert.NotEqual(-1, bulletIndex);
+                Assert.True(sizeIndex < fontIndex);
+                Assert.True(fontIndex < bulletIndex);
+            }
+
+            File.Delete(filePath);
+
+            static int IndexOf<T>(IReadOnlyList<DocumentFormat.OpenXml.OpenXmlElement> children)
+                where T : DocumentFormat.OpenXml.OpenXmlElement {
+                return children.ToList().FindIndex(child => child is T);
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.TextFormatting.cs
+++ b/OfficeIMO.Tests/PowerPoint.TextFormatting.cs
@@ -248,7 +248,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void BulletSizingAndFontStayInSchemaOrder() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempFilePath(".pptx");
 
             using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
                 PowerPointSlide slide = presentation.AddSlide();
@@ -287,6 +287,12 @@ namespace OfficeIMO.Tests {
                 where T : DocumentFormat.OpenXml.OpenXmlElement {
                 return children.ToList().FindIndex(child => child is T);
             }
+        }
+
+        private static string CreateTempFilePath(string extension) {
+            string path = Path.GetTempFileName();
+            File.Delete(path);
+            return Path.ChangeExtension(path, extension);
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix PowerPoint theme font serialization so Latin, East Asian, and complex script fonts are written before supplemental script fonts
- fix chart series shape-property insertion so styled series write `c:spPr` in schema order instead of appending it after values/markers
- fix shape property/effect ordering so combinations like fill, outline, glow, shadow, reflection, and soft edges validate even when setters are called after effects already exist
- fix chart-level data label position ordering so `SetDataLabels(...).SetDataLabelPosition(...)` validates instead of appending `c:dLblPos` after show flags
- fix hidden-slide serialization so `slide.Hide()` writes the schema-valid `p:sld show="0"` attribute instead of invalid `p:sldId show="0"`
- fix outline child ordering so arrowheads, dash presets, and outline fills validate regardless of setter order
- fix doughnut chart `BestFit` data-label position serialization so PowerPoint opens the modern deck without repair
- fix paragraph bullet child ordering so styled bullets with custom size/font validate instead of writing `a:buSzPct` after `a:buChar`
- add `PowerPointLayoutBox.SplitGrid(...)` plus cm/inches/points helpers for reusable row/column layout systems
- expand the modern PowerPoint example into a 7-slide deck covering agenda/list layouts, aligned cards, process flow/arrows, charts, tables, notes, themes, backgrounds, effects, and transitions
- add OpenXmlValidator coverage to chart creation parity tests for pie, doughnut, line, and scatter chart output
- add combined chart-axis mutation validation covering titles, label styles, rotations, tick labels, gridlines, scale/crossing, number formats, and display units for category/value/scatter axes
- add combined table mutation validation covering style flags, row/column sizing, padding, borders, cell text formatting, autofit, template row/column insertions, removal, binding, and merged cells
- add transition/background/notes mutation validation covering Morph cleanup, p14 transition replacement, background image cleanup, solid background replacement, and notes persistence
- add a `--powerpoint` example-runner switch that runs the full PowerPoint examples set and validates every generated deck
- document the modern deck and full PowerPoint examples validation commands in `OfficeIMO.PowerPoint/README.md`

## Root cause
`SetThemeFonts()` removed the primary font nodes and appended them to the end of `majorFont` and `minorFont`. Those elements already contain supplemental script font entries, so appending `a:latin`, `a:ea`, and `a:cs` after `a:font` produced invalid theme XML and PowerPoint repair prompts.

The modern smoke/example deck exposed the same class of schema-ordering issue in a few more places: chart series styling appended `c:spPr` too late, shape fill/outline/effects could be appended after schema-later children, effect children could be inserted out of order, and chart-level data label position was appended after the label show flags.

The new full PowerPoint examples runner also exposed a separate hidden-slide bug: `slide.Hide()` was writing `show="0"` on `p:sldId`, but the Open XML schema declares the `show` attribute on the slide root `p:sld`.

A follow-up shape-line regression found the same append-order risk inside `a:ln`: setting arrowheads before outline color or dash presets could append fill/dash nodes after line-end nodes. Outline children now use schema-aware insertion too.

PowerPoint itself also rejected the regenerated modern deck even though `OpenXmlValidator` passed. Isolating the deck showed slides 1-2 opened, adding slide 3 failed, removing only the slide 3 doughnut chart opened, and removing only `<c:dLblPos val="bestFit" />` from that doughnut chart opened. Doughnut charts now omit explicit `BestFit` label position to preserve PowerPoint default behavior without triggering repair.

The richer list/card/process example then exposed paragraph list ordering: setting bullet size/font after applying a bullet appended those children after `a:buChar`, which validates incorrectly. Paragraph bullet children now use schema-aware insertion.

## Validation
- reproduced the original theme-font failure with `ValidateDocument errors: 2` in `/ppt/theme/theme1.xml`
- confirmed the theme-font repro returns `ValidateDocument errors: 0` after the fix
- generated `OfficeIMO.Examples/bin/Debug/net10.0/Documents/Modern PowerPoint Deck.pptx`; the example reports `Validation: no Open XML errors found.`
- opened regenerated `Modern PowerPoint Deck.pptx` through PowerPoint COM successfully: `Opened=True`, `Slides=7`
- confirmed `FluentPowerPoint.pptx` and `Slides Management.pptx` no longer emit invalid `p:sldId show="0"`; hidden slides now serialize as `p:sld show="0"`
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj -f net10.0 --disable-build-servers -m:1 /clp:ErrorsOnly`
- `dotnet run --project OfficeIMO.Examples/OfficeIMO.Examples.csproj -f net10.0 --no-build -- --powerpoint`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PowerPointSlidesManagement" --disable-build-servers -m:1 /clp:ErrorsOnly`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PowerPointChartAxisFormatTests" --disable-build-servers -m:1 /clp:ErrorsOnly`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PowerPointChartCreationParity" --disable-build-servers -m:1 /clp:ErrorsOnly`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PowerPointTables|FullyQualifiedName~PowerPointTableEnhancements|FullyQualifiedName~PowerPointTableFormatting|FullyQualifiedName~PowerPointTableCellFormatting" --disable-build-servers -m:1 /clp:ErrorsOnly`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PowerPointAdvancedFeatures" --disable-build-servers -m:1 /clp:ErrorsOnly`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PowerPointShapeLineStylesTests" --disable-build-servers -m:1 /clp:ErrorsOnly`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PowerPointShapeLineStylesTests|FullyQualifiedName~PowerPointShapeEffectsTests|FullyQualifiedName~PowerPointShapeStyles" --disable-build-servers -m:1 /clp:ErrorsOnly`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PowerPointChartCreationParity|FullyQualifiedName~PowerPointChartFormatting" --disable-build-servers -m:1 /clp:ErrorsOnly`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PowerPointShapeGridTests|FullyQualifiedName~PowerPointTextFormatting|FullyQualifiedName~PowerPointFunctionalSmokeTests" --disable-build-servers -m:1 /clp:ErrorsOnly`
- `dotnet build OfficeIMO.Examples/OfficeIMO.Examples.csproj -f net10.0 --disable-build-servers -m:1 /clp:ErrorsOnly`
- `dotnet run --project OfficeIMO.Examples/OfficeIMO.Examples.csproj -f net10.0 --no-build -- --modern-powerpoint`
- `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PowerPoint" --disable-build-servers -m:1 /clp:ErrorsOnly`
