### PR TITLE
Fix saving DOTX templates as DOCX documents

### DIFF
--- a/OfficeIMO.Tests/Word.Converter.cs
+++ b/OfficeIMO.Tests/Word.Converter.cs
@@ -40,8 +40,8 @@ public partial class Word {
         Assert.False(Path.IsPathRooted(templateFileName));
         Assert.False(Path.IsPathRooted(outputFileName));
 
-        string templatePath = Path.Combine(_directoryDocuments, templateFileName);
-        string outFilePath = Path.Combine(_directoryWithFiles, outputFileName);
+        string templatePath = Path.Join(_directoryDocuments, templateFileName);
+        string outFilePath = Path.Join(_directoryWithFiles, outputFileName);
 
         using (WordDocument document = WordDocument.Load(templatePath)) {
             if (useSaveAs) {

--- a/OfficeIMO.Tests/Word.Converter.cs
+++ b/OfficeIMO.Tests/Word.Converter.cs
@@ -40,8 +40,8 @@ public partial class Word {
         Assert.False(Path.IsPathRooted(templateFileName));
         Assert.False(Path.IsPathRooted(outputFileName));
 
-        string templatePath = Path.Join(_directoryDocuments, templateFileName);
-        string outFilePath = Path.Join(_directoryWithFiles, outputFileName);
+        string templatePath = JoinPath(_directoryDocuments, templateFileName);
+        string outFilePath = JoinPath(_directoryWithFiles, outputFileName);
 
         using (WordDocument document = WordDocument.Load(templatePath)) {
             if (useSaveAs) {
@@ -55,5 +55,17 @@ public partial class Word {
         using WordprocessingDocument saved = WordprocessingDocument.Open(outFilePath, false);
         Assert.Equal(WordprocessingDocumentType.Document, saved.DocumentType);
         Assert.Equal("application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml", saved.MainDocumentPart?.ContentType);
+    }
+
+    private static string JoinPath(string basePath, string fileName) {
+#if NET472
+        char separator = Path.DirectorySeparatorChar;
+        return basePath.EndsWith(separator.ToString(), StringComparison.Ordinal) ||
+               basePath.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+            ? basePath + fileName
+            : basePath + separator + fileName;
+#else
+        return Path.Join(basePath, fileName);
+#endif
     }
 }

--- a/OfficeIMO.Tests/Word.Converter.cs
+++ b/OfficeIMO.Tests/Word.Converter.cs
@@ -35,8 +35,13 @@ public partial class Word {
     [InlineData(false)]
     [InlineData(true)]
     public void Test_SaveDotXAsDocX_ChangesPackageType(bool useSaveAs) {
-        string templatePath = Path.Combine(_directoryDocuments, "ExampleTemplate.dotx");
-        string outFilePath = Path.Combine(_directoryWithFiles, useSaveAs ? "ExampleTemplate_SaveAs.docx" : "ExampleTemplate_Save.docx");
+        const string templateFileName = "ExampleTemplate.dotx";
+        string outputFileName = useSaveAs ? "ExampleTemplate_SaveAs.docx" : "ExampleTemplate_Save.docx";
+        Assert.False(Path.IsPathRooted(templateFileName));
+        Assert.False(Path.IsPathRooted(outputFileName));
+
+        string templatePath = Path.Combine(_directoryDocuments, templateFileName);
+        string outFilePath = Path.Combine(_directoryWithFiles, outputFileName);
 
         using (WordDocument document = WordDocument.Load(templatePath)) {
             if (useSaveAs) {

--- a/OfficeIMO.Tests/Word.Converter.cs
+++ b/OfficeIMO.Tests/Word.Converter.cs
@@ -1,3 +1,5 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Word;
 using Xunit;
 
@@ -27,5 +29,26 @@ public partial class Word {
 
         Assert.False(templatePath.IsFileLocked());
         Assert.True(File.Exists(outFilePath));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Test_SaveDotXAsDocX_ChangesPackageType(bool useSaveAs) {
+        string templatePath = Path.Combine(_directoryDocuments, "ExampleTemplate.dotx");
+        string outFilePath = Path.Combine(_directoryWithFiles, useSaveAs ? "ExampleTemplate_SaveAs.docx" : "ExampleTemplate_Save.docx");
+
+        using (WordDocument document = WordDocument.Load(templatePath)) {
+            if (useSaveAs) {
+                using WordDocument savedDocument = document.SaveAs(outFilePath);
+            } else {
+                document.Save(outFilePath);
+            }
+        }
+
+        Assert.True(File.Exists(outFilePath));
+        using WordprocessingDocument saved = WordprocessingDocument.Open(outFilePath, false);
+        Assert.Equal(WordprocessingDocumentType.Document, saved.DocumentType);
+        Assert.Equal("application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml", saved.MainDocumentPart?.ContentType);
     }
 }

--- a/OfficeIMO.Word/WordDocument.cs
+++ b/OfficeIMO.Word/WordDocument.cs
@@ -1041,6 +1041,13 @@ namespace OfficeIMO.Word {
             };
         }
 
+        private static void AlignDocumentTypeWithFilePath(WordprocessingDocument document, string filePath) {
+            var documentType = GetDocumentType(filePath);
+            if (document.DocumentType != documentType) {
+                document.ChangeDocumentType(documentType);
+            }
+        }
+
         private static WordDocument CreateInternal(string? filePath, Stream? stream, WordprocessingDocumentType documentType, bool autoSave) {
             WordDocument word = new WordDocument();
             if (stream != null) {
@@ -1464,6 +1471,7 @@ namespace OfficeIMO.Word {
                     // Allow concurrent readers (other tests may have opened the sample file with Read/ReadWrite sharing)
                     using var fs = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete);
                     using (var clone = this._wordprocessingDocument.Clone(fs)) {
+                        AlignDocumentTypeWithFilePath(clone, filePath);
                         CopyPackageProperties(_wordprocessingDocument.PackageProperties, clone.PackageProperties);
                     }
                     fs.Seek(0, SeekOrigin.Begin);
@@ -1542,6 +1550,7 @@ namespace OfficeIMO.Word {
 
                 using var fs = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete);
                 using (var clone = _wordprocessingDocument.Clone(fs)) {
+                    AlignDocumentTypeWithFilePath(clone, filePath);
                     CopyPackageProperties(_wordprocessingDocument.PackageProperties, clone.PackageProperties);
                 }
                 fs.Seek(0, SeekOrigin.Begin);


### PR DESCRIPTION
## Summary
- align cloned WordprocessingDocument package type with the target file extension during Save and SaveAs
- add regression coverage for saving DOTX templates as DOCX documents through both save paths

## Root cause
Saving a loaded DOTX to a DOCX path cloned the OpenXML package without changing the package document type. The resulting file had a .docx extension while retaining template package metadata/content type, which caused Word to report the output as corrupt or needing repair.

## Validation
- dotnet test C:\Support\GitHub\OfficeIMO\OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net8.0 --filter "FullyQualifiedName~Test_SaveDotXAsDocX_ChangesPackageType|FullyQualifiedName~Test_ConvertDotXtoDocX"
