### PR TITLE
Add release-based VS Code publishing

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET SDK
         if: matrix.build-mode == 'manual'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.418
@@ -50,7 +50,7 @@ jobs:
 
       - name: Cache NuGet packages
         if: matrix.build-mode == 'manual'
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -58,7 +58,7 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -79,6 +79,6 @@ jobs:
           }
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -42,15 +42,15 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -69,15 +69,15 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -131,20 +131,20 @@ jobs:
           }
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results-windows
           path: '**/*.trx'
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage-reports-windows
           path: '**/coverage.cobertura.xml'
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: '**/coverage.cobertura.xml'
           fail_ci_if_error: false
@@ -156,15 +156,15 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -217,13 +217,13 @@ jobs:
           }
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results-ubuntu
           path: '**/*.trx'
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: '**/coverage.cobertura.xml'
           fail_ci_if_error: false
@@ -235,15 +235,15 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -296,13 +296,13 @@ jobs:
           }
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results-macos
           path: '**/*.trx'
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: '**/coverage.cobertura.xml'
           fail_ci_if_error: false
@@ -314,15 +314,15 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -1,6 +1,9 @@
 name: VS Code Extension
 
 on:
+  release:
+    types:
+      - published
   push:
     branches:
       - master
@@ -51,20 +54,23 @@ env:
 jobs:
   package:
     name: Package VSIX
+    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'officeimo-markup-v') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -79,19 +85,45 @@ jobs:
       - name: Package extension
         shell: pwsh
         env:
+          IS_PRE_RELEASE: ${{ (github.event_name == 'release' && github.event.release.prerelease) || (github.event_name == 'workflow_dispatch' && inputs.pre_release) }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          SHOULD_PUBLISH: ${{ github.event_name == 'release' || inputs.publish_marketplace }}
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
+          if ('${{ github.event_name }}' -eq 'release') {
+            $tagPrefix = 'officeimo-markup-v'
+            if (-not $env:RELEASE_TAG.StartsWith($tagPrefix, [System.StringComparison]::Ordinal)) {
+              throw "OfficeIMO VS Code Marketplace publishing only accepts release tags named officeimo-markup-v<version>. Current tag: $env:RELEASE_TAG. Example: officeimo-markup-v0.1.12"
+            }
+
+            git fetch origin master
+            if ($LASTEXITCODE -ne 0) {
+              throw 'Failed to fetch origin/master for release source validation.'
+            }
+
+            git merge-base --is-ancestor HEAD origin/master
+            if ($LASTEXITCODE -ne 0) {
+              throw 'Release publishing is only allowed from commits contained in origin/master.'
+            }
+
+            $package = Get-Content -LiteralPath 'OfficeIMO.Markup.VSCode/package.json' -Raw | ConvertFrom-Json
+            $tagVersion = $env:RELEASE_TAG.Substring($tagPrefix.Length)
+            if ($tagVersion -ne $package.version) {
+              throw "Release tag $env:RELEASE_TAG must match OfficeIMO.Markup.VSCode package version $($package.version). Update package.json/package-lock.json or create release tag officeimo-markup-v$($package.version)."
+            }
+          }
+
           $params = @{
             OutputDirectory = 'dist'
             SkipNpmCi = $true
           }
 
-          if ('${{ github.event_name }}' -eq 'workflow_dispatch' -and '${{ inputs.pre_release }}' -eq 'true') {
+          if ($env:IS_PRE_RELEASE -eq 'true') {
             $params.PreRelease = $true
           }
 
-          if ('${{ github.event_name }}' -eq 'workflow_dispatch' -and '${{ inputs.publish_marketplace }}' -eq 'true') {
-            if ('${{ github.ref_name }}' -ne 'master') {
+          if ($env:SHOULD_PUBLISH -eq 'true') {
+            if ('${{ github.event_name }}' -eq 'workflow_dispatch' -and '${{ github.ref_name }}' -ne 'master') {
               throw 'Marketplace publishing is only allowed from the master branch.'
             }
 
@@ -101,8 +133,26 @@ jobs:
           ./OfficeIMO.Markup.VSCode/scripts/package-vsix.ps1 @params
 
       - name: Upload VSIX
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: officeimo-markup-vsix
           path: OfficeIMO.Markup.VSCode/dist/*.vsix
           if-no-files-found: error
+
+  attach-release-asset:
+    if: ${{ github.event_name == 'release' }}
+    needs: package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: officeimo-markup-vsix
+          path: release-vsix
+
+      - name: Attach VSIX to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" release-vsix/*.vsix --repo "${GITHUB_REPOSITORY}" --clobber

--- a/OfficeIMO.Markup.VSCode/README.md
+++ b/OfficeIMO.Markup.VSCode/README.md
@@ -132,6 +132,8 @@ CI packaging and publishing are handled by `.github/workflows/vscode-extension.y
 
 - Pull requests and pushes touching the extension or its runtime dependencies package the VSIX and upload it as the `officeimo-markup-vsix` artifact.
 - Manual `workflow_dispatch` can set `publish_marketplace=true` to publish to the Visual Studio Marketplace.
+- Publishing a GitHub Release named `officeimo-markup-v<version>` from a commit contained in `master` publishes that version to the Visual Studio Marketplace and attaches the packaged VSIX to the release.
+- Mark the GitHub Release as pre-release to publish a VS Code pre-release build.
 - `VSCE_PAT` must be configured as a repository or organization secret before marketplace publishing is enabled.
 - `pre_release=true` packages and publishes the extension as a VS Code pre-release.
 


### PR DESCRIPTION
## What changed
- Added GitHub Release based Marketplace publishing for the OfficeIMO Markup VS Code extension.
- Release publishes now require `officeimo-markup-v<version>` and verify the tag against `OfficeIMO.Markup.VSCode/package.json`.
- The GitHub Release prerelease flag controls Marketplace pre-release publishing.
- Packaged VSIX files remain Actions artifacts and are attached to matching GitHub Releases from a release-only job.
- Updated VS Code workflow actions to current majors.

## Release flow
- PRs: validate/package only, no Marketplace publish.
- Manual dispatch: still available for package/publish from `master`.
- GitHub Release `officeimo-markup-v0.1.12`: publish to Marketplace and attach VSIX to the release.

## Validation
- `git diff --check`
