### PR TITLE
Fix Excel package ordering for Office compatibility

### DIFF
--- a/OfficeIMO.Excel/ExcelChartUtils.Build.cs
+++ b/OfficeIMO.Excel/ExcelChartUtils.Build.cs
@@ -345,15 +345,14 @@ namespace OfficeIMO.Excel {
         }
 
         private static DoughnutChart CreateDoughnutChart(ExcelChartDataRange range, IReadOnlyList<SeriesDescriptor> seriesDescriptors) {
-            var chart = new DoughnutChart(
-                new VaryColors { Val = true },
-                new HoleSize { Val = 50 });
+            var chart = new DoughnutChart(new VaryColors { Val = true });
 
             foreach (var descriptor in seriesDescriptors) {
                 chart.Append(CreatePieChartSeries(descriptor.Index, range, descriptor.Series));
             }
 
             chart.Append(CreateDefaultDataLabels());
+            chart.Append(new HoleSize { Val = 50 });
             return chart;
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.CalculationCleanup.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CalculationCleanup.cs
@@ -30,6 +30,8 @@ namespace OfficeIMO.Excel {
                 var extensionList = workbook.Elements<ExtensionList>().FirstOrDefault();
                 if (extensionList != null) {
                     workbook.InsertBefore(calculationProperties, extensionList);
+                } else if (workbook.Elements<PivotCaches>().FirstOrDefault() is { } pivotCaches) {
+                    workbook.InsertBefore(calculationProperties, pivotCaches);
                 } else {
                     workbook.Append(calculationProperties);
                 }


### PR DESCRIPTION
## Summary
- keep workbook calculation properties before pivot caches when there is no extension list
- emit doughnut chart children in Open XML schema order so generated charts validate cleanly

## Validation
- dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Debug
- consumed by the PSWriteOffice showcase build/open validation pass

## Notes
- this fixes ordering issues discovered while building the PSWriteOffice Excel showcase
- broader PivotTable and sparkline desktop-open compatibility still needs a focused follow-up
