### PR TITLE
Enable agent readiness for OfficeIMO website

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -44,7 +44,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 7ebebd771b3e99fd590babfd1c905b21df89243e
+      powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -23,5 +23,5 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 7ebebd771b3e99fd590babfd1c905b21df89243e
+      powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -22,5 +22,5 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ (github.event.repository.private && vars.OFFICEIMO_FORCE_GITHUB_HOSTED != 'true') && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 7ebebd771b3e99fd590babfd1c905b21df89243e
+      powerforge_ref: 6b08cecc26f870d0d6797be673b4a959638aed42
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -548,9 +548,20 @@
       "cacheHeadersOut": "_headers"
     },
     {
+      "task": "agent-ready",
+      "id": "agent-ready",
+      "dependsOn": "optimize-site",
+      "skipModes": ["dev"],
+      "operation": "prepare",
+      "config": "./site.json",
+      "siteRoot": "./_site",
+      "output": "./_reports/agent-ready.json",
+      "failOnFailures": true
+    },
+    {
       "task": "audit",
       "id": "audit-ci",
-      "dependsOn": "optimize-site",
+      "dependsOn": "agent-ready",
       "modes": ["ci"],
       "config": "./site.json",
       "siteRoot": "./_site",
@@ -564,7 +575,7 @@
     {
       "task": "doctor",
       "id": "doctor-site",
-      "dependsOn": "optimize-site",
+      "dependsOn": "agent-ready",
       "skipModes": ["dev", "ci"],
       "config": "./site.json",
       "siteRoot": "./_site",

--- a/Website/site.json
+++ b/Website/site.json
@@ -79,6 +79,9 @@
   "Head": {
     "Links": [
       { "Rel": "icon", "Href": "/favicon.svg", "Type": "image/svg+xml" }
+    ],
+    "Meta": [
+      { "Name": "robots", "Content": "index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1" }
     ]
   },
   "Social": {
@@ -119,6 +122,84 @@
     ],
     "OrganizationEmail": "support@evotec.xyz",
     "OrganizationContactUrl": "https://officeimo.com/docs/getting-started/"
+  },
+  "AgentReadiness": {
+    "Enabled": true,
+    "HeadersPath": "_headers",
+    "LinkHeaders": true,
+    "Robots": true,
+    "SecurityHeaders": {
+      "Enabled": true,
+      "ContentSecurityPolicyValue": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+    },
+    "ContentSignals": {
+      "Enabled": true,
+      "Search": true,
+      "AiInput": true,
+      "AiTrain": false
+    },
+    "BotRules": [
+      { "UserAgent": "GPTBot", "Allow": "/" },
+      { "UserAgent": "ChatGPT-User", "Allow": "/" },
+      { "UserAgent": "OAI-SearchBot", "Allow": "/" },
+      { "UserAgent": "ClaudeBot", "Allow": "/" },
+      { "UserAgent": "Claude-SearchBot", "Allow": "/" },
+      { "UserAgent": "Claude-User", "Allow": "/" },
+      { "UserAgent": "PerplexityBot", "Allow": "/" },
+      { "UserAgent": "Perplexity-User", "Allow": "/" },
+      { "UserAgent": "Google-Extended", "Allow": "/" },
+      { "UserAgent": "Applebot-Extended", "Allow": "/" },
+      { "UserAgent": "Meta-ExternalAgent", "Allow": "/" },
+      { "UserAgent": "Amazonbot", "Allow": "/" },
+      { "UserAgent": "CCBot", "Allow": "/" }
+    ],
+    "ApiCatalog": {
+      "Enabled": true,
+      "Entries": [
+        { "Anchor": "/api/word/", "ServiceDesc": "/api/word/index.json", "ServiceDoc": "/api/word/", "Title": "OfficeIMO.Word API Reference" },
+        { "Anchor": "/api/excel/", "ServiceDesc": "/api/excel/index.json", "ServiceDoc": "/api/excel/", "Title": "OfficeIMO.Excel API Reference" },
+        { "Anchor": "/api/markdown/", "ServiceDesc": "/api/markdown/index.json", "ServiceDoc": "/api/markdown/", "Title": "OfficeIMO.Markdown API Reference" },
+        { "Anchor": "/api/powerpoint/", "ServiceDesc": "/api/powerpoint/index.json", "ServiceDoc": "/api/powerpoint/", "Title": "OfficeIMO.PowerPoint API Reference" },
+        { "Anchor": "/api/csv/", "ServiceDesc": "/api/csv/index.json", "ServiceDoc": "/api/csv/", "Title": "OfficeIMO.CSV API Reference" },
+        { "Anchor": "/api/visio/", "ServiceDesc": "/api/visio/index.json", "ServiceDoc": "/api/visio/", "Title": "OfficeIMO.Visio API Reference" },
+        { "Anchor": "/api/reader/", "ServiceDesc": "/api/reader/index.json", "ServiceDoc": "/api/reader/", "Title": "OfficeIMO.Reader API Reference" },
+        { "Anchor": "/api/powershell/", "ServiceDesc": "/api/powershell/index.json", "ServiceDoc": "/api/powershell/", "Title": "PSWriteOffice Cmdlet Reference" }
+      ]
+    },
+    "AgentSkills": {
+      "Enabled": true,
+      "Skills": [
+        {
+          "Name": "officeimo-site-assistant",
+          "Type": "skill-md",
+          "Description": "Use OfficeIMO documentation, API reference, sitemap, and llms files.",
+          "Content": "---\nname: officeimo-site-assistant\ndescription: Use OfficeIMO documentation, API reference, sitemap, and llms resources.\n---\n\n# OfficeIMO Site Assistant\n\nUse this skill when answering questions about OfficeIMO.\n\n- Prefer canonical pages from https://officeimo.com.\n- Use `/docs/` for product and workflow guidance.\n- Use `/api/` routes for .NET API reference and `/api/powershell/` for PSWriteOffice cmdlets.\n- Check `/llms.txt`, `/llms.json`, and `/llms-full.txt` when present for agent-readable summaries.\n- Check `/.well-known/api-catalog` before assuming API documentation paths.\n- Respect `/robots.txt` and Content-Signal preferences.\n"
+        }
+      ]
+    },
+    "AgentsJson": {
+      "Enabled": true,
+      "Description": "Agent-facing discovery metadata for OfficeIMO documentation, API reference, and support resources."
+    },
+    "A2AAgentCard": {
+      "Enabled": true,
+      "Name": "OfficeIMO Documentation Discovery",
+      "Description": "Discover OfficeIMO documentation, API reference, llms summaries, sitemap, and project resources.",
+      "Url": "/",
+      "DocumentationUrl": "/docs/",
+      "Skills": [
+        {
+          "Id": "documentation-discovery",
+          "Name": "Documentation discovery",
+          "Description": "Find OfficeIMO product documentation, API reference, release resources, and support pages.",
+          "Tags": ["documentation", "api-reference", "sitemap", "llms"]
+        }
+      ]
+    },
+    "McpServerCard": { "Enabled": false },
+    "OpenApi": { "Enabled": false },
+    "WebMcp": false,
+    "MarkdownNegotiation": true
   },
   "EditLinks": {
     "Enabled": true,


### PR DESCRIPTION
## Summary
- Enable PowerForge agent readiness for OfficeIMO with robots, Content-Signal, Link headers, security headers, API catalog, Agent Skills, agents.json, A2A card, and markdown negotiation config.
- Add agent-ready preparation before CI audit and non-CI doctor checks.
- Update website workflows to use the updated PowerForge agent-readiness implementation.

## Validation
- Parsed Website/site.json and Website/pipeline.json with ConvertFrom-Json.
- Ran git diff --check.
- Ran a temp PowerForge build and confirmed the robots meta renders.
- Ran agent-ready prepare against a temp site root to verify discovery artifacts and headers are generated.
