### PR TITLE
Add PowerPoint designer composition helpers

### DIFF
--- a/OfficeIMO.Examples/PowerPoint/DesignerPowerPointDeck.cs
+++ b/OfficeIMO.Examples/PowerPoint/DesignerPowerPointDeck.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Examples.PowerPoint {
     public static class DesignerPowerPointDeck {
         public static void Example_DesignerPowerPointDeck(string folderPath, bool openPowerPoint) {
             Console.WriteLine("[*] PowerPoint - Designer composition deck");
-            string filePath = Path.Combine(folderPath, "Designer PowerPoint Deck.pptx");
+            string filePath = Path.Join(folderPath, "Designer PowerPoint Deck.pptx");
 
             using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
             presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);

--- a/OfficeIMO.Examples/PowerPoint/DesignerPowerPointDeck.cs
+++ b/OfficeIMO.Examples/PowerPoint/DesignerPowerPointDeck.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Validation;
+using OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.Examples.PowerPoint {
+    /// <summary>
+    /// Demonstrates high-level designer compositions for visually stronger decks.
+    /// </summary>
+    public static class DesignerPowerPointDeck {
+        public static void Example_DesignerPowerPointDeck(string folderPath, bool openPowerPoint) {
+            Console.WriteLine("[*] PowerPoint - Designer composition deck");
+            string filePath = Path.Combine(folderPath, "Designer PowerPoint Deck.pptx");
+
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+            presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+            PowerPointDesignDirection portfolioDirection = new("Portfolio", PowerPointDesignMood.Corporate,
+                PowerPointSlideDensity.Balanced, PowerPointVisualStyle.Geometric, "Poppins", "Lato");
+            PowerPointDesignDirection executiveDirection = new("Executive Calm", PowerPointDesignMood.Corporate,
+                PowerPointSlideDensity.Relaxed, PowerPointVisualStyle.Soft, "Segoe UI Semibold", "Segoe UI",
+                showDirectionMotif: false);
+            IReadOnlyList<PowerPointDeckDesign> alternatives = PowerPointDeckDesign.CreateAlternativesFromBrand(
+                "#008C95", "designer-example", new[] { portfolioDirection, executiveDirection },
+                name: "OfficeIMO Teal", eyebrow: "OfficeIMO.PowerPoint",
+                footerLeft: "OFFICEIMO", footerRight: "The Good Slides");
+            PowerPointDeckDesign design = alternatives[0];
+            PowerPointDeckComposer deck = presentation.UseDesigner(design);
+
+            deck.AddSectionSlide("Case Study", "Project portfolio", "section",
+                options => options.SectionVariant = PowerPointSectionLayoutVariant.Poster);
+
+            deck.AddCaseStudySlide("Randstad - print environment rollout",
+                new[] {
+                    new PowerPointCaseStudySection("Client",
+                        "A distributed organization needed one clear story for service delivery and operational support."),
+                    new PowerPointCaseStudySection("Challenge",
+                        "The client needed better device availability, consistent support, and less manual coordination across many locations."),
+                    new PowerPointCaseStudySection("Solution",
+                        "A structured service model combined standardized devices, support ownership, monitoring, and reporting."),
+                    new PowerPointCaseStudySection("Result",
+                        "The project summary keeps the executive story, metrics, and visual emphasis in one editable slide.")
+                },
+                new[] {
+                    new PowerPointMetric("150", "devices"),
+                    new PowerPointMetric("60", "locations")
+                },
+                "case-study",
+                options => {
+                    options.BrandText = "OFFICEIMO";
+                    options.BandLabel = "Project portfolio";
+                    options.Variant = PowerPointCaseStudyLayoutVariant.EditorialSplit;
+                });
+
+            deck.AddProcessSlide("How we work",
+                "Transparent phases reduce risk and speed up delivery",
+                new[] {
+                    new PowerPointProcessStep("Analysis", "Understand the environment, needs, and business constraints."),
+                    new PowerPointProcessStep("Discovery", "Review configuration, process maturity, and dependencies."),
+                    new PowerPointProcessStep("Recommendations", "Prioritize actions and define the target architecture."),
+                    new PowerPointProcessStep("Implementation", "Deliver changes in controlled stages."),
+                    new PowerPointProcessStep("Care", "Keep the environment stable after rollout.")
+                },
+                "process",
+                options => options.Variant = PowerPointProcessLayoutVariant.NumberedColumns);
+
+            deck.AddCardGridSlide("Scope of services",
+                "Reusable cards choose the placement grid for you.",
+                new[] {
+                    new PowerPointCardContent("Deployments", new[] { "Intune", "Autopilot", "Policy baseline" }),
+                    new PowerPointCardContent("Maintenance", new[] { "Incident handling", "Monitoring", "Optimization" }),
+                    new PowerPointCardContent("Consulting", new[] { "Roadmap", "Architecture", "Discovery" }),
+                    new PowerPointCardContent("Audits", new[] { "Configuration", "Security review", "Modernization plan" })
+                },
+                "card-grid",
+                options => {
+                    options.SupportingText = "Use this when the deck needs strong structure but the content should remain editable.";
+                    options.Variant = PowerPointCardGridLayoutVariant.SoftTiles;
+                });
+
+            deck.AddLogoWallSlide("Competence proof",
+                "Logo and certification walls stay editable, but can still feel designed.",
+                new[] {
+                    new PowerPointLogoItem("Xerox", "Authorized service"),
+                    new PowerPointLogoItem("Lenovo", "Partner"),
+                    new PowerPointLogoItem("Brother", "Print"),
+                    new PowerPointLogoItem("Samsung", "Devices"),
+                    new PowerPointLogoItem("Epson", "Service"),
+                    new PowerPointLogoItem("ASUS", "Hardware"),
+                    new PowerPointLogoItem("Ricoh", "Print"),
+                    new PowerPointLogoItem("Xiaomi", "Mobile")
+                },
+                "logo-wall",
+                options => {
+                    options.FeatureTitle = "Audit-ready proof area";
+                    options.SupportingText = "Use real logo image paths when available; otherwise names remain editable.";
+                });
+
+            deck.AddCoverageSlide("Service coverage",
+                "Normalized pins create a map-like layout without needing a custom map asset.",
+                new[] {
+                    new PowerPointCoverageLocation("Gdansk", 0.55, 0.18),
+                    new PowerPointCoverageLocation("Szczecin", 0.18, 0.30),
+                    new PowerPointCoverageLocation("Olsztyn", 0.67, 0.27),
+                    new PowerPointCoverageLocation("Warszawa", 0.60, 0.48),
+                    new PowerPointCoverageLocation("Poznan", 0.34, 0.46),
+                    new PowerPointCoverageLocation("Wroclaw", 0.36, 0.70),
+                    new PowerPointCoverageLocation("Krakow", 0.58, 0.78),
+                    new PowerPointCoverageLocation("Rzeszow", 0.75, 0.76)
+                },
+                "coverage",
+                options => {
+                    options.SupportingText = "Regional teams and service locations";
+                    options.MapLabel = "8 editable locations";
+                });
+
+            deck.AddCapabilitySlide("Service capability",
+                "Structured text plus visual support for content-heavy service slides.",
+                new[] {
+                    new PowerPointCapabilitySection("Warranty and post-warranty service",
+                        "Nationwide service operations for distributed environments.",
+                        new[] { "Computers, notebooks, tablets", "Printers and scanners" }),
+                    new PowerPointCapabilitySection("Extended care",
+                        "Support beyond standard vendor warranty.",
+                        new[] { "Individual SLA options", "Continuity-focused monitoring" }),
+                    new PowerPointCapabilitySection("Operational gain",
+                        "Keep the content readable without manual layout.",
+                        new[] { "Clear ownership", "Consistent service story" })
+                },
+                "capability",
+                options => {
+                    options.VisualKind = PowerPointCapabilityVisualKind.CoverageMap;
+                    options.VisualLabel = "Service locations";
+                    options.Locations.Add(new PowerPointCoverageLocation("Warszawa", 0.60, 0.48));
+                    options.Locations.Add(new PowerPointCoverageLocation("Gdansk", 0.55, 0.18));
+                    options.Locations.Add(new PowerPointCoverageLocation("Wroclaw", 0.36, 0.70));
+                    options.Locations.Add(new PowerPointCoverageLocation("Krakow", 0.58, 0.78));
+                    options.Metrics.Add(new PowerPointMetric("12", "teams"));
+                    options.Metrics.Add(new PowerPointMetric("8", "locations"));
+                });
+
+            deck.ComposeSlide(composer => {
+                composer.AddTitle("Raw composition", "Use primitives when the slide needs its own structure.");
+                PowerPointLayoutBox[] rows = composer.ContentRows(2, gutterCm: 0.55, topCm: 3.75);
+                composer.AddCardGrid(new[] {
+                    new PowerPointCardContent("Story", new[] { "Title block", "Narrative area" }),
+                    new PowerPointCardContent("Evidence", new[] { "Metrics", "Visual support" }),
+                    new PowerPointCardContent("Outcome", new[] { "Summary", "Next step" })
+                }, rows[0], new PowerPointCardGridSlideOptions {
+                    MaxColumns = 3,
+                    Variant = PowerPointCardGridLayoutVariant.AccentTop
+                });
+
+                PowerPointLayoutBox[] lowerColumns = rows[1].SplitColumnsCm(2, 0.65);
+                composer.AddCalloutBand("Composer regions keep the slide flexible without requiring manual coordinates.",
+                    lowerColumns[0].TakeTopCm(1.45));
+                composer.AddMetricStrip(new[] {
+                    new PowerPointMetric("3", "primitives"),
+                    new PowerPointMetric("1", "shared grid")
+                }, lowerColumns[1].TakeTopCm(1.45));
+            }, "composed", options => options.FooterRight = "Composable");
+
+            presentation.Save();
+
+            List<ValidationErrorInfo> errors = presentation.ValidateDocument();
+            if (errors.Count > 0) {
+                string details = string.Join(Environment.NewLine, errors.Take(5).Select(error => error.Description));
+                throw new InvalidOperationException($"PowerPoint validation failed with {errors.Count} error(s).{Environment.NewLine}{details}");
+            }
+
+            Console.WriteLine($"    Saved: {filePath}");
+            Console.WriteLine("    Validation: no Open XML errors found.");
+            Helpers.Open(filePath, openPowerPoint);
+        }
+    }
+}

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -21,6 +21,7 @@ namespace OfficeIMO.Examples {
             PowerPoint.BasicPowerPointDocument.Example_BasicPowerPoint(folderPath, false);
             PowerPoint.AdvancedPowerPoint.Example_AdvancedPowerPoint(folderPath, false);
             PowerPoint.ModernPowerPointDeck.Example_ModernPowerPointDeck(folderPath, false);
+            PowerPoint.DesignerPowerPointDeck.Example_DesignerPowerPointDeck(folderPath, false);
             PowerPoint.FluentPowerPoint.Example_FluentPowerPoint(folderPath, false);
             PowerPoint.ShapesPowerPoint.Example_PowerPointShapes(folderPath, false);
             PowerPoint.SlidesManagementPowerPoint.Example_SlidesManagement(folderPath, false);
@@ -75,6 +76,11 @@ namespace OfficeIMO.Examples {
             Setup(folderPath);
             if (HasArgument(args, "--modern-powerpoint")) {
                 PowerPoint.ModernPowerPointDeck.Example_ModernPowerPointDeck(folderPath, false);
+                return;
+            }
+
+            if (HasArgument(args, "--designer-powerpoint")) {
+                PowerPoint.DesignerPowerPointDeck.Example_DesignerPowerPointDeck(folderPath, false);
                 return;
             }
 

--- a/OfficeIMO.PowerPoint/PowerPointDeckComposer.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDeckComposer.cs
@@ -124,7 +124,7 @@ namespace OfficeIMO.PowerPoint {
         private string ResolveSeed(string seed) {
             _slideIndex++;
             if (string.IsNullOrWhiteSpace(seed)) {
-                return "slide-" + _slideIndex.ToString();
+                return "slide-" + _slideIndex;
             }
 
             return seed.Trim();

--- a/OfficeIMO.PowerPoint/PowerPointDeckComposer.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDeckComposer.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Presentation-bound designer facade that applies one deck design across many semantic slides.
+    /// </summary>
+    public sealed class PowerPointDeckComposer {
+        private readonly PowerPointPresentation _presentation;
+        private readonly PowerPointDeckDesign _design;
+        private int _slideIndex;
+
+        internal PowerPointDeckComposer(PowerPointPresentation presentation, PowerPointDeckDesign design,
+            bool applyTheme) {
+            _presentation = presentation ?? throw new ArgumentNullException(nameof(presentation));
+            _design = design ?? throw new ArgumentNullException(nameof(design));
+
+            if (applyTheme) {
+                _design.ApplyTo(_presentation);
+            }
+        }
+
+        /// <summary>
+        ///     Underlying presentation.
+        /// </summary>
+        public PowerPointPresentation Presentation => _presentation;
+
+        /// <summary>
+        ///     Active deck design.
+        /// </summary>
+        public PowerPointDeckDesign Design => _design;
+
+        /// <summary>
+        ///     Adds a section/title slide using the active deck design.
+        /// </summary>
+        public PowerPointSlide AddSectionSlide(string title, string? subtitle = null, string? seed = null,
+            Action<PowerPointDesignerSlideOptions>? configure = null) {
+            PowerPointDesignerSlideOptions options = Configure(new PowerPointDesignerSlideOptions(),
+                seed ?? title, configure);
+            return _presentation.AddDesignerSectionSlide(title, subtitle, _design.Theme, options);
+        }
+
+        /// <summary>
+        ///     Adds a case-study slide using the active deck design.
+        /// </summary>
+        public PowerPointSlide AddCaseStudySlide(string clientTitle, IEnumerable<PowerPointCaseStudySection> sections,
+            IEnumerable<PowerPointMetric>? metrics = null, string? seed = null,
+            Action<PowerPointCaseStudySlideOptions>? configure = null) {
+            PowerPointCaseStudySlideOptions options = Configure(new PowerPointCaseStudySlideOptions(),
+                seed ?? clientTitle, configure);
+            return _presentation.AddDesignerCaseStudySlide(clientTitle, sections, metrics, _design.Theme, options);
+        }
+
+        /// <summary>
+        ///     Adds a process/timeline slide using the active deck design.
+        /// </summary>
+        public PowerPointSlide AddProcessSlide(string title, string? subtitle, IEnumerable<PowerPointProcessStep> steps,
+            string? seed = null, Action<PowerPointProcessSlideOptions>? configure = null) {
+            PowerPointProcessSlideOptions options = Configure(new PowerPointProcessSlideOptions(),
+                seed ?? title, configure);
+            return _presentation.AddDesignerProcessSlide(title, subtitle, steps, _design.Theme, options);
+        }
+
+        /// <summary>
+        ///     Adds a card-grid slide using the active deck design.
+        /// </summary>
+        public PowerPointSlide AddCardGridSlide(string title, string? subtitle, IEnumerable<PowerPointCardContent> cards,
+            string? seed = null, Action<PowerPointCardGridSlideOptions>? configure = null) {
+            PowerPointCardGridSlideOptions options = Configure(new PowerPointCardGridSlideOptions(),
+                seed ?? title, configure);
+            return _presentation.AddDesignerCardGridSlide(title, subtitle, cards, _design.Theme, options);
+        }
+
+        /// <summary>
+        ///     Adds a logo/proof wall slide using the active deck design.
+        /// </summary>
+        public PowerPointSlide AddLogoWallSlide(string title, string? subtitle, IEnumerable<PowerPointLogoItem> logos,
+            string? seed = null, Action<PowerPointLogoWallSlideOptions>? configure = null) {
+            PowerPointLogoWallSlideOptions options = Configure(new PowerPointLogoWallSlideOptions(),
+                seed ?? title, configure);
+            return _presentation.AddDesignerLogoWallSlide(title, subtitle, logos, _design.Theme, options);
+        }
+
+        /// <summary>
+        ///     Adds a coverage/location slide using the active deck design.
+        /// </summary>
+        public PowerPointSlide AddCoverageSlide(string title, string? subtitle,
+            IEnumerable<PowerPointCoverageLocation> locations, string? seed = null,
+            Action<PowerPointCoverageSlideOptions>? configure = null) {
+            PowerPointCoverageSlideOptions options = Configure(new PowerPointCoverageSlideOptions(),
+                seed ?? title, configure);
+            return _presentation.AddDesignerCoverageSlide(title, subtitle, locations, _design.Theme, options);
+        }
+
+        /// <summary>
+        ///     Adds a capability/content slide using the active deck design.
+        /// </summary>
+        public PowerPointSlide AddCapabilitySlide(string title, string? subtitle,
+            IEnumerable<PowerPointCapabilitySection> sections, string? seed = null,
+            Action<PowerPointCapabilitySlideOptions>? configure = null) {
+            PowerPointCapabilitySlideOptions options = Configure(new PowerPointCapabilitySlideOptions(),
+                seed ?? title, configure);
+            return _presentation.AddDesignerCapabilitySlide(title, subtitle, sections, _design.Theme, options);
+        }
+
+        /// <summary>
+        ///     Adds a custom designer slide with raw composition primitives and active deck chrome.
+        /// </summary>
+        public PowerPointSlide ComposeSlide(Action<PowerPointSlideComposer> compose, string? seed = null,
+            Action<PowerPointDesignerSlideOptions>? configure = null, bool dark = false) {
+            PowerPointDesignerSlideOptions options = Configure(new PowerPointDesignerSlideOptions(),
+                seed ?? "custom", configure);
+            return _presentation.ComposeDesignerSlide(compose, _design.Theme, options, dark);
+        }
+
+        private T Configure<T>(T options, string seed, Action<T>? configure)
+            where T : PowerPointDesignerSlideOptions {
+            string resolvedSeed = ResolveSeed(seed);
+            _design.Configure(options, resolvedSeed);
+            configure?.Invoke(options);
+            return options;
+        }
+
+        private string ResolveSeed(string seed) {
+            _slideIndex++;
+            if (string.IsNullOrWhiteSpace(seed)) {
+                return "slide-" + _slideIndex.ToString();
+            }
+
+            return seed.Trim();
+        }
+    }
+
+    public static partial class PowerPointDesignExtensions {
+        /// <summary>
+        ///     Creates a presentation-bound designer facade and optionally applies the deck theme immediately.
+        /// </summary>
+        public static PowerPointDeckComposer UseDesigner(this PowerPointPresentation presentation,
+            PowerPointDeckDesign design, bool applyTheme = true) {
+            return new PowerPointDeckComposer(presentation, design, applyTheme);
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointDeckDesign.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDeckDesign.cs
@@ -89,7 +89,7 @@ namespace OfficeIMO.PowerPoint {
             IReadOnlyList<PowerPointDesignDirection> directions = PowerPointDesignDirection.BuiltIn;
             for (int i = 0; i < count; i++) {
                 PowerPointDesignDirection direction = directions[i % directions.Count];
-                string candidateSeed = seed + "/direction-" + (i + 1).ToString();
+                string candidateSeed = seed + "/direction-" + (i + 1);
                 string candidateName = string.IsNullOrWhiteSpace(name)
                     ? direction.Name + " Direction"
                     : name + " " + direction.Name;
@@ -138,7 +138,7 @@ namespace OfficeIMO.PowerPoint {
             PowerPointDeckDesign[] designs = new PowerPointDeckDesign[directionList.Count];
             for (int i = 0; i < directionList.Count; i++) {
                 PowerPointDesignDirection direction = directionList[i];
-                string candidateSeed = seed + "/" + NormalizeSeedPart(direction.Name) + "-" + (i + 1).ToString();
+                string candidateSeed = seed + "/" + NormalizeSeedPart(direction.Name) + "-" + (i + 1);
                 string candidateName = string.IsNullOrWhiteSpace(name)
                     ? direction.Name + " Direction"
                     : name + " " + direction.Name;

--- a/OfficeIMO.PowerPoint/PowerPointDeckDesign.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDeckDesign.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Generic;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Deck-level design facade for applying a consistent but variable visual direction to many slides.
+    /// </summary>
+    public sealed class PowerPointDeckDesign {
+        private PowerPointDeckDesign(PowerPointDesignTheme theme, PowerPointDesignIntent baseIntent,
+            PowerPointDesignDirection direction, string seed, string? eyebrow, string? footerLeft,
+            string? footerRight, bool showDirectionMotif) {
+            Theme = theme;
+            BaseIntent = baseIntent;
+            Direction = direction;
+            Seed = seed;
+            Eyebrow = eyebrow;
+            FooterLeft = footerLeft;
+            FooterRight = footerRight;
+            ShowDirectionMotif = showDirectionMotif;
+        }
+
+        /// <summary>
+        ///     Creates a deck design from a brand accent, deck seed, and mood.
+        /// </summary>
+        public static PowerPointDeckDesign FromBrand(string accentColor, string seed,
+            PowerPointDesignMood mood = PowerPointDesignMood.Corporate, string? name = null,
+            string? eyebrow = null, string? footerLeft = null, string? footerRight = null,
+            string headingFontName = "Poppins", string bodyFontName = "Lato") {
+            if (string.IsNullOrWhiteSpace(seed)) {
+                throw new ArgumentException("Deck design seed cannot be null or empty.", nameof(seed));
+            }
+
+            PowerPointDesignTheme theme = PowerPointDesignTheme
+                .FromBrand(accentColor, name, headingFontName, bodyFontName)
+                .WithVariation(seed)
+                .WithMood(mood);
+
+            PowerPointDesignIntent intent = PowerPointDesignIntent.FromMood(mood, seed);
+            PowerPointDesignDirection direction = new(mood.ToString(), mood, intent.Density, intent.VisualStyle,
+                theme.HeadingFontName, theme.BodyFontName, mood != PowerPointDesignMood.Minimal);
+
+            return new PowerPointDeckDesign(theme, intent, direction, seed, eyebrow, footerLeft, footerRight,
+                direction.ShowDirectionMotif);
+        }
+
+        /// <summary>
+        ///     Creates a deck design from a brand accent, deck seed, and named creative direction.
+        /// </summary>
+        public static PowerPointDeckDesign FromBrand(string accentColor, string seed,
+            PowerPointDesignDirection direction, string? name = null, string? eyebrow = null,
+            string? footerLeft = null, string? footerRight = null) {
+            if (direction == null) {
+                throw new ArgumentNullException(nameof(direction));
+            }
+            if (string.IsNullOrWhiteSpace(seed)) {
+                throw new ArgumentException("Deck design seed cannot be null or empty.", nameof(seed));
+            }
+
+            PowerPointDesignTheme theme = PowerPointDesignTheme
+                .FromBrand(accentColor, name, direction.HeadingFontName, direction.BodyFontName)
+                .WithVariation(seed)
+                .WithMood(direction.Mood);
+            theme.HeadingFontName = direction.HeadingFontName;
+            theme.BodyFontName = direction.BodyFontName;
+            theme.Validate();
+
+            PowerPointDesignIntent intent = PowerPointDesignIntent.FromMood(direction.Mood, seed);
+            intent.Density = direction.Density;
+            intent.VisualStyle = direction.VisualStyle;
+
+            return new PowerPointDeckDesign(theme, intent, direction, seed, eyebrow, footerLeft, footerRight,
+                direction.ShowDirectionMotif);
+        }
+
+        /// <summary>
+        ///     Creates several deterministic design directions from the same brand accent and content seed.
+        /// </summary>
+        public static IReadOnlyList<PowerPointDeckDesign> CreateAlternativesFromBrand(string accentColor, string seed,
+            int count = 3, string? name = null, string? eyebrow = null, string? footerLeft = null,
+            string? footerRight = null, string headingFontName = "Poppins", string bodyFontName = "Lato") {
+            if (string.IsNullOrWhiteSpace(seed)) {
+                throw new ArgumentException("Deck design seed cannot be null or empty.", nameof(seed));
+            }
+            if (count <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(count), "At least one design alternative is required.");
+            }
+
+            PowerPointDeckDesign[] designs = new PowerPointDeckDesign[count];
+            IReadOnlyList<PowerPointDesignDirection> directions = PowerPointDesignDirection.BuiltIn;
+            for (int i = 0; i < count; i++) {
+                PowerPointDesignDirection direction = directions[i % directions.Count];
+                string candidateSeed = seed + "/direction-" + (i + 1).ToString();
+                string candidateName = string.IsNullOrWhiteSpace(name)
+                    ? direction.Name + " Direction"
+                    : name + " " + direction.Name;
+                string candidateHeadingFont = headingFontName == "Poppins" && bodyFontName == "Lato"
+                    ? direction.HeadingFontName
+                    : headingFontName;
+                string candidateBodyFont = headingFontName == "Poppins" && bodyFontName == "Lato"
+                    ? direction.BodyFontName
+                    : bodyFontName;
+                PowerPointDesignDirection candidateDirection = new(direction.Name, direction.Mood,
+                    direction.Density, direction.VisualStyle, candidateHeadingFont, candidateBodyFont,
+                    direction.ShowDirectionMotif);
+                designs[i] = FromBrand(accentColor, candidateSeed, candidateDirection, candidateName,
+                    eyebrow, footerLeft, footerRight);
+            }
+
+            return designs;
+        }
+
+        /// <summary>
+        ///     Creates deterministic design alternatives from caller-supplied creative directions.
+        /// </summary>
+        public static IReadOnlyList<PowerPointDeckDesign> CreateAlternativesFromBrand(string accentColor, string seed,
+            IEnumerable<PowerPointDesignDirection> directions, string? name = null, string? eyebrow = null,
+            string? footerLeft = null, string? footerRight = null, string? headingFontName = null,
+            string? bodyFontName = null) {
+            if (string.IsNullOrWhiteSpace(seed)) {
+                throw new ArgumentException("Deck design seed cannot be null or empty.", nameof(seed));
+            }
+            if (directions == null) {
+                throw new ArgumentNullException(nameof(directions));
+            }
+
+            List<PowerPointDesignDirection> directionList = new();
+            foreach (PowerPointDesignDirection direction in directions) {
+                if (direction == null) {
+                    throw new ArgumentException("Design direction list cannot contain null entries.", nameof(directions));
+                }
+                directionList.Add(direction);
+            }
+
+            if (directionList.Count == 0) {
+                throw new ArgumentException("At least one design direction is required.", nameof(directions));
+            }
+
+            PowerPointDeckDesign[] designs = new PowerPointDeckDesign[directionList.Count];
+            for (int i = 0; i < directionList.Count; i++) {
+                PowerPointDesignDirection direction = directionList[i];
+                string candidateSeed = seed + "/" + NormalizeSeedPart(direction.Name) + "-" + (i + 1).ToString();
+                string candidateName = string.IsNullOrWhiteSpace(name)
+                    ? direction.Name + " Direction"
+                    : name + " " + direction.Name;
+                string candidateHeadingFont = string.IsNullOrWhiteSpace(headingFontName)
+                    ? direction.HeadingFontName
+                    : headingFontName!;
+                string candidateBodyFont = string.IsNullOrWhiteSpace(bodyFontName)
+                    ? direction.BodyFontName
+                    : bodyFontName!;
+                PowerPointDesignDirection candidateDirection = new(direction.Name, direction.Mood,
+                    direction.Density, direction.VisualStyle, candidateHeadingFont, candidateBodyFont,
+                    direction.ShowDirectionMotif);
+                designs[i] = FromBrand(accentColor, candidateSeed, candidateDirection, candidateName,
+                    eyebrow, footerLeft, footerRight);
+            }
+
+            return designs;
+        }
+
+        /// <summary>
+        ///     Theme used by the deck.
+        /// </summary>
+        public PowerPointDesignTheme Theme { get; }
+
+        /// <summary>
+        ///     Base intent used to derive per-slide deterministic variants.
+        /// </summary>
+        public PowerPointDesignIntent BaseIntent { get; }
+
+        /// <summary>
+        ///     Creative direction used by this deck design.
+        /// </summary>
+        public PowerPointDesignDirection Direction { get; }
+
+        /// <summary>
+        ///     Stable deck seed.
+        /// </summary>
+        public string Seed { get; }
+
+        /// <summary>
+        ///     Optional default eyebrow text for generated slides.
+        /// </summary>
+        public string? Eyebrow { get; set; }
+
+        /// <summary>
+        ///     Optional default left footer text.
+        /// </summary>
+        public string? FooterLeft { get; set; }
+
+        /// <summary>
+        ///     Optional default right footer text.
+        /// </summary>
+        public string? FooterRight { get; set; }
+
+        /// <summary>
+        ///     Default direction motif behavior for generated slides.
+        /// </summary>
+        public bool ShowDirectionMotif { get; set; }
+
+        /// <summary>
+        ///     Applies the deck theme to the presentation.
+        /// </summary>
+        public PowerPointPresentation ApplyTo(PowerPointPresentation presentation) {
+            if (presentation == null) {
+                throw new ArgumentNullException(nameof(presentation));
+            }
+
+            return presentation.ApplyDesignerTheme(Theme);
+        }
+
+        /// <summary>
+        ///     Creates a per-slide intent while preserving the deck's mood, density, and visual style.
+        /// </summary>
+        public PowerPointDesignIntent IntentFor(string slideSeed) {
+            if (string.IsNullOrWhiteSpace(slideSeed)) {
+                throw new ArgumentException("Slide seed cannot be null or empty.", nameof(slideSeed));
+            }
+
+            PowerPointDesignIntent intent = BaseIntent.Clone();
+            intent.Seed = Seed + "/" + slideSeed;
+            return intent;
+        }
+
+        /// <summary>
+        ///     Applies deck chrome and a per-slide intent to an options object.
+        /// </summary>
+        public T Configure<T>(T options, string slideSeed) where T : PowerPointDesignerSlideOptions {
+            if (options == null) {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            options.DesignIntent = IntentFor(slideSeed);
+            options.ShowDirectionMotif = options.ShowDirectionMotif && ShowDirectionMotif;
+
+            if (string.IsNullOrWhiteSpace(options.Eyebrow)) {
+                options.Eyebrow = Eyebrow;
+            }
+            if (string.IsNullOrWhiteSpace(options.FooterLeft) || options.FooterLeft == "OfficeIMO") {
+                options.FooterLeft = FooterLeft;
+            }
+            if (string.IsNullOrWhiteSpace(options.FooterRight)) {
+                options.FooterRight = FooterRight;
+            }
+
+            return options;
+        }
+
+        /// <summary>
+        ///     Creates default designer slide options for the supplied slide seed.
+        /// </summary>
+        public PowerPointDesignerSlideOptions Options(string slideSeed) {
+            return Configure(new PowerPointDesignerSlideOptions(), slideSeed);
+        }
+
+        private static string NormalizeSeedPart(string value) {
+            if (string.IsNullOrWhiteSpace(value)) {
+                return "direction";
+            }
+
+            char[] chars = value.Trim().ToLowerInvariant().ToCharArray();
+            for (int i = 0; i < chars.Length; i++) {
+                char c = chars[i];
+                if (!char.IsLetterOrDigit(c)) {
+                    chars[i] = '-';
+                }
+            }
+
+            string normalized = new(chars);
+            while (normalized.IndexOf("--", StringComparison.Ordinal) >= 0) {
+                normalized = normalized.Replace("--", "-");
+            }
+
+            return normalized.Trim('-');
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointDesignDirection.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDesignDirection.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Named creative direction used to generate distinct deck personalities from one brand accent.
+    /// </summary>
+    public sealed class PowerPointDesignDirection {
+        /// <summary>
+        ///     Clean consulting-style deck direction with geometric structure.
+        /// </summary>
+        public static PowerPointDesignDirection Structured { get; } = new(
+            "Structured",
+            PowerPointDesignMood.Corporate,
+            PowerPointSlideDensity.Balanced,
+            PowerPointVisualStyle.Geometric,
+            "Poppins",
+            "Lato",
+            showDirectionMotif: true);
+
+        /// <summary>
+        ///     Spacious editorial direction with softer surfaces and calmer typography.
+        /// </summary>
+        public static PowerPointDesignDirection Editorial { get; } = new(
+            "Editorial",
+            PowerPointDesignMood.Editorial,
+            PowerPointSlideDensity.Relaxed,
+            PowerPointVisualStyle.Soft,
+            "Aptos Display",
+            "Aptos",
+            showDirectionMotif: true);
+
+        /// <summary>
+        ///     Quiet direction for understated decks with very little decoration.
+        /// </summary>
+        public static PowerPointDesignDirection Quiet { get; } = new(
+            "Quiet",
+            PowerPointDesignMood.Minimal,
+            PowerPointSlideDensity.Relaxed,
+            PowerPointVisualStyle.Minimal,
+            "Aptos Display",
+            "Aptos",
+            showDirectionMotif: false);
+
+        /// <summary>
+        ///     Higher-energy direction with stronger accents and compact content rhythm.
+        /// </summary>
+        public static PowerPointDesignDirection Signal { get; } = new(
+            "Signal",
+            PowerPointDesignMood.Energetic,
+            PowerPointSlideDensity.Compact,
+            PowerPointVisualStyle.Geometric,
+            "Poppins",
+            "Aptos",
+            showDirectionMotif: true);
+
+        /// <summary>
+        ///     Simple executive direction using system-safe typography and balanced spacing.
+        /// </summary>
+        public static PowerPointDesignDirection Executive { get; } = new(
+            "Executive",
+            PowerPointDesignMood.Corporate,
+            PowerPointSlideDensity.Balanced,
+            PowerPointVisualStyle.Soft,
+            "Segoe UI Semibold",
+            "Segoe UI",
+            showDirectionMotif: false);
+
+        /// <summary>
+        ///     Built-in directions used by deck alternatives.
+        /// </summary>
+        public static IReadOnlyList<PowerPointDesignDirection> BuiltIn { get; } = new[] {
+            Structured,
+            Editorial,
+            Quiet,
+            Signal,
+            Executive
+        };
+
+        /// <summary>
+        ///     Creates a reusable direction definition.
+        /// </summary>
+        public PowerPointDesignDirection(string name, PowerPointDesignMood mood,
+            PowerPointSlideDensity density, PowerPointVisualStyle visualStyle,
+            string headingFontName, string bodyFontName, bool showDirectionMotif = true) {
+            if (string.IsNullOrWhiteSpace(name)) {
+                throw new ArgumentException("Direction name cannot be null or empty.", nameof(name));
+            }
+            if (string.IsNullOrWhiteSpace(headingFontName)) {
+                throw new ArgumentException("Heading font cannot be null or empty.", nameof(headingFontName));
+            }
+            if (string.IsNullOrWhiteSpace(bodyFontName)) {
+                throw new ArgumentException("Body font cannot be null or empty.", nameof(bodyFontName));
+            }
+
+            Name = name;
+            Mood = mood;
+            Density = density;
+            VisualStyle = visualStyle;
+            HeadingFontName = headingFontName;
+            BodyFontName = bodyFontName;
+            ShowDirectionMotif = showDirectionMotif;
+        }
+
+        /// <summary>
+        ///     Direction display name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        ///     Broad visual mood.
+        /// </summary>
+        public PowerPointDesignMood Mood { get; }
+
+        /// <summary>
+        ///     Preferred content density.
+        /// </summary>
+        public PowerPointSlideDensity Density { get; }
+
+        /// <summary>
+        ///     Preferred primitive visual style.
+        /// </summary>
+        public PowerPointVisualStyle VisualStyle { get; }
+
+        /// <summary>
+        ///     Heading font for generated text.
+        /// </summary>
+        public string HeadingFontName { get; }
+
+        /// <summary>
+        ///     Body font for generated text.
+        /// </summary>
+        public string BodyFontName { get; }
+
+        /// <summary>
+        ///     Whether this direction uses repeated direction markers by default.
+        /// </summary>
+        public bool ShowDirectionMotif { get; }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointDesignExtensions.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDesignExtensions.cs
@@ -905,7 +905,7 @@ namespace OfficeIMO.PowerPoint {
             for (int i = 0; i < count; i++) {
                 PowerPointLayoutBox box = boxes[i];
                 PowerPointProcessStep step = steps[i];
-                string number = !string.IsNullOrWhiteSpace(step.Number) ? step.Number! : (i + 1).ToString() + ".";
+                string number = !string.IsNullOrWhiteSpace(step.Number) ? step.Number! : (i + 1) + ".";
                 AddProcessNode(slide, theme, i, box.LeftCm, box.TopCm, nodeSize, number);
                 AddText(slide, step.Title, box.LeftCm, box.TopCm + 1.55, box.WidthCm, 0.7, 13,
                     theme.AccentContrastColor, theme.HeadingFontName, bold: true);

--- a/OfficeIMO.PowerPoint/PowerPointDesignExtensions.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDesignExtensions.cs
@@ -870,7 +870,6 @@ namespace OfficeIMO.PowerPoint {
                 return;
             }
 
-            int count = steps.Count;
             double left = options.DesignIntent.Density == PowerPointSlideDensity.Relaxed ? 2.35 : 2.1;
             double top = slideHeightCm * 0.47;
             double width = slideWidthCm - 4.2;

--- a/OfficeIMO.PowerPoint/PowerPointDesignExtensions.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDesignExtensions.cs
@@ -1,0 +1,1217 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Presentation;
+using A = DocumentFormat.OpenXml.Drawing;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     High-level slide composition helpers for building polished decks without hand-placing every shape.
+    /// </summary>
+    public static partial class PowerPointDesignExtensions {
+        /// <summary>
+        ///     Applies the designer theme colors and fonts to all slide masters.
+        /// </summary>
+        public static PowerPointPresentation ApplyDesignerTheme(this PowerPointPresentation presentation,
+            PowerPointDesignTheme? theme = null) {
+            if (presentation == null) {
+                throw new ArgumentNullException(nameof(presentation));
+            }
+
+            PowerPointDesignTheme resolvedTheme = ResolveTheme(theme);
+            presentation.ThemeName = resolvedTheme.Name;
+            presentation.SetThemeColorsForAllMasters(new Dictionary<PowerPointThemeColor, string> {
+                [PowerPointThemeColor.Dark1] = resolvedTheme.PrimaryTextColor,
+                [PowerPointThemeColor.Light1] = resolvedTheme.BackgroundColor,
+                [PowerPointThemeColor.Dark2] = resolvedTheme.AccentDarkColor,
+                [PowerPointThemeColor.Light2] = resolvedTheme.SurfaceColor,
+                [PowerPointThemeColor.Accent1] = resolvedTheme.AccentColor,
+                [PowerPointThemeColor.Accent2] = resolvedTheme.Accent2Color,
+                [PowerPointThemeColor.Accent3] = resolvedTheme.Accent3Color,
+                [PowerPointThemeColor.Accent4] = resolvedTheme.WarningColor,
+                [PowerPointThemeColor.Accent5] = resolvedTheme.PanelBorderColor,
+                [PowerPointThemeColor.Accent6] = resolvedTheme.MutedTextColor
+            });
+            presentation.SetThemeFontsForAllMasters(new PowerPointThemeFontSet(
+                resolvedTheme.HeadingFontName,
+                resolvedTheme.BodyFontName,
+                null,
+                null,
+                null,
+                null));
+
+            return presentation;
+        }
+
+        /// <summary>
+        ///     Adds a full-bleed section/title slide with diagonal planes and optional footer chrome.
+        /// </summary>
+        public static PowerPointSlide AddDesignerSectionSlide(this PowerPointPresentation presentation, string title,
+            string? subtitle = null, PowerPointDesignTheme? theme = null,
+            PowerPointDesignerSlideOptions? options = null) {
+            if (presentation == null) {
+                throw new ArgumentNullException(nameof(presentation));
+            }
+            if (title == null) {
+                throw new ArgumentNullException(nameof(title));
+            }
+
+            PowerPointDesignTheme resolvedTheme = ResolveTheme(theme);
+            PowerPointDesignerSlideOptions resolvedOptions = options ?? new PowerPointDesignerSlideOptions();
+            PowerPointSlide slide = presentation.AddSlide();
+            double width = presentation.SlideSize.WidthCm;
+            double height = presentation.SlideSize.HeightCm;
+            PowerPointSectionLayoutVariant variant = ResolveSectionVariant(resolvedOptions);
+
+            if (variant == PowerPointSectionLayoutVariant.EditorialRail) {
+                AddSectionEditorialRail(slide, resolvedTheme, resolvedOptions, title, subtitle, width, height);
+            } else if (variant == PowerPointSectionLayoutVariant.Poster) {
+                AddSectionPoster(slide, resolvedTheme, resolvedOptions, title, subtitle, width, height);
+            } else {
+                AddSectionGeometricCover(slide, resolvedTheme, resolvedOptions, title, subtitle, width, height);
+            }
+
+            return slide;
+        }
+
+        /// <summary>
+        ///     Adds a case-study slide with summary columns, a strong visual band, metrics, and optional tags.
+        /// </summary>
+        public static PowerPointSlide AddDesignerCaseStudySlide(this PowerPointPresentation presentation,
+            string clientTitle, IEnumerable<PowerPointCaseStudySection> sections,
+            IEnumerable<PowerPointMetric>? metrics = null,
+            PowerPointDesignTheme? theme = null,
+            PowerPointCaseStudySlideOptions? options = null) {
+            if (presentation == null) {
+                throw new ArgumentNullException(nameof(presentation));
+            }
+            if (clientTitle == null) {
+                throw new ArgumentNullException(nameof(clientTitle));
+            }
+
+            PowerPointDesignTheme resolvedTheme = ResolveTheme(theme);
+            PowerPointCaseStudySlideOptions resolvedOptions = options ?? new PowerPointCaseStudySlideOptions();
+            List<PowerPointCaseStudySection> sectionList = NormalizeSections(sections, 4, nameof(sections));
+            List<PowerPointMetric> metricList = (metrics ?? Enumerable.Empty<PowerPointMetric>()).Where(m => m != null).ToList();
+
+            PowerPointSlide slide = presentation.AddSlide();
+            double width = presentation.SlideSize.WidthCm;
+            double height = presentation.SlideSize.HeightCm;
+            slide.BackgroundColor = resolvedTheme.BackgroundColor;
+
+            PowerPointCaseStudyLayoutVariant variant = ResolveCaseStudyVariant(resolvedOptions, sectionList, metricList);
+            if (variant == PowerPointCaseStudyLayoutVariant.EditorialSplit) {
+                AddSubtleLightBackground(slide, resolvedTheme, width, height);
+                AddChrome(slide, resolvedTheme, width, height, dark: false, resolvedOptions);
+                AddCaseStudyEditorialSplit(slide, resolvedTheme, clientTitle, sectionList, resolvedOptions, metricList, width, height);
+            } else if (variant == PowerPointCaseStudyLayoutVariant.VisualHero) {
+                AddSubtleLightBackground(slide, resolvedTheme, width, height);
+                AddChrome(slide, resolvedTheme, width, height, dark: false, resolvedOptions);
+                AddCaseStudyVisualHero(slide, resolvedTheme, clientTitle, sectionList, resolvedOptions, metricList, width, height);
+            } else {
+                AddChrome(slide, resolvedTheme, width, height, dark: false, resolvedOptions);
+                AddCaseStudyColumns(slide, resolvedTheme, clientTitle, sectionList, width);
+                AddCaseStudyBand(slide, resolvedTheme, resolvedOptions, metricList, width, height);
+            }
+
+            return slide;
+        }
+
+        /// <summary>
+        ///     Adds a card grid slide that automatically chooses rows and columns for the supplied content.
+        /// </summary>
+        public static PowerPointSlide AddDesignerCardGridSlide(this PowerPointPresentation presentation,
+            string title, string? subtitle, IEnumerable<PowerPointCardContent> cards,
+            PowerPointDesignTheme? theme = null,
+            PowerPointCardGridSlideOptions? options = null) {
+            if (presentation == null) {
+                throw new ArgumentNullException(nameof(presentation));
+            }
+            if (title == null) {
+                throw new ArgumentNullException(nameof(title));
+            }
+
+            PowerPointDesignTheme resolvedTheme = ResolveTheme(theme);
+            PowerPointCardGridSlideOptions resolvedOptions = options ?? new PowerPointCardGridSlideOptions();
+            List<PowerPointCardContent> cardList = NormalizeCards(cards);
+
+            PowerPointSlide slide = presentation.AddSlide();
+            double width = presentation.SlideSize.WidthCm;
+            double height = presentation.SlideSize.HeightCm;
+            slide.BackgroundColor = resolvedTheme.BackgroundColor;
+
+            AddSubtleLightBackground(slide, resolvedTheme, width, height);
+            AddChrome(slide, resolvedTheme, width, height, dark: false, resolvedOptions);
+            AddText(slide, title, 1.5, 1.45, width * 0.6, 1.0, 29,
+                resolvedTheme.PrimaryTextColor, resolvedTheme.HeadingFontName, bold: true);
+            if (!string.IsNullOrWhiteSpace(subtitle)) {
+                AddText(slide, subtitle!, 1.55, 2.7, width * 0.58, 0.5, 12,
+                    resolvedTheme.SecondaryTextColor, resolvedTheme.BodyFontName, bold: true);
+            }
+
+            AddCardGrid(slide, resolvedTheme, cardList, resolvedOptions,
+                ResolveCardGridVariant(resolvedOptions, cardList), width, height);
+
+            return slide;
+        }
+
+        /// <summary>
+        ///     Adds a dark process slide with a readable timeline and automatic spacing.
+        /// </summary>
+        public static PowerPointSlide AddDesignerProcessSlide(this PowerPointPresentation presentation,
+            string title, string? subtitle, IEnumerable<PowerPointProcessStep> steps,
+            PowerPointDesignTheme? theme = null,
+            PowerPointProcessSlideOptions? options = null) {
+            if (presentation == null) {
+                throw new ArgumentNullException(nameof(presentation));
+            }
+            if (title == null) {
+                throw new ArgumentNullException(nameof(title));
+            }
+
+            PowerPointDesignTheme resolvedTheme = ResolveTheme(theme);
+            PowerPointProcessSlideOptions resolvedOptions = options ?? new PowerPointProcessSlideOptions();
+            List<PowerPointProcessStep> stepList = NormalizeSteps(steps);
+
+            PowerPointSlide slide = presentation.AddSlide();
+            double width = presentation.SlideSize.WidthCm;
+            double height = presentation.SlideSize.HeightCm;
+            slide.BackgroundColor = resolvedTheme.AccentDarkColor;
+
+            if (resolvedOptions.ShowDiagonalPlanes) {
+                AddDiagonalPlanes(slide, resolvedTheme, width, height, dark: true);
+            }
+            AddChrome(slide, resolvedTheme, width, height, dark: true, resolvedOptions);
+            AddText(slide, title, 1.85, 1.45, width * 0.52, 1.1, 33,
+                resolvedTheme.AccentContrastColor, resolvedTheme.HeadingFontName, bold: true);
+            if (!string.IsNullOrWhiteSpace(subtitle)) {
+                AddText(slide, subtitle!, 1.9, 2.78, width * 0.58, 0.5, 13,
+                    resolvedTheme.AccentLightColor, resolvedTheme.BodyFontName, bold: true);
+            }
+
+            AddProcessTimeline(slide, resolvedTheme, stepList, resolvedOptions, width, height);
+            return slide;
+        }
+
+        private static PowerPointDesignTheme ResolveTheme(PowerPointDesignTheme? theme) {
+            PowerPointDesignTheme resolved = theme ?? PowerPointDesignTheme.ModernBlue;
+            resolved.Validate();
+            return resolved;
+        }
+
+        private static List<PowerPointCaseStudySection> NormalizeSections(IEnumerable<PowerPointCaseStudySection> sections,
+            int maxCount, string paramName) {
+            if (sections == null) {
+                throw new ArgumentNullException(paramName);
+            }
+
+            List<PowerPointCaseStudySection> list = sections.Where(section => section != null).ToList();
+            if (list.Count == 0) {
+                throw new ArgumentException("At least one section is required.", paramName);
+            }
+            if (list.Count > maxCount) {
+                throw new ArgumentOutOfRangeException(paramName, $"This composition supports up to {maxCount} sections.");
+            }
+
+            return list;
+        }
+
+        internal static List<PowerPointCardContent> NormalizeCards(IEnumerable<PowerPointCardContent> cards) {
+            if (cards == null) {
+                throw new ArgumentNullException(nameof(cards));
+            }
+
+            List<PowerPointCardContent> list = cards.Where(card => card != null).ToList();
+            if (list.Count == 0) {
+                throw new ArgumentException("At least one card is required.", nameof(cards));
+            }
+
+            return list;
+        }
+
+        internal static List<PowerPointProcessStep> NormalizeSteps(IEnumerable<PowerPointProcessStep> steps) {
+            if (steps == null) {
+                throw new ArgumentNullException(nameof(steps));
+            }
+
+            List<PowerPointProcessStep> list = steps.Where(step => step != null).ToList();
+            if (list.Count == 0) {
+                throw new ArgumentException("At least one step is required.", nameof(steps));
+            }
+            if (list.Count > 8) {
+                throw new ArgumentOutOfRangeException(nameof(steps), "This composition supports up to 8 steps.");
+            }
+
+            return list;
+        }
+
+        private static PowerPointSectionLayoutVariant ResolveSectionVariant(PowerPointDesignerSlideOptions options) {
+            if (options.SectionVariant != PowerPointSectionLayoutVariant.Auto) {
+                return options.SectionVariant;
+            }
+
+            if (string.IsNullOrWhiteSpace(options.DesignIntent.Seed)) {
+                return PowerPointSectionLayoutVariant.GeometricCover;
+            }
+
+            return options.DesignIntent.Pick(3, "section") switch {
+                0 => PowerPointSectionLayoutVariant.GeometricCover,
+                1 => PowerPointSectionLayoutVariant.EditorialRail,
+                _ => PowerPointSectionLayoutVariant.Poster
+            };
+        }
+
+        internal static PowerPointCaseStudyLayoutVariant ResolveCaseStudyVariant(PowerPointCaseStudySlideOptions options,
+            IReadOnlyList<PowerPointCaseStudySection> sections, IReadOnlyList<PowerPointMetric> metrics) {
+            if (options.Variant != PowerPointCaseStudyLayoutVariant.Auto) {
+                return options.Variant;
+            }
+
+            if (string.IsNullOrWhiteSpace(options.DesignIntent.Seed)) {
+                return PowerPointCaseStudyLayoutVariant.VisualBand;
+            }
+            if (options.DesignIntent.VisualStyle == PowerPointVisualStyle.Soft ||
+                options.DesignIntent.VisualStyle == PowerPointVisualStyle.Minimal ||
+                sections.Count >= 4) {
+                return PowerPointCaseStudyLayoutVariant.EditorialSplit;
+            }
+            if (metrics.Count > 0 && sections.Count <= 3) {
+                return PowerPointCaseStudyLayoutVariant.VisualHero;
+            }
+
+            return options.DesignIntent.Pick(3, "case-study") switch {
+                0 => PowerPointCaseStudyLayoutVariant.VisualBand,
+                1 => PowerPointCaseStudyLayoutVariant.EditorialSplit,
+                _ => PowerPointCaseStudyLayoutVariant.VisualHero
+            };
+        }
+
+        internal static PowerPointCardGridLayoutVariant ResolveCardGridVariant(PowerPointCardGridSlideOptions options,
+            IReadOnlyList<PowerPointCardContent> cards) {
+            if (options.Variant != PowerPointCardGridLayoutVariant.Auto) {
+                return options.Variant;
+            }
+
+            if (string.IsNullOrWhiteSpace(options.DesignIntent.Seed)) {
+                return PowerPointCardGridLayoutVariant.AccentTop;
+            }
+            if (options.DesignIntent.VisualStyle == PowerPointVisualStyle.Soft ||
+                options.DesignIntent.VisualStyle == PowerPointVisualStyle.Minimal) {
+                return PowerPointCardGridLayoutVariant.SoftTiles;
+            }
+            if (options.DesignIntent.Density == PowerPointSlideDensity.Compact || cards.Count > 4) {
+                return PowerPointCardGridLayoutVariant.AccentTop;
+            }
+
+            return options.DesignIntent.Pick(2, "card-grid") == 0
+                ? PowerPointCardGridLayoutVariant.AccentTop
+                : PowerPointCardGridLayoutVariant.SoftTiles;
+        }
+
+        internal static PowerPointProcessLayoutVariant ResolveProcessVariant(PowerPointProcessSlideOptions options,
+            IReadOnlyList<PowerPointProcessStep> steps) {
+            if (options.Variant != PowerPointProcessLayoutVariant.Auto) {
+                return options.Variant;
+            }
+
+            if (string.IsNullOrWhiteSpace(options.DesignIntent.Seed)) {
+                return PowerPointProcessLayoutVariant.Rail;
+            }
+            if (steps.Count >= 6 || options.DesignIntent.VisualStyle == PowerPointVisualStyle.Minimal) {
+                return PowerPointProcessLayoutVariant.Rail;
+            }
+            if (options.DesignIntent.Density == PowerPointSlideDensity.Compact) {
+                return PowerPointProcessLayoutVariant.NumberedColumns;
+            }
+
+            return options.DesignIntent.Pick(2, "process") == 0
+                ? PowerPointProcessLayoutVariant.Rail
+                : PowerPointProcessLayoutVariant.NumberedColumns;
+        }
+
+        private static void AddSectionGeometricCover(PowerPointSlide slide, PowerPointDesignTheme theme,
+            PowerPointDesignerSlideOptions options, string title, string? subtitle, double slideWidthCm,
+            double slideHeightCm) {
+            slide.BackgroundColor = theme.AccentDarkColor;
+            AddDiagonalPlanes(slide, theme, slideWidthCm, slideHeightCm, dark: true);
+            AddChrome(slide, theme, slideWidthCm, slideHeightCm, dark: true, options);
+
+            AddText(slide, title, 1.85, slideHeightCm * 0.47, slideWidthCm * 0.58, 1.35, 40,
+                theme.AccentContrastColor, theme.HeadingFontName, bold: true);
+
+            if (!string.IsNullOrWhiteSpace(subtitle)) {
+                AddText(slide, subtitle!, 1.9, slideHeightCm * 0.59, slideWidthCm * 0.52, 0.8, 15,
+                    theme.AccentLightColor, theme.BodyFontName);
+            }
+
+            if (ShouldShowDirectionMotif(options)) {
+                AddDirectionMotif(slide, 1.95, slideHeightCm * 0.67, 11, 0.46, theme.WarningColor);
+            }
+        }
+
+        private static void AddSectionEditorialRail(PowerPointSlide slide, PowerPointDesignTheme theme,
+            PowerPointDesignerSlideOptions options, string title, string? subtitle, double slideWidthCm,
+            double slideHeightCm) {
+            slide.BackgroundColor = theme.BackgroundColor;
+            AddSubtleLightBackground(slide, theme, slideWidthCm, slideHeightCm);
+            AddChrome(slide, theme, slideWidthCm, slideHeightCm, dark: false, options);
+
+            PowerPointAutoShape rail = slide.AddRectangleCm(1.45, 1.85, 0.18, slideHeightCm - 3.8,
+                "Section Editorial Rail");
+            rail.FillColor = theme.AccentColor;
+            rail.OutlineColor = theme.AccentColor;
+
+            PowerPointAutoShape block = slide.AddRectangleCm(1.9, 3.65, slideWidthCm * 0.42, 0.18,
+                "Section Editorial Rule");
+            block.FillColor = theme.WarningColor;
+            block.OutlineColor = theme.WarningColor;
+
+            AddText(slide, title, 1.9, 2.15, slideWidthCm * 0.55, 1.2, 38,
+                theme.PrimaryTextColor, theme.HeadingFontName, bold: true);
+
+            if (!string.IsNullOrWhiteSpace(subtitle)) {
+                AddText(slide, subtitle!, 1.95, 4.15, slideWidthCm * 0.47, 0.8, 14,
+                    theme.SecondaryTextColor, theme.BodyFontName);
+            }
+
+            PowerPointAutoShape accentPanel = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram,
+                slideWidthCm * 0.64, 0, slideWidthCm * 0.26, slideHeightCm, "Section Editorial Accent Plane");
+            accentPanel.FillColor = theme.AccentLightColor;
+            accentPanel.FillTransparency = 30;
+            accentPanel.OutlineColor = theme.AccentLightColor;
+
+            if (ShouldShowDirectionMotif(options)) {
+                AddDirectionMotif(slide, slideWidthCm - 5.25, 2.05, 10, 0.36, theme.AccentColor, flip: true);
+            }
+        }
+
+        private static void AddSectionPoster(PowerPointSlide slide, PowerPointDesignTheme theme,
+            PowerPointDesignerSlideOptions options, string title, string? subtitle, double slideWidthCm,
+            double slideHeightCm) {
+            slide.BackgroundColor = theme.AccentDarkColor;
+            AddChrome(slide, theme, slideWidthCm, slideHeightCm, dark: true, options);
+
+            PowerPointAutoShape wash = slide.AddRectangleCm(0, 0, slideWidthCm, slideHeightCm,
+                "Section Poster Wash");
+            wash.FillColor = theme.AccentColor;
+            wash.FillTransparency = 50;
+            wash.OutlineColor = theme.AccentColor;
+            wash.SendToBack();
+
+            PowerPointAutoShape frame = slide.AddRectangleCm(1.45, 1.55, slideWidthCm - 2.9, slideHeightCm - 3.2,
+                "Section Poster Frame");
+            frame.FillColor = theme.AccentDarkColor;
+            frame.FillTransparency = 100;
+            frame.OutlineColor = theme.AccentLightColor;
+            frame.OutlineWidthPoints = 0.7;
+
+            PowerPointTextBox titleBox = AddText(slide, title, 2.4, slideHeightCm * 0.42, slideWidthCm - 4.8, 1.4,
+                42, theme.AccentContrastColor, theme.HeadingFontName, bold: true);
+            CenterText(titleBox);
+
+            if (!string.IsNullOrWhiteSpace(subtitle)) {
+                PowerPointTextBox subtitleBox = AddText(slide, subtitle!, 4.1, slideHeightCm * 0.58,
+                    slideWidthCm - 8.2, 0.65, 14, theme.AccentLightColor, theme.BodyFontName);
+                CenterText(subtitleBox);
+            }
+
+            if (ShouldShowDirectionMotif(options)) {
+                AddDirectionMotif(slide, slideWidthCm * 0.39, slideHeightCm * 0.68, 12, 0.4, theme.WarningColor);
+            }
+        }
+
+        private static void AddCaseStudyColumns(PowerPointSlide slide, PowerPointDesignTheme theme, string clientTitle,
+            IReadOnlyList<PowerPointCaseStudySection> sections, double slideWidthCm) {
+            double left = 1.45;
+            double top = 1.75;
+            double gutter = 0.85;
+            double width = slideWidthCm - 2.9;
+            PowerPointLayoutBox[] columns = PowerPointLayoutBox
+                .FromCentimeters(left, top, width, 6.15)
+                .SplitColumnsCm(sections.Count, gutter);
+
+            for (int i = 0; i < sections.Count; i++) {
+                PowerPointLayoutBox box = columns[i];
+                PowerPointCaseStudySection section = sections[i];
+                AddText(slide, section.Heading, box.LeftCm, box.TopCm, box.WidthCm, 0.55, i == 0 ? 19 : 11,
+                    theme.PrimaryTextColor, theme.HeadingFontName, bold: true);
+
+                if (i == 0) {
+                    PowerPointAutoShape rule = slide.AddRectangleCm(box.LeftCm, box.TopCm + 0.78, box.WidthCm, 0.025,
+                        "Case Study Client Rule");
+                    rule.FillColor = theme.PanelBorderColor;
+                    rule.OutlineColor = theme.PanelBorderColor;
+                }
+
+                string body = i == 0 ? clientTitle + Environment.NewLine + section.Body : section.Body;
+                PowerPointTextBox bodyBox = AddText(slide, body, box.LeftCm, box.TopCm + 1.05, box.WidthCm, 4.5,
+                    i == 0 ? 13 : 10, i == 0 ? theme.PrimaryTextColor : theme.SecondaryTextColor,
+                    theme.BodyFontName, bold: i == 0);
+                bodyBox.TextAutoFit = PowerPointTextAutoFit.Normal;
+                bodyBox.TextAutoFitOptions = new PowerPointTextAutoFitOptions(fontScalePercent: 80, lineSpaceReductionPercent: 20);
+            }
+        }
+
+        private static void AddCaseStudyEditorialSplit(PowerPointSlide slide, PowerPointDesignTheme theme,
+            string clientTitle, IReadOnlyList<PowerPointCaseStudySection> sections, PowerPointCaseStudySlideOptions options,
+            IReadOnlyList<PowerPointMetric> metrics, double slideWidthCm, double slideHeightCm) {
+            AddText(slide, clientTitle, 1.45, 1.6, slideWidthCm * 0.58, 1.35, 22,
+                theme.PrimaryTextColor, theme.HeadingFontName, bold: true);
+
+            PowerPointAutoShape titleRule = slide.AddRectangleCm(1.47, 3.18, slideWidthCm * 0.24, 0.08,
+                "Case Study Editorial Rule");
+            titleRule.FillColor = theme.AccentColor;
+            titleRule.OutlineColor = theme.AccentColor;
+
+            int textCount = Math.Min(sections.Count, 4);
+            PowerPointLayoutBox[,] boxes = PowerPointLayoutBox
+                .FromCentimeters(1.45, 3.75, slideWidthCm * 0.54, 5.05)
+                .SplitGridCm(textCount > 2 ? 2 : 1, textCount > 1 ? 2 : 1, 0.55, 0.55);
+
+            for (int i = 0; i < textCount; i++) {
+                int row = i / (textCount > 1 ? 2 : 1);
+                int column = i % (textCount > 1 ? 2 : 1);
+                PowerPointLayoutBox box = boxes[row, column];
+                PowerPointCaseStudySection section = sections[i];
+
+                PowerPointAutoShape panel = slide.AddRectangleCm(box.LeftCm, box.TopCm, box.WidthCm, box.HeightCm,
+                    "Case Study Editorial Section " + (i + 1));
+                panel.FillColor = theme.PanelColor;
+                panel.OutlineColor = theme.PanelBorderColor;
+                panel.OutlineWidthPoints = 0.45;
+                panel.SetShadow("000000", blurPoints: 3, distancePoints: 0.8, angleDegrees: 90, transparencyPercent: 90);
+
+                PowerPointAutoShape accent = slide.AddRectangleCm(box.LeftCm, box.TopCm, 0.12, box.HeightCm,
+                    "Case Study Editorial Accent " + (i + 1));
+                accent.FillColor = GetAccent(theme, i);
+                accent.OutlineColor = GetAccent(theme, i);
+
+                AddText(slide, section.Heading, box.LeftCm + 0.45, box.TopCm + 0.38, box.WidthCm - 0.75, 0.45, 11,
+                    theme.PrimaryTextColor, theme.HeadingFontName, bold: true);
+                PowerPointTextBox body = AddText(slide, section.Body, box.LeftCm + 0.45, box.TopCm + 1.0,
+                    box.WidthCm - 0.75, box.HeightCm - 1.25, 9, theme.SecondaryTextColor, theme.BodyFontName);
+                body.TextAutoFitOptions = new PowerPointTextAutoFitOptions(fontScalePercent: 82, lineSpaceReductionPercent: 18);
+            }
+
+            double visualLeft = slideWidthCm * 0.68;
+            double visualTop = 2.15;
+            double visualWidth = slideWidthCm - visualLeft - 1.45;
+            double visualHeight = 4.75;
+            AddVisualFrame(slide, theme, options.VisualImagePath, visualLeft, visualTop, visualWidth, visualHeight,
+                options.DesignIntent);
+
+            if (metrics.Count > 0) {
+                PowerPointAutoShape metricBand = slide.AddRectangleCm(visualLeft, visualTop + visualHeight + 0.55,
+                    visualWidth, 1.8, "Case Study Editorial Metric Band");
+                metricBand.FillColor = theme.AccentColor;
+                metricBand.OutlineColor = theme.AccentColor;
+                metricBand.SetShadow("000000", blurPoints: 3, distancePoints: 0.8, angleDegrees: 90, transparencyPercent: 88);
+                AddMetrics(slide, theme, metrics, visualLeft + 0.35, visualTop + visualHeight + 0.8,
+                    visualWidth - 0.7, 1.35);
+            }
+
+            AddTags(slide, theme, options.Tags, 1.45, slideHeightCm - 2.05, slideWidthCm * 0.52, 0.55);
+        }
+
+        private static void AddCaseStudyBand(PowerPointSlide slide, PowerPointDesignTheme theme,
+            PowerPointCaseStudySlideOptions options, IReadOnlyList<PowerPointMetric> metrics,
+            double slideWidthCm, double slideHeightCm) {
+            double bandTop = slideHeightCm * 0.55;
+            double bandHeight = slideHeightCm * 0.36;
+            PowerPointAutoShape band = slide.AddRectangleCm(1.2, bandTop, slideWidthCm - 2.4, bandHeight,
+                "Case Study Visual Band");
+            band.FillColor = theme.AccentColor;
+            band.OutlineColor = theme.AccentColor;
+            band.SetSoftEdges(1.1);
+
+            PowerPointAutoShape wash = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, 8.0, bandTop + 0.25,
+                7.2, bandHeight - 0.5, "Case Study Band Wash");
+            wash.FillColor = theme.Accent2Color;
+            wash.FillTransparency = 45;
+            wash.OutlineColor = theme.Accent2Color;
+
+            AddText(slide, options.BrandText ?? string.Empty, 2.0, bandTop + 0.85, 4.4, 0.7, 20,
+                theme.AccentContrastColor, theme.HeadingFontName, bold: true);
+
+            if (!string.IsNullOrWhiteSpace(options.BandLabel)) {
+                AddText(slide, options.BandLabel!, 2.0, bandTop + bandHeight - 1.35, 6.8, 0.5, 17,
+                    theme.AccentLightColor, theme.HeadingFontName, bold: true);
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.PersonImagePath)) {
+                AddPictureIfExists(slide, options.PersonImagePath!, 9.2, bandTop - 1.0, 5.1, bandHeight + 0.4, crop: true);
+            }
+
+            AddMetrics(slide, theme, metrics, slideWidthCm * 0.46, bandTop + 1.75, slideWidthCm * 0.22, 1.65);
+            AddVisualFrame(slide, theme, options.VisualImagePath, slideWidthCm - 8.6, bandTop + 0.9, 6.8, bandHeight - 1.5,
+                options.DesignIntent);
+            AddTags(slide, theme, options.Tags, 9.4, bandTop + bandHeight - 1.15, slideWidthCm - 12.6, 0.7);
+        }
+
+        internal static void AddMetrics(PowerPointSlide slide, PowerPointDesignTheme theme, IReadOnlyList<PowerPointMetric> metrics,
+            double leftCm, double topCm, double widthCm, double heightCm) {
+            if (metrics.Count == 0) {
+                return;
+            }
+
+            int count = Math.Min(metrics.Count, 3);
+            PowerPointLayoutBox[] boxes = PowerPointLayoutBox
+                .FromCentimeters(leftCm, topCm, widthCm, heightCm)
+                .SplitColumnsCm(count, 0.45);
+            double valueHeight = Math.Min(0.88, heightCm * 0.52);
+            double labelTopOffset = valueHeight + Math.Min(0.14, heightCm * 0.08);
+            double labelHeight = Math.Max(0.32, heightCm - labelTopOffset);
+            int valueFontSize = heightCm < 1.6 ? 24 : 29;
+            int labelFontSize = heightCm < 1.6 ? 8 : 9;
+            for (int i = 0; i < count; i++) {
+                PowerPointMetric metric = metrics[i];
+                PowerPointLayoutBox box = boxes[i];
+                PowerPointTextBox value = AddText(slide, metric.Value, box.LeftCm, box.TopCm, box.WidthCm, valueHeight,
+                    valueFontSize,
+                    theme.AccentContrastColor, theme.HeadingFontName, bold: true);
+                CenterText(value);
+                PowerPointTextBox label = AddText(slide, metric.Label, box.LeftCm, box.TopCm + labelTopOffset,
+                    box.WidthCm, labelHeight, labelFontSize,
+                    theme.AccentContrastColor, theme.BodyFontName, bold: true);
+                CenterText(label);
+            }
+        }
+
+        internal static void AddVisualFrame(PowerPointSlide slide, PowerPointDesignTheme theme, string? imagePath,
+            double leftCm, double topCm, double widthCm, double heightCm, PowerPointDesignIntent? intent = null) {
+            PowerPointAutoShape frame = slide.AddRectangleCm(leftCm, topCm, widthCm, heightCm, "Case Study Visual Frame");
+            frame.FillColor = theme.AccentDarkColor;
+            frame.OutlineColor = theme.AccentDarkColor;
+            frame.OutlineWidthPoints = 0;
+            frame.SetShadow("000000", blurPoints: 5, distancePoints: 1.5, angleDegrees: 90, transparencyPercent: 82);
+
+            if (!string.IsNullOrWhiteSpace(imagePath) && File.Exists(imagePath)) {
+                AddPictureIfExists(slide, imagePath!, leftCm + 0.08, topCm + 0.08, widthCm - 0.16, heightCm - 0.16, crop: true);
+                return;
+            }
+
+            AddVisualPlaceholder(slide, theme, leftCm + 0.08, topCm + 0.08, widthCm - 0.16, heightCm - 0.16, intent);
+        }
+
+        private static void AddVisualPlaceholder(PowerPointSlide slide, PowerPointDesignTheme theme,
+            double leftCm, double topCm, double widthCm, double heightCm, PowerPointDesignIntent? intent) {
+            PowerPointAutoShape surface = slide.AddRectangleCm(leftCm, topCm, widthCm, heightCm,
+                "Case Study Visual Surface");
+            surface.FillColor = theme.AccentDarkColor;
+            surface.OutlineColor = theme.AccentDarkColor;
+
+            VisualPlaceholderVariant variant = ResolveVisualPlaceholderVariant(intent);
+            if (variant == VisualPlaceholderVariant.Collage) {
+                AddVisualCollagePlaceholder(slide, theme, leftCm, topCm, widthCm, heightCm);
+                return;
+            }
+            if (variant == VisualPlaceholderVariant.Diagram) {
+                AddVisualDiagramPlaceholder(slide, theme, leftCm, topCm, widthCm, heightCm);
+                return;
+            }
+
+            AddVisualDashboardPlaceholder(slide, theme, leftCm, topCm, widthCm, heightCm);
+        }
+
+        private static void AddVisualDashboardPlaceholder(PowerPointSlide slide, PowerPointDesignTheme theme,
+            double leftCm, double topCm, double widthCm, double heightCm) {
+            PowerPointAutoShape glow = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, leftCm + widthCm * 0.08,
+                topCm, widthCm * 0.42, heightCm, "Case Study Visual Wash");
+            glow.FillColor = theme.Accent2Color;
+            glow.FillTransparency = 68;
+            glow.OutlineColor = theme.Accent2Color;
+
+            double panelTop = topCm + heightCm * 0.24;
+            double panelLeft = leftCm + widthCm * 0.17;
+            double panelWidth = widthCm * 0.66;
+            double panelHeight = heightCm * 0.42;
+            PowerPointAutoShape panel = slide.AddRectangleCm(panelLeft, panelTop, panelWidth, panelHeight,
+                "Case Study Visual Content Panel");
+            panel.FillColor = theme.AccentColor;
+            panel.FillTransparency = 35;
+            panel.OutlineColor = theme.AccentColor;
+            panel.OutlineWidthPoints = 0;
+
+            PowerPointAutoShape imageBlock = slide.AddRectangleCm(panelLeft + panelWidth * 0.08, panelTop + panelHeight * 0.18,
+                panelWidth * 0.34, panelHeight * 0.56, "Case Study Visual Image Block");
+            imageBlock.FillColor = theme.AccentLightColor;
+            imageBlock.FillTransparency = 10;
+            imageBlock.OutlineColor = theme.AccentLightColor;
+
+            for (int i = 0; i < 3; i++) {
+                double barWidth = panelWidth * (i == 0 ? 0.36 : 0.28);
+                PowerPointAutoShape bar = slide.AddRectangleCm(panelLeft + panelWidth * 0.49,
+                    panelTop + panelHeight * (0.23 + i * 0.18), barWidth, 0.045,
+                    "Case Study Visual Line " + (i + 1));
+                bar.FillColor = theme.AccentLightColor;
+                bar.FillTransparency = i == 0 ? 5 : 35;
+                bar.OutlineColor = theme.AccentLightColor;
+            }
+
+            PowerPointAutoShape baseLine = slide.AddLineCm(leftCm + widthCm * 0.18, topCm + heightCm * 0.84,
+                leftCm + widthCm * 0.82, topCm + heightCm * 0.84, "Case Study Visual Base Line");
+            baseLine.OutlineColor = theme.AccentLightColor;
+            baseLine.OutlineWidthPoints = 0.9;
+        }
+
+        private static void AddVisualCollagePlaceholder(PowerPointSlide slide, PowerPointDesignTheme theme,
+            double leftCm, double topCm, double widthCm, double heightCm) {
+            PowerPointAutoShape wash = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, leftCm + widthCm * 0.58,
+                topCm, widthCm * 0.24, heightCm, "Visual Collage Wash");
+            wash.FillColor = theme.Accent2Color;
+            wash.FillTransparency = 62;
+            wash.OutlineColor = theme.Accent2Color;
+
+            AddVisualTile(slide, theme, leftCm + widthCm * 0.10, topCm + heightCm * 0.17,
+                widthCm * 0.38, heightCm * 0.42, "Visual Collage Tile 1", theme.AccentLightColor, 62);
+            AddVisualTile(slide, theme, leftCm + widthCm * 0.43, topCm + heightCm * 0.09,
+                widthCm * 0.43, heightCm * 0.28, "Visual Collage Tile 2", theme.AccentColor, 70);
+            AddVisualTile(slide, theme, leftCm + widthCm * 0.36, topCm + heightCm * 0.55,
+                widthCm * 0.48, heightCm * 0.25, "Visual Collage Tile 3", theme.Accent3Color, 72);
+
+            for (int i = 0; i < 3; i++) {
+                double dot = 0.18 - i * 0.025;
+                PowerPointAutoShape node = slide.AddEllipseCm(leftCm + widthCm * (0.24 + i * 0.19),
+                    topCm + heightCm * (0.77 - i * 0.08), dot, dot, "Visual Collage Marker " + (i + 1));
+                node.FillColor = GetAccent(theme, i);
+                node.OutlineColor = theme.AccentLightColor;
+                node.OutlineWidthPoints = 0.55;
+            }
+        }
+
+        private static void AddVisualDiagramPlaceholder(PowerPointSlide slide, PowerPointDesignTheme theme,
+            double leftCm, double topCm, double widthCm, double heightCm) {
+            PowerPointAutoShape rail = slide.AddRectangleCm(leftCm + widthCm * 0.12, topCm + heightCm * 0.49,
+                widthCm * 0.76, 0.045, "Visual Diagram Rail");
+            rail.FillColor = theme.AccentLightColor;
+            rail.FillTransparency = 15;
+            rail.OutlineColor = theme.AccentLightColor;
+
+            for (int i = 0; i < 4; i++) {
+                double cx = leftCm + widthCm * (0.16 + i * 0.22);
+                double cy = topCm + heightCm * (i % 2 == 0 ? 0.35 : 0.61);
+                PowerPointAutoShape node = slide.AddEllipseCm(cx, cy, 0.58, 0.58, "Visual Diagram Node " + (i + 1));
+                node.FillColor = GetAccent(theme, i);
+                node.FillTransparency = i == 0 ? 0 : 22;
+                node.OutlineColor = theme.AccentLightColor;
+                node.OutlineWidthPoints = 0.55;
+
+                PowerPointAutoShape label = slide.AddRectangleCm(cx + 0.78, cy + 0.22,
+                    widthCm * (i == 0 ? 0.22 : 0.16), 0.04, "Visual Diagram Label " + (i + 1));
+                label.FillColor = theme.AccentLightColor;
+                label.FillTransparency = i == 0 ? 0 : 35;
+                label.OutlineColor = theme.AccentLightColor;
+            }
+
+            PowerPointAutoShape plate = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, leftCm + widthCm * 0.20,
+                topCm + heightCm * 0.14, widthCm * 0.50, heightCm * 0.72, "Visual Diagram Plate");
+            plate.FillColor = theme.AccentColor;
+            plate.FillTransparency = 82;
+            plate.OutlineColor = theme.AccentLightColor;
+            plate.OutlineWidthPoints = 0.45;
+        }
+
+        private static void AddVisualTile(PowerPointSlide slide, PowerPointDesignTheme theme,
+            double leftCm, double topCm, double widthCm, double heightCm, string name, string fillColor,
+            int fillTransparency) {
+            PowerPointAutoShape tile = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, leftCm, topCm, widthCm, heightCm, name);
+            tile.FillColor = fillColor;
+            tile.FillTransparency = fillTransparency;
+            tile.OutlineColor = theme.AccentLightColor;
+            tile.OutlineWidthPoints = 0.45;
+        }
+
+        private static VisualPlaceholderVariant ResolveVisualPlaceholderVariant(PowerPointDesignIntent? intent) {
+            if (intent == null) {
+                return VisualPlaceholderVariant.Dashboard;
+            }
+            if (string.IsNullOrWhiteSpace(intent.Seed) &&
+                intent.Mood == PowerPointDesignMood.Corporate &&
+                intent.Density == PowerPointSlideDensity.Balanced &&
+                intent.VisualStyle == PowerPointVisualStyle.Geometric) {
+                return VisualPlaceholderVariant.Dashboard;
+            }
+            if (intent.VisualStyle == PowerPointVisualStyle.Soft) {
+                return VisualPlaceholderVariant.Collage;
+            }
+            if (intent.VisualStyle == PowerPointVisualStyle.Minimal) {
+                return VisualPlaceholderVariant.Diagram;
+            }
+
+            return intent.Pick(3, "visual-placeholder") switch {
+                0 => VisualPlaceholderVariant.Dashboard,
+                1 => VisualPlaceholderVariant.Collage,
+                _ => VisualPlaceholderVariant.Diagram
+            };
+        }
+
+        private static void AddTags(PowerPointSlide slide, PowerPointDesignTheme theme, IList<string> tags,
+            double leftCm, double topCm, double widthCm, double heightCm) {
+            if (tags.Count == 0) {
+                return;
+            }
+
+            int count = Math.Min(tags.Count, 7);
+            PowerPointLayoutBox[] boxes = PowerPointLayoutBox
+                .FromCentimeters(leftCm, topCm, widthCm, heightCm)
+                .SplitColumnsCm(count, 0.28);
+            for (int i = 0; i < count; i++) {
+                PowerPointLayoutBox box = boxes[i];
+                PowerPointAutoShape pill = slide.AddRectangleCm(box.LeftCm, box.TopCm, box.WidthCm, box.HeightCm,
+                    "Case Study Tag " + (i + 1));
+                pill.FillColor = i == count - 1 ? theme.Accent2Color : theme.AccentColor;
+                pill.FillTransparency = i == count - 1 ? 0 : 40;
+                pill.OutlineColor = theme.AccentLightColor;
+                pill.OutlineWidthPoints = 0.6;
+
+                PowerPointTextBox label = AddText(slide, tags[i], box.LeftCm + 0.08, box.TopCm + 0.16,
+                    box.WidthCm - 0.16, box.HeightCm - 0.25, 8, theme.AccentContrastColor, theme.BodyFontName,
+                    bold: i == count - 1);
+                CenterText(label);
+            }
+        }
+
+        internal static void AddCardGrid(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointCardContent> cards, PowerPointCardGridSlideOptions options,
+            PowerPointCardGridLayoutVariant variant, double slideWidthCm, double slideHeightCm) {
+            double top = options.DesignIntent.Density == PowerPointSlideDensity.Relaxed ? 4.35 : 4.05;
+            double height = string.IsNullOrWhiteSpace(options.SupportingText)
+                ? slideHeightCm - 6.0
+                : slideHeightCm - 8.7;
+            PowerPointLayoutBox bounds = PowerPointLayoutBox.FromCentimeters(1.5, top, slideWidthCm - 3.0, height);
+            AddCardGrid(slide, theme, cards, options, variant, bounds);
+
+            if (!string.IsNullOrWhiteSpace(options.SupportingText)) {
+                PowerPointAutoShape band = slide.AddRectangleCm(1.55, slideHeightCm - 3.25, slideWidthCm - 3.1, 1.8,
+                    "Designer Supporting Band");
+                band.FillColor = theme.PanelColor;
+                band.OutlineColor = theme.PanelBorderColor;
+                band.SetShadow("000000", blurPoints: 4, distancePoints: 1, angleDegrees: 90, transparencyPercent: 88);
+                AddText(slide, options.SupportingText!, 2.15, slideHeightCm - 2.8, slideWidthCm - 4.3, 0.9, 13,
+                    theme.SecondaryTextColor, theme.BodyFontName);
+            }
+        }
+
+        internal static void AddCardGrid(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointCardContent> cards, PowerPointCardGridSlideOptions options,
+            PowerPointCardGridLayoutVariant variant, PowerPointLayoutBox bounds) {
+            int maxColumns = Math.Max(1, options.MaxColumns);
+            int columns = Math.Min(maxColumns, cards.Count);
+            int rows = (int)Math.Ceiling(cards.Count / (double)columns);
+            double columnGap = variant == PowerPointCardGridLayoutVariant.SoftTiles ? 0.42 : 0.65;
+            double rowGap = variant == PowerPointCardGridLayoutVariant.SoftTiles ? 0.42 : 0.55;
+            PowerPointLayoutBox[,] grid = PowerPointLayoutBox
+                .FromCentimeters(bounds.LeftCm, bounds.TopCm, bounds.WidthCm, bounds.HeightCm)
+                .SplitGridCm(rows, columns, rowGap, columnGap);
+
+            for (int i = 0; i < cards.Count; i++) {
+                int row = i / columns;
+                int column = i % columns;
+                AddDesignerCard(slide, theme, cards[i], grid[row, column], i, variant);
+            }
+        }
+
+        private static void AddDesignerCard(PowerPointSlide slide, PowerPointDesignTheme theme, PowerPointCardContent card,
+            PowerPointLayoutBox box, int index, PowerPointCardGridLayoutVariant variant) {
+            string accent = card.AccentColor ?? GetAccent(theme, index);
+            PowerPointAutoShape panel = slide.AddRectangleCm(box.LeftCm, box.TopCm, box.WidthCm, box.HeightCm,
+                "Designer Card " + (index + 1));
+            panel.FillColor = theme.PanelColor;
+            panel.OutlineColor = theme.PanelBorderColor;
+            panel.OutlineWidthPoints = variant == PowerPointCardGridLayoutVariant.SoftTiles ? 0.35 : 0.8;
+            panel.SetShadow("000000", blurPoints: variant == PowerPointCardGridLayoutVariant.SoftTiles ? 3 : 5,
+                distancePoints: variant == PowerPointCardGridLayoutVariant.SoftTiles ? 0.8 : 1.5,
+                angleDegrees: 90, transparencyPercent: 88);
+
+            if (variant == PowerPointCardGridLayoutVariant.SoftTiles) {
+                panel.FillColor = theme.SurfaceColor;
+                PowerPointAutoShape accentStrip = slide.AddRectangleCm(box.LeftCm, box.TopCm, 0.13, box.HeightCm,
+                    "Designer Card Accent " + (index + 1));
+                accentStrip.FillColor = accent;
+                accentStrip.OutlineColor = accent;
+            } else {
+                PowerPointAutoShape accentBar = slide.AddRectangleCm(box.LeftCm, box.TopCm, box.WidthCm, 0.18,
+                    "Designer Card Accent " + (index + 1));
+                accentBar.FillColor = accent;
+                accentBar.OutlineColor = accent;
+            }
+
+            double titleLeft = variant == PowerPointCardGridLayoutVariant.SoftTiles ? box.LeftCm + 0.6 : box.LeftCm + 0.45;
+            AddText(slide, card.Title, titleLeft, box.TopCm + 0.65, box.WidthCm - 0.9, 0.6, 15,
+                theme.PrimaryTextColor, theme.HeadingFontName, bold: true);
+
+            PowerPointTextBox body = slide.AddTextBox("", PowerPointLayoutBox.FromCentimeters(
+                titleLeft + 0.1, box.TopCm + 1.55, box.WidthCm - 1.05, box.HeightCm - 1.9));
+            body.SetTextMarginsCm(0, 0, 0, 0);
+            body.TextAutoFit = PowerPointTextAutoFit.Normal;
+
+            if (card.Items.Count == 0) {
+                body.SetParagraphs(new[] { " " });
+                return;
+            }
+
+            body.SetBullets(card.Items.Select(item => " " + item), configure: paragraph => {
+                paragraph.SetFontName(theme.BodyFontName)
+                    .SetFontSize(10)
+                    .SetColor(theme.SecondaryTextColor)
+                    .SetHangingPoints(16)
+                    .SetSpaceAfterPoints(4)
+                    .SetBulletSizePercent(70);
+            });
+        }
+
+        internal static void AddProcessTimeline(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointProcessStep> steps, PowerPointProcessSlideOptions options,
+            double slideWidthCm, double slideHeightCm) {
+            PowerPointProcessLayoutVariant variant = ResolveProcessVariant(options, steps);
+            if (variant == PowerPointProcessLayoutVariant.NumberedColumns) {
+                AddProcessColumns(slide, theme, steps, options, slideWidthCm, slideHeightCm);
+                return;
+            }
+
+            int count = steps.Count;
+            double left = options.DesignIntent.Density == PowerPointSlideDensity.Relaxed ? 2.35 : 2.1;
+            double top = slideHeightCm * 0.47;
+            double width = slideWidthCm - 4.2;
+            double height = 4.7;
+            AddProcessRailTimeline(slide, theme, steps, PowerPointLayoutBox.FromCentimeters(left, top, width, height));
+        }
+
+        internal static void AddProcessTimeline(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointProcessStep> steps, PowerPointProcessSlideOptions options,
+            PowerPointLayoutBox bounds) {
+            PowerPointProcessLayoutVariant variant = ResolveProcessVariant(options, steps);
+            if (variant == PowerPointProcessLayoutVariant.NumberedColumns) {
+                AddProcessColumns(slide, theme, steps, options, bounds);
+                return;
+            }
+
+            AddProcessRailTimeline(slide, theme, steps, bounds);
+        }
+
+        private static void AddProcessRailTimeline(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointProcessStep> steps, PowerPointLayoutBox bounds) {
+            int count = steps.Count;
+            PowerPointLayoutBox[] boxes = PowerPointLayoutBox
+                .FromCentimeters(bounds.LeftCm, bounds.TopCm, bounds.WidthCm, bounds.HeightCm)
+                .SplitColumnsCm(count, count > 5 ? 0.45 : 0.75);
+
+            double nodeSize = count > 5 ? 0.95 : 1.16;
+            double railY = bounds.TopCm + nodeSize / 2;
+            double railStart = boxes[0].LeftCm + nodeSize / 2;
+            double railEnd = boxes[count - 1].LeftCm + nodeSize / 2;
+            AddProcessRail(slide, theme, railStart, railEnd, railY);
+
+            for (int i = 0; i < count; i++) {
+                PowerPointLayoutBox box = boxes[i];
+                PowerPointProcessStep step = steps[i];
+                string number = !string.IsNullOrWhiteSpace(step.Number) ? step.Number! : (i + 1).ToString() + ".";
+                AddProcessNode(slide, theme, i, box.LeftCm, box.TopCm, nodeSize, number);
+                AddText(slide, step.Title, box.LeftCm, box.TopCm + 1.55, box.WidthCm, 0.7, 13,
+                    theme.AccentContrastColor, theme.HeadingFontName, bold: true);
+                AddText(slide, step.Body, box.LeftCm, box.TopCm + 2.45, box.WidthCm, 1.7, 10,
+                    theme.AccentLightColor, theme.BodyFontName);
+            }
+        }
+
+        private static void AddProcessColumns(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointProcessStep> steps, PowerPointProcessSlideOptions options,
+            double slideWidthCm, double slideHeightCm) {
+            double left = 1.85;
+            double top = slideHeightCm * 0.45;
+            double width = slideWidthCm - 3.7;
+            double height = 4.85;
+            AddProcessColumns(slide, theme, steps, options, PowerPointLayoutBox.FromCentimeters(left, top, width, height));
+        }
+
+        private static void AddProcessColumns(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointProcessStep> steps, PowerPointProcessSlideOptions options,
+            PowerPointLayoutBox bounds) {
+            int count = steps.Count;
+            double gutter = options.DesignIntent.Density == PowerPointSlideDensity.Compact ? 0.35 : 0.6;
+            PowerPointLayoutBox[] boxes = PowerPointLayoutBox
+                .FromCentimeters(bounds.LeftCm, bounds.TopCm, bounds.WidthCm, bounds.HeightCm)
+                .SplitColumnsCm(count, gutter);
+
+            for (int i = 0; i < count; i++) {
+                PowerPointLayoutBox box = boxes[i];
+                PowerPointProcessStep step = steps[i];
+                string number = !string.IsNullOrWhiteSpace(step.Number) ? step.Number! : (i + 1).ToString("00");
+
+                PowerPointAutoShape panel = slide.AddRectangleCm(box.LeftCm, box.TopCm, box.WidthCm, box.HeightCm,
+                    "Process Column " + (i + 1));
+                panel.FillColor = theme.AccentColor;
+                panel.FillTransparency = 72;
+                panel.OutlineColor = theme.AccentLightColor;
+                panel.OutlineWidthPoints = 0.35;
+
+                PowerPointAutoShape rule = slide.AddRectangleCm(box.LeftCm, box.TopCm, box.WidthCm * 0.34, 0.08,
+                    "Process Column Rule " + (i + 1));
+                rule.FillColor = GetAccent(theme, i);
+                rule.OutlineColor = GetAccent(theme, i);
+
+                AddText(slide, number.TrimEnd('.'), box.LeftCm + 0.26, box.TopCm + 0.45, box.WidthCm - 0.52, 0.85,
+                    count > 5 ? 20 : 25, theme.AccentContrastColor, theme.HeadingFontName, bold: true);
+                AddText(slide, step.Title, box.LeftCm + 0.26, box.TopCm + 1.65, box.WidthCm - 0.52, 0.72, 13,
+                    theme.AccentContrastColor, theme.HeadingFontName, bold: true);
+                AddText(slide, step.Body, box.LeftCm + 0.26, box.TopCm + 2.55, box.WidthCm - 0.52, 1.55, 10,
+                    theme.AccentLightColor, theme.BodyFontName);
+            }
+        }
+
+        private static void AddSubtleLightBackground(PowerPointSlide slide, PowerPointDesignTheme theme,
+            double slideWidthCm, double slideHeightCm) {
+            PowerPointAutoShape diagonal = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, slideWidthCm * 0.28, 0,
+                slideWidthCm * 0.22, slideHeightCm, "Designer Light Diagonal");
+            diagonal.FillColor = theme.SurfaceColor;
+            diagonal.FillTransparency = 35;
+            diagonal.OutlineColor = theme.SurfaceColor;
+            diagonal.SendToBack();
+        }
+
+        private static void AddDiagonalPlanes(PowerPointSlide slide, PowerPointDesignTheme theme, double slideWidthCm,
+            double slideHeightCm, bool dark) {
+            string baseColor = dark ? theme.AccentColor : theme.SurfaceColor;
+            string second = dark ? theme.AccentDarkColor : theme.AccentLightColor;
+
+            PowerPointAutoShape left = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, -1.0, 0,
+                slideWidthCm * 0.48, slideHeightCm, "Designer Plane Left");
+            left.FillColor = baseColor;
+            left.FillTransparency = dark ? 18 : 60;
+            left.OutlineColor = baseColor;
+
+            PowerPointAutoShape middle = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, slideWidthCm * 0.46, 0,
+                slideWidthCm * 0.27, slideHeightCm, "Designer Plane Middle");
+            middle.FillColor = second;
+            middle.FillTransparency = dark ? 35 : 72;
+            middle.OutlineColor = second;
+        }
+
+        private static void AddChrome(PowerPointSlide slide, PowerPointDesignTheme theme, double slideWidthCm,
+            double slideHeightCm, bool dark, PowerPointDesignerSlideOptions options) {
+            string text = dark ? theme.AccentLightColor : theme.MutedTextColor;
+            string footer = dark ? theme.AccentContrastColor : theme.AccentDarkColor;
+
+            if (!string.IsNullOrWhiteSpace(options.Eyebrow)) {
+                AddText(slide, options.Eyebrow!, 1.8, 1.05, 8.0, 0.35, 8, text, theme.BodyFontName);
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.FooterLeft)) {
+                AddText(slide, options.FooterLeft!, 1.75, slideHeightCm - 1.35, 6.0, 0.45, 16, footer,
+                    theme.HeadingFontName, bold: true);
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.FooterRight)) {
+                PowerPointTextBox right = AddText(slide, options.FooterRight!, slideWidthCm - 5.4,
+                    slideHeightCm - 1.35, 4.1, 0.45, 12, footer, theme.HeadingFontName, bold: true);
+                RightAlignText(right);
+            }
+
+            if (ShouldShowDirectionMotif(options) && !dark) {
+                AddDirectionMotif(slide, slideWidthCm - 4.9, 1.48, 12, 0.35, theme.AccentColor, flip: true);
+            }
+        }
+
+        private static bool ShouldShowDirectionMotif(PowerPointDesignerSlideOptions options) {
+            return options.ShowDirectionMotif && options.DesignIntent.VisualStyle != PowerPointVisualStyle.Minimal;
+        }
+
+        private enum VisualPlaceholderVariant {
+            Dashboard,
+            Collage,
+            Diagram
+        }
+
+        private static void AddProcessRail(PowerPointSlide slide, PowerPointDesignTheme theme,
+            double startXCm, double endXCm, double yCm) {
+            PowerPointAutoShape rail = slide.AddLineCm(startXCm, yCm, endXCm, yCm, "Process Rail");
+            rail.OutlineColor = theme.AccentLightColor;
+            rail.OutlineWidthPoints = 1.1;
+        }
+
+        private static void AddProcessNode(PowerPointSlide slide, PowerPointDesignTheme theme, int index,
+            double leftCm, double topCm, double sizeCm, string number) {
+            PowerPointAutoShape halo = slide.AddEllipseCm(leftCm - 0.08, topCm - 0.08,
+                sizeCm + 0.16, sizeCm + 0.16, "Process Node Halo " + (index + 1));
+            halo.FillColor = theme.AccentLightColor;
+            halo.FillTransparency = 78;
+            halo.OutlineColor = theme.AccentLightColor;
+            halo.OutlineWidthPoints = 0.2;
+
+            PowerPointAutoShape node = slide.AddEllipseCm(leftCm, topCm, sizeCm, sizeCm,
+                "Process Node " + (index + 1));
+            node.FillColor = theme.AccentDarkColor;
+            node.FillTransparency = 8;
+            node.OutlineColor = theme.AccentLightColor;
+            node.OutlineWidthPoints = 1.2;
+
+            PowerPointTextBox numberBox = AddText(slide, number.TrimEnd('.'), leftCm, topCm - 0.01, sizeCm, sizeCm,
+                sizeCm < 1 ? 16 : 20, theme.AccentContrastColor, theme.HeadingFontName, bold: true);
+            CenterText(numberBox);
+        }
+
+        private static void AddDirectionMotif(PowerPointSlide slide, double leftCm, double topCm, int count,
+            double spacingCm, string color, bool flip = false) {
+            for (int i = 0; i < count; i++) {
+                PowerPointAutoShape arrow = slide.AddShapeCm(A.ShapeTypeValues.Triangle,
+                    leftCm + i * spacingCm, topCm, 0.22, 0.24, "Designer Direction " + (i + 1));
+                arrow.FillColor = color;
+                arrow.FillTransparency = Math.Min(45, i * 3);
+                arrow.OutlineColor = color;
+                arrow.Rotation = flip ? 270 : 90;
+            }
+        }
+
+        internal static PowerPointTextBox AddText(PowerPointSlide slide, string text, double leftCm, double topCm,
+            double widthCm, double heightCm, int fontSize, string color, string fontName, bool bold = false) {
+            PowerPointTextBox box = slide.AddTextBoxCm(text, leftCm, topCm, widthCm, heightCm);
+            box.SetTextMarginsCm(0, 0, 0, 0);
+            box.FontName = fontName;
+            box.FontSize = fontSize;
+            box.Color = color;
+            box.Bold = bold;
+            box.TextAutoFit = PowerPointTextAutoFit.Normal;
+            return box;
+        }
+
+        private static PowerPointPicture? AddPictureIfExists(PowerPointSlide slide, string imagePath,
+            double leftCm, double topCm, double widthCm, double heightCm, bool crop) {
+            if (!File.Exists(imagePath)) {
+                return null;
+            }
+
+            PowerPointPicture picture = slide.AddPictureCm(imagePath, leftCm, topCm, widthCm, heightCm);
+            if (crop && TryGetImageDimensions(imagePath, out double imageWidth, out double imageHeight)) {
+                picture.FitToBox(imageWidth, imageHeight, crop: true);
+            }
+            return picture;
+        }
+
+        private static bool TryGetImageDimensions(string imagePath, out double width, out double height) {
+            width = 0;
+            height = 0;
+
+            using FileStream stream = File.OpenRead(imagePath);
+            if (TryGetPngDimensions(stream, out width, out height)) {
+                return true;
+            }
+
+            stream.Position = 0;
+            return TryGetJpegDimensions(stream, out width, out height);
+        }
+
+        private static bool TryGetPngDimensions(Stream stream, out double width, out double height) {
+            width = 0;
+            height = 0;
+
+            byte[] header = new byte[24];
+            if (stream.Read(header, 0, header.Length) != header.Length) {
+                return false;
+            }
+
+            byte[] signature = { 137, 80, 78, 71, 13, 10, 26, 10 };
+            for (int i = 0; i < signature.Length; i++) {
+                if (header[i] != signature[i]) {
+                    return false;
+                }
+            }
+
+            width = ReadBigEndianInt32(header, 16);
+            height = ReadBigEndianInt32(header, 20);
+            return width > 0 && height > 0;
+        }
+
+        private static bool TryGetJpegDimensions(Stream stream, out double width, out double height) {
+            width = 0;
+            height = 0;
+
+            int first = stream.ReadByte();
+            int second = stream.ReadByte();
+            if (first != 0xFF || second != 0xD8) {
+                return false;
+            }
+
+            while (stream.Position < stream.Length) {
+                int markerPrefix;
+                do {
+                    markerPrefix = stream.ReadByte();
+                    if (markerPrefix < 0) {
+                        return false;
+                    }
+                } while (markerPrefix != 0xFF);
+
+                int marker;
+                do {
+                    marker = stream.ReadByte();
+                    if (marker < 0) {
+                        return false;
+                    }
+                } while (marker == 0xFF);
+
+                if (marker is 0xD8 or 0xD9) {
+                    continue;
+                }
+
+                int segmentLength = ReadBigEndianUInt16(stream);
+                if (segmentLength < 2 || stream.Position + segmentLength - 2 > stream.Length) {
+                    return false;
+                }
+
+                if (IsJpegStartOfFrame(marker)) {
+                    stream.ReadByte();
+                    height = ReadBigEndianUInt16(stream);
+                    width = ReadBigEndianUInt16(stream);
+                    return width > 0 && height > 0;
+                }
+
+                stream.Position += segmentLength - 2;
+            }
+
+            return false;
+        }
+
+        private static bool IsJpegStartOfFrame(int marker) {
+            return marker is 0xC0 or 0xC1 or 0xC2 or 0xC3 or 0xC5 or 0xC6 or 0xC7 or
+                0xC9 or 0xCA or 0xCB or 0xCD or 0xCE or 0xCF;
+        }
+
+        private static int ReadBigEndianInt32(byte[] bytes, int offset) {
+            return (bytes[offset] << 24) | (bytes[offset + 1] << 16) | (bytes[offset + 2] << 8) | bytes[offset + 3];
+        }
+
+        private static int ReadBigEndianUInt16(Stream stream) {
+            int high = stream.ReadByte();
+            int low = stream.ReadByte();
+            if (high < 0 || low < 0) {
+                return -1;
+            }
+
+            return (high << 8) | low;
+        }
+
+        private static void CenterText(PowerPointTextBox textBox) {
+            foreach (PowerPointParagraph paragraph in textBox.Paragraphs) {
+                paragraph.Alignment = A.TextAlignmentTypeValues.Center;
+            }
+            textBox.TextVerticalAlignment = A.TextAnchoringTypeValues.Center;
+        }
+
+        private static void RightAlignText(PowerPointTextBox textBox) {
+            foreach (PowerPointParagraph paragraph in textBox.Paragraphs) {
+                paragraph.Alignment = A.TextAlignmentTypeValues.Right;
+            }
+        }
+
+        private static string GetAccent(PowerPointDesignTheme theme, int index) {
+            string[] colors = {
+                theme.AccentColor,
+                theme.Accent3Color,
+                theme.Accent2Color,
+                theme.AccentDarkColor,
+                theme.WarningColor
+            };
+            return colors[index % colors.Length];
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointDesignModels.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDesignModels.cs
@@ -1,0 +1,641 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Broad visual direction for designer compositions.
+    /// </summary>
+    public enum PowerPointDesignMood {
+        /// <summary>Clean business presentation style.</summary>
+        Corporate,
+        /// <summary>More editorial spacing and emphasis.</summary>
+        Editorial,
+        /// <summary>More vivid accent treatment.</summary>
+        Energetic,
+        /// <summary>Reduced decoration and quieter surfaces.</summary>
+        Minimal
+    }
+
+    /// <summary>
+    ///     Preferred amount of content breathing room on generated slides.
+    /// </summary>
+    public enum PowerPointSlideDensity {
+        /// <summary>Fits more content into each slide region.</summary>
+        Compact,
+        /// <summary>Default balance between content and whitespace.</summary>
+        Balanced,
+        /// <summary>Adds more breathing room around content.</summary>
+        Relaxed
+    }
+
+    /// <summary>
+    ///     Visual language used by designer primitives.
+    /// </summary>
+    public enum PowerPointVisualStyle {
+        /// <summary>Uses angular planes and structural accents.</summary>
+        Geometric,
+        /// <summary>Uses softer panels and lighter accents.</summary>
+        Soft,
+        /// <summary>Uses the fewest decorative elements.</summary>
+        Minimal
+    }
+
+    /// <summary>
+    ///     Section/title slide layout variants. Auto uses the design intent seed to pick a stable variant.
+    /// </summary>
+    public enum PowerPointSectionLayoutVariant {
+        /// <summary>Choose a deterministic variant from the design intent.</summary>
+        Auto,
+        /// <summary>Full-bleed dark title slide with geometric planes.</summary>
+        GeometricCover,
+        /// <summary>Editorial light title slide with a strong accent rail.</summary>
+        EditorialRail,
+        /// <summary>Poster-style dark title slide with a large centered title area.</summary>
+        Poster
+    }
+
+    /// <summary>
+    ///     Case-study slide layout variants. Auto uses the design intent seed to pick a stable variant.
+    /// </summary>
+    public enum PowerPointCaseStudyLayoutVariant {
+        /// <summary>Choose a deterministic variant from the design intent.</summary>
+        Auto,
+        /// <summary>Summary columns with a strong visual band.</summary>
+        VisualBand,
+        /// <summary>Editorial split with narrative cards and a right-side visual panel.</summary>
+        EditorialSplit,
+        /// <summary>Large visual frame paired with a compact narrative stack.</summary>
+        VisualHero
+    }
+
+    /// <summary>
+    ///     Process slide layout variants. Auto uses the design intent seed to pick a stable variant.
+    /// </summary>
+    public enum PowerPointProcessLayoutVariant {
+        /// <summary>Choose a deterministic variant from the design intent.</summary>
+        Auto,
+        /// <summary>Horizontal rail with numbered nodes.</summary>
+        Rail,
+        /// <summary>Separate numbered columns without a rail.</summary>
+        NumberedColumns
+    }
+
+    /// <summary>
+    ///     Card grid layout variants. Auto uses the design intent seed to pick a stable variant.
+    /// </summary>
+    public enum PowerPointCardGridLayoutVariant {
+        /// <summary>Choose a deterministic variant from the design intent.</summary>
+        Auto,
+        /// <summary>Cards with a horizontal accent bar.</summary>
+        AccentTop,
+        /// <summary>Softer cards with a vertical accent strip.</summary>
+        SoftTiles
+    }
+
+    /// <summary>
+    ///     Logo/certification wall layout variants. Auto uses the design intent seed to pick a stable variant.
+    /// </summary>
+    public enum PowerPointLogoWallLayoutVariant {
+        /// <summary>Choose a deterministic variant from the design intent.</summary>
+        Auto,
+        /// <summary>Balanced grid of partner, certification, or product marks.</summary>
+        LogoMosaic,
+        /// <summary>Logo grid paired with a larger certificate or proof frame.</summary>
+        CertificateFeature
+    }
+
+    /// <summary>
+    ///     Coverage/location slide layout variants. Auto uses the design intent seed to pick a stable variant.
+    /// </summary>
+    public enum PowerPointCoverageLayoutVariant {
+        /// <summary>Choose a deterministic variant from the design intent.</summary>
+        Auto,
+        /// <summary>Large map-like board with pins and a compact location strip.</summary>
+        PinBoard,
+        /// <summary>Location list paired with a focused map-like panel.</summary>
+        ListMap
+    }
+
+    /// <summary>
+    ///     Capability/content slide layout variants. Auto uses the design intent seed to pick a stable variant.
+    /// </summary>
+    public enum PowerPointCapabilityLayoutVariant {
+        /// <summary>Choose a deterministic variant from the design intent.</summary>
+        Auto,
+        /// <summary>Narrative sections on the left, visual support on the right.</summary>
+        TextVisual,
+        /// <summary>Visual support on the left, narrative sections on the right.</summary>
+        VisualText,
+        /// <summary>Full-width stacked section panels with optional metrics below.</summary>
+        Stacked
+    }
+
+    /// <summary>
+    ///     Visual support type for capability/content slides.
+    /// </summary>
+    public enum PowerPointCapabilityVisualKind {
+        /// <summary>A polished image frame or editable placeholder.</summary>
+        VisualFrame,
+        /// <summary>An editable coverage map-like panel with normalized pins.</summary>
+        CoverageMap,
+        /// <summary>An editable logo/proof wall.</summary>
+        LogoWall
+    }
+
+    /// <summary>
+    ///     Describes the intended feel of generated designer slides without requiring manual placement.
+    /// </summary>
+    public sealed class PowerPointDesignIntent {
+        /// <summary>
+        ///     Creates a neutral, reusable design intent.
+        /// </summary>
+        public PowerPointDesignIntent() {
+        }
+
+        /// <summary>
+        ///     Creates a design intent from a broad deck mood.
+        /// </summary>
+        public static PowerPointDesignIntent FromMood(PowerPointDesignMood mood, string? seed = null) {
+            PowerPointDesignIntent intent = new() {
+                Seed = seed,
+                Mood = mood
+            };
+
+            switch (mood) {
+                case PowerPointDesignMood.Editorial:
+                    intent.Density = PowerPointSlideDensity.Relaxed;
+                    intent.VisualStyle = PowerPointVisualStyle.Soft;
+                    break;
+                case PowerPointDesignMood.Energetic:
+                    intent.Density = PowerPointSlideDensity.Balanced;
+                    intent.VisualStyle = PowerPointVisualStyle.Geometric;
+                    break;
+                case PowerPointDesignMood.Minimal:
+                    intent.Density = PowerPointSlideDensity.Relaxed;
+                    intent.VisualStyle = PowerPointVisualStyle.Minimal;
+                    break;
+                default:
+                    intent.Density = PowerPointSlideDensity.Balanced;
+                    intent.VisualStyle = PowerPointVisualStyle.Geometric;
+                    break;
+            }
+
+            return intent;
+        }
+
+        /// <summary>
+        ///     Creates a copy of this intent.
+        /// </summary>
+        public PowerPointDesignIntent Clone() {
+            return new PowerPointDesignIntent {
+                Seed = Seed,
+                Mood = Mood,
+                Density = Density,
+                VisualStyle = VisualStyle
+            };
+        }
+
+        /// <summary>
+        ///     Optional stable seed used to choose deterministic variants.
+        /// </summary>
+        public string? Seed { get; set; }
+
+        /// <summary>
+        ///     Broad visual mood.
+        /// </summary>
+        public PowerPointDesignMood Mood { get; set; } = PowerPointDesignMood.Corporate;
+
+        /// <summary>
+        ///     Desired content density.
+        /// </summary>
+        public PowerPointSlideDensity Density { get; set; } = PowerPointSlideDensity.Balanced;
+
+        /// <summary>
+        ///     Preferred primitive visual style.
+        /// </summary>
+        public PowerPointVisualStyle VisualStyle { get; set; } = PowerPointVisualStyle.Geometric;
+
+        internal int Pick(int choices, string salt) {
+            if (choices <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(choices));
+            }
+
+            string value = string.Join("|", Seed ?? string.Empty, Mood, Density, VisualStyle, salt);
+            unchecked {
+                int hash = (int)2166136261;
+                for (int i = 0; i < value.Length; i++) {
+                    hash ^= value[i];
+                    hash *= 16777619;
+                }
+                return (hash & int.MaxValue) % choices;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Common chrome options for high-level designer slides.
+    /// </summary>
+    public class PowerPointDesignerSlideOptions {
+        /// <summary>
+        ///     Small label placed near the top of the slide.
+        /// </summary>
+        public string? Eyebrow { get; set; }
+
+        /// <summary>
+        ///     Left footer text, often a logo wordmark or product name.
+        /// </summary>
+        public string? FooterLeft { get; set; } = "OfficeIMO";
+
+        /// <summary>
+        ///     Right footer text.
+        /// </summary>
+        public string? FooterRight { get; set; }
+
+        /// <summary>
+        ///     Adds a row of editable triangle markers for movement and visual rhythm.
+        /// </summary>
+        public bool ShowDirectionMotif { get; set; } = true;
+
+        /// <summary>
+        ///     Design intent used for deterministic visual variation.
+        /// </summary>
+        public PowerPointDesignIntent DesignIntent { get; set; } = new();
+
+        /// <summary>
+        ///     Section slide layout variant. Used by section/title slide helpers.
+        /// </summary>
+        public PowerPointSectionLayoutVariant SectionVariant { get; set; } = PowerPointSectionLayoutVariant.Auto;
+    }
+
+    /// <summary>
+    ///     Options for a case-study summary slide.
+    /// </summary>
+    public sealed class PowerPointCaseStudySlideOptions : PowerPointDesignerSlideOptions {
+        /// <summary>
+        ///     Case-study layout variant. Auto uses the design intent seed.
+        /// </summary>
+        public PowerPointCaseStudyLayoutVariant Variant { get; set; } = PowerPointCaseStudyLayoutVariant.Auto;
+
+        /// <summary>
+        ///     Optional supporting image displayed in the bottom visual area.
+        /// </summary>
+        public string? VisualImagePath { get; set; }
+
+        /// <summary>
+        ///     Optional person or product cutout displayed in the bottom brand band.
+        /// </summary>
+        public string? PersonImagePath { get; set; }
+
+        /// <summary>
+        ///     Brand text displayed inside the bottom band when no logo asset is provided.
+        /// </summary>
+        public string? BrandText { get; set; } = "OfficeIMO";
+
+        /// <summary>
+        ///     Label shown in the bottom band.
+        /// </summary>
+        public string? BandLabel { get; set; } = "Project portfolio";
+
+        /// <summary>
+        ///     Optional tags displayed as pills along the bottom band.
+        /// </summary>
+        public IList<string> Tags { get; } = new List<string>();
+    }
+
+    /// <summary>
+    ///     Options for a card-grid slide.
+    /// </summary>
+    public sealed class PowerPointCardGridSlideOptions : PowerPointDesignerSlideOptions {
+        /// <summary>
+        ///     Maximum cards per row before the layout wraps.
+        /// </summary>
+        public int MaxColumns { get; set; } = 4;
+
+        /// <summary>
+        ///     Card layout variant. Auto uses the design intent seed.
+        /// </summary>
+        public PowerPointCardGridLayoutVariant Variant { get; set; } = PowerPointCardGridLayoutVariant.Auto;
+
+        /// <summary>
+        ///     Optional supporting text block displayed below the cards.
+        /// </summary>
+        public string? SupportingText { get; set; }
+    }
+
+    /// <summary>
+    ///     Options for process/timeline slides.
+    /// </summary>
+    public sealed class PowerPointProcessSlideOptions : PowerPointDesignerSlideOptions {
+        /// <summary>
+        ///     Adds translucent diagonal planes behind the timeline.
+        /// </summary>
+        public bool ShowDiagonalPlanes { get; set; } = true;
+
+        /// <summary>
+        ///     Process layout variant. Auto uses the design intent seed.
+        /// </summary>
+        public PowerPointProcessLayoutVariant Variant { get; set; } = PowerPointProcessLayoutVariant.Auto;
+    }
+
+    /// <summary>
+    ///     Options for logo, partner, or certification wall slides.
+    /// </summary>
+    public sealed class PowerPointLogoWallSlideOptions : PowerPointDesignerSlideOptions {
+        /// <summary>
+        ///     Logo wall layout variant. Auto uses the design intent seed.
+        /// </summary>
+        public PowerPointLogoWallLayoutVariant Variant { get; set; } = PowerPointLogoWallLayoutVariant.Auto;
+
+        /// <summary>
+        ///     Maximum logo tiles per row before the layout wraps.
+        /// </summary>
+        public int MaxColumns { get; set; } = 5;
+
+        /// <summary>
+        ///     Optional supporting text displayed below or beside the logo wall.
+        /// </summary>
+        public string? SupportingText { get; set; }
+
+        /// <summary>
+        ///     Optional image displayed as a featured proof/certificate visual.
+        /// </summary>
+        public string? FeaturedImagePath { get; set; }
+
+        /// <summary>
+        ///     Optional caption shown near the featured proof/certificate visual.
+        /// </summary>
+        public string? FeatureTitle { get; set; }
+    }
+
+    /// <summary>
+    ///     Options for coverage and location slides.
+    /// </summary>
+    public sealed class PowerPointCoverageSlideOptions : PowerPointDesignerSlideOptions {
+        /// <summary>
+        ///     Coverage layout variant. Auto uses the design intent seed.
+        /// </summary>
+        public PowerPointCoverageLayoutVariant Variant { get; set; } = PowerPointCoverageLayoutVariant.Auto;
+
+        /// <summary>
+        ///     Optional supporting text displayed with the location list or location strip.
+        /// </summary>
+        public string? SupportingText { get; set; }
+
+        /// <summary>
+        ///     Optional label placed on the editable map-like surface.
+        /// </summary>
+        public string? MapLabel { get; set; }
+    }
+
+    /// <summary>
+    ///     Options for capability/content slides.
+    /// </summary>
+    public sealed class PowerPointCapabilitySlideOptions : PowerPointDesignerSlideOptions {
+        /// <summary>
+        ///     Capability layout variant. Auto uses the design intent seed.
+        /// </summary>
+        public PowerPointCapabilityLayoutVariant Variant { get; set; } = PowerPointCapabilityLayoutVariant.Auto;
+
+        /// <summary>
+        ///     Visual support type displayed beside or below the narrative sections.
+        /// </summary>
+        public PowerPointCapabilityVisualKind VisualKind { get; set; } = PowerPointCapabilityVisualKind.VisualFrame;
+
+        /// <summary>
+        ///     Optional image path for the visual frame.
+        /// </summary>
+        public string? VisualImagePath { get; set; }
+
+        /// <summary>
+        ///     Optional label displayed with the visual support area.
+        /// </summary>
+        public string? VisualLabel { get; set; }
+
+        /// <summary>
+        ///     Optional logo/proof items when VisualKind is LogoWall.
+        /// </summary>
+        public IList<PowerPointLogoItem> Logos { get; } = new List<PowerPointLogoItem>();
+
+        /// <summary>
+        ///     Optional coverage locations when VisualKind is CoverageMap.
+        /// </summary>
+        public IList<PowerPointCoverageLocation> Locations { get; } = new List<PowerPointCoverageLocation>();
+
+        /// <summary>
+        ///     Optional metrics displayed as a supporting strip.
+        /// </summary>
+        public IList<PowerPointMetric> Metrics { get; } = new List<PowerPointMetric>();
+    }
+
+    /// <summary>
+    ///     A text section in a case-study slide.
+    /// </summary>
+    public sealed class PowerPointCaseStudySection {
+        /// <summary>
+        ///     Creates a case-study text section.
+        /// </summary>
+        public PowerPointCaseStudySection(string heading, string body) {
+            Heading = heading ?? throw new ArgumentNullException(nameof(heading));
+            Body = body ?? throw new ArgumentNullException(nameof(body));
+        }
+
+        /// <summary>
+        ///     Section heading.
+        /// </summary>
+        public string Heading { get; }
+
+        /// <summary>
+        ///     Section body text.
+        /// </summary>
+        public string Body { get; }
+    }
+
+    /// <summary>
+    ///     A metric displayed prominently on a designer slide.
+    /// </summary>
+    public sealed class PowerPointMetric {
+        /// <summary>
+        ///     Creates a metric with a value and label.
+        /// </summary>
+        public PowerPointMetric(string value, string label) {
+            Value = value ?? throw new ArgumentNullException(nameof(value));
+            Label = label ?? throw new ArgumentNullException(nameof(label));
+        }
+
+        /// <summary>
+        ///     Prominent metric value.
+        /// </summary>
+        public string Value { get; }
+
+        /// <summary>
+        ///     Metric label or caption.
+        /// </summary>
+        public string Label { get; }
+    }
+
+    /// <summary>
+    ///     A card with a title and optional bullet items.
+    /// </summary>
+    public sealed class PowerPointCardContent {
+        /// <summary>
+        ///     Creates a designer card.
+        /// </summary>
+        public PowerPointCardContent(string title, IEnumerable<string>? items = null, string? accentColor = null) {
+            Title = title ?? throw new ArgumentNullException(nameof(title));
+            Items = (items ?? Enumerable.Empty<string>()).Where(item => item != null).ToList();
+            AccentColor = accentColor;
+        }
+
+        /// <summary>
+        ///     Card title.
+        /// </summary>
+        public string Title { get; }
+
+        /// <summary>
+        ///     Bullet items displayed in the card.
+        /// </summary>
+        public IReadOnlyList<string> Items { get; }
+
+        /// <summary>
+        ///     Optional accent color override.
+        /// </summary>
+        public string? AccentColor { get; }
+    }
+
+    /// <summary>
+    ///     A single step in a process/timeline slide.
+    /// </summary>
+    public sealed class PowerPointProcessStep {
+        /// <summary>
+        ///     Creates a process step.
+        /// </summary>
+        public PowerPointProcessStep(string title, string body, string? number = null) {
+            Title = title ?? throw new ArgumentNullException(nameof(title));
+            Body = body ?? throw new ArgumentNullException(nameof(body));
+            Number = number;
+        }
+
+        /// <summary>
+        ///     Optional displayed step number. When omitted, the composition assigns one.
+        /// </summary>
+        public string? Number { get; }
+
+        /// <summary>
+        ///     Step title.
+        /// </summary>
+        public string Title { get; }
+
+        /// <summary>
+        ///     Step body text.
+        /// </summary>
+        public string Body { get; }
+    }
+
+    /// <summary>
+    ///     A logo, partner, product, or certification mark for a logo wall.
+    /// </summary>
+    public sealed class PowerPointLogoItem {
+        /// <summary>
+        ///     Creates a logo wall item. When ImagePath is omitted, the name is rendered as editable text.
+        /// </summary>
+        public PowerPointLogoItem(string name, string? subtitle = null, string? imagePath = null,
+            string? accentColor = null) {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Subtitle = subtitle;
+            ImagePath = imagePath;
+            AccentColor = accentColor;
+        }
+
+        /// <summary>
+        ///     Logo or certification name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        ///     Optional short descriptor.
+        /// </summary>
+        public string? Subtitle { get; }
+
+        /// <summary>
+        ///     Optional image path for an actual logo/certification mark.
+        /// </summary>
+        public string? ImagePath { get; }
+
+        /// <summary>
+        ///     Optional accent color override for the tile.
+        /// </summary>
+        public string? AccentColor { get; }
+    }
+
+    /// <summary>
+    ///     A location marker for coverage and map-like slides.
+    /// </summary>
+    public sealed class PowerPointCoverageLocation {
+        /// <summary>
+        ///     Creates a coverage location. X and Y are normalized positions from 0 to 1 inside the map panel.
+        /// </summary>
+        public PowerPointCoverageLocation(string name, double x, double y, string? detail = null) {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            X = x;
+            Y = y;
+            Detail = detail;
+        }
+
+        /// <summary>
+        ///     Location name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        ///     Normalized horizontal position from 0 to 1 inside the map panel.
+        /// </summary>
+        public double X { get; }
+
+        /// <summary>
+        ///     Normalized vertical position from 0 to 1 inside the map panel.
+        /// </summary>
+        public double Y { get; }
+
+        /// <summary>
+        ///     Optional location detail.
+        /// </summary>
+        public string? Detail { get; }
+    }
+
+    /// <summary>
+    ///     A narrative section for capability/content slides.
+    /// </summary>
+    public sealed class PowerPointCapabilitySection {
+        /// <summary>
+        ///     Creates a capability section with optional body text and bullet items.
+        /// </summary>
+        public PowerPointCapabilitySection(string heading, string? body = null, IEnumerable<string>? items = null,
+            string? accentColor = null) {
+            Heading = heading ?? throw new ArgumentNullException(nameof(heading));
+            Body = body;
+            Items = (items ?? Enumerable.Empty<string>()).Where(item => item != null).ToList();
+            AccentColor = accentColor;
+        }
+
+        /// <summary>
+        ///     Section heading.
+        /// </summary>
+        public string Heading { get; }
+
+        /// <summary>
+        ///     Optional body text.
+        /// </summary>
+        public string? Body { get; }
+
+        /// <summary>
+        ///     Optional bullet items.
+        /// </summary>
+        public IReadOnlyList<string> Items { get; }
+
+        /// <summary>
+        ///     Optional accent color override.
+        /// </summary>
+        public string? AccentColor { get; }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointDesignSpecializedExtensions.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDesignSpecializedExtensions.cs
@@ -1,0 +1,829 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using A = DocumentFormat.OpenXml.Drawing;
+
+namespace OfficeIMO.PowerPoint {
+    public static partial class PowerPointDesignExtensions {
+        /// <summary>
+        ///     Adds a logo, partner, or certification wall slide with optional proof/certificate emphasis.
+        /// </summary>
+        public static PowerPointSlide AddDesignerLogoWallSlide(this PowerPointPresentation presentation,
+            string title, string? subtitle, IEnumerable<PowerPointLogoItem> logos,
+            PowerPointDesignTheme? theme = null, PowerPointLogoWallSlideOptions? options = null) {
+            if (presentation == null) {
+                throw new ArgumentNullException(nameof(presentation));
+            }
+            if (title == null) {
+                throw new ArgumentNullException(nameof(title));
+            }
+
+            PowerPointDesignTheme resolvedTheme = ResolveTheme(theme);
+            PowerPointLogoWallSlideOptions resolvedOptions = options ?? new PowerPointLogoWallSlideOptions();
+            List<PowerPointLogoItem> logoList = NormalizeLogoItems(logos);
+
+            PowerPointSlide slide = presentation.AddSlide();
+            double width = presentation.SlideSize.WidthCm;
+            double height = presentation.SlideSize.HeightCm;
+            slide.BackgroundColor = resolvedTheme.BackgroundColor;
+
+            AddSubtleLightBackground(slide, resolvedTheme, width, height);
+            AddChrome(slide, resolvedTheme, width, height, dark: false, resolvedOptions);
+            AddText(slide, title, 1.5, 1.45, width * 0.58, 1.0, 29,
+                resolvedTheme.PrimaryTextColor, resolvedTheme.HeadingFontName, bold: true);
+            if (!string.IsNullOrWhiteSpace(subtitle)) {
+                AddText(slide, subtitle!, 1.55, 2.7, width * 0.58, 0.55, 12,
+                    resolvedTheme.SecondaryTextColor, resolvedTheme.BodyFontName, bold: true);
+            }
+
+            PowerPointLogoWallLayoutVariant variant = ResolveLogoWallVariant(resolvedOptions, logoList);
+            if (variant == PowerPointLogoWallLayoutVariant.CertificateFeature) {
+                AddLogoCertificateFeature(slide, resolvedTheme, logoList, resolvedOptions, width, height);
+            } else {
+                AddLogoMosaic(slide, resolvedTheme, logoList, resolvedOptions, width, height);
+            }
+
+            return slide;
+        }
+
+        /// <summary>
+        ///     Adds a coverage/location slide with editable pins and a structured location list.
+        /// </summary>
+        public static PowerPointSlide AddDesignerCoverageSlide(this PowerPointPresentation presentation,
+            string title, string? subtitle, IEnumerable<PowerPointCoverageLocation> locations,
+            PowerPointDesignTheme? theme = null, PowerPointCoverageSlideOptions? options = null) {
+            if (presentation == null) {
+                throw new ArgumentNullException(nameof(presentation));
+            }
+            if (title == null) {
+                throw new ArgumentNullException(nameof(title));
+            }
+
+            PowerPointDesignTheme resolvedTheme = ResolveTheme(theme);
+            PowerPointCoverageSlideOptions resolvedOptions = options ?? new PowerPointCoverageSlideOptions();
+            List<PowerPointCoverageLocation> locationList = NormalizeLocations(locations);
+
+            PowerPointSlide slide = presentation.AddSlide();
+            double width = presentation.SlideSize.WidthCm;
+            double height = presentation.SlideSize.HeightCm;
+            slide.BackgroundColor = resolvedTheme.BackgroundColor;
+
+            AddSubtleLightBackground(slide, resolvedTheme, width, height);
+            AddChrome(slide, resolvedTheme, width, height, dark: false, resolvedOptions);
+            AddText(slide, title, 1.5, 1.45, width * 0.58, 1.0, 29,
+                resolvedTheme.PrimaryTextColor, resolvedTheme.HeadingFontName, bold: true);
+            if (!string.IsNullOrWhiteSpace(subtitle)) {
+                AddText(slide, subtitle!, 1.55, 2.7, width * 0.58, 0.55, 12,
+                    resolvedTheme.SecondaryTextColor, resolvedTheme.BodyFontName, bold: true);
+            }
+
+            PowerPointCoverageLayoutVariant variant = ResolveCoverageVariant(resolvedOptions, locationList);
+            if (variant == PowerPointCoverageLayoutVariant.ListMap) {
+                PowerPointLayoutBox[] columns = PowerPointLayoutBox
+                    .FromCentimeters(1.5, 4.05, width - 3.0, height - 5.9)
+                    .SplitColumnsCm(2, 0.85);
+                AddCoverageList(slide, resolvedTheme, locationList, columns[0], resolvedOptions.SupportingText);
+                AddCoverageMap(slide, resolvedTheme, locationList, columns[1], resolvedOptions);
+            } else {
+                AddCoverageMap(slide, resolvedTheme, locationList,
+                    PowerPointLayoutBox.FromCentimeters(2.0, 4.0, width - 4.0, height - 7.1), resolvedOptions);
+                AddCoverageStrip(slide, resolvedTheme, locationList,
+                    PowerPointLayoutBox.FromCentimeters(2.0, height - 2.55, width - 4.0, 1.05));
+            }
+
+            return slide;
+        }
+
+        /// <summary>
+        ///     Adds a capability/content slide with structured narrative sections and optional visual support.
+        /// </summary>
+        public static PowerPointSlide AddDesignerCapabilitySlide(this PowerPointPresentation presentation,
+            string title, string? subtitle, IEnumerable<PowerPointCapabilitySection> sections,
+            PowerPointDesignTheme? theme = null, PowerPointCapabilitySlideOptions? options = null) {
+            if (presentation == null) {
+                throw new ArgumentNullException(nameof(presentation));
+            }
+            if (title == null) {
+                throw new ArgumentNullException(nameof(title));
+            }
+
+            PowerPointDesignTheme resolvedTheme = ResolveTheme(theme);
+            PowerPointCapabilitySlideOptions resolvedOptions = options ?? new PowerPointCapabilitySlideOptions();
+            List<PowerPointCapabilitySection> sectionList = NormalizeCapabilitySections(sections);
+
+            PowerPointSlide slide = presentation.AddSlide();
+            double width = presentation.SlideSize.WidthCm;
+            double height = presentation.SlideSize.HeightCm;
+            slide.BackgroundColor = resolvedTheme.BackgroundColor;
+
+            AddSubtleLightBackground(slide, resolvedTheme, width, height);
+            AddChrome(slide, resolvedTheme, width, height, dark: false, resolvedOptions);
+            AddText(slide, title, 1.5, 1.45, width * 0.60, 1.0, 29,
+                resolvedTheme.PrimaryTextColor, resolvedTheme.HeadingFontName, bold: true);
+            if (!string.IsNullOrWhiteSpace(subtitle)) {
+                AddText(slide, subtitle!, 1.55, 2.7, width * 0.64, 0.55, 12,
+                    resolvedTheme.SecondaryTextColor, resolvedTheme.BodyFontName, bold: true);
+            }
+
+            PowerPointCapabilityLayoutVariant variant = ResolveCapabilityVariant(resolvedOptions, sectionList);
+            if (variant == PowerPointCapabilityLayoutVariant.Stacked) {
+                AddCapabilityStacked(slide, resolvedTheme, sectionList, resolvedOptions, width, height);
+            } else {
+                AddCapabilitySplit(slide, resolvedTheme, sectionList, resolvedOptions, width, height,
+                    visualFirst: variant == PowerPointCapabilityLayoutVariant.VisualText);
+            }
+
+            return slide;
+        }
+
+        internal static void AddLogoWall(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointLogoItem> logos, PowerPointLogoWallSlideOptions options,
+            PowerPointLogoWallLayoutVariant variant, PowerPointLayoutBox bounds) {
+            if (variant == PowerPointLogoWallLayoutVariant.CertificateFeature) {
+                PowerPointLayoutBox[] columns = bounds.SplitColumnsCm(2, 0.7);
+                AddLogoGrid(slide, theme, logos, columns[0], options);
+                AddCertificatePanel(slide, theme, columns[1], options);
+                return;
+            }
+
+            AddLogoGrid(slide, theme, logos, bounds, options);
+        }
+
+        internal static void AddCoverageMap(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointCoverageLocation> locations, PowerPointLayoutBox bounds,
+            PowerPointCoverageSlideOptions options) {
+            PowerPointAutoShape panel = slide.AddRectangleCm(bounds.LeftCm, bounds.TopCm, bounds.WidthCm,
+                bounds.HeightCm, "Coverage Map Panel");
+            panel.FillColor = theme.AccentDarkColor;
+            panel.FillTransparency = 0;
+            panel.OutlineColor = theme.AccentDarkColor;
+            panel.OutlineWidthPoints = 0;
+            panel.SetShadow("000000", blurPoints: 5, distancePoints: 1.2, angleDegrees: 90, transparencyPercent: 86);
+
+            PowerPointAutoShape wash = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram, bounds.LeftCm + bounds.WidthCm * 0.16,
+                bounds.TopCm, bounds.WidthCm * 0.28, bounds.HeightCm, "Coverage Map Wash");
+            wash.FillColor = theme.AccentLightColor;
+            wash.FillTransparency = 72;
+            wash.OutlineColor = theme.AccentLightColor;
+            wash.OutlineWidthPoints = 0;
+
+            PowerPointAutoShape gridLine1 = slide.AddLineCm(bounds.LeftCm + bounds.WidthCm * 0.16,
+                bounds.TopCm + bounds.HeightCm * 0.33, bounds.LeftCm + bounds.WidthCm * 0.88,
+                bounds.TopCm + bounds.HeightCm * 0.33, "Coverage Map Latitude 1");
+            gridLine1.OutlineColor = theme.AccentLightColor;
+            gridLine1.OutlineWidthPoints = 0.35;
+            PowerPointAutoShape gridLine2 = slide.AddLineCm(bounds.LeftCm + bounds.WidthCm * 0.18,
+                bounds.TopCm + bounds.HeightCm * 0.66, bounds.LeftCm + bounds.WidthCm * 0.84,
+                bounds.TopCm + bounds.HeightCm * 0.66, "Coverage Map Latitude 2");
+            gridLine2.OutlineColor = theme.AccentLightColor;
+            gridLine2.OutlineWidthPoints = 0.35;
+            PowerPointAutoShape gridLine3 = slide.AddLineCm(bounds.LeftCm + bounds.WidthCm * 0.38,
+                bounds.TopCm + bounds.HeightCm * 0.08, bounds.LeftCm + bounds.WidthCm * 0.34,
+                bounds.TopCm + bounds.HeightCm * 0.92, "Coverage Map Longitude 1");
+            gridLine3.OutlineColor = theme.AccentLightColor;
+            gridLine3.OutlineWidthPoints = 0.35;
+            PowerPointAutoShape gridLine4 = slide.AddLineCm(bounds.LeftCm + bounds.WidthCm * 0.64,
+                bounds.TopCm + bounds.HeightCm * 0.12, bounds.LeftCm + bounds.WidthCm * 0.58,
+                bounds.TopCm + bounds.HeightCm * 0.88, "Coverage Map Longitude 2");
+            gridLine4.OutlineColor = theme.AccentLightColor;
+            gridLine4.OutlineWidthPoints = 0.35;
+
+            AddCoverageRegion(slide, theme, bounds, 0.12, 0.23, 0.31, 0.27, "Coverage Region North", theme.AccentLightColor, 78);
+            AddCoverageRegion(slide, theme, bounds, 0.43, 0.18, 0.36, 0.25, "Coverage Region East", theme.Accent2Color, 74);
+            AddCoverageRegion(slide, theme, bounds, 0.20, 0.55, 0.34, 0.24, "Coverage Region South", theme.AccentLightColor, 82);
+            AddCoverageRegion(slide, theme, bounds, 0.58, 0.52, 0.28, 0.25, "Coverage Region Central", theme.Accent2Color, 78);
+
+            int routePoints = Math.Min(locations.Count, 6);
+            for (int i = 0; i < routePoints - 1; i++) {
+                AddCoverageRoute(slide, theme, bounds, locations[i], locations[i + 1], i);
+            }
+
+            int maxPins = Math.Min(locations.Count, 18);
+            for (int i = 0; i < maxPins; i++) {
+                AddCoveragePin(slide, theme, bounds, locations[i], i);
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.MapLabel)) {
+                AddText(slide, options.MapLabel!, bounds.LeftCm + 0.55, bounds.TopCm + bounds.HeightCm - 0.85,
+                    bounds.WidthCm - 1.1, 0.45, 10, theme.AccentContrastColor, theme.BodyFontName, bold: true);
+            }
+        }
+
+        private static void AddCapabilitySplit(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointCapabilitySection> sections, PowerPointCapabilitySlideOptions options,
+            double slideWidthCm, double slideHeightCm, bool visualFirst) {
+            PowerPointLayoutBox[] columns = PowerPointLayoutBox
+                .FromCentimeters(1.5, 4.0, slideWidthCm - 3.0, slideHeightCm - 5.7)
+                .SplitColumnsCm(2, 0.85);
+            PowerPointLayoutBox visual = visualFirst ? columns[0] : columns[1];
+            PowerPointLayoutBox narrative = visualFirst ? columns[1] : columns[0];
+
+            double metricReserve = options.Metrics.Count > 0 ? 1.45 : 0;
+            PowerPointLayoutBox sectionBounds = metricReserve > 0
+                ? PowerPointLayoutBox.FromCentimeters(narrative.LeftCm, narrative.TopCm,
+                    narrative.WidthCm, narrative.HeightCm - metricReserve)
+                : narrative;
+
+            AddCapabilitySections(slide, theme, sections, sectionBounds);
+            AddCapabilityVisual(slide, theme, options, visual);
+
+            if (options.Metrics.Count > 0) {
+                PowerPointLayoutBox metricBox = PowerPointLayoutBox.FromCentimeters(
+                    narrative.LeftCm,
+                    narrative.BottomCm - 1.05,
+                    narrative.WidthCm,
+                    1.05);
+                PowerPointAutoShape band = slide.AddRectangleCm(metricBox.LeftCm, metricBox.TopCm,
+                    metricBox.WidthCm, metricBox.HeightCm, "Capability Metric Band");
+                band.FillColor = theme.AccentColor;
+                band.OutlineColor = theme.AccentColor;
+                AddMetrics(slide, theme, options.Metrics.ToList(), metricBox.LeftCm + 0.25, metricBox.TopCm + 0.12,
+                    metricBox.WidthCm - 0.5, metricBox.HeightCm - 0.18);
+            }
+        }
+
+        private static void AddCapabilityStacked(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointCapabilitySection> sections, PowerPointCapabilitySlideOptions options,
+            double slideWidthCm, double slideHeightCm) {
+            double metricReserve = options.Metrics.Count > 0 ? 1.45 : 0;
+            PowerPointLayoutBox bounds = PowerPointLayoutBox.FromCentimeters(
+                1.5, 4.0, slideWidthCm - 3.0, slideHeightCm - 5.55 - metricReserve);
+            AddCapabilitySections(slide, theme, sections, bounds, maxColumns: Math.Min(3, sections.Count));
+
+            if (options.Metrics.Count > 0) {
+                PowerPointLayoutBox metricBox = PowerPointLayoutBox.FromCentimeters(
+                    1.5, slideHeightCm - 2.55, slideWidthCm - 3.0, 1.15);
+                PowerPointAutoShape band = slide.AddRectangleCm(metricBox.LeftCm, metricBox.TopCm,
+                    metricBox.WidthCm, metricBox.HeightCm, "Capability Metric Band");
+                band.FillColor = theme.AccentColor;
+                band.OutlineColor = theme.AccentColor;
+                AddMetrics(slide, theme, options.Metrics.ToList(), metricBox.LeftCm + 0.35, metricBox.TopCm + 0.13,
+                    metricBox.WidthCm - 0.7, metricBox.HeightCm - 0.2);
+            }
+        }
+
+        private static void AddCapabilitySections(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointCapabilitySection> sections, PowerPointLayoutBox bounds, int maxColumns = 1) {
+            if (maxColumns > 1) {
+                int columns = Math.Min(maxColumns, sections.Count);
+                int rows = (int)Math.Ceiling(sections.Count / (double)columns);
+                PowerPointLayoutBox[,] grid = bounds.SplitGridCm(rows, columns, 0.35, 0.45);
+                for (int i = 0; i < sections.Count; i++) {
+                    AddCapabilityPanel(slide, theme, sections[i], grid[i / columns, i % columns], i);
+                }
+                return;
+            }
+
+            PowerPointLayoutBox[] rowsBox = bounds.SplitRowsCm(sections.Count, 0.30);
+            for (int i = 0; i < sections.Count; i++) {
+                AddCapabilityPanel(slide, theme, sections[i], rowsBox[i], i);
+            }
+        }
+
+        private static void AddCapabilityPanel(PowerPointSlide slide, PowerPointDesignTheme theme,
+            PowerPointCapabilitySection section, PowerPointLayoutBox box, int index) {
+            PowerPointAutoShape panel = slide.AddRectangleCm(box.LeftCm, box.TopCm, box.WidthCm, box.HeightCm,
+                "Capability Section " + (index + 1));
+            panel.FillColor = theme.PanelColor;
+            panel.OutlineColor = theme.PanelBorderColor;
+            panel.OutlineWidthPoints = 0.45;
+            panel.SetShadow("000000", blurPoints: 2.5, distancePoints: 0.6, angleDegrees: 90, transparencyPercent: 92);
+
+            string accent = section.AccentColor ?? GetAccent(theme, index);
+            PowerPointAutoShape accentRule = slide.AddRectangleCm(box.LeftCm, box.TopCm, 0.12, box.HeightCm,
+                "Capability Section Accent " + (index + 1));
+            accentRule.FillColor = accent;
+            accentRule.OutlineColor = accent;
+
+            AddText(slide, section.Heading, box.LeftCm + 0.45, box.TopCm + 0.32, box.WidthCm - 0.75,
+                0.45, 12, theme.PrimaryTextColor, theme.HeadingFontName, bold: true);
+
+            double currentTop = box.TopCm + 0.88;
+            if (!string.IsNullOrWhiteSpace(section.Body)) {
+                PowerPointTextBox body = AddText(slide, section.Body!, box.LeftCm + 0.45, currentTop,
+                    box.WidthCm - 0.75, Math.Min(0.75, box.HeightCm - 1.1), 9,
+                    theme.SecondaryTextColor, theme.BodyFontName);
+                body.TextAutoFitOptions = new PowerPointTextAutoFitOptions(fontScalePercent: 82,
+                    lineSpaceReductionPercent: 18);
+                currentTop += 0.78;
+            }
+
+            if (section.Items.Count > 0 && currentTop < box.BottomCm - 0.3) {
+                PowerPointTextBox bullets = slide.AddTextBox("", PowerPointLayoutBox.FromCentimeters(
+                    box.LeftCm + 0.52, currentTop, box.WidthCm - 0.85, box.BottomCm - currentTop - 0.25));
+                bullets.SetTextMarginsCm(0, 0, 0, 0);
+                bullets.TextAutoFit = PowerPointTextAutoFit.Normal;
+                bullets.TextAutoFitOptions = new PowerPointTextAutoFitOptions(fontScalePercent: 78,
+                    lineSpaceReductionPercent: 20);
+                bullets.SetBullets(section.Items.Select(item => " " + item), configure: paragraph => {
+                    paragraph.SetFontName(theme.BodyFontName)
+                        .SetFontSize(9)
+                        .SetColor(theme.SecondaryTextColor)
+                        .SetHangingPoints(14)
+                        .SetSpaceAfterPoints(3)
+                        .SetBulletSizePercent(70);
+                });
+            }
+        }
+
+        private static void AddCapabilityVisual(PowerPointSlide slide, PowerPointDesignTheme theme,
+            PowerPointCapabilitySlideOptions options, PowerPointLayoutBox bounds) {
+            if (options.VisualKind == PowerPointCapabilityVisualKind.CoverageMap && options.Locations.Count > 0) {
+                AddCoverageMap(slide, theme, options.Locations.ToList(), bounds,
+                    new PowerPointCoverageSlideOptions {
+                        MapLabel = options.VisualLabel,
+                        DesignIntent = options.DesignIntent
+                    });
+                return;
+            }
+
+            if (options.VisualKind == PowerPointCapabilityVisualKind.LogoWall && options.Logos.Count > 0) {
+                AddLogoWall(slide, theme, options.Logos.ToList(), new PowerPointLogoWallSlideOptions {
+                    MaxColumns = Math.Min(3, Math.Max(1, options.Logos.Count)),
+                    Variant = PowerPointLogoWallLayoutVariant.LogoMosaic,
+                    DesignIntent = options.DesignIntent
+                }, PowerPointLogoWallLayoutVariant.LogoMosaic, bounds);
+                return;
+            }
+
+            AddVisualFrame(slide, theme, options.VisualImagePath, bounds.LeftCm, bounds.TopCm, bounds.WidthCm,
+                bounds.HeightCm, options.DesignIntent);
+            if (!string.IsNullOrWhiteSpace(options.VisualLabel)) {
+                AddText(slide, options.VisualLabel!, bounds.LeftCm + 0.35, bounds.BottomCm - 0.55,
+                    bounds.WidthCm - 0.7, 0.35, 9, theme.AccentContrastColor, theme.BodyFontName, bold: true);
+            }
+        }
+
+        private static void AddCaseStudyVisualHero(PowerPointSlide slide, PowerPointDesignTheme theme,
+            string clientTitle, IReadOnlyList<PowerPointCaseStudySection> sections, PowerPointCaseStudySlideOptions options,
+            IReadOnlyList<PowerPointMetric> metrics, double slideWidthCm, double slideHeightCm) {
+            AddText(slide, clientTitle, 1.45, 1.55, slideWidthCm * 0.62, 1.25, 27,
+                theme.PrimaryTextColor, theme.HeadingFontName, bold: true);
+
+            PowerPointAutoShape titleRule = slide.AddRectangleCm(1.48, 3.03, slideWidthCm * 0.20, 0.08,
+                "Case Study Visual Hero Rule");
+            titleRule.FillColor = theme.AccentColor;
+            titleRule.OutlineColor = theme.AccentColor;
+
+            double visualLeft = 1.45;
+            double visualTop = 3.55;
+            double visualWidth = slideWidthCm * 0.48;
+            double visualHeight = slideHeightCm - 5.35;
+            AddVisualFrame(slide, theme, options.VisualImagePath, visualLeft, visualTop, visualWidth, visualHeight,
+                options.DesignIntent);
+
+            PowerPointLayoutBox right = PowerPointLayoutBox.FromCentimeters(
+                visualLeft + visualWidth + 0.85,
+                visualTop,
+                slideWidthCm - visualLeft - visualWidth - 2.3,
+                visualHeight);
+
+            double metricsHeight = metrics.Count > 0 ? 1.55 : 0;
+            double sectionHeight = right.HeightCm - metricsHeight - (metrics.Count > 0 ? 0.55 : 0);
+            int sectionCount = Math.Min(sections.Count, 4);
+            PowerPointLayoutBox[] rows = PowerPointLayoutBox
+                .FromCentimeters(right.LeftCm, right.TopCm, right.WidthCm, sectionHeight)
+                .SplitRowsCm(sectionCount, 0.25);
+
+            for (int i = 0; i < sectionCount; i++) {
+                PowerPointLayoutBox row = rows[i];
+                PowerPointCaseStudySection section = sections[i];
+                PowerPointAutoShape accent = slide.AddRectangleCm(row.LeftCm, row.TopCm + 0.05,
+                    0.12, row.HeightCm - 0.1, "Case Study Visual Hero Accent " + (i + 1));
+                accent.FillColor = GetAccent(theme, i);
+                accent.OutlineColor = GetAccent(theme, i);
+
+                AddText(slide, section.Heading, row.LeftCm + 0.45, row.TopCm + 0.08,
+                    row.WidthCm - 0.45, 0.42, 11, theme.PrimaryTextColor, theme.HeadingFontName, bold: true);
+                PowerPointTextBox body = AddText(slide, section.Body, row.LeftCm + 0.45,
+                    row.TopCm + 0.62, row.WidthCm - 0.45, row.HeightCm - 0.7, 9,
+                    theme.SecondaryTextColor, theme.BodyFontName);
+                body.TextAutoFitOptions = new PowerPointTextAutoFitOptions(fontScalePercent: 82,
+                    lineSpaceReductionPercent: 18);
+            }
+
+            if (metrics.Count > 0) {
+                PowerPointLayoutBox metricBox = right.TakeBottomCm(metricsHeight);
+                PowerPointAutoShape metricBand = slide.AddRectangleCm(metricBox.LeftCm, metricBox.TopCm,
+                    metricBox.WidthCm, metricBox.HeightCm, "Case Study Visual Hero Metric Band");
+                metricBand.FillColor = theme.AccentColor;
+                metricBand.OutlineColor = theme.AccentColor;
+                metricBand.SetShadow("000000", blurPoints: 3, distancePoints: 0.8, angleDegrees: 90, transparencyPercent: 88);
+                AddMetrics(slide, theme, metrics, metricBox.LeftCm + 0.35, metricBox.TopCm + 0.2,
+                    metricBox.WidthCm - 0.7, metricBox.HeightCm - 0.3);
+            }
+
+            AddTags(slide, theme, options.Tags, 1.45, slideHeightCm - 1.85, visualWidth, 0.55);
+        }
+
+        private static void AddLogoMosaic(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointLogoItem> logos, PowerPointLogoWallSlideOptions options,
+            double slideWidthCm, double slideHeightCm) {
+            double bottomReserve = string.IsNullOrWhiteSpace(options.SupportingText) ? 1.65 : 3.05;
+            PowerPointLayoutBox bounds = PowerPointLayoutBox
+                .FromCentimeters(1.5, 4.0, slideWidthCm - 3.0, slideHeightCm - 4.0 - bottomReserve);
+            AddLogoGrid(slide, theme, logos, bounds, options);
+
+            if (!string.IsNullOrWhiteSpace(options.SupportingText)) {
+                PowerPointAutoShape band = slide.AddRectangleCm(1.55, slideHeightCm - 2.65,
+                    slideWidthCm - 3.1, 1.2, "Logo Wall Supporting Band");
+                band.FillColor = theme.PanelColor;
+                band.OutlineColor = theme.PanelBorderColor;
+                band.SetShadow("000000", blurPoints: 3, distancePoints: 0.8, angleDegrees: 90, transparencyPercent: 90);
+                AddText(slide, options.SupportingText!, 2.0, slideHeightCm - 2.25, slideWidthCm - 4.0, 0.45,
+                    12, theme.SecondaryTextColor, theme.BodyFontName, bold: true);
+            }
+        }
+
+        private static void AddLogoCertificateFeature(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointLogoItem> logos, PowerPointLogoWallSlideOptions options,
+            double slideWidthCm, double slideHeightCm) {
+            double height = string.IsNullOrWhiteSpace(options.SupportingText)
+                ? slideHeightCm - 5.25
+                : slideHeightCm - 7.6;
+            PowerPointLayoutBox[] columns = PowerPointLayoutBox
+                .FromCentimeters(1.5, 4.0, slideWidthCm - 3.0, height)
+                .SplitColumnsCm(2, 0.9);
+            AddLogoGrid(slide, theme, logos, columns[0], options);
+            AddCertificatePanel(slide, theme, columns[1], options);
+
+            if (!string.IsNullOrWhiteSpace(options.SupportingText)) {
+                AddText(slide, options.SupportingText!, 1.55, slideHeightCm - 3.05,
+                    slideWidthCm * 0.55, 0.5, 11, theme.SecondaryTextColor, theme.BodyFontName, bold: true);
+            }
+        }
+
+        private static void AddLogoGrid(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointLogoItem> logos, PowerPointLayoutBox bounds, PowerPointLogoWallSlideOptions options) {
+            int maxColumns = Math.Max(1, options.MaxColumns);
+            if (bounds.WidthCm < 12) {
+                maxColumns = Math.Min(maxColumns, 4);
+            }
+            int columns = Math.Min(maxColumns, logos.Count);
+            int rows = (int)Math.Ceiling(logos.Count / (double)columns);
+            PowerPointLayoutBox[,] grid = bounds.SplitGridCm(rows, columns, 0.36, 0.36);
+
+            for (int i = 0; i < logos.Count; i++) {
+                int row = i / columns;
+                int column = i % columns;
+                AddLogoTile(slide, theme, logos[i], grid[row, column], i);
+            }
+        }
+
+        private static void AddLogoTile(PowerPointSlide slide, PowerPointDesignTheme theme,
+            PowerPointLogoItem logo, PowerPointLayoutBox box, int index) {
+            string accent = logo.AccentColor ?? GetAccent(theme, index);
+            PowerPointAutoShape tile = slide.AddRectangleCm(box.LeftCm, box.TopCm, box.WidthCm, box.HeightCm,
+                "Logo Wall Tile " + (index + 1));
+            tile.FillColor = theme.PanelColor;
+            tile.OutlineColor = theme.PanelBorderColor;
+            tile.OutlineWidthPoints = 0.45;
+            tile.SetShadow("000000", blurPoints: 2.5, distancePoints: 0.6, angleDegrees: 90, transparencyPercent: 91);
+
+            PowerPointAutoShape accentRule = slide.AddRectangleCm(box.LeftCm, box.TopCm, box.WidthCm, 0.08,
+                "Logo Wall Accent " + (index + 1));
+            accentRule.FillColor = accent;
+            accentRule.OutlineColor = accent;
+
+            if (!string.IsNullOrWhiteSpace(logo.ImagePath) && File.Exists(logo.ImagePath!)) {
+                AddPictureIfExists(slide, logo.ImagePath!, box.LeftCm + 0.35, box.TopCm + 0.35,
+                    box.WidthCm - 0.7, box.HeightCm - 0.85, crop: false);
+            } else {
+                int fontSize = box.WidthCm < 2.25 ? 12 : box.WidthCm < 2.7 ? 14 : 16;
+                PowerPointTextBox name = AddText(slide, logo.Name, box.LeftCm + 0.25, box.TopCm + 0.45,
+                    box.WidthCm - 0.5, box.HeightCm * 0.45, fontSize, theme.PrimaryTextColor,
+                    theme.HeadingFontName, bold: true);
+                name.TextAutoFitOptions = new PowerPointTextAutoFitOptions(fontScalePercent: 78, lineSpaceReductionPercent: 20);
+                CenterText(name);
+            }
+
+            if (!string.IsNullOrWhiteSpace(logo.Subtitle)) {
+                PowerPointTextBox subtitle = AddText(slide, logo.Subtitle!, box.LeftCm + 0.35,
+                    box.TopCm + box.HeightCm - 0.55, box.WidthCm - 0.7, 0.3, 8,
+                    theme.MutedTextColor, theme.BodyFontName);
+                CenterText(subtitle);
+            }
+        }
+
+        private static void AddCertificatePanel(PowerPointSlide slide, PowerPointDesignTheme theme,
+            PowerPointLayoutBox bounds, PowerPointLogoWallSlideOptions options) {
+            PowerPointAutoShape frame = slide.AddRectangleCm(bounds.LeftCm, bounds.TopCm, bounds.WidthCm,
+                bounds.HeightCm, "Logo Wall Certificate Frame");
+            frame.FillColor = theme.PanelColor;
+            frame.OutlineColor = theme.PanelBorderColor;
+            frame.OutlineWidthPoints = 0.45;
+            frame.SetShadow("000000", blurPoints: 4, distancePoints: 1.0, angleDegrees: 90, transparencyPercent: 88);
+
+            if (!string.IsNullOrWhiteSpace(options.FeaturedImagePath) && File.Exists(options.FeaturedImagePath!)) {
+                AddPictureIfExists(slide, options.FeaturedImagePath!, bounds.LeftCm + 0.35, bounds.TopCm + 0.35,
+                    bounds.WidthCm - 0.7, bounds.HeightCm - 0.95, crop: false);
+            } else {
+                PowerPointAutoShape rail = slide.AddRectangleCm(bounds.LeftCm + 0.46, bounds.TopCm + 0.46,
+                    0.10, bounds.HeightCm - 0.92, "Logo Wall Certificate Rail");
+                rail.FillColor = theme.AccentColor;
+                rail.OutlineColor = theme.AccentColor;
+
+                PowerPointAutoShape watermark = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram,
+                    bounds.LeftCm + bounds.WidthCm * 0.60, bounds.TopCm + 0.08,
+                    bounds.WidthCm * 0.23, bounds.HeightCm - 0.16, "Logo Wall Certificate Watermark");
+                watermark.FillColor = theme.AccentLightColor;
+                watermark.FillTransparency = 66;
+                watermark.OutlineColor = theme.AccentLightColor;
+                watermark.OutlineWidthPoints = 0;
+
+                PowerPointAutoShape document = slide.AddRectangleCm(bounds.LeftCm + bounds.WidthCm * 0.24,
+                    bounds.TopCm + 0.55, bounds.WidthCm * 0.52, bounds.HeightCm - 1.45,
+                    "Logo Wall Certificate Document");
+                document.FillColor = theme.BackgroundColor;
+                document.OutlineColor = theme.PanelBorderColor;
+                document.OutlineWidthPoints = 0.55;
+                document.SetShadow("000000", blurPoints: 2.5, distancePoints: 0.5, angleDegrees: 90, transparencyPercent: 92);
+
+                PowerPointAutoShape documentHeader = slide.AddRectangleCm(bounds.LeftCm + bounds.WidthCm * 0.29,
+                    bounds.TopCm + 0.92, bounds.WidthCm * 0.42, 0.08, "Logo Wall Certificate Header");
+                documentHeader.FillColor = theme.AccentColor;
+                documentHeader.OutlineColor = theme.AccentColor;
+
+                PowerPointAutoShape seal = slide.AddEllipseCm(bounds.LeftCm + bounds.WidthCm * 0.42,
+                    bounds.TopCm + bounds.HeightCm * 0.43, bounds.WidthCm * 0.16, bounds.WidthCm * 0.16,
+                    "Logo Wall Certificate Seal");
+                seal.FillColor = theme.AccentColor;
+                seal.FillTransparency = 15;
+                seal.OutlineColor = theme.AccentColor;
+                seal.OutlineWidthPoints = 0.8;
+
+                PowerPointAutoShape sealCenter = slide.AddEllipseCm(bounds.LeftCm + bounds.WidthCm * 0.455,
+                    bounds.TopCm + bounds.HeightCm * 0.43 + bounds.WidthCm * 0.035,
+                    bounds.WidthCm * 0.09, bounds.WidthCm * 0.09, "Logo Wall Certificate Seal Center");
+                sealCenter.FillColor = theme.AccentContrastColor;
+                sealCenter.FillTransparency = 42;
+                sealCenter.OutlineColor = theme.AccentContrastColor;
+
+                for (int i = 0; i < 5; i++) {
+                    PowerPointAutoShape line = slide.AddRectangleCm(bounds.LeftCm + bounds.WidthCm * 0.32,
+                        bounds.TopCm + 1.25 + i * 0.38, bounds.WidthCm * (i == 0 ? 0.34 : 0.25), 0.032,
+                        "Logo Wall Certificate Line " + (i + 1));
+                    line.FillColor = i == 0 ? theme.AccentColor : theme.AccentLightColor;
+                    line.FillTransparency = i == 0 ? 0 : 18;
+                    line.OutlineColor = line.FillColor;
+                }
+
+                for (int i = 0; i < 3; i++) {
+                    PowerPointAutoShape signatureLine = slide.AddRectangleCm(bounds.LeftCm + bounds.WidthCm * (0.32 + i * 0.12),
+                        bounds.TopCm + bounds.HeightCm - 1.18, bounds.WidthCm * 0.08, 0.025,
+                        "Logo Wall Certificate Signature " + (i + 1));
+                    signatureLine.FillColor = theme.PanelBorderColor;
+                    signatureLine.OutlineColor = theme.PanelBorderColor;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.FeatureTitle)) {
+                AddText(slide, options.FeatureTitle!, bounds.LeftCm + 0.45, bounds.TopCm + bounds.HeightCm - 0.55,
+                    bounds.WidthCm - 0.9, 0.35, 9, theme.SecondaryTextColor, theme.BodyFontName, bold: true);
+            }
+        }
+
+        private static void AddCoverageList(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointCoverageLocation> locations, PowerPointLayoutBox bounds, string? supportingText) {
+            if (!string.IsNullOrWhiteSpace(supportingText)) {
+                PowerPointAutoShape band = slide.AddRectangleCm(bounds.LeftCm, bounds.TopCm,
+                    bounds.WidthCm, 1.1, "Coverage Supporting Band");
+                band.FillColor = theme.PanelColor;
+                band.OutlineColor = theme.PanelBorderColor;
+                AddText(slide, supportingText!, bounds.LeftCm + 0.35, bounds.TopCm + 0.35,
+                    bounds.WidthCm - 0.7, 0.4, 11, theme.SecondaryTextColor, theme.BodyFontName, bold: true);
+                bounds = PowerPointLayoutBox.FromCentimeters(bounds.LeftCm, bounds.TopCm + 1.35,
+                    bounds.WidthCm, bounds.HeightCm - 1.35);
+            }
+
+            int count = Math.Min(locations.Count, 8);
+            PowerPointLayoutBox[] rows = bounds.SplitRowsCm(count, 0.16);
+            for (int i = 0; i < count; i++) {
+                PowerPointCoverageLocation location = locations[i];
+                PowerPointLayoutBox row = rows[i];
+                PowerPointAutoShape marker = slide.AddEllipseCm(row.LeftCm, row.TopCm + 0.08,
+                    0.32, 0.32, "Coverage List Marker " + (i + 1));
+                marker.FillColor = GetAccent(theme, i);
+                marker.OutlineColor = GetAccent(theme, i);
+
+                string text = string.IsNullOrWhiteSpace(location.Detail)
+                    ? location.Name
+                    : location.Name + " - " + location.Detail;
+                AddText(slide, text, row.LeftCm + 0.55, row.TopCm, row.WidthCm - 0.55,
+                    row.HeightCm, 10, theme.SecondaryTextColor, theme.BodyFontName, bold: i < 3);
+            }
+        }
+
+        private static void AddCoverageStrip(PowerPointSlide slide, PowerPointDesignTheme theme,
+            IReadOnlyList<PowerPointCoverageLocation> locations, PowerPointLayoutBox bounds) {
+            PowerPointAutoShape band = slide.AddRectangleCm(bounds.LeftCm, bounds.TopCm, bounds.WidthCm,
+                bounds.HeightCm, "Coverage Location Strip");
+            band.FillColor = theme.PanelColor;
+            band.OutlineColor = theme.PanelBorderColor;
+            band.SetShadow("000000", blurPoints: 3, distancePoints: 0.7, angleDegrees: 90, transparencyPercent: 91);
+
+            string text = string.Join(", ", locations.Take(12).Select(location => location.Name));
+            AddText(slide, text, bounds.LeftCm + 0.55, bounds.TopCm + 0.32, bounds.WidthCm - 1.1,
+                0.38, 10, theme.SecondaryTextColor, theme.BodyFontName, bold: true);
+        }
+
+        private static void AddCoverageRegion(PowerPointSlide slide, PowerPointDesignTheme theme,
+            PowerPointLayoutBox bounds, double x, double y, double width, double height, string name,
+            string fillColor, int fillTransparency) {
+            PowerPointAutoShape region = slide.AddShapeCm(A.ShapeTypeValues.Parallelogram,
+                bounds.LeftCm + bounds.WidthCm * x,
+                bounds.TopCm + bounds.HeightCm * y,
+                bounds.WidthCm * width,
+                bounds.HeightCm * height,
+                name);
+            region.FillColor = fillColor;
+            region.FillTransparency = fillTransparency;
+            region.OutlineColor = theme.AccentLightColor;
+            region.OutlineWidthPoints = 0.25;
+        }
+
+        private static void AddCoverageRoute(PowerPointSlide slide, PowerPointDesignTheme theme,
+            PowerPointLayoutBox bounds, PowerPointCoverageLocation start, PowerPointCoverageLocation end, int index) {
+            PowerPointAutoShape route = slide.AddLineCm(
+                bounds.LeftCm + bounds.WidthCm * start.X,
+                bounds.TopCm + bounds.HeightCm * start.Y,
+                bounds.LeftCm + bounds.WidthCm * end.X,
+                bounds.TopCm + bounds.HeightCm * end.Y,
+                "Coverage Route " + (index + 1));
+            route.OutlineColor = theme.AccentLightColor;
+            route.OutlineWidthPoints = 0.45;
+        }
+
+        private static void AddCoveragePin(PowerPointSlide slide, PowerPointDesignTheme theme,
+            PowerPointLayoutBox bounds, PowerPointCoverageLocation location, int index) {
+            double x = bounds.LeftCm + bounds.WidthCm * location.X;
+            double y = bounds.TopCm + bounds.HeightCm * location.Y;
+            string accent = GetAccent(theme, index);
+
+            PowerPointAutoShape halo = slide.AddEllipseCm(x - 0.22, y - 0.22, 0.44, 0.44,
+                "Coverage Pin Halo " + (index + 1));
+            halo.FillColor = theme.AccentContrastColor;
+            halo.FillTransparency = 72;
+            halo.OutlineColor = theme.AccentContrastColor;
+            halo.OutlineWidthPoints = 0;
+
+            PowerPointAutoShape pinOuter = slide.AddEllipseCm(x - 0.16, y - 0.16, 0.32, 0.32,
+                "Coverage Pin Outer " + (index + 1));
+            pinOuter.FillColor = theme.AccentDarkColor;
+            pinOuter.FillTransparency = 35;
+            pinOuter.OutlineColor = theme.AccentContrastColor;
+            pinOuter.OutlineWidthPoints = 0.45;
+
+            PowerPointAutoShape pin = slide.AddEllipseCm(x - 0.09, y - 0.09, 0.18, 0.18,
+                "Coverage Pin " + (index + 1));
+            pin.FillColor = accent;
+            pin.OutlineColor = theme.AccentContrastColor;
+            pin.OutlineWidthPoints = 0.25;
+        }
+
+        internal static List<PowerPointLogoItem> NormalizeLogoItems(IEnumerable<PowerPointLogoItem> logos) {
+            if (logos == null) {
+                throw new ArgumentNullException(nameof(logos));
+            }
+
+            List<PowerPointLogoItem> list = logos.Where(logo => logo != null).ToList();
+            if (list.Count == 0) {
+                throw new ArgumentException("At least one logo item is required.", nameof(logos));
+            }
+            if (list.Count > 24) {
+                throw new ArgumentOutOfRangeException(nameof(logos), "This composition supports up to 24 logo items.");
+            }
+
+            return list;
+        }
+
+        internal static List<PowerPointCoverageLocation> NormalizeLocations(IEnumerable<PowerPointCoverageLocation> locations) {
+            if (locations == null) {
+                throw new ArgumentNullException(nameof(locations));
+            }
+
+            List<PowerPointCoverageLocation> list = locations.Where(location => location != null).ToList();
+            if (list.Count == 0) {
+                throw new ArgumentException("At least one location is required.", nameof(locations));
+            }
+            if (list.Count > 24) {
+                throw new ArgumentOutOfRangeException(nameof(locations), "This composition supports up to 24 locations.");
+            }
+
+            foreach (PowerPointCoverageLocation location in list) {
+                if (location.X < 0 || location.X > 1) {
+                    throw new ArgumentOutOfRangeException(nameof(locations), "Location X must be between 0 and 1.");
+                }
+                if (location.Y < 0 || location.Y > 1) {
+                    throw new ArgumentOutOfRangeException(nameof(locations), "Location Y must be between 0 and 1.");
+                }
+            }
+
+            return list;
+        }
+
+        private static List<PowerPointCapabilitySection> NormalizeCapabilitySections(
+            IEnumerable<PowerPointCapabilitySection> sections) {
+            if (sections == null) {
+                throw new ArgumentNullException(nameof(sections));
+            }
+
+            List<PowerPointCapabilitySection> list = sections.Where(section => section != null).ToList();
+            if (list.Count == 0) {
+                throw new ArgumentException("At least one capability section is required.", nameof(sections));
+            }
+            if (list.Count > 6) {
+                throw new ArgumentOutOfRangeException(nameof(sections), "This composition supports up to 6 sections.");
+            }
+
+            return list;
+        }
+
+        internal static PowerPointLogoWallLayoutVariant ResolveLogoWallVariant(PowerPointLogoWallSlideOptions options,
+            IReadOnlyList<PowerPointLogoItem> logos) {
+            if (options.Variant != PowerPointLogoWallLayoutVariant.Auto) {
+                return options.Variant;
+            }
+
+            bool hasFeaturedProof = !string.IsNullOrWhiteSpace(options.FeaturedImagePath) ||
+                !string.IsNullOrWhiteSpace(options.FeatureTitle);
+            if (hasFeaturedProof && logos.Count <= 12) {
+                return PowerPointLogoWallLayoutVariant.CertificateFeature;
+            }
+
+            if (logos.Count > Math.Max(6, options.MaxColumns) ||
+                options.DesignIntent.VisualStyle == PowerPointVisualStyle.Minimal) {
+                return PowerPointLogoWallLayoutVariant.LogoMosaic;
+            }
+
+            if (string.IsNullOrWhiteSpace(options.DesignIntent.Seed)) {
+                return PowerPointLogoWallLayoutVariant.LogoMosaic;
+            }
+
+            return options.DesignIntent.Pick(2, "logo-wall") == 0
+                ? PowerPointLogoWallLayoutVariant.LogoMosaic
+                : PowerPointLogoWallLayoutVariant.CertificateFeature;
+        }
+
+        internal static PowerPointCoverageLayoutVariant ResolveCoverageVariant(PowerPointCoverageSlideOptions options,
+            IReadOnlyList<PowerPointCoverageLocation> locations) {
+            if (options.Variant != PowerPointCoverageLayoutVariant.Auto) {
+                return options.Variant;
+            }
+
+            if (locations.Count > 6 ||
+                !string.IsNullOrWhiteSpace(options.SupportingText) ||
+                options.DesignIntent.VisualStyle == PowerPointVisualStyle.Soft ||
+                options.DesignIntent.VisualStyle == PowerPointVisualStyle.Minimal) {
+                return PowerPointCoverageLayoutVariant.ListMap;
+            }
+
+            if (string.IsNullOrWhiteSpace(options.DesignIntent.Seed)) {
+                return PowerPointCoverageLayoutVariant.PinBoard;
+            }
+
+            return options.DesignIntent.Pick(2, "coverage") == 0
+                ? PowerPointCoverageLayoutVariant.PinBoard
+                : PowerPointCoverageLayoutVariant.ListMap;
+        }
+
+        internal static PowerPointCapabilityLayoutVariant ResolveCapabilityVariant(PowerPointCapabilitySlideOptions options,
+            IReadOnlyList<PowerPointCapabilitySection> sections) {
+            if (options.Variant != PowerPointCapabilityLayoutVariant.Auto) {
+                return options.Variant;
+            }
+
+            bool hasCoverageVisual = options.VisualKind == PowerPointCapabilityVisualKind.CoverageMap &&
+                options.Locations.Count > 0;
+            bool hasLogoVisual = options.VisualKind == PowerPointCapabilityVisualKind.LogoWall &&
+                options.Logos.Count > 0;
+            bool hasImageVisual = !string.IsNullOrWhiteSpace(options.VisualImagePath);
+            bool hasVisualEvidence = hasCoverageVisual || hasLogoVisual || hasImageVisual;
+
+            if (sections.Count >= 4) {
+                return PowerPointCapabilityLayoutVariant.Stacked;
+            }
+
+            if (options.DesignIntent.VisualStyle == PowerPointVisualStyle.Minimal && sections.Count >= 3) {
+                return PowerPointCapabilityLayoutVariant.Stacked;
+            }
+
+            if (hasVisualEvidence && sections.Count <= 3) {
+                return options.DesignIntent.Mood == PowerPointDesignMood.Editorial
+                    ? PowerPointCapabilityLayoutVariant.VisualText
+                    : PowerPointCapabilityLayoutVariant.TextVisual;
+            }
+
+            if (string.IsNullOrWhiteSpace(options.DesignIntent.Seed)) {
+                return PowerPointCapabilityLayoutVariant.TextVisual;
+            }
+
+            return options.DesignIntent.Pick(3, "capability") switch {
+                0 => PowerPointCapabilityLayoutVariant.TextVisual,
+                1 => PowerPointCapabilityLayoutVariant.VisualText,
+                _ => PowerPointCapabilityLayoutVariant.Stacked
+            };
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointDesignTheme.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDesignTheme.cs
@@ -84,7 +84,7 @@ namespace OfficeIMO.PowerPoint {
             double coolShift = 18d + pick * 8d;
 
             PowerPointDesignTheme clone = Clone();
-            clone.Name = Name + " Variant " + (pick + 1).ToString();
+            clone.Name = Name + " Variant " + (pick + 1);
             clone.Accent2Color = ShiftHue(AccentColor, coolShift, saturationScale: 0.95, lightnessShift: 0.02);
             clone.Accent3Color = ShiftHue(AccentColor, -coolShift - 18, saturationScale: 0.75, lightnessShift: 0.04);
             clone.WarningColor = WarmAccent(pick);
@@ -100,7 +100,7 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public PowerPointDesignTheme WithMood(PowerPointDesignMood mood) {
             PowerPointDesignTheme clone = Clone();
-            clone.Name = Name + " " + mood.ToString();
+            clone.Name = Name + " " + mood;
 
             switch (mood) {
                 case PowerPointDesignMood.Editorial:

--- a/OfficeIMO.PowerPoint/PowerPointDesignTheme.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDesignTheme.cs
@@ -81,7 +81,7 @@ namespace OfficeIMO.PowerPoint {
             }
 
             int pick = StablePick(seed, 7);
-            double coolShift = 18 + pick * 8;
+            double coolShift = 18d + pick * 8d;
 
             PowerPointDesignTheme clone = Clone();
             clone.Name = Name + " Variant " + (pick + 1).ToString();
@@ -322,16 +322,17 @@ namespace OfficeIMO.PowerPoint {
             double delta = max - min;
 
             lightness = (max + min) / 2d;
-            if (delta == 0) {
+            const double epsilon = 1e-12;
+            if (Math.Abs(delta) < epsilon) {
                 hue = 0;
                 saturation = 0;
                 return;
             }
 
             saturation = delta / (1d - Math.Abs(2d * lightness - 1d));
-            if (max == red) {
+            if (red >= green && red >= blue) {
                 hue = 60d * (((green - blue) / delta) % 6d);
-            } else if (max == green) {
+            } else if (green >= red && green >= blue) {
                 hue = 60d * (((blue - red) / delta) + 2d);
             } else {
                 hue = 60d * (((red - green) / delta) + 4d);

--- a/OfficeIMO.PowerPoint/PowerPointDesignTheme.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDesignTheme.cs
@@ -1,0 +1,413 @@
+using System;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Defines a reusable visual system for high-level PowerPoint slide compositions.
+    /// </summary>
+    public sealed class PowerPointDesignTheme {
+        /// <summary>
+        ///     Creates a modern blue theme suitable for clean business decks.
+        /// </summary>
+        public static PowerPointDesignTheme ModernBlue => new() {
+            Name = "OfficeIMO Modern Blue",
+            BackgroundColor = "FFFFFF",
+            SurfaceColor = "F7FAFC",
+            PanelColor = "FFFFFF",
+            PanelBorderColor = "D8E1E8",
+            PrimaryTextColor = "30343B",
+            SecondaryTextColor = "65717D",
+            MutedTextColor = "8A949E",
+            AccentColor = "0098C8",
+            AccentDarkColor = "006AA1",
+            AccentLightColor = "D9F4FA",
+            AccentContrastColor = "FFFFFF",
+            Accent2Color = "00B7C9",
+            Accent3Color = "6F6AA6",
+            WarningColor = "F4A100",
+            HeadingFontName = "Poppins",
+            BodyFontName = "Lato"
+        };
+
+        /// <summary>
+        ///     Creates a theme from a primary brand accent while keeping readable defaults.
+        /// </summary>
+        public static PowerPointDesignTheme FromBrand(string accentColor, string? name = null,
+            string headingFontName = "Poppins", string bodyFontName = "Lato") {
+            string accent = NormalizeHex(accentColor, nameof(accentColor));
+            return new PowerPointDesignTheme {
+                Name = name ?? "OfficeIMO Brand Theme",
+                AccentColor = accent,
+                AccentDarkColor = Shade(accent, -0.28),
+                AccentLightColor = Shade(accent, 0.82),
+                Accent2Color = Shade(accent, 0.18),
+                Accent3Color = Shade(RotateAccent(accent), 0.1),
+                WarningColor = "F4A100",
+                HeadingFontName = headingFontName,
+                BodyFontName = bodyFontName
+            };
+        }
+
+        /// <summary>
+        ///     Creates a copy of the theme that can be modified without changing the source instance.
+        /// </summary>
+        public PowerPointDesignTheme Clone() {
+            return new PowerPointDesignTheme {
+                Name = Name,
+                BackgroundColor = BackgroundColor,
+                SurfaceColor = SurfaceColor,
+                PanelColor = PanelColor,
+                PanelBorderColor = PanelBorderColor,
+                PrimaryTextColor = PrimaryTextColor,
+                SecondaryTextColor = SecondaryTextColor,
+                MutedTextColor = MutedTextColor,
+                AccentColor = AccentColor,
+                AccentDarkColor = AccentDarkColor,
+                AccentLightColor = AccentLightColor,
+                AccentContrastColor = AccentContrastColor,
+                Accent2Color = Accent2Color,
+                Accent3Color = Accent3Color,
+                WarningColor = WarningColor,
+                HeadingFontName = HeadingFontName,
+                BodyFontName = BodyFontName
+            };
+        }
+
+        /// <summary>
+        ///     Creates a deterministic palette variation that keeps the primary brand accent but changes supporting colors.
+        /// </summary>
+        public PowerPointDesignTheme WithVariation(string seed) {
+            if (string.IsNullOrWhiteSpace(seed)) {
+                throw new ArgumentException("Variation seed cannot be null or empty.", nameof(seed));
+            }
+
+            int pick = StablePick(seed, 7);
+            double coolShift = 18 + pick * 8;
+
+            PowerPointDesignTheme clone = Clone();
+            clone.Name = Name + " Variant " + (pick + 1).ToString();
+            clone.Accent2Color = ShiftHue(AccentColor, coolShift, saturationScale: 0.95, lightnessShift: 0.02);
+            clone.Accent3Color = ShiftHue(AccentColor, -coolShift - 18, saturationScale: 0.75, lightnessShift: 0.04);
+            clone.WarningColor = WarmAccent(pick);
+            clone.AccentLightColor = Shade(AccentColor, 0.78 + pick * 0.02);
+            clone.SurfaceColor = Shade(clone.Accent2Color, 0.91);
+            clone.PanelBorderColor = Shade(clone.Accent3Color, 0.72);
+            clone.Validate();
+            return clone;
+        }
+
+        /// <summary>
+        ///     Creates a theme variation tuned for a broad deck mood.
+        /// </summary>
+        public PowerPointDesignTheme WithMood(PowerPointDesignMood mood) {
+            PowerPointDesignTheme clone = Clone();
+            clone.Name = Name + " " + mood.ToString();
+
+            switch (mood) {
+                case PowerPointDesignMood.Editorial:
+                    clone.BackgroundColor = "FFFFFF";
+                    clone.SurfaceColor = Shade(clone.Accent3Color, 0.91);
+                    clone.PanelColor = "FFFFFF";
+                    clone.PanelBorderColor = Shade(clone.Accent3Color, 0.68);
+                    clone.HeadingFontName = "Aptos Display";
+                    clone.BodyFontName = "Aptos";
+                    break;
+                case PowerPointDesignMood.Energetic:
+                    clone.SurfaceColor = Shade(clone.WarningColor, 0.88);
+                    clone.PanelBorderColor = Shade(clone.Accent2Color, 0.62);
+                    clone.AccentLightColor = Shade(clone.AccentColor, 0.70);
+                    clone.HeadingFontName = "Poppins";
+                    clone.BodyFontName = "Aptos";
+                    break;
+                case PowerPointDesignMood.Minimal:
+                    clone.SurfaceColor = "F5F7F9";
+                    clone.PanelBorderColor = "DDE4EA";
+                    clone.Accent2Color = Shade(clone.AccentColor, 0.34);
+                    clone.Accent3Color = Shade(clone.AccentDarkColor, 0.50);
+                    clone.WarningColor = clone.Accent2Color;
+                    clone.HeadingFontName = "Aptos Display";
+                    clone.BodyFontName = "Aptos";
+                    break;
+                default:
+                    break;
+            }
+
+            clone.Validate();
+            return clone;
+        }
+
+        /// <summary>
+        ///     Theme display name.
+        /// </summary>
+        public string Name { get; set; } = "OfficeIMO Design";
+
+        /// <summary>
+        ///     Main slide background color.
+        /// </summary>
+        public string BackgroundColor { get; set; } = "FFFFFF";
+
+        /// <summary>
+        ///     Alternate surface color for subtle bands and washes.
+        /// </summary>
+        public string SurfaceColor { get; set; } = "F7FAFC";
+
+        /// <summary>
+        ///     Card and panel fill color.
+        /// </summary>
+        public string PanelColor { get; set; } = "FFFFFF";
+
+        /// <summary>
+        ///     Card and panel outline color.
+        /// </summary>
+        public string PanelBorderColor { get; set; } = "D8E1E8";
+
+        /// <summary>
+        ///     Primary text color.
+        /// </summary>
+        public string PrimaryTextColor { get; set; } = "30343B";
+
+        /// <summary>
+        ///     Secondary text color.
+        /// </summary>
+        public string SecondaryTextColor { get; set; } = "65717D";
+
+        /// <summary>
+        ///     Muted caption and chrome text color.
+        /// </summary>
+        public string MutedTextColor { get; set; } = "8A949E";
+
+        /// <summary>
+        ///     Main accent color.
+        /// </summary>
+        public string AccentColor { get; set; } = "0098C8";
+
+        /// <summary>
+        ///     Dark accent color for section slides and strong bands.
+        /// </summary>
+        public string AccentDarkColor { get; set; } = "006AA1";
+
+        /// <summary>
+        ///     Light accent color for soft backgrounds and dividers.
+        /// </summary>
+        public string AccentLightColor { get; set; } = "D9F4FA";
+
+        /// <summary>
+        ///     Text color used on top of accent fills.
+        /// </summary>
+        public string AccentContrastColor { get; set; } = "FFFFFF";
+
+        /// <summary>
+        ///     Secondary accent color.
+        /// </summary>
+        public string Accent2Color { get; set; } = "00B7C9";
+
+        /// <summary>
+        ///     Tertiary accent color.
+        /// </summary>
+        public string Accent3Color { get; set; } = "6F6AA6";
+
+        /// <summary>
+        ///     Warm accent used for markers and direction motifs.
+        /// </summary>
+        public string WarningColor { get; set; } = "F4A100";
+
+        /// <summary>
+        ///     Font used for headings.
+        /// </summary>
+        public string HeadingFontName { get; set; } = "Poppins";
+
+        /// <summary>
+        ///     Font used for body text.
+        /// </summary>
+        public string BodyFontName { get; set; } = "Lato";
+
+        internal void Validate() {
+            ValidateHex(BackgroundColor, nameof(BackgroundColor));
+            ValidateHex(SurfaceColor, nameof(SurfaceColor));
+            ValidateHex(PanelColor, nameof(PanelColor));
+            ValidateHex(PanelBorderColor, nameof(PanelBorderColor));
+            ValidateHex(PrimaryTextColor, nameof(PrimaryTextColor));
+            ValidateHex(SecondaryTextColor, nameof(SecondaryTextColor));
+            ValidateHex(MutedTextColor, nameof(MutedTextColor));
+            ValidateHex(AccentColor, nameof(AccentColor));
+            ValidateHex(AccentDarkColor, nameof(AccentDarkColor));
+            ValidateHex(AccentLightColor, nameof(AccentLightColor));
+            ValidateHex(AccentContrastColor, nameof(AccentContrastColor));
+            ValidateHex(Accent2Color, nameof(Accent2Color));
+            ValidateHex(Accent3Color, nameof(Accent3Color));
+            ValidateHex(WarningColor, nameof(WarningColor));
+
+            if (string.IsNullOrWhiteSpace(HeadingFontName)) {
+                throw new ArgumentException("Heading font cannot be null or empty.", nameof(HeadingFontName));
+            }
+            if (string.IsNullOrWhiteSpace(BodyFontName)) {
+                throw new ArgumentException("Body font cannot be null or empty.", nameof(BodyFontName));
+            }
+        }
+
+        private static string NormalizeHex(string value, string name) {
+            if (string.IsNullOrWhiteSpace(value)) {
+                throw new ArgumentException("Color cannot be null or empty.", name);
+            }
+            if (value.StartsWith("#", StringComparison.Ordinal)) {
+                value = value.Substring(1);
+            }
+            ValidateHex(value, name);
+            return value.ToUpperInvariant();
+        }
+
+        private static string Shade(string value, double amount) {
+            int r = Convert.ToInt32(value.Substring(0, 2), 16);
+            int g = Convert.ToInt32(value.Substring(2, 2), 16);
+            int b = Convert.ToInt32(value.Substring(4, 2), 16);
+            r = ShadeChannel(r, amount);
+            g = ShadeChannel(g, amount);
+            b = ShadeChannel(b, amount);
+            return r.ToString("X2") + g.ToString("X2") + b.ToString("X2");
+        }
+
+        private static int ShadeChannel(int value, double amount) {
+            double target = amount >= 0 ? 255 : 0;
+            return (int)Math.Round(value + (target - value) * Math.Abs(amount));
+        }
+
+        private static string RotateAccent(string value) {
+            return value.Substring(2, 2) + value.Substring(4, 2) + value.Substring(0, 2);
+        }
+
+        private static string WarmAccent(int index) {
+            string[] colors = {
+                "F4A100",
+                "F59E0B",
+                "E9B44C",
+                "FF8A3D",
+                "D4AF37",
+                "F97316",
+                "EF4444"
+            };
+            return colors[Math.Abs(index) % colors.Length];
+        }
+
+        private static int StablePick(string value, int choices) {
+            unchecked {
+                int hash = (int)2166136261;
+                for (int i = 0; i < value.Length; i++) {
+                    hash ^= value[i];
+                    hash *= 16777619;
+                }
+                return (hash & int.MaxValue) % choices;
+            }
+        }
+
+        private static string ShiftHue(string value, double degrees, double saturationScale, double lightnessShift) {
+            int r = Convert.ToInt32(value.Substring(0, 2), 16);
+            int g = Convert.ToInt32(value.Substring(2, 2), 16);
+            int b = Convert.ToInt32(value.Substring(4, 2), 16);
+            RgbToHsl(r, g, b, out double hue, out double saturation, out double lightness);
+            hue = (hue + degrees) % 360;
+            if (hue < 0) {
+                hue += 360;
+            }
+            saturation = Clamp(saturation * saturationScale, 0.28, 0.9);
+            lightness = Clamp(lightness + lightnessShift, 0.26, 0.62);
+            HslToRgb(hue, saturation, lightness, out r, out g, out b);
+            return r.ToString("X2") + g.ToString("X2") + b.ToString("X2");
+        }
+
+        private static void RgbToHsl(int r, int g, int b, out double hue, out double saturation, out double lightness) {
+            double red = r / 255d;
+            double green = g / 255d;
+            double blue = b / 255d;
+            double max = Math.Max(red, Math.Max(green, blue));
+            double min = Math.Min(red, Math.Min(green, blue));
+            double delta = max - min;
+
+            lightness = (max + min) / 2d;
+            if (delta == 0) {
+                hue = 0;
+                saturation = 0;
+                return;
+            }
+
+            saturation = delta / (1d - Math.Abs(2d * lightness - 1d));
+            if (max == red) {
+                hue = 60d * (((green - blue) / delta) % 6d);
+            } else if (max == green) {
+                hue = 60d * (((blue - red) / delta) + 2d);
+            } else {
+                hue = 60d * (((red - green) / delta) + 4d);
+            }
+            if (hue < 0) {
+                hue += 360d;
+            }
+        }
+
+        private static void HslToRgb(double hue, double saturation, double lightness, out int r, out int g, out int b) {
+            double chroma = (1d - Math.Abs(2d * lightness - 1d)) * saturation;
+            double x = chroma * (1d - Math.Abs((hue / 60d) % 2d - 1d));
+            double m = lightness - chroma / 2d;
+            double red;
+            double green;
+            double blue;
+
+            if (hue < 60) {
+                red = chroma;
+                green = x;
+                blue = 0;
+            } else if (hue < 120) {
+                red = x;
+                green = chroma;
+                blue = 0;
+            } else if (hue < 180) {
+                red = 0;
+                green = chroma;
+                blue = x;
+            } else if (hue < 240) {
+                red = 0;
+                green = x;
+                blue = chroma;
+            } else if (hue < 300) {
+                red = x;
+                green = 0;
+                blue = chroma;
+            } else {
+                red = chroma;
+                green = 0;
+                blue = x;
+            }
+
+            r = ToByte(red + m);
+            g = ToByte(green + m);
+            b = ToByte(blue + m);
+        }
+
+        private static int ToByte(double value) {
+            return (int)Math.Round(Clamp(value, 0, 1) * 255d);
+        }
+
+        private static double Clamp(double value, double min, double max) {
+            if (value < min) {
+                return min;
+            }
+            if (value > max) {
+                return max;
+            }
+            return value;
+        }
+
+        private static void ValidateHex(string value, string name) {
+            if (string.IsNullOrWhiteSpace(value)) {
+                throw new ArgumentException("Color cannot be null or empty.", name);
+            }
+            if (value.Length != 6) {
+                throw new ArgumentException("Color must be a six-character RGB hex value without '#'.", name);
+            }
+            for (int i = 0; i < value.Length; i++) {
+                char c = value[i];
+                bool valid = c is >= '0' and <= '9' or >= 'A' and <= 'F' or >= 'a' and <= 'f';
+                if (!valid) {
+                    throw new ArgumentException("Color must be a six-character RGB hex value without '#'.", name);
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointLayoutBox.cs
+++ b/OfficeIMO.PowerPoint/PowerPointLayoutBox.cs
@@ -335,6 +335,80 @@ namespace OfficeIMO.PowerPoint {
         }
 
         /// <summary>
+        ///     Returns a new layout box inset equally on every side.
+        /// </summary>
+        public PowerPointLayoutBox InsetCm(double insetCm) {
+            return InsetCm(insetCm, insetCm, insetCm, insetCm);
+        }
+
+        /// <summary>
+        ///     Returns a new layout box inset horizontally and vertically.
+        /// </summary>
+        public PowerPointLayoutBox InsetCm(double horizontalCm, double verticalCm) {
+            return InsetCm(horizontalCm, verticalCm, horizontalCm, verticalCm);
+        }
+
+        /// <summary>
+        ///     Returns a new layout box inset by individual side values.
+        /// </summary>
+        public PowerPointLayoutBox InsetCm(double leftCm, double topCm, double rightCm, double bottomCm) {
+            if (leftCm < 0) {
+                throw new ArgumentOutOfRangeException(nameof(leftCm));
+            }
+            if (topCm < 0) {
+                throw new ArgumentOutOfRangeException(nameof(topCm));
+            }
+            if (rightCm < 0) {
+                throw new ArgumentOutOfRangeException(nameof(rightCm));
+            }
+            if (bottomCm < 0) {
+                throw new ArgumentOutOfRangeException(nameof(bottomCm));
+            }
+
+            long left = PowerPointUnits.FromCentimeters(leftCm);
+            long top = PowerPointUnits.FromCentimeters(topCm);
+            long right = PowerPointUnits.FromCentimeters(rightCm);
+            long bottom = PowerPointUnits.FromCentimeters(bottomCm);
+            if (left + right >= Width || top + bottom >= Height) {
+                throw new ArgumentOutOfRangeException(nameof(leftCm), "Insets exceed the layout box.");
+            }
+
+            return new PowerPointLayoutBox(Left + left, Top + top, Width - left - right, Height - top - bottom);
+        }
+
+        /// <summary>
+        ///     Returns the top part of the layout box with the requested height.
+        /// </summary>
+        public PowerPointLayoutBox TakeTopCm(double heightCm) {
+            if (heightCm <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(heightCm));
+            }
+
+            long height = PowerPointUnits.FromCentimeters(heightCm);
+            if (height > Height) {
+                throw new ArgumentOutOfRangeException(nameof(heightCm), "Requested height exceeds the layout box.");
+            }
+
+            return new PowerPointLayoutBox(Left, Top, Width, height);
+        }
+
+        /// <summary>
+        ///     Returns the bottom part of the layout box with the requested height.
+        /// </summary>
+        public PowerPointLayoutBox TakeBottomCm(double heightCm) {
+            if (heightCm <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(heightCm));
+            }
+
+            long height = PowerPointUnits.FromCentimeters(heightCm);
+            if (height > Height) {
+                throw new ArgumentOutOfRangeException(nameof(heightCm), "Requested height exceeds the layout box.");
+            }
+
+            return new PowerPointLayoutBox(Left, Bottom - height, Width, height);
+        }
+
+        /// <summary>
         ///     Applies the layout box to the provided shape.
         /// </summary>
         /// <param name="shape">Shape to update.</param>

--- a/OfficeIMO.PowerPoint/PowerPointSlideComposer.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlideComposer.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using A = DocumentFormat.OpenXml.Drawing;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Structured composition surface for building custom designer slides without manual placement for every shape.
+    /// </summary>
+    public sealed class PowerPointSlideComposer {
+        private readonly PowerPointSlide _slide;
+        private readonly PowerPointDesignTheme _theme;
+        private readonly PowerPointDesignerSlideOptions _options;
+        private readonly double _slideWidthCm;
+        private readonly double _slideHeightCm;
+        private readonly bool _dark;
+
+        internal PowerPointSlideComposer(PowerPointSlide slide, PowerPointDesignTheme theme,
+            PowerPointDesignerSlideOptions options, double slideWidthCm, double slideHeightCm, bool dark) {
+            _slide = slide;
+            _theme = theme;
+            _options = options;
+            _slideWidthCm = slideWidthCm;
+            _slideHeightCm = slideHeightCm;
+            _dark = dark;
+        }
+
+        /// <summary>
+        ///     Underlying editable slide for advanced callers that need to add custom OfficeIMO shapes.
+        /// </summary>
+        public PowerPointSlide Slide => _slide;
+
+        /// <summary>
+        ///     Returns the default editable content area below the title and above the footer.
+        /// </summary>
+        public PowerPointLayoutBox ContentArea(double topCm = 3.65, double bottomMarginCm = 1.65,
+            double horizontalMarginCm = 1.5) {
+            if (topCm < 0) {
+                throw new ArgumentOutOfRangeException(nameof(topCm));
+            }
+            if (bottomMarginCm < 0) {
+                throw new ArgumentOutOfRangeException(nameof(bottomMarginCm));
+            }
+            if (horizontalMarginCm < 0) {
+                throw new ArgumentOutOfRangeException(nameof(horizontalMarginCm));
+            }
+
+            double height = _slideHeightCm - topCm - bottomMarginCm;
+            double width = _slideWidthCm - horizontalMarginCm * 2;
+            if (height <= 0 || width <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(topCm), "Content area does not fit on the slide.");
+            }
+
+            return PowerPointLayoutBox.FromCentimeters(horizontalMarginCm, topCm, width, height);
+        }
+
+        /// <summary>
+        ///     Returns columns inside the default content area.
+        /// </summary>
+        public PowerPointLayoutBox[] ContentColumns(int columnCount, double gutterCm = 0.65,
+            double topCm = 3.65, double bottomMarginCm = 1.65, double horizontalMarginCm = 1.5) {
+            return ContentArea(topCm, bottomMarginCm, horizontalMarginCm).SplitColumnsCm(columnCount, gutterCm);
+        }
+
+        /// <summary>
+        ///     Returns rows inside the default content area.
+        /// </summary>
+        public PowerPointLayoutBox[] ContentRows(int rowCount, double gutterCm = 0.55,
+            double topCm = 3.65, double bottomMarginCm = 1.65, double horizontalMarginCm = 1.5) {
+            return ContentArea(topCm, bottomMarginCm, horizontalMarginCm).SplitRowsCm(rowCount, gutterCm);
+        }
+
+        /// <summary>
+        ///     Returns a row/column grid inside the default content area.
+        /// </summary>
+        public PowerPointLayoutBox[,] ContentGrid(int rowCount, int columnCount, double rowGutterCm = 0.55,
+            double columnGutterCm = 0.55, double topCm = 3.65, double bottomMarginCm = 1.65,
+            double horizontalMarginCm = 1.5) {
+            return ContentArea(topCm, bottomMarginCm, horizontalMarginCm)
+                .SplitGridCm(rowCount, columnCount, rowGutterCm, columnGutterCm);
+        }
+
+        /// <summary>
+        ///     Adds a standard title block using the active theme and slide surface.
+        /// </summary>
+        public void AddTitle(string title, string? subtitle = null) {
+            if (title == null) {
+                throw new ArgumentNullException(nameof(title));
+            }
+
+            string titleColor = _dark ? _theme.AccentContrastColor : _theme.PrimaryTextColor;
+            string subtitleColor = _dark ? _theme.AccentLightColor : _theme.SecondaryTextColor;
+            PowerPointDesignExtensions.AddText(_slide, title, 1.65, 1.45, _slideWidthCm * 0.62, 1.05, 31,
+                titleColor, _theme.HeadingFontName, bold: true);
+
+            if (!string.IsNullOrWhiteSpace(subtitle)) {
+                PowerPointDesignExtensions.AddText(_slide, subtitle!, 1.7, 2.65, _slideWidthCm * 0.58, 0.55, 12,
+                    subtitleColor, _theme.BodyFontName, bold: true);
+            }
+        }
+
+        /// <summary>
+        ///     Adds a raw themed text block at the requested bounds.
+        /// </summary>
+        public PowerPointTextBox AddTextBlock(string text, PowerPointLayoutBox bounds, int fontSize = 12,
+            bool bold = false, string? color = null) {
+            if (text == null) {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            string resolvedColor = color ?? (_dark ? _theme.AccentLightColor : _theme.SecondaryTextColor);
+            return PowerPointDesignExtensions.AddText(_slide, text, bounds.LeftCm, bounds.TopCm, bounds.WidthCm,
+                bounds.HeightCm, fontSize, resolvedColor, _theme.BodyFontName, bold);
+        }
+
+        /// <summary>
+        ///     Adds a designer card grid using the supplied semantic card content.
+        /// </summary>
+        public void AddCardGrid(IEnumerable<PowerPointCardContent> cards, PowerPointCardGridSlideOptions? options = null) {
+            PowerPointCardGridSlideOptions resolved = options ?? new PowerPointCardGridSlideOptions();
+            InheritDesignIntent(resolved);
+            List<PowerPointCardContent> cardList = PowerPointDesignExtensions.NormalizeCards(cards);
+            PowerPointCardGridLayoutVariant variant =
+                PowerPointDesignExtensions.ResolveCardGridVariant(resolved, cardList);
+
+            PowerPointDesignExtensions.AddCardGrid(_slide, _theme, cardList, resolved, variant,
+                _slideWidthCm, _slideHeightCm);
+        }
+
+        /// <summary>
+        ///     Adds a designer card grid inside a caller-selected region.
+        /// </summary>
+        public void AddCardGrid(IEnumerable<PowerPointCardContent> cards, PowerPointLayoutBox bounds,
+            PowerPointCardGridSlideOptions? options = null) {
+            PowerPointCardGridSlideOptions resolved = options ?? new PowerPointCardGridSlideOptions();
+            InheritDesignIntent(resolved);
+            List<PowerPointCardContent> cardList = PowerPointDesignExtensions.NormalizeCards(cards);
+            PowerPointCardGridLayoutVariant variant =
+                PowerPointDesignExtensions.ResolveCardGridVariant(resolved, cardList);
+
+            PowerPointDesignExtensions.AddCardGrid(_slide, _theme, cardList, resolved, variant, bounds);
+        }
+
+        /// <summary>
+        ///     Adds a process/timeline primitive using the supplied semantic steps.
+        /// </summary>
+        public void AddProcessTimeline(IEnumerable<PowerPointProcessStep> steps, PowerPointProcessSlideOptions? options = null) {
+            PowerPointProcessSlideOptions resolved = options ?? new PowerPointProcessSlideOptions();
+            InheritDesignIntent(resolved);
+            List<PowerPointProcessStep> stepList = PowerPointDesignExtensions.NormalizeSteps(steps);
+            PowerPointDesignExtensions.AddProcessTimeline(_slide, _theme, stepList, resolved,
+                _slideWidthCm, _slideHeightCm);
+        }
+
+        /// <summary>
+        ///     Adds a process/timeline primitive inside a caller-selected region.
+        /// </summary>
+        public void AddProcessTimeline(IEnumerable<PowerPointProcessStep> steps, PowerPointLayoutBox bounds,
+            PowerPointProcessSlideOptions? options = null) {
+            PowerPointProcessSlideOptions resolved = options ?? new PowerPointProcessSlideOptions();
+            InheritDesignIntent(resolved);
+            List<PowerPointProcessStep> stepList = PowerPointDesignExtensions.NormalizeSteps(steps);
+            PowerPointDesignExtensions.AddProcessTimeline(_slide, _theme, stepList, resolved, bounds);
+        }
+
+        /// <summary>
+        ///     Adds a themed metric strip inside explicit bounds.
+        /// </summary>
+        public void AddMetricStrip(IEnumerable<PowerPointMetric> metrics, PowerPointLayoutBox bounds) {
+            if (metrics == null) {
+                throw new ArgumentNullException(nameof(metrics));
+            }
+
+            PowerPointAutoShape band = _slide.AddRectangleCm(bounds.LeftCm, bounds.TopCm, bounds.WidthCm,
+                bounds.HeightCm, "Composer Metric Band");
+            band.FillColor = _dark ? _theme.AccentColor : _theme.AccentColor;
+            band.FillTransparency = _dark ? 55 : 0;
+            band.OutlineColor = _dark ? _theme.AccentLightColor : _theme.AccentColor;
+            band.OutlineWidthPoints = 0.45;
+            band.SetShadow("000000", blurPoints: 3, distancePoints: 0.8, angleDegrees: 90, transparencyPercent: 90);
+
+            PowerPointDesignExtensions.AddMetrics(_slide, _theme, metrics.Where(metric => metric != null).ToList(),
+                bounds.LeftCm, bounds.TopCm, bounds.WidthCm, bounds.HeightCm);
+        }
+
+        /// <summary>
+        ///     Adds a polished image or editable placeholder surface inside explicit bounds.
+        /// </summary>
+        public void AddVisualFrame(PowerPointLayoutBox bounds, string? imagePath = null) {
+            PowerPointDesignExtensions.AddVisualFrame(_slide, _theme, imagePath, bounds.LeftCm, bounds.TopCm,
+                bounds.WidthCm, bounds.HeightCm, _options.DesignIntent);
+        }
+
+        /// <summary>
+        ///     Adds a lightweight callout band inside explicit bounds.
+        /// </summary>
+        public void AddCalloutBand(string text, PowerPointLayoutBox bounds, string? accentColor = null) {
+            if (text == null) {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            string accent = accentColor ?? _theme.AccentColor;
+            PowerPointAutoShape band = _slide.AddRectangleCm(bounds.LeftCm, bounds.TopCm, bounds.WidthCm,
+                bounds.HeightCm, "Composer Callout Band");
+            band.FillColor = _dark ? _theme.AccentColor : _theme.PanelColor;
+            band.FillTransparency = _dark ? 60 : 0;
+            band.OutlineColor = _dark ? _theme.AccentLightColor : _theme.PanelBorderColor;
+            band.OutlineWidthPoints = 0.45;
+            band.SetShadow("000000", blurPoints: 3, distancePoints: 0.8, angleDegrees: 90, transparencyPercent: 90);
+
+            PowerPointAutoShape rule = _slide.AddRectangleCm(bounds.LeftCm, bounds.TopCm, 0.13, bounds.HeightCm,
+                "Composer Callout Accent");
+            rule.FillColor = accent;
+            rule.OutlineColor = accent;
+
+            PowerPointDesignExtensions.AddText(_slide, text, bounds.LeftCm + 0.55, bounds.TopCm + 0.28,
+                bounds.WidthCm - 0.85, bounds.HeightCm - 0.45, 13,
+                _dark ? _theme.AccentContrastColor : _theme.SecondaryTextColor, _theme.BodyFontName, bold: true);
+        }
+
+        /// <summary>
+        ///     Adds a logo, partner, or certification wall inside a caller-selected region.
+        /// </summary>
+        public void AddLogoWall(IEnumerable<PowerPointLogoItem> logos, PowerPointLayoutBox bounds,
+            PowerPointLogoWallSlideOptions? options = null) {
+            PowerPointLogoWallSlideOptions resolved = options ?? new PowerPointLogoWallSlideOptions();
+            InheritDesignIntent(resolved);
+            IReadOnlyList<PowerPointLogoItem> logoList = PowerPointDesignExtensions.NormalizeLogoItems(logos);
+            PowerPointLogoWallLayoutVariant variant =
+                PowerPointDesignExtensions.ResolveLogoWallVariant(resolved, logoList);
+
+            PowerPointDesignExtensions.AddLogoWall(_slide, _theme, logoList, resolved, variant, bounds);
+        }
+
+        /// <summary>
+        ///     Adds an editable coverage map-like surface with normalized location pins inside explicit bounds.
+        /// </summary>
+        public void AddCoverageMap(IEnumerable<PowerPointCoverageLocation> locations, PowerPointLayoutBox bounds,
+            PowerPointCoverageSlideOptions? options = null) {
+            PowerPointCoverageSlideOptions resolved = options ?? new PowerPointCoverageSlideOptions();
+            InheritDesignIntent(resolved);
+            IReadOnlyList<PowerPointCoverageLocation> locationList = PowerPointDesignExtensions.NormalizeLocations(locations);
+            PowerPointDesignExtensions.AddCoverageMap(_slide, _theme, locationList, bounds, resolved);
+        }
+
+        private void InheritDesignIntent(PowerPointDesignerSlideOptions childOptions) {
+            if (childOptions.DesignIntent.Seed == null &&
+                childOptions.DesignIntent.Mood == PowerPointDesignMood.Corporate &&
+                childOptions.DesignIntent.Density == PowerPointSlideDensity.Balanced &&
+                childOptions.DesignIntent.VisualStyle == PowerPointVisualStyle.Geometric) {
+                childOptions.DesignIntent = _options.DesignIntent;
+            }
+        }
+    }
+
+    public static partial class PowerPointDesignExtensions {
+        /// <summary>
+        ///     Creates a designer slide and exposes reusable primitives for custom composition.
+        /// </summary>
+        public static PowerPointSlide ComposeDesignerSlide(this PowerPointPresentation presentation,
+            Action<PowerPointSlideComposer> compose, PowerPointDesignTheme? theme = null,
+            PowerPointDesignerSlideOptions? options = null, bool dark = false) {
+            if (presentation == null) {
+                throw new ArgumentNullException(nameof(presentation));
+            }
+            if (compose == null) {
+                throw new ArgumentNullException(nameof(compose));
+            }
+
+            PowerPointDesignTheme resolvedTheme = ResolveTheme(theme);
+            PowerPointDesignerSlideOptions resolvedOptions = options ?? new PowerPointDesignerSlideOptions();
+            PowerPointSlide slide = presentation.AddSlide();
+            double width = presentation.SlideSize.WidthCm;
+            double height = presentation.SlideSize.HeightCm;
+
+            slide.BackgroundColor = dark ? resolvedTheme.AccentDarkColor : resolvedTheme.BackgroundColor;
+            if (dark && resolvedOptions.DesignIntent.VisualStyle == PowerPointVisualStyle.Geometric) {
+                AddDiagonalPlanes(slide, resolvedTheme, width, height, dark: true);
+            } else if (!dark && resolvedOptions.DesignIntent.VisualStyle != PowerPointVisualStyle.Minimal) {
+                AddSubtleLightBackground(slide, resolvedTheme, width, height);
+            }
+
+            AddChrome(slide, resolvedTheme, width, height, dark, resolvedOptions);
+            compose(new PowerPointSlideComposer(slide, resolvedTheme, resolvedOptions, width, height, dark));
+            return slide;
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/README.md
+++ b/OfficeIMO.PowerPoint/README.md
@@ -50,6 +50,141 @@ box.SetSizeCm(6, 2);
 ppt.Save();
 ```
 
+## Designer composition sample
+
+For business decks where you want polished placement without manually positioning every text box, use the designer
+composition helpers. They create editable PowerPoint shapes, text, optional pictures, and theme-driven layouts.
+Use `PowerPointDesignIntent` and layout variants when the same content should not produce the same slide every time.
+
+```csharp
+using OfficeIMO.PowerPoint;
+
+using var ppt = PowerPointPresentation.Create("designer-demo.pptx");
+ppt.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+var alternatives = PowerPointDeckDesign.CreateAlternativesFromBrand("#008C95", "client-demo",
+    name: "Client Theme", eyebrow: "Client Group",
+    footerLeft: "CLIENT", footerRight: "Service deck");
+var design = alternatives[1]; // pick the stable Editorial creative direction for this deck
+var deck = ppt.UseDesigner(design);
+
+// Or supply your own creative directions so decks do not all share the same house style.
+var clientDirections = new[] {
+    new PowerPointDesignDirection("Board Brief", PowerPointDesignMood.Corporate,
+        PowerPointSlideDensity.Relaxed, PowerPointVisualStyle.Soft, "Georgia", "Aptos",
+        showDirectionMotif: false),
+    new PowerPointDesignDirection("Field Ops", PowerPointDesignMood.Energetic,
+        PowerPointSlideDensity.Compact, PowerPointVisualStyle.Geometric, "Poppins", "Segoe UI")
+};
+var clientAlternatives = PowerPointDeckDesign.CreateAlternativesFromBrand("#008C95", "client-demo",
+    clientDirections, name: "Client Theme", footerLeft: "CLIENT");
+
+deck.AddSectionSlide("Case Study", "Project portfolio", "cover",
+    options => options.SectionVariant = PowerPointSectionLayoutVariant.EditorialRail);
+
+deck.AddCaseStudySlide("Example client",
+    new[] {
+        new PowerPointCaseStudySection("Client", "A concise customer story."),
+        new PowerPointCaseStudySection("Challenge", "Many details needed structure."),
+        new PowerPointCaseStudySection("Solution", "Separate story, evidence, and outcome."),
+        new PowerPointCaseStudySection("Result", "Keep the output editable and readable.")
+    },
+    seed: "case-study",
+    configure: options => options.Variant = PowerPointCaseStudyLayoutVariant.EditorialSplit);
+
+deck.AddProcessSlide("How we work", "Transparent phases reduce risk",
+    new[] {
+        new PowerPointProcessStep("Analysis", "Understand the environment and constraints."),
+        new PowerPointProcessStep("Discovery", "Review configuration and dependencies."),
+        new PowerPointProcessStep("Delivery", "Implement changes in controlled stages.")
+    },
+    seed: "process",
+    configure: options => options.Variant = PowerPointProcessLayoutVariant.NumberedColumns);
+
+deck.AddCardGridSlide("Scope of services", "Cards choose their own grid.",
+    new[] {
+        new PowerPointCardContent("Deployments", new[] { "Intune", "Autopilot" }),
+        new PowerPointCardContent("Maintenance", new[] { "Incidents", "Monitoring" }),
+        new PowerPointCardContent("Audits", new[] { "Configuration", "Security" })
+    },
+    seed: "services",
+    configure: options => options.Variant = PowerPointCardGridLayoutVariant.SoftTiles);
+
+deck.AddLogoWallSlide("Proof points", "Reusable logo and certification wall.",
+    new[] {
+        new PowerPointLogoItem("Lenovo", "Partner"),
+        new PowerPointLogoItem("Samsung", "Devices"),
+        new PowerPointLogoItem("Epson", "Service")
+    },
+    seed: "proof",
+    configure: options => options.FeatureTitle = "Featured certification");
+
+deck.AddCoverageSlide("Service coverage", "Pins are normalized inside the editable map panel.",
+    new[] {
+        new PowerPointCoverageLocation("Warszawa", 0.60, 0.48),
+        new PowerPointCoverageLocation("Gdansk", 0.55, 0.18),
+        new PowerPointCoverageLocation("Krakow", 0.58, 0.78)
+    },
+    seed: "coverage",
+    configure: options => {
+        options.MapLabel = "Editable locations";
+    });
+
+deck.AddCapabilitySlide("Service capability", "Structured text with visual support.",
+    new[] {
+        new PowerPointCapabilitySection("Warranty service",
+            "Nationwide support for distributed environments.",
+            new[] { "Computers and notebooks", "Printers and scanners" }),
+        new PowerPointCapabilitySection("Extended care",
+            "Support beyond standard vendor warranty.",
+            new[] { "SLA options", "Continuity monitoring" })
+    },
+    seed: "capability",
+    configure: options => {
+        options.VisualKind = PowerPointCapabilityVisualKind.CoverageMap;
+        options.VisualLabel = "Service locations";
+        options.Locations.Add(new PowerPointCoverageLocation("Warszawa", 0.60, 0.48));
+        options.Locations.Add(new PowerPointCoverageLocation("Gdansk", 0.55, 0.18));
+        options.Metrics.Add(new PowerPointMetric("8", "locations"));
+    });
+
+deck.ComposeSlide(composer => {
+    composer.AddTitle("Custom slide", "Use primitives when a recipe is too fixed.");
+    var columns = composer.ContentColumns(2);
+    composer.AddCardGrid(new[] {
+        new PowerPointCardContent("Story", new[] { "Context", "Need" }),
+        new PowerPointCardContent("Evidence", new[] { "Metrics", "Visual" })
+    }, columns[0]);
+    composer.AddCoverageMap(new[] {
+        new PowerPointCoverageLocation("North", 0.45, 0.20),
+        new PowerPointCoverageLocation("Central", 0.60, 0.48)
+    }, columns[1].TakeTopCm(3.0));
+    composer.AddCalloutBand("Use composer regions when the slide needs its own structure.",
+        columns[1].TakeBottomCm(1.5));
+}, "custom");
+
+ppt.Save();
+```
+
+Runnable sample:
+
+```powershell
+dotnet run --project OfficeIMO.Examples/OfficeIMO.Examples.csproj -f net10.0 -- --designer-powerpoint
+```
+
+The helpers are intentionally not fixed templates. Start with `PowerPointDeckDesign.FromBrand(...)` to define the
+deck personality once, including brand color, stable seed, mood, fonts, and chrome. Use a named
+`PowerPointDesignDirection` such as `Structured`, `Editorial`, `Quiet`, `Signal`, or `Executive` when you want a
+recognizable creative direction without hand-tuning every slide. The deck design configures per-slide
+`PowerPointDesignIntent` values so repeated content can receive stable but different accents, motifs, and automatic
+layout choices. Auto variants use both the design intent and the content shape: dense card grids stay compact, softer
+moods get softer cards, long processes stay readable, proof slides emphasize supplied certificate details, many
+locations become list-plus-map slides, section-heavy capability slides stack into readable panels, and content-rich
+case studies choose stronger structure. Use
+`PowerPointDeckDesign.CreateAlternativesFromBrand(...)` when you want a few stable directions from the same brand before
+choosing the deck personality. Use explicit layout variants when a deck needs a controlled art direction, or use
+`ComposeDesignerSlide` and `PowerPointLayoutBox` regions when the slide needs a custom composition while still reusing
+cards, metrics, process steps, logo walls, coverage maps, and callout bands.
+
 ## Common Tasks by Example
 
 ### Title + content

--- a/OfficeIMO.Tests/PowerPoint.DesignCompositions.cs
+++ b/OfficeIMO.Tests/PowerPoint.DesignCompositions.cs
@@ -1,0 +1,1197 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Validation;
+using OfficeIMO.PowerPoint;
+using Xunit;
+using A = DocumentFormat.OpenXml.Drawing;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointDesignCompositions {
+        [Fact]
+        public void DesignerCompositions_CreateValidEditableDeck() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+                    presentation.ApplyDesignerTheme();
+
+                    presentation.AddDesignerSectionSlide("Case Study", "Project portfolio",
+                        options: new PowerPointDesignerSlideOptions {
+                            Eyebrow = "OfficeIMO.PowerPoint",
+                            FooterLeft = "OfficeIMO",
+                            FooterRight = "The Good Slides"
+                        });
+
+                    presentation.AddDesignerProcessSlide("How we work",
+                        "Clear phases reduce risk and speed up delivery",
+                        new[] {
+                            new PowerPointProcessStep("Discovery", "Map the environment and constraints."),
+                            new PowerPointProcessStep("Design", "Select the strongest architecture and scope."),
+                            new PowerPointProcessStep("Delivery", "Implement changes with controlled rollout."),
+                            new PowerPointProcessStep("Care", "Keep the environment stable after go-live.")
+                        });
+
+                    presentation.AddDesignerCardGridSlide("Scope of services",
+                        "Reusable cards pick their own grid.",
+                        new[] {
+                            new PowerPointCardContent("Deployments", new[] { "Intune", "Autopilot", "Policy baseline" }),
+                            new PowerPointCardContent("Maintenance", new[] { "Incidents", "Monitoring", "Optimization" }),
+                            new PowerPointCardContent("Consulting", new[] { "Roadmap", "Architecture", "Discovery" }),
+                            new PowerPointCardContent("Audits", new[] { "Configuration", "Security", "Modernization" })
+                        },
+                        options: new PowerPointCardGridSlideOptions {
+                            SupportingText = "Most common areas can be expressed as cards, tags, or metrics without manual coordinates."
+                        });
+
+                    PowerPointCaseStudySlideOptions caseOptions = new() {
+                        Eyebrow = "OfficeIMO.PowerPoint",
+                        FooterLeft = "OfficeIMO",
+                        FooterRight = "The Good Slides",
+                        BrandText = "OFFICEIMO",
+                        BandLabel = "Project portfolio"
+                    };
+                    caseOptions.Tags.Add("Services");
+                    caseOptions.Tags.Add("Monitoring");
+                    caseOptions.Tags.Add("Systems");
+                    caseOptions.Tags.Add("Case Study");
+
+                    presentation.AddDesignerCaseStudySlide("Example client",
+                        new[] {
+                            new PowerPointCaseStudySection("Client", "A national organization needed a concise service story."),
+                            new PowerPointCaseStudySection("Challenge", "The source material mixed details, outcomes, and implementation context."),
+                            new PowerPointCaseStudySection("Solution", "A structured slide separates narrative columns, metrics, and visual support."),
+                            new PowerPointCaseStudySection("Result", "The output remains editable and keeps visual hierarchy without hand-placement.")
+                        },
+                        new[] {
+                            new PowerPointMetric("150", "devices"),
+                            new PowerPointMetric("60", "locations")
+                        },
+                        options: caseOptions);
+
+                    List<ValidationErrorInfo> errors = presentation.ValidateDocument();
+                    Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+                    presentation.Save();
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                    List<ValidationErrorInfo> errors = presentation.ValidateDocument();
+                    Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+                    Assert.Equal(4, presentation.Slides.Count);
+                    Assert.Contains(presentation.Slides.SelectMany(slide => slide.TextBoxes),
+                        textBox => textBox.Text == "Scope of services");
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCardGrid_KeepsCardsWithinSlideBounds() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerCardGridSlide("Services", null,
+                    Enumerable.Range(1, 7).Select(index =>
+                        new PowerPointCardContent("Card " + index, new[] { "One", "Two" })),
+                    options: new PowerPointCardGridSlideOptions { MaxColumns = 3 });
+
+                PowerPointLayoutBox slideBounds = new(0, 0, presentation.SlideSize.WidthEmus, presentation.SlideSize.HeightEmus);
+                for (int i = 1; i <= 7; i++) {
+                    PowerPointShape? card = slide.GetShape("Designer Card " + i);
+                    Assert.NotNull(card);
+                    Assert.True(card!.Left >= slideBounds.Left, "Card is left of the slide.");
+                    Assert.True(card.Top >= slideBounds.Top, "Card is above the slide.");
+                    Assert.True(card.Right <= slideBounds.Right, "Card is right of the slide.");
+                    Assert.True(card.Bottom <= slideBounds.Bottom, "Card is below the slide.");
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerProcessSlide_RejectsTooManyStepsForReadableLayout() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                IEnumerable<PowerPointProcessStep> steps = Enumerable.Range(1, 9)
+                    .Select(index => new PowerPointProcessStep("Step " + index, "Body"));
+
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                    presentation.AddDesignerProcessSlide("Too much", null, steps));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerTheme_UsesPresentationGradeFontsByDefault() {
+            PowerPointDesignTheme theme = PowerPointDesignTheme.ModernBlue;
+
+            Assert.Equal("Poppins", theme.HeadingFontName);
+            Assert.Equal("Lato", theme.BodyFontName);
+        }
+
+        [Fact]
+        public void DesignerTheme_FromBrandCreatesDistinctPalette() {
+            PowerPointDesignTheme theme = PowerPointDesignTheme.FromBrand("#7A3E9D", "Brand Theme",
+                headingFontName: "Aptos Display", bodyFontName: "Aptos");
+
+            Assert.Equal("Brand Theme", theme.Name);
+            Assert.Equal("7A3E9D", theme.AccentColor);
+            Assert.NotEqual(theme.AccentColor, theme.AccentDarkColor);
+            Assert.NotEqual(theme.AccentColor, theme.AccentLightColor);
+            Assert.Equal("Aptos Display", theme.HeadingFontName);
+            Assert.Equal("Aptos", theme.BodyFontName);
+        }
+
+        [Fact]
+        public void DesignerTheme_WithVariationKeepsBrandAccentButChangesSupportingPalette() {
+            PowerPointDesignTheme theme = PowerPointDesignTheme.FromBrand("#008C95", "Brand Theme");
+
+            PowerPointDesignTheme first = theme.WithVariation("client-a");
+            PowerPointDesignTheme second = theme.WithVariation("client-b");
+
+            Assert.Equal(theme.AccentColor, first.AccentColor);
+            Assert.Equal(theme.AccentColor, second.AccentColor);
+            Assert.NotEqual(first.Accent2Color, second.Accent2Color);
+            Assert.NotEqual(first.Accent3Color, second.Accent3Color);
+            Assert.NotEqual(first.WarningColor, second.WarningColor);
+            Assert.Contains(first.WarningColor, new[] { "F4A100", "F59E0B", "E9B44C", "FF8A3D", "D4AF37", "F97316", "EF4444" });
+        }
+
+        [Fact]
+        public void DesignerDeckDesign_ConfiguresThemeIntentAndChromeFromOnePlace() {
+            PowerPointDeckDesign design = PowerPointDeckDesign.FromBrand("#008C95", "client-a",
+                PowerPointDesignMood.Editorial, name: "Client A", eyebrow: "Portfolio",
+                footerLeft: "CLIENT A", footerRight: "Service deck");
+
+            Assert.Equal("008C95", design.Theme.AccentColor);
+            Assert.Equal(PowerPointDesignMood.Editorial, design.BaseIntent.Mood);
+            Assert.Equal(PowerPointSlideDensity.Relaxed, design.BaseIntent.Density);
+            Assert.Equal(PowerPointVisualStyle.Soft, design.BaseIntent.VisualStyle);
+            Assert.Equal("Aptos Display", design.Theme.HeadingFontName);
+
+            PowerPointCaseStudySlideOptions options = design.Configure(new PowerPointCaseStudySlideOptions {
+                Variant = PowerPointCaseStudyLayoutVariant.VisualHero
+            }, "case-study");
+
+            Assert.Equal("Portfolio", options.Eyebrow);
+            Assert.Equal("CLIENT A", options.FooterLeft);
+            Assert.Equal("Service deck", options.FooterRight);
+            Assert.Equal("client-a/case-study", options.DesignIntent.Seed);
+            Assert.Equal(PowerPointDesignMood.Editorial, options.DesignIntent.Mood);
+            Assert.Equal(PowerPointCaseStudyLayoutVariant.VisualHero, options.Variant);
+        }
+
+        [Fact]
+        public void DesignerDeckDesign_CanCreateDistinctAlternativesFromOneBrand() {
+            IReadOnlyList<PowerPointDeckDesign> alternatives =
+                PowerPointDeckDesign.CreateAlternativesFromBrand("#008C95", "client-a",
+                    count: 5, name: "Client A", eyebrow: "Portfolio",
+                    footerLeft: "CLIENT A", footerRight: "Service deck");
+
+            Assert.Equal(5, alternatives.Count);
+            Assert.All(alternatives, design => Assert.Equal("008C95", design.Theme.AccentColor));
+            Assert.Equal(PowerPointDesignMood.Corporate, alternatives[0].BaseIntent.Mood);
+            Assert.Equal(PowerPointDesignMood.Editorial, alternatives[1].BaseIntent.Mood);
+            Assert.Equal(PowerPointDesignMood.Minimal, alternatives[2].BaseIntent.Mood);
+            Assert.Equal(PowerPointDesignMood.Energetic, alternatives[3].BaseIntent.Mood);
+            Assert.Equal(PowerPointVisualStyle.Soft, alternatives[4].BaseIntent.VisualStyle);
+            Assert.Equal("Executive", alternatives[4].Direction.Name);
+            Assert.Equal("Segoe UI Semibold", alternatives[4].Theme.HeadingFontName);
+            Assert.NotEqual(alternatives[0].Theme.Accent2Color, alternatives[1].Theme.Accent2Color);
+            Assert.False(alternatives[2].ShowDirectionMotif);
+            Assert.Equal("Portfolio", alternatives[3].Options("cover").Eyebrow);
+            Assert.Equal("client-a/direction-4/cover", alternatives[3].Options("cover").DesignIntent.Seed);
+        }
+
+        [Fact]
+        public void DesignerDeckDesign_CanUseNamedCreativeDirection() {
+            PowerPointDeckDesign design = PowerPointDeckDesign.FromBrand("#008C95", "executive-client",
+                PowerPointDesignDirection.Executive, name: "Executive Client", footerLeft: "CLIENT");
+
+            Assert.Equal("Executive", design.Direction.Name);
+            Assert.Equal(PowerPointDesignMood.Corporate, design.BaseIntent.Mood);
+            Assert.Equal(PowerPointVisualStyle.Soft, design.BaseIntent.VisualStyle);
+            Assert.Equal("Segoe UI Semibold", design.Theme.HeadingFontName);
+            Assert.Equal("Segoe UI", design.Theme.BodyFontName);
+            Assert.False(design.ShowDirectionMotif);
+            Assert.Equal("CLIENT", design.Options("cover").FooterLeft);
+        }
+
+        [Fact]
+        public void DesignerDeckDesign_CanCreateAlternativesFromCustomDirections() {
+            PowerPointDesignDirection boardBrief = new("Board Brief", PowerPointDesignMood.Corporate,
+                PowerPointSlideDensity.Relaxed, PowerPointVisualStyle.Soft, "Georgia", "Aptos",
+                showDirectionMotif: false);
+            PowerPointDesignDirection fieldOps = new("Field Ops", PowerPointDesignMood.Energetic,
+                PowerPointSlideDensity.Compact, PowerPointVisualStyle.Geometric, "Poppins", "Segoe UI");
+
+            IReadOnlyList<PowerPointDeckDesign> alternatives =
+                PowerPointDeckDesign.CreateAlternativesFromBrand("#008C95", "custom-client",
+                    new[] { boardBrief, fieldOps }, name: "Client", footerLeft: "CLIENT");
+
+            Assert.Equal(2, alternatives.Count);
+            Assert.Equal("Board Brief", alternatives[0].Direction.Name);
+            Assert.Equal(PowerPointVisualStyle.Soft, alternatives[0].BaseIntent.VisualStyle);
+            Assert.Equal("Georgia", alternatives[0].Theme.HeadingFontName);
+            Assert.False(alternatives[0].ShowDirectionMotif);
+            Assert.Equal("custom-client/board-brief-1/cover", alternatives[0].Options("cover").DesignIntent.Seed);
+
+            Assert.Equal("Field Ops", alternatives[1].Direction.Name);
+            Assert.Equal(PowerPointSlideDensity.Compact, alternatives[1].BaseIntent.Density);
+            Assert.Equal("Segoe UI", alternatives[1].Theme.BodyFontName);
+            Assert.True(alternatives[1].ShowDirectionMotif);
+            Assert.Equal("CLIENT", alternatives[1].Options("cover").FooterLeft);
+        }
+
+        [Fact]
+        public void DesignerDeckDesign_MinimalProfileSuppressesDirectionMotifs() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+                PowerPointDeckDesign design = PowerPointDeckDesign.FromBrand("#008C95", "minimal-client",
+                    PowerPointDesignMood.Minimal, footerLeft: "Minimal Co");
+
+                PowerPointSlide slide = presentation.AddDesignerSectionSlide("Quiet Story", "No marker row",
+                    theme: design.Theme,
+                    options: design.Options("cover"));
+
+                Assert.Equal(PowerPointVisualStyle.Minimal, design.BaseIntent.VisualStyle);
+                Assert.Null(slide.GetShape("Designer Direction 1"));
+                Assert.Contains(slide.TextBoxes, textBox => textBox.Text == "Minimal Co");
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerDeckComposer_AppliesDesignAndKeepsRecipeOverridesSimple() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+                PowerPointDeckDesign design = PowerPointDeckDesign.FromBrand("#008C95", "composer-client",
+                    PowerPointDesignMood.Energetic, footerLeft: "Composer Co", footerRight: "Proposal");
+
+                PowerPointDeckComposer deck = presentation.UseDesigner(design);
+                deck.AddSectionSlide("Case Study", "Project portfolio", "cover",
+                    options => options.SectionVariant = PowerPointSectionLayoutVariant.EditorialRail);
+                deck.AddProcessSlide("How we work", null,
+                    new[] {
+                        new PowerPointProcessStep("Discover", "Understand the environment."),
+                        new PowerPointProcessStep("Deliver", "Ship controlled changes.")
+                    },
+                    "process",
+                    options => options.Variant = PowerPointProcessLayoutVariant.NumberedColumns);
+                deck.ComposeSlide(composer => composer.AddTitle("Custom", "Still has shared chrome."),
+                    "custom", options => options.FooterRight = "Composable");
+
+                Assert.Equal(design.Theme.Name, presentation.ThemeName);
+                Assert.Equal(3, presentation.Slides.Count);
+                Assert.NotNull(presentation.Slides[0].GetShape("Section Editorial Rail"));
+                Assert.NotNull(presentation.Slides[1].GetShape("Process Column 1"));
+                Assert.Contains(presentation.Slides[2].TextBoxes, textBox => textBox.Text == "Composable");
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerDeckComposer_SameContentCanUseDifferentDeckPersonalities() {
+            string corporatePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string minimalPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation corporate = PowerPointPresentation.Create(corporatePath);
+                corporate.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+                PowerPointDeckDesign corporateDesign = PowerPointDeckDesign.FromBrand("#008C95", "same-content-a",
+                    PowerPointDesignMood.Corporate);
+                PowerPointDeckComposer corporateDeck = corporate.UseDesigner(corporateDesign);
+                corporateDeck.AddSectionSlide("Same Story", "Different personality", "cover");
+
+                using PowerPointPresentation minimal = PowerPointPresentation.Create(minimalPath);
+                minimal.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+                PowerPointDeckDesign minimalDesign = PowerPointDeckDesign.FromBrand("#008C95", "same-content-b",
+                    PowerPointDesignMood.Minimal);
+                PowerPointDeckComposer minimalDeck = minimal.UseDesigner(minimalDesign);
+                minimalDeck.AddSectionSlide("Same Story", "Different personality", "cover");
+
+                Assert.NotEqual(corporateDesign.Theme.HeadingFontName, minimalDesign.Theme.HeadingFontName);
+                Assert.NotNull(corporate.Slides[0].GetShape("Designer Direction 1"));
+                Assert.Null(minimal.Slides[0].GetShape("Designer Direction 1"));
+                Assert.Equal("008C95", corporateDesign.Theme.AccentColor);
+                Assert.Equal("008C95", minimalDesign.Theme.AccentColor);
+            } finally {
+                if (File.Exists(corporatePath)) {
+                    File.Delete(corporatePath);
+                }
+                if (File.Exists(minimalPath)) {
+                    File.Delete(minimalPath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerDirectionMotif_UsesEditableTrianglesInsteadOfTextGlyphs() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerSectionSlide("Case Study", "Project portfolio");
+
+                for (int i = 1; i <= 11; i++) {
+                    PowerPointAutoShape arrow = Assert.IsAssignableFrom<PowerPointAutoShape>(
+                        slide.GetShape("Designer Direction " + i));
+                    Assert.Equal(A.ShapeTypeValues.Triangle, arrow.ShapeType);
+                    Assert.Equal(90, arrow.Rotation);
+                }
+
+                Assert.DoesNotContain(slide.TextBoxes,
+                    textBox => textBox.Text.Contains("→", StringComparison.Ordinal) ||
+                               textBox.Text.Contains("➜", StringComparison.Ordinal));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerSectionSlide_CanUseEditorialRailVariant() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerSectionSlide("Case Study", "Project portfolio",
+                    options: new PowerPointDesignerSlideOptions {
+                        SectionVariant = PowerPointSectionLayoutVariant.EditorialRail
+                    });
+
+                Assert.NotNull(slide.GetShape("Section Editorial Rail"));
+                Assert.NotNull(slide.GetShape("Section Editorial Accent Plane"));
+                Assert.Null(slide.GetShape("Section Poster Frame"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCaseStudySlide_UsesPolishedVisualPlaceholderWithoutHeavyBorder() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerCaseStudySlide("Example client",
+                    new[] {
+                        new PowerPointCaseStudySection("Client", "Short story."),
+                        new PowerPointCaseStudySection("Challenge", "Needs a clean visual support area.")
+                    });
+
+                PowerPointShape? frame = slide.GetShape("Case Study Visual Frame");
+                Assert.NotNull(frame);
+                Assert.NotEqual("111111", frame!.FillColor);
+                Assert.NotEqual("111111", frame.OutlineColor);
+                Assert.True(frame.OutlineWidthPoints <= 0.5);
+                Assert.NotNull(slide.GetShape("Case Study Visual Surface"));
+                Assert.NotNull(slide.GetShape("Case Study Visual Content Panel"));
+                Assert.DoesNotContain(slide.TextBoxes,
+                    textBox => textBox.Text.Equals("Visual", StringComparison.OrdinalIgnoreCase));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCaseStudySlide_VisualPlaceholderVariesWithDesignIntent() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide softSlide = presentation.AddDesignerCaseStudySlide("Soft client",
+                    new[] {
+                        new PowerPointCaseStudySection("Client", "Short story."),
+                        new PowerPointCaseStudySection("Challenge", "Needs a clean visual support area.")
+                    },
+                    options: new PowerPointCaseStudySlideOptions {
+                        DesignIntent = PowerPointDesignIntent.FromMood(PowerPointDesignMood.Editorial, "soft-case")
+                    });
+
+                PowerPointSlide minimalSlide = presentation.AddDesignerCaseStudySlide("Minimal client",
+                    new[] {
+                        new PowerPointCaseStudySection("Client", "Short story."),
+                        new PowerPointCaseStudySection("Challenge", "Needs a clean visual support area.")
+                    },
+                    options: new PowerPointCaseStudySlideOptions {
+                        DesignIntent = PowerPointDesignIntent.FromMood(PowerPointDesignMood.Minimal, "minimal-case")
+                    });
+
+                Assert.NotNull(softSlide.GetShape("Visual Collage Tile 1"));
+                Assert.Null(softSlide.GetShape("Case Study Visual Content Panel"));
+                Assert.NotNull(minimalSlide.GetShape("Visual Diagram Node 1"));
+                Assert.Null(minimalSlide.GetShape("Case Study Visual Content Panel"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCaseStudySlide_CanUseEditorialSplitVariant() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerCaseStudySlide("Example client",
+                    new[] {
+                        new PowerPointCaseStudySection("Client", "Short story."),
+                        new PowerPointCaseStudySection("Challenge", "Needs clean structure."),
+                        new PowerPointCaseStudySection("Solution", "Use reusable sections."),
+                        new PowerPointCaseStudySection("Result", "Keep the slide editable.")
+                    },
+                    new[] {
+                        new PowerPointMetric("150", "devices")
+                    },
+                    options: new PowerPointCaseStudySlideOptions {
+                        Variant = PowerPointCaseStudyLayoutVariant.EditorialSplit
+                    });
+
+                Assert.NotNull(slide.GetShape("Case Study Editorial Section 1"));
+                Assert.NotNull(slide.GetShape("Case Study Editorial Metric Band"));
+                Assert.Null(slide.GetShape("Case Study Visual Band"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCaseStudySlide_AutoUsesEditorialSplitForContentRichStory() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerCaseStudySlide("Example client",
+                    new[] {
+                        new PowerPointCaseStudySection("Client", "Short story."),
+                        new PowerPointCaseStudySection("Challenge", "Needs clean structure."),
+                        new PowerPointCaseStudySection("Solution", "Use reusable sections."),
+                        new PowerPointCaseStudySection("Result", "Keep the slide editable.")
+                    },
+                    new[] {
+                        new PowerPointMetric("150", "devices")
+                    },
+                    options: new PowerPointCaseStudySlideOptions {
+                        DesignIntent = PowerPointDesignIntent.FromMood(PowerPointDesignMood.Corporate, "auto-rich-case")
+                    });
+
+                Assert.NotNull(slide.GetShape("Case Study Editorial Section 1"));
+                Assert.NotNull(slide.GetShape("Case Study Editorial Metric Band"));
+                Assert.Null(slide.GetShape("Case Study Visual Band"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCaseStudySlide_CanUseVisualHeroVariant() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerCaseStudySlide("Example client",
+                    new[] {
+                        new PowerPointCaseStudySection("Client", "Short story."),
+                        new PowerPointCaseStudySection("Challenge", "Needs strong visual hierarchy."),
+                        new PowerPointCaseStudySection("Solution", "Let the visual carry the left side."),
+                        new PowerPointCaseStudySection("Result", "Keep supporting text compact.")
+                    },
+                    new[] {
+                        new PowerPointMetric("150", "devices")
+                    },
+                    options: new PowerPointCaseStudySlideOptions {
+                        Variant = PowerPointCaseStudyLayoutVariant.VisualHero
+                    });
+
+                Assert.NotNull(slide.GetShape("Case Study Visual Hero Rule"));
+                Assert.NotNull(slide.GetShape("Case Study Visual Hero Metric Band"));
+                Assert.NotNull(slide.GetShape("Case Study Visual Frame"));
+                Assert.Null(slide.GetShape("Case Study Editorial Section 1"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerProcessSlide_UsesSingleRailWithDeliberateNodes() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerProcessSlide("Process", null,
+                    new[] {
+                        new PowerPointProcessStep("One", "Start here."),
+                        new PowerPointProcessStep("Two", "Then continue."),
+                        new PowerPointProcessStep("Three", "Finish cleanly.")
+                    });
+
+                PowerPointAutoShape rail = Assert.IsAssignableFrom<PowerPointAutoShape>(
+                    slide.GetShape("Process Rail"));
+                Assert.Equal(A.ShapeTypeValues.Line, rail.ShapeType);
+                Assert.True(rail.OutlineWidthPoints <= 1.2);
+
+                PowerPointAutoShape firstNode = Assert.IsAssignableFrom<PowerPointAutoShape>(
+                    slide.GetShape("Process Node 1"));
+                PowerPointAutoShape secondNode = Assert.IsAssignableFrom<PowerPointAutoShape>(
+                    slide.GetShape("Process Node 2"));
+                Assert.Equal(A.ShapeTypeValues.Ellipse, firstNode.ShapeType);
+                Assert.Equal(A.ShapeTypeValues.Ellipse, secondNode.ShapeType);
+                Assert.True(rail.LeftCm < firstNode.RightCm);
+                Assert.True(rail.RightCm > secondNode.LeftCm);
+                Assert.Null(slide.GetShape("Process Arrow 1"));
+                Assert.Null(slide.GetShape("Process Marker 1"));
+                Assert.Null(slide.GetShape("Process Arrow Accent 1"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerProcessSlide_CanUseAlternateNumberedColumnVariant() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerProcessSlide("Process", null,
+                    new[] {
+                        new PowerPointProcessStep("One", "Start here."),
+                        new PowerPointProcessStep("Two", "Then continue."),
+                        new PowerPointProcessStep("Three", "Finish cleanly.")
+                    },
+                    options: new PowerPointProcessSlideOptions {
+                        Variant = PowerPointProcessLayoutVariant.NumberedColumns
+                    });
+
+                Assert.NotNull(slide.GetShape("Process Column 1"));
+                Assert.NotNull(slide.GetShape("Process Column Rule 1"));
+                Assert.Null(slide.GetShape("Process Rail"));
+                Assert.Null(slide.GetShape("Process Node 1"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerProcessSlide_AutoUsesRailForLongFlows() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerProcessSlide("Process", null,
+                    Enumerable.Range(1, 6).Select(index =>
+                        new PowerPointProcessStep("Step " + index, "Keep the flow readable.")),
+                    options: new PowerPointProcessSlideOptions {
+                        DesignIntent = PowerPointDesignIntent.FromMood(PowerPointDesignMood.Corporate, "auto-long-process")
+                    });
+
+                Assert.NotNull(slide.GetShape("Process Rail"));
+                Assert.NotNull(slide.GetShape("Process Node 6"));
+                Assert.Null(slide.GetShape("Process Column 1"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCardGrid_CanUseAlternateSoftTileVariant() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerCardGridSlide("Services", null,
+                    new[] {
+                        new PowerPointCardContent("Deployments", new[] { "Intune" }),
+                        new PowerPointCardContent("Maintenance", new[] { "Monitoring" })
+                    },
+                    options: new PowerPointCardGridSlideOptions {
+                        Variant = PowerPointCardGridLayoutVariant.SoftTiles
+                    });
+
+                PowerPointShape? accent = slide.GetShape("Designer Card Accent 1");
+                Assert.NotNull(accent);
+                Assert.True(accent!.WidthCm < 0.25);
+                Assert.True(accent.HeightCm > 1.0);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCardGrid_AutoUsesCompactAccentBarsForLargeGrids() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerCardGridSlide("Services", null,
+                    Enumerable.Range(1, 5).Select(index =>
+                        new PowerPointCardContent("Area " + index, new[] { "One", "Two" })),
+                    options: new PowerPointCardGridSlideOptions {
+                        DesignIntent = PowerPointDesignIntent.FromMood(PowerPointDesignMood.Corporate, "auto-large-grid")
+                    });
+
+                PowerPointShape? accent = slide.GetShape("Designer Card Accent 1");
+                Assert.NotNull(accent);
+                Assert.True(accent!.WidthCm > 1.0);
+                Assert.True(accent.HeightCm < 0.3);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCardGrid_AutoUsesSoftTilesForEditorialMood() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerCardGridSlide("Services", null,
+                    new[] {
+                        new PowerPointCardContent("Deployments", new[] { "Intune" }),
+                        new PowerPointCardContent("Maintenance", new[] { "Monitoring" })
+                    },
+                    options: new PowerPointCardGridSlideOptions {
+                        DesignIntent = PowerPointDesignIntent.FromMood(PowerPointDesignMood.Editorial, "auto-soft-grid")
+                    });
+
+                PowerPointShape? accent = slide.GetShape("Designer Card Accent 1");
+                Assert.NotNull(accent);
+                Assert.True(accent!.WidthCm < 0.25);
+                Assert.True(accent.HeightCm > 1.0);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Composer_CreatesValidCustomSlideFromReusablePrimitives() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                    PowerPointDesignTheme theme = PowerPointDesignTheme.FromBrand("2B8A6E", "Green Brand");
+                    presentation.ApplyDesignerTheme(theme);
+                    presentation.ComposeDesignerSlide(composer => {
+                        composer.AddTitle("Custom story", "A raw composition can still use designer primitives.");
+                        composer.AddCardGrid(new[] {
+                            new PowerPointCardContent("Operations", new[] { "Monitoring", "Reporting" }),
+                            new PowerPointCardContent("Delivery", new[] { "Rollout", "Care" })
+                        }, new PowerPointCardGridSlideOptions {
+                            Variant = PowerPointCardGridLayoutVariant.SoftTiles
+                        });
+                        composer.AddVisualFrame(PowerPointLayoutBox.FromCentimeters(20.5, 9.6, 5.6, 3.0));
+                    }, theme, new PowerPointDesignerSlideOptions {
+                        Eyebrow = "OfficeIMO.PowerPoint",
+                        FooterLeft = "OFFICEIMO",
+                        FooterRight = "Custom"
+                    });
+
+                    List<ValidationErrorInfo> errors = presentation.ValidateDocument();
+                    Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+                    presentation.Save();
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                    List<ValidationErrorInfo> errors = presentation.ValidateDocument();
+                    Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+                    Assert.Contains(presentation.Slides.SelectMany(slide => slide.TextBoxes),
+                        textBox => textBox.Text == "Custom story");
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Composer_CanPlacePrimitivesInsideSemanticContentRegions() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                    PowerPointLayoutBox leftColumn = default;
+                    PowerPointSlide slide = presentation.ComposeDesignerSlide(composer => {
+                        composer.AddTitle("Structured custom slide", "Regions reduce coordinate work.");
+                        PowerPointLayoutBox[] columns = composer.ContentColumns(2, gutterCm: 0.75);
+                        leftColumn = columns[0];
+
+                        composer.AddCardGrid(new[] {
+                            new PowerPointCardContent("Story", new[] { "Context", "Need" }),
+                            new PowerPointCardContent("Evidence", new[] { "Metrics", "Signal" })
+                        }, columns[0], new PowerPointCardGridSlideOptions {
+                            MaxColumns = 1,
+                            Variant = PowerPointCardGridLayoutVariant.SoftTiles
+                        });
+
+                        composer.AddProcessTimeline(new[] {
+                            new PowerPointProcessStep("Find", "Identify the story."),
+                            new PowerPointProcessStep("Shape", "Choose structure."),
+                            new PowerPointProcessStep("Finish", "Render cleanly.")
+                        }, columns[1], new PowerPointProcessSlideOptions {
+                            Variant = PowerPointProcessLayoutVariant.Rail
+                        });
+
+                        PowerPointLayoutBox[] lower = composer.ContentRows(2)[1].SplitColumnsCm(2, 0.55);
+                        composer.AddCalloutBand("Use regions when a full recipe is too rigid.",
+                            lower[0].TakeTopCm(1.35));
+                        composer.AddMetricStrip(new[] {
+                            new PowerPointMetric("2", "regions")
+                        }, lower[1].TakeTopCm(1.35).InsetCm(0.05));
+                    });
+
+                    PowerPointShape? firstCard = slide.GetShape("Designer Card 1");
+                    Assert.NotNull(firstCard);
+                    Assert.True(firstCard!.Left >= leftColumn.Left);
+                    Assert.True(firstCard.Right <= leftColumn.Right);
+                    Assert.NotNull(slide.GetShape("Process Rail"));
+                    Assert.NotNull(slide.GetShape("Composer Callout Band"));
+                    Assert.NotNull(slide.GetShape("Composer Metric Band"));
+
+                    List<ValidationErrorInfo> errors = presentation.ValidateDocument();
+                    Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+                    presentation.Save();
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                    List<ValidationErrorInfo> errors = presentation.ValidateDocument();
+                    Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerLogoWallSlide_CanPairLogoGridWithCertificateFeature() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                    PowerPointSlide slide = presentation.AddDesignerLogoWallSlide("Proof points",
+                        "Reusable logo and certification wall.",
+                        new[] {
+                            new PowerPointLogoItem("Lenovo", "Partner"),
+                            new PowerPointLogoItem("Samsung", "Devices"),
+                            new PowerPointLogoItem("Brother", "Print"),
+                            new PowerPointLogoItem("Epson", "Service")
+                        },
+                        options: new PowerPointLogoWallSlideOptions {
+                            Variant = PowerPointLogoWallLayoutVariant.CertificateFeature,
+                            FeatureTitle = "Featured certification"
+                        });
+
+                    Assert.NotNull(slide.GetShape("Logo Wall Tile 1"));
+                    Assert.NotNull(slide.GetShape("Logo Wall Certificate Frame"));
+                    Assert.NotNull(slide.GetShape("Logo Wall Certificate Document"));
+                    Assert.NotNull(slide.GetShape("Logo Wall Certificate Header"));
+                    Assert.NotNull(slide.GetShape("Logo Wall Certificate Seal Center"));
+
+                    List<ValidationErrorInfo> errors = presentation.ValidateDocument();
+                    Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+                    presentation.Save();
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                    List<ValidationErrorInfo> errors = presentation.ValidateDocument();
+                    Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerLogoWallSlide_AutoUsesCertificateFeatureWhenProofIsProvided() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerLogoWallSlide("Competence proof",
+                    "Auto should choose proof emphasis when the caller supplies a featured certificate caption.",
+                    new[] {
+                        new PowerPointLogoItem("Xerox"),
+                        new PowerPointLogoItem("Lenovo"),
+                        new PowerPointLogoItem("Brother"),
+                        new PowerPointLogoItem("Samsung")
+                    },
+                    options: new PowerPointLogoWallSlideOptions {
+                        FeatureTitle = "ISO 9001 registration",
+                        DesignIntent = PowerPointDesignIntent.FromMood(PowerPointDesignMood.Minimal, "proof-auto")
+                    });
+
+                Assert.NotNull(slide.GetShape("Logo Wall Tile 1"));
+                Assert.NotNull(slide.GetShape("Logo Wall Certificate Frame"));
+                Assert.NotNull(slide.GetShape("Logo Wall Certificate Document"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCoverageSlide_AddsEditablePinsAndRejectsInvalidCoordinates() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerCoverageSlide("Service coverage",
+                    "Pins use normalized positions inside the map panel.",
+                    new[] {
+                        new PowerPointCoverageLocation("Warszawa", 0.62, 0.44),
+                        new PowerPointCoverageLocation("Gdansk", 0.54, 0.16),
+                        new PowerPointCoverageLocation("Wroclaw", 0.34, 0.68)
+                    },
+                    options: new PowerPointCoverageSlideOptions {
+                        Variant = PowerPointCoverageLayoutVariant.ListMap,
+                        SupportingText = "Regional service teams"
+                    });
+
+                Assert.NotNull(slide.GetShape("Coverage Map Panel"));
+                Assert.NotNull(slide.GetShape("Coverage Pin 1"));
+                Assert.NotNull(slide.GetShape("Coverage Route 1"));
+                Assert.NotNull(slide.GetShape("Coverage Map Latitude 1"));
+                Assert.NotNull(slide.GetShape("Coverage List Marker 1"));
+
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                    presentation.AddDesignerCoverageSlide("Invalid", null,
+                        new[] { new PowerPointCoverageLocation("Outside", 1.2, 0.4) }));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCoverageSlide_AutoUsesListMapForManyLocations() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerCoverageSlide("Coverage",
+                    "A larger location set needs a readable list instead of only a pin strip.",
+                    new[] {
+                        new PowerPointCoverageLocation("Warszawa", 0.61, 0.45),
+                        new PowerPointCoverageLocation("Gdansk", 0.55, 0.18),
+                        new PowerPointCoverageLocation("Poznan", 0.38, 0.45),
+                        new PowerPointCoverageLocation("Wroclaw", 0.34, 0.68),
+                        new PowerPointCoverageLocation("Katowice", 0.52, 0.72),
+                        new PowerPointCoverageLocation("Krakow", 0.58, 0.78),
+                        new PowerPointCoverageLocation("Lublin", 0.75, 0.62)
+                    },
+                    options: new PowerPointCoverageSlideOptions {
+                        DesignIntent = PowerPointDesignIntent.FromMood(PowerPointDesignMood.Corporate, "coverage-auto")
+                    });
+
+                Assert.NotNull(slide.GetShape("Coverage Map Panel"));
+                Assert.NotNull(slide.GetShape("Coverage List Marker 1"));
+                Assert.Null(slide.GetShape("Coverage Location Strip"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Composer_CanPlaceLogoWallAndCoverageMapInsideRegions() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                    PowerPointSlide slide = presentation.ComposeDesignerSlide(composer => {
+                        composer.AddTitle("Capability view", "Mix proof and reach without a fixed recipe.");
+                        PowerPointLayoutBox[] columns = composer.ContentColumns(2, gutterCm: 0.8);
+                        composer.AddLogoWall(new[] {
+                            new PowerPointLogoItem("Xerox"),
+                            new PowerPointLogoItem("Lenovo"),
+                            new PowerPointLogoItem("Samsung"),
+                            new PowerPointLogoItem("Epson")
+                        }, columns[0], new PowerPointLogoWallSlideOptions {
+                            MaxColumns = 2,
+                            Variant = PowerPointLogoWallLayoutVariant.LogoMosaic
+                        });
+                        composer.AddCoverageMap(new[] {
+                            new PowerPointCoverageLocation("North", 0.45, 0.18),
+                            new PowerPointCoverageLocation("Central", 0.58, 0.48),
+                            new PowerPointCoverageLocation("South", 0.40, 0.72)
+                        }, columns[1], new PowerPointCoverageSlideOptions {
+                            MapLabel = "3 regions"
+                        });
+                    });
+
+                    Assert.NotNull(slide.GetShape("Logo Wall Tile 1"));
+                    Assert.NotNull(slide.GetShape("Coverage Map Panel"));
+                    Assert.NotNull(slide.GetShape("Coverage Pin 1"));
+
+                    List<ValidationErrorInfo> errors = presentation.ValidateDocument();
+                    Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+                    presentation.Save();
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                    List<ValidationErrorInfo> errors = presentation.ValidateDocument();
+                    Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Composer_LogoWallAutoUsesCertificateFeatureWhenProofIsProvided() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.ComposeDesignerSlide(composer => {
+                    composer.AddTitle("Proof region");
+                    composer.AddLogoWall(new[] {
+                        new PowerPointLogoItem("Lenovo"),
+                        new PowerPointLogoItem("Samsung"),
+                        new PowerPointLogoItem("Brother")
+                    }, composer.ContentArea(), new PowerPointLogoWallSlideOptions {
+                        FeatureTitle = "Authorized partner"
+                    });
+                });
+
+                Assert.NotNull(slide.GetShape("Logo Wall Tile 1"));
+                Assert.NotNull(slide.GetShape("Logo Wall Certificate Frame"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCapabilitySlide_CanCombineSectionsWithCoverageVisual() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointCapabilitySlideOptions options = new() {
+                    Variant = PowerPointCapabilityLayoutVariant.TextVisual,
+                    VisualKind = PowerPointCapabilityVisualKind.CoverageMap,
+                    VisualLabel = "Service teams"
+                };
+                options.Locations.Add(new PowerPointCoverageLocation("Warszawa", 0.60, 0.48));
+                options.Locations.Add(new PowerPointCoverageLocation("Gdansk", 0.55, 0.18));
+
+                PowerPointSlide slide = presentation.AddDesignerCapabilitySlide("Service capability",
+                    "Narrative sections and visual support share one composition.",
+                    new[] {
+                        new PowerPointCapabilitySection("Warranty service",
+                            "Nationwide repair support.", new[] { "Computers", "Printers" }),
+                        new PowerPointCapabilitySection("Extended care",
+                            "Service beyond standard warranty.", new[] { "SLA options", "Monitoring" })
+                    },
+                    options: options);
+
+                Assert.NotNull(slide.GetShape("Capability Section 1"));
+                Assert.NotNull(slide.GetShape("Capability Section Accent 1"));
+                Assert.NotNull(slide.GetShape("Coverage Map Panel"));
+                Assert.NotNull(slide.GetShape("Coverage Pin 1"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCapabilitySlide_AutoUsesStackedLayoutForSectionHeavySlides() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointSlide slide = presentation.AddDesignerCapabilitySlide("Scope",
+                    "Auto should keep section-heavy content structured.",
+                    new[] {
+                        new PowerPointCapabilitySection("Deployments", items: new[] { "Intune", "Autopilot" }),
+                        new PowerPointCapabilitySection("Maintenance", items: new[] { "Monitoring", "Optimization" }),
+                        new PowerPointCapabilitySection("Consulting", items: new[] { "Roadmap", "Discovery" }),
+                        new PowerPointCapabilitySection("Audits", items: new[] { "Configuration", "Security review" })
+                    },
+                    options: new PowerPointCapabilitySlideOptions {
+                        DesignIntent = PowerPointDesignIntent.FromMood(PowerPointDesignMood.Editorial, "capability-auto")
+                    });
+
+                Assert.NotNull(slide.GetShape("Capability Section 4"));
+                Assert.Null(slide.GetShape("Coverage Map Panel"));
+                Assert.Null(slide.GetShape("Logo Wall Tile 1"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCapabilitySlide_CanUseStackedSectionsWithMetrics() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                presentation.SlideSize.SetPreset(PowerPointSlideSizePreset.Screen16x9);
+
+                PowerPointCapabilitySlideOptions options = new() {
+                    Variant = PowerPointCapabilityLayoutVariant.Stacked
+                };
+                options.Metrics.Add(new PowerPointMetric("4", "areas"));
+                options.Metrics.Add(new PowerPointMetric("24/7", "support"));
+
+                PowerPointSlide slide = presentation.AddDesignerCapabilitySlide("Operations",
+                    "Stacked sections work when no single visual should dominate.",
+                    new[] {
+                        new PowerPointCapabilitySection("Monitoring", items: new[] { "Availability", "Incidents" }),
+                        new PowerPointCapabilitySection("Reporting", items: new[] { "KPIs", "Trends" }),
+                        new PowerPointCapabilitySection("Optimization", items: new[] { "Backlog", "Roadmap" })
+                    },
+                    options: options);
+
+                Assert.NotNull(slide.GetShape("Capability Section 3"));
+                Assert.NotNull(slide.GetShape("Capability Metric Band"));
+                Assert.Null(slide.GetShape("Coverage Map Panel"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DesignerCapabilitySlide_RejectsTooManySectionsForReadableLayout() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                IEnumerable<PowerPointCapabilitySection> sections = Enumerable.Range(1, 7)
+                    .Select(index => new PowerPointCapabilitySection("Section " + index));
+
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                    presentation.AddDesignerCapabilitySlide("Too much", null, sections));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        private static string FormatValidationErrors(IEnumerable<ValidationErrorInfo> errors) {
+            return string.Join(Environment.NewLine + Environment.NewLine,
+                errors.Select(error =>
+                    $"Description: {error.Description}\n" +
+                    $"Id: {error.Id}\n" +
+                    $"ErrorType: {error.ErrorType}\n" +
+                    $"Part: {error.Part?.Uri}\n" +
+                    $"Path: {error.Path?.XPath}"));
+        }
+    }
+}

--- a/OfficeIMO.Tests/PowerPoint.DesignCompositions.cs
+++ b/OfficeIMO.Tests/PowerPoint.DesignCompositions.cs
@@ -1195,8 +1195,10 @@ namespace OfficeIMO.Tests {
         }
 
         private static string CreateTempPresentationPath() {
-            string fileName = Path.GetFileName(Guid.NewGuid().ToString("N") + ".pptx");
-            return Path.Combine(Path.GetTempPath(), fileName);
+            string tempFilePath = Path.GetTempFileName();
+            string presentationPath = Path.ChangeExtension(tempFilePath, ".pptx");
+            File.Delete(tempFilePath);
+            return presentationPath;
         }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.DesignCompositions.cs
+++ b/OfficeIMO.Tests/PowerPoint.DesignCompositions.cs
@@ -1195,7 +1195,8 @@ namespace OfficeIMO.Tests {
         }
 
         private static string CreateTempPresentationPath() {
-            return Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".pptx");
+            string fileName = Path.GetFileName(Guid.NewGuid().ToString("N") + ".pptx");
+            return Path.Combine(Path.GetTempPath(), fileName);
         }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.DesignCompositions.cs
+++ b/OfficeIMO.Tests/PowerPoint.DesignCompositions.cs
@@ -11,7 +11,7 @@ namespace OfficeIMO.Tests {
     public class PowerPointDesignCompositions {
         [Fact]
         public void DesignerCompositions_CreateValidEditableDeck() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
@@ -92,7 +92,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCardGrid_KeepsCardsWithinSlideBounds() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -121,7 +121,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerProcessSlide_RejectsTooManyStepsForReadableLayout() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -261,7 +261,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerDeckDesign_MinimalProfileSuppressesDirectionMotifs() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -285,7 +285,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerDeckComposer_AppliesDesignAndKeepsRecipeOverridesSimple() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -320,8 +320,8 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerDeckComposer_SameContentCanUseDifferentDeckPersonalities() {
-            string corporatePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
-            string minimalPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string corporatePath = CreateTempPresentationPath();
+            string minimalPath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation corporate = PowerPointPresentation.Create(corporatePath);
@@ -355,7 +355,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerDirectionMotif_UsesEditableTrianglesInsteadOfTextGlyphs() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -382,7 +382,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerSectionSlide_CanUseEditorialRailVariant() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -405,7 +405,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCaseStudySlide_UsesPolishedVisualPlaceholderWithoutHeavyBorder() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -435,7 +435,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCaseStudySlide_VisualPlaceholderVariesWithDesignIntent() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -472,7 +472,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCaseStudySlide_CanUseEditorialSplitVariant() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -504,7 +504,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCaseStudySlide_AutoUsesEditorialSplitForContentRichStory() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -536,7 +536,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCaseStudySlide_CanUseVisualHeroVariant() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -569,7 +569,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerProcessSlide_UsesSingleRailWithDeliberateNodes() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -607,7 +607,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerProcessSlide_CanUseAlternateNumberedColumnVariant() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -636,7 +636,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerProcessSlide_AutoUsesRailForLongFlows() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -661,7 +661,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCardGrid_CanUseAlternateSoftTileVariant() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -689,7 +689,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCardGrid_AutoUsesCompactAccentBarsForLargeGrids() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -715,7 +715,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCardGrid_AutoUsesSoftTilesForEditorialMood() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -743,7 +743,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void Composer_CreatesValidCustomSlideFromReusablePrimitives() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
@@ -786,7 +786,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void Composer_CanPlacePrimitivesInsideSemanticContentRegions() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
@@ -848,7 +848,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerLogoWallSlide_CanPairLogoGridWithCertificateFeature() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
@@ -891,7 +891,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerLogoWallSlide_AutoUsesCertificateFeatureWhenProofIsProvided() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -922,7 +922,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCoverageSlide_AddsEditablePinsAndRejectsInvalidCoordinates() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -958,7 +958,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCoverageSlide_AutoUsesListMapForManyLocations() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -991,7 +991,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void Composer_CanPlaceLogoWallAndCoverageMapInsideRegions() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
@@ -1040,7 +1040,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void Composer_LogoWallAutoUsesCertificateFeatureWhenProofIsProvided() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -1068,7 +1068,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCapabilitySlide_CanCombineSectionsWithCoverageVisual() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -1105,7 +1105,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCapabilitySlide_AutoUsesStackedLayoutForSectionHeavySlides() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -1135,7 +1135,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCapabilitySlide_CanUseStackedSectionsWithMetrics() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -1168,7 +1168,7 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void DesignerCapabilitySlide_RejectsTooManySectionsForReadableLayout() {
-            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string filePath = CreateTempPresentationPath();
 
             try {
                 using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
@@ -1192,6 +1192,10 @@ namespace OfficeIMO.Tests {
                     $"ErrorType: {error.ErrorType}\n" +
                     $"Part: {error.Part?.Uri}\n" +
                     $"Path: {error.Path?.XPath}"));
+        }
+
+        private static string CreateTempPresentationPath() {
+            return Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".pptx");
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a high-level designer composition layer for OfficeIMO.PowerPoint so callers can create more attractive, editable business decks without manually positioning every shape.

The new API introduces reusable deck themes, creative directions, deck-level designer defaults, high-level slide recipes, and a raw slide composer for custom layouts. It also adds content-aware auto layout decisions so different content and different deck directions do not always produce the same slide structure.

## What changed

- Added `PowerPointDesignTheme`, `PowerPointDesignIntent`, `PowerPointDesignDirection`, and `PowerPointDeckDesign` for stable brand-aware variation.
- Added `PowerPointDeckComposer` and `PowerPointSlideComposer` for recipe-based and raw-composition authoring.
- Added designer slide helpers for section, case study, process, card grid, logo/proof wall, coverage/map, and capability slides.
- Added editable visual primitives for metrics, cards, proof/certificate areas, map-like coverage visuals, logo walls, and callout bands.
- Added a runnable `--designer-powerpoint` example deck and README usage documentation.
- Added focused PowerPoint composition tests covering variants, auto decisions, custom directions, composer regions, Open XML validation, and editable visual subparts.

## Goal fit

This is intentionally not a copy of the provided Medicover-style deck. It moves OfficeIMO.PowerPoint toward the requested goal by giving users semantic building blocks and deck-level art direction, while still keeping everything editable in PowerPoint.

It also avoids the biggest trap of hardcoded examples: callers can provide a brand color, seed, mood, font pair, or custom creative directions, and can either use slide recipes or drop down to raw composition regions. Auto variants now inspect content shape, for example dense cards, proof/certificate details, many locations, long processes, and section-heavy capability slides.

What is still not solved in this PR: it does not ingest an existing PPTX and infer its design system, it does not yet provide a gallery of many radically different visual languages, and it does not use real map/logo/image assets unless callers supply paths. Those are good next layers, but this PR gives the library a safer foundation than hardcoding two demo slides.

## Validation

- `dotnet build OfficeIMO.PowerPoint\OfficeIMO.PowerPoint.csproj -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false -v:minimal`
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net8.0 --filter PowerPointDesignCompositions -v:minimal`
- `dotnet build OfficeIMO.Examples\OfficeIMO.Examples.csproj -f net8.0 --no-restore -m:1 -p:BuildInParallel=false -p:UseSharedCompilation=false -v:minimal`
- `dotnet run --project OfficeIMO.Examples\OfficeIMO.Examples.csproj -f net8.0 --no-build -- --designer-powerpoint`
- Opened and exported the generated designer deck through desktop PowerPoint: 8 slides exported successfully with no repair prompt.

Note: the example build still reports an existing unrelated nullable warning in `OfficeIMO.Examples\Word\Shapes\Shapes.ShapeChoiceFallbackTextBox.cs`.
