### PR TITLE
Reduce production quality findings and narrow CodeQL scope

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,44 @@
+name: "OfficeIMO production CodeQL config"
+
+paths:
+  - OfficeIMO.CSV
+  - OfficeIMO.Epub
+  - OfficeIMO.Excel
+  - OfficeIMO.Excel.GoogleSheets
+  - OfficeIMO.GoogleWorkspace
+  - OfficeIMO.Markdown
+  - OfficeIMO.Markdown.Html
+  - OfficeIMO.MarkdownRenderer
+  - OfficeIMO.MarkdownRenderer.IntelligenceX
+  - OfficeIMO.MarkdownRenderer.SamplePlugin
+  - OfficeIMO.MarkdownRenderer.Wpf
+  - OfficeIMO.Pdf
+  - OfficeIMO.PowerPoint
+  - OfficeIMO.Reader
+  - OfficeIMO.Reader.Csv
+  - OfficeIMO.Reader.Epub
+  - OfficeIMO.Reader.Html
+  - OfficeIMO.Reader.Json
+  - OfficeIMO.Reader.Text
+  - OfficeIMO.Reader.Xml
+  - OfficeIMO.Reader.Zip
+  - OfficeIMO.Shared
+  - OfficeIMO.Visio
+  - OfficeIMO.Word
+  - OfficeIMO.Word.GoogleDocs
+  - OfficeIMO.Word.Html
+  - OfficeIMO.Word.Markdown
+  - OfficeIMO.Word.Pdf
+  - OfficeIMO.Zip
+
+paths-ignore:
+  - Assets/PowerPointTemplates
+  - Docs
+  - OfficeIMO.CSV.Tests
+  - OfficeIMO.Excel.Benchmarks
+  - OfficeIMO.Examples
+  - OfficeIMO.Markdown.Benchmarks
+  - OfficeIMO.MarkdownRenderer.Wpf.Tests
+  - OfficeIMO.Tests
+  - OfficeIMO.VerifyTests
+  - Website/static/assets/prism

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,12 +62,19 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Restore and Build
         if: matrix.build-mode == 'manual'
         run: |
-          dotnet restore
-          dotnet build --configuration Release
+          $projects = Get-ChildItem -Recurse -Filter *.csproj | Where-Object {
+            $_.FullName -notmatch '\\(OfficeIMO\.Examples|OfficeIMO\.Tests|OfficeIMO\.CSV\.Tests|OfficeIMO\.VerifyTests|OfficeIMO\.Markdown\.Benchmarks|OfficeIMO\.Excel\.Benchmarks|OfficeIMO\.MarkdownRenderer\.Wpf\.Tests)\\'
+          } | Sort-Object FullName
+
+          dotnet restore OfficeIMO.sln
+          foreach ($project in $projects) {
+            dotnet build $project.FullName --configuration Release --no-restore
+          }
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,9 +66,11 @@ jobs:
 
       - name: Restore and Build
         if: matrix.build-mode == 'manual'
+        shell: pwsh
         run: |
+          $excludedProjects = '[\\\\/](OfficeIMO\.Examples|OfficeIMO\.Tests|OfficeIMO\.CSV\.Tests|OfficeIMO\.VerifyTests|OfficeIMO\.Markdown\.Benchmarks|OfficeIMO\.Excel\.Benchmarks|OfficeIMO\.MarkdownRenderer\.Wpf\.Tests)[\\\\/]'
           $projects = Get-ChildItem -Recurse -Filter *.csproj | Where-Object {
-            $_.FullName -notmatch '\\(OfficeIMO\.Examples|OfficeIMO\.Tests|OfficeIMO\.CSV\.Tests|OfficeIMO\.VerifyTests|OfficeIMO\.Markdown\.Benchmarks|OfficeIMO\.Excel\.Benchmarks|OfficeIMO\.MarkdownRenderer\.Wpf\.Tests)\\'
+            $_.FullName -notmatch $excludedProjects
           } | Sort-Object FullName
 
           dotnet restore OfficeIMO.sln

--- a/OfficeIMO.Excel/BuiltinDocumentProperties.cs
+++ b/OfficeIMO.Excel/BuiltinDocumentProperties.cs
@@ -20,7 +20,13 @@ namespace OfficeIMO.Excel {
 
         private void EnsureCorePropertiesPart() {
             // Touch the package properties to ensure the backing object is initialized.
-            try { GC.KeepAlive(_spreadsheetDocument.PackageProperties); } catch { }
+            try {
+                GC.KeepAlive(_spreadsheetDocument.PackageProperties);
+            } catch (ObjectDisposedException) {
+                // Package properties are best-effort when the package is already disposed.
+            } catch (InvalidOperationException) {
+                // Some package states do not expose core properties yet; callers retry on set.
+            }
         }
 
         /// <summary>The document creator/author.</summary>

--- a/OfficeIMO.Excel/BuiltinDocumentProperties.cs
+++ b/OfficeIMO.Excel/BuiltinDocumentProperties.cs
@@ -20,7 +20,7 @@ namespace OfficeIMO.Excel {
 
         private void EnsureCorePropertiesPart() {
             // Touch the package properties to ensure the backing object is initialized.
-            try { var _ = _spreadsheetDocument.PackageProperties; } catch { }
+            try { GC.KeepAlive(_spreadsheetDocument.PackageProperties); } catch { }
         }
 
         /// <summary>The document creator/author.</summary>

--- a/OfficeIMO.Excel/ExcelDocument.PivotTables.cs
+++ b/OfficeIMO.Excel/ExcelDocument.PivotTables.cs
@@ -5,12 +5,13 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public IReadOnlyList<ExcelPivotTableInfo> GetPivotTables() {
             return Locking.ExecuteRead(EnsureLock(), () => {
-                using var _ = Locking.EnterNoLockScope();
-                var list = new List<ExcelPivotTableInfo>();
-                foreach (var sheet in Sheets) {
-                    list.AddRange(sheet.GetPivotTables());
+                using (Locking.EnterNoLockScope()) {
+                    var list = new List<ExcelPivotTableInfo>();
+                    foreach (var sheet in Sheets) {
+                        list.AddRange(sheet.GetPivotTables());
+                    }
+                    return list;
                 }
-                return list;
             });
         }
     }

--- a/OfficeIMO.Excel/ExcelDocument.Toc.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Toc.cs
@@ -43,7 +43,6 @@ namespace OfficeIMO.Excel {
             int headerRow = r;
             toc.Cell(headerRow, 1, "Sheet"); toc.CellBold(headerRow, 1, true); toc.CellBackground(headerRow, 1, "#F2F2F2");
             toc.Cell(headerRow, 2, "Details"); toc.CellBold(headerRow, 2, true); toc.CellBackground(headerRow, 2, "#F2F2F2");
-            int colRanges = includeNamedRanges ? 3 : 0;
             if (includeNamedRanges) { toc.Cell(headerRow, 3, "Named Ranges"); toc.CellBold(headerRow, 3, true); toc.CellBackground(headerRow, 3, "#F2F2F2"); }
             r++;
 

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -368,19 +368,15 @@ namespace OfficeIMO.Excel {
 
             // Initialize without taking a new lock if we're already in a write scope
             if (Locking.IsNoLock || (_lock != null && _lock.IsWriteLockHeld)) {
-                if (_tableNameCache == null) {
-                    var set = new HashSet<string>(_tableNameComparer);
-                    var wb = WorkbookPartRoot;
-                    if (wb != null) {
-                        foreach (var ws in wb.WorksheetParts) {
-                            foreach (var tdp in ws.TableDefinitionParts) {
-                                var n = tdp.Table?.Name?.Value;
-                                if (!string.IsNullOrEmpty(n)) set.Add(n!);
-                            }
-                        }
+                var set = new HashSet<string>(_tableNameComparer);
+                var wb = WorkbookPartRoot;
+                foreach (var ws in wb.WorksheetParts) {
+                    foreach (var tdp in ws.TableDefinitionParts) {
+                        var n = tdp.Table?.Name?.Value;
+                        if (!string.IsNullOrEmpty(n)) set.Add(n!);
                     }
-                    _tableNameCache = set;
                 }
+                _tableNameCache = set;
                 return _tableNameCache!;
             }
 
@@ -389,12 +385,10 @@ namespace OfficeIMO.Excel {
                 if (_tableNameCache != null) return _tableNameCache;
                 var set = new HashSet<string>(_tableNameComparer);
                 var wb = WorkbookPartRoot;
-                if (wb != null) {
-                    foreach (var ws in wb.WorksheetParts) {
-                        foreach (var tdp in ws.TableDefinitionParts) {
-                            var n = tdp.Table?.Name?.Value;
-                            if (!string.IsNullOrEmpty(n)) set.Add(n!);
-                        }
+                foreach (var ws in wb.WorksheetParts) {
+                    foreach (var tdp in ws.TableDefinitionParts) {
+                        var n = tdp.Table?.Name?.Value;
+                        if (!string.IsNullOrEmpty(n)) set.Add(n!);
                     }
                 }
                 _tableNameCache = set;
@@ -444,15 +438,13 @@ namespace OfficeIMO.Excel {
 
                 // Check if we're in a NoLock scope or already have a lock - if so, initialize without locking
                 if (Locking.IsNoLock || (_lock != null && _lock.IsWriteLockHeld)) {
-                    if (_sharedStringTablePart == null) {
-                        if (_workBookPart.GetPartsOfType<SharedStringTablePart>().Any()) {
-                            _sharedStringTablePart = _workBookPart.GetPartsOfType<SharedStringTablePart>().First();
-                        } else {
-                            _sharedStringTablePart = _workBookPart.AddNewPart<SharedStringTablePart>();
-                            _sharedStringTablePart.SharedStringTable = new SharedStringTable();
-                        }
+                    if (_workBookPart.GetPartsOfType<SharedStringTablePart>().Any()) {
+                        _sharedStringTablePart = _workBookPart.GetPartsOfType<SharedStringTablePart>().First();
+                    } else {
+                        _sharedStringTablePart = _workBookPart.AddNewPart<SharedStringTablePart>();
+                        _sharedStringTablePart.SharedStringTable = new SharedStringTable();
                     }
-                    return _sharedStringTablePart;
+                    return _sharedStringTablePart!;
                 }
 
                 // Use write lock for initialization when no lock is held
@@ -1346,7 +1338,7 @@ namespace OfficeIMO.Excel {
 
             PackagePropertiesSnapshot propertiesSnapshot = PackagePropertiesSnapshot.Capture(_spreadSheetDocument);
 
-            var snapshot = new MemoryStream();
+            using var snapshot = new MemoryStream();
             using (_spreadSheetDocument.Clone(snapshot)) { }
             snapshot.Position = 0;
 
@@ -1629,7 +1621,7 @@ namespace OfficeIMO.Excel {
                 if (packageBytes.Length == 0) return packageBytes;
 
                 try {
-                    var working = new MemoryStream(packageBytes.Length + StreamBufferSize);
+                    using var working = new MemoryStream(packageBytes.Length + StreamBufferSize);
                     working.Write(packageBytes, 0, packageBytes.Length);
                     working.Position = 0;
 

--- a/OfficeIMO.Excel/ExcelSheet.AutoFilterCleanup.cs
+++ b/OfficeIMO.Excel/ExcelSheet.AutoFilterCleanup.cs
@@ -13,7 +13,7 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                var tableAutoFilter = table?.Elements<AutoFilter>().FirstOrDefault();
+                var tableAutoFilter = table!.Elements<AutoFilter>().FirstOrDefault();
                 if (!A1.TryParseRange(tableRange!, out _, out int c1, out _, out int c2)) {
                     tableAutoFilter?.Remove();
                     tableDefinitionPart.Table?.Save();

--- a/OfficeIMO.Excel/ExcelSheet.Headers.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.cs
@@ -102,7 +102,7 @@ namespace OfficeIMO.Excel {
         /// Forces rebuilding the header map for the current UsedRange and options.
         /// </summary>
         public void RefreshHeaderCache(ExcelReadOptions? options = null) {
-            var _ = GetHeaderMap(options);
+            GetHeaderMap(options);
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.Preflight.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Preflight.cs
@@ -88,13 +88,13 @@ namespace OfficeIMO.Excel {
                 // Drop orphaned Drawing reference
                 var drawing = ws.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.Drawing>();
                 if (drawing?.Id?.Value is string dId) {
-                    try { _worksheetPart.GetPartById(dId); } catch { ws.RemoveChild(drawing); }
+                    try { _worksheetPart.GetPartById(dId); } catch (ArgumentOutOfRangeException) { ws.RemoveChild(drawing); }
                 }
 
                 // Drop orphaned LegacyDrawingHeaderFooter reference
                 var legacy = ws.GetFirstChild<LegacyDrawingHeaderFooter>();
                 if (legacy?.Id?.Value is string lId) {
-                    try { _worksheetPart.GetPartById(lId); } catch { ws.RemoveChild(legacy); }
+                    try { _worksheetPart.GetPartById(lId); } catch (ArgumentOutOfRangeException) { ws.RemoveChild(legacy); }
                 }
 
                 ws.Save();

--- a/OfficeIMO.Excel/ExcelSheet.Preflight.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Preflight.cs
@@ -88,13 +88,13 @@ namespace OfficeIMO.Excel {
                 // Drop orphaned Drawing reference
                 var drawing = ws.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.Drawing>();
                 if (drawing?.Id?.Value is string dId) {
-                    try { var _ = _worksheetPart.GetPartById(dId); } catch { ws.RemoveChild(drawing); }
+                    try { _worksheetPart.GetPartById(dId); } catch { ws.RemoveChild(drawing); }
                 }
 
                 // Drop orphaned LegacyDrawingHeaderFooter reference
                 var legacy = ws.GetFirstChild<LegacyDrawingHeaderFooter>();
                 if (legacy?.Id?.Value is string lId) {
-                    try { var _ = _worksheetPart.GetPartById(lId); } catch { ws.RemoveChild(legacy); }
+                    try { _worksheetPart.GetPartById(lId); } catch { ws.RemoveChild(legacy); }
                 }
 
                 ws.Save();

--- a/OfficeIMO.Excel/ExcelSheet.TableCleanup.cs
+++ b/OfficeIMO.Excel/ExcelSheet.TableCleanup.cs
@@ -222,10 +222,6 @@ namespace OfficeIMO.Excel {
         private HashSet<uint> CollectUsedTableIds(WorksheetPart excludeWorksheetPart) {
             var usedIds = new HashSet<uint>();
             var workbookPart = WorkbookPartRoot;
-            if (workbookPart == null) {
-                return usedIds;
-            }
-
             foreach (var worksheetPart in workbookPart.WorksheetParts) {
                 if (worksheetPart == excludeWorksheetPart) {
                     continue;
@@ -245,10 +241,6 @@ namespace OfficeIMO.Excel {
         private HashSet<string> CollectUsedTableNames(WorksheetPart excludeWorksheetPart) {
             var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var workbookPart = WorkbookPartRoot;
-            if (workbookPart == null) {
-                return usedNames;
-            }
-
             foreach (var worksheetPart in workbookPart.WorksheetParts) {
                 if (worksheetPart == excludeWorksheetPart) {
                     continue;
@@ -270,10 +262,6 @@ namespace OfficeIMO.Excel {
             cache.Clear();
 
             var workbookPart = WorkbookPartRoot;
-            if (workbookPart == null) {
-                return;
-            }
-
             foreach (var worksheetPart in workbookPart.WorksheetParts) {
                 foreach (var tableDefinitionPart in worksheetPart.TableDefinitionParts) {
                     string? name = tableDefinitionPart.Table?.Name?.Value;

--- a/OfficeIMO.Excel/ExcelSheet.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Tables.cs
@@ -18,7 +18,8 @@ namespace OfficeIMO.Excel {
             WriteLock(() => {
                 foreach (var tdp in _worksheetPart.TableDefinitionParts) {
                     var table = tdp.Table;
-                    if (table?.Reference?.Value != range) continue;
+                    if (table is null) continue;
+                    if (table.Reference?.Value != range) continue;
                     table.TotalsRowShown = true;
                     var tableColumns = table.TableColumns ?? throw new InvalidOperationException("Table columns are missing.");
                     var headerNames = tableColumns.Elements<TableColumn>().Select(tc => tc.Name?.Value ?? string.Empty).ToList();
@@ -58,7 +59,7 @@ namespace OfficeIMO.Excel {
                 // If there is, we'll add the AutoFilter to the table instead of the worksheet
                 foreach (var tableDefinitionPart in _worksheetPart.TableDefinitionParts) {
                     var table = tableDefinitionPart.Table;
-                    if (table?.Reference?.Value == range) {
+                    if (table is not null && table.Reference?.Value == range) {
                         // Found a table on the same range - add/update its AutoFilter
 
                         // First, remove any worksheet-level AutoFilter to avoid conflicts
@@ -254,13 +255,11 @@ namespace OfficeIMO.Excel {
                     // Get max existing table ID across all sheets to ensure uniqueness when opening existing files
                     uint maxExistingId = 0;
                     var wbPart = WorkbookPartRoot;
-                    if (wbPart != null) {
-                        foreach (var ws in wbPart.WorksheetParts) {
-                            foreach (var part in ws.TableDefinitionParts) {
-                                var idv = part.Table?.Id?.Value;
-                                if (idv != null && idv.Value > maxExistingId)
-                                    maxExistingId = idv.Value;
-                            }
+                    foreach (var ws in wbPart.WorksheetParts) {
+                        foreach (var part in ws.TableDefinitionParts) {
+                            var idv = part.Table?.Id?.Value;
+                            if (idv != null && idv.Value > maxExistingId)
+                                maxExistingId = idv.Value;
                         }
                     }
                     // Ensure _nextTableId always advances beyond any seen IDs
@@ -421,7 +420,7 @@ namespace OfficeIMO.Excel {
                     sanitized.Append(ch);
                 } else if (char.IsWhiteSpace(ch)) {
                     sanitized.Append('_');
-                    if (ch != '_') changed = true;
+                    changed = true;
                 } else {
                     sanitized.Append('_');
                     changed = true;

--- a/OfficeIMO.Excel/Utilities/ObjectFlattener.cs
+++ b/OfficeIMO.Excel/Utilities/ObjectFlattener.cs
@@ -400,7 +400,6 @@ namespace OfficeIMO.Excel {
 
             // 3) PinnedLast moved to the end in the given order
             var pinnedLastMatches = new List<string>();
-            var pinLastSet = new HashSet<string>(opts.PinnedLast ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
             foreach (var pin in opts.PinnedLast ?? Array.Empty<string>()) {
                 var match = prioritized.FirstOrDefault(p => string.Equals(p, pin, StringComparison.OrdinalIgnoreCase) ||
                                                             string.Equals(LastSegment(p), pin, StringComparison.OrdinalIgnoreCase));

--- a/OfficeIMO.Markdown/Blocks/MarkdownListRendering.cs
+++ b/OfficeIMO.Markdown/Blocks/MarkdownListRendering.cs
@@ -81,11 +81,11 @@ internal static class MarkdownListRendering {
                 }
                 currentLevel = level;
             } else if (level < currentLevel) {
-                if (liOpen) { sb.Append("</li>"); liOpen = false; }
+                if (liOpen) { sb.Append("</li>"); }
                 for (int k = currentLevel; k > level; k--) { sb.Append("</").Append(listTag).Append("></li>"); }
                 currentLevel = level;
             } else {
-                if (liOpen) { sb.Append("</li>"); liOpen = false; }
+                if (liOpen) { sb.Append("</li>"); }
             }
 
             int scopeStart = scopeStartByLevel[level];

--- a/OfficeIMO.Markdown/Blocks/TableBlock.cs
+++ b/OfficeIMO.Markdown/Blocks/TableBlock.cs
@@ -832,17 +832,23 @@ public sealed class TableBlock : MarkdownBlock, IMarkdownBlock, ISyntaxMarkdownB
             : source.InputNormalization;
         clone.FencedBlockExtensions.Clear();
         for (int i = 0; i < source.FencedBlockExtensions.Count; i++) {
-            clone.FencedBlockExtensions.Add(source.FencedBlockExtensions[i]);
+            if (source.FencedBlockExtensions[i] != null) {
+                clone.FencedBlockExtensions.Add(source.FencedBlockExtensions[i]);
+            }
         }
 
         clone.BlockParserExtensions.Clear();
         for (int i = 0; i < source.BlockParserExtensions.Count; i++) {
-            clone.BlockParserExtensions.Add(source.BlockParserExtensions[i]);
+            if (source.BlockParserExtensions[i] != null) {
+                clone.BlockParserExtensions.Add(source.BlockParserExtensions[i]);
+            }
         }
 
         clone.InlineParserExtensions.Clear();
         for (int i = 0; i < source.InlineParserExtensions.Count; i++) {
-            clone.InlineParserExtensions.Add(source.InlineParserExtensions[i]);
+            if (source.InlineParserExtensions[i] != null) {
+                clone.InlineParserExtensions.Add(source.InlineParserExtensions[i]);
+            }
         }
 
         for (int i = 0; i < source.DocumentTransforms.Count; i++) {

--- a/OfficeIMO.Markdown/Blocks/TableBlock.cs
+++ b/OfficeIMO.Markdown/Blocks/TableBlock.cs
@@ -832,23 +832,17 @@ public sealed class TableBlock : MarkdownBlock, IMarkdownBlock, ISyntaxMarkdownB
             : source.InputNormalization;
         clone.FencedBlockExtensions.Clear();
         for (int i = 0; i < source.FencedBlockExtensions.Count; i++) {
-            if (source.FencedBlockExtensions[i] != null) {
-                clone.FencedBlockExtensions.Add(source.FencedBlockExtensions[i]);
-            }
+            clone.FencedBlockExtensions.Add(source.FencedBlockExtensions[i]);
         }
 
         clone.BlockParserExtensions.Clear();
         for (int i = 0; i < source.BlockParserExtensions.Count; i++) {
-            if (source.BlockParserExtensions[i] != null) {
-                clone.BlockParserExtensions.Add(source.BlockParserExtensions[i]);
-            }
+            clone.BlockParserExtensions.Add(source.BlockParserExtensions[i]);
         }
 
         clone.InlineParserExtensions.Clear();
         for (int i = 0; i < source.InlineParserExtensions.Count; i++) {
-            if (source.InlineParserExtensions[i] != null) {
-                clone.InlineParserExtensions.Add(source.InlineParserExtensions[i]);
-            }
+            clone.InlineParserExtensions.Add(source.InlineParserExtensions[i]);
         }
 
         for (int i = 0; i < source.DocumentTransforms.Count; i++) {

--- a/OfficeIMO.Markdown/Inlines/ImageLinkInline.cs
+++ b/OfficeIMO.Markdown/Inlines/ImageLinkInline.cs
@@ -46,10 +46,10 @@ public sealed class ImageLinkInline : MarkdownInline, IRenderableMarkdownInline,
         var extra = linkAllowed ? LinkHtmlAttributes.BuildExternalLinkAttributes(o, LinkUrl) : string.Empty;
 
         if (!linkAllowed && !imageAllowed) return ImageHtmlAttributes.BuildBlockedPlaceholder(PlainAlt);
-        if (!imageAllowed && linkAllowed) {
+        if (!imageAllowed) {
             return $"<a href=\"{HtmlAttributeUrlEncoder.Encode(LinkUrl)}\"{linkTitle}{extra}>{System.Net.WebUtility.HtmlEncode(PlainAlt)}</a>";
         }
-        if (imageAllowed && !linkAllowed) {
+        if (!linkAllowed) {
             return $"<img src=\"{HtmlAttributeUrlEncoder.Encode(ImageUrl)}\" alt=\"{System.Net.WebUtility.HtmlEncode(PlainAlt)}\"{title}{imgExtra} />";
         }
 

--- a/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
@@ -42,9 +42,7 @@ public sealed class MarkdownWriteOptions {
             ImageRenderingMode = ImageRenderingMode
         };
         for (int i = 0; i < BlockRenderExtensions.Count; i++) {
-            if (BlockRenderExtensions[i] != null) {
-                clone.BlockRenderExtensions.Add(BlockRenderExtensions[i]);
-            }
+            clone.BlockRenderExtensions.Add(BlockRenderExtensions[i]);
         }
 
         return clone;

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.Blocks.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.Blocks.cs
@@ -1644,7 +1644,7 @@ public static partial class MarkdownReader {
                         trailingSyntax = ParseBlockSyntaxNodesFromSourceLines(sourceLines.GetRange(headingLineCount, lines.Count - headingLineCount), options, state);
                     } else {
                         var nestedSyntax = new List<MarkdownSyntaxNode>();
-                        _ = ParseBlocksFromLines(trailingLines.ToArray(), options, state ?? new MarkdownReaderState(), nestedSyntax, lineOffset: lineOffset + headingLineCount);
+                        ParseBlocksFromLines(trailingLines.ToArray(), options, state ?? new MarkdownReaderState(), nestedSyntax, lineOffset: lineOffset + headingLineCount);
                         trailingSyntax = nestedSyntax;
                     }
 
@@ -1672,7 +1672,7 @@ public static partial class MarkdownReader {
                         trailingSyntax = ParseBlockSyntaxNodesFromSourceLines(sourceLines.GetRange(firstBlank + 1, lines.Count - firstBlank - 1), options, state);
                     } else {
                         var nestedSyntax = new List<MarkdownSyntaxNode>();
-                        _ = ParseBlocksFromLines(trailingLines.ToArray(), options, state ?? new MarkdownReaderState(), nestedSyntax, lineOffset: lineOffset + firstBlank + 1);
+                        ParseBlocksFromLines(trailingLines.ToArray(), options, state ?? new MarkdownReaderState(), nestedSyntax, lineOffset: lineOffset + firstBlank + 1);
                         trailingSyntax = nestedSyntax;
                     }
 
@@ -1935,7 +1935,7 @@ public static partial class MarkdownReader {
             parsedSyntax = ParseBlockSyntaxNodesFromSourceLines(sourceLines, options, state);
         } else {
             var leadSyntax = new List<MarkdownSyntaxNode>();
-            _ = ParseBlocksFromLines(lines.ToArray(), options, state ?? new MarkdownReaderState(), leadSyntax, lineOffset);
+            ParseBlocksFromLines(lines.ToArray(), options, state ?? new MarkdownReaderState(), leadSyntax, lineOffset);
             parsedSyntax = leadSyntax;
         }
 

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.cs
@@ -2172,7 +2172,7 @@ public static partial class MarkdownReader {
         var active = new List<MarkdownInlineParserExtension>(options.InlineParserExtensions.Count);
         for (var i = 0; i < options.InlineParserExtensions.Count; i++) {
             var extension = options.InlineParserExtensions[i];
-            if (extension.AppliesTo(options)) {
+            if (extension != null && extension.AppliesTo(options)) {
                 active.Add(extension);
             }
         }

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.Inlines.cs
@@ -2165,14 +2165,14 @@ public static partial class MarkdownReader {
         ParseInlines(text ?? string.Empty, options ?? new MarkdownReaderOptions(), state);
 
     private static IReadOnlyList<MarkdownInlineParserExtension> BuildEffectiveInlineParserExtensions(MarkdownReaderOptions options) {
-        if (options?.InlineParserExtensions == null || options.InlineParserExtensions.Count == 0) {
+        if (options.InlineParserExtensions.Count == 0) {
             return Array.Empty<MarkdownInlineParserExtension>();
         }
 
         var active = new List<MarkdownInlineParserExtension>(options.InlineParserExtensions.Count);
         for (var i = 0; i < options.InlineParserExtensions.Count; i++) {
             var extension = options.InlineParserExtensions[i];
-            if (extension != null && extension.AppliesTo(options)) {
+            if (extension.AppliesTo(options)) {
                 active.Add(extension);
             }
         }
@@ -2192,7 +2192,7 @@ public static partial class MarkdownReader {
         Func<int, int, bool, bool, InlineSequence> parseNestedInlineSegment,
         out MarkdownInlineParseResult result) {
         result = default;
-        if (inlineParserExtensions == null || inlineParserExtensions.Count == 0) {
+        if (inlineParserExtensions.Count == 0) {
             return false;
         }
 
@@ -2208,10 +2208,6 @@ public static partial class MarkdownReader {
 
         for (var i = 0; i < inlineParserExtensions.Count; i++) {
             var extension = inlineParserExtensions[i];
-            if (extension == null) {
-                continue;
-            }
-
             if (!extension.Parser(context, out result)) {
                 continue;
             }

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.cs
@@ -926,20 +926,14 @@ public static partial class MarkdownReader {
     }
 
     private static void CopyFencedBlockExtensions(MarkdownReaderOptions source, MarkdownReaderOptions target) {
-        if (source == null || target == null) {
-            return;
-        }
-
         var extensions = source.FencedBlockExtensions;
-        if (extensions == null || extensions.Count == 0) {
+        if (extensions.Count == 0) {
             return;
         }
 
         for (int i = 0; i < extensions.Count; i++) {
             var extension = extensions[i];
-            if (extension != null) {
-                target.FencedBlockExtensions.Add(extension);
-            }
+            target.FencedBlockExtensions.Add(extension);
         }
     }
 
@@ -950,15 +944,13 @@ public static partial class MarkdownReader {
 
         var extensions = source.BlockParserExtensions;
         target.BlockParserExtensions.Clear();
-        if (extensions == null || extensions.Count == 0) {
+        if (extensions.Count == 0) {
             return;
         }
 
         for (int i = 0; i < extensions.Count; i++) {
             var extension = extensions[i];
-            if (extension != null) {
-                target.BlockParserExtensions.Add(extension);
-            }
+            target.BlockParserExtensions.Add(extension);
         }
     }
 
@@ -969,15 +961,13 @@ public static partial class MarkdownReader {
 
         var extensions = source.InlineParserExtensions;
         target.InlineParserExtensions.Clear();
-        if (extensions == null || extensions.Count == 0) {
+        if (extensions.Count == 0) {
             return;
         }
 
         for (int i = 0; i < extensions.Count; i++) {
             var extension = extensions[i];
-            if (extension != null) {
-                target.InlineParserExtensions.Add(extension);
-            }
+            target.InlineParserExtensions.Add(extension);
         }
     }
 
@@ -987,15 +977,13 @@ public static partial class MarkdownReader {
         }
 
         var transforms = source.DocumentTransforms;
-        if (transforms == null || transforms.Count == 0) {
+        if (transforms.Count == 0) {
             return;
         }
 
         for (int i = 0; i < transforms.Count; i++) {
             var transform = transforms[i];
-            if (transform != null) {
-                target.DocumentTransforms.Add(transform);
-            }
+            target.DocumentTransforms.Add(transform);
         }
     }
 

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.cs
@@ -933,7 +933,9 @@ public static partial class MarkdownReader {
 
         for (int i = 0; i < extensions.Count; i++) {
             var extension = extensions[i];
-            target.FencedBlockExtensions.Add(extension);
+            if (extension != null) {
+                target.FencedBlockExtensions.Add(extension);
+            }
         }
     }
 
@@ -950,7 +952,9 @@ public static partial class MarkdownReader {
 
         for (int i = 0; i < extensions.Count; i++) {
             var extension = extensions[i];
-            target.BlockParserExtensions.Add(extension);
+            if (extension != null) {
+                target.BlockParserExtensions.Add(extension);
+            }
         }
     }
 
@@ -967,7 +971,9 @@ public static partial class MarkdownReader {
 
         for (int i = 0; i < extensions.Count; i++) {
             var extension = extensions[i];
-            target.InlineParserExtensions.Add(extension);
+            if (extension != null) {
+                target.InlineParserExtensions.Add(extension);
+            }
         }
     }
 

--- a/OfficeIMO.Markdown/Reader/Parsers/CalloutParser.cs
+++ b/OfficeIMO.Markdown/Reader/Parsers/CalloutParser.cs
@@ -13,7 +13,6 @@ public static partial class MarkdownReader {
                 state);
 
             // Collect contiguous quote lines as callout body, stripping one leading ">" level.
-            var inner = new System.Collections.Generic.List<string>();
             var innerSourceLines = new System.Collections.Generic.List<MarkdownSourceLineSlice>();
             int j = i + 1;
             while (j < lines.Length) {
@@ -22,7 +21,6 @@ public static partial class MarkdownReader {
                 if (!t.StartsWith(">")) break;
 
                 var bodyLine = t.Length >= 2 && t[1] == ' ' ? t.Substring(2) : t.Substring(1);
-                inner.Add(bodyLine);
                 innerSourceLines.Add(new MarkdownSourceLineSlice(
                     bodyLine,
                     state.SourceLineOffset + j + 1,

--- a/OfficeIMO.Markdown/Reader/Parsers/HtmlBlockParser.cs
+++ b/OfficeIMO.Markdown/Reader/Parsers/HtmlBlockParser.cs
@@ -348,7 +348,6 @@ public static partial class MarkdownReader {
                         quoteChar = current;
                     } else if (current == '>') {
                         endIndex = idx;
-                        idx++;
                         break;
                     } else if (current == '<') {
                         return false;

--- a/OfficeIMO.Markdown/Reader/Pipeline/MarkdownReaderPipeline.cs
+++ b/OfficeIMO.Markdown/Reader/Pipeline/MarkdownReaderPipeline.cs
@@ -44,14 +44,13 @@ public sealed class MarkdownReaderPipeline {
         MarkdownReaderOptions options,
         MarkdownBlockParserPlacement placement) {
         var extensions = options.BlockParserExtensions;
-        if (extensions == null || extensions.Count == 0) {
+        if (extensions.Count == 0) {
             return;
         }
 
         for (int i = 0; i < extensions.Count; i++) {
             var extension = extensions[i];
-            if (extension == null
-                || extension.Placement != placement
+            if (extension.Placement != placement
                 || !extension.AppliesTo(options)) {
                 continue;
             }

--- a/OfficeIMO.Markdown/Reader/Pipeline/MarkdownReaderPipeline.cs
+++ b/OfficeIMO.Markdown/Reader/Pipeline/MarkdownReaderPipeline.cs
@@ -50,7 +50,8 @@ public sealed class MarkdownReaderPipeline {
 
         for (int i = 0; i < extensions.Count; i++) {
             var extension = extensions[i];
-            if (extension.Placement != placement
+            if (extension == null
+                || extension.Placement != placement
                 || !extension.AppliesTo(options)) {
                 continue;
             }

--- a/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
+++ b/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
@@ -152,13 +152,13 @@ internal static class HtmlRenderer {
 
     private static string? TryRenderBlockOverride(IMarkdownBlock block, MarkdownBodyRenderContext context) {
         var extensions = context.Options.BlockRenderExtensions;
-        if (extensions == null || extensions.Count == 0) {
+        if (extensions.Count == 0) {
             return null;
         }
 
         for (int i = extensions.Count - 1; i >= 0; i--) {
             var extension = extensions[i];
-            if (extension == null || !extension.Matches(block)) {
+            if (!extension.Matches(block)) {
                 continue;
             }
 

--- a/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
+++ b/OfficeIMO.Markdown/Utilities/HtmlRenderer.cs
@@ -158,7 +158,7 @@ internal static class HtmlRenderer {
 
         for (int i = extensions.Count - 1; i >= 0; i--) {
             var extension = extensions[i];
-            if (!extension.Matches(block)) {
+            if (extension == null || !extension.Matches(block)) {
                 continue;
             }
 

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.cs
@@ -113,7 +113,7 @@ public sealed class PdfReadDocument {
             foreach (var kid in kids.Items) {
                 var d = ResolveDict(kid);
                 if (d is null) { continue; }
-                if (d is not null) TraversePagesNode(d, outList);
+                TraversePagesNode(d, outList);
             }
         }
     }

--- a/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
+++ b/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
@@ -52,7 +52,7 @@ internal static class ResourceResolver {
                     var localMap = cidMap!;
                     map[kv.Key] = bytes => SumWidthsCid(bytes, localMap);
                 } else {
-                    map[kv.Key] = bytes => bytes != null ? (bytes.Length / 2) * 1000.0 : 0.0; // conservative default
+                    map[kv.Key] = bytes => bytes != null ? (bytes.Length / 2d) * 1000.0 : 0.0; // conservative default
                 }
             } else {
                 int firstChar = (int)(fontVal.Get<PdfNumber>("FirstChar")?.Value ?? 0);

--- a/OfficeIMO.Pdf/Rendering/PdfWriter.cs
+++ b/OfficeIMO.Pdf/Rendering/PdfWriter.cs
@@ -13,7 +13,6 @@ internal static partial class PdfWriter {
         // Reserve IDs (1-based). We'll assign as we add to `objects`.
         int infoId = 0, catalogId = 0, pagesId = 0;
         var pageIds = new List<int>();
-        var contentIds = new List<int>();
 
         // Collect fonts used across pages
         var fontObjectIds = new Dictionary<PdfStandardFont, int>();
@@ -50,7 +49,7 @@ internal static partial class PdfWriter {
             }
 
             var normalFont = ChooseNormal(pageOpts.DefaultFont);
-            _ = EnsurePageFontResource(normalFont, "F1");
+            EnsurePageFontResource(normalFont, "F1");
             if (page.UsedBold) {
                 var boldFont = ChooseBold(normalFont);
                 EnsurePageFontResource(boldFont, "F2");
@@ -112,8 +111,6 @@ internal static partial class PdfWriter {
                 content,
                 Encoding.ASCII.GetBytes("\nendstream\nendobj\n")
             );
-            contentIds.Add(contentId);
-
             // Annotations (link URIs)
             var pageAnnotIds = new List<int>();
             if (page.Annotations.Count > 0) {
@@ -173,7 +170,7 @@ internal static partial class PdfWriter {
         }
 
         long xrefPos = ms.Position;
-        var sw = new StreamWriter(ms, Encoding.ASCII, 1024, leaveOpen: true) { NewLine = "\n" };
+        using var sw = new StreamWriter(ms, Encoding.ASCII, 1024, leaveOpen: true) { NewLine = "\n" };
         sw.WriteLine("xref");
         sw.WriteLine("0 " + (objects.Count + 1).ToString(CultureInfo.InvariantCulture));
         sw.WriteLine("0000000000 65535 f ");

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.cs
@@ -113,9 +113,9 @@ internal static partial class PdfWriter {
                 double estWidth = line.Length * fontSize * em;
                 if (align == PdfAlign.Center) dx = Math.Max(0, (widthUsed - estWidth) / 2);
                 else if (align == PdfAlign.Right) dx = Math.Max(0, (widthUsed - estWidth));
-                if (dx != 0) sb.Append(F(dx)).Append(" 0 Td\n");
+                if (Math.Abs(dx) > 0.0001) sb.Append(F(dx)).Append(" 0 Td\n");
                 sb.Append('<').Append(EncodeWinAnsiHex(line)).Append("> Tj\n");
-                if (dx != 0) sb.Append(F(-dx)).Append(" 0 Td\n");
+                if (Math.Abs(dx) > 0.0001) sb.Append(F(-dx)).Append(" 0 Td\n");
                 if (i != lines.Count - 1) sb.Append("T*\n");
             }
             sb.Append("ET\n");
@@ -241,7 +241,6 @@ internal static partial class PdfWriter {
                     for (int rowIndex = 0; rowIndex < tb.Rows.Count; rowIndex++) {
                         var row = tb.Rows[rowIndex];
                         double rowHeight = rowHeights[rowIndex];
-                        double rowTop = y;
                         double rowBottom = y - rowHeight;
                         if (currentOpts.Debug?.ShowTableRowBoxes == true) { pageDirty = true; DrawRowRect(sb, new PdfColor(1, 0, 1), 0.6, xOrigin, rowBottom, tableWidth, rowHeight); }
                         if (style?.HeaderFill is not null && rowIndex == 0) { pageDirty = true; DrawRowFill(sb, style.HeaderFill.Value, xOrigin, rowBottom, tableWidth, rowHeight); } else if (style?.RowStripeFill is not null && rowIndex % 2 == 1) { pageDirty = true; DrawRowFill(sb, style.RowStripeFill.Value, xOrigin, rowBottom, tableWidth, rowHeight); }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.cs
@@ -128,8 +128,6 @@ internal static partial class PdfWriter {
                     heights.Add(fontSize * 1.4);
                     lines.Add(new());
                     lineWidth = 0;
-                    lastLine = lines[lines.Count - 1];
-                    needed = tokenW;
                 }
                 if (token.Length > 0) {
                     if (lineWidth > 0) lineWidth += spaceW;
@@ -189,7 +187,7 @@ internal static partial class PdfWriter {
             double dx = 0;
             if (block.Align == PdfAlign.Center) dx = Math.Max(0, (widthUsed - lineWForAlign) / 2);
             else if (block.Align == PdfAlign.Right) dx = Math.Max(0, widthUsed - lineWForAlign);
-            if (dx != 0) sb.Append(F(dx)).Append(" 0 Td\n");
+            if (Math.Abs(dx) > 0.0001) sb.Append(F(dx)).Append(" 0 Td\n");
 
             double xCursor = dx;
             for (int si = 0; si < segs.Count; si++) {
@@ -231,7 +229,7 @@ internal static partial class PdfWriter {
                 }
                 xCursor += wSeg;
             }
-            if (xCursor != 0) sb.Append(F(-xCursor)).Append(" 0 Td\n");
+            if (Math.Abs(xCursor) > 0.0001) sb.Append(F(-xCursor)).Append(" 0 Td\n");
         }
         sb.Append("ET\n");
 

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Grid.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Grid.cs
@@ -277,8 +277,8 @@ namespace OfficeIMO.PowerPoint {
 
             for (int columns = min; columns <= max; columns++) {
                 int rows = (int)Math.Ceiling(count / (double)columns);
-                double availableWidth = bounds.Width - gutterX * (columns - 1);
-                double availableHeight = bounds.Height - gutterY * (rows - 1);
+                double availableWidth = bounds.Width - (double)gutterX * (columns - 1);
+                double availableHeight = bounds.Height - (double)gutterY * (rows - 1);
                 if (availableWidth <= 0 || availableHeight <= 0) {
                     continue;
                 }

--- a/OfficeIMO.Reader/DocumentReader.cs
+++ b/OfficeIMO.Reader/DocumentReader.cs
@@ -577,7 +577,7 @@ public static class DocumentReader {
                     yield return EnrichChunk(
                         BuildFolderWarningChunk(
                         file,
-                        warningIndex++,
+                        warningIndex,
                         limitWarning),
                         source,
                         opt.ComputeHashes);
@@ -627,14 +627,21 @@ public static class DocumentReader {
                 continue;
             }
 
-            foreach (var chunk in fileChunks!) {
+            if (fileChunks == null) {
+                state.FilesSkipped++;
+                NotifyProgress(onProgress, ReaderProgressEventKind.FileSkipped, state, source, "File parsing produced no chunks.", fileChunkCount: 0);
+                yield return EnrichChunk(BuildFolderWarningChunk(file, warningIndex++, "File parsing produced no chunks."), source, opt.ComputeHashes);
+                continue;
+            }
+
+            foreach (var chunk in fileChunks) {
                 cancellationToken.ThrowIfCancellationRequested();
                 yield return chunk;
             }
 
             state.FilesParsed++;
             state.BytesRead += lengthValue;
-            state.ChunksProduced += fileChunks!.Count;
+            state.ChunksProduced += fileChunks.Count;
             NotifyProgress(onProgress, ReaderProgressEventKind.FileCompleted, state, source, null, fileChunks.Count);
         }
 
@@ -729,9 +736,16 @@ public static class DocumentReader {
                 continue;
             }
 
+            if (fileChunks == null) {
+                state.FilesSkipped++;
+                NotifyProgress(onProgress, ReaderProgressEventKind.FileSkipped, state, source, "File parsing produced no chunks.", fileChunkCount: 0);
+                yield return BuildSourceDocument(source, parsed: false, chunks: null, sourceWarnings: new[] { "File parsing produced no chunks." });
+                continue;
+            }
+
             state.FilesParsed++;
             state.BytesRead += lengthValue;
-            state.ChunksProduced += fileChunks!.Count;
+            state.ChunksProduced += fileChunks.Count;
             NotifyProgress(onProgress, ReaderProgressEventKind.FileCompleted, state, source, null, fileChunks.Count);
 
             yield return BuildSourceDocument(source, parsed: true, chunks: fileChunks, sourceWarnings: null);

--- a/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
+++ b/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
@@ -200,7 +200,7 @@ namespace OfficeIMO.Word.Html {
             var targetSection = doc.Sections.LastOrDefault() ?? throw new System.InvalidOperationException("The document does not contain any sections to append HTML to the footer.");
             doc.AddHeadersAndFooters();
             var footers = targetSection.Footer ?? throw new System.InvalidOperationException("The target section does not have any footers defined. Call AddHeadersAndFooters() before appending HTML to the footer.");
-            _ = GetOrCreateFooter(doc, targetSection, footers, footerType);
+            GetOrCreateFooter(doc, targetSection, footers, footerType);
 
             doc.AddHtmlToFooterAsync(html, footerType, options).GetAwaiter().GetResult();
         }

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
@@ -184,42 +184,36 @@ namespace OfficeIMO.Word.Markdown {
         }
 
         private static void CopyFencedBlockExtensions(Omd.MarkdownReaderOptions source, Omd.MarkdownReaderOptions target) {
-            if (source.FencedBlockExtensions == null || source.FencedBlockExtensions.Count == 0) {
+            if (source.FencedBlockExtensions.Count == 0) {
                 return;
             }
 
             for (int i = 0; i < source.FencedBlockExtensions.Count; i++) {
                 var extension = source.FencedBlockExtensions[i];
-                if (extension != null) {
-                    target.FencedBlockExtensions.Add(extension);
-                }
+                target.FencedBlockExtensions.Add(extension);
             }
         }
 
         private static void CopyBlockParserExtensions(Omd.MarkdownReaderOptions source, Omd.MarkdownReaderOptions target) {
             target.BlockParserExtensions.Clear();
-            if (source.BlockParserExtensions == null || source.BlockParserExtensions.Count == 0) {
+            if (source.BlockParserExtensions.Count == 0) {
                 return;
             }
 
             for (int i = 0; i < source.BlockParserExtensions.Count; i++) {
                 var extension = source.BlockParserExtensions[i];
-                if (extension != null) {
-                    target.BlockParserExtensions.Add(extension);
-                }
+                target.BlockParserExtensions.Add(extension);
             }
         }
 
         private static void CopyDocumentTransforms(Omd.MarkdownReaderOptions source, Omd.MarkdownReaderOptions target) {
-            if (source.DocumentTransforms == null || source.DocumentTransforms.Count == 0) {
+            if (source.DocumentTransforms.Count == 0) {
                 return;
             }
 
             for (var i = 0; i < source.DocumentTransforms.Count; i++) {
                 var transform = source.DocumentTransforms[i];
-                if (transform != null) {
-                    target.DocumentTransforms.Add(transform);
-                }
+                target.DocumentTransforms.Add(transform);
             }
         }
 
@@ -1311,7 +1305,6 @@ namespace OfficeIMO.Word.Markdown {
             int quoteDepth = 0,
             double pageContentWidthPixels = 0,
             Omd.ColumnAlignment alignment = Omd.ColumnAlignment.None) {
-            _ = currentList;
             new BlockRenderer(host, options, document, listLevel, quoteDepth, pageContentWidthPixels, alignment).Render(block);
         }
 

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.cs
@@ -190,7 +190,9 @@ namespace OfficeIMO.Word.Markdown {
 
             for (int i = 0; i < source.FencedBlockExtensions.Count; i++) {
                 var extension = source.FencedBlockExtensions[i];
-                target.FencedBlockExtensions.Add(extension);
+                if (extension != null) {
+                    target.FencedBlockExtensions.Add(extension);
+                }
             }
         }
 
@@ -202,7 +204,9 @@ namespace OfficeIMO.Word.Markdown {
 
             for (int i = 0; i < source.BlockParserExtensions.Count; i++) {
                 var extension = source.BlockParserExtensions[i];
-                target.BlockParserExtensions.Add(extension);
+                if (extension != null) {
+                    target.BlockParserExtensions.Add(extension);
+                }
             }
         }
 

--- a/OfficeIMO.Word.Markdown/Extraction/WordMarkdownExtractionExtensions.cs
+++ b/OfficeIMO.Word.Markdown/Extraction/WordMarkdownExtractionExtensions.cs
@@ -141,7 +141,6 @@ public static class WordMarkdownExtractionExtensions {
                 warnings,
                 out var flushed);
             if (flushed != null) yield return flushed;
-            blockIndex++;
         }
 
         // Final flush.

--- a/OfficeIMO.Word.Markdown/WordMarkdownSemanticBlocks.cs
+++ b/OfficeIMO.Word.Markdown/WordMarkdownSemanticBlocks.cs
@@ -56,10 +56,6 @@ public static class WordMarkdownSemanticBlocks {
         string name) {
         for (int i = 0; i < options.FencedBlockExtensions.Count; i++) {
             var extension = options.FencedBlockExtensions[i];
-            if (extension == null) {
-                continue;
-            }
-
             for (int j = 0; j < extension.Languages.Count; j++) {
                 if (string.Equals(extension.Languages[j], language, StringComparison.OrdinalIgnoreCase)) {
                     return;

--- a/OfficeIMO.Word.Markdown/WordMarkdownSemanticBlocks.cs
+++ b/OfficeIMO.Word.Markdown/WordMarkdownSemanticBlocks.cs
@@ -56,6 +56,10 @@ public static class WordMarkdownSemanticBlocks {
         string name) {
         for (int i = 0; i < options.FencedBlockExtensions.Count; i++) {
             var extension = options.FencedBlockExtensions[i];
+            if (extension == null) {
+                continue;
+            }
+
             for (int j = 0; j < extension.Languages.Count; j++) {
                 if (string.Equals(extension.Languages[j], language, StringComparison.OrdinalIgnoreCase)) {
                     return;

--- a/OfficeIMO.Word/ExtensionsHeadersAndFooters.cs
+++ b/OfficeIMO.Word/ExtensionsHeadersAndFooters.cs
@@ -83,29 +83,27 @@ namespace OfficeIMO.Word {
             header.Save(headerPart);
             var headerElement = headerPart.Header ?? throw new InvalidOperationException("Header element is missing.");
 
-            if (headerPart != null) {
-                var id = document._wordprocessingDocument.MainDocumentPart!.GetIdOfPart(headerPart);
-                //var id1 = document._wordprocessingDocument.MainDocumentPart.GetIdOfPart(part.HeaderParts.FirstOrDefault());
+            var id = document._wordprocessingDocument.MainDocumentPart!.GetIdOfPart(headerPart);
+            //var id1 = document._wordprocessingDocument.MainDocumentPart.GetIdOfPart(part.HeaderParts.FirstOrDefault());
 
-                if (id != null) {
-                    var headerReference = new HeaderReference() {
-                        Type = headerFooterValue,
-                        Id = id
-                    };
+            if (id != null) {
+                var headerReference = new HeaderReference() {
+                    Type = headerFooterValue,
+                    Id = id
+                };
 
-                    // Header/footer references must appear before other section
-                    // properties (such as pgSz/pgMar) to satisfy the Open XML
-                    // schema content model.
-                    var lastHdrFtrRef = sectionProperties
-                        .ChildElements
-                        .Where(e => e is HeaderReference || e is FooterReference)
-                        .LastOrDefault();
+                // Header/footer references must appear before other section
+                // properties (such as pgSz/pgMar) to satisfy the Open XML
+                // schema content model.
+                var lastHdrFtrRef = sectionProperties
+                    .ChildElements
+                    .Where(e => e is HeaderReference || e is FooterReference)
+                    .LastOrDefault();
 
-                    if (lastHdrFtrRef != null) {
-                        sectionProperties.InsertAfter(headerReference, lastHdrFtrRef);
-                    } else {
-                        sectionProperties.InsertAt(headerReference, 0);
-                    }
+                if (lastHdrFtrRef != null) {
+                    sectionProperties.InsertAfter(headerReference, lastHdrFtrRef);
+                } else {
+                    sectionProperties.InsertAt(headerReference, 0);
                 }
             }
 
@@ -140,26 +138,24 @@ namespace OfficeIMO.Word {
             footer.Save(footerPart);
             var footerElement = footerPart.Footer ?? throw new InvalidOperationException("Footer element is missing.");
 
-            if (footerPart != null) {
-                var id = document._wordprocessingDocument.MainDocumentPart!.GetIdOfPart(footerPart);
-                if (id != null) {
-                    var footerReference = new FooterReference() {
-                        Type = headerFooterValue,
-                        Id = id
-                    };
+            var id = document._wordprocessingDocument.MainDocumentPart!.GetIdOfPart(footerPart);
+            if (id != null) {
+                var footerReference = new FooterReference() {
+                    Type = headerFooterValue,
+                    Id = id
+                };
 
-                    // Footer references must live in the same leading group as
-                    // header references inside sectPr.
-                    var lastHdrFtrRef = sectionProperties
-                        .ChildElements
-                        .Where(e => e is HeaderReference || e is FooterReference)
-                        .LastOrDefault();
+                // Footer references must live in the same leading group as
+                // header references inside sectPr.
+                var lastHdrFtrRef = sectionProperties
+                    .ChildElements
+                    .Where(e => e is HeaderReference || e is FooterReference)
+                    .LastOrDefault();
 
-                    if (lastHdrFtrRef != null) {
-                        sectionProperties.InsertAfter(footerReference, lastHdrFtrRef);
-                    } else {
-                        sectionProperties.InsertAt(footerReference, 0);
-                    }
+                if (lastHdrFtrRef != null) {
+                    sectionProperties.InsertAfter(footerReference, lastHdrFtrRef);
+                } else {
+                    sectionProperties.InsertAt(footerReference, 0);
                 }
             }
 

--- a/OfficeIMO.Word/ExtensionsHeadersAndFooters.cs
+++ b/OfficeIMO.Word/ExtensionsHeadersAndFooters.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 
@@ -32,15 +33,9 @@ namespace OfficeIMO.Word {
         /// <param name="headerFooterValue"></param>
         /// <returns></returns>
         internal static bool GetHeaderReference(WordDocument document, WordSection section, HeaderFooterValues headerFooterValue) {
-            var sectionProperties = section._sectionProperties;
-
-            foreach (var element in sectionProperties.ChildElements.OfType<HeaderReference>()) {
-                if (element.Type?.Value == headerFooterValue) {
-                    // we found the header reference already exists; we do nothing;
-                    return true;
-                }
-            }
-            return false;
+            return section._sectionProperties.ChildElements
+                .OfType<HeaderReference>()
+                .Any(element => element.Type?.Value == headerFooterValue);
         }
 
 
@@ -52,13 +47,9 @@ namespace OfficeIMO.Word {
         /// <param name="headerFooterValue"></param>
         /// <returns></returns>
         internal static bool GetFooterReference(WordDocument document, WordSection section, HeaderFooterValues headerFooterValue) {
-            var sectionProperties = section._sectionProperties;
-            foreach (var element in sectionProperties.ChildElements.OfType<FooterReference>()) {
-                if (element.Type?.Value == headerFooterValue) {
-                    return true;
-                }
-            }
-            return false;
+            return section._sectionProperties.ChildElements
+                .OfType<FooterReference>()
+                .Any(element => element.Type?.Value == headerFooterValue);
         }
 
         /// <summary>
@@ -92,19 +83,7 @@ namespace OfficeIMO.Word {
                     Id = id
                 };
 
-                // Header/footer references must appear before other section
-                // properties (such as pgSz/pgMar) to satisfy the Open XML
-                // schema content model.
-                var lastHdrFtrRef = sectionProperties
-                    .ChildElements
-                    .Where(e => e is HeaderReference || e is FooterReference)
-                    .LastOrDefault();
-
-                if (lastHdrFtrRef != null) {
-                    sectionProperties.InsertAfter(headerReference, lastHdrFtrRef);
-                } else {
-                    sectionProperties.InsertAt(headerReference, 0);
-                }
+                InsertHeaderFooterReference(sectionProperties, headerReference);
             }
 
             var headers = section.Header ?? throw new InvalidOperationException("Headers collection is missing.");
@@ -145,18 +124,7 @@ namespace OfficeIMO.Word {
                     Id = id
                 };
 
-                // Footer references must live in the same leading group as
-                // header references inside sectPr.
-                var lastHdrFtrRef = sectionProperties
-                    .ChildElements
-                    .Where(e => e is HeaderReference || e is FooterReference)
-                    .LastOrDefault();
-
-                if (lastHdrFtrRef != null) {
-                    sectionProperties.InsertAfter(footerReference, lastHdrFtrRef);
-                } else {
-                    sectionProperties.InsertAt(footerReference, 0);
-                }
+                InsertHeaderFooterReference(sectionProperties, footerReference);
             }
 
             var footers = section.Footer ?? throw new InvalidOperationException("Footers collection is missing.");
@@ -166,6 +134,22 @@ namespace OfficeIMO.Word {
                 footers.First = new WordFooter(document, HeaderFooterValues.First, footerElement, section);
             } else {
                 footers.Even = new WordFooter(document, HeaderFooterValues.Even, footerElement, section);
+            }
+        }
+
+        private static void InsertHeaderFooterReference(SectionProperties sectionProperties, OpenXmlElement reference) {
+            // Header/footer references must appear before other section
+            // properties (such as pgSz/pgMar) to satisfy the Open XML
+            // schema content model.
+            var lastHdrFtrRef = sectionProperties
+                .ChildElements
+                .Where(e => e is HeaderReference || e is FooterReference)
+                .LastOrDefault();
+
+            if (lastHdrFtrRef != null) {
+                sectionProperties.InsertAfter(reference, lastHdrFtrRef);
+            } else {
+                sectionProperties.InsertAt(reference, 0);
             }
         }
 

--- a/OfficeIMO.Word/Helpers.Cloners.cs
+++ b/OfficeIMO.Word/Helpers.Cloners.cs
@@ -79,18 +79,20 @@ public static partial class Helpers {
     /// <param name="source">The source stream.</param>
     /// <param name="target">The target stream.</param>
     public static void CopyStream(Stream? source, Stream target) {
-        if (source != null) {
-            MemoryStream? mstream = source as MemoryStream;
-            if (mstream != null) {
-                mstream.WriteTo(target);
-            } else {
-                byte[] buffer = new byte[2048];
-                int length = buffer.Length, size;
+        if (source is null) {
+            return;
+        }
 
-                while ((size = source.Read(buffer, 0, length)) != 0) {
-                    target.Write(buffer, 0, size);
-                }
-            }
+        if (source is MemoryStream memoryStream) {
+            memoryStream.WriteTo(target);
+            return;
+        }
+
+        byte[] buffer = new byte[2048];
+        int length = buffer.Length;
+        int size;
+        while ((size = source.Read(buffer, 0, length)) != 0) {
+            target.Write(buffer, 0, size);
         }
     }
 }

--- a/OfficeIMO.Word/WordChart.PublicMethods.cs
+++ b/OfficeIMO.Word/WordChart.PublicMethods.cs
@@ -214,7 +214,7 @@ namespace OfficeIMO.Word {
         public void AddScatter(string name, List<double> xValues, List<double> yValues, SixLabors.ImageSharp.Color color) {
             EnsureChartExistsScatter();
             if (_chart != null) {
-                var scatterChart = _chart?.PlotArea?.GetFirstChild<ScatterChart>();
+                var scatterChart = _chart.PlotArea?.GetFirstChild<ScatterChart>();
                 if (scatterChart != null) {
                     var series = AddScatterChartSeries(this._index, name, color, xValues, yValues);
                     InsertSeries(scatterChart, series);

--- a/OfficeIMO.Word/WordChart.cs
+++ b/OfficeIMO.Word/WordChart.cs
@@ -125,7 +125,7 @@ namespace OfficeIMO.Word {
             categoryAxis1.Append(delete1);
             categoryAxis1.Append(axisPosition1);
             if (!string.IsNullOrEmpty(_xAxisTitle)) {
-                categoryAxis1.Append(AddAxisTitle(_xAxisTitle ?? string.Empty));
+                categoryAxis1.Append(AddAxisTitle(_xAxisTitle));
             }
             categoryAxis1.Append(majorTickMark1);
             categoryAxis1.Append(minorTickMark1);
@@ -170,7 +170,7 @@ namespace OfficeIMO.Word {
             valueAxis1.Append(axisPosition2);
             valueAxis1.Append(majorGridlines1);  // MajorGridlines should come before NumberingFormat
             if (!string.IsNullOrEmpty(_yAxisTitle)) {
-                valueAxis1.Append(AddAxisTitle(_yAxisTitle ?? string.Empty));
+                valueAxis1.Append(AddAxisTitle(_yAxisTitle));
             }
             valueAxis1.Append(numberingFormat1);
             valueAxis1.Append(majorTickMark2);

--- a/OfficeIMO.Word/WordChart.cs
+++ b/OfficeIMO.Word/WordChart.cs
@@ -125,7 +125,7 @@ namespace OfficeIMO.Word {
             categoryAxis1.Append(delete1);
             categoryAxis1.Append(axisPosition1);
             if (!string.IsNullOrEmpty(_xAxisTitle)) {
-                categoryAxis1.Append(AddAxisTitle(_xAxisTitle));
+                categoryAxis1.Append(AddAxisTitle(_xAxisTitle!));
             }
             categoryAxis1.Append(majorTickMark1);
             categoryAxis1.Append(minorTickMark1);
@@ -170,7 +170,7 @@ namespace OfficeIMO.Word {
             valueAxis1.Append(axisPosition2);
             valueAxis1.Append(majorGridlines1);  // MajorGridlines should come before NumberingFormat
             if (!string.IsNullOrEmpty(_yAxisTitle)) {
-                valueAxis1.Append(AddAxisTitle(_yAxisTitle));
+                valueAxis1.Append(AddAxisTitle(_yAxisTitle!));
             }
             valueAxis1.Append(numberingFormat1);
             valueAxis1.Append(majorTickMark2);

--- a/OfficeIMO.Word/WordDocument.Inspection.cs
+++ b/OfficeIMO.Word/WordDocument.Inspection.cs
@@ -46,11 +46,9 @@ namespace OfficeIMO.Word {
                 for (int elementIndex = 0; elementIndex < elements.Count; elementIndex++) {
                     var element = elements[elementIndex];
                     if (element is WordParagraph paragraphPart) {
-                        var group = new List<WordParagraph> { paragraphPart };
                         while (elementIndex + 1 < elements.Count
                                && elements[elementIndex + 1] is WordParagraph nextParagraph
                                && ReferenceEquals(nextParagraph._paragraph, paragraphPart._paragraph)) {
-                            group.Add(nextParagraph);
                             elementIndex++;
                         }
 

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -1098,9 +1098,7 @@ namespace OfficeIMO.Word {
                             } else
                                 candCharPos = 0;
                         }
-
                     }
-                    textPos++;
                 }
 
 

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -2,6 +2,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word.Fluent;
+using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1773,7 +1774,9 @@ namespace OfficeIMO.Word {
             if (ownedPackageStream != null) {
                 try {
                     ownedPackageStream.Dispose();
-                } catch {
+                } catch (ObjectDisposedException) {
+                    // ignored
+                } catch (IOException) {
                     // ignored
                 }
 
@@ -1815,7 +1818,9 @@ namespace OfficeIMO.Word {
             if (ownedPackageStream != null) {
                 try {
                     await Task.Run(() => ownedPackageStream.Dispose()).ConfigureAwait(false);
-                } catch {
+                } catch (ObjectDisposedException) {
+                    // ignored
+                } catch (IOException) {
                     // ignored
                 }
 

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -11,9 +11,9 @@ namespace OfficeIMO.Word {
     /// Provides functionality for creating, loading and manipulating Word documents.
     /// </summary>
     public partial class WordDocument : IDisposable {
-        internal List<int> _listNumbersUsed = new List<int>();
         internal int? _tableOfContentIndex;
         internal TableOfContentStyle? _tableOfContentStyle;
+        private MemoryStream? _ownedPackageStream;
         private bool _tableOfContentUpdateQueued;
         private bool _disposed;
 
@@ -1018,7 +1018,8 @@ namespace OfficeIMO.Word {
         public static WordDocument Create(string filePath = "", bool autoSave = false) {
             if (!string.IsNullOrEmpty(filePath)) {
                 // Ensure the file exists
-                using var _ = new FileStream(filePath, FileMode.Create);
+                using (new FileStream(filePath, FileMode.Create)) {
+                }
             }
 
             var documentType = GetDocumentType(filePath);
@@ -1046,7 +1047,8 @@ namespace OfficeIMO.Word {
                 word.OriginalStream = stream;
             }
 
-            WordprocessingDocument wordDocument = WordprocessingDocument.Create(new MemoryStream(), documentType, autoSave);
+            var packageStream = new MemoryStream();
+            WordprocessingDocument wordDocument = WordprocessingDocument.Create(packageStream, documentType, autoSave);
 
             wordDocument.AddMainDocumentPart();
             var mainPart = wordDocument.MainDocumentPart!;
@@ -1090,6 +1092,7 @@ namespace OfficeIMO.Word {
             mainPart.Document.Body = new DocumentFormat.OpenXml.Wordprocessing.Body();
 
             word.FilePath = filePath ?? string.Empty;
+            word._ownedPackageStream = packageStream;
             word._wordprocessingDocument = wordDocument;
             word._document = mainPart.Document;
             word.InitializeSdtIdState();
@@ -1115,13 +1118,13 @@ namespace OfficeIMO.Word {
             ThemePart themePart1 = mainPart.AddNewPart<ThemePart>("rId7");
             GenerateThemePart1Content(themePart1);
 
-            WordSettings wordSettings = new WordSettings(word);
-            WordCompatibilitySettings compatibilitySettings = new WordCompatibilitySettings(word);
-            ApplicationProperties applicationProperties = new ApplicationProperties(word);
-            BuiltinDocumentProperties builtinDocumentProperties = new BuiltinDocumentProperties(word);
-            WordSection wordSection = new WordSection(word, null!);
-            WordBackground wordBackground = new WordBackground(word);
-            WordDocumentStatistics statistics = new WordDocumentStatistics(word);
+            new WordSettings(word);
+            new WordCompatibilitySettings(word);
+            new ApplicationProperties(word);
+            new BuiltinDocumentProperties(word);
+            new WordSection(word, null!);
+            new WordBackground(word);
+            new WordDocumentStatistics(word);
 
             WordListStyles.InitializeAbstractNumberId(word._wordprocessingDocument);
 
@@ -1169,15 +1172,15 @@ namespace OfficeIMO.Word {
             Sections.Clear();
             InitializeSdtIdState();
             // add settings if not existing
-            var wordSettings = new WordSettings(this);
-            var applicationProperties = new ApplicationProperties(this);
-            var builtinDocumentProperties = new BuiltinDocumentProperties(this);
-            var wordCustomProperties = new WordCustomProperties(this);
-            var wordDocumentVariables = new WordDocumentVariables(this);
-            var bibliography = new WordBibliography(this);
-            var wordBackground = new WordBackground(this);
-            var statistics = new WordDocumentStatistics(this);
-            var compatibilitySettings = new WordCompatibilitySettings(this);
+            new WordSettings(this);
+            new ApplicationProperties(this);
+            new BuiltinDocumentProperties(this);
+            new WordCustomProperties(this);
+            new WordDocumentVariables(this);
+            new WordBibliography(this);
+            new WordBackground(this);
+            new WordDocumentStatistics(this);
+            new WordCompatibilitySettings(this);
             //CustomDocumentProperties customDocumentProperties = new CustomDocumentProperties(this);
             // add a section that's assigned to top of the document
             var wordSection = new WordSection(this, null!, null!);
@@ -1191,9 +1194,9 @@ namespace OfficeIMO.Word {
                     }
                 } else if (element is Table) {
                     // WordTable wordTable = new WordTable(this, wordSection, (Table)element);
-                } else if (element is SectionProperties sectionProperties) {
+                } else if (element is SectionProperties) {
                     // we don't do anything as we already created it above - i think
-                } else if (element is SdtBlock sdtBlock) {
+                } else if (element is SdtBlock) {
                     // we don't do anything as we load stuff with get on demand
                 } else if (element is OpenXmlUnknownElement) {
                     // this happens when adding dirty element - mainly during TOC Update() function
@@ -1274,6 +1277,7 @@ namespace OfficeIMO.Word {
                 InitialiseStyleDefinitions(wordDocument, readOnly, applyOverrideStyles);
 
                 word.FilePath = filePath;
+                word._ownedPackageStream = memoryStream;
                 word._wordprocessingDocument = wordDocument;
                 word._document = wordDocument.MainDocumentPart?.Document ?? throw new InvalidOperationException("Document is missing.");
                 word.LoadDocument();
@@ -1323,6 +1327,7 @@ namespace OfficeIMO.Word {
 
             var word = new WordDocument {
                 FilePath = filePath,
+                _ownedPackageStream = memoryStream,
                 _wordprocessingDocument = wordDocument,
                 _document = wordDocument.MainDocumentPart?.Document ?? throw new InvalidOperationException("Document is missing.")
             };
@@ -1764,6 +1769,17 @@ namespace OfficeIMO.Word {
                 this._wordprocessingDocument = null!;
             }
 
+            var ownedPackageStream = _ownedPackageStream;
+            if (ownedPackageStream != null) {
+                try {
+                    ownedPackageStream.Dispose();
+                } catch {
+                    // ignored
+                }
+
+                _ownedPackageStream = null;
+            }
+
             if (this.OriginalStream != null) {
                 // Original stream is owned by the caller and should remain open.
             }
@@ -1793,6 +1809,17 @@ namespace OfficeIMO.Word {
                 }
 
                 this._wordprocessingDocument = null!;
+            }
+
+            var ownedPackageStream = _ownedPackageStream;
+            if (ownedPackageStream != null) {
+                try {
+                    await Task.Run(() => ownedPackageStream.Dispose()).ConfigureAwait(false);
+                } catch {
+                    // ignored
+                }
+
+                _ownedPackageStream = null;
             }
 
             if (this.OriginalStream != null) {
@@ -1956,13 +1983,13 @@ namespace OfficeIMO.Word {
             if (AutoUpdateToc && TableOfContent != null) {
                 TableOfContent.Update();
             }
-            _ = new WordCustomProperties(this, true);
+            new WordCustomProperties(this, true);
             var settingsPart = _wordprocessingDocument.MainDocumentPart!.DocumentSettingsPart;
             bool hasVariables = settingsPart?.Settings?.GetFirstChild<DocumentVariables>() != null;
             if (hasVariables || DocumentVariables.Count > 0) {
-                _ = new WordDocumentVariables(this, true);
+                new WordDocumentVariables(this, true);
             }
-            _ = new WordBibliography(this, true);
+            new WordBibliography(this, true);
         }
     }
 }

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -443,8 +443,7 @@ namespace OfficeIMO.Word {
                 }
                 if (list.Count == 0) {
                     // Fallback: enumerate footnotes part when no body references were materialized yet.
-                    var footnotesPart = _wordprocessingDocument.MainDocumentPart?.FootnotesPart;
-                    var footnotes = footnotesPart != null ? footnotesPart.Footnotes : null;
+                    var footnotes = _wordprocessingDocument.MainDocumentPart?.FootnotesPart?.Footnotes;
                     if (footnotes != null) {
                         foreach (var fn in footnotes.ChildElements.OfType<DocumentFormat.OpenXml.Wordprocessing.Footnote>()) {
                             if (fn.Type != null) continue; // skip separators

--- a/OfficeIMO.Word/WordDocumentVariables.cs
+++ b/OfficeIMO.Word/WordDocumentVariables.cs
@@ -82,7 +82,7 @@ namespace OfficeIMO.Word {
             var toRemove = _variables.Elements<DocumentVariable>()
                 .Where(v => {
                     var name = v.Name?.Value;
-                    return string.IsNullOrEmpty(name) || (name != null && !_document.DocumentVariables.ContainsKey(name));
+                    return string.IsNullOrEmpty(name) || !_document.DocumentVariables.ContainsKey(name);
                 })
                 .ToList();
             foreach (var variable in toRemove) {

--- a/OfficeIMO.Word/WordDocumentVariables.cs
+++ b/OfficeIMO.Word/WordDocumentVariables.cs
@@ -82,7 +82,11 @@ namespace OfficeIMO.Word {
             var toRemove = _variables.Elements<DocumentVariable>()
                 .Where(v => {
                     var name = v.Name?.Value;
-                    return string.IsNullOrEmpty(name) || !_document.DocumentVariables.ContainsKey(name);
+                    if (string.IsNullOrEmpty(name)) {
+                        return true;
+                    }
+
+                    return !_document.DocumentVariables.ContainsKey(name!);
                 })
                 .ToList();
             foreach (var variable in toRemove) {

--- a/OfficeIMO.Word/WordFind.cs
+++ b/OfficeIMO.Word/WordFind.cs
@@ -66,7 +66,6 @@ public static class StringExtensions {
     /// <param name="count">Outputs the number of replacements performed.</param>
     /// <returns>The resulting string after replacements.</returns>
     public static string FindAndReplace(this string str, string oldValue, string newValue, StringComparison comparisonType, ref int count) {
-        List<string> list = new List<string>();
         // Check inputs.
         if (str == null) {
             // Same as original .NET C# string.Replace behavior.

--- a/OfficeIMO.Word/WordFooter.cs
+++ b/OfficeIMO.Word/WordFooter.cs
@@ -104,18 +104,20 @@ namespace OfficeIMO.Word {
             }
 
             var partsToDelete = new HashSet<FooterPart>();
-            var footersToRemove = (document ?? throw new InvalidOperationException("Main document is missing.")).Descendants<FooterReference>()
+            var documentRoot = document ?? throw new InvalidOperationException("Main document is missing.");
+            var mainDocumentPart = docPart ?? throw new InvalidOperationException("Main document part is missing.");
+            var footersToRemove = documentRoot.Descendants<FooterReference>()
                 .Where(f => f.Type != null && types.Contains(WordSection.GetType(f.Type))).ToList();
             foreach (var footer in footersToRemove) {
-                if (footer.Id == null || docPart == null) continue;
-                var part = docPart.GetPartById(footer.Id.Value!) as FooterPart;
+                if (footer.Id == null) continue;
+                var part = mainDocumentPart.GetPartById(footer.Id.Value!) as FooterPart;
                 if (part != null) {
                     partsToDelete.Add(part);
                 }
                 footer.Remove();
             }
             foreach (var part in partsToDelete) {
-                docPart!.DeletePart(part);
+                mainDocumentPart.DeletePart(part);
             }
         }
         /// <summary>

--- a/OfficeIMO.Word/WordFooter.cs
+++ b/OfficeIMO.Word/WordFooter.cs
@@ -105,7 +105,7 @@ namespace OfficeIMO.Word {
 
             var partsToDelete = new HashSet<FooterPart>();
             var documentRoot = document ?? throw new InvalidOperationException("Main document is missing.");
-            var mainDocumentPart = docPart ?? throw new InvalidOperationException("Main document part is missing.");
+            var mainDocumentPart = docPart!;
             var footersToRemove = documentRoot.Descendants<FooterReference>()
                 .Where(f => f.Type != null && types.Contains(WordSection.GetType(f.Type))).ToList();
             foreach (var footer in footersToRemove) {

--- a/OfficeIMO.Word/WordHeader.cs
+++ b/OfficeIMO.Word/WordHeader.cs
@@ -92,18 +92,20 @@ namespace OfficeIMO.Word {
             }
 
             var partsToDelete = new HashSet<HeaderPart>();
-            var headersToRemove = (document ?? throw new InvalidOperationException("Main document is missing.")).Descendants<HeaderReference>()
+            var documentRoot = document ?? throw new InvalidOperationException("Main document is missing.");
+            var mainDocumentPart = docPart!;
+            var headersToRemove = documentRoot.Descendants<HeaderReference>()
                 .Where(h => h.Type != null && types.Contains(WordSection.GetType(h.Type))).ToList();
             foreach (var header in headersToRemove) {
-                if (header.Id == null || docPart == null) continue;
-                var part = docPart.GetPartById(header.Id.Value!) as HeaderPart;
+                if (header.Id == null) continue;
+                var part = mainDocumentPart.GetPartById(header.Id.Value!) as HeaderPart;
                 if (part != null) {
                     partsToDelete.Add(part);
                 }
                 header.Remove();
             }
             foreach (var part in partsToDelete) {
-                docPart!.DeletePart(part);
+                mainDocumentPart.DeletePart(part);
             }
         }
         /// <summary>

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -1064,32 +1064,35 @@ namespace OfficeIMO.Word {
                 if (blip == null) return;
 
                 var extList = blip.GetFirstChild<BlipExtensionList>();
-                if (extList == null && value != null) {
+                if (extList == null) {
+                    if (value == null) {
+                        return;
+                    }
                     extList = new BlipExtensionList();
                     blip.Append(extList);
                 }
 
-                if (extList != null) {
-                    var extension = extList
-                        .OfType<BlipExtension>()
-                        .FirstOrDefault(e => e.Uri == "{28A0092B-C50C-407E-A947-70E740481C1C}");
-                    if (extension == null && value != null) {
-                        extension = new BlipExtension { Uri = "{28A0092B-C50C-407E-A947-70E740481C1C}" };
-                        extList.Append(extension);
+                var extension = extList
+                    .OfType<BlipExtension>()
+                    .FirstOrDefault(e => e.Uri == "{28A0092B-C50C-407E-A947-70E740481C1C}");
+                if (extension == null) {
+                    if (value == null) {
+                        return;
                     }
-                    if (extension != null) {
-                        var useLocalDpiElement = extension.GetFirstChild<DocumentFormat.OpenXml.Office2010.Drawing.UseLocalDpi>();
-                        if (value == null) {
-                            useLocalDpiElement?.Remove();
-                        } else {
-                            if (useLocalDpiElement == null) {
-                                useLocalDpiElement = new DocumentFormat.OpenXml.Office2010.Drawing.UseLocalDpi();
-                                useLocalDpiElement.AddNamespaceDeclaration("a14", "http://schemas.microsoft.com/office/drawing/2010/main");
-                                extension.Append(useLocalDpiElement);
-                            }
-                            useLocalDpiElement.Val = value.Value;
-                        }
+                    extension = new BlipExtension { Uri = "{28A0092B-C50C-407E-A947-70E740481C1C}" };
+                    extList.Append(extension);
+                }
+
+                var useLocalDpiElement = extension.GetFirstChild<DocumentFormat.OpenXml.Office2010.Drawing.UseLocalDpi>();
+                if (value == null) {
+                    useLocalDpiElement?.Remove();
+                } else {
+                    if (useLocalDpiElement == null) {
+                        useLocalDpiElement = new DocumentFormat.OpenXml.Office2010.Drawing.UseLocalDpi();
+                        useLocalDpiElement.AddNamespaceDeclaration("a14", "http://schemas.microsoft.com/office/drawing/2010/main");
+                        extension.Append(useLocalDpiElement);
                     }
+                    useLocalDpiElement.Val = value.Value;
                 }
             }
         }
@@ -1135,13 +1138,14 @@ namespace OfficeIMO.Word {
                 if (pic == null) return;
                 var nvp = pic.NonVisualPictureProperties ?? (pic.NonVisualPictureProperties = new Pic.NonVisualPictureProperties());
                 var nv = nvp.NonVisualPictureDrawingProperties;
-                if (nv == null && value != null) {
+                if (nv == null) {
+                    if (value == null) {
+                        return;
+                    }
                     nv = new Pic.NonVisualPictureDrawingProperties();
                     nvp.Append(nv);
                 }
-                if (nv != null) {
-                    nv.PreferRelativeResize = value;
-                }
+                nv.PreferRelativeResize = value;
             }
         }
 

--- a/OfficeIMO.Word/WordImage.cs
+++ b/OfficeIMO.Word/WordImage.cs
@@ -127,25 +127,7 @@ namespace OfficeIMO.Word {
         /// <summary>
         /// Gets the relationship id of the embedded image.
         /// </summary>
-        public string? RelationshipId {
-            get {
-                if (_Image.Inline != null) {
-                    var picture = _Image.Inline?.Graphic?.GraphicData?.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
-                    return picture?.BlipFill?.Blip?.Embed;
-                }
-
-                var anchor = _Image.Anchor;
-                if (anchor != null) {
-                    var anchorGraphic = anchor.OfType<Graphic>().FirstOrDefault();
-                    if (anchorGraphic?.GraphicData != null) {
-                        var picture = anchorGraphic.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
-                        return picture?.BlipFill?.Blip?.Embed;
-                    }
-                }
-
-                return null;
-            }
-        }
+        public string? RelationshipId => GetBlip()?.Embed?.Value;
 
         /// <summary>
         /// Gets the relationship id of an externally linked image, if any.
@@ -178,41 +160,12 @@ namespace OfficeIMO.Word {
         /// Get or sets the image's file name
         /// </summary>
         public string? FileName {
-            get {
-                if (_Image.Inline != null) {
-                    var picture = _Image.Inline?.Graphic?.GraphicData?.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
-                    return picture?.NonVisualPictureProperties?.NonVisualDrawingProperties?.Name;
-                }
-
-                var anchor = _Image.Anchor;
-                if (anchor != null) {
-                    var anchorGraphic = anchor.OfType<Graphic>().FirstOrDefault();
-                    if (anchorGraphic?.GraphicData != null) {
-                        var picture = anchorGraphic.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
-                        return picture?.NonVisualPictureProperties?.NonVisualDrawingProperties?.Name;
-                    }
-                }
-
-                return null;
-            }
+            get => GetPicture()?.NonVisualPictureProperties?.NonVisualDrawingProperties?.Name;
             set {
                 if (value == null) throw new ArgumentNullException(nameof(value));
-                if (_Image.Inline != null) {
-                    var picture = _Image.Inline?.Graphic?.GraphicData?.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
-                    if (picture?.NonVisualPictureProperties?.NonVisualDrawingProperties != null) {
-                        picture.NonVisualPictureProperties.NonVisualDrawingProperties.Name = value;
-                    }
-                } else {
-                    var anchor = _Image.Anchor;
-                    if (anchor != null) {
-                        var anchorGraphic = anchor.OfType<Graphic>().FirstOrDefault();
-                        if (anchorGraphic?.GraphicData != null) {
-                            var picture = anchorGraphic.GraphicData.GetFirstChild<DocumentFormat.OpenXml.Drawing.Pictures.Picture>();
-                            if (picture?.NonVisualPictureProperties?.NonVisualDrawingProperties != null) {
-                                picture.NonVisualPictureProperties.NonVisualDrawingProperties.Name = value;
-                            }
-                        }
-                    }
+                var drawingProperties = GetPicture()?.NonVisualPictureProperties?.NonVisualDrawingProperties;
+                if (drawingProperties != null) {
+                    drawingProperties.Name = value;
                 }
             }
         }
@@ -221,35 +174,8 @@ namespace OfficeIMO.Word {
         /// Gets or sets the image's description.
         /// </summary>
         public string? Description {
-            get {
-
-                if (_Image.Inline != null) {
-                    return _Image.Inline.DocProperties?.Description;
-
-                }
-
-                var anchor = _Image.Anchor;
-                if (anchor != null) {
-                    var anchoDocPropertiesr = anchor.OfType<DocProperties>().FirstOrDefault();
-                    return anchoDocPropertiesr?.Description;
-                }
-
-                return null;
-            }
-            set {
-                if (_Image.Inline != null) {
-                    if (_Image.Inline.DocProperties == null) _Image.Inline.DocProperties = new DocProperties();
-                    _Image.Inline.DocProperties.Description = value;
-                } else {
-                    var anchor = _Image.Anchor;
-                    if (anchor != null) {
-                        var anchoDocPropertiesr = anchor.OfType<DocProperties>().FirstOrDefault();
-                        if (anchoDocPropertiesr != null) {
-                            anchoDocPropertiesr.Description = value;
-                        }
-                    }
-                }
-            }
+            get => GetDocProperties()?.Description;
+            set => GetWritableDocProperties()?.Description = value;
         }
 
         /// <summary>
@@ -257,36 +183,15 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? Title {
             get {
-                if (_Image.Inline != null) {
-                    _title = _Image.Inline.DocProperties?.Title;
-                } else {
-                    var anchor = _Image.Anchor;
-                    if (anchor != null) {
-                        var docProp = anchor.OfType<DocProperties>().FirstOrDefault();
-                        _title = docProp?.Title;
-                    }
-                }
+                _title = GetDocProperties()?.Title;
                 return _title;
             }
             set {
                 _title = value;
-                if (_Image.Inline != null) {
-                    if (_Image.Inline.DocProperties == null) _Image.Inline.DocProperties = new DocProperties();
-                    _Image.Inline.DocProperties.Title = value;
-                } else {
-                    var anchor = _Image.Anchor;
-                    if (anchor != null) {
-                        var docProp = anchor.OfType<DocProperties>().FirstOrDefault();
-                        if (docProp != null) docProp.Title = value;
-                    }
-                }
-                var pic = GetPicture();
-                if (pic != null) {
-                    var nv = pic.NonVisualPictureProperties;
-                    var nvd = nv?.NonVisualDrawingProperties;
-                    if (nvd != null) {
-                        nvd.Title = value;
-                    }
+                GetWritableDocProperties()?.Title = value;
+                var drawingProperties = GetPicture()?.NonVisualPictureProperties?.NonVisualDrawingProperties;
+                if (drawingProperties != null) {
+                    drawingProperties.Title = value;
                 }
             }
         }
@@ -296,37 +201,15 @@ namespace OfficeIMO.Word {
         /// </summary>
         public bool? Hidden {
             get {
-                if (_Image.Inline != null) {
-                    _hidden = _Image.Inline.DocProperties?.Hidden?.Value;
-                } else {
-                    var anchor = _Image.Anchor;
-                    if (anchor != null) {
-                        var docProp = anchor.OfType<DocProperties>().FirstOrDefault();
-                        _hidden = docProp?.Hidden?.Value;
-                    }
-                }
+                _hidden = GetDocProperties()?.Hidden?.Value;
                 return _hidden;
             }
             set {
                 _hidden = value;
-                if (_Image.Inline != null) {
-                    if (_Image.Inline.DocProperties == null) _Image.Inline.DocProperties = new DocProperties();
-                    _Image.Inline.DocProperties.Hidden = value;
-                } else {
-                    var anchor = _Image.Anchor;
-                    if (anchor != null) {
-                        var docProp = anchor.OfType<DocProperties>().FirstOrDefault();
-                        if (docProp != null) docProp.Hidden = value;
-                    }
-                }
-                var pic = GetPicture();
-                if (pic != null) {
-                    var nv = pic.NonVisualPictureProperties;
-                    var nvd = nv?.NonVisualPictureDrawingProperties;
-                    var nvdProps = nv?.NonVisualDrawingProperties;
-                    if (nvdProps != null) {
-                        nvdProps.Hidden = value;
-                    }
+                GetWritableDocProperties()?.Hidden = value;
+                var drawingProperties = GetPicture()?.NonVisualPictureProperties?.NonVisualDrawingProperties;
+                if (drawingProperties != null) {
+                    drawingProperties.Hidden = value;
                 }
             }
         }
@@ -673,6 +556,23 @@ namespace OfficeIMO.Word {
             }
 
             return null;
+        }
+
+        private DocProperties? GetDocProperties() {
+            if (_Image.Inline != null) {
+                return _Image.Inline.DocProperties;
+            }
+
+            return _Image.Anchor?.OfType<DocProperties>().FirstOrDefault();
+        }
+
+        private DocProperties? GetWritableDocProperties() {
+            if (_Image.Inline != null) {
+                _Image.Inline.DocProperties ??= new DocProperties();
+                return _Image.Inline.DocProperties;
+            }
+
+            return _Image.Anchor?.OfType<DocProperties>().FirstOrDefault();
         }
 
         private void SetPicture(Pic.Picture picture) {

--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -223,7 +223,9 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="document">Document whose settings are managed.</param>
         public WordSettings(WordDocument document) {
-            ArgumentNullException.ThrowIfNull(document);
+            if (document == null) {
+                throw new ArgumentNullException(nameof(document));
+            }
             if (document.FileOpenAccess != FileAccess.Read) {
                 var mainPart = document._wordprocessingDocument.MainDocumentPart;
                 if (mainPart == null) {

--- a/OfficeIMO.Word/WordSettings.cs
+++ b/OfficeIMO.Word/WordSettings.cs
@@ -223,7 +223,7 @@ namespace OfficeIMO.Word {
         /// </summary>
         /// <param name="document">Document whose settings are managed.</param>
         public WordSettings(WordDocument document) {
-            _ = document ?? throw new ArgumentNullException(nameof(document));
+            ArgumentNullException.ThrowIfNull(document);
             if (document.FileOpenAccess != FileAccess.Read) {
                 var mainPart = document._wordprocessingDocument.MainDocumentPart;
                 if (mainPart == null) {

--- a/OfficeIMO.Word/WordTable.cs
+++ b/OfficeIMO.Word/WordTable.cs
@@ -450,7 +450,7 @@ namespace OfficeIMO.Word {
 
             if (initializeChildren) {
                 foreach (TableRow row in table.ChildElements.OfType<TableRow>().ToList()) {
-                    _ = new WordTableRow(this, row, document);
+                    new WordTableRow(this, row, document);
                 }
             }
 

--- a/OfficeIMO.Word/WordTableOfContent.cs
+++ b/OfficeIMO.Word/WordTableOfContent.cs
@@ -186,7 +186,7 @@ namespace OfficeIMO.Word {
 
         internal void QueueUpdateOnOpen(bool force = false) {
             if (force) {
-                _ = MarkFieldsAsDirty();
+                MarkFieldsAsDirty();
             } else if (!MarkFieldsAsDirty()) {
                 return;
             }

--- a/OfficeIMO.Word/WordTableRow.cs
+++ b/OfficeIMO.Word/WordTableRow.cs
@@ -178,7 +178,7 @@ namespace OfficeIMO.Word {
 
             if (initializeCells) {
                 foreach (TableCell cell in row.ChildElements.OfType<TableCell>()) {
-                    _ = new WordTableCell(document, wordTable, this, cell);
+                    new WordTableCell(document, wordTable, this, cell);
                 }
             }
         }

--- a/OfficeIMO.Word/WordTextBox.cs
+++ b/OfficeIMO.Word/WordTextBox.cs
@@ -82,18 +82,18 @@ namespace OfficeIMO.Word {
         /// </summary>
         public List<WordParagraph> Paragraphs {
             get {
+                var content = GetTextBoxContent();
+                if (content == null) {
+                    return new List<WordParagraph>();
+                }
+
                 if (_textBoxInfo2 != null) {
-                    return _textBoxInfo2.Descendants<Run>().Select(run => new WordParagraph(_document, _paragraph!, run)).ToList();
+                    return content.Descendants<Run>().Select(run => new WordParagraph(_document, _paragraph!, run)).ToList();
                 }
-                if (_vmlTextBox != null) {
-                    var content = _vmlTextBox.Descendants<DocumentFormat.OpenXml.Wordprocessing.TextBoxContent>().FirstOrDefault();
-                    if (content != null) {
-                        return content.Descendants<Run>()
-                            .Select(run => new WordParagraph(_document, run.Ancestors<Paragraph>().FirstOrDefault()!, run))
-                            .ToList();
-                    }
-                }
-                return new List<WordParagraph>();
+
+                return content.Descendants<Run>()
+                    .Select(run => new WordParagraph(_document, run.Ancestors<Paragraph>().FirstOrDefault()!, run))
+                    .ToList();
             }
         }
         /// <summary>
@@ -105,24 +105,11 @@ namespace OfficeIMO.Word {
         /// Gets or sets horizontal relative position of the text box
         /// </summary>
         public HorizontalRelativePositionValues? HorizontalPositionRelativeFrom {
-            get {
-                var anchor = _anchor;
-                if (anchor != null) {
-                    var horizontalPosition = anchor.HorizontalPosition;
-                    if (horizontalPosition != null) {
-                        return horizontalPosition.RelativeFrom?.Value;
-                    }
-                }
-
-                return null;
-            }
+            get => _anchor?.HorizontalPosition?.RelativeFrom?.Value;
             set {
-                var anchor = _anchor;
-                if (anchor != null) {
-                    var horizontalPosition = anchor.HorizontalPosition;
-                    if (horizontalPosition != null && value.HasValue) {
-                        horizontalPosition.RelativeFrom = value.Value;
-                    }
+                var horizontalPosition = _anchor?.HorizontalPosition;
+                if (horizontalPosition != null && value.HasValue) {
+                    horizontalPosition.RelativeFrom = value.Value;
                 }
             }
         }
@@ -140,31 +127,30 @@ namespace OfficeIMO.Word {
         /// </summary>
         public WordHorizontalAlignmentValues HorizontalAlignment {
             get {
-                var anchor = _anchor;
-                if (anchor != null) {
-                    var horizontalPosition = anchor.HorizontalPosition;
-                    if (horizontalPosition != null && horizontalPosition.HorizontalAlignment != null) {
-                        return HorizontalAlignmentHelper.FromString(horizontalPosition.HorizontalAlignment.Text);
-                    }
+                var alignmentText = _anchor?.HorizontalPosition?.HorizontalAlignment?.Text;
+                if (alignmentText != null) {
+                    return HorizontalAlignmentHelper.FromString(alignmentText);
                 }
+
                 return WordHorizontalAlignmentValues.Center;
             }
             set {
                 var anchor = _anchor;
-                if (anchor != null) {
-                    HorizontalPosition? horizontalPosition = anchor.HorizontalPosition;
-                    if (horizontalPosition == null) {
-                        horizontalPosition = AddHorizontalPosition(anchor, true);
-                    }
-                    if (horizontalPosition != null) {
-                        if (horizontalPosition.HorizontalAlignment == null) {
-                            horizontalPosition.HorizontalAlignment = new DrawingHorizontalAlignment() {
-                                Text = HorizontalAlignmentHelper.ToString(value)
-                            };
-                        } else {
-                            horizontalPosition.HorizontalAlignment.Text = HorizontalAlignmentHelper.ToString(value);
-                        }
-                    }
+                if (anchor == null) {
+                    return;
+                }
+
+                var horizontalPosition = anchor.HorizontalPosition ?? AddHorizontalPosition(anchor);
+                if (horizontalPosition == null) {
+                    return;
+                }
+
+                if (horizontalPosition.HorizontalAlignment == null) {
+                    horizontalPosition.HorizontalAlignment = new DrawingHorizontalAlignment() {
+                        Text = HorizontalAlignmentHelper.ToString(value)
+                    };
+                } else {
+                    horizontalPosition.HorizontalAlignment.Text = HorizontalAlignmentHelper.ToString(value);
                 }
             }
         }
@@ -173,23 +159,11 @@ namespace OfficeIMO.Word {
         /// Gets or sets the relative4 vertical alignment of the text box
         /// </summary>
         public VerticalRelativePositionValues VerticalPositionRelativeFrom {
-            get {
-                var anchor = _anchor;
-                if (anchor != null) {
-                    var verticalPosition = anchor.VerticalPosition;
-                    if (verticalPosition != null) {
-                        return verticalPosition.RelativeFrom?.Value ?? VerticalRelativePositionValues.Page;
-                    }
-                }
-                return VerticalRelativePositionValues.Page;
-            }
+            get => _anchor?.VerticalPosition?.RelativeFrom?.Value ?? VerticalRelativePositionValues.Page;
             set {
-                var anchor = _anchor;
-                if (anchor != null) {
-                    var verticalPosition = anchor.VerticalPosition;
-                    if (verticalPosition != null) {
-                        verticalPosition.RelativeFrom = value;
-                    }
+                var verticalPosition = _anchor?.VerticalPosition;
+                if (verticalPosition != null) {
+                    verticalPosition.RelativeFrom = value;
                 }
             }
         }
@@ -199,24 +173,15 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? VerticalPositionOffset {
             get {
-                var anchor = _anchor;
-                if (anchor != null) {
-                    var verticalPosition = anchor.VerticalPosition;
-                    if (verticalPosition?.PositionOffset?.Text != null && int.TryParse(verticalPosition.PositionOffset.Text, out var parsed)) {
-                        return parsed;
-                    }
-                }
-
-                return null;
+                var positionOffset = _anchor?.VerticalPosition?.PositionOffset?.Text;
+                return int.TryParse(positionOffset, out var parsed) ? parsed : null;
             }
             set {
                 var anchor = _anchor;
-                if (anchor != null) {
-                    var verticalPosition = AddVerticalPosition(anchor, true);
-                    if (verticalPosition != null && value.HasValue) {
-                        verticalPosition.PositionOffset ??= new PositionOffset();
-                        verticalPosition.PositionOffset.Text = value.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
-                    }
+                var verticalPosition = anchor == null ? null : AddVerticalPosition(anchor, true);
+                if (verticalPosition != null && value.HasValue) {
+                    verticalPosition.PositionOffset ??= new PositionOffset();
+                    verticalPosition.PositionOffset.Text = value.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
                 }
             }
         }
@@ -227,23 +192,15 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? HorizontalPositionOffset {
             get {
-                var anchor = _anchor;
-                if (anchor != null) {
-                    var horizontalPosition = anchor.HorizontalPosition;
-                    if (horizontalPosition?.PositionOffset?.Text != null && int.TryParse(horizontalPosition.PositionOffset.Text, out var px)) {
-                        return px;
-                    }
-                }
-                return null;
+                var positionOffset = _anchor?.HorizontalPosition?.PositionOffset?.Text;
+                return int.TryParse(positionOffset, out var parsed) ? parsed : null;
             }
             set {
                 var anchor = _anchor;
-                if (anchor != null) {
-                    var horizontalPosition = AddHorizontalPosition(anchor, true);
-                    if (horizontalPosition != null && value.HasValue) {
-                        horizontalPosition.PositionOffset ??= new PositionOffset();
-                        horizontalPosition.PositionOffset.Text = value.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
-                    }
+                var horizontalPosition = anchor == null ? null : AddHorizontalPosition(anchor, true);
+                if (horizontalPosition != null && value.HasValue) {
+                    horizontalPosition.PositionOffset ??= new PositionOffset();
+                    horizontalPosition.PositionOffset.Text = value.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
                 }
             }
         }
@@ -252,15 +209,9 @@ namespace OfficeIMO.Word {
         /// Allows to set horizontally position of the text box in centimeters
         /// </summary>
         public double? HorizontalPositionOffsetCentimeters {
-            get {
-                if (HorizontalPositionOffset != null) {
-                    return Helpers.ConvertEmusToCentimeters(HorizontalPositionOffset.Value);
-                }
-
-                return null;
-            }
+            get => HorizontalPositionOffset.HasValue ? Helpers.ConvertEmusToCentimeters(HorizontalPositionOffset.Value) : null;
             set {
-                if (value != null) {
+                if (value.HasValue) {
                     HorizontalPositionOffset = Helpers.ConvertCentimetersToEmus(value.Value);
                 }
             }
@@ -270,16 +221,10 @@ namespace OfficeIMO.Word {
         /// Allows to set vertically position of the text box in centimeters
         /// </summary>
         public double? VerticalPositionOffsetCentimeters {
-            get {
-                if (VerticalPositionOffset != null) {
-                    return Helpers.ConvertEmusToCentimeters(VerticalPositionOffset.Value);
-                }
-
-                return null;
-            }
+            get => VerticalPositionOffset.HasValue ? Helpers.ConvertEmusToCentimeters(VerticalPositionOffset.Value) : null;
 
             set {
-                if (value != null) {
+                if (value.HasValue) {
                     VerticalPositionOffset = Helpers.ConvertCentimetersToEmus(value.Value);
                 }
             }
@@ -290,44 +235,36 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? RelativeWidthPercentage {
             get {
-                var anchor = _anchor;
-                if (anchor != null) {
-                    var relativeWidth = anchor.ChildElements.OfType<DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth>().FirstOrDefault();
-                    if (relativeWidth != null) {
-                        if (relativeWidth.PercentageWidth != null) {
-                            return int.Parse(relativeWidth.PercentageWidth.Text) / 1000;
-                        }
-                    }
+                var percentageWidth = _anchor?
+                    .ChildElements.OfType<DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth>()
+                    .FirstOrDefault()?
+                    .PercentageWidth?.Text;
+                if (percentageWidth != null) {
+                    return int.Parse(percentageWidth) / 1000;
                 }
+
                 return null;
             }
             set {
                 var anchor = _anchor;
-                if (anchor != null) {
-                    if (value != null) {
-                        var setValue = value.Value * 1000;
-
-                        var relativeWidth = anchor.ChildElements.OfType<DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth>().FirstOrDefault();
-                        if (relativeWidth == null) {
-                            relativeWidth = new DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth() {
-                                PercentageWidth = new DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentageWidth() {
-                                    Text = setValue.ToString()
-                                }
-                            };
-                            anchor.Append(relativeWidth);
-                        } else {
-                            if (relativeWidth.PercentageWidth == null) {
-                                relativeWidth.PercentageWidth = new DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentageWidth() {
-                                    Text = setValue.ToString()
-                                };
-                            } else {
-                                relativeWidth.PercentageWidth.Text = setValue.ToString();
-                            }
-                        }
-                    } else {
-                        // value is null
-                    }
+                if (anchor == null || value == null) {
+                    return;
                 }
+
+                var setValue = value.Value * 1000;
+                var relativeWidth = anchor.ChildElements.OfType<DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth>().FirstOrDefault();
+                if (relativeWidth == null) {
+                    relativeWidth = new DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth() {
+                        PercentageWidth = new DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentageWidth() {
+                            Text = setValue.ToString()
+                        }
+                    };
+                    anchor.Append(relativeWidth);
+                    return;
+                }
+
+                relativeWidth.PercentageWidth ??= new DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentageWidth();
+                relativeWidth.PercentageWidth.Text = setValue.ToString();
             }
         }
 
@@ -336,44 +273,36 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? RelativeHeightPercentage {
             get {
-                var anchor = _anchor;
-                if (anchor != null) {
-                    var relativeHeight = anchor.ChildElements.OfType<DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeHeight>().FirstOrDefault();
-                    if (relativeHeight != null) {
-                        if (relativeHeight.PercentageHeight != null) {
-                            return int.Parse(relativeHeight.PercentageHeight.Text) / 1000;
-                        }
-                    }
+                var percentageHeight = _anchor?
+                    .ChildElements.OfType<DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeHeight>()
+                    .FirstOrDefault()?
+                    .PercentageHeight?.Text;
+                if (percentageHeight != null) {
+                    return int.Parse(percentageHeight) / 1000;
                 }
+
                 return null;
             }
             set {
                 var anchor = _anchor;
-                if (anchor != null) {
-                    if (value != null) {
-                        var setValue = value.Value * 1000;
-
-                        var relativeHeight = anchor.ChildElements.OfType<DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeHeight>().FirstOrDefault();
-                        if (relativeHeight == null) {
-                            relativeHeight = new DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeHeight() {
-                                PercentageHeight = new DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentageHeight() {
-                                    Text = setValue.ToString()
-                                }
-                            };
-                            anchor.Append(relativeHeight);
-                        } else {
-                            if (relativeHeight.PercentageHeight == null) {
-                                relativeHeight.PercentageHeight = new DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentageHeight() {
-                                    Text = setValue.ToString()
-                                };
-                            } else {
-                                relativeHeight.PercentageHeight.Text = setValue.ToString();
-                            }
-                        }
-                    } else {
-                        // value is null
-                    }
+                if (anchor == null || value == null) {
+                    return;
                 }
+
+                var setValue = value.Value * 1000;
+                var relativeHeight = anchor.ChildElements.OfType<DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeHeight>().FirstOrDefault();
+                if (relativeHeight == null) {
+                    relativeHeight = new DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeHeight() {
+                        PercentageHeight = new DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentageHeight() {
+                            Text = setValue.ToString()
+                        }
+                    };
+                    anchor.Append(relativeHeight);
+                    return;
+                }
+
+                relativeHeight.PercentageHeight ??= new DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentageHeight();
+                relativeHeight.PercentageHeight.Text = setValue.ToString();
             }
         }
 
@@ -438,18 +367,10 @@ namespace OfficeIMO.Word {
         /// Sets size relative horizontally
         /// </summary>
         public DocumentFormat.OpenXml.Office2010.Word.Drawing.SizeRelativeHorizontallyValues? SizeRelativeHorizontally {
-            get {
-                var anchor = _anchor;
-                if (anchor != null) {
-                    var relativeWidth = anchor.ChildElements.OfType<DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth>().FirstOrDefault();
-                    if (relativeWidth != null) {
-                        if (relativeWidth.ObjectId != null) {
-                            return relativeWidth.ObjectId;
-                        }
-                    }
-                }
-                return null;
-            }
+            get => _anchor?
+                .ChildElements.OfType<DocumentFormat.OpenXml.Office2010.Word.Drawing.RelativeWidth>()
+                .FirstOrDefault()?
+                .ObjectId?.Value;
             set {
 
             }
@@ -459,31 +380,14 @@ namespace OfficeIMO.Word {
         /// Width of the text box
         /// </summary>
         public Int64 Width {
-            get {
-                long result = 0L;
-                var anchor = _anchor;
-                if (anchor != null) {
-                    var extent = anchor.ChildElements.OfType<Extent>().FirstOrDefault();
-                    if (extent?.Cx?.HasValue == true) {
-                        result = extent.Cx.Value;
-                    }
-                }
-                return result;
-            }
+            get => _anchorExtent?.Cx?.Value ?? 0L;
             set {
                 var anchor = _anchor;
-                if (anchor != null) {
-                    var extent = anchor.ChildElements.OfType<DocumentFormat.OpenXml.Drawing.Wordprocessing.Extent>().FirstOrDefault();
-                    if (extent == null) {
-                        extent = new DocumentFormat.OpenXml.Drawing.Wordprocessing.Extent() {
-                            Cx = value,
-                            Cy = 0L
-                        };
-                        anchor.Append(extent);
-                    } else {
-                        extent.Cx = value;
-                    }
+                if (anchor == null) {
+                    return;
                 }
+
+                EnsureAnchorExtent(anchor, cx: value, cy: 0L).Cx = value;
             }
         }
 
@@ -491,31 +395,14 @@ namespace OfficeIMO.Word {
         /// Height of the text box
         /// </summary>
         public Int64 Height {
-            get {
-                long result = 0L;
-                var anchor = _anchor;
-                if (anchor != null) {
-                    var extent = anchor.ChildElements.OfType<DocumentFormat.OpenXml.Drawing.Wordprocessing.Extent>().FirstOrDefault();
-                    if (extent?.Cy?.HasValue == true) {
-                        result = extent.Cy.Value;
-                    }
-                }
-                return result;
-            }
+            get => _anchorExtent?.Cy?.Value ?? 0L;
             set {
                 var anchor = _anchor;
-                if (anchor != null) {
-                    var extent = anchor.ChildElements.OfType<DocumentFormat.OpenXml.Drawing.Wordprocessing.Extent>().FirstOrDefault();
-                    if (extent == null) {
-                        extent = new DocumentFormat.OpenXml.Drawing.Wordprocessing.Extent() {
-                            Cx = 0L,
-                            Cy = value
-                        };
-                        anchor.Append(extent);
-                    } else {
-                        extent.Cy = value;
-                    }
+                if (anchor == null) {
+                    return;
                 }
+
+                EnsureAnchorExtent(anchor, cx: 0L, cy: value).Cy = value;
             }
         }
 
@@ -545,59 +432,15 @@ namespace OfficeIMO.Word {
             }
         }
 
-        private Drawing? _drawing {
-            get {
-                AlternateContent? alternateContent = _run.ChildElements.OfType<AlternateContent>().FirstOrDefault();
-                if (alternateContent != null) {
-                    AlternateContentChoice? alternateContentChoice = alternateContent.ChildElements.OfType<AlternateContentChoice>().FirstOrDefault();
-                    if (alternateContentChoice != null) {
-                        Drawing? drawing = alternateContentChoice.ChildElements.OfType<Drawing>().FirstOrDefault();
-                        if (drawing != null) {
-                            return drawing;
-                        }
-                    }
-                }
-                return null;
-            }
-        }
+        private AlternateContentChoice? _alternateContentChoice =>
+            _run.ChildElements.OfType<AlternateContent>().FirstOrDefault()?
+                .ChildElements.OfType<AlternateContentChoice>().FirstOrDefault();
 
-        private Inline? _inline {
-            get {
-                AlternateContent? alternateContent = _run.ChildElements.OfType<AlternateContent>().FirstOrDefault();
-                if (alternateContent != null) {
-                    AlternateContentChoice? alternateContentChoice = alternateContent.ChildElements.OfType<AlternateContentChoice>().FirstOrDefault();
-                    if (alternateContentChoice != null) {
-                        Drawing? drawing = alternateContentChoice.ChildElements.OfType<Drawing>().FirstOrDefault();
-                        if (drawing != null) {
-                            Inline? inline = drawing.Inline;
-                            if (inline != null) {
-                                return inline;
-                            }
-                        }
-                    }
-                }
-                return null;
-            }
-        }
+        private Drawing? _drawing => _alternateContentChoice?.ChildElements.OfType<Drawing>().FirstOrDefault();
 
-        private Anchor? _anchor {
-            get {
-                AlternateContent? alternateContent = _run.ChildElements.OfType<AlternateContent>().FirstOrDefault();
-                if (alternateContent != null) {
-                    AlternateContentChoice? alternateContentChoice = alternateContent.ChildElements.OfType<AlternateContentChoice>().FirstOrDefault();
-                    if (alternateContentChoice != null) {
-                        Drawing? drawing = alternateContentChoice.ChildElements.OfType<Drawing>().FirstOrDefault();
-                        if (drawing != null) {
-                            Anchor? anchor = drawing.Anchor;
-                            if (anchor != null) {
-                                return anchor;
-                            }
-                        }
-                    }
-                }
-                return null;
-            }
-        }
+        private Inline? _inline => _drawing?.Inline;
+
+        private Anchor? _anchor => _drawing?.Anchor;
 
         internal static Anchor ConvertInlineToAnchor(Inline inline, WrapTextImage wrapTextImage) {
             Anchor anchor1 = new Anchor() { DistanceFromTop = (UInt32Value)91440U, DistanceFromBottom = (UInt32Value)91440U, DistanceFromLeft = (UInt32Value)114300U, DistanceFromRight = (UInt32Value)114300U, SimplePos = false, RelativeHeight = (UInt32Value)251659264U, BehindDoc = false, Locked = false, LayoutInCell = true, AllowOverlap = true, EditId = "39C62DE8", AnchorId = "3E379294" };
@@ -662,83 +505,28 @@ namespace OfficeIMO.Word {
 
             inline1.Append(extent1);
             inline1.Append(effectExtent1);
-            if (docProperties1 != null) inline1.Append(docProperties1);
-            if (nonVisualGraphicFrameDrawingProperties1 != null) inline1.Append(nonVisualGraphicFrameDrawingProperties1);
-            if (graphic1 != null) inline1.Append(graphic1);
+            inline1.Append(docProperties1);
+            inline1.Append(nonVisualGraphicFrameDrawingProperties1);
+            inline1.Append(graphic1);
 
             return inline1;
         }
 
-        private DocumentFormat.OpenXml.Drawing.GraphicData? _graphicData {
-            get {
-                Anchor? anchor = _anchor;
-                if (anchor != null) {
-                    DocumentFormat.OpenXml.Drawing.Graphic? graphic = anchor.ChildElements.OfType<DocumentFormat.OpenXml.Drawing.Graphic>().FirstOrDefault();
-                    if (graphic != null) {
-                        return graphic.GraphicData;
-                    }
-                }
-                return null;
-            }
-        }
+        private DocumentFormat.OpenXml.Drawing.GraphicData? _graphicData =>
+            _anchor?.ChildElements.OfType<DocumentFormat.OpenXml.Drawing.Graphic>().FirstOrDefault()?.GraphicData;
 
-        private DocumentFormat.OpenXml.Office2010.Word.DrawingShape.WordprocessingShape? _wordprocessingShape {
-            get {
-                var graphicData = _graphicData;
-                if (graphicData != null) {
-                    DocumentFormat.OpenXml.Office2010.Word.DrawingShape.WordprocessingShape? wsp = graphicData.GetFirstChild<DocumentFormat.OpenXml.Office2010.Word.DrawingShape.WordprocessingShape>();
-                    if (wsp != null) {
-                        return wsp;
-                    }
-                }
-                return null;
-            }
-        }
+        private Extent? _anchorExtent => _anchor?.ChildElements.OfType<Extent>().FirstOrDefault();
 
-        private TextBoxInfo2? _textBoxInfo2 {
-            get {
-                var wordprocessingShape = _wordprocessingShape;
-                if (wordprocessingShape != null) {
-                    DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2? textBoxInfo = wordprocessingShape.GetFirstChild<DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2>();
-                    if (textBoxInfo != null) {
-                        return textBoxInfo;
-                    }
-                }
-                return null;
-            }
-        }
+        private DocumentFormat.OpenXml.Office2010.Word.DrawingShape.WordprocessingShape? _wordprocessingShape =>
+            _graphicData?.GetFirstChild<DocumentFormat.OpenXml.Office2010.Word.DrawingShape.WordprocessingShape>();
 
-        private Paragraph? _paragraph {
-            get {
-                var wordprocessingShape = _wordprocessingShape;
-                if (wordprocessingShape != null) {
-                    DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2? textBoxInfo = wordprocessingShape.GetFirstChild<DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2>();
-                    if (textBoxInfo != null) {
-                        DocumentFormat.OpenXml.Wordprocessing.TextBoxContent? textBoxContent = textBoxInfo.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.TextBoxContent>();
-                        if (textBoxContent != null) {
-                            Paragraph? sdtBlock = textBoxContent.GetFirstChild<Paragraph>();
-                            if (sdtBlock != null) {
-                                return sdtBlock;
-                            }
-                        }
-                    }
-                }
-                return null;
-            }
-        }
+        private TextBoxInfo2? _textBoxInfo2 =>
+            _wordprocessingShape?.GetFirstChild<DocumentFormat.OpenXml.Office2010.Word.DrawingShape.TextBoxInfo2>();
 
-        private SdtContentBlock? _sdtContentBlock {
-            get {
-                var sdtBlock = _paragraph;
-                if (sdtBlock != null) {
-                    SdtContentBlock? sdtContentBlock = sdtBlock.GetFirstChild<SdtContentBlock>();
-                    if (sdtContentBlock != null) {
-                        return sdtContentBlock;
-                    }
-                }
-                return null;
-            }
-        }
+        private Paragraph? _paragraph =>
+            _textBoxInfo2?.GetFirstChild<DocumentFormat.OpenXml.Wordprocessing.TextBoxContent>()?.GetFirstChild<Paragraph>();
+
+        private SdtContentBlock? _sdtContentBlock => _paragraph?.GetFirstChild<SdtContentBlock>();
 
         private List<WordElement> GetWordElements() {
             var elements = new List<WordElement>();
@@ -774,30 +562,43 @@ namespace OfficeIMO.Word {
             return null;
         }
 
-        private VerticalPosition? AddVerticalPosition(Anchor? anchor, bool expectedPositionOffset = false) {
-            if (anchor != null) {
-                var verticalPosition = anchor.VerticalPosition;
-                if (verticalPosition == null) {
-                    anchor.VerticalPosition = new VerticalPosition() {
-                        RelativeFrom = VerticalRelativePositionValues.Page,
-                        VerticalAlignment = new DrawingVerticalAlignment() {
-                            Text = "top"
-                        }
-                    };
-                    verticalPosition = anchor.VerticalPosition;
-                }
-
-                if (expectedPositionOffset) {
-                    var positionOffset = verticalPosition.PositionOffset;
-                    if (positionOffset == null) {
-                        verticalPosition.PositionOffset = new PositionOffset() {
-                            Text = "0"
-                        };
-                    }
-                }
-                return verticalPosition;
+        private static Extent EnsureAnchorExtent(Anchor anchor, long cx, long cy) {
+            var extent = anchor.ChildElements.OfType<Extent>().FirstOrDefault();
+            if (extent != null) {
+                return extent;
             }
-            return null;
+
+            extent = new Extent() {
+                Cx = cx,
+                Cy = cy
+            };
+            anchor.Append(extent);
+            return extent;
+        }
+
+        private VerticalPosition? AddVerticalPosition(Anchor? anchor, bool expectedPositionOffset = false) {
+            if (anchor == null) {
+                return null;
+            }
+
+            var verticalPosition = anchor.VerticalPosition;
+            if (verticalPosition == null) {
+                anchor.VerticalPosition = new VerticalPosition() {
+                    RelativeFrom = VerticalRelativePositionValues.Page,
+                    VerticalAlignment = new DrawingVerticalAlignment() {
+                        Text = "top"
+                    }
+                };
+                verticalPosition = anchor.VerticalPosition;
+            }
+
+            if (expectedPositionOffset && verticalPosition.PositionOffset == null) {
+                verticalPosition.PositionOffset = new PositionOffset() {
+                    Text = "0"
+                };
+            }
+
+            return verticalPosition;
         }
 
         /// <summary>
@@ -807,39 +608,41 @@ namespace OfficeIMO.Word {
         /// <param name="expectedPositionOffset"></param>
         /// <returns></returns>
         private HorizontalPosition? AddHorizontalPosition(Anchor? anchor, bool expectedPositionOffset = false) {
-            if (anchor != null) {
-                var horizontalPosition = anchor.HorizontalPosition;
-                if (horizontalPosition == null && expectedPositionOffset) {
-                    // position offset and horizontal alignment don't play together
-                    anchor.HorizontalPosition = new HorizontalPosition() {
-                        RelativeFrom = HorizontalRelativePositionValues.Page,
-                    };
-                    horizontalPosition = anchor.HorizontalPosition;
-                } else if (horizontalPosition == null) {
-                    anchor.HorizontalPosition = new HorizontalPosition() {
-                        RelativeFrom = HorizontalRelativePositionValues.Page,
-                        HorizontalAlignment = new DrawingHorizontalAlignment() {
-                            Text = "center"
-                        }
-                    };
-                    horizontalPosition = anchor.HorizontalPosition;
-                }
-                if (expectedPositionOffset) {
-                    var positionOffset = horizontalPosition.PositionOffset;
-                    if (positionOffset == null) {
-                        positionOffset = new PositionOffset() {
-                            Text = "0"
-                        };
-                        horizontalPosition.Append(positionOffset);
-                    }
-                    // we need to remove horizontal alignment if we want to use position offset
-                    if (horizontalPosition.HorizontalAlignment != null) {
-                        horizontalPosition.HorizontalAlignment.Remove();
-                    }
-                }
-                return horizontalPosition;
+            if (anchor == null) {
+                return null;
             }
-            return null;
+
+            var horizontalPosition = anchor.HorizontalPosition;
+            if (horizontalPosition == null && expectedPositionOffset) {
+                // position offset and horizontal alignment don't play together
+                anchor.HorizontalPosition = new HorizontalPosition() {
+                    RelativeFrom = HorizontalRelativePositionValues.Page,
+                };
+                horizontalPosition = anchor.HorizontalPosition;
+            } else if (horizontalPosition == null) {
+                anchor.HorizontalPosition = new HorizontalPosition() {
+                    RelativeFrom = HorizontalRelativePositionValues.Page,
+                    HorizontalAlignment = new DrawingHorizontalAlignment() {
+                        Text = "center"
+                    }
+                };
+                horizontalPosition = anchor.HorizontalPosition;
+            }
+
+            if (expectedPositionOffset) {
+                var positionOffset = horizontalPosition.PositionOffset;
+                if (positionOffset == null) {
+                    positionOffset = new PositionOffset() {
+                        Text = "0"
+                    };
+                    horizontalPosition.Append(positionOffset);
+                }
+
+                // we need to remove horizontal alignment if we want to use position offset
+                horizontalPosition.HorizontalAlignment?.Remove();
+            }
+
+            return horizontalPosition;
         }
 
         private void AddAlternateContent(WordDocument wordDocument, WordParagraph wordParagraph, string text, WrapTextImage wrapTextImage) {
@@ -878,9 +681,9 @@ namespace OfficeIMO.Word {
 
             inline1.Append(extent1);
             inline1.Append(effectExtent1);
-            if (docProperties1 != null) inline1.Append(docProperties1);
-            if (nonVisualGraphicFrameDrawingProperties1 != null) inline1.Append(nonVisualGraphicFrameDrawingProperties1);
-            if (graphic1 != null) inline1.Append(graphic1);
+            inline1.Append(docProperties1);
+            inline1.Append(nonVisualGraphicFrameDrawingProperties1);
+            inline1.Append(graphic1);
 
             return inline1;
         }

--- a/OfficeIMO.Word/WordWatermark.cs
+++ b/OfficeIMO.Word/WordWatermark.cs
@@ -40,42 +40,11 @@ namespace OfficeIMO.Word {
         /// Gets or sets the watermark text.
         /// </summary>
         public string Text {
-            get {
-                var paragraph = _sdtBlock.SdtContentBlock?.ChildElements.OfType<Paragraph>().FirstOrDefault();
-                if (paragraph != null) {
-                    var run = paragraph.Descendants().OfType<Run>().FirstOrDefault();
-                    if (run != null) {
-                        var picture = run.Descendants().OfType<Picture>().FirstOrDefault();
-                        if (picture != null) {
-                            var shape = picture.Descendants().OfType<Shape>().FirstOrDefault();
-                            if (shape != null) {
-                                TextPath? textPath = shape.GetFirstChild<V.TextPath>();
-                                if (textPath != null) {
-                                    return textPath.String?.Value ?? string.Empty;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                return "";
-            }
+            get => _textPath?.String?.Value ?? string.Empty;
             set {
-                var paragraph = _sdtBlock.SdtContentBlock?.ChildElements.OfType<Paragraph>().FirstOrDefault();
-                if (paragraph != null) {
-                    var run = paragraph.Descendants().OfType<Run>().FirstOrDefault();
-                    if (run != null) {
-                        var picture = run.Descendants().OfType<Picture>().FirstOrDefault();
-                        if (picture != null) {
-                            var shape = picture.Descendants().OfType<Shape>().FirstOrDefault();
-                            if (shape != null) {
-                                TextPath? textPath = shape.GetFirstChild<V.TextPath>();
-                                if (textPath != null) {
-                                    textPath.String = value;
-                                }
-                            }
-                        }
-                    }
+                var textPath = _textPath;
+                if (textPath != null) {
+                    textPath.String = value;
                 }
             }
         }
@@ -85,37 +54,10 @@ namespace OfficeIMO.Word {
         /// </summary>
         public int? Rotation {
             get {
-                var shape = _shape;
-                if (shape != null) {
-
-                    // Style = "position:absolute;margin-left:0;margin-top:0;width:527.85pt;height:131.95pt;rotation:315;z-index:-251657216;mso-position-horizontal:center;mso-position-horizontal-relative:margin;mso-position-vertical:center;mso-position-vertical-relative:margin", OptionalString = "_x0000_s1025", AllowInCell = false, FillColor = "silver", Stroked = false, Type = "#_x0000_t136" };
-                    //
-                    var style = shape.Style?.Value;
-                    if (style != null) {
-                        var rotation = style.Split(';').FirstOrDefault(c => c.StartsWith("rotation:", StringComparison.Ordinal));
-                        if (rotation != null) {
-                            var rotationValue = rotation.Split(':').LastOrDefault();
-                            if (rotationValue != null) {
-                                return int.Parse(rotationValue);
-                            }
-                        }
-                    }
-                }
-                return null;
+                var rotationValue = GetShapeStyleComponent("rotation");
+                return rotationValue == null ? null : int.Parse(rotationValue);
             }
-            set {
-                var shape = _shape;
-                var style = shape?.Style?.Value;
-                if (shape?.Style != null && style != null) {
-                    var rotation = style.Split(';').FirstOrDefault(c => c.StartsWith("rotation:", StringComparison.Ordinal));
-                    if (rotation != null) {
-                        var rotationValue = rotation.Split(':').LastOrDefault();
-                        if (rotationValue != null) {
-                            shape.Style.Value = style.Replace(rotation, "rotation:" + value);
-                        }
-                    }
-                }
-            }
+            set => SetShapeStyleComponent("rotation", value?.ToString() ?? string.Empty);
         }
 
         /// <summary>
@@ -123,35 +65,15 @@ namespace OfficeIMO.Word {
         /// </summary>
         public double? Width {
             get {
-                var shape = _shape;
-                if (shape != null) {
-                    var style = shape.Style?.Value;
-                    if (style != null) {
-                        var width = style.Split(';').FirstOrDefault(c => c.StartsWith("width:", StringComparison.Ordinal));
-                        if (width != null) {
-                            var widthValue = width.Split(':').LastOrDefault();
-                            if (widthValue != null) {
-                                string stringValue = widthValue.Replace("pt", "");
-                                return double.Parse(stringValue, CultureInfo.InvariantCulture);
-                            }
-                        }
-                    }
+                var widthValue = GetShapeStyleComponent("width");
+                if (widthValue == null) {
+                    return null;
                 }
-                return null;
+
+                string stringValue = widthValue.Replace("pt", "");
+                return double.Parse(stringValue, CultureInfo.InvariantCulture);
             }
-            set {
-                var shape = _shape;
-                var style = shape?.Style?.Value;
-                if (shape?.Style != null && style != null) {
-                    var width = style.Split(';').FirstOrDefault(c => c.StartsWith("width:", StringComparison.Ordinal));
-                    if (width != null) {
-                        var widthValue = width.Split(':').LastOrDefault();
-                        if (widthValue != null) {
-                            shape.Style.Value = style.Replace(width, "width:" + value + "pt");
-                        }
-                    }
-                }
-            }
+            set => SetShapeStyleComponent("width", value + "pt");
         }
 
         /// <summary>
@@ -159,35 +81,15 @@ namespace OfficeIMO.Word {
         /// </summary>
         public double? Height {
             get {
-                var shape = _shape;
-                if (shape != null) {
-                    var style = shape.Style?.Value;
-                    if (style != null) {
-                        var height = style.Split(';').FirstOrDefault(c => c.StartsWith("height:", StringComparison.Ordinal));
-                        if (height != null) {
-                            var heightValue = height.Split(':').LastOrDefault();
-                            if (heightValue != null) {
-                                string stringValue = heightValue.Replace("pt", "");
-                                return double.Parse(stringValue, CultureInfo.InvariantCulture);
-                            }
-                        }
-                    }
+                var heightValue = GetShapeStyleComponent("height");
+                if (heightValue == null) {
+                    return null;
                 }
-                return null;
+
+                string stringValue = heightValue.Replace("pt", "");
+                return double.Parse(stringValue, CultureInfo.InvariantCulture);
             }
-            set {
-                var shape = _shape;
-                var style = shape?.Style?.Value;
-                if (shape?.Style != null && style != null) {
-                    var height = style.Split(';').FirstOrDefault(c => c.StartsWith("height:", StringComparison.Ordinal));
-                    if (height != null) {
-                        var heightValue = height.Split(':').LastOrDefault();
-                        if (heightValue != null) {
-                            shape.Style.Value = style.Replace(height, "height:" + value + "pt");
-                        }
-                    }
-                }
-            }
+            set => SetShapeStyleComponent("height", value + "pt");
         }
 
         /// <summary>
@@ -195,32 +97,15 @@ namespace OfficeIMO.Word {
         /// </summary>
         public double? HorizontalOffset {
             get {
-                var shape = _shape;
-                if (shape != null) {
-                    var style = shape.Style?.Value;
-                    if (style != null) {
-                        var left = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-left:", StringComparison.Ordinal));
-                        if (left != null) {
-                            var value = left.Split(':').LastOrDefault();
-                            if (value != null) {
-                                string stringValue = value.Replace("pt", "");
-                                return double.Parse(stringValue, CultureInfo.InvariantCulture);
-                            }
-                        }
-                    }
+                var value = GetShapeStyleComponent("margin-left");
+                if (value == null) {
+                    return null;
                 }
-                return null;
+
+                string stringValue = value.Replace("pt", "");
+                return double.Parse(stringValue, CultureInfo.InvariantCulture);
             }
-            set {
-                var shape = _shape;
-                var style = shape?.Style?.Value;
-                if (shape?.Style != null && style != null) {
-                    var left = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-left:", StringComparison.Ordinal));
-                    if (left != null) {
-                        shape.Style.Value = style.Replace(left, "margin-left:" + value + "pt");
-                    }
-                }
-            }
+            set => SetShapeStyleComponent("margin-left", value + "pt");
         }
 
         /// <summary>
@@ -228,32 +113,15 @@ namespace OfficeIMO.Word {
         /// </summary>
         public double? VerticalOffset {
             get {
-                var shape = _shape;
-                if (shape != null) {
-                    var style = shape.Style?.Value;
-                    if (style != null) {
-                        var top = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-top:", StringComparison.Ordinal));
-                        if (top != null) {
-                            var value = top.Split(':').LastOrDefault();
-                            if (value != null) {
-                                string stringValue = value.Replace("pt", "");
-                                return double.Parse(stringValue, CultureInfo.InvariantCulture);
-                            }
-                        }
-                    }
+                var value = GetShapeStyleComponent("margin-top");
+                if (value == null) {
+                    return null;
                 }
-                return null;
+
+                string stringValue = value.Replace("pt", "");
+                return double.Parse(stringValue, CultureInfo.InvariantCulture);
             }
-            set {
-                var shape = _shape;
-                var style = shape?.Style?.Value;
-                if (shape?.Style != null && style != null) {
-                    var top = style.Split(';').FirstOrDefault(c => c.StartsWith("margin-top:", StringComparison.Ordinal));
-                    if (top != null) {
-                        shape.Style.Value = style.Replace(top, "margin-top:" + value + "pt");
-                    }
-                }
-            }
+            set => SetShapeStyleComponent("margin-top", value + "pt");
         }
 
         /// <summary>
@@ -261,36 +129,10 @@ namespace OfficeIMO.Word {
         /// </summary>
         public string? FontFamily {
             get {
-                var shape = _shape;
-                if (shape != null) {
-                    var textPath = shape.GetFirstChild<V.TextPath>();
-                    if (textPath?.Style?.Value is { } style) {
-                        var family = style.Split(';').FirstOrDefault(c => c.StartsWith("font-family:", StringComparison.Ordinal));
-                        if (family != null) {
-                            var value = family.Split(':').LastOrDefault();
-                            if (value != null) {
-                                return value.Trim('"');
-                            }
-                        }
-                    }
-                }
-                return null;
+                var value = GetTextPathStyleComponent("font-family");
+                return value?.Trim('"');
             }
-            set {
-                var shape = _shape;
-                if (shape != null) {
-                    var textPath = shape.GetFirstChild<V.TextPath>();
-                    if (textPath != null) {
-                        var style = textPath.Style?.Value ?? string.Empty;
-                        var dict = style.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
-                            .Select(p => p.Split(':'))
-                            .ToDictionary(p => p[0], p => p.Length > 1 ? p[1] : string.Empty);
-                        dict["font-family"] = "\"" + value + "\"";
-                        textPath.Style ??= new StringValue();
-                        textPath.Style.Value = string.Join(";", dict.Select(kvp => $"{kvp.Key}:{kvp.Value}"));
-                    }
-                }
-            }
+            set => SetTextPathStyleComponent("font-family", "\"" + value + "\"");
         }
 
         /// <summary>
@@ -298,37 +140,15 @@ namespace OfficeIMO.Word {
         /// </summary>
         public double? FontSize {
             get {
-                var shape = _shape;
-                if (shape != null) {
-                    var textPath = shape.GetFirstChild<V.TextPath>();
-                    if (textPath?.Style?.Value is { } style) {
-                        var size = style.Split(';').FirstOrDefault(c => c.StartsWith("font-size:", StringComparison.Ordinal));
-                        if (size != null) {
-                            var value = size.Split(':').LastOrDefault();
-                            if (value != null) {
-                                string stringValue = value.Replace("pt", "");
-                                return double.Parse(stringValue, CultureInfo.InvariantCulture);
-                            }
-                        }
-                    }
+                var value = GetTextPathStyleComponent("font-size");
+                if (value == null) {
+                    return null;
                 }
-                return null;
+
+                string stringValue = value.Replace("pt", "");
+                return double.Parse(stringValue, CultureInfo.InvariantCulture);
             }
-            set {
-                var shape = _shape;
-                if (shape != null) {
-                    var textPath = shape.GetFirstChild<V.TextPath>();
-                    if (textPath != null) {
-                        var style = textPath.Style?.Value ?? string.Empty;
-                        var dict = style.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
-                            .Select(p => p.Split(':'))
-                            .ToDictionary(p => p[0], p => p.Length > 1 ? p[1] : string.Empty);
-                        dict["font-size"] = value + "pt";
-                        textPath.Style ??= new StringValue();
-                        textPath.Style.Value = string.Join(";", dict.Select(kvp => $"{kvp.Key}:{kvp.Value}"));
-                    }
-                }
-            }
+            set => SetTextPathStyleComponent("font-size", value + "pt");
         }
 
         /// <summary>
@@ -449,46 +269,72 @@ namespace OfficeIMO.Word {
         }
 
         private Shape? _shape {
-            get {
-
-                var shape = _picture?.Descendants().OfType<Shape>().FirstOrDefault();
-                if (shape != null) {
-                    return shape;
-                }
-                return null;
-            }
+            get => _picture?.Descendants().OfType<Shape>().FirstOrDefault();
         }
 
         private Picture? _picture {
-            get {
-                if (_sdtBlock?.SdtContentBlock != null) {
-                    Paragraph? paragraph = _sdtBlock.SdtContentBlock.ChildElements.OfType<Paragraph>().FirstOrDefault();
-                    if (paragraph != null) {
-                        Run? run = paragraph.Descendants().OfType<Run>().FirstOrDefault();
-                        if (run != null) {
-                            Picture? picture = run.Descendants().OfType<Picture>().FirstOrDefault();
-                            if (picture != null) {
-                                return picture;
-                            }
-                        }
-                    }
-                }
-                return null;
-            }
+            get => _sdtBlock?.SdtContentBlock?
+                .ChildElements.OfType<Paragraph>().FirstOrDefault()?
+                .Descendants().OfType<Run>().FirstOrDefault()?
+                .Descendants().OfType<Picture>().FirstOrDefault();
         }
 
         private SdtContentBlock? _sdtContentBlock {
-            get {
-                var sdtBlock = _sdtBlock;
-                if (sdtBlock != null) {
-                    SdtContentBlock? sdtContentBlock = sdtBlock.GetFirstChild<SdtContentBlock>();
-                    if (sdtContentBlock != null) {
-                        return sdtContentBlock;
-                    }
-                }
+            get => _sdtBlock?.GetFirstChild<SdtContentBlock>();
+        }
+
+        private V.TextPath? _textPath => _shape?.GetFirstChild<V.TextPath>();
+
+        private string? GetShapeStyleComponent(string key) =>
+            GetStyleComponent(_shape?.Style?.Value, key);
+
+        private void SetShapeStyleComponent(string key, string replacementValue) {
+            var shape = _shape;
+            var style = shape?.Style?.Value;
+            if (shape?.Style == null || style == null) {
+                return;
+            }
+
+            var component = GetStyleSegment(style, key);
+            if (component == null) {
+                return;
+            }
+
+            shape.Style.Value = style.Replace(component, key + ":" + replacementValue);
+        }
+
+        private string? GetTextPathStyleComponent(string key) =>
+            GetStyleComponent(_textPath?.Style?.Value, key);
+
+        private void SetTextPathStyleComponent(string key, string replacementValue) {
+            var textPath = _textPath;
+            if (textPath == null) {
+                return;
+            }
+
+            var dict = ParseStyleMap(textPath.Style?.Value ?? string.Empty);
+            dict[key] = replacementValue;
+            textPath.Style ??= new StringValue();
+            textPath.Style.Value = string.Join(";", dict.Select(kvp => $"{kvp.Key}:{kvp.Value}"));
+        }
+
+        private static string? GetStyleComponent(string? style, string key) {
+            var component = GetStyleSegment(style, key);
+            return component?.Split(':').LastOrDefault();
+        }
+
+        private static string? GetStyleSegment(string? style, string key) {
+            if (style == null) {
                 return null;
             }
+
+            return style.Split(';').FirstOrDefault(component => component.StartsWith(key + ":", StringComparison.Ordinal));
         }
+
+        private static Dictionary<string, string> ParseStyleMap(string style) =>
+            style.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(part => part.Split(':'))
+                .ToDictionary(part => part[0], part => part.Length > 1 ? part[1] : string.Empty);
 
         private SdtBlock GetStyle(WordWatermarkStyle style) {
             switch (style) {


### PR DESCRIPTION
## Summary
- scope CodeQL analysis to production projects and add an explicit CodeQL config for that boundary
- clean up production code paths across Word, Excel, Markdown, PDF, PowerPoint, Reader, Word.Markdown, and Word.Html to reduce nullability noise, dead branches, and repeated Open XML traversal patterns
- simplify several Word internals such as watermark, textbox, image, footer, and document helpers while preserving existing behavior

## Verification
- dotnet build OfficeIMO.Word/OfficeIMO.Word.csproj --configuration Release -f net8.0 -m:1 --disable-build-servers /nr:false
- targeted Release builds were also completed during the cleanup passes for OfficeIMO.Excel, OfficeIMO.Markdown, OfficeIMO.Pdf, OfficeIMO.Word, OfficeIMO.Reader, OfficeIMO.PowerPoint, OfficeIMO.Word.Markdown, and OfficeIMO.Word.Html

## Notes
- production code only
- branch was kept aligned with master during the work to reduce merge risk