### PR TITLE
Improve OfficeIMO Excel performance

### DIFF
--- a/Docs/benchmarks/README.md
+++ b/Docs/benchmarks/README.md
@@ -4,12 +4,32 @@ This folder stores small, committed benchmark artifacts for `OfficeIMO.Excel`.
 
 - `officeimo.excel.snapshot-YYYY-MM-DD.json`: lightweight end-to-end scenario snapshot for write, read, and round-trip flows
 - `officeimo.excel.write-profile-YYYY-MM-DD.json`: write-stage breakdown intended to highlight where optimization work should focus
+- `officeimo.excel.read-profile-YYYY-MM-DD.json`: read-stage comparison for automatic, forced sequential, and forced parallel range conversion
 
-Both artifact types now store raw sample lists and medians in addition to averages so noisy runs are easier to spot.
+Both artifact types now store raw sample lists and medians in addition to averages so noisy runs are easier to spot. Write profiles also include OfficeIMO timing-hook sub-stages such as AutoFit plan, width calculation, and width application when those hooks are emitted.
+OfficeIMO benchmark runs use the report-export AutoFit mode (`Execution.SaveWorksheetAfterAutoFit = false`) so worksheet changes are committed once at document save/dispose time instead of after each AutoFit operation.
 
 Generate them from the benchmark harness:
 
 ```powershell
 dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --snapshot .\Docs\benchmarks\officeimo.excel.snapshot-YYYY-MM-DD.json
 dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --profile-write .\Docs\benchmarks\officeimo.excel.write-profile-YYYY-MM-DD.json
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --profile-read .\Docs\benchmarks\officeimo.excel.read-profile-YYYY-MM-DD.json
+```
+
+Add `--website-data .\Website\data\benchmarks.json` to a snapshot run when the public benchmark table should be refreshed from the same measured values.
+
+Short aliases can be used when the default `Docs\benchmarks` output path is sufficient:
+
+```powershell
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- snapshot --rows 2500
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- write-profile --rows 25000
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- read-profile --rows 2500
+```
+
+Both commands default to 2,500 rows and accept `--rows <count>` for larger tiers, for example:
+
+```powershell
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --snapshot .\Docs\benchmarks\officeimo.excel.snapshot-25000-YYYY-MM-DD.json --rows 25000
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --profile-write .\Docs\benchmarks\officeimo.excel.write-profile-25000-YYYY-MM-DD.json --rows 25000
 ```

--- a/Docs/benchmarks/officeimo.excel.read-profile-2026-05-12.json
+++ b/Docs/benchmarks/officeimo.excel.read-profile-2026-05-12.json
@@ -1,0 +1,113 @@
+{
+  "GeneratedAtUtc": "2026-05-11T23:08:53.732782Z",
+  "Framework": ".NET 8.0.26",
+  "MachineName": "EVOMAGIC",
+  "RowCount": 2500,
+  "Scenarios": [
+    {
+      "Library": "OfficeIMO.Excel",
+      "Name": "ReadObjects",
+      "Notes": "Automatic execution policy.",
+      "OutputMetric": 2500,
+      "AverageMilliseconds": 81.15276,
+      "MedianMilliseconds": 79.2168,
+      "SamplesMilliseconds": [
+        79.2168,
+        77.2161,
+        91.2204,
+        78.6984,
+        79.4121
+      ]
+    },
+    {
+      "Library": "OfficeIMO.Excel",
+      "Name": "ReadObjects.Sequential",
+      "Notes": "Forced sequential range conversion.",
+      "OutputMetric": 2500,
+      "AverageMilliseconds": 78.20128000000001,
+      "MedianMilliseconds": 77.3292,
+      "SamplesMilliseconds": [
+        81.2807,
+        78.1954,
+        77.2836,
+        77.3292,
+        76.9175
+      ]
+    },
+    {
+      "Library": "OfficeIMO.Excel",
+      "Name": "ReadObjects.Parallel",
+      "Notes": "Forced parallel range conversion.",
+      "OutputMetric": 2500,
+      "AverageMilliseconds": 85.14496,
+      "MedianMilliseconds": 89.3032,
+      "SamplesMilliseconds": [
+        75.4491,
+        72.2758,
+        92.221,
+        96.4757,
+        89.3032
+      ]
+    },
+    {
+      "Library": "OfficeIMO.Excel",
+      "Name": "ReadRangeAsDataTable",
+      "Notes": "Automatic execution policy.",
+      "OutputMetric": 2500,
+      "AverageMilliseconds": 82.32208,
+      "MedianMilliseconds": 81.409,
+      "SamplesMilliseconds": [
+        86.6295,
+        81.409,
+        82.1566,
+        80.9743,
+        80.441
+      ]
+    },
+    {
+      "Library": "OfficeIMO.Excel",
+      "Name": "ReadRangeAsDataTable.Sequential",
+      "Notes": "Forced sequential range conversion.",
+      "OutputMetric": 2500,
+      "AverageMilliseconds": 98.97162,
+      "MedianMilliseconds": 98.7175,
+      "SamplesMilliseconds": [
+        96.7826,
+        100.2989,
+        94.8036,
+        104.2555,
+        98.7175
+      ]
+    },
+    {
+      "Library": "OfficeIMO.Excel",
+      "Name": "ReadRangeAsDataTable.Parallel",
+      "Notes": "Forced parallel range conversion.",
+      "OutputMetric": 2500,
+      "AverageMilliseconds": 45.3763,
+      "MedianMilliseconds": 45.4877,
+      "SamplesMilliseconds": [
+        45.6032,
+        45.3741,
+        45.4877,
+        45.5298,
+        44.8867
+      ]
+    },
+    {
+      "Library": "ClosedXML",
+      "Name": "ReadRows",
+      "Notes": "Worksheet row iteration over the same workbook payload.",
+      "OutputMetric": 2500,
+      "AverageMilliseconds": 89.15508,
+      "MedianMilliseconds": 87.073,
+      "SamplesMilliseconds": [
+        88.7734,
+        87.073,
+        104.6628,
+        82.1711,
+        83.0951
+      ]
+    }
+  ]
+}

--- a/Docs/benchmarks/officeimo.excel.snapshot-2026-05-11.json
+++ b/Docs/benchmarks/officeimo.excel.snapshot-2026-05-11.json
@@ -1,0 +1,120 @@
+{
+  "GeneratedAtUtc": "2026-05-11T20:29:04.9637624Z",
+  "Framework": ".NET 8.0.26",
+  "MachineName": "EVOMAGIC",
+  "RowCount": 2500,
+  "Scenarios": [
+    {
+      "Name": "Excel: Write report (2,500 rows)",
+      "Library": "OfficeIMO.Excel",
+      "Result": "96.1 ms avg",
+      "Notes": "Insert objects, table, and AutoFit on a single worksheet.",
+      "OutputMetric": 116483,
+      "AverageMilliseconds": 96.10812000000001,
+      "MedianMilliseconds": 92.5889,
+      "SamplesMilliseconds": [
+        103.9374,
+        106.6889,
+        85.7597,
+        91.5657,
+        92.5889
+      ]
+    },
+    {
+      "Name": "Excel: Write report (2,500 rows)",
+      "Library": "ClosedXML",
+      "Result": "295.2 ms avg",
+      "Notes": "Insert table and adjust columns on a single worksheet.",
+      "OutputMetric": 123939,
+      "AverageMilliseconds": 295.18466,
+      "MedianMilliseconds": 282.0313,
+      "SamplesMilliseconds": [
+        268.3282,
+        349.6834,
+        297.2462,
+        282.0313,
+        278.6342
+      ]
+    },
+    {
+      "Name": "Excel: Read objects (2,500 rows)",
+      "Library": "OfficeIMO.Excel",
+      "Result": "93.1 ms avg",
+      "Notes": "Reader path materializing dictionary-style rows.",
+      "OutputMetric": 2500,
+      "AverageMilliseconds": 93.07083999999999,
+      "MedianMilliseconds": 96.0153,
+      "SamplesMilliseconds": [
+        96.9836,
+        89.1854,
+        96.1484,
+        96.0153,
+        87.0215
+      ]
+    },
+    {
+      "Name": "Excel: Read DataTable (2,500 rows)",
+      "Library": "OfficeIMO.Excel",
+      "Result": "97.3 ms avg",
+      "Notes": "Reader path materializing a DataTable from the same workbook.",
+      "OutputMetric": 2500,
+      "AverageMilliseconds": 97.28184,
+      "MedianMilliseconds": 94.868,
+      "SamplesMilliseconds": [
+        92.8474,
+        94.868,
+        105.5181,
+        112.2982,
+        80.8775
+      ]
+    },
+    {
+      "Name": "Excel: Read rows (2,500 rows)",
+      "Library": "ClosedXML",
+      "Result": "119.5 ms avg",
+      "Notes": "Worksheet row iteration over the same workbook payload.",
+      "OutputMetric": 2500,
+      "AverageMilliseconds": 119.4952,
+      "MedianMilliseconds": 115.4397,
+      "SamplesMilliseconds": [
+        111.2301,
+        142.0559,
+        122.9706,
+        115.4397,
+        105.7797
+      ]
+    },
+    {
+      "Name": "Excel: Load/edit/save (2,500 rows)",
+      "Library": "OfficeIMO.Excel",
+      "Result": "100.8 ms avg",
+      "Notes": "Load workbook, add review column, save to memory.",
+      "OutputMetric": 118097,
+      "AverageMilliseconds": 100.80865999999999,
+      "MedianMilliseconds": 112.225,
+      "SamplesMilliseconds": [
+        118.2237,
+        117.5052,
+        112.225,
+        82.852,
+        73.2374
+      ]
+    },
+    {
+      "Name": "Excel: Load/edit/save (2,500 rows)",
+      "Library": "ClosedXML",
+      "Result": "105.8 ms avg",
+      "Notes": "Load workbook, add review column, save to memory.",
+      "OutputMetric": 124386,
+      "AverageMilliseconds": 105.84762,
+      "MedianMilliseconds": 116.0685,
+      "SamplesMilliseconds": [
+        119.2336,
+        116.0685,
+        130.9499,
+        82.5183,
+        80.4678
+      ]
+    }
+  ]
+}

--- a/Docs/benchmarks/officeimo.excel.snapshot-2026-05-12.json
+++ b/Docs/benchmarks/officeimo.excel.snapshot-2026-05-12.json
@@ -1,0 +1,120 @@
+{
+  "GeneratedAtUtc": "2026-05-11T22:54:08.9369037Z",
+  "Framework": ".NET 8.0.26",
+  "MachineName": "EVOMAGIC",
+  "RowCount": 2500,
+  "Scenarios": [
+    {
+      "Name": "Excel: Write report (2,500 rows)",
+      "Library": "OfficeIMO.Excel",
+      "Result": "114.9 ms avg",
+      "Notes": "Insert objects, table, and AutoFit on a single worksheet.",
+      "OutputMetric": 116469,
+      "AverageMilliseconds": 114.94811999999999,
+      "MedianMilliseconds": 114.3054,
+      "SamplesMilliseconds": [
+        114.3054,
+        106.2104,
+        109.2927,
+        123.7596,
+        121.1725
+      ]
+    },
+    {
+      "Name": "Excel: Write report (2,500 rows)",
+      "Library": "ClosedXML",
+      "Result": "271.8 ms avg",
+      "Notes": "Insert table and adjust columns on a single worksheet.",
+      "OutputMetric": 123939,
+      "AverageMilliseconds": 271.7689,
+      "MedianMilliseconds": 244.3058,
+      "SamplesMilliseconds": [
+        253.2523,
+        240.5588,
+        243.1662,
+        244.3058,
+        377.5614
+      ]
+    },
+    {
+      "Name": "Excel: Read objects (2,500 rows)",
+      "Library": "OfficeIMO.Excel",
+      "Result": "84.3 ms avg",
+      "Notes": "Reader path materializing dictionary-style rows.",
+      "OutputMetric": 2500,
+      "AverageMilliseconds": 84.30488,
+      "MedianMilliseconds": 86.0787,
+      "SamplesMilliseconds": [
+        75.191,
+        82.3627,
+        90.4177,
+        87.4743,
+        86.0787
+      ]
+    },
+    {
+      "Name": "Excel: Read DataTable (2,500 rows)",
+      "Library": "OfficeIMO.Excel",
+      "Result": "85.7 ms avg",
+      "Notes": "Reader path materializing a DataTable from the same workbook.",
+      "OutputMetric": 2500,
+      "AverageMilliseconds": 85.67260000000002,
+      "MedianMilliseconds": 82.25,
+      "SamplesMilliseconds": [
+        81.8613,
+        93.0048,
+        78.8221,
+        82.25,
+        92.4248
+      ]
+    },
+    {
+      "Name": "Excel: Read rows (2,500 rows)",
+      "Library": "ClosedXML",
+      "Result": "119.3 ms avg",
+      "Notes": "Worksheet row iteration over the same workbook payload.",
+      "OutputMetric": 2500,
+      "AverageMilliseconds": 119.25846000000001,
+      "MedianMilliseconds": 126.3089,
+      "SamplesMilliseconds": [
+        127.7241,
+        126.3089,
+        132.94,
+        107.8892,
+        101.4301
+      ]
+    },
+    {
+      "Name": "Excel: Load/edit/save (2,500 rows)",
+      "Library": "OfficeIMO.Excel",
+      "Result": "108.4 ms avg",
+      "Notes": "Load workbook, add review column, save to memory.",
+      "OutputMetric": 117995,
+      "AverageMilliseconds": 108.4274,
+      "MedianMilliseconds": 105.9919,
+      "SamplesMilliseconds": [
+        120.8741,
+        126.4159,
+        105.9919,
+        105.9413,
+        82.9138
+      ]
+    },
+    {
+      "Name": "Excel: Load/edit/save (2,500 rows)",
+      "Library": "ClosedXML",
+      "Result": "124.7 ms avg",
+      "Notes": "Load workbook, add review column, save to memory.",
+      "OutputMetric": 124387,
+      "AverageMilliseconds": 124.68519999999998,
+      "MedianMilliseconds": 117.0461,
+      "SamplesMilliseconds": [
+        165.8781,
+        117.0461,
+        118.356,
+        113.364,
+        108.7818
+      ]
+    }
+  ]
+}

--- a/Docs/benchmarks/officeimo.excel.write-profile-2026-05-11.json
+++ b/Docs/benchmarks/officeimo.excel.write-profile-2026-05-11.json
@@ -1,0 +1,188 @@
+{
+  "GeneratedAtUtc": "2026-05-11T21:18:08.1678224Z",
+  "Framework": ".NET 8.0.26",
+  "MachineName": "EVOMAGIC",
+  "RowCount": 2500,
+  "Libraries": [
+    {
+      "Library": "OfficeIMO.Excel",
+      "OutputBytes": 116481,
+      "Stages": [
+        {
+          "Name": "InsertObjects",
+          "AverageMilliseconds": 15.234279999999998,
+          "MedianMilliseconds": 17.2228,
+          "SamplesMilliseconds": [
+            17.2228,
+            18.0234,
+            22.044,
+            11.6025,
+            7.2787
+          ]
+        },
+        {
+          "Name": "AddTable.ScanExistingIds",
+          "AverageMilliseconds": 0.013219999999999999,
+          "MedianMilliseconds": 0.0131,
+          "SamplesMilliseconds": [
+            0.0173,
+            0.0131,
+            0.0222,
+            0.0079,
+            0.0056
+          ]
+        },
+        {
+          "Name": "AddTable",
+          "AverageMilliseconds": 27.463160000000006,
+          "MedianMilliseconds": 36.2433,
+          "SamplesMilliseconds": [
+            36.2433,
+            36.6115,
+            42.5915,
+            12.4535,
+            9.416
+          ]
+        },
+        {
+          "Name": "AutoFitColumns.BuildPlan",
+          "AverageMilliseconds": 27.41166,
+          "MedianMilliseconds": 27.8823,
+          "SamplesMilliseconds": [
+            27.8823,
+            34.546,
+            16.9743,
+            25.0534,
+            32.6023
+          ]
+        },
+        {
+          "Name": "AutoFitColumns.CalculateWidths",
+          "AverageMilliseconds": 2.44514,
+          "MedianMilliseconds": 3.0921,
+          "SamplesMilliseconds": [
+            1.1649,
+            0.8849,
+            3.0921,
+            3.9201,
+            3.1637
+          ]
+        },
+        {
+          "Name": "AutoFitColumns.ApplyWidths",
+          "AverageMilliseconds": 14.685060000000002,
+          "MedianMilliseconds": 8.7673,
+          "SamplesMilliseconds": [
+            25.0888,
+            23.9597,
+            8.7673,
+            7.6557,
+            7.9538
+          ]
+        },
+        {
+          "Name": "AutoFitColumns",
+          "AverageMilliseconds": 44.571600000000004,
+          "MedianMilliseconds": 43.7462,
+          "SamplesMilliseconds": [
+            54.1731,
+            59.4163,
+            28.8598,
+            36.6626,
+            43.7462
+          ]
+        },
+        {
+          "Name": "DisposeAndSave",
+          "AverageMilliseconds": 22.642179999999996,
+          "MedianMilliseconds": 17.2258,
+          "SamplesMilliseconds": [
+            31.0183,
+            32.735,
+            17.2258,
+            16.1258,
+            16.106
+          ]
+        },
+        {
+          "Name": "Total",
+          "AverageMilliseconds": 110.2207,
+          "MedianMilliseconds": 110.9786,
+          "SamplesMilliseconds": [
+            139.0775,
+            147.0686,
+            110.9786,
+            77.1429,
+            76.8359
+          ]
+        }
+      ]
+    },
+    {
+      "Library": "ClosedXML",
+      "OutputBytes": 123939,
+      "Stages": [
+        {
+          "Name": "InsertTable",
+          "AverageMilliseconds": 13.617420000000001,
+          "MedianMilliseconds": 13.6784,
+          "SamplesMilliseconds": [
+            13.4909,
+            13.2684,
+            13.6784,
+            13.8462,
+            13.8032
+          ]
+        },
+        {
+          "Name": "StyleTable",
+          "AverageMilliseconds": 0.00023999999999999998,
+          "MedianMilliseconds": 0.0002,
+          "SamplesMilliseconds": [
+            0.0002,
+            0.0003,
+            0.0002,
+            0.0002,
+            0.0003
+          ]
+        },
+        {
+          "Name": "AutoFitColumns",
+          "AverageMilliseconds": 149.75258,
+          "MedianMilliseconds": 152.967,
+          "SamplesMilliseconds": [
+            152.967,
+            135.1344,
+            139.7468,
+            157.9869,
+            162.9278
+          ]
+        },
+        {
+          "Name": "SaveAs",
+          "AverageMilliseconds": 105.54034000000001,
+          "MedianMilliseconds": 98.2347,
+          "SamplesMilliseconds": [
+            98.2347,
+            92.9002,
+            96.2833,
+            101.9658,
+            138.3177
+          ]
+        },
+        {
+          "Name": "Total",
+          "AverageMilliseconds": 268.92762,
+          "MedianMilliseconds": 264.707,
+          "SamplesMilliseconds": [
+            264.707,
+            241.3389,
+            249.7215,
+            273.809,
+            315.0617
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Docs/benchmarks/officeimo.excel.write-profile-2026-05-12.json
+++ b/Docs/benchmarks/officeimo.excel.write-profile-2026-05-12.json
@@ -1,0 +1,188 @@
+{
+  "GeneratedAtUtc": "2026-05-11T22:20:00.6303938Z",
+  "Framework": ".NET 8.0.26",
+  "MachineName": "EVOMAGIC",
+  "RowCount": 2500,
+  "Libraries": [
+    {
+      "Library": "OfficeIMO.Excel",
+      "OutputBytes": 116480,
+      "Stages": [
+        {
+          "Name": "InsertObjects",
+          "AverageMilliseconds": 16.82694,
+          "MedianMilliseconds": 16.2036,
+          "SamplesMilliseconds": [
+            18.7372,
+            15.6239,
+            17.9142,
+            15.6558,
+            16.2036
+          ]
+        },
+        {
+          "Name": "AddTable.ScanExistingIds",
+          "AverageMilliseconds": 0.00754,
+          "MedianMilliseconds": 0.0075,
+          "SamplesMilliseconds": [
+            0.0089,
+            0.0053,
+            0.0075,
+            0.0049,
+            0.0111
+          ]
+        },
+        {
+          "Name": "AddTable",
+          "AverageMilliseconds": 27.788460000000004,
+          "MedianMilliseconds": 29.0074,
+          "SamplesMilliseconds": [
+            30.7294,
+            29.0074,
+            32.0725,
+            28.6526,
+            18.4804
+          ]
+        },
+        {
+          "Name": "AutoFitColumns.BuildPlan",
+          "AverageMilliseconds": 23.99692,
+          "MedianMilliseconds": 23.3419,
+          "SamplesMilliseconds": [
+            23.3419,
+            34.7369,
+            15.9479,
+            15.6662,
+            30.2917
+          ]
+        },
+        {
+          "Name": "AutoFitColumns.CalculateWidths",
+          "AverageMilliseconds": 1.31428,
+          "MedianMilliseconds": 1.0843,
+          "SamplesMilliseconds": [
+            1.1661,
+            0.9618,
+            1.0843,
+            0.9914,
+            2.3678
+          ]
+        },
+        {
+          "Name": "AutoFitColumns.ApplyWidths",
+          "AverageMilliseconds": 0.0773,
+          "MedianMilliseconds": 0.0742,
+          "SamplesMilliseconds": [
+            0.0629,
+            0.0819,
+            0.064,
+            0.0742,
+            0.1035
+          ]
+        },
+        {
+          "Name": "AutoFitColumns",
+          "AverageMilliseconds": 25.40956,
+          "MedianMilliseconds": 24.6007,
+          "SamplesMilliseconds": [
+            24.6007,
+            35.7991,
+            17.1117,
+            16.7444,
+            32.7919
+          ]
+        },
+        {
+          "Name": "DisposeAndSave",
+          "AverageMilliseconds": 29.134299999999996,
+          "MedianMilliseconds": 30.2988,
+          "SamplesMilliseconds": [
+            29.6893,
+            32.1848,
+            30.2988,
+            37.4954,
+            16.0032
+          ]
+        },
+        {
+          "Name": "Total",
+          "AverageMilliseconds": 99.44335999999998,
+          "MedianMilliseconds": 98.7836,
+          "SamplesMilliseconds": [
+            104.1664,
+            112.8559,
+            97.6336,
+            98.7836,
+            83.7773
+          ]
+        }
+      ]
+    },
+    {
+      "Library": "ClosedXML",
+      "OutputBytes": 123939,
+      "Stages": [
+        {
+          "Name": "InsertTable",
+          "AverageMilliseconds": 13.411939999999998,
+          "MedianMilliseconds": 13.1974,
+          "SamplesMilliseconds": [
+            14.6862,
+            13.1974,
+            12.5289,
+            13.5832,
+            13.064
+          ]
+        },
+        {
+          "Name": "StyleTable",
+          "AverageMilliseconds": 0.00023999999999999998,
+          "MedianMilliseconds": 0.0003,
+          "SamplesMilliseconds": [
+            0.0001,
+            0.0003,
+            0.0003,
+            0.0003,
+            0.0002
+          ]
+        },
+        {
+          "Name": "AutoFitColumns",
+          "AverageMilliseconds": 134.33368000000002,
+          "MedianMilliseconds": 132.4938,
+          "SamplesMilliseconds": [
+            144.2105,
+            136.6655,
+            126.7137,
+            132.4938,
+            131.5849
+          ]
+        },
+        {
+          "Name": "SaveAs",
+          "AverageMilliseconds": 102.6326,
+          "MedianMilliseconds": 90.261,
+          "SamplesMilliseconds": [
+            106.6739,
+            90.261,
+            88.8258,
+            87.5256,
+            139.8767
+          ]
+        },
+        {
+          "Name": "Total",
+          "AverageMilliseconds": 250.39054000000002,
+          "MedianMilliseconds": 240.1384,
+          "SamplesMilliseconds": [
+            265.5822,
+            240.1384,
+            228.08,
+            233.6153,
+            284.5368
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Docs/benchmarks/officeimo.excel.write-profile-25000-2026-05-11.json
+++ b/Docs/benchmarks/officeimo.excel.write-profile-25000-2026-05-11.json
@@ -1,0 +1,188 @@
+{
+  "GeneratedAtUtc": "2026-05-11T22:11:41.9001097Z",
+  "Framework": ".NET 8.0.26",
+  "MachineName": "EVOMAGIC",
+  "RowCount": 25000,
+  "Libraries": [
+    {
+      "Library": "OfficeIMO.Excel",
+      "OutputBytes": 1125661,
+      "Stages": [
+        {
+          "Name": "InsertObjects",
+          "AverageMilliseconds": 215.14956,
+          "MedianMilliseconds": 222.748,
+          "SamplesMilliseconds": [
+            169.0495,
+            222.7794,
+            219.3187,
+            241.8522,
+            222.748
+          ]
+        },
+        {
+          "Name": "AddTable.ScanExistingIds",
+          "AverageMilliseconds": 0.01842,
+          "MedianMilliseconds": 0.0176,
+          "SamplesMilliseconds": [
+            0.0199,
+            0.0136,
+            0.0162,
+            0.0248,
+            0.0176
+          ]
+        },
+        {
+          "Name": "AddTable",
+          "AverageMilliseconds": 147.22913999999997,
+          "MedianMilliseconds": 137.2618,
+          "SamplesMilliseconds": [
+            106.359,
+            137.2618,
+            133.3937,
+            197.0074,
+            162.1238
+          ]
+        },
+        {
+          "Name": "AutoFitColumns.BuildPlan",
+          "AverageMilliseconds": 177.13574,
+          "MedianMilliseconds": 174.4564,
+          "SamplesMilliseconds": [
+            174.4564,
+            160.5935,
+            171.1164,
+            192.0957,
+            187.4167
+          ]
+        },
+        {
+          "Name": "AutoFitColumns.CalculateWidths",
+          "AverageMilliseconds": 5.42772,
+          "MedianMilliseconds": 0.7817,
+          "SamplesMilliseconds": [
+            4.0188,
+            20.9143,
+            0.7817,
+            0.722,
+            0.7018
+          ]
+        },
+        {
+          "Name": "AutoFitColumns.ApplyWidths",
+          "AverageMilliseconds": 105.68498,
+          "MedianMilliseconds": 109.7374,
+          "SamplesMilliseconds": [
+            81.0639,
+            116.5166,
+            109.7374,
+            93.7039,
+            127.4031
+          ]
+        },
+        {
+          "Name": "AutoFitColumns",
+          "AverageMilliseconds": 288.2948,
+          "MedianMilliseconds": 286.574,
+          "SamplesMilliseconds": [
+            259.5805,
+            298.0726,
+            281.6846,
+            286.574,
+            315.5623
+          ]
+        },
+        {
+          "Name": "DisposeAndSave",
+          "AverageMilliseconds": 195.13134,
+          "MedianMilliseconds": 193.697,
+          "SamplesMilliseconds": [
+            198.1295,
+            186.3042,
+            209.4594,
+            193.697,
+            188.0666
+          ]
+        },
+        {
+          "Name": "Total",
+          "AverageMilliseconds": 846.19388,
+          "MedianMilliseconds": 844.7747,
+          "SamplesMilliseconds": [
+            733.717,
+            844.7747,
+            844.1991,
+            919.4627,
+            888.8159
+          ]
+        }
+      ]
+    },
+    {
+      "Library": "ClosedXML",
+      "OutputBytes": 1168291,
+      "Stages": [
+        {
+          "Name": "InsertTable",
+          "AverageMilliseconds": 57.290020000000005,
+          "MedianMilliseconds": 56.0987,
+          "SamplesMilliseconds": [
+            76.3616,
+            66.6696,
+            56.0987,
+            44.7558,
+            42.5644
+          ]
+        },
+        {
+          "Name": "StyleTable",
+          "AverageMilliseconds": 0.00046,
+          "MedianMilliseconds": 0.0004,
+          "SamplesMilliseconds": [
+            0.0006,
+            0.0009,
+            0.0003,
+            0.0001,
+            0.0004
+          ]
+        },
+        {
+          "Name": "AutoFitColumns",
+          "AverageMilliseconds": 558.27634,
+          "MedianMilliseconds": 580.2205,
+          "SamplesMilliseconds": [
+            611.4265,
+            617.513,
+            580.2205,
+            515.2362,
+            466.9855
+          ]
+        },
+        {
+          "Name": "SaveAs",
+          "AverageMilliseconds": 380.04908000000006,
+          "MedianMilliseconds": 382.7142,
+          "SamplesMilliseconds": [
+            408.9646,
+            389.1845,
+            365.4884,
+            382.7142,
+            353.8937
+          ]
+        },
+        {
+          "Name": "Total",
+          "AverageMilliseconds": 995.62902,
+          "MedianMilliseconds": 1001.8179,
+          "SamplesMilliseconds": [
+            1096.77,
+            1073.3842,
+            1001.8179,
+            942.7217,
+            863.4513
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Docs/benchmarks/officeimo.excel.write-profile-25000-2026-05-12.json
+++ b/Docs/benchmarks/officeimo.excel.write-profile-25000-2026-05-12.json
@@ -1,0 +1,188 @@
+{
+  "GeneratedAtUtc": "2026-05-11T22:21:26.256145Z",
+  "Framework": ".NET 8.0.26",
+  "MachineName": "EVOMAGIC",
+  "RowCount": 25000,
+  "Libraries": [
+    {
+      "Library": "OfficeIMO.Excel",
+      "OutputBytes": 1125663,
+      "Stages": [
+        {
+          "Name": "InsertObjects",
+          "AverageMilliseconds": 211.39712,
+          "MedianMilliseconds": 228.751,
+          "SamplesMilliseconds": [
+            174.9044,
+            181.7469,
+            235.1323,
+            228.751,
+            236.451
+          ]
+        },
+        {
+          "Name": "AddTable.ScanExistingIds",
+          "AverageMilliseconds": 0.019020000000000002,
+          "MedianMilliseconds": 0.0188,
+          "SamplesMilliseconds": [
+            0.0167,
+            0.017,
+            0.0188,
+            0.0219,
+            0.0207
+          ]
+        },
+        {
+          "Name": "AddTable",
+          "AverageMilliseconds": 153.07752,
+          "MedianMilliseconds": 161.2342,
+          "SamplesMilliseconds": [
+            110.815,
+            173.0806,
+            144.9353,
+            161.2342,
+            175.3225
+          ]
+        },
+        {
+          "Name": "AutoFitColumns.BuildPlan",
+          "AverageMilliseconds": 162.73342,
+          "MedianMilliseconds": 169.5805,
+          "SamplesMilliseconds": [
+            169.5805,
+            193.2194,
+            122.8908,
+            172.8373,
+            155.1391
+          ]
+        },
+        {
+          "Name": "AutoFitColumns.CalculateWidths",
+          "AverageMilliseconds": 6.0917200000000005,
+          "MedianMilliseconds": 1.5631,
+          "SamplesMilliseconds": [
+            4.6121,
+            22.8034,
+            1.5631,
+            0.7223,
+            0.7577
+          ]
+        },
+        {
+          "Name": "AutoFitColumns.ApplyWidths",
+          "AverageMilliseconds": 0.09186000000000001,
+          "MedianMilliseconds": 0.0774,
+          "SamplesMilliseconds": [
+            0.053,
+            0.0778,
+            0.2036,
+            0.0774,
+            0.0475
+          ]
+        },
+        {
+          "Name": "AutoFitColumns",
+          "AverageMilliseconds": 168.95275999999998,
+          "MedianMilliseconds": 173.684,
+          "SamplesMilliseconds": [
+            174.2877,
+            216.131,
+            124.6938,
+            173.684,
+            155.9673
+          ]
+        },
+        {
+          "Name": "DisposeAndSave",
+          "AverageMilliseconds": 186.92054000000002,
+          "MedianMilliseconds": 185.3732,
+          "SamplesMilliseconds": [
+            150.0284,
+            214.6335,
+            185.3732,
+            172.6001,
+            211.9675
+          ]
+        },
+        {
+          "Name": "Total",
+          "AverageMilliseconds": 720.72648,
+          "MedianMilliseconds": 736.5744,
+          "SamplesMilliseconds": [
+            610.6019,
+            785.94,
+            690.4712,
+            736.5744,
+            780.0449
+          ]
+        }
+      ]
+    },
+    {
+      "Library": "ClosedXML",
+      "OutputBytes": 1168291,
+      "Stages": [
+        {
+          "Name": "InsertTable",
+          "AverageMilliseconds": 59.65198,
+          "MedianMilliseconds": 54.2589,
+          "SamplesMilliseconds": [
+            102.6738,
+            43.9275,
+            42.522,
+            54.8777,
+            54.2589
+          ]
+        },
+        {
+          "Name": "StyleTable",
+          "AverageMilliseconds": 0.00028,
+          "MedianMilliseconds": 0.0003,
+          "SamplesMilliseconds": [
+            0.0003,
+            0.0003,
+            0.0002,
+            0.0003,
+            0.0003
+          ]
+        },
+        {
+          "Name": "AutoFitColumns",
+          "AverageMilliseconds": 540.38972,
+          "MedianMilliseconds": 540.5365,
+          "SamplesMilliseconds": [
+            498.8216,
+            573.0074,
+            483.9059,
+            540.5365,
+            605.6772
+          ]
+        },
+        {
+          "Name": "SaveAs",
+          "AverageMilliseconds": 370.35824,
+          "MedianMilliseconds": 377.5666,
+          "SamplesMilliseconds": [
+            355.1714,
+            362.3559,
+            378.948,
+            377.5666,
+            377.7493
+          ]
+        },
+        {
+          "Name": "Total",
+          "AverageMilliseconds": 970.4102800000001,
+          "MedianMilliseconds": 972.9935,
+          "SamplesMilliseconds": [
+            956.6746,
+            979.2999,
+            905.3882,
+            972.9935,
+            1037.6952
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/OfficeIMO.Excel.Benchmarks/ExcelBenchmarkSnapshotRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelBenchmarkSnapshotRunner.cs
@@ -1,41 +1,50 @@
+using System.Globalization;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using ClosedXML.Excel;
 
 namespace OfficeIMO.Excel.Benchmarks;
 
 internal static class ExcelBenchmarkSnapshotRunner {
-    private const int SnapshotRowCount = 2500;
+    private const int DefaultRowCount = 2500;
     private const int WarmupIterations = 2;
     private const int MeasuredIterations = 5;
 
-    internal static string WriteSnapshot(string outputPath) {
+    internal static string WriteSnapshot(string outputPath, int rowCount = DefaultRowCount, string? websiteBenchmarkDataPath = null) {
         if (string.IsNullOrWhiteSpace(outputPath)) {
             throw new ArgumentException("Output path must not be empty.", nameof(outputPath));
         }
+        if (rowCount <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(rowCount));
+        }
 
-        var rows = ExcelBenchmarkScenarioFactory.CreateSalesRecords(SnapshotRowCount);
+        var rows = ExcelBenchmarkScenarioFactory.CreateSalesRecords(rowCount);
         var workbookBytes = ExcelBenchmarkScenarioFactory.CreateWorkbookBytes(rows);
+        string rowLabel = rowCount.ToString("N0", CultureInfo.InvariantCulture);
+        string dataRange = ExcelBenchmarkScenarioFactory.BuildDataRange(rowCount);
 
         var snapshot = new ExcelBenchmarkSnapshot {
             GeneratedAtUtc = DateTime.UtcNow,
             Framework = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription,
             MachineName = Environment.MachineName,
-            RowCount = SnapshotRowCount,
+            RowCount = rowCount,
             Scenarios = [
-                Measure("Excel: Write report (2,500 rows)", "OfficeIMO.Excel", "Insert objects, table, and AutoFit on a single worksheet.",
+                Measure($"Excel: Write report ({rowLabel} rows)", "OfficeIMO.Excel", "Insert objects, table, and AutoFit on a single worksheet.",
                     () => OfficeImoWrite(rows)),
-                Measure("Excel: Write report (2,500 rows)", "ClosedXML", "Insert table and adjust columns on a single worksheet.",
+                Measure($"Excel: Write report ({rowLabel} rows)", "ClosedXML", "Insert table and adjust columns on a single worksheet.",
                     () => ClosedXmlWrite(rows)),
-                Measure("Excel: Read objects (2,500 rows)", "OfficeIMO.Excel", "Reader path materializing dictionary-style rows.",
-                    () => OfficeImoReadObjects(workbookBytes)),
-                Measure("Excel: Read DataTable (2,500 rows)", "OfficeIMO.Excel", "Reader path materializing a DataTable from the same workbook.",
-                    () => OfficeImoReadDataTable(workbookBytes)),
-                Measure("Excel: Read rows (2,500 rows)", "ClosedXML", "Worksheet row iteration over the same workbook payload.",
+                Measure($"Excel: Read objects ({rowLabel} rows)", "OfficeIMO.Excel", "Reader path materializing dictionary-style rows.",
+                    () => OfficeImoReadObjects(workbookBytes, dataRange)),
+                Measure($"Excel: Read typed objects ({rowLabel} rows)", "OfficeIMO.Excel", "Reader path mapping rows directly to typed objects.",
+                    () => OfficeImoReadObjectsAs(workbookBytes, dataRange)),
+                Measure($"Excel: Read DataTable ({rowLabel} rows)", "OfficeIMO.Excel", "Reader path materializing a DataTable from the same workbook.",
+                    () => OfficeImoReadDataTable(workbookBytes, dataRange)),
+                Measure($"Excel: Read rows ({rowLabel} rows)", "ClosedXML", "Worksheet row iteration over the same workbook payload.",
                     () => ClosedXmlReadRows(workbookBytes)),
-                Measure("Excel: Load/edit/save (2,500 rows)", "OfficeIMO.Excel", "Load workbook, add review column, save to memory.",
-                    () => OfficeImoRoundTrip(workbookBytes)),
-                Measure("Excel: Load/edit/save (2,500 rows)", "ClosedXML", "Load workbook, add review column, save to memory.",
-                    () => ClosedXmlRoundTrip(workbookBytes))
+                Measure($"Excel: Load/edit/save ({rowLabel} rows)", "OfficeIMO.Excel", "Load workbook, add review column, save to memory.",
+                    () => OfficeImoRoundTrip(workbookBytes, rowCount)),
+                Measure($"Excel: Load/edit/save ({rowLabel} rows)", "ClosedXML", "Load workbook, add review column, save to memory.",
+                    () => ClosedXmlRoundTrip(workbookBytes, rowCount))
             ]
         };
 
@@ -46,8 +55,53 @@ internal static class ExcelBenchmarkSnapshotRunner {
 
         var options = new JsonSerializerOptions { WriteIndented = true };
         File.WriteAllText(outputPath, JsonSerializer.Serialize(snapshot, options));
+        if (!string.IsNullOrWhiteSpace(websiteBenchmarkDataPath)) {
+            WriteWebsiteBenchmarkData(websiteBenchmarkDataPath, snapshot, DateOnly.FromDateTime(DateTime.Now));
+        }
+
         return outputPath;
     }
+
+    private static void WriteWebsiteBenchmarkData(string path, ExcelBenchmarkSnapshot snapshot, DateOnly snapshotDate) {
+        if (!File.Exists(path)) {
+            throw new FileNotFoundException("Website benchmark data file was not found.", path);
+        }
+
+        JsonNode root = JsonNode.Parse(File.ReadAllText(path)) ?? throw new InvalidOperationException("Website benchmark data is empty.");
+        JsonArray scenarios = root["scenarios"]?.AsArray() ?? throw new InvalidOperationException("Website benchmark data does not contain a scenarios array.");
+        var snapshotScenarios = snapshot.Scenarios.ToDictionary(
+            scenario => BuildScenarioKey(scenario.Name, scenario.Library),
+            scenario => scenario,
+            StringComparer.Ordinal);
+        string dateText = snapshotDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        foreach (JsonNode? scenarioNode in scenarios) {
+            if (scenarioNode is null) {
+                continue;
+            }
+
+            string? name = scenarioNode["name"]?.GetValue<string>();
+            string? library = scenarioNode["library"]?.GetValue<string>();
+            if (name is null || library is null || !snapshotScenarios.TryGetValue(BuildScenarioKey(name, library), out var snapshotScenario)) {
+                continue;
+            }
+
+            scenarioNode["result"] = snapshotScenario.Result;
+            scenarioNode["notes"] = string.Create(
+                CultureInfo.InvariantCulture,
+                $"5-sample snapshot dated {dateText}. Median {snapshotScenario.MedianMilliseconds:F1} ms. {snapshotScenario.Notes}");
+        }
+
+        string? directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(path, root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private static string BuildScenarioKey(string name, string library)
+        => string.Concat(name, "\u001f", library);
 
     private static ExcelBenchmarkSnapshotScenario Measure(string name, string library, string notes, Func<int> action) {
         var measurement = BenchmarkMeasurement.Measure(WarmupIterations, MeasuredIterations, action);
@@ -55,7 +109,7 @@ internal static class ExcelBenchmarkSnapshotRunner {
         return new ExcelBenchmarkSnapshotScenario {
             Name = name,
             Library = library,
-            Result = $"{measurement.AverageMilliseconds:F1} ms avg",
+            Result = string.Create(CultureInfo.InvariantCulture, $"{measurement.AverageMilliseconds:F1} ms avg"),
             Notes = notes,
             OutputMetric = measurement.OutputMetric,
             AverageMilliseconds = measurement.AverageMilliseconds,
@@ -67,6 +121,7 @@ internal static class ExcelBenchmarkSnapshotRunner {
     private static int OfficeImoWrite(IReadOnlyList<ExcelBenchmarkScenarioFactory.SalesRecord> rows) {
         using var stream = new MemoryStream();
         using (var document = ExcelDocument.Create(stream)) {
+            document.Execution.SaveWorksheetAfterAutoFit = false;
             var sheet = document.AddWorkSheet("Data");
             ExcelBenchmarkScenarioFactory.PopulateOfficeImoWorksheet(sheet, rows);
         }
@@ -83,16 +138,22 @@ internal static class ExcelBenchmarkSnapshotRunner {
         return checked((int)stream.Length);
     }
 
-    private static int OfficeImoReadObjects(byte[] workbookBytes) {
+    private static int OfficeImoReadObjects(byte[] workbookBytes, string dataRange) {
         using var stream = new MemoryStream(workbookBytes, writable: false);
         using var reader = ExcelDocumentReader.Open(stream);
-        return reader.GetSheet("Data").ReadObjects(ExcelBenchmarkScenarioFactory.BuildDataRange(SnapshotRowCount)).Count();
+        return reader.GetSheet("Data").ReadObjects(dataRange).Count();
     }
 
-    private static int OfficeImoReadDataTable(byte[] workbookBytes) {
+    private static int OfficeImoReadObjectsAs(byte[] workbookBytes, string dataRange) {
         using var stream = new MemoryStream(workbookBytes, writable: false);
         using var reader = ExcelDocumentReader.Open(stream);
-        return reader.GetSheet("Data").ReadRangeAsDataTable(ExcelBenchmarkScenarioFactory.BuildDataRange(SnapshotRowCount), headersInFirstRow: true).Rows.Count;
+        return reader.GetSheet("Data").ReadObjects<ReadSalesRecord>(dataRange).Count();
+    }
+
+    private static int OfficeImoReadDataTable(byte[] workbookBytes, string dataRange) {
+        using var stream = new MemoryStream(workbookBytes, writable: false);
+        using var reader = ExcelDocumentReader.Open(stream);
+        return reader.GetSheet("Data").ReadRangeAsDataTable(dataRange, headersInFirstRow: true).Rows.Count;
     }
 
     private static int ClosedXmlReadRows(byte[] workbookBytes) {
@@ -111,7 +172,7 @@ internal static class ExcelBenchmarkSnapshotRunner {
         return count;
     }
 
-    private static int OfficeImoRoundTrip(byte[] workbookBytes) {
+    private static int OfficeImoRoundTrip(byte[] workbookBytes, int rowCount) {
         using var input = new MemoryStream(workbookBytes, writable: false);
         using var output = new MemoryStream();
 
@@ -119,7 +180,7 @@ internal static class ExcelBenchmarkSnapshotRunner {
             var sheet = document["Data"];
             sheet.CellValue(1, 9, "ReviewStatus");
 
-            int limit = Math.Min(SnapshotRowCount + 1, 101);
+            int limit = Math.Min(rowCount + 1, 101);
             for (int row = 2; row <= limit; row++) {
                 sheet.CellValue(row, 9, "Reviewed");
             }
@@ -130,14 +191,14 @@ internal static class ExcelBenchmarkSnapshotRunner {
         return checked((int)output.Length);
     }
 
-    private static int ClosedXmlRoundTrip(byte[] workbookBytes) {
+    private static int ClosedXmlRoundTrip(byte[] workbookBytes, int rowCount) {
         using var input = new MemoryStream(workbookBytes, writable: false);
         using var output = new MemoryStream();
         using var workbook = new XLWorkbook(input);
         var worksheet = workbook.Worksheet("Data");
 
         worksheet.Cell(1, 9).Value = "ReviewStatus";
-        int limit = Math.Min(SnapshotRowCount + 1, 101);
+        int limit = Math.Min(rowCount + 1, 101);
         for (int row = 2; row <= limit; row++) {
             worksheet.Cell(row, 9).Value = "Reviewed";
         }
@@ -163,5 +224,16 @@ internal static class ExcelBenchmarkSnapshotRunner {
         public double AverageMilliseconds { get; init; }
         public double MedianMilliseconds { get; init; }
         public List<double> SamplesMilliseconds { get; init; } = [];
+    }
+
+    private sealed class ReadSalesRecord {
+        public int Id { get; set; }
+        public string Region { get; set; } = string.Empty;
+        public string Owner { get; set; } = string.Empty;
+        public DateTime CreatedOn { get; set; }
+        public double Amount { get; set; }
+        public int Units { get; set; }
+        public bool Active { get; set; }
+        public string Notes { get; set; } = string.Empty;
     }
 }

--- a/OfficeIMO.Excel.Benchmarks/ExcelReadProfileRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelReadProfileRunner.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using ClosedXML.Excel;
+
+namespace OfficeIMO.Excel.Benchmarks;
+
+internal static class ExcelReadProfileRunner {
+    private const int DefaultRowCount = 2500;
+    private const int WarmupIterations = 2;
+    private const int MeasuredIterations = 5;
+
+    internal static string WriteProfile(string outputPath, int rowCount = DefaultRowCount) {
+        if (string.IsNullOrWhiteSpace(outputPath)) {
+            throw new ArgumentException("Output path must not be empty.", nameof(outputPath));
+        }
+        if (rowCount <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(rowCount));
+        }
+
+        var rows = ExcelBenchmarkScenarioFactory.CreateSalesRecords(rowCount);
+        byte[] workbookBytes = ExcelBenchmarkScenarioFactory.CreateWorkbookBytes(rows);
+        string dataRange = ExcelBenchmarkScenarioFactory.BuildDataRange(rowCount);
+
+        var profile = new ExcelReadProfile {
+            GeneratedAtUtc = DateTime.UtcNow,
+            Framework = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription,
+            MachineName = Environment.MachineName,
+            RowCount = rowCount,
+            Scenarios = [
+                Measure("OfficeIMO.Excel", "ReadObjects", "Automatic execution policy.", () => OfficeImoReadObjects(workbookBytes, dataRange, null)),
+                Measure("OfficeIMO.Excel", "ReadObjects.Sequential", "Forced sequential range conversion.", () => OfficeImoReadObjects(workbookBytes, dataRange, ExecutionMode.Sequential)),
+                Measure("OfficeIMO.Excel", "ReadObjects.Parallel", "Forced parallel range conversion.", () => OfficeImoReadObjects(workbookBytes, dataRange, ExecutionMode.Parallel)),
+                Measure("OfficeIMO.Excel", "ReadObjectsAs", "Typed object materialization with automatic execution policy.", () => OfficeImoReadObjectsAs(workbookBytes, dataRange, null)),
+                Measure("OfficeIMO.Excel", "ReadObjectsAs.Sequential", "Typed object materialization with forced sequential range conversion.", () => OfficeImoReadObjectsAs(workbookBytes, dataRange, ExecutionMode.Sequential)),
+                Measure("OfficeIMO.Excel", "ReadObjectsAs.Parallel", "Typed object materialization with forced parallel range conversion.", () => OfficeImoReadObjectsAs(workbookBytes, dataRange, ExecutionMode.Parallel)),
+                Measure("OfficeIMO.Excel", "ReadRangeAsDataTable", "Automatic execution policy.", () => OfficeImoReadDataTable(workbookBytes, dataRange, null)),
+                Measure("OfficeIMO.Excel", "ReadRangeAsDataTable.Sequential", "Forced sequential range conversion.", () => OfficeImoReadDataTable(workbookBytes, dataRange, ExecutionMode.Sequential)),
+                Measure("OfficeIMO.Excel", "ReadRangeAsDataTable.Parallel", "Forced parallel range conversion.", () => OfficeImoReadDataTable(workbookBytes, dataRange, ExecutionMode.Parallel)),
+                Measure("ClosedXML", "ReadRows", "Worksheet row iteration over the same workbook payload.", () => ClosedXmlReadRows(workbookBytes))
+            ]
+        };
+
+        string? directory = Path.GetDirectoryName(outputPath);
+        if (!string.IsNullOrEmpty(directory)) {
+            Directory.CreateDirectory(directory);
+        }
+
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        File.WriteAllText(outputPath, JsonSerializer.Serialize(profile, options));
+        return outputPath;
+    }
+
+    private static ExcelReadProfileScenario Measure(string library, string name, string notes, Func<int> action) {
+        var measurement = BenchmarkMeasurement.Measure(WarmupIterations, MeasuredIterations, action);
+
+        return new ExcelReadProfileScenario {
+            Library = library,
+            Name = name,
+            Notes = notes,
+            OutputMetric = measurement.OutputMetric,
+            AverageMilliseconds = measurement.AverageMilliseconds,
+            MedianMilliseconds = measurement.MedianMilliseconds,
+            SamplesMilliseconds = measurement.SamplesMilliseconds.ToList()
+        };
+    }
+
+    private static int OfficeImoReadObjects(byte[] workbookBytes, string dataRange, ExecutionMode? mode) {
+        using var stream = new MemoryStream(workbookBytes, writable: false);
+        using var reader = ExcelDocumentReader.Open(stream);
+        return reader.GetSheet("Data").ReadObjects(dataRange, mode).Count();
+    }
+
+    private static int OfficeImoReadObjectsAs(byte[] workbookBytes, string dataRange, ExecutionMode? mode) {
+        using var stream = new MemoryStream(workbookBytes, writable: false);
+        using var reader = ExcelDocumentReader.Open(stream);
+        return reader.GetSheet("Data").ReadObjects<ReadSalesRecord>(dataRange, mode).Count();
+    }
+
+    private static int OfficeImoReadDataTable(byte[] workbookBytes, string dataRange, ExecutionMode? mode) {
+        using var stream = new MemoryStream(workbookBytes, writable: false);
+        using var reader = ExcelDocumentReader.Open(stream);
+        return reader.GetSheet("Data").ReadRangeAsDataTable(dataRange, headersInFirstRow: true, mode: mode).Rows.Count;
+    }
+
+    private static int ClosedXmlReadRows(byte[] workbookBytes) {
+        using var stream = new MemoryStream(workbookBytes, writable: false);
+        using var workbook = new XLWorkbook(stream);
+        var worksheet = workbook.Worksheet("Data");
+        int lastRow = worksheet.LastRowUsed()?.RowNumber() ?? 0;
+        int count = 0;
+
+        for (int row = 2; row <= lastRow; row++) {
+            _ = worksheet.Cell(row, 1).GetValue<int>();
+            _ = worksheet.Cell(row, 5).GetValue<double>();
+            count++;
+        }
+
+        return count;
+    }
+
+    private sealed class ExcelReadProfile {
+        public DateTime GeneratedAtUtc { get; init; }
+        public string Framework { get; init; } = string.Empty;
+        public string MachineName { get; init; } = string.Empty;
+        public int RowCount { get; init; }
+        public List<ExcelReadProfileScenario> Scenarios { get; init; } = [];
+    }
+
+    private sealed class ExcelReadProfileScenario {
+        public string Library { get; init; } = string.Empty;
+        public string Name { get; init; } = string.Empty;
+        public string Notes { get; init; } = string.Empty;
+        public int OutputMetric { get; init; }
+        public double AverageMilliseconds { get; init; }
+        public double MedianMilliseconds { get; init; }
+        public List<double> SamplesMilliseconds { get; init; } = [];
+    }
+
+    private sealed class ReadSalesRecord {
+        public int Id { get; set; }
+        public string Region { get; set; } = string.Empty;
+        public string Owner { get; set; } = string.Empty;
+        public DateTime CreatedOn { get; set; }
+        public double Amount { get; set; }
+        public int Units { get; set; }
+        public bool Active { get; set; }
+        public string Notes { get; set; } = string.Empty;
+    }
+}

--- a/OfficeIMO.Excel.Benchmarks/ExcelWriteProfileRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelWriteProfileRunner.cs
@@ -79,6 +79,11 @@ internal static class ExcelWriteProfileRunner {
         var document = ExcelDocument.Create(stream);
 
         try {
+            document.Execution.SaveWorksheetAfterAutoFit = false;
+            if (totals != null) {
+                document.Execution.OnTiming = (operation, elapsed) => AddStage(totals, operation, elapsed.TotalMilliseconds);
+            }
+
             var sheet = document.AddWorkSheet("Data");
 
             stageWatch.Restart();

--- a/OfficeIMO.Excel.Benchmarks/Program.cs
+++ b/OfficeIMO.Excel.Benchmarks/Program.cs
@@ -1,16 +1,92 @@
 using OfficeIMO.Excel.Benchmarks;
 using BenchmarkDotNet.Running;
+using System.Globalization;
 
-if (args.Length >= 2 && string.Equals(args[0], "--snapshot", StringComparison.OrdinalIgnoreCase)) {
-    string outputPath = ExcelBenchmarkSnapshotRunner.WriteSnapshot(args[1]);
+if (IsCommand(args, "--snapshot", "snapshot")) {
+    bool hasOutputPath = HasOutputPath(args);
+    int rowCount = ParseRowCount(args, startIndex: hasOutputPath ? 2 : 1);
+    string? websiteDataPath = ParseOptionValue(args, "--website-data", "--website-benchmarks");
+    string outputPath = ExcelBenchmarkSnapshotRunner.WriteSnapshot(
+        hasOutputPath ? args[1] : BuildDefaultOutputPath("officeimo.excel.snapshot", rowCount),
+        rowCount,
+        websiteDataPath);
     Console.WriteLine($"Excel benchmark snapshot written to '{outputPath}'.");
+    if (!string.IsNullOrWhiteSpace(websiteDataPath)) {
+        Console.WriteLine($"Website benchmark data updated at '{websiteDataPath}'.");
+    }
     return;
 }
 
-if (args.Length >= 2 && string.Equals(args[0], "--profile-write", StringComparison.OrdinalIgnoreCase)) {
-    string outputPath = ExcelWriteProfileRunner.WriteProfile(args[1]);
+if (IsCommand(args, "--profile-write", "profile-write", "write-profile")) {
+    bool hasOutputPath = HasOutputPath(args);
+    int rowCount = ParseRowCount(args, startIndex: hasOutputPath ? 2 : 1);
+    string outputPath = ExcelWriteProfileRunner.WriteProfile(
+        hasOutputPath ? args[1] : BuildDefaultOutputPath("officeimo.excel.write-profile", rowCount),
+        rowCount);
     Console.WriteLine($"Excel write profile written to '{outputPath}'.");
     return;
 }
 
+if (IsCommand(args, "--profile-read", "profile-read", "read-profile")) {
+    bool hasOutputPath = HasOutputPath(args);
+    int rowCount = ParseRowCount(args, startIndex: hasOutputPath ? 2 : 1);
+    string outputPath = ExcelReadProfileRunner.WriteProfile(
+        hasOutputPath ? args[1] : BuildDefaultOutputPath("officeimo.excel.read-profile", rowCount),
+        rowCount);
+    Console.WriteLine($"Excel read profile written to '{outputPath}'.");
+    return;
+}
+
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+static bool IsCommand(string[] args, params string[] names)
+    => args.Length >= 1 && names.Any(name => string.Equals(args[0], name, StringComparison.OrdinalIgnoreCase));
+
+static bool HasOutputPath(string[] args)
+    => args.Length >= 2 && !args[1].StartsWith("-", StringComparison.Ordinal);
+
+static string BuildDefaultOutputPath(string baseName, int rowCount) {
+    string suffix = rowCount == 2500 ? string.Empty : "-" + rowCount.ToString(CultureInfo.InvariantCulture);
+    return Path.Combine("Docs", "benchmarks", baseName + suffix + ".json");
+}
+
+static int ParseRowCount(string[] args, int startIndex) {
+    const int defaultRowCount = 2500;
+
+    for (int i = startIndex; i < args.Length; i++) {
+        if (!string.Equals(args[i], "--rows", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(args[i], "--row-count", StringComparison.OrdinalIgnoreCase)) {
+            continue;
+        }
+
+        if (i + 1 >= args.Length) {
+            throw new ArgumentException("Missing value for --rows.");
+        }
+
+        string value = args[i + 1].Replace(",", string.Empty, StringComparison.Ordinal).Replace("_", string.Empty, StringComparison.Ordinal);
+        if (!int.TryParse(value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out int rowCount)
+            || rowCount <= 0) {
+            throw new ArgumentException("--rows must be a positive integer.");
+        }
+
+        return rowCount;
+    }
+
+    return defaultRowCount;
+}
+
+static string? ParseOptionValue(string[] args, params string[] optionNames) {
+    for (int i = 0; i < args.Length; i++) {
+        if (!optionNames.Any(name => string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase))) {
+            continue;
+        }
+
+        if (i + 1 >= args.Length || args[i + 1].StartsWith("-", StringComparison.Ordinal)) {
+            throw new ArgumentException($"Missing value for {args[i]}.");
+        }
+
+        return args[i + 1];
+    }
+
+    return null;
+}

--- a/OfficeIMO.Excel.Benchmarks/README.md
+++ b/OfficeIMO.Excel.Benchmarks/README.md
@@ -28,7 +28,19 @@ Generate a lightweight JSON baseline snapshot with:
 dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --snapshot .\Docs\benchmarks\officeimo.excel.snapshot.json
 ```
 
+The default snapshot uses 2,500 rows. Use `--rows` to generate larger comparison tiers:
+
+```powershell
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --snapshot .\Docs\benchmarks\officeimo.excel.snapshot-25000.json --rows 25000
+```
+
 The snapshot JSON records averages, medians, and raw samples for each scenario.
+
+To refresh the public website benchmark table from the same snapshot run, add `--website-data`:
+
+```powershell
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --snapshot .\Docs\benchmarks\officeimo.excel.snapshot.json --website-data .\Website\data\benchmarks.json
+```
 
 Generate a write-stage profile to identify where report-export time is spent:
 
@@ -36,4 +48,25 @@ Generate a write-stage profile to identify where report-export time is spent:
 dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --profile-write .\Docs\benchmarks\officeimo.excel.write-profile.json
 ```
 
-The write profile JSON records averages, medians, and raw samples for each stage so outlier runs are visible.
+Generate a read-stage profile to compare automatic, forced sequential, and forced parallel range conversion:
+
+```powershell
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --profile-read .\Docs\benchmarks\officeimo.excel.read-profile.json
+```
+
+The profile and snapshot commands also accept short aliases with a default output path under `Docs\benchmarks`:
+
+```powershell
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- write-profile --rows 25000
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- read-profile --rows 2500
+```
+
+The write profile also accepts `--rows`, which is the preferred way to investigate 25,000+ row report-export costs without running the full BenchmarkDotNet suite:
+
+```powershell
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --profile-write .\Docs\benchmarks\officeimo.excel.write-profile-25000.json --rows 25000
+```
+
+The write profile JSON records averages, medians, and raw samples for each stage so outlier runs are visible. OfficeIMO timing hooks also add AutoFit sub-stages (`BuildPlan`, `CalculateWidths`, and `ApplyWidths`) to make large-sheet tuning more targeted.
+
+The harness configures OfficeIMO with `Execution.SaveWorksheetAfterAutoFit = false`, matching the normal report-export pattern where all worksheet mutations are committed once when the document is saved or disposed.

--- a/OfficeIMO.Excel/COMPATIBILITY.md
+++ b/OfficeIMO.Excel/COMPATIBILITY.md
@@ -22,7 +22,7 @@ It is intentionally honest. "Partial" means usable, not "done".
 | Encryption/password support | Roadmap | This remains a notable gap for enterprise-style workbook scenarios. |
 | Streaming for very large workbooks | Partial | In-memory/file/stream workflows are strong, but the package still needs clearer large-workbook guidance and published benchmarks. |
 | Import fidelity for ugly real-world workbooks | Partial | Correctness has improved, but corpus depth is still lighter than it should be for competitive claims. |
-| Public benchmark evidence | Partial | Committed benchmark snapshots and write-stage profiles now exist. Recent optimization work materially improved report-style write performance, but OfficeIMO still trails ClosedXML on that workload. |
+| Public benchmark evidence | Partial | Committed benchmark snapshots plus write/read profiles now exist. Recent local snapshots show OfficeIMO ahead of ClosedXML on covered write/read/load-edit-save workloads, including the refreshed 25,000-row report-export profile, but broader row-count and hardware coverage is still needed before making large-workbook claims. |
 
 ## Current Strengths
 
@@ -33,7 +33,7 @@ It is intentionally honest. "Partial" means usable, not "done".
 
 ## Highest-Priority Gaps
 
-1. Keep reducing report-export overhead, with `InsertObjects()` now the largest staged cost and the remaining variance concentrated in occasional outlier samples rather than the steady-state path.
+1. Keep reducing report-export overhead, with table creation, auto-fit, and save costs now as important as `InsertObjects()` on the 25,000-row profile.
 2. Publish and refresh benchmark result sets on stable hardware instead of relying on a single developer machine snapshot.
 3. Expand the corpus with messy, externally-authored workbooks and round-trip assertions.
 4. Formalize formula/recalculation expectations so users know what is computed versus preserved.
@@ -42,10 +42,12 @@ It is intentionally honest. "Partial" means usable, not "done".
 
 ## Latest Snapshot Highlights
 
-- Updated 5-sample end-to-end snapshot on 2026-04-05: `OfficeIMO.Excel` now averages `258.0 ms` for the 2,500-row report scenario, while `ClosedXML` averages `273.3 ms`.
-- Read scenarios are still in the same general band as the comparison run: `ReadObjects()` averaged `118.3 ms`, `ReadRangeAsDataTable()` averaged `139.1 ms`, and the comparable `ClosedXML` row iteration averaged `99.9 ms`.
-- Load/edit/save remains a strength in the refreshed snapshot: `OfficeIMO.Excel` averaged `123.6 ms` versus `ClosedXML` at `149.9 ms`.
-- The latest write profile dated 2026-04-05 shows the current staged cost shape after the conservative auto-fit fast path and array-backed `InsertObjects()` buffers: `InsertObjects()` is about `179.3 ms`, `AddTable()` is about `28.3 ms`, `AutoFitColumns()` is about `88.2 ms`, and the OfficeIMO staged write total is about `318.6 ms`.
+- Updated 5-sample end-to-end snapshot on 2026-05-12: `OfficeIMO.Excel` averages `114.9 ms` for the 2,500-row report scenario, while `ClosedXML` averages `271.8 ms`.
+- Read scenarios are ahead in the refreshed comparison run after the A1 parser/read-path cleanup: `ReadObjects()` averaged `84.3 ms`, `ReadRangeAsDataTable()` averaged `85.7 ms`, and the comparable `ClosedXML` row iteration averaged `119.3 ms`.
+- The 2026-05-12 read profile records the execution-mode shape explicitly: `ReadObjects()` automatic/sequential/parallel averaged about `81.2 ms` / `78.2 ms` / `85.1 ms`, while `ReadRangeAsDataTable()` automatic/sequential/parallel averaged about `82.3 ms` / `99.0 ms` / `45.4 ms`; this is why the default threshold remains evidence-driven rather than forced globally.
+- Load/edit/save remains ahead in the refreshed snapshot: `OfficeIMO.Excel` averaged `108.4 ms` versus `ClosedXML` at `124.7 ms`.
+- The latest 2,500-row write profile dated 2026-05-12 shows the current staged cost shape with report-export AutoFit saves deferred to the document boundary: `InsertObjects()` is about `16.8 ms`, `AddTable()` is about `27.8 ms`, `AutoFitColumns()` is about `25.4 ms`, and the OfficeIMO staged write total is about `99.4 ms` versus ClosedXML at about `250.4 ms`.
+- A 25,000-row write profile on 2026-05-12 shows the larger-report shape after the row-major append, appended-cell style-cache, bulk shared-string registration, table range-scan, contiguous table-range verification, column-reference caching, auto-fit planning, auto-fit shared-string text/run caching, auto-fit style/number-format cache fast paths, and deferred AutoFit worksheet saves: `InsertObjects()` is about `211.4 ms`, `AddTable()` is about `153.1 ms`, `AutoFitColumns()` is about `169.0 ms`, and the OfficeIMO staged write total is about `720.7 ms` versus ClosedXML at about `970.4 ms`. The AutoFit profile records `BuildPlan`, `CalculateWidths`, and `ApplyWidths` sub-stages.
 - The benchmark artifacts now include raw samples and medians so outliers are visible instead of hidden behind a single average.
 
 ## Evidence In Repo

--- a/OfficeIMO.Excel/ExcelChartUtils.cs
+++ b/OfficeIMO.Excel/ExcelChartUtils.cs
@@ -43,8 +43,7 @@ namespace OfficeIMO.Excel {
         }
 
         internal static string BuildCellA1(int row, int column) {
-            string col = A1.ColumnIndexToLetters(column);
-            return $"${col}${row}";
+            return A1.AbsoluteCellReference(row, column);
         }
 
         internal static string BuildRangeA1(int row1, int col1, int row2, int col2) {

--- a/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
+++ b/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
@@ -397,16 +397,14 @@ namespace OfficeIMO.Excel {
             }
 
             // Bounds check: Excel supports 1..1,048,576 rows and 1..16,384 columns (XFD)
-            const int MaxRow = 1_048_576;
-            const int MaxCol = 16_384;
-            bool outOfBounds = (r1 < 1 || c1 < 1 || r2 > MaxRow || c2 > MaxCol || c1 > MaxCol || r1 > MaxRow);
+            bool outOfBounds = (r1 < 1 || c1 < 1 || r2 > A1.MaxRows || c2 > A1.MaxColumns || c1 > A1.MaxColumns || r1 > A1.MaxRows);
             if (outOfBounds && validationMode == NameValidationMode.Strict)
                 throw new ArgumentOutOfRangeException(nameof(range), "A1 range exceeds Excel bounds (rows ≤ 1,048,576; cols ≤ 16,384). Use Sanitize to clamp.");
             // Sanitize: clamp into valid range
-            r1 = Math.Max(1, Math.Min(MaxRow, r1));
-            r2 = Math.Max(1, Math.Min(MaxRow, r2));
-            c1 = Math.Max(1, Math.Min(MaxCol, c1));
-            c2 = Math.Max(1, Math.Min(MaxCol, c2));
+            r1 = Math.Max(1, Math.Min(A1.MaxRows, r1));
+            r2 = Math.Max(1, Math.Min(A1.MaxRows, r2));
+            c1 = Math.Max(1, Math.Min(A1.MaxColumns, c1));
+            c2 = Math.Max(1, Math.Min(A1.MaxColumns, c2));
 
             string start = A1.AbsoluteCellReference(r1, c1);
             string end = A1.AbsoluteCellReference(r2, c2);

--- a/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
+++ b/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
@@ -408,8 +408,8 @@ namespace OfficeIMO.Excel {
             c1 = Math.Max(1, Math.Min(MaxCol, c1));
             c2 = Math.Max(1, Math.Min(MaxCol, c2));
 
-            string start = $"${A1.ColumnIndexToLetters(c1)}${r1}";
-            string end = $"${A1.ColumnIndexToLetters(c2)}${r2}";
+            string start = A1.AbsoluteCellReference(r1, c1);
+            string end = A1.AbsoluteCellReference(r2, c2);
 
             string normalized = start;
             if (start != end) {

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -521,6 +521,53 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        internal Dictionary<string, int> GetSharedStringIndices(IEnumerable<string> texts) {
+            if (texts == null) {
+                throw new ArgumentNullException(nameof(texts));
+            }
+
+            lock (_sharedStringLock) {
+                var sharedStringTable = SharedStringTablePart.SharedStringTable ??= new SharedStringTable();
+                int tableCount;
+
+                if (_sharedStringCache.Count == 0) {
+                    tableCount = 0;
+                    foreach (SharedStringItem item in sharedStringTable.Elements<SharedStringItem>()) {
+                        _sharedStringCache[item.InnerText] = tableCount;
+                        tableCount++;
+                    }
+                } else {
+                    tableCount = sharedStringTable.Elements<SharedStringItem>().Count();
+                }
+
+                var result = new Dictionary<string, int>(StringComparer.Ordinal);
+                bool changed = false;
+
+                foreach (string text in texts) {
+                    if (result.ContainsKey(text)) {
+                        continue;
+                    }
+
+                    if (_sharedStringCache.TryGetValue(text, out int existingIndex)) {
+                        result[text] = existingIndex;
+                        continue;
+                    }
+
+                    int newIndex = tableCount++;
+                    sharedStringTable.AppendChild(new SharedStringItem(new Text(text)));
+                    _sharedStringCache[text] = newIndex;
+                    result[text] = newIndex;
+                    changed = true;
+                }
+
+                if (changed) {
+                    sharedStringTable.Save();
+                }
+
+                return result;
+            }
+        }
+
         /// <summary>
         /// Creates a new Excel document at the specified path.
         /// </summary>

--- a/OfficeIMO.Excel/ExcelSheet.AutoFitText.cs
+++ b/OfficeIMO.Excel/ExcelSheet.AutoFitText.cs
@@ -24,9 +24,24 @@ namespace OfficeIMO.Excel {
             return new AutoFitTextContext(
                 _excelDocument.SharedStringTablePart?.SharedStringTable?.Elements<SharedStringItem>().ToList(),
                 stylesheet?.CellFormats?.Elements<CellFormat>().ToList(),
-                stylesheet?.NumberingFormats?.Elements<NumberingFormat>().ToDictionary(
-                    nf => nf.NumberFormatId?.Value ?? 0U,
-                    nf => nf.FormatCode?.Value));
+                BuildCustomNumberFormatCache(stylesheet));
+        }
+
+        private static Dictionary<uint, string?>? BuildCustomNumberFormatCache(Stylesheet? stylesheet) {
+            var numberingFormats = stylesheet?.NumberingFormats;
+            if (numberingFormats == null) {
+                return null;
+            }
+
+            var cache = new Dictionary<uint, string?>();
+            foreach (var format in numberingFormats.Elements<NumberingFormat>()) {
+                uint id = format.NumberFormatId?.Value ?? 0U;
+                if (!cache.ContainsKey(id)) {
+                    cache.Add(id, format.FormatCode?.Value);
+                }
+            }
+
+            return cache;
         }
 
         private string GetCellAutoFitText(Cell cell, AutoFitTextContext? context = null) {

--- a/OfficeIMO.Excel/ExcelSheet.AutoFitText.cs
+++ b/OfficeIMO.Excel/ExcelSheet.AutoFitText.cs
@@ -19,12 +19,21 @@ namespace OfficeIMO.Excel {
             || value == ' '
             || value == '%';
 
-        private string GetCellAutoFitText(Cell cell, IReadOnlyList<SharedStringItem>? sharedStrings = null) {
+        private AutoFitTextContext CreateAutoFitTextContext() {
+            var stylesheet = WorkbookPartRoot?.WorkbookStylesPart?.Stylesheet;
+            return new AutoFitTextContext(
+                _excelDocument.SharedStringTablePart?.SharedStringTable?.Elements<SharedStringItem>().ToList(),
+                stylesheet?.CellFormats?.Elements<CellFormat>().ToList(),
+                stylesheet?.NumberingFormats?.Elements<NumberingFormat>().ToDictionary(
+                    nf => nf.NumberFormatId?.Value ?? 0U,
+                    nf => nf.FormatCode?.Value));
+        }
+
+        private string GetCellAutoFitText(Cell cell, AutoFitTextContext? context = null) {
             var dataType = cell.DataType?.Value;
 
             if (dataType == XCellValues.SharedString) {
-                var item = GetSharedStringItem(cell, sharedStrings);
-                return item == null ? string.Empty : GetSharedStringText(item);
+                return GetCachedSharedStringText(cell, context);
             }
 
             if (dataType == XCellValues.InlineString) {
@@ -45,19 +54,19 @@ namespace OfficeIMO.Excel {
             }
 
             if (dataType == null || dataType == XCellValues.Number) {
-                return FormatAutoFitNumericText(cell, raw);
+                return FormatAutoFitNumericText(cell, raw, context);
             }
 
             return raw;
         }
 
-        private string FormatAutoFitNumericText(Cell cell, string raw) {
+        private string FormatAutoFitNumericText(Cell cell, string raw, AutoFitTextContext? context) {
             if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out double value)) {
                 return raw;
             }
 
-            uint numberFormatId = GetCellNumberFormatId(cell);
-            string? formatCode = GetNumberFormatCode(numberFormatId);
+            uint numberFormatId = GetCellNumberFormatId(cell, context);
+            string? formatCode = GetNumberFormatCode(numberFormatId, context);
 
             if (numberFormatId == 0U || string.IsNullOrWhiteSpace(formatCode) || string.Equals(formatCode, "General", StringComparison.OrdinalIgnoreCase)) {
                 return raw;
@@ -70,20 +79,53 @@ namespace OfficeIMO.Excel {
             return FormatAutoFitNumberValue(value, numberFormatId, formatCode!) ?? raw;
         }
 
-        private uint GetCellNumberFormatId(Cell cell) {
+        private uint GetCellNumberFormatId(Cell cell, AutoFitTextContext? context) {
             if (cell.StyleIndex == null) {
                 return 0U;
             }
 
-            var cellFormats = WorkbookPartRoot?.WorkbookStylesPart?.Stylesheet?.CellFormats;
-            var cellFormat = cellFormats?.Elements<CellFormat>().ElementAtOrDefault((int)cell.StyleIndex.Value);
-            return cellFormat?.NumberFormatId?.Value ?? 0U;
+            uint styleIndex = cell.StyleIndex.Value;
+            if (context != null && context.NumberFormatIdsByStyle.TryGetValue(styleIndex, out uint cachedFormatId)) {
+                return cachedFormatId;
+            }
+
+            CellFormat? cellFormat = null;
+            if (context?.CellFormats != null) {
+                cellFormat = styleIndex < context.CellFormats.Count ? context.CellFormats[(int)styleIndex] : null;
+            } else {
+                var cellFormats = WorkbookPartRoot?.WorkbookStylesPart?.Stylesheet?.CellFormats;
+                cellFormat = cellFormats?.Elements<CellFormat>().ElementAtOrDefault((int)styleIndex);
+            }
+
+            uint numberFormatId = cellFormat?.NumberFormatId?.Value ?? 0U;
+            if (context != null) {
+                context.NumberFormatIdsByStyle[styleIndex] = numberFormatId;
+            }
+
+            return numberFormatId;
         }
 
-        private string? GetNumberFormatCode(uint numberFormatId) {
+        private string? GetNumberFormatCode(uint numberFormatId, AutoFitTextContext? context) {
+            if (context != null && context.NumberFormatCodes.TryGetValue(numberFormatId, out string? cachedCode)) {
+                return cachedCode;
+            }
+
+            string? code = GetNumberFormatCodeCore(numberFormatId, context);
+            if (context != null) {
+                context.NumberFormatCodes[numberFormatId] = code;
+            }
+
+            return code;
+        }
+
+        private string? GetNumberFormatCodeCore(uint numberFormatId, AutoFitTextContext? context) {
             string? builtIn = GetBuiltInNumberFormatCode(numberFormatId);
             if (builtIn != null) {
                 return builtIn;
+            }
+
+            if (context?.CustomNumberFormats != null) {
+                return context.CustomNumberFormats.TryGetValue(numberFormatId, out string? formatCode) ? formatCode : null;
             }
 
             var numberingFormats = WorkbookPartRoot?.WorkbookStylesPart?.Stylesheet?.NumberingFormats;
@@ -298,20 +340,52 @@ namespace OfficeIMO.Excel {
             return builder.ToString();
         }
 
-        private SharedStringItem? GetSharedStringItem(Cell cell, IReadOnlyList<SharedStringItem>? sharedStrings = null) {
+        private static bool TryGetSharedStringIndex(Cell cell, out int id) {
             var raw = cell.CellValue?.InnerText;
-            if (string.IsNullOrEmpty(raw) || !int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int id)) {
-                return null;
-            }
-
-            sharedStrings ??= _excelDocument.SharedStringTablePart?.SharedStringTable?.Elements<SharedStringItem>().ToList();
-            return sharedStrings != null && id >= 0 && id < sharedStrings.Count ? sharedStrings[id] : null;
+            return int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out id);
         }
 
-        private IReadOnlyList<AutoFitTextRun>? GetCellAutoFitRichTextRuns(Cell cell, IReadOnlyList<SharedStringItem>? sharedStrings = null) {
+        private string GetCachedSharedStringText(Cell cell, AutoFitTextContext? context) {
+            if (!TryGetSharedStringIndex(cell, out int id)) {
+                return string.Empty;
+            }
+
+            if (context != null && context.SharedStringTexts.TryGetValue(id, out string? cachedText)) {
+                return cachedText;
+            }
+
+            var sharedStrings = context?.SharedStrings ?? _excelDocument.SharedStringTablePart?.SharedStringTable?.Elements<SharedStringItem>().ToList();
+            string text = sharedStrings != null && id >= 0 && id < sharedStrings.Count
+                ? GetSharedStringText(sharedStrings[id])
+                : string.Empty;
+
+            if (context != null) {
+                context.SharedStringTexts[id] = text;
+            }
+
+            return text;
+        }
+
+        private IReadOnlyList<AutoFitTextRun>? GetCellAutoFitRichTextRuns(Cell cell, AutoFitTextContext? context = null) {
             if (cell.DataType?.Value == XCellValues.SharedString) {
-                var item = GetSharedStringItem(cell, sharedStrings);
-                return item == null ? null : GetSharedStringRichTextRuns(item);
+                if (!TryGetSharedStringIndex(cell, out int id)) {
+                    return null;
+                }
+
+                if (context != null && context.SharedStringRichTextRuns.TryGetValue(id, out var cachedRuns)) {
+                    return cachedRuns;
+                }
+
+                var sharedStrings = context?.SharedStrings ?? _excelDocument.SharedStringTablePart?.SharedStringTable?.Elements<SharedStringItem>().ToList();
+                var runs = sharedStrings != null && id >= 0 && id < sharedStrings.Count
+                    ? GetSharedStringRichTextRuns(sharedStrings[id])
+                    : null;
+
+                if (context != null) {
+                    context.SharedStringRichTextRuns[id] = runs;
+                }
+
+                return runs;
             }
 
             if (cell.DataType?.Value == XCellValues.InlineString) {
@@ -321,7 +395,30 @@ namespace OfficeIMO.Excel {
             return null;
         }
 
+        private sealed class AutoFitTextContext {
+            internal AutoFitTextContext(
+                IReadOnlyList<SharedStringItem>? sharedStrings,
+                IReadOnlyList<CellFormat>? cellFormats,
+                Dictionary<uint, string?>? customNumberFormats) {
+                SharedStrings = sharedStrings;
+                CellFormats = cellFormats;
+                CustomNumberFormats = customNumberFormats;
+            }
+
+            internal IReadOnlyList<SharedStringItem>? SharedStrings { get; }
+            internal IReadOnlyList<CellFormat>? CellFormats { get; }
+            internal Dictionary<uint, string?>? CustomNumberFormats { get; }
+            internal Dictionary<uint, uint> NumberFormatIdsByStyle { get; } = new Dictionary<uint, uint>();
+            internal Dictionary<uint, string?> NumberFormatCodes { get; } = new Dictionary<uint, string?>();
+            internal Dictionary<int, string> SharedStringTexts { get; } = new Dictionary<int, string>();
+            internal Dictionary<int, IReadOnlyList<AutoFitTextRun>?> SharedStringRichTextRuns { get; } = new Dictionary<int, IReadOnlyList<AutoFitTextRun>?>();
+        }
+
         private static IReadOnlyList<AutoFitTextRun>? GetSharedStringRichTextRuns(SharedStringItem item) {
+            if (item.Text != null) {
+                return null;
+            }
+
             var runs = item.Elements<Run>().ToList();
             if (runs.Count == 0) {
                 return null;
@@ -332,6 +429,10 @@ namespace OfficeIMO.Excel {
 
         private static IReadOnlyList<AutoFitTextRun>? GetInlineStringRichTextRuns(InlineString? inlineString) {
             if (inlineString == null) {
+                return null;
+            }
+
+            if (inlineString.Text != null) {
                 return null;
             }
 

--- a/OfficeIMO.Excel/ExcelSheet.AutoFitText.cs
+++ b/OfficeIMO.Excel/ExcelSheet.AutoFitText.cs
@@ -36,9 +36,7 @@ namespace OfficeIMO.Excel {
             var cache = new Dictionary<uint, string?>();
             foreach (var format in numberingFormats.Elements<NumberingFormat>()) {
                 uint id = format.NumberFormatId?.Value ?? 0U;
-                if (!cache.ContainsKey(id)) {
-                    cache.Add(id, format.FormatCode?.Value);
-                }
+                cache[id] = format.FormatCode?.Value;
             }
 
             return cache;

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -266,11 +266,11 @@ namespace OfficeIMO.Excel {
             Cell cell,
             object? value,
             EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>? dataType,
+            uint baseStyleIndex,
             ref Dictionary<uint, uint>? dateStyleIndexes,
             ref Dictionary<uint, uint>? durationStyleIndexes,
             ref Dictionary<uint, uint>? wrapStyleIndexes) {
             bool wroteNumber = dataType?.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.Number;
-            uint baseStyleIndex = cell.StyleIndex?.Value ?? 0U;
 
             if (wroteNumber && (value is DateTime || value is DateTimeOffset)) {
                 cell.StyleIndex = GetOrAddBuiltInNumberFormatStyleIndex(ref dateStyleIndexes, baseStyleIndex, 14);

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -262,6 +262,112 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        private void ApplyAutomaticCellFormattingForAppendedCell(
+            Cell cell,
+            object? value,
+            EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>? dataType,
+            ref uint? dateStyleIndex,
+            ref uint? durationStyleIndex,
+            ref uint? wrapStyleIndex) {
+            bool wroteNumber = dataType?.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.Number;
+
+            if (wroteNumber && (value is DateTime || value is DateTimeOffset)) {
+                dateStyleIndex ??= GetOrCreateDefaultBuiltInNumberFormatStyleIndex(14);
+                cell.StyleIndex = dateStyleIndex.Value;
+                return;
+            }
+
+            if (value is TimeSpan) {
+                durationStyleIndex ??= GetOrCreateDefaultBuiltInNumberFormatStyleIndex(46);
+                cell.StyleIndex = durationStyleIndex.Value;
+                return;
+            }
+
+            if (value is string s && (s.Contains("\n") || s.Contains("\r"))) {
+                wrapStyleIndex ??= GetOrCreateDefaultWrapTextStyleIndex();
+                cell.StyleIndex = wrapStyleIndex.Value;
+            }
+        }
+
+        private uint GetOrCreateDefaultBuiltInNumberFormatStyleIndex(uint builtInFormatId) {
+            var workbookPart = _excelDocument.WorkbookPartRoot ?? throw new InvalidOperationException("WorkbookPart is null");
+            WorkbookStylesPart? stylesPart = workbookPart.WorkbookStylesPart;
+            if (stylesPart == null) {
+                stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+            }
+
+            Stylesheet stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
+            EnsureDefaultStylePrimitives(stylesheet);
+
+            var cellFormatsEl = stylesheet.CellFormats ??= new CellFormats(new CellFormat());
+            uint index = 0;
+            foreach (var format in cellFormatsEl.Elements<CellFormat>()) {
+                if ((format.NumberFormatId?.Value ?? 0U) == builtInFormatId
+                    && format.ApplyNumberFormat?.Value == true
+                    && (format.FontId?.Value ?? 0U) == 0U
+                    && (format.FillId?.Value ?? 0U) == 0U
+                    && (format.BorderId?.Value ?? 0U) == 0U
+                    && (format.FormatId?.Value ?? 0U) == 0U) {
+                    return index;
+                }
+
+                index++;
+            }
+
+            var newFormat = new CellFormat {
+                NumberFormatId = builtInFormatId,
+                FontId = 0U,
+                FillId = 0U,
+                BorderId = 0U,
+                FormatId = 0U,
+                ApplyNumberFormat = true
+            };
+            cellFormatsEl.Append(newFormat);
+            cellFormatsEl.Count = index + 1U;
+            stylesPart.Stylesheet.Save();
+            return index;
+        }
+
+        private uint GetOrCreateDefaultWrapTextStyleIndex() {
+            var workbookPart = _excelDocument.WorkbookPartRoot ?? throw new InvalidOperationException("WorkbookPart is null");
+            WorkbookStylesPart? stylesPart = workbookPart.WorkbookStylesPart;
+            if (stylesPart == null) {
+                stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+            }
+
+            Stylesheet stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
+            EnsureDefaultStylePrimitives(stylesheet);
+
+            var cellFormatsEl = stylesheet.CellFormats ??= new CellFormats(new CellFormat());
+            uint index = 0;
+            foreach (var format in cellFormatsEl.Elements<CellFormat>()) {
+                if ((format.NumberFormatId?.Value ?? 0U) == 0U
+                    && (format.FontId?.Value ?? 0U) == 0U
+                    && (format.FillId?.Value ?? 0U) == 0U
+                    && (format.BorderId?.Value ?? 0U) == 0U
+                    && (format.FormatId?.Value ?? 0U) == 0U
+                    && format.Alignment?.WrapText?.Value == true) {
+                    return index;
+                }
+
+                index++;
+            }
+
+            var newFormat = new CellFormat {
+                NumberFormatId = 0U,
+                FontId = 0U,
+                FillId = 0U,
+                BorderId = 0U,
+                FormatId = 0U,
+                ApplyAlignment = true,
+                Alignment = new Alignment { WrapText = true }
+            };
+            cellFormatsEl.Append(newFormat);
+            cellFormatsEl.Count = index + 1U;
+            stylesPart.Stylesheet.Save();
+            return index;
+        }
+
         private void ApplyWrapText(Cell cell) {
             var workbookPart = _excelDocument.WorkbookPartRoot ?? throw new InvalidOperationException("WorkbookPart is null");
             WorkbookStylesPart? stylesPart = workbookPart.WorkbookStylesPart;

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -266,30 +266,48 @@ namespace OfficeIMO.Excel {
             Cell cell,
             object? value,
             EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>? dataType,
-            ref uint? dateStyleIndex,
-            ref uint? durationStyleIndex,
-            ref uint? wrapStyleIndex) {
+            ref Dictionary<uint, uint>? dateStyleIndexes,
+            ref Dictionary<uint, uint>? durationStyleIndexes,
+            ref Dictionary<uint, uint>? wrapStyleIndexes) {
             bool wroteNumber = dataType?.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.Number;
+            uint baseStyleIndex = cell.StyleIndex?.Value ?? 0U;
 
             if (wroteNumber && (value is DateTime || value is DateTimeOffset)) {
-                dateStyleIndex ??= GetOrCreateDefaultBuiltInNumberFormatStyleIndex(14);
-                cell.StyleIndex = dateStyleIndex.Value;
+                cell.StyleIndex = GetOrAddBuiltInNumberFormatStyleIndex(ref dateStyleIndexes, baseStyleIndex, 14);
                 return;
             }
 
             if (value is TimeSpan) {
-                durationStyleIndex ??= GetOrCreateDefaultBuiltInNumberFormatStyleIndex(46);
-                cell.StyleIndex = durationStyleIndex.Value;
+                cell.StyleIndex = GetOrAddBuiltInNumberFormatStyleIndex(ref durationStyleIndexes, baseStyleIndex, 46);
                 return;
             }
 
             if (value is string s && (s.Contains("\n") || s.Contains("\r"))) {
-                wrapStyleIndex ??= GetOrCreateDefaultWrapTextStyleIndex();
-                cell.StyleIndex = wrapStyleIndex.Value;
+                cell.StyleIndex = GetOrAddWrapTextStyleIndex(ref wrapStyleIndexes, baseStyleIndex);
             }
         }
 
-        private uint GetOrCreateDefaultBuiltInNumberFormatStyleIndex(uint builtInFormatId) {
+        private uint GetOrAddBuiltInNumberFormatStyleIndex(ref Dictionary<uint, uint>? styleIndexes, uint baseStyleIndex, uint builtInFormatId) {
+            styleIndexes ??= new Dictionary<uint, uint>();
+            if (!styleIndexes.TryGetValue(baseStyleIndex, out uint styleIndex)) {
+                styleIndex = GetOrCreateBuiltInNumberFormatStyleIndex(baseStyleIndex, builtInFormatId);
+                styleIndexes[baseStyleIndex] = styleIndex;
+            }
+
+            return styleIndex;
+        }
+
+        private uint GetOrAddWrapTextStyleIndex(ref Dictionary<uint, uint>? styleIndexes, uint baseStyleIndex) {
+            styleIndexes ??= new Dictionary<uint, uint>();
+            if (!styleIndexes.TryGetValue(baseStyleIndex, out uint styleIndex)) {
+                styleIndex = GetOrCreateWrapTextStyleIndex(baseStyleIndex);
+                styleIndexes[baseStyleIndex] = styleIndex;
+            }
+
+            return styleIndex;
+        }
+
+        private uint GetOrCreateBuiltInNumberFormatStyleIndex(uint baseStyleIndex, uint builtInFormatId) {
             var workbookPart = _excelDocument.WorkbookPartRoot ?? throw new InvalidOperationException("WorkbookPart is null");
             WorkbookStylesPart? stylesPart = workbookPart.WorkbookStylesPart;
             if (stylesPart == null) {
@@ -299,7 +317,7 @@ namespace OfficeIMO.Excel {
             Stylesheet stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
             EnsureDefaultStylePrimitives(stylesheet);
 
-            var newFormat = GetBaseCellFormat(stylesheet, 0U);
+            var newFormat = GetBaseCellFormat(stylesheet, baseStyleIndex);
             newFormat.NumberFormatId = builtInFormatId;
             newFormat.ApplyNumberFormat = true;
             uint index = AppendOrReuseCellFormat(stylesheet, newFormat);
@@ -307,7 +325,7 @@ namespace OfficeIMO.Excel {
             return index;
         }
 
-        private uint GetOrCreateDefaultWrapTextStyleIndex() {
+        private uint GetOrCreateWrapTextStyleIndex(uint baseStyleIndex) {
             var workbookPart = _excelDocument.WorkbookPartRoot ?? throw new InvalidOperationException("WorkbookPart is null");
             WorkbookStylesPart? stylesPart = workbookPart.WorkbookStylesPart;
             if (stylesPart == null) {
@@ -317,7 +335,7 @@ namespace OfficeIMO.Excel {
             Stylesheet stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
             EnsureDefaultStylePrimitives(stylesheet);
 
-            var newFormat = GetBaseCellFormat(stylesheet, 0U);
+            var newFormat = GetBaseCellFormat(stylesheet, baseStyleIndex);
             var alignment = newFormat.Alignment != null
                 ? (Alignment)newFormat.Alignment.CloneNode(true)
                 : new Alignment();

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -299,31 +299,10 @@ namespace OfficeIMO.Excel {
             Stylesheet stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
             EnsureDefaultStylePrimitives(stylesheet);
 
-            var cellFormatsEl = stylesheet.CellFormats ??= new CellFormats(new CellFormat());
-            uint index = 0;
-            foreach (var format in cellFormatsEl.Elements<CellFormat>()) {
-                if ((format.NumberFormatId?.Value ?? 0U) == builtInFormatId
-                    && format.ApplyNumberFormat?.Value == true
-                    && (format.FontId?.Value ?? 0U) == 0U
-                    && (format.FillId?.Value ?? 0U) == 0U
-                    && (format.BorderId?.Value ?? 0U) == 0U
-                    && (format.FormatId?.Value ?? 0U) == 0U) {
-                    return index;
-                }
-
-                index++;
-            }
-
-            var newFormat = new CellFormat {
-                NumberFormatId = builtInFormatId,
-                FontId = 0U,
-                FillId = 0U,
-                BorderId = 0U,
-                FormatId = 0U,
-                ApplyNumberFormat = true
-            };
-            cellFormatsEl.Append(newFormat);
-            cellFormatsEl.Count = index + 1U;
+            var newFormat = GetBaseCellFormat(stylesheet, 0U);
+            newFormat.NumberFormatId = builtInFormatId;
+            newFormat.ApplyNumberFormat = true;
+            uint index = AppendOrReuseCellFormat(stylesheet, newFormat);
             stylesPart.Stylesheet.Save();
             return index;
         }
@@ -338,32 +317,14 @@ namespace OfficeIMO.Excel {
             Stylesheet stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
             EnsureDefaultStylePrimitives(stylesheet);
 
-            var cellFormatsEl = stylesheet.CellFormats ??= new CellFormats(new CellFormat());
-            uint index = 0;
-            foreach (var format in cellFormatsEl.Elements<CellFormat>()) {
-                if ((format.NumberFormatId?.Value ?? 0U) == 0U
-                    && (format.FontId?.Value ?? 0U) == 0U
-                    && (format.FillId?.Value ?? 0U) == 0U
-                    && (format.BorderId?.Value ?? 0U) == 0U
-                    && (format.FormatId?.Value ?? 0U) == 0U
-                    && format.Alignment?.WrapText?.Value == true) {
-                    return index;
-                }
-
-                index++;
-            }
-
-            var newFormat = new CellFormat {
-                NumberFormatId = 0U,
-                FontId = 0U,
-                FillId = 0U,
-                BorderId = 0U,
-                FormatId = 0U,
-                ApplyAlignment = true,
-                Alignment = new Alignment { WrapText = true }
-            };
-            cellFormatsEl.Append(newFormat);
-            cellFormatsEl.Count = index + 1U;
+            var newFormat = GetBaseCellFormat(stylesheet, 0U);
+            var alignment = newFormat.Alignment != null
+                ? (Alignment)newFormat.Alignment.CloneNode(true)
+                : new Alignment();
+            alignment.WrapText = true;
+            newFormat.Alignment = alignment;
+            newFormat.ApplyAlignment = true;
+            uint index = AppendOrReuseCellFormat(stylesheet, newFormat);
             stylesPart.Stylesheet.Save();
             return index;
         }

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -131,7 +131,7 @@ namespace OfficeIMO.Excel {
 
             for (int i = 0; i < prepared.Length; i++) {
                 var p = prepared[i];
-                if (p.Row <= 0 || p.Col <= 0 || p.Row < currentRow) {
+                if (p.Row <= 0 || p.Col <= 0 || p.Col > A1.MaxColumns || p.Row < currentRow) {
                     return false;
                 }
 
@@ -183,16 +183,13 @@ namespace OfficeIMO.Excel {
                     CellValue = p.Val,
                     DataType = p.Type
                 };
-                uint? baseStyleIndex = baseStyleIndexes[p.Col];
-                if (baseStyleIndex.HasValue) {
-                    cell.StyleIndex = baseStyleIndex.Value;
-                }
 
                 row!.Append(cell);
                 ApplyAutomaticCellFormattingForAppendedCell(
                     cell,
                     source[i].Value,
                     p.Type,
+                    baseStyleIndexes[p.Col] ?? 0U,
                     ref appendedDateStyleIndexes,
                     ref appendedDurationStyleIndexes,
                     ref appendedWrapStyleIndexes);

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -162,12 +162,13 @@ namespace OfficeIMO.Excel {
                 columnNames[column] = GetColumnName(column);
             }
 
+            var baseStyleIndexes = GetAppendBaseStyleIndexes(sheetData, firstRow, maxColumn);
             Row? row = null;
             int rowIndex = 0;
             string rowReference = string.Empty;
-            uint? appendedDateStyleIndex = null;
-            uint? appendedDurationStyleIndex = null;
-            uint? appendedWrapStyleIndex = null;
+            Dictionary<uint, uint>? appendedDateStyleIndexes = null;
+            Dictionary<uint, uint>? appendedDurationStyleIndexes = null;
+            Dictionary<uint, uint>? appendedWrapStyleIndexes = null;
             for (int i = 0; i < prepared.Length; i++) {
                 var p = prepared[i];
                 if (p.Row != rowIndex) {
@@ -182,18 +183,57 @@ namespace OfficeIMO.Excel {
                     CellValue = p.Val,
                     DataType = p.Type
                 };
+                uint? baseStyleIndex = baseStyleIndexes[p.Col];
+                if (baseStyleIndex.HasValue) {
+                    cell.StyleIndex = baseStyleIndex.Value;
+                }
+
                 row!.Append(cell);
                 ApplyAutomaticCellFormattingForAppendedCell(
                     cell,
                     source[i].Value,
                     p.Type,
-                    ref appendedDateStyleIndex,
-                    ref appendedDurationStyleIndex,
-                    ref appendedWrapStyleIndex);
+                    ref appendedDateStyleIndexes,
+                    ref appendedDurationStyleIndexes,
+                    ref appendedWrapStyleIndexes);
             }
 
             ClearHeaderCache();
             return true;
+        }
+
+        private static uint?[] GetAppendBaseStyleIndexes(SheetData sheetData, int firstRow, int maxColumn) {
+            var baseStyleIndexes = new uint?[maxColumn + 1];
+            var baseStyleRows = new int[maxColumn + 1];
+
+            foreach (var existingRow in sheetData.Elements<Row>()) {
+                if (existingRow.RowIndex == null) {
+                    continue;
+                }
+
+                int existingRowIndex = (int)existingRow.RowIndex.Value;
+                if (existingRowIndex >= firstRow) {
+                    continue;
+                }
+
+                foreach (var existingCell in existingRow.Elements<Cell>()) {
+                    if (existingCell.CellReference == null || existingCell.StyleIndex == null) {
+                        continue;
+                    }
+
+                    int columnIndex = A1.ParseColumnIndexFromCellReference(existingCell.CellReference.Value);
+                    if (columnIndex <= 0 || columnIndex > maxColumn) {
+                        continue;
+                    }
+
+                    if (existingRowIndex >= baseStyleRows[columnIndex]) {
+                        baseStyleRows[columnIndex] = existingRowIndex;
+                        baseStyleIndexes[columnIndex] = existingCell.StyleIndex.Value;
+                    }
+                }
+            }
+
+            return baseStyleIndexes;
         }
 
         private sealed class BatchCellWriter {

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -94,6 +94,10 @@ namespace OfficeIMO.Excel {
         private void ApplyPreparedCells(
             (int Row, int Col, CellValue Val, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues> Type)[] prepared,
             IList<(int Row, int Column, object Value)> source) {
+            if (TryApplyPreparedCellsByAppendingRows(prepared, source)) {
+                return;
+            }
+
             var writer = new BatchCellWriter(this);
 
             for (int i = 0; i < prepared.Length; i++) {
@@ -108,10 +112,96 @@ namespace OfficeIMO.Excel {
             ClearHeaderCache();
         }
 
+        private bool TryApplyPreparedCellsByAppendingRows(
+            (int Row, int Col, CellValue Val, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues> Type)[] prepared,
+            IList<(int Row, int Column, object Value)> source) {
+            if (prepared.Length != source.Count) {
+                return false;
+            }
+
+            if (prepared.Length == 0) {
+                ClearHeaderCache();
+                return true;
+            }
+
+            int firstRow = prepared[0].Row;
+            int currentRow = 0;
+            int currentColumn = 0;
+            int maxColumn = 0;
+
+            for (int i = 0; i < prepared.Length; i++) {
+                var p = prepared[i];
+                if (p.Row <= 0 || p.Col <= 0 || p.Row < currentRow) {
+                    return false;
+                }
+
+                if (p.Row != currentRow) {
+                    currentRow = p.Row;
+                    currentColumn = 0;
+                }
+
+                if (p.Col <= currentColumn) {
+                    return false;
+                }
+
+                currentColumn = p.Col;
+                if (p.Col > maxColumn) {
+                    maxColumn = p.Col;
+                }
+            }
+
+            var sheetData = GetOrCreateSheetData();
+            foreach (var existingRow in sheetData.Elements<Row>()) {
+                if (existingRow.RowIndex != null && existingRow.RowIndex.Value >= (uint)firstRow) {
+                    return false;
+                }
+            }
+
+            var columnNames = new string[maxColumn + 1];
+            for (int column = 1; column <= maxColumn; column++) {
+                columnNames[column] = GetColumnName(column);
+            }
+
+            Row? row = null;
+            int rowIndex = 0;
+            string rowReference = string.Empty;
+            uint? appendedDateStyleIndex = null;
+            uint? appendedDurationStyleIndex = null;
+            uint? appendedWrapStyleIndex = null;
+            for (int i = 0; i < prepared.Length; i++) {
+                var p = prepared[i];
+                if (p.Row != rowIndex) {
+                    rowIndex = p.Row;
+                    rowReference = rowIndex.ToString(CultureInfo.InvariantCulture);
+                    row = new Row { RowIndex = (uint)rowIndex };
+                    sheetData.Append(row);
+                }
+
+                var cell = new Cell {
+                    CellReference = columnNames[p.Col] + rowReference,
+                    CellValue = p.Val,
+                    DataType = p.Type
+                };
+                row!.Append(cell);
+                ApplyAutomaticCellFormattingForAppendedCell(
+                    cell,
+                    source[i].Value,
+                    p.Type,
+                    ref appendedDateStyleIndex,
+                    ref appendedDurationStyleIndex,
+                    ref appendedWrapStyleIndex);
+            }
+
+            ClearHeaderCache();
+            return true;
+        }
+
         private sealed class BatchCellWriter {
             private readonly ExcelSheet _sheet;
             private readonly SheetData _sheetData;
             private readonly Dictionary<int, BatchRowState> _rows;
+            private Row? _lastRow;
+            private int _lastRowIndex;
 
             internal BatchCellWriter(ExcelSheet sheet) {
                 _sheet = sheet;
@@ -124,17 +214,39 @@ namespace OfficeIMO.Excel {
                     }
 
                     _rows[(int)row.RowIndex.Value] = new BatchRowState(row);
+                    if (row.RowIndex.Value >= _lastRowIndex) {
+                        _lastRowIndex = (int)row.RowIndex.Value;
+                        _lastRow = row;
+                    }
                 }
             }
 
             internal Cell GetOrCreateCell(int rowIndex, int columnIndex) {
                 if (!_rows.TryGetValue(rowIndex, out BatchRowState? rowState)) {
-                    var row = _sheet.GetOrCreateRowElement(_sheetData, rowIndex);
+                    var row = GetOrCreateRow(rowIndex);
                     rowState = new BatchRowState(row);
                     _rows[rowIndex] = rowState;
                 }
 
                 return rowState.GetOrCreateCell(columnIndex, rowIndex);
+            }
+
+            private Row GetOrCreateRow(int rowIndex) {
+                if (_lastRow != null && rowIndex > _lastRowIndex) {
+                    var appended = new Row { RowIndex = (uint)rowIndex };
+                    _sheetData.Append(appended);
+                    _lastRow = appended;
+                    _lastRowIndex = rowIndex;
+                    return appended;
+                }
+
+                var row = _sheet.GetOrCreateRowElement(_sheetData, rowIndex);
+                if (row.RowIndex != null && row.RowIndex.Value >= _lastRowIndex) {
+                    _lastRow = row;
+                    _lastRowIndex = (int)row.RowIndex.Value;
+                }
+
+                return row;
             }
 
             private sealed class BatchRowState {
@@ -168,7 +280,7 @@ namespace OfficeIMO.Excel {
                         return existing;
                     }
 
-                    string cellReference = GetColumnName(columnIndex) + rowIndex.ToString(CultureInfo.InvariantCulture);
+                    string cellReference = A1.CellReference(rowIndex, columnIndex);
                     var cell = new Cell { CellReference = cellReference };
 
                     if (_lastCell == null) {

--- a/OfficeIMO.Excel/ExcelSheet.ColumnsRows.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ColumnsRows.cs
@@ -15,9 +15,14 @@ namespace OfficeIMO.Excel {
         /// <param name="mode">Overrides how the auto-fit work is scheduled across columns.</param>
         /// <param name="ct">Cancels the auto-fit pass while widths are being measured or applied.</param>
         public void AutoFitColumns(ExecutionMode? mode = null, CancellationToken ct = default) {
-            var columns = GetAllColumnIndices();
-            if (columns.Count == 0) return;
-            AutoFitColumnsInternal(columns.OrderBy(i => i).ToList(), mode, ct);
+            var planWatch = EffectiveExecution.OnTiming == null ? null : System.Diagnostics.Stopwatch.StartNew();
+            var measurementPlan = BuildAutoFitMeasurementPlanForAllColumns(ct);
+            if (planWatch != null) {
+                planWatch.Stop();
+                EffectiveExecution.ReportTiming("AutoFitColumns.BuildPlan", planWatch.Elapsed);
+            }
+            if (measurementPlan.Columns.Count == 0) return;
+            AutoFitColumnsInternal(measurementPlan, mode, ct);
         }
 
         /// <summary>
@@ -48,8 +53,19 @@ namespace OfficeIMO.Excel {
 
         private void AutoFitColumnsInternal(IReadOnlyList<int> columnsList, ExecutionMode? mode, CancellationToken ct) {
             if (columnsList.Count == 0) return;
-            double[] computed = new double[columnsList.Count];
+            var planWatch = EffectiveExecution.OnTiming == null ? null : System.Diagnostics.Stopwatch.StartNew();
             var measurementPlan = BuildAutoFitMeasurementPlan(columnsList, ct);
+            if (planWatch != null) {
+                planWatch.Stop();
+                EffectiveExecution.ReportTiming("AutoFitColumns.BuildPlan", planWatch.Elapsed);
+            }
+            AutoFitColumnsInternal(measurementPlan, mode, ct);
+        }
+
+        private void AutoFitColumnsInternal(AutoFitMeasurementPlan measurementPlan, ExecutionMode? mode, CancellationToken ct) {
+            var columnsList = measurementPlan.Columns;
+            if (columnsList.Count == 0) return;
+            double[] computed = new double[columnsList.Count];
             int workload = Math.Max(columnsList.Count, measurementPlan.Measurements.Count);
 
             ExecuteWithPolicy(
@@ -61,23 +77,47 @@ namespace OfficeIMO.Excel {
                     var sheetData = worksheet.GetFirstChild<SheetData>();
                     if (sheetData == null) return;
 
+                    var calculateWatch = EffectiveExecution.OnTiming == null ? null : System.Diagnostics.Stopwatch.StartNew();
                     computed = CalculateColumnWidths(measurementPlan, ct, parallel: false);
+                    if (calculateWatch != null) {
+                        calculateWatch.Stop();
+                        EffectiveExecution.ReportTiming("AutoFitColumns.CalculateWidths", calculateWatch.Elapsed);
+                    }
 
+                    var applyWatch = EffectiveExecution.OnTiming == null ? null : System.Diagnostics.Stopwatch.StartNew();
                     for (int i = 0; i < columnsList.Count; i++) {
                         SetColumnWidthCore(columnsList[i], computed[i]);
                     }
 
-                    worksheet.Save();
+                    if (EffectiveExecution.SaveWorksheetAfterAutoFit) {
+                        worksheet.Save();
+                    }
+                    if (applyWatch != null) {
+                        applyWatch.Stop();
+                        EffectiveExecution.ReportTiming("AutoFitColumns.ApplyWidths", applyWatch.Elapsed);
+                    }
                 },
                 computeParallel: () => {
+                    var calculateWatch = EffectiveExecution.OnTiming == null ? null : System.Diagnostics.Stopwatch.StartNew();
                     computed = CalculateColumnWidths(measurementPlan, ct, parallel: true);
+                    if (calculateWatch != null) {
+                        calculateWatch.Stop();
+                        EffectiveExecution.ReportTiming("AutoFitColumns.CalculateWidths", calculateWatch.Elapsed);
+                    }
                 },
                 applySequential: () => {
                     var worksheet = WorksheetRoot;
+                    var applyWatch = EffectiveExecution.OnTiming == null ? null : System.Diagnostics.Stopwatch.StartNew();
                     for (int i = 0; i < columnsList.Count; i++) {
                         SetColumnWidthCore(columnsList[i], computed[i]);
                     }
-                    worksheet.Save();
+                    if (EffectiveExecution.SaveWorksheetAfterAutoFit) {
+                        worksheet.Save();
+                    }
+                    if (applyWatch != null) {
+                        applyWatch.Stop();
+                        EffectiveExecution.ReportTiming("AutoFitColumns.ApplyWidths", applyWatch.Elapsed);
+                    }
                 },
                 ct: ct
             );
@@ -112,6 +152,57 @@ namespace OfficeIMO.Excel {
             return columnIndexes;
         }
 
+        private AutoFitMeasurementPlan BuildAutoFitMeasurementPlanForAllColumns(CancellationToken ct) {
+            var worksheet = WorksheetRoot;
+            SheetData? sheetData = worksheet.GetFirstChild<SheetData>();
+            if (sheetData == null) {
+                return new AutoFitMeasurementPlan(Array.Empty<int>(), new List<AutoFitMeasurement>());
+            }
+
+            var columnsList = new List<int>();
+            var targetColumns = new Dictionary<int, int>();
+            var measurements = new List<AutoFitMeasurement>();
+            var uniqueMeasurements = new HashSet<AutoFitMeasurementKey>();
+            var textContext = CreateAutoFitTextContext();
+
+            foreach (var row in sheetData.Elements<Row>()) {
+                ct.ThrowIfCancellationRequested();
+
+                foreach (var cell in row.Elements<Cell>()) {
+                    string? reference = cell.CellReference?.Value;
+                    if (string.IsNullOrEmpty(reference)) {
+                        continue;
+                    }
+
+                    int columnIndex = GetColumnIndex(reference!);
+                    if (!targetColumns.TryGetValue(columnIndex, out int targetIndex)) {
+                        targetIndex = columnsList.Count;
+                        targetColumns[columnIndex] = targetIndex;
+                        columnsList.Add(columnIndex);
+                    }
+
+                    AddAutoFitMeasurement(cell, targetIndex, textContext, uniqueMeasurements, measurements);
+                }
+            }
+
+            var columns = worksheet.GetFirstChild<Columns>();
+            if (columns != null) {
+                foreach (var column in columns.Elements<Column>()) {
+                    uint min = column.Min?.Value ?? 0;
+                    uint max = column.Max?.Value ?? 0;
+                    for (uint i = min; i <= max; i++) {
+                        int columnIndex = (int)i;
+                        if (!targetColumns.ContainsKey(columnIndex)) {
+                            targetColumns[columnIndex] = columnsList.Count;
+                            columnsList.Add(columnIndex);
+                        }
+                    }
+                }
+            }
+
+            return new AutoFitMeasurementPlan(columnsList, measurements);
+        }
+
         private AutoFitMeasurementPlan BuildAutoFitMeasurementPlan(IReadOnlyList<int> columnsList, CancellationToken ct) {
             var worksheet = WorksheetRoot;
             SheetData? sheetData = worksheet.GetFirstChild<SheetData>();
@@ -126,7 +217,7 @@ namespace OfficeIMO.Excel {
 
             var measurements = new List<AutoFitMeasurement>();
             var uniqueMeasurements = new HashSet<AutoFitMeasurementKey>();
-            var sharedStrings = _excelDocument.SharedStringTablePart?.SharedStringTable?.Elements<SharedStringItem>().ToList();
+            var textContext = CreateAutoFitTextContext();
             foreach (var row in sheetData.Elements<Row>()) {
                 ct.ThrowIfCancellationRequested();
 
@@ -141,20 +232,29 @@ namespace OfficeIMO.Excel {
                         continue;
                     }
 
-                    string text = GetCellAutoFitText(cell, sharedStrings);
-                    if (string.IsNullOrWhiteSpace(text)) {
-                        continue;
-                    }
-
-                    uint styleIndex = cell.StyleIndex?.Value ?? 0U;
-                    var runs = GetCellAutoFitRichTextRuns(cell, sharedStrings);
-                    if (uniqueMeasurements.Add(new AutoFitMeasurementKey(targetIndex, styleIndex, text, runs))) {
-                        measurements.Add(new AutoFitMeasurement(targetIndex, styleIndex, text, runs));
-                    }
+                    AddAutoFitMeasurement(cell, targetIndex, textContext, uniqueMeasurements, measurements);
                 }
             }
 
             return new AutoFitMeasurementPlan(columnsList, measurements);
+        }
+
+        private void AddAutoFitMeasurement(
+            Cell cell,
+            int targetIndex,
+            AutoFitTextContext textContext,
+            HashSet<AutoFitMeasurementKey> uniqueMeasurements,
+            List<AutoFitMeasurement> measurements) {
+            string text = GetCellAutoFitText(cell, textContext);
+            if (string.IsNullOrWhiteSpace(text)) {
+                return;
+            }
+
+            uint styleIndex = cell.StyleIndex?.Value ?? 0U;
+            var runs = GetCellAutoFitRichTextRuns(cell, textContext);
+            if (uniqueMeasurements.Add(new AutoFitMeasurementKey(targetIndex, styleIndex, text, runs))) {
+                measurements.Add(new AutoFitMeasurement(targetIndex, styleIndex, text, runs));
+            }
         }
 
         private double[] CalculateColumnWidths(IReadOnlyList<int> columnsList, CancellationToken ct) {
@@ -687,7 +787,9 @@ namespace OfficeIMO.Excel {
                     }
 
                     UpdateSheetFormat();
-                    worksheet.Save();
+                    if (EffectiveExecution.SaveWorksheetAfterAutoFit) {
+                        worksheet.Save();
+                    }
                 },
                 computeParallel: () => {
                     // Parallel compute phase - calculate heights without DOM mutation
@@ -714,7 +816,9 @@ namespace OfficeIMO.Excel {
                         SetRowHeightCore(rowIndexes[i], computed[i]);
                     }
                     UpdateSheetFormat();
-                    worksheet.Save();
+                    if (EffectiveExecution.SaveWorksheetAfterAutoFit) {
+                        worksheet.Save();
+                    }
                 },
                 ct: ct
             );
@@ -730,7 +834,9 @@ namespace OfficeIMO.Excel {
             WriteLockConditional(() => {
                 var width = CalculateColumnWidths([columnIndex], CancellationToken.None)[0];
                 SetColumnWidthCore(columnIndex, width);
-                WorksheetRoot.Save();
+                if (EffectiveExecution.SaveWorksheetAfterAutoFit) {
+                    WorksheetRoot.Save();
+                }
             });
         }
 
@@ -979,7 +1085,9 @@ namespace OfficeIMO.Excel {
                 var height = CalculateRowHeight(rowIndex);
                 SetRowHeightCore(rowIndex, height);
                 UpdateSheetFormat();
-                WorksheetRoot.Save();
+                if (EffectiveExecution.SaveWorksheetAfterAutoFit) {
+                    WorksheetRoot.Save();
+                }
             });
         }
 
@@ -1036,7 +1144,7 @@ namespace OfficeIMO.Excel {
                     pane.HorizontalSplit = leftCols;  // HorizontalSplit = number of columns to freeze
                 }
 
-                pane.TopLeftCell = GetColumnName(leftCols + 1) + (topRows + 1).ToString(CultureInfo.InvariantCulture);
+                pane.TopLeftCell = A1.CellReference(topRows + 1, leftCols + 1);
 
                 if (topRows > 0 && leftCols > 0) {
                     pane.ActivePane = PaneValues.BottomRight;

--- a/OfficeIMO.Excel/ExcelSheet.Comments.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Comments.cs
@@ -23,7 +23,7 @@ namespace OfficeIMO.Excel {
             if (string.IsNullOrEmpty(text)) throw new ArgumentException("Comment text is required.", nameof(text));
 
             WriteLock(() => {
-                string reference = A1.ColumnIndexToLetters(column) + row.ToString(CultureInfo.InvariantCulture);
+                string reference = A1.CellReference(row, column);
                 string authorDisplay = NormalizeAuthor(author, initials);
 
                 var commentsPart = GetOrCreateCommentsPart();
@@ -67,7 +67,7 @@ namespace OfficeIMO.Excel {
             if (column <= 0) throw new ArgumentOutOfRangeException(nameof(column), "Row and column are 1-based and must be positive.");
 
             WriteLock(() => {
-                string reference = A1.ColumnIndexToLetters(column) + row.ToString(CultureInfo.InvariantCulture);
+                string reference = A1.CellReference(row, column);
 
                 var commentsPart = WorksheetCommentsPartRoot;
                 if (commentsPart?.Comments?.CommentList == null) {
@@ -101,7 +101,7 @@ namespace OfficeIMO.Excel {
         public bool HasComment(int row, int column) {
             if (row <= 0) throw new ArgumentOutOfRangeException(nameof(row), "Row and column are 1-based and must be positive.");
             if (column <= 0) throw new ArgumentOutOfRangeException(nameof(column), "Row and column are 1-based and must be positive.");
-            string reference = A1.ColumnIndexToLetters(column) + row.ToString(CultureInfo.InvariantCulture);
+            string reference = A1.CellReference(row, column);
             var commentsPart = WorksheetCommentsPartRoot;
             return commentsPart?.Comments?.CommentList?
                 .Elements<Comment>()

--- a/OfficeIMO.Excel/ExcelSheet.Core.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Core.cs
@@ -184,7 +184,7 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            string cellReference = GetColumnName(column) + row.ToString(CultureInfo.InvariantCulture);
+            string cellReference = A1.CellReference(row, column);
 
             // Find or create cell with proper ordering (by numeric column index)
             Cell? cell = null;
@@ -258,29 +258,40 @@ namespace OfficeIMO.Excel {
         }
 
         private static string GetColumnName(int columnIndex) {
-            int dividend = columnIndex;
-            StringBuilder columnName = new StringBuilder();
-
-            while (dividend > 0) {
-                int modulo = (dividend - 1) % 26;
-                columnName.Insert(0, Convert.ToChar(65 + modulo));
-                dividend = (dividend - modulo) / 26;
-            }
-
-            return columnName.ToString();
+            return A1.ColumnIndexToLetters(columnIndex);
         }
 
         private static int GetColumnIndex(string cellReference) {
             int columnIndex = 0;
-            foreach (char ch in cellReference.Where(char.IsLetter)) {
-                columnIndex = (columnIndex * 26) + (ch - 'A' + 1);
+            for (int i = 0; i < cellReference.Length; i++) {
+                char ch = cellReference[i];
+                if (ch >= 'A' && ch <= 'Z') {
+                    columnIndex = (columnIndex * 26) + (ch - 'A' + 1);
+                    continue;
+                }
+
+                if (ch >= 'a' && ch <= 'z') {
+                    columnIndex = (columnIndex * 26) + (ch - 'a' + 1);
+                    continue;
+                }
+
+                if (columnIndex > 0) {
+                    break;
+                }
             }
             return columnIndex;
         }
 
         private static int GetRowIndex(string cellReference) {
-            var digits = new string(cellReference.Where(char.IsDigit).ToArray());
-            return int.Parse(digits, CultureInfo.InvariantCulture);
+            int rowIndex = 0;
+            for (int i = 0; i < cellReference.Length; i++) {
+                char ch = cellReference[i];
+                if (ch >= '0' && ch <= '9') {
+                    rowIndex = (rowIndex * 10) + (ch - '0');
+                }
+            }
+
+            return rowIndex;
         }
 
         // Exposed as internal so other components in the same assembly (e.g., SheetComposer)

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.cs
@@ -101,9 +101,10 @@ namespace OfficeIMO.Excel {
                     ssPlanner.ApplyAndFixup(prepared, _excelDocument);
                     stylePlanner.ApplyTo(_excelDocument);
 
+                    var writer = new BatchCellWriter(this);
                     for (int i = 0; i < prepared.Length; i++) {
                         var p = prepared[i];
-                        var cell = GetCell(p.Row, p.Col);
+                        var cell = writer.GetOrCreateCell(p.Row, p.Col);
                         cell.CellValue = p.Val;
                         cell.DataType = p.Type;
                         if (wrapFlags[i])
@@ -139,8 +140,8 @@ namespace OfficeIMO.Excel {
 
             int rowsCount = table.Rows.Count + (includeHeaders ? 1 : 0);
             int colsCount = Math.Max(1, table.Columns.Count);
-            string startRef = GetColumnName(startColumn) + startRow.ToString(CultureInfo.InvariantCulture);
-            string endRef = GetColumnName(startColumn + colsCount - 1) + (startRow + rowsCount - 1).ToString(CultureInfo.InvariantCulture);
+            string startRef = A1.CellReference(startRow, startColumn);
+            string endRef = A1.CellReference(startRow + rowsCount - 1, startColumn + colsCount - 1);
             string range = startRef + ":" + endRef;
 
             // Create the Table with optional AutoFilter and style

--- a/OfficeIMO.Excel/ExcelSheet.Dimension.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Dimension.cs
@@ -57,8 +57,8 @@ namespace OfficeIMO.Excel {
                 return "A1";
             }
 
-            string start = A1.ColumnIndexToLetters(minCol) + minRow.ToString(System.Globalization.CultureInfo.InvariantCulture);
-            string end = A1.ColumnIndexToLetters(maxCol) + maxRow.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            string start = A1.CellReference(minRow, minCol);
+            string end = A1.CellReference(maxRow, maxCol);
             return start == end ? start : start + ":" + end;
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.Hyperlinks.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Hyperlinks.cs
@@ -23,7 +23,7 @@ namespace OfficeIMO.Excel {
                 // Avoid nested locks: write value using core method
                 CellValueCore(row, column, text);
 
-                var reference = GetColumnName(column) + row.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                var reference = A1.CellReference(row, column);
                 // Ensure Hyperlinks container exists
                 var ws = WorksheetRoot;
                 var hyperlinks = ws.Elements<Hyperlinks>().FirstOrDefault();
@@ -77,7 +77,7 @@ namespace OfficeIMO.Excel {
             WriteLock(() => {
                 string text = string.IsNullOrEmpty(display) ? normalizedLocation : display!;
                 CellValueCore(row, column, text);
-                var reference = GetColumnName(column) + row.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                var reference = A1.CellReference(row, column);
                 var ws = WorksheetRoot;
                 var hyperlinks = ws.Elements<Hyperlinks>().FirstOrDefault();
                 if (hyperlinks == null) {

--- a/OfficeIMO.Excel/ExcelSheet.PivotTables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PivotTables.cs
@@ -356,8 +356,8 @@ namespace OfficeIMO.Excel {
             int width = Math.Max(1, columnCount);
             int endColumn = startColumn + width - 1;
             int endRow = startRow + 1; // header + at least one data row
-            string start = $"{A1.ColumnIndexToLetters(startColumn)}{startRow}";
-            string end = $"{A1.ColumnIndexToLetters(endColumn)}{endRow}";
+            string start = A1.CellReference(startRow, startColumn);
+            string end = A1.CellReference(endRow, endColumn);
             return $"{start}:{end}";
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Tables.cs
@@ -307,11 +307,14 @@ namespace OfficeIMO.Excel {
                 var usedHeaders = new System.Collections.Generic.HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
                 for (uint i = 0; i < columnsCount; i++) {
                     string baseName = $"Column{i + 1}";
+                    string headerValue = string.Empty;
+                    bool headerCellIsSharedString = false;
                     // If the table has headers, try to get the actual header value
                     if (hasHeader && startRowIndex > 0) {
                         var headerCell = GetCell(startRowIndex, startColumnIndex + (int)i);
                         if (headerCell != null) {
-                            string headerValue = GetCellText(headerCell);
+                            headerCellIsSharedString = headerCell.DataType?.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString;
+                            headerValue = GetCellText(headerCell);
                             if (!string.IsNullOrWhiteSpace(headerValue)) {
                                 baseName = headerValue;
                             }
@@ -324,7 +327,7 @@ namespace OfficeIMO.Excel {
                     }
                     tableColumns.Append(new TableColumn { Id = i + 1, Name = candidate });
 
-                    if (hasHeader) {
+                    if (hasHeader && (!headerCellIsSharedString || !string.Equals(headerValue, candidate, System.StringComparison.Ordinal))) {
                         CellValueCore(startRowIndex, startColumnIndex + (int)i, candidate);
                     }
                 }
@@ -472,14 +475,54 @@ namespace OfficeIMO.Excel {
         private void EnsureRangeCellsExist(int startRowIndex, int endRowIndex, int startColumnIndex, int endColumnIndex) {
             var sheetData = GetOrCreateSheetData();
 
+            if (RangeCellsAlreadyExistAsContiguousRows(sheetData, startRowIndex, endRowIndex, startColumnIndex, endColumnIndex)) {
+                return;
+            }
+
             var rows = sheetData.Elements<Row>()
                 .Where(r => r.RowIndex != null)
                 .ToDictionary(r => (int)r.RowIndex!.Value);
+
+            int columnCount = endColumnIndex - startColumnIndex + 1;
+            bool useBitMask = columnCount <= 64;
+            ulong fullMask = columnCount == 64 ? ulong.MaxValue : (1UL << columnCount) - 1UL;
 
             for (int rowIndex = startRowIndex; rowIndex <= endRowIndex; rowIndex++) {
                 if (!rows.TryGetValue(rowIndex, out Row? row)) {
                     row = GetOrCreateRowElement(sheetData, rowIndex);
                     rows[rowIndex] = row;
+                }
+
+                if (useBitMask) {
+                    ulong existingMask = 0UL;
+                    foreach (var cell in row.Elements<Cell>()) {
+                        var cellReference = cell.CellReference?.Value;
+                        if (string.IsNullOrEmpty(cellReference)) {
+                            continue;
+                        }
+
+                        int columnIndex = GetColumnIndex(cellReference!);
+                        if (columnIndex < startColumnIndex || columnIndex > endColumnIndex) {
+                            continue;
+                        }
+
+                        existingMask |= 1UL << (columnIndex - startColumnIndex);
+                        if (existingMask == fullMask) {
+                            break;
+                        }
+                    }
+
+                    if (existingMask == fullMask) {
+                        continue;
+                    }
+
+                    for (int offset = 0; offset < columnCount; offset++) {
+                        if ((existingMask & (1UL << offset)) == 0UL) {
+                            GetCell(rowIndex, startColumnIndex + offset);
+                        }
+                    }
+
+                    continue;
                 }
 
                 var existingColumns = new HashSet<int>();
@@ -496,6 +539,58 @@ namespace OfficeIMO.Excel {
                     }
                 }
             }
+        }
+
+        private static bool RangeCellsAlreadyExistAsContiguousRows(SheetData sheetData, int startRowIndex, int endRowIndex, int startColumnIndex, int endColumnIndex) {
+            int expectedRow = startRowIndex;
+            int expectedColumnCount = endColumnIndex - startColumnIndex + 1;
+
+            foreach (var row in sheetData.Elements<Row>()) {
+                if (row.RowIndex == null) {
+                    continue;
+                }
+
+                int rowIndex = (int)row.RowIndex.Value;
+                if (rowIndex < startRowIndex) {
+                    continue;
+                }
+
+                if (rowIndex > endRowIndex) {
+                    break;
+                }
+
+                if (rowIndex != expectedRow || !RowHasExactContiguousCells(row, startColumnIndex, endColumnIndex, expectedColumnCount)) {
+                    return false;
+                }
+
+                expectedRow++;
+            }
+
+            return expectedRow > endRowIndex;
+        }
+
+        private static bool RowHasExactContiguousCells(Row row, int startColumnIndex, int endColumnIndex, int expectedColumnCount) {
+            int expectedColumn = startColumnIndex;
+            int cellCount = 0;
+
+            foreach (var cell in row.Elements<Cell>()) {
+                string? cellReference = cell.CellReference?.Value;
+                if (string.IsNullOrEmpty(cellReference)) {
+                    return false;
+                }
+
+                if (GetColumnIndex(cellReference!) != expectedColumn) {
+                    return false;
+                }
+
+                expectedColumn++;
+                cellCount++;
+                if (cellCount > expectedColumnCount) {
+                    return false;
+                }
+            }
+
+            return cellCount == expectedColumnCount && expectedColumn == endColumnIndex + 1;
         }
 
     }

--- a/OfficeIMO.Excel/ExcelSheet.ViewCleanup.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ViewCleanup.cs
@@ -47,7 +47,7 @@ namespace OfficeIMO.Excel {
                     pane.Remove();
                     pane = null;
                 } else {
-                    paneCell = A1.ColumnIndexToLetters(frozenColumns + 1) + (frozenRows + 1).ToString(CultureInfo.InvariantCulture);
+                    paneCell = A1.CellReference(frozenRows + 1, frozenColumns + 1);
                     pane.TopLeftCell = paneCell;
 
                     if (frozenRows > 0 && frozenColumns > 0) {

--- a/OfficeIMO.Excel/ExecutionPolicy.cs
+++ b/OfficeIMO.Excel/ExecutionPolicy.cs
@@ -44,7 +44,9 @@ namespace OfficeIMO.Excel {
 
         /// <summary>
         /// Optional timing callback invoked by long-running operations to report elapsed time.
-        /// Provides a lightweight hook for performance monitoring in large workbooks.
+        /// Provides a lightweight hook for performance monitoring in large workbooks. Operation
+        /// names may include whole operations such as "AutoFitColumns" and scoped sub-stages such
+        /// as "AutoFitColumns.BuildPlan", "AutoFitColumns.CalculateWidths", or "AutoFitColumns.ApplyWidths".
         /// </summary>
         public Action<string, TimeSpan>? OnTiming { get; set; }
 
@@ -65,6 +67,13 @@ namespace OfficeIMO.Excel {
         /// are requested to avoid penalizing hot paths.
         /// </summary>
         public WorksheetValidationMode WorksheetValidation { get; set; } = WorksheetValidationMode.DiagnosticsOnly;
+
+        /// <summary>
+        /// Saves the worksheet part immediately after AutoFit mutates row heights or column widths.
+        /// Disable for large report-generation pipelines that call <see cref="ExcelDocument.Save()"/> or dispose
+        /// the document after a batch of worksheet mutations.
+        /// </summary>
+        public bool SaveWorksheetAfterAutoFit { get; set; } = true;
 
         /// <summary>
         /// Enables invoking <see cref="DocumentFormat.OpenXml.Validation.OpenXmlValidator"/> while debugging. This

--- a/OfficeIMO.Excel/README.md
+++ b/OfficeIMO.Excel/README.md
@@ -25,6 +25,7 @@ OfficeIMO.Excel provides a lightweight, typed, and ergonomic API for reading and
   - `Automatic` switches to parallel per operation when the workload exceeds a threshold.
   - `doc.Execution.MaxDegreeOfParallelism` caps parallelism (set to CPU count for best results).
   - Optional diagnostics callbacks: `OnDecision(op, items, mode)`, `OnTiming(op, elapsed)`.
+  - `doc.Execution.SaveWorksheetAfterAutoFit = false` defers AutoFit worksheet-part saves until `Save()`/dispose, which is faster for large report exports that batch all worksheet changes.
 - Safe across tasks:
   - Multiple tasks can operate on the same `ExcelDocument`; the library coordinates writes.
   - Multiple `ExcelDocument` instances can run in parallel without interaction.
@@ -36,6 +37,7 @@ using var doc = ExcelDocument.Create(path);
 // Prefer all cores for compute; keep writes safe
 doc.Execution.Mode = ExecutionMode.Automatic;
 doc.Execution.MaxDegreeOfParallelism = Environment.ProcessorCount;
+doc.Execution.SaveWorksheetAfterAutoFit = false; // report-export mode: save once at the document boundary
 doc.Execution.OnDecision = (op, n, m) => Console.WriteLine($"[Exec] {op}: {n} → {m}");
 // AutoFit with parallel compute
 var s = doc.AddWorkSheet("Data");

--- a/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
@@ -36,7 +36,8 @@ namespace OfficeIMO.Excel {
             return OpenFromBytes(
                 File.ReadAllBytes(path),
                 options,
-                $"Failed to open '{path}' after normalizing package content types. The package may declare an invalid content type for '/docProps/app.xml'.");
+                normalizeContentTypes: false,
+                contextMessage: $"Failed to open '{path}' after normalizing package content types. The package may declare an invalid content type for '/docProps/app.xml'.");
         }
 
         /// <summary>
@@ -49,7 +50,8 @@ namespace OfficeIMO.Excel {
             return OpenFromBytes(
                 ReadAllBytes(stream),
                 options,
-                "Failed to open workbook stream after normalizing package content types. The package may declare an invalid content type for '/docProps/app.xml'.");
+                normalizeContentTypes: false,
+                contextMessage: "Failed to open workbook stream after normalizing package content types. The package may declare an invalid content type for '/docProps/app.xml'.");
         }
 
         /// <summary>
@@ -88,25 +90,34 @@ namespace OfficeIMO.Excel {
                 _doc.Dispose();
         }
 
-        private static ExcelDocumentReader OpenFromBytes(byte[] bytes, ExcelReadOptions? options, string contextMessage) {
-            MemoryStream? normalizedStream = null;
+        private static ExcelDocumentReader OpenFromBytes(byte[] bytes, ExcelReadOptions? options, bool normalizeContentTypes, string contextMessage) {
+            MemoryStream? packageStream = null;
             try {
-                normalizedStream = new MemoryStream(bytes.Length + 4096);
-                normalizedStream.Write(bytes, 0, bytes.Length);
-                normalizedStream.Position = 0;
+                packageStream = new MemoryStream(bytes.Length + 4096);
+                packageStream.Write(bytes, 0, bytes.Length);
+                packageStream.Position = 0;
 
-                ExcelPackageUtilities.NormalizeContentTypes(normalizedStream, leaveOpen: true);
-                normalizedStream.Position = 0;
+                if (normalizeContentTypes) {
+                    ExcelPackageUtilities.NormalizeContentTypes(packageStream, leaveOpen: true);
+                    packageStream.Position = 0;
+                }
 
-                var doc = SpreadsheetDocument.Open(normalizedStream, false);
+                var doc = SpreadsheetDocument.Open(packageStream, false);
                 return new ExcelDocumentReader(doc, options ?? new ExcelReadOptions(), owns: true);
-            } catch (Exception ex) when (ex is InvalidDataException || ex is OpenXmlPackageException || ex is XmlException) {
-                normalizedStream?.Dispose();
+            } catch (Exception ex) when (!normalizeContentTypes && IsRecoverableOpenException(ex)) {
+                packageStream?.Dispose();
+                return OpenFromBytes(bytes, options, normalizeContentTypes: true, contextMessage);
+            } catch (Exception ex) when (IsRecoverableOpenException(ex)) {
+                packageStream?.Dispose();
                 throw new IOException($"{contextMessage} See inner exception for details.", ex);
             } catch {
-                normalizedStream?.Dispose();
+                packageStream?.Dispose();
                 throw;
             }
+        }
+
+        private static bool IsRecoverableOpenException(Exception ex) {
+            return ex is InvalidDataException || ex is OpenXmlPackageException || ex is XmlException;
         }
 
         private static byte[] ReadAllBytes(Stream stream) {

--- a/OfficeIMO.Excel/Read/ExcelReadOptions.cs
+++ b/OfficeIMO.Excel/Read/ExcelReadOptions.cs
@@ -64,7 +64,9 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public ExcelReadOptions() {
             Execution.OperationThresholds["ReadRange"] = 10_000;
+            Execution.OperationThresholds["ReadRangeAsDataTable"] = 2_000;
             Execution.OperationThresholds["ReadObjects"] = 2_000;
+            Execution.OperationThresholds["ReadObjectsAs"] = 2_000;
             Execution.OperationThresholds["ReadRows"] = 20_000;
         }
     }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Columns.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Columns.cs
@@ -30,8 +30,7 @@ namespace OfficeIMO.Excel {
 
                 object? value = null;
                 foreach (var cell in row.Elements<Cell>()) {
-                    if (cell.CellReference?.Value is null) continue;
-                    var (rr, cc) = A1.ParseCellRef(cell.CellReference.Value);
+                    int cc = A1.ParseColumnIndexFromCellReference(cell.CellReference?.Value);
                     if (cc != c1) continue;
                     value = ConvertCell(cell);
                     break;

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.EnumerateRange.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.EnumerateRange.cs
@@ -16,7 +16,7 @@ namespace OfficeIMO.Excel {
             foreach (var row in sheetData.Elements<Row>()) {
                 var rIndex = checked((int)row.RowIndex!.Value);
                 if (rIndex < r1) continue;
-                if (rIndex > r2) break;
+                if (rIndex > r2) continue;
 
                 foreach (var cell in row.Elements<Cell>()) {
                     int cIndex = A1.ParseColumnIndexFromCellReference(cell.CellReference?.Value);

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.EnumerateRange.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.EnumerateRange.cs
@@ -19,7 +19,7 @@ namespace OfficeIMO.Excel {
                 if (rIndex > r2) break;
 
                 foreach (var cell in row.Elements<Cell>()) {
-                    var (_, cIndex) = A1.ParseCellRef(cell.CellReference?.Value ?? string.Empty);
+                    int cIndex = A1.ParseColumnIndexFromCellReference(cell.CellReference?.Value);
                     if (cIndex < c1 || cIndex > c2) continue;
                     var value = ConvertCell(cell);
                     if (value is not null || CellHasExplicitBlank(cell))

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
@@ -16,14 +16,30 @@ namespace OfficeIMO.Excel {
         /// Header cells are matched to public writable properties on T by name (case-insensitive).
         /// </summary>
         public IEnumerable<T> ReadObjects<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(string a1Range, OfficeIMO.Excel.ExecutionMode? mode = null, CancellationToken ct = default) where T : new() {
-            var values = ReadRange(a1Range, mode, ct);
-            int rows = values.GetLength(0);
-            int cols = values.GetLength(1);
-            if (rows == 0 || cols == 0) yield break;
+            var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
+            if (r1 > r2 || c1 > c2) throw new ArgumentException($"Invalid range '{a1Range}'.");
+
+            int rows = r2 - r1 + 1;
+            int cols = c2 - c1 + 1;
+            if (rows <= 1 || cols == 0) return Array.Empty<T>();
+
+            var rawCells = SnapshotAndConvertRangeCells(r1, c1, r2, c2, "ReadObjectsAs", mode, ct, rows * cols);
 
             // Build property map from normalized, disambiguated headers so repeated
             // source headers remain addressable instead of colliding.
-            var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => values[0, c]?.ToString(), _opt.NormalizeHeaders);
+            var headerValues = new object?[cols];
+            foreach (var cell in rawCells) {
+                if (cell.Row != r1) {
+                    continue;
+                }
+
+                int cc = cell.Col - c1;
+                if ((uint)cc < (uint)cols) {
+                    headerValues[cc] = cell.TypedValue;
+                }
+            }
+
+            var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => headerValues[c]?.ToString(), _opt.NormalizeHeaders);
 
             var writableProps = typeof(T).GetProperties(BindingFlags.Instance | BindingFlags.Public)
                 .Where(p => p.CanWrite)
@@ -111,21 +127,45 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            for (int r = 1; r < rows; r++) {
-                if (ct.IsCancellationRequested) yield break;
+            int dataRowCount = rows - 1;
+            var rowValues = new object?[dataRowCount][];
+            foreach (var cell in rawCells) {
+                if (cell.Row <= r1) {
+                    continue;
+                }
+
+                int rr = cell.Row - r1 - 1;
+                int cc = cell.Col - c1;
+                if ((uint)rr < (uint)dataRowCount && (uint)cc < (uint)cols) {
+                    var values = rowValues[rr];
+                    if (values == null) {
+                        values = new object?[cols];
+                        rowValues[rr] = values;
+                    }
+
+                    values[cc] = cell.TypedValue;
+                }
+            }
+
+            var result = new List<T>(dataRowCount);
+            for (int r = 0; r < dataRowCount; r++) {
+                if (ct.IsCancellationRequested) break;
                 var obj = new T();
+                var values = rowValues[r];
                 for (int c = 0; c < cols; c++) {
                     if (map[c].ColIndex == -1) continue;
                     var pi = map[c].Prop;
-                    var raw = values[r, c];
+                    var raw = values?[c];
                     if (raw is null) continue;
 
                     object? converted = TryChangeType(raw, pi.PropertyType, _opt.Culture);
                     if (converted is not null || IsNullableType(pi.PropertyType))
                         pi.SetValue(obj, converted);
                 }
-                yield return obj;
+                result.Add(obj);
             }
+
+            return result;
         }
 
         private static bool IsNullableType(Type t) {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
@@ -27,22 +27,15 @@ namespace OfficeIMO.Excel {
             var width = c2 - c1 + 1;
             var result = new object?[height, width];
 
-            var raw = new List<CellRaw>(capacity: Math.Max(1024, height * width / 4));
-            SnapshotCellsInto(raw, r1, c1, r2, c2);
-
             var policy = _opt.Execution;
             var decided = mode ?? policy.Mode;
-            if (decided == OfficeIMO.Excel.ExecutionMode.Automatic) decided = policy.Decide("ReadRange", raw.Count);
-
-            if (decided == OfficeIMO.Excel.ExecutionMode.Parallel && raw.Count > 0) {
-                var po = new ParallelOptions {
-                    CancellationToken = ct,
-                    MaxDegreeOfParallelism = policy.MaxDegreeOfParallelism ?? -1
-                };
-                Parallel.For(0, raw.Count, po, i => raw[i] = ConvertRaw(raw[i]));
-            } else {
-                for (int i = 0; i < raw.Count; i++) raw[i] = ConvertRaw(raw[i]);
+            int workload = height * width;
+            if (decided == OfficeIMO.Excel.ExecutionMode.Sequential) {
+                FillRangeSequential(result, r1, c1, r2, c2);
+                return result;
             }
+
+            var raw = SnapshotAndConvertRangeCells(r1, c1, r2, c2, "ReadRange", mode, ct, workload);
 
             foreach (var cell in raw) {
                 var rr = cell.Row - r1;
@@ -58,14 +51,25 @@ namespace OfficeIMO.Excel {
         /// Reads a rectangular range to a DataTable. If headersInFirstRow = true, first row becomes column names.
         /// </summary>
         public DataTable ReadRangeAsDataTable(string a1Range, bool headersInFirstRow = true, OfficeIMO.Excel.ExecutionMode? mode = null, CancellationToken ct = default) {
-            var values = ReadRange(a1Range, mode, ct);
-            var dt = new DataTable(_sheetName);
-            int rows = values.GetLength(0);
-            int cols = values.GetLength(1);
+            var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
+            if (r1 > r2 || c1 > c2) throw new ArgumentException($"Invalid range '{a1Range}'.");
 
-            // Columns
+            var dt = new DataTable(_sheetName);
+            int rows = r2 - r1 + 1;
+            int cols = c2 - c1 + 1;
+            var raw = SnapshotAndConvertRangeCells(r1, c1, r2, c2, "ReadRangeAsDataTable", mode, ct, rows * cols);
+
             if (headersInFirstRow && rows > 0) {
-                var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => values[0, c]?.ToString(), _opt.NormalizeHeaders);
+                var headerValues = new object?[cols];
+                foreach (var cell in raw) {
+                    if (cell.Row != r1) continue;
+                    int cc = cell.Col - c1;
+                    if ((uint)cc < (uint)cols) {
+                        headerValues[cc] = cell.TypedValue;
+                    }
+                }
+
+                var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => headerValues[c]?.ToString(), _opt.NormalizeHeaders);
                 for (int c = 0; c < cols; c++) {
                     dt.Columns.Add(headers[c], typeof(object));
                 }
@@ -73,13 +77,22 @@ namespace OfficeIMO.Excel {
                 for (int c = 0; c < cols; c++) dt.Columns.Add($"Column{c + 1}", typeof(object));
             }
 
-            // Rows
             int startRow = headersInFirstRow ? 1 : 0;
-            for (int r = startRow; r < rows; r++) {
-                var row = dt.NewRow();
-                for (int c = 0; c < cols; c++) row[c] = values[r, c] ?? DBNull.Value;
-                dt.Rows.Add(row);
+            int dataRowCount = Math.Max(0, rows - startRow);
+            var dataRows = new DataRow[dataRowCount];
+            for (int r = 0; r < dataRowCount; r++) {
+                dataRows[r] = dt.NewRow();
+                dt.Rows.Add(dataRows[r]);
             }
+
+            foreach (var cell in raw) {
+                int rr = cell.Row - r1 - startRow;
+                int cc = cell.Col - c1;
+                if ((uint)rr < (uint)dataRowCount && (uint)cc < (uint)cols) {
+                    dataRows[rr][cc] = cell.TypedValue ?? DBNull.Value;
+                }
+            }
+
             return dt;
         }
 
@@ -87,18 +100,88 @@ namespace OfficeIMO.Excel {
         /// Reads a rectangular range into a sequence of dictionaries using the first row as headers.
         /// </summary>
         public IEnumerable<Dictionary<string, object?>> ReadObjects(string a1Range, OfficeIMO.Excel.ExecutionMode? mode = null, CancellationToken ct = default) {
-            var values = ReadRange(a1Range, mode, ct);
-            int rows = values.GetLength(0);
-            int cols = values.GetLength(1);
-            if (rows == 0 || cols == 0) yield break;
+            var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
+            if (r1 > r2 || c1 > c2) throw new ArgumentException($"Invalid range '{a1Range}'.");
 
-            var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => values[0, c]?.ToString(), _opt.NormalizeHeaders);
-
-            for (int r = 1; r < rows; r++) {
-                var dict = new Dictionary<string, object?>(cols, System.StringComparer.OrdinalIgnoreCase);
-                for (int c = 0; c < cols; c++) dict[headers[c]] = values[r, c];
-                yield return dict;
+            int rows = r2 - r1 + 1;
+            int cols = c2 - c1 + 1;
+            if (rows <= 1 || cols == 0) {
+                return Array.Empty<Dictionary<string, object?>>();
             }
+
+            var raw = SnapshotAndConvertRangeCells(r1, c1, r2, c2, "ReadObjects", mode, ct, rows * cols);
+
+            var headerValues = new object?[cols];
+            foreach (var cell in raw) {
+                if (cell.Row != r1) continue;
+                int cc = cell.Col - c1;
+                if ((uint)cc < (uint)cols) {
+                    headerValues[cc] = cell.TypedValue;
+                }
+            }
+
+            var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => headerValues[c]?.ToString(), _opt.NormalizeHeaders);
+            int dataRowCount = rows - 1;
+            var rowValues = new object?[dataRowCount][];
+
+            foreach (var cell in raw) {
+                if (cell.Row <= r1) continue;
+                int rr = cell.Row - r1 - 1;
+                int cc = cell.Col - c1;
+                if ((uint)rr < (uint)dataRowCount && (uint)cc < (uint)cols) {
+                    var values = rowValues[rr];
+                    if (values == null) {
+                        values = new object?[cols];
+                        rowValues[rr] = values;
+                    }
+
+                    values[cc] = cell.TypedValue;
+                }
+            }
+
+            var result = new List<Dictionary<string, object?>>(dataRowCount);
+            for (int r = 0; r < dataRowCount; r++) {
+                var values = rowValues[r];
+                var dict = new Dictionary<string, object?>(cols, StringComparer.OrdinalIgnoreCase);
+                for (int c = 0; c < cols; c++) {
+                    dict.Add(headers[c], values?[c]);
+                }
+
+                result.Add(dict);
+            }
+
+            return result;
+        }
+
+        private List<CellRaw> SnapshotAndConvertRangeCells(
+            int r1,
+            int c1,
+            int r2,
+            int c2,
+            string operationName,
+            OfficeIMO.Excel.ExecutionMode? mode,
+            CancellationToken ct,
+            int workload) {
+            var policy = _opt.Execution;
+            var decided = mode ?? policy.Mode;
+            var raw = new List<CellRaw>(capacity: Math.Max(1024, workload / 4));
+            SnapshotCellsInto(raw, r1, c1, r2, c2);
+            if (decided == OfficeIMO.Excel.ExecutionMode.Automatic) decided = policy.Decide(operationName, raw.Count);
+
+            if (decided == OfficeIMO.Excel.ExecutionMode.Parallel && raw.Count > 0) {
+                var po = new ParallelOptions {
+                    CancellationToken = ct,
+                    MaxDegreeOfParallelism = policy.MaxDegreeOfParallelism ?? -1
+                };
+                Parallel.For(0, raw.Count, po, i => raw[i] = ConvertRaw(raw[i]));
+            } else {
+                for (int i = 0; i < raw.Count; i++) {
+                    ct.ThrowIfCancellationRequested();
+                    raw[i] = ConvertRaw(raw[i]);
+                }
+            }
+
+            return raw;
         }
 
         private void SnapshotCellsInto(List<CellRaw> buffer, int r1, int c1, int r2, int c2) {
@@ -110,7 +193,7 @@ namespace OfficeIMO.Excel {
                 if (rIndex < r1 || rIndex > r2) continue;
 
                 foreach (var cell in row.Elements<Cell>()) {
-                    var (_, cIndex) = A1.ParseCellRef(cell.CellReference?.Value ?? string.Empty);
+                    int cIndex = A1.ParseColumnIndexFromCellReference(cell.CellReference?.Value);
                     if (cIndex < c1 || cIndex > c2) continue;
 
                     var raw = new CellRaw {
@@ -125,6 +208,42 @@ namespace OfficeIMO.Excel {
 
                     if (raw.RawText != null || raw.InlineText != null || CellHasExplicitBlank(cell) || _opt.FillBlanksInRanges)
                         buffer.Add(raw);
+                }
+            }
+        }
+
+        private void FillRangeSequential(object?[,] result, int r1, int c1, int r2, int c2) {
+            var sheetData = WorksheetRoot.GetFirstChild<SheetData>();
+            if (sheetData == null) return;
+
+            int height = result.GetLength(0);
+            int width = result.GetLength(1);
+
+            foreach (var row in sheetData.Elements<Row>()) {
+                var rIndex = checked((int)row.RowIndex!.Value);
+                if (rIndex < r1) continue;
+                if (rIndex > r2) break;
+
+                int rr = rIndex - r1;
+                if ((uint)rr >= (uint)height) continue;
+
+                foreach (var cell in row.Elements<Cell>()) {
+                    int cIndex = A1.ParseColumnIndexFromCellReference(cell.CellReference?.Value);
+                    if (cIndex < c1 || cIndex > c2) continue;
+
+                    int cc = cIndex - c1;
+                    if ((uint)cc >= (uint)width) continue;
+
+                    var raw = new CellRaw {
+                        TypeHint = cell.DataType?.Value,
+                        StyleIndex = cell.StyleIndex?.Value,
+                        HasFormula = cell.CellFormula is not null,
+                        RawText = ExtractRawText(cell),
+                        InlineText = ExtractInlineString(cell)
+                    };
+
+                    if (raw.RawText != null || raw.InlineText != null || CellHasExplicitBlank(cell) || _opt.FillBlanksInRanges)
+                        result[rr, cc] = ConvertRaw(raw).TypedValue;
                 }
             }
         }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
@@ -31,7 +31,7 @@ namespace OfficeIMO.Excel {
             var decided = mode ?? policy.Mode;
             int workload = height * width;
             if (decided == OfficeIMO.Excel.ExecutionMode.Sequential) {
-                FillRangeSequential(result, r1, c1, r2, c2);
+                FillRangeSequential(result, r1, c1, r2, c2, ct);
                 return result;
             }
 
@@ -202,6 +202,7 @@ namespace OfficeIMO.Excel {
                         TypeHint = cell.DataType?.Value,
                         StyleIndex = cell.StyleIndex?.Value,
                         HasFormula = cell.CellFormula is not null,
+                        FormulaText = ExtractFormulaText(cell),
                         RawText = ExtractRawText(cell),
                         InlineText = ExtractInlineString(cell)
                     };
@@ -212,7 +213,7 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private void FillRangeSequential(object?[,] result, int r1, int c1, int r2, int c2) {
+        private void FillRangeSequential(object?[,] result, int r1, int c1, int r2, int c2, CancellationToken ct) {
             var sheetData = WorksheetRoot.GetFirstChild<SheetData>();
             if (sheetData == null) return;
 
@@ -220,6 +221,7 @@ namespace OfficeIMO.Excel {
             int width = result.GetLength(1);
 
             foreach (var row in sheetData.Elements<Row>()) {
+                ct.ThrowIfCancellationRequested();
                 var rIndex = checked((int)row.RowIndex!.Value);
                 if (rIndex < r1) continue;
                 if (rIndex > r2) continue;
@@ -228,6 +230,7 @@ namespace OfficeIMO.Excel {
                 if ((uint)rr >= (uint)height) continue;
 
                 foreach (var cell in row.Elements<Cell>()) {
+                    ct.ThrowIfCancellationRequested();
                     int cIndex = A1.ParseColumnIndexFromCellReference(cell.CellReference?.Value);
                     if (cIndex < c1 || cIndex > c2) continue;
 
@@ -238,6 +241,7 @@ namespace OfficeIMO.Excel {
                         TypeHint = cell.DataType?.Value,
                         StyleIndex = cell.StyleIndex?.Value,
                         HasFormula = cell.CellFormula is not null,
+                        FormulaText = ExtractFormulaText(cell),
                         RawText = ExtractRawText(cell),
                         InlineText = ExtractInlineString(cell)
                     };

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
@@ -222,7 +222,7 @@ namespace OfficeIMO.Excel {
             foreach (var row in sheetData.Elements<Row>()) {
                 var rIndex = checked((int)row.RowIndex!.Value);
                 if (rIndex < r1) continue;
-                if (rIndex > r2) break;
+                if (rIndex > r2) continue;
 
                 int rr = rIndex - r1;
                 if ((uint)rr >= (uint)height) continue;

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Rows.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Rows.cs
@@ -45,8 +45,7 @@ namespace OfficeIMO.Excel {
                 bool hasCells = false;
 
                 foreach (var cell in row.Elements<Cell>()) {
-                    if (cell.CellReference?.Value is null) continue;
-                    var (rr, cc) = A1.ParseCellRef(cell.CellReference.Value);
+                    int cc = A1.ParseColumnIndexFromCellReference(cell.CellReference?.Value);
                     if (cc < c1 || cc > c2) continue;
                     var val = ConvertCell(cell);
                     arr[cc - c1] = val ?? arr[cc - c1];

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Stream.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Stream.cs
@@ -121,8 +121,7 @@ namespace OfficeIMO.Excel {
                     if (!rowMap.TryGetValue(absoluteRow, out var rowEl)) continue;
 
                     foreach (var cell in rowEl.Elements<Cell>()) {
-                        if (cell.CellReference?.Value is null) continue;
-                        var (r, c) = A1.ParseCellRef(cell.CellReference.Value);
+                        int c = A1.ParseColumnIndexFromCellReference(cell.CellReference?.Value);
                         if (c < cc1 || c > cc2) continue;
                         var val = ConvertCell(cell);
                         outRows[i][c - cc1] = val ?? outRows[i][c - cc1];

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.cs
@@ -38,7 +38,7 @@ namespace OfficeIMO.Excel {
             foreach (var row in sheetData.Elements<Row>()) {
                 var rIndex = checked((int)row.RowIndex!.Value);
                 foreach (var cell in row.Elements<Cell>()) {
-                    var (_, cIndex) = A1.ParseCellRef(cell.CellReference?.Value ?? string.Empty);
+                    int cIndex = A1.ParseColumnIndexFromCellReference(cell.CellReference?.Value);
                     var value = ConvertCell(cell);
                     if (value is not null || CellHasExplicitBlank(cell))
                         yield return new CellValueInfo(rIndex, cIndex, value);
@@ -66,18 +66,13 @@ namespace OfficeIMO.Excel {
             var inline = cell.InlineString;
             if (inline?.Text?.Text != null) return inline.Text.Text;
             if (inline?.HasChildren == true) {
-                var runs = inline.Elements<Run>().Select(r => r.Text?.Text ?? string.Empty);
-                return string.Concat(runs);
+                return SharedStringCache.GetRunText(inline);
             }
             return null;
         }
 
         private object? ConvertCell(Cell cell) {
-            var cellRef = cell.CellReference?.Value;
-            var coords = cellRef != null ? A1.ParseCellRef(cellRef) : (Row: 0, Col: 0);
             var raw = new CellRaw {
-                Row = coords.Row,
-                Col = coords.Col,
                 TypeHint = cell.DataType?.Value,
                 StyleIndex = cell.StyleIndex?.Value,
                 HasFormula = cell.CellFormula is not null,

--- a/OfficeIMO.Excel/Read/Helpers/A1.cs
+++ b/OfficeIMO.Excel/Read/Helpers/A1.cs
@@ -4,6 +4,15 @@ namespace OfficeIMO.Excel {
     /// consumers can reuse consistent logic without re-implementing regexes or math.
     /// </summary>
     public static class A1 {
+        /// <summary>Maximum row index supported by the Excel worksheet grid.</summary>
+        public const int MaxRows = 1048576;
+
+        /// <summary>Maximum column index supported by the Excel worksheet grid.</summary>
+        public const int MaxColumns = 16384;
+
+        private const int ColumnLettersBufferLength = 7;
+        private const int CellReferenceBufferLength = 24;
+
         /// <summary>
         /// Parses a single A1 cell reference (e.g., "B5") into a 1-based (row, column) tuple.
         /// Returns (0,0) when the input does not match a valid simple cell reference.
@@ -69,7 +78,11 @@ namespace OfficeIMO.Excel {
             foreach (char character in letters) {
                 char ch = ToUpperAscii(character);
                 if (ch < 'A' || ch > 'Z') continue;
-                res = res * 26 + (ch - 'A' + 1);
+                int value = ch - 'A' + 1;
+                if (res > (int.MaxValue - value) / 26) {
+                    return 0;
+                }
+                res = res * 26 + value;
             }
             return res;
         }
@@ -89,7 +102,12 @@ namespace OfficeIMO.Excel {
                     break;
                 }
 
-                col = col * 26 + (ch - 'A' + 1);
+                int value = ch - 'A' + 1;
+                if (col > (int.MaxValue - value) / 26) {
+                    return 0;
+                }
+
+                col = col * 26 + value;
             }
 
             return col;
@@ -106,7 +124,7 @@ namespace OfficeIMO.Excel {
         /// </example>
         public static string ColumnIndexToLetters(int index) {
             if (index <= 0) return "A";
-            char[] buffer = new char[7];
+            char[] buffer = new char[ColumnLettersBufferLength];
             int position = 0;
             AppendColumnLetters(index, buffer, ref position);
             return new string(buffer, 0, position);
@@ -131,6 +149,10 @@ namespace OfficeIMO.Excel {
             }
 
             string source = text!;
+            if (!IsValidSlice(source, start, length)) {
+                return false;
+            }
+
             TrimBounds(source, ref start, ref length);
             if (length <= 0) {
                 return false;
@@ -144,7 +166,14 @@ namespace OfficeIMO.Excel {
                     break;
                 }
 
-                col = col * 26 + (ch - 'A' + 1);
+                int value = ch - 'A' + 1;
+                if (col > (int.MaxValue - value) / 26) {
+                    row = 0;
+                    col = 0;
+                    return false;
+                }
+
+                col = col * 26 + value;
             }
 
             if (i == start || i == end) {
@@ -161,16 +190,28 @@ namespace OfficeIMO.Excel {
                     return false;
                 }
 
-                row = row * 10 + (ch - '0');
+                int digit = ch - '0';
+                if (row > (int.MaxValue - digit) / 10) {
+                    row = 0;
+                    col = 0;
+                    return false;
+                }
+
+                row = row * 10 + digit;
             }
 
-            if (row <= 0) {
+            if (row <= 0 || col <= 0) {
                 row = 0;
                 col = 0;
                 return false;
             }
 
             return true;
+        }
+
+        private static bool IsValidSlice(string text, int start, int length) {
+            return (uint)start <= (uint)text.Length
+                && (uint)length <= (uint)(text.Length - start);
         }
 
         private static void TrimBounds(string text, ref int start, ref int length) {
@@ -201,7 +242,7 @@ namespace OfficeIMO.Excel {
                 throw new ArgumentOutOfRangeException(nameof(column), "A1 references are 1-based and require a positive column.");
             }
 
-            char[] buffer = new char[24];
+            char[] buffer = new char[CellReferenceBufferLength];
             int position = 0;
             if (absolute) {
                 buffer[position++] = '$';

--- a/OfficeIMO.Excel/Read/Helpers/A1.cs
+++ b/OfficeIMO.Excel/Read/Helpers/A1.cs
@@ -92,11 +92,12 @@ namespace OfficeIMO.Excel {
             string text = cellRef!;
             int start = 0;
             int length = text.Length;
-            TrimStart(text, ref start, ref length);
+            TrimBounds(text, ref start, ref length);
             int col = 0;
 
             int end = start + length;
-            for (int i = start; i < end; i++) {
+            int i = start;
+            for (; i < end; i++) {
                 char ch = ToUpperAscii(text[i]);
                 if (ch < 'A' || ch > 'Z') {
                     break;
@@ -110,7 +111,26 @@ namespace OfficeIMO.Excel {
                 col = col * 26 + value;
             }
 
-            return col;
+            if (i == start || i == end) {
+                return 0;
+            }
+
+            int row = 0;
+            for (; i < end; i++) {
+                char ch = text[i];
+                if (ch < '0' || ch > '9') {
+                    return 0;
+                }
+
+                int digit = ch - '0';
+                if (row > (int.MaxValue - digit) / 10) {
+                    return 0;
+                }
+
+                row = row * 10 + digit;
+            }
+
+            return row > 0 ? col : 0;
         }
 
         /// <summary>

--- a/OfficeIMO.Excel/Read/Helpers/A1.cs
+++ b/OfficeIMO.Excel/Read/Helpers/A1.cs
@@ -1,15 +1,9 @@
-using System.Globalization;
-using System.Text.RegularExpressions;
-
 namespace OfficeIMO.Excel {
     /// <summary>
     /// Utility helpers for parsing and converting Excel A1 references. Public so examples and
     /// consumers can reuse consistent logic without re-implementing regexes or math.
     /// </summary>
     public static class A1 {
-        private static readonly Regex RangeRx = new("^\\s*([A-Za-z]+)(\\d+)\\s*:\\s*([A-Za-z]+)(\\d+)\\s*$", RegexOptions.Compiled);
-        private static readonly Regex CellRx = new("^\\s*([A-Za-z]+)(\\d+)\\s*$", RegexOptions.Compiled);
-
         /// <summary>
         /// Parses a single A1 cell reference (e.g., "B5") into a 1-based (row, column) tuple.
         /// Returns (0,0) when the input does not match a valid simple cell reference.
@@ -17,12 +11,7 @@ namespace OfficeIMO.Excel {
         /// <param name="cellRef">A1 cell reference, without sheet prefix.</param>
         /// <returns>Tuple of row and column (1-based). Returns (0,0) if invalid.</returns>
         public static (int Row, int Col) ParseCellRef(string cellRef) {
-            if (string.IsNullOrWhiteSpace(cellRef)) return (0, 0);
-            var m = CellRx.Match(cellRef);
-            if (!m.Success) return (0, 0);
-            var col = ColumnLettersToIndex(m.Groups[1].Value);
-            var row = int.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture);
-            return (row, col);
+            return TryParseCellRef(cellRef, 0, cellRef?.Length ?? 0, out int row, out int col) ? (row, col) : (0, 0);
         }
 
         /// <summary>
@@ -32,12 +21,19 @@ namespace OfficeIMO.Excel {
         public static bool TryParseRange(string a1Range, out int r1, out int c1, out int r2, out int c2) {
             r1 = c1 = r2 = c2 = 0;
             if (string.IsNullOrWhiteSpace(a1Range)) return false;
-            var m = RangeRx.Match(a1Range);
-            if (!m.Success) return false;
-            c1 = ColumnLettersToIndex(m.Groups[1].Value);
-            r1 = int.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture);
-            c2 = ColumnLettersToIndex(m.Groups[3].Value);
-            r2 = int.Parse(m.Groups[4].Value, CultureInfo.InvariantCulture);
+            int start = 0;
+            int length = a1Range.Length;
+            TrimBounds(a1Range, ref start, ref length);
+
+            int separator = a1Range.IndexOf(':', start, length);
+            if (separator < 0) return false;
+
+            if (!TryParseCellRef(a1Range, start, separator - start, out r1, out c1)
+                || !TryParseCellRef(a1Range, separator + 1, start + length - separator - 1, out r2, out c2)) {
+                r1 = c1 = r2 = c2 = 0;
+                return false;
+            }
+
             if (c1 > c2) (c1, c2) = (c2, c1);
             if (r1 > r2) (r1, r2) = (r2, r1);
             return true;
@@ -55,14 +51,10 @@ namespace OfficeIMO.Excel {
         /// // r1=2, c1=2, r2=10, c2=4
         /// </example>
         public static (int r1, int c1, int r2, int c2) ParseRange(string a1Range) {
-            var m = RangeRx.Match(a1Range);
-            if (!m.Success) throw new ArgumentException($"Invalid A1 range '{a1Range}'.");
-            var c1 = ColumnLettersToIndex(m.Groups[1].Value);
-            var r1 = int.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture);
-            var c2 = ColumnLettersToIndex(m.Groups[3].Value);
-            var r2 = int.Parse(m.Groups[4].Value, CultureInfo.InvariantCulture);
-            if (c1 > c2) (c1, c2) = (c2, c1);
-            if (r1 > r2) (r1, r2) = (r2, r1);
+            if (!TryParseRange(a1Range, out int r1, out int c1, out int r2, out int c2)) {
+                throw new ArgumentException($"Invalid A1 range '{a1Range}'.");
+            }
+
             return (r1, c1, r2, c2);
         }
 
@@ -74,11 +66,33 @@ namespace OfficeIMO.Excel {
         /// <returns>1-based column index, or 0 when input yields no letters.</returns>
         public static int ColumnLettersToIndex(string letters) {
             int res = 0;
-            foreach (char ch in letters.ToUpperInvariant()) {
+            foreach (char character in letters) {
+                char ch = ToUpperAscii(character);
                 if (ch < 'A' || ch > 'Z') continue;
                 res = res * 26 + (ch - 'A' + 1);
             }
             return res;
+        }
+
+        internal static int ParseColumnIndexFromCellReference(string? cellRef) {
+            if (string.IsNullOrWhiteSpace(cellRef)) return 0;
+            string text = cellRef!;
+            int start = 0;
+            int length = text.Length;
+            TrimStart(text, ref start, ref length);
+            int col = 0;
+
+            int end = start + length;
+            for (int i = start; i < end; i++) {
+                char ch = ToUpperAscii(text[i]);
+                if (ch < 'A' || ch > 'Z') {
+                    break;
+                }
+
+                col = col * 26 + (ch - 'A' + 1);
+            }
+
+            return col;
         }
 
         /// <summary>
@@ -92,14 +106,147 @@ namespace OfficeIMO.Excel {
         /// </example>
         public static string ColumnIndexToLetters(int index) {
             if (index <= 0) return "A";
-            string letters = string.Empty;
+            char[] buffer = new char[7];
+            int position = 0;
+            AppendColumnLetters(index, buffer, ref position);
+            return new string(buffer, 0, position);
+        }
+
+        /// <summary>
+        /// Builds an A1 cell reference from 1-based row and column indexes.
+        /// </summary>
+        public static string CellReference(int row, int column) {
+            return BuildCellReference(row, column, absolute: false);
+        }
+
+        internal static string AbsoluteCellReference(int row, int column) {
+            return BuildCellReference(row, column, absolute: true);
+        }
+
+        private static bool TryParseCellRef(string? text, int start, int length, out int row, out int col) {
+            row = 0;
+            col = 0;
+            if (string.IsNullOrEmpty(text) || length <= 0) {
+                return false;
+            }
+
+            string source = text!;
+            TrimBounds(source, ref start, ref length);
+            if (length <= 0) {
+                return false;
+            }
+
+            int end = start + length;
+            int i = start;
+            for (; i < end; i++) {
+                char ch = ToUpperAscii(source[i]);
+                if (ch < 'A' || ch > 'Z') {
+                    break;
+                }
+
+                col = col * 26 + (ch - 'A' + 1);
+            }
+
+            if (i == start || i == end) {
+                row = 0;
+                col = 0;
+                return false;
+            }
+
+            for (; i < end; i++) {
+                char ch = source[i];
+                if (ch < '0' || ch > '9') {
+                    row = 0;
+                    col = 0;
+                    return false;
+                }
+
+                row = row * 10 + (ch - '0');
+            }
+
+            if (row <= 0) {
+                row = 0;
+                col = 0;
+                return false;
+            }
+
+            return true;
+        }
+
+        private static void TrimBounds(string text, ref int start, ref int length) {
+            TrimStart(text, ref start, ref length);
+            while (length > 0 && char.IsWhiteSpace(text[start + length - 1])) {
+                length--;
+            }
+        }
+
+        private static void TrimStart(string text, ref int start, ref int length) {
+            while (length > 0 && char.IsWhiteSpace(text[start])) {
+                start++;
+                length--;
+            }
+        }
+
+        private static char ToUpperAscii(char character) {
+            return character >= 'a' && character <= 'z'
+                ? (char)(character - ('a' - 'A'))
+                : character;
+        }
+
+        private static string BuildCellReference(int row, int column, bool absolute) {
+            if (row <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(row), "A1 references are 1-based and require a positive row.");
+            }
+            if (column <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(column), "A1 references are 1-based and require a positive column.");
+            }
+
+            char[] buffer = new char[24];
+            int position = 0;
+            if (absolute) {
+                buffer[position++] = '$';
+            }
+            AppendColumnLetters(column, buffer, ref position);
+            if (absolute) {
+                buffer[position++] = '$';
+            }
+            AppendPositiveInt(row, buffer, ref position);
+            return new string(buffer, 0, position);
+        }
+
+        private static void AppendColumnLetters(int index, char[] buffer, ref int position) {
+            int letters = 0;
             int n = index;
             while (n > 0) {
-                int rem = (n - 1) % 26;
-                letters = (char)('A' + rem) + letters;
+                letters++;
                 n = (n - 1) / 26;
             }
-            return letters;
+
+            int start = position;
+            position += letters;
+            n = index;
+            for (int i = position - 1; i >= start; i--) {
+                int rem = (n - 1) % 26;
+                buffer[i] = (char)('A' + rem);
+                n = (n - 1) / 26;
+            }
+        }
+
+        private static void AppendPositiveInt(int value, char[] buffer, ref int position) {
+            int digits = 1;
+            int n = value;
+            while (n >= 10) {
+                digits++;
+                n /= 10;
+            }
+
+            int start = position;
+            position += digits;
+            n = value;
+            for (int i = position - 1; i >= start; i--) {
+                buffer[i] = (char)('0' + (n % 10));
+                n /= 10;
+            }
         }
     }
 }

--- a/OfficeIMO.Excel/Read/Helpers/SharedStringCache.cs
+++ b/OfficeIMO.Excel/Read/Helpers/SharedStringCache.cs
@@ -5,6 +5,8 @@ using System.Text;
 
 namespace OfficeIMO.Excel {
     internal sealed class SharedStringCache {
+        private const int MinimumInitialCapacity = 1024;
+
         private readonly List<string> _items;
 
         private SharedStringCache(List<string> items) => _items = items;
@@ -13,7 +15,7 @@ namespace OfficeIMO.Excel {
             var part = doc.WorkbookPart!.SharedStringTablePart;
             if (part?.SharedStringTable == null) return new SharedStringCache(new List<string>());
 
-            var list = new List<string>(Math.Max(1024, (int)(part.SharedStringTable.Count?.Value ?? 0)));
+            var list = new List<string>(Math.Max(MinimumInitialCapacity, (int)(part.SharedStringTable.Count?.Value ?? 0)));
             foreach (var item in part.SharedStringTable.Elements<SharedStringItem>()) {
                 if (item.Text?.Text != null)
                     list.Add(item.Text.Text);

--- a/OfficeIMO.Excel/Read/Helpers/SharedStringCache.cs
+++ b/OfficeIMO.Excel/Read/Helpers/SharedStringCache.cs
@@ -1,5 +1,7 @@
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using System.Text;
 
 namespace OfficeIMO.Excel {
     internal sealed class SharedStringCache {
@@ -16,11 +18,31 @@ namespace OfficeIMO.Excel {
                 if (item.Text?.Text != null)
                     list.Add(item.Text.Text);
                 else if (item.HasChildren)
-                    list.Add(string.Concat(item.Elements<Run>().Select(r => r.Text?.Text ?? string.Empty)));
+                    list.Add(GetRunText(item));
                 else
                     list.Add(string.Empty);
             }
             return new SharedStringCache(list);
+        }
+
+        internal static string GetRunText(OpenXmlElement parent) {
+            string? first = null;
+            StringBuilder? builder = null;
+
+            foreach (var run in parent.Elements<Run>()) {
+                string text = run.Text?.Text ?? string.Empty;
+                if (builder != null) {
+                    builder.Append(text);
+                } else if (first == null) {
+                    first = text;
+                } else {
+                    builder = new StringBuilder(first.Length + text.Length);
+                    builder.Append(first);
+                    builder.Append(text);
+                }
+            }
+
+            return builder?.ToString() ?? first ?? string.Empty;
         }
 
         public string? Get(int index) {

--- a/OfficeIMO.Excel/SharedStringPlanner.cs
+++ b/OfficeIMO.Excel/SharedStringPlanner.cs
@@ -30,12 +30,7 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
-            var map = new Dictionary<string, int>(StringComparer.Ordinal);
-            foreach (var s in _distinct.Keys) {
-                int idx = doc.GetSharedStringIndex(s);
-                map[s] = idx;
-            }
-            _finalIndex = map;
+            _finalIndex = doc.GetSharedStringIndices(_distinct.Keys);
         }
 
         /// <summary>
@@ -47,11 +42,11 @@ namespace OfficeIMO.Excel {
 
             // prepared.Val.Text currently holds the raw string; replace with index text
             var text = prepared.Val?.Text ?? string.Empty;
-            var sanitized = Utilities.ExcelSanitizer.SanitizeString(text);
-            if (_finalIndex.TryGetValue(sanitized, out int idx)) {
+            if (_finalIndex.TryGetValue(text, out int idx)) {
                 prepared.Val = new CellValue(idx.ToString(CultureInfo.InvariantCulture));
             } else {
                 // Fallback: if not found (shouldn't happen), keep as string cell
+                var sanitized = Utilities.ExcelSanitizer.SanitizeString(text);
                 prepared.Val = new CellValue(sanitized);
                 prepared.Type = DocumentFormat.OpenXml.Spreadsheet.CellValues.String;
             }

--- a/OfficeIMO.Markup.VSCode/package-lock.json
+++ b/OfficeIMO.Markup.VSCode/package-lock.json
@@ -252,41 +252,10 @@
       "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
       "license": "MIT"
     },
-    "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
-      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/gast": "12.0.0",
-        "@chevrotain/types": "12.0.0"
-      }
-    },
-    "node_modules/@chevrotain/gast": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
-      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/types": "12.0.0"
-      }
-    },
-    "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
-      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@chevrotain/types": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
-      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@chevrotain/utils": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
-      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -759,12 +728,12 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
-      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
       "license": "MIT",
       "dependencies": {
-        "langium": "^4.0.0"
+        "@chevrotain/types": "~11.1.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1956,35 +1925,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/chevrotain": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
-      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@chevrotain/cst-dts-gen": "12.0.0",
-        "@chevrotain/gast": "12.0.0",
-        "@chevrotain/regexp-to-ast": "12.0.0",
-        "@chevrotain/types": "12.0.0",
-        "@chevrotain/utils": "12.0.0"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/chevrotain-allstar": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz",
-      "integrity": "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash-es": "^4.17.21"
-      },
-      "peerDependencies": {
-        "chevrotain": "^12.0.0"
-      }
-    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -2965,6 +2905,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
@@ -3812,24 +3762,6 @@
       "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
       "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
-    "node_modules/langium": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
-      "integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@chevrotain/regexp-to-ast": "~12.0.0",
-        "chevrotain": "~12.0.0",
-        "chevrotain-allstar": "~0.4.1",
-        "vscode-languageserver": "~9.0.1",
-        "vscode-languageserver-textdocument": "~1.0.11",
-        "vscode-uri": "~3.1.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
     "node_modules/layout-base": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
@@ -3996,14 +3928,14 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
-      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.0",
+        "@mermaid-js/parser": "^1.1.1",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
         "cytoscape": "^3.33.1",
@@ -4014,14 +3946,14 @@
         "dagre-d3-es": "7.0.14",
         "dayjs": "^1.11.19",
         "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
         "katex": "^0.16.25",
         "khroma": "^2.1.0",
-        "lodash-es": "^4.17.23",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/mermaid/node_modules/uuid": {
@@ -5562,55 +5494,6 @@
       "funding": {
         "url": "https://bevry.me/fund"
       }
-    },
-    "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
-      },
-      "bin": {
-        "installServerIntoExtension": "bin/installServerIntoExtension"
-      }
-    },
-    "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
-      }
-    },
-    "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
-      "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
+++ b/OfficeIMO.Pdf/Reading/Core/TextContentParser.cs
@@ -110,7 +110,7 @@ internal static class TextContentParser {
             if (bytes.Length >= 2) {
                 string one = decodeWithFont(font, new byte[] { bytes[0] });
                 string two = decodeWithFont(font, new byte[] { bytes[0], bytes[1] });
-                twoByte = string.IsNullOrEmpty(one) && !string.IsNullOrEmpty(two);
+                twoByte = IsNullOrEmptyDecodedGlyph(one) && !IsNullOrEmptyDecodedGlyph(two);
             }
             var sbOut = new StringBuilder(bytes.Length);
             double advTotal = 0;
@@ -306,6 +306,9 @@ internal static class TextContentParser {
             return joined;
         }
     }
+
+    private static bool IsNullOrEmptyDecodedGlyph(string? value) =>
+        string.IsNullOrEmpty(value) || value.All(static character => character == '\0');
 
     public static List<FormInvocation> ExtractFormInvocations(string content) {
         var invocations = new List<FormInvocation>();

--- a/OfficeIMO.Tests/Excel.AutoFit.cs
+++ b/OfficeIMO.Tests/Excel.AutoFit.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -204,6 +205,73 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AutoFitColumnsFor_BatchApplySplitsSpanningColumnOnce() {
+            string filePath = Path.Combine(_directoryWithFiles, "AutoFit.BatchSplitColumn.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Very long text that should expand the first column significantly");
+                sheet.CellValue(1, 2, "Keep");
+                sheet.CellValue(1, 3, "Very long text that should expand the third column significantly");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                var worksheet = wsPart.Worksheet;
+                var columns = worksheet.GetFirstChild<Columns>() ?? worksheet.InsertAt(new Columns(), 0);
+                columns.RemoveAllChildren();
+                columns.Append(new Column { Min = 1, Max = 3, Width = 10, CustomWidth = true });
+                worksheet.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var sheet = document.Sheets.First();
+                sheet.AutoFitColumnsFor(new[] { 1, 3 });
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                var cols = wsPart.Worksheet.GetFirstChild<Columns>()!.Elements<Column>().ToList();
+                Assert.Equal(new uint[] { 1, 2, 3 }, cols.Select(c => c.Min!.Value).ToArray());
+
+                var column1 = cols.First(c => c.Min != null && c.Max != null && c.Min.Value == 1 && c.Max.Value == 1);
+                var column2 = cols.First(c => c.Min != null && c.Max != null && c.Min.Value == 2 && c.Max.Value == 2);
+                var column3 = cols.First(c => c.Min != null && c.Max != null && c.Min.Value == 3 && c.Max.Value == 3);
+
+                Assert.True(column1.BestFit?.Value ?? false);
+                Assert.True(column3.BestFit?.Value ?? false);
+                Assert.Equal(10.0, column2.Width!.Value);
+                Assert.False(column2.BestFit?.Value ?? false);
+
+                OpenXmlValidator validator = new();
+                Assert.Empty(validator.Validate(spreadsheet));
+            }
+        }
+
+        [Fact]
+        public void Test_AutoFitColumns_DeferredWorksheetSavePersistsOnDispose() {
+            string filePath = Path.Combine(_directoryWithFiles, "AutoFit.DeferredWorksheetSave.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.Execution.SaveWorksheetAfterAutoFit = false;
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Very long text that should still persist after deferred AutoFit save");
+                sheet.AutoFitColumns();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                var column = wsPart.Worksheet.GetFirstChild<Columns>()?.Elements<Column>().FirstOrDefault(c => c.Min?.Value == 1 && c.Max?.Value == 1);
+                Column nonNullColumn = Assert.IsType<Column>(column);
+                Assert.True(nonNullColumn.BestFit?.Value ?? false);
+                Assert.True(nonNullColumn.Width?.Value > 0);
+
+                OpenXmlValidator validator = new();
+                Assert.Empty(validator.Validate(spreadsheet));
+            }
+        }
+
+        [Fact]
         public void Test_AutoFitColumns_ClampsToExcelMaxWidth() {
             string filePath = Path.Combine(_directoryWithFiles, "AutoFit.MaxWidth.xlsx");
             using (var document = ExcelDocument.Create(filePath)) {
@@ -390,6 +458,29 @@ namespace OfficeIMO.Tests {
                 Assert.True(Width(3) > Width(4));
                 Assert.True(Width(5) > Width(6));
             }
+        }
+
+        [Fact]
+        public void Test_AutoFitColumns_ReportsTimingSubStages() {
+            string filePath = Path.Combine(_directoryWithFiles, "AutoFit.Timing.xlsx");
+            var timings = new List<(string Operation, TimeSpan Elapsed)>();
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.Execution.OnTiming = (operation, elapsed) => timings.Add((operation, elapsed));
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Long text for timing instrumentation");
+                sheet.CellValue(2, 1, "Repeated shared string text");
+                sheet.CellValue(3, 1, "Repeated shared string text");
+                sheet.CellValue(1, 2, 1234.5);
+                sheet.AutoFitColumns();
+                document.Save();
+            }
+
+            var operations = timings.Select(t => t.Operation).ToArray();
+            Assert.Contains("AutoFitColumns.BuildPlan", operations);
+            Assert.Contains("AutoFitColumns.CalculateWidths", operations);
+            Assert.Contains("AutoFitColumns.ApplyWidths", operations);
+            Assert.All(timings, timing => Assert.True(timing.Elapsed >= TimeSpan.Zero));
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Excel.AutoFit.cs
+++ b/OfficeIMO.Tests/Excel.AutoFit.cs
@@ -432,6 +432,42 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AutoFit_ToleratesDuplicateCustomNumberFormatIds() {
+            string filePath = Path.Combine(_directoryWithFiles, "AutoFit.DuplicateNumberFormats.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, 1234.5d);
+
+                var workbookPart = document._spreadSheetDocument.WorkbookPart!;
+                var stylesPart = workbookPart.WorkbookStylesPart ?? workbookPart.AddNewPart<WorkbookStylesPart>();
+                stylesPart.Stylesheet ??= new Stylesheet(
+                    new Fonts(new DocumentFormat.OpenXml.Spreadsheet.Font()) { Count = 1 },
+                    new Fills(new Fill()) { Count = 1 },
+                    new Borders(new Border()) { Count = 1 },
+                    new CellFormats(new CellFormat()) { Count = 1 });
+
+                var stylesheet = stylesPart.Stylesheet;
+                stylesheet.NumberingFormats ??= new NumberingFormats();
+                stylesheet.NumberingFormats.Append(new NumberingFormat { NumberFormatId = 164U, FormatCode = "0.0" });
+                stylesheet.NumberingFormats.Append(new NumberingFormat { NumberFormatId = 164U, FormatCode = "0.00" });
+                stylesheet.NumberingFormats.Count = (uint)stylesheet.NumberingFormats.ChildElements.Count;
+
+                stylesheet.CellFormats ??= new CellFormats(new CellFormat()) { Count = 1 };
+                stylesheet.CellFormats.Append(new CellFormat { NumberFormatId = 164U, ApplyNumberFormat = true });
+                stylesheet.CellFormats.Count = (uint)stylesheet.CellFormats.ChildElements.Count;
+
+                var cell = document._spreadSheetDocument.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>().First(c => c.CellReference == "A1");
+                cell.StyleIndex = stylesheet.CellFormats.Count!.Value - 1;
+                stylesPart.Stylesheet.Save();
+
+                var exception = Record.Exception(() => sheet.AutoFitColumns());
+                Assert.Null(exception);
+                document.Save();
+            }
+        }
+
+        [Fact]
         public void Test_AutoFit_UsesFormattedDisplayTextForNumbersAndDates() {
             string filePath = Path.Combine(_directoryWithFiles, "AutoFit.FormattedDisplayText.xlsx");
             var date = new DateTime(2026, 5, 7);

--- a/OfficeIMO.Tests/Excel.CellAndRange.cs
+++ b/OfficeIMO.Tests/Excel.CellAndRange.cs
@@ -83,5 +83,28 @@ namespace OfficeIMO.Tests {
             }
             File.Delete(filePath);
         }
+
+        [Fact]
+        public void A1ParsingPreservesSimpleCellAndRangeSemantics() {
+            Assert.Equal((12, 28), A1.ParseCellRef(" ab12 "));
+            Assert.Equal((0, 0), A1.ParseCellRef("A"));
+            Assert.Equal((0, 0), A1.ParseCellRef("A0"));
+            Assert.Equal((0, 0), A1.ParseCellRef("A1:B2"));
+
+            Assert.True(A1.TryParseRange(" c10 : a2 ", out int r1, out int c1, out int r2, out int c2));
+            Assert.Equal((2, 1, 10, 3), (r1, c1, r2, c2));
+
+            Assert.False(A1.TryParseRange("A1", out _, out _, out _, out _));
+            Assert.Equal(28, A1.ColumnLettersToIndex("a-b1"));
+            Assert.Equal("A", A1.ColumnIndexToLetters(0));
+            Assert.Equal("A", A1.ColumnIndexToLetters(1));
+            Assert.Equal("Z", A1.ColumnIndexToLetters(26));
+            Assert.Equal("AA", A1.ColumnIndexToLetters(27));
+            Assert.Equal("AB", A1.ColumnIndexToLetters(28));
+            Assert.Equal("XFD", A1.ColumnIndexToLetters(16384));
+            Assert.Equal("AB12", A1.CellReference(12, 28));
+            Assert.Throws<ArgumentOutOfRangeException>(() => A1.CellReference(0, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => A1.CellReference(1, 0));
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.CellAndRange.cs
+++ b/OfficeIMO.Tests/Excel.CellAndRange.cs
@@ -90,11 +90,20 @@ namespace OfficeIMO.Tests {
             Assert.Equal((0, 0), A1.ParseCellRef("A"));
             Assert.Equal((0, 0), A1.ParseCellRef("A0"));
             Assert.Equal((0, 0), A1.ParseCellRef("A1:B2"));
+            Assert.Equal((A1.MaxRows, A1.MaxColumns), A1.ParseCellRef("XFD1048576"));
+            Assert.Equal((1, A1.MaxColumns + 1), A1.ParseCellRef("XFE1"));
+            Assert.Equal((A1.MaxRows + 1, A1.MaxColumns), A1.ParseCellRef("XFD1048577"));
+            Assert.Equal((0, 0), A1.ParseCellRef("ZZZZZZZ1"));
+            Assert.Equal((0, 0), A1.ParseCellRef("A2147483648"));
 
             Assert.True(A1.TryParseRange(" c10 : a2 ", out int r1, out int c1, out int r2, out int c2));
             Assert.Equal((2, 1, 10, 3), (r1, c1, r2, c2));
 
             Assert.False(A1.TryParseRange("A1", out _, out _, out _, out _));
+            Assert.True(A1.TryParseRange("A1:XFE1", out r1, out c1, out r2, out c2));
+            Assert.Equal((1, 1, 1, A1.MaxColumns + 1), (r1, c1, r2, c2));
+            Assert.False(A1.TryParseRange("A1:ZZZZZZZ1", out _, out _, out _, out _));
+            Assert.False(A1.TryParseRange("A1:A2147483648", out _, out _, out _, out _));
             Assert.Equal(28, A1.ColumnLettersToIndex("a-b1"));
             Assert.Equal("A", A1.ColumnIndexToLetters(0));
             Assert.Equal("A", A1.ColumnIndexToLetters(1));

--- a/OfficeIMO.Tests/Excel.CellValuesParallel.cs
+++ b/OfficeIMO.Tests/Excel.CellValuesParallel.cs
@@ -235,6 +235,47 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CellValuesParallelAppendedPlainCellsDoNotInheritLastRowStyle() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesParallelPlainCellsNoLastRowStyle.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                var workbookPart = document._spreadSheetDocument.WorkbookPart!;
+                var stylesPart = workbookPart.WorkbookStylesPart ?? workbookPart.AddNewPart<WorkbookStylesPart>();
+                stylesPart.Stylesheet = new Stylesheet(
+                    new Fonts(
+                        new DocumentFormat.OpenXml.Spreadsheet.Font(),
+                        new DocumentFormat.OpenXml.Spreadsheet.Font(new FontName { Val = "OfficeIMO Last Row Test" })) { Count = 2 },
+                    new Fills(new Fill()) { Count = 1 },
+                    new Borders(new Border()) { Count = 1 },
+                    new CellFormats(
+                        new CellFormat(),
+                        new CellFormat { FontId = 1U, ApplyFont = true }) { Count = 2 });
+                stylesPart.Stylesheet.Save();
+
+                var sheetData = sheet.WorksheetPart.Worksheet.GetFirstChild<SheetData>()!;
+                var styledRow = new Row { RowIndex = 1U };
+                styledRow.Append(new Cell { CellReference = "A1", StyleIndex = 1U });
+                sheetData.Append(styledRow);
+
+                sheet.CellValues(new[] {
+                    (2, 1, (object)"Plain"),
+                    (3, 1, (object)"Still Plain")
+                }, ExecutionMode.Parallel);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>().ToDictionary(c => c.CellReference!.Value!);
+
+                Assert.True(cells.ContainsKey("A2"));
+                Assert.True(cells.ContainsKey("A3"));
+                Assert.Null(cells["A2"].StyleIndex);
+                Assert.Null(cells["A3"].StyleIndex);
+            }
+        }
+
+        [Fact]
         public void Test_CellValuesParallelSanitizesControlCharacters() {
             string filePath = Path.Combine(_directoryWithFiles, "CellValuesParallelSanitizedControls.xlsx");
 

--- a/OfficeIMO.Tests/Excel.CellValuesParallel.cs
+++ b/OfficeIMO.Tests/Excel.CellValuesParallel.cs
@@ -124,6 +124,54 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CellValuesParallelAppendedAutoFormatsPreserveDefaultStyle() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesParallelPreserveDefaultStyle.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                var workbookPart = document._spreadSheetDocument.WorkbookPart!;
+                var stylesPart = workbookPart.WorkbookStylesPart ?? workbookPart.AddNewPart<WorkbookStylesPart>();
+                stylesPart.Stylesheet = new Stylesheet(
+                    new Fonts(
+                        new DocumentFormat.OpenXml.Spreadsheet.Font(),
+                        new DocumentFormat.OpenXml.Spreadsheet.Font(new FontName { Val = "OfficeIMO Default Test" })) { Count = 2 },
+                    new Fills(new Fill()) { Count = 1 },
+                    new Borders(new Border()) { Count = 1 },
+                    new CellFormats(new CellFormat { FontId = 1U, ApplyFont = true }) { Count = 1 });
+                stylesPart.Stylesheet.Save();
+
+                sheet.CellValues(new[] {
+                    (1, 1, (object)new DateTime(2026, 5, 12)),
+                    (1, 2, (object)TimeSpan.FromHours(27)),
+                    (1, 3, (object)"Line 1\nLine 2")
+                }, ExecutionMode.Parallel);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var styles = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+                var formats = styles.CellFormats!.Elements<CellFormat>().ToList();
+                var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>().ToDictionary(c => c.CellReference!.Value!);
+
+                var dateFormat = formats[(int)cells["A1"].StyleIndex!.Value];
+                var durationFormat = formats[(int)cells["B1"].StyleIndex!.Value];
+                var wrapFormat = formats[(int)cells["C1"].StyleIndex!.Value];
+
+                Assert.Equal(1U, dateFormat.FontId!.Value);
+                Assert.Equal(14U, dateFormat.NumberFormatId!.Value);
+                Assert.True(dateFormat.ApplyNumberFormat!.Value);
+
+                Assert.Equal(1U, durationFormat.FontId!.Value);
+                Assert.Equal(46U, durationFormat.NumberFormatId!.Value);
+                Assert.True(durationFormat.ApplyNumberFormat!.Value);
+
+                Assert.Equal(1U, wrapFormat.FontId!.Value);
+                Assert.True(wrapFormat.Alignment!.WrapText!.Value);
+                Assert.True(wrapFormat.ApplyAlignment!.Value);
+            }
+        }
+
+        [Fact]
         public void Test_CellValuesParallelSanitizesControlCharacters() {
             string filePath = Path.Combine(_directoryWithFiles, "CellValuesParallelSanitizedControls.xlsx");
 

--- a/OfficeIMO.Tests/Excel.CellValuesParallel.cs
+++ b/OfficeIMO.Tests/Excel.CellValuesParallel.cs
@@ -172,6 +172,69 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CellValuesParallelAppendedAutoFormatsPreserveTemplateColumnStyle() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesParallelPreserveTemplateColumnStyle.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                var workbookPart = document._spreadSheetDocument.WorkbookPart!;
+                var stylesPart = workbookPart.WorkbookStylesPart ?? workbookPart.AddNewPart<WorkbookStylesPart>();
+                stylesPart.Stylesheet = new Stylesheet(
+                    new Fonts(
+                        new DocumentFormat.OpenXml.Spreadsheet.Font(),
+                        new DocumentFormat.OpenXml.Spreadsheet.Font(new FontName { Val = "OfficeIMO Template Test" })) { Count = 2 },
+                    new Fills(new Fill()) { Count = 1 },
+                    new Borders(new Border()) { Count = 1 },
+                    new CellFormats(
+                        new CellFormat(),
+                        new CellFormat {
+                            FontId = 1U,
+                            ApplyFont = true,
+                            Alignment = new Alignment { Horizontal = HorizontalAlignmentValues.Center },
+                            ApplyAlignment = true
+                        }) { Count = 2 });
+                stylesPart.Stylesheet.Save();
+
+                var sheetData = sheet.WorksheetPart.Worksheet.GetFirstChild<SheetData>()!;
+                var templateRow = new Row { RowIndex = 1U };
+                templateRow.Append(
+                    new Cell { CellReference = "A1", StyleIndex = 1U },
+                    new Cell { CellReference = "B1", StyleIndex = 1U },
+                    new Cell { CellReference = "C1", StyleIndex = 1U });
+                sheetData.Append(templateRow);
+
+                sheet.CellValues(new[] {
+                    (2, 1, (object)new DateTime(2026, 5, 12)),
+                    (2, 2, (object)TimeSpan.FromHours(27)),
+                    (2, 3, (object)"Line 1\nLine 2")
+                }, ExecutionMode.Parallel);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var styles = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+                var formats = styles.CellFormats!.Elements<CellFormat>().ToList();
+                var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>().ToDictionary(c => c.CellReference!.Value!);
+
+                var dateFormat = formats[(int)cells["A2"].StyleIndex!.Value];
+                var durationFormat = formats[(int)cells["B2"].StyleIndex!.Value];
+                var wrapFormat = formats[(int)cells["C2"].StyleIndex!.Value];
+
+                Assert.Equal(1U, dateFormat.FontId!.Value);
+                Assert.Equal(14U, dateFormat.NumberFormatId!.Value);
+                Assert.Equal(HorizontalAlignmentValues.Center, dateFormat.Alignment!.Horizontal!.Value);
+
+                Assert.Equal(1U, durationFormat.FontId!.Value);
+                Assert.Equal(46U, durationFormat.NumberFormatId!.Value);
+                Assert.Equal(HorizontalAlignmentValues.Center, durationFormat.Alignment!.Horizontal!.Value);
+
+                Assert.Equal(1U, wrapFormat.FontId!.Value);
+                Assert.Equal(HorizontalAlignmentValues.Center, wrapFormat.Alignment!.Horizontal!.Value);
+                Assert.True(wrapFormat.Alignment!.WrapText!.Value);
+            }
+        }
+
+        [Fact]
         public void Test_CellValuesParallelSanitizesControlCharacters() {
             string filePath = Path.Combine(_directoryWithFiles, "CellValuesParallelSanitizedControls.xlsx");
 

--- a/OfficeIMO.Tests/Excel.Reader.cs
+++ b/OfficeIMO.Tests/Excel.Reader.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
 using Xunit;
 
@@ -49,6 +51,41 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(2, onlyCell.Row);
                 Assert.Equal(2, onlyCell.Column);
                 Assert.Equal("Inside", onlyCell.Value);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_EnumerateRange_DoesNotStopAtOutOfOrderRowsBeyondRange() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderEnumerateRangeOutOfOrderRows.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Header");
+                    sheet.CellValue(2, 1, "InRange");
+                    sheet.CellValue(5, 1, "Outside");
+                    document.Save();
+                }
+
+                using (var spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                    var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                    var sheetData = worksheetPart.Worksheet!.GetFirstChild<SheetData>()!;
+                    var row2 = sheetData.Elements<Row>().First(r => r.RowIndex?.Value == 2U);
+                    row2.Remove();
+                    sheetData.Append(row2);
+                    worksheetPart.Worksheet.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                var cells = reader.GetSheet("Data").EnumerateRange("A1:A2").ToList();
+
+                Assert.Contains(cells, c => c.Row == 1 && c.Column == 1 && Equals(c.Value, "Header"));
+                Assert.Contains(cells, c => c.Row == 2 && c.Column == 1 && Equals(c.Value, "InRange"));
+                Assert.DoesNotContain(cells, c => c.Row == 5);
             } finally {
                 if (File.Exists(filePath)) {
                     File.Delete(filePath);

--- a/OfficeIMO.Tests/Excel.Reader.cs
+++ b/OfficeIMO.Tests/Excel.Reader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
@@ -110,6 +111,54 @@ namespace OfficeIMO.Tests {
                 var cell = reader.GetSheet("data").EnumerateCells().Single(c => c.Row == 3 && c.Column == 1);
 
                 Assert.Equal("SUM(A1:A2)", cell.Value);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRangeSequential_FormulaText_IsReturnedWhenCachedResultsAreDisabled() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderSequentialFormulaText.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, 2);
+                    sheet.CellValue(2, 1, 3);
+                    sheet.CellFormula(3, 1, "=SUM(A1:A2)");
+                    document.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath, new ExcelReadOptions { UseCachedFormulaResult = false });
+                object?[,] values = reader.GetSheet("Data").ReadRange("A3:A3", ExecutionMode.Sequential);
+
+                Assert.Equal("SUM(A1:A2)", values[0, 0]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRangeSequential_HonorsCancellation() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderSequentialCancellation.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Value");
+                    document.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                using var cts = new CancellationTokenSource();
+                cts.Cancel();
+
+                Assert.Throws<OperationCanceledException>(() =>
+                    reader.GetSheet("Data").ReadRange("A1:A1", ExecutionMode.Sequential, cts.Token));
             } finally {
                 if (File.Exists(filePath)) {
                     File.Delete(filePath);

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -4,6 +4,8 @@ using System.Data;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
 using Xunit;
 
@@ -45,6 +47,32 @@ namespace OfficeIMO.Tests {
 
         private sealed class StrictMappedRow {
             public string? Name { get; set; }
+        }
+
+        private static void AssertRangeEqual(object?[,] expected, object?[,] actual) {
+            Assert.Equal(expected.GetLength(0), actual.GetLength(0));
+            Assert.Equal(expected.GetLength(1), actual.GetLength(1));
+
+            for (int r = 0; r < expected.GetLength(0); r++) {
+                for (int c = 0; c < expected.GetLength(1); c++) {
+                    Assert.Equal(expected[r, c], actual[r, c]);
+                }
+            }
+        }
+
+        private static void AssertDataTablesEqual(DataTable expected, DataTable actual) {
+            Assert.Equal(expected.Columns.Count, actual.Columns.Count);
+            Assert.Equal(expected.Rows.Count, actual.Rows.Count);
+
+            for (int c = 0; c < expected.Columns.Count; c++) {
+                Assert.Equal(expected.Columns[c].ColumnName, actual.Columns[c].ColumnName);
+            }
+
+            for (int r = 0; r < expected.Rows.Count; r++) {
+                for (int c = 0; c < expected.Columns.Count; c++) {
+                    Assert.Equal(expected.Rows[r][c], actual.Rows[r][c]);
+                }
+            }
         }
 
         [Fact]
@@ -99,6 +127,285 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("OK", table.Rows[0]["Status"]);
                 Assert.Equal("Warning", table.Rows[0]["Status_2"]);
                 Assert.Equal("Error", table.Rows[0]["status_3"]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRange_ForcedExecutionModesReturnSameValues() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderExecutionModes.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Name");
+                    sheet.CellValue(1, 2, "Amount");
+                    sheet.CellValue(1, 3, "Active");
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellValue(2, 2, 12.5d);
+                    sheet.CellValue(2, 3, true);
+                    sheet.CellValue(3, 1, "Beta");
+                    sheet.CellValue(3, 2, 25d);
+                    sheet.CellValue(3, 3, false);
+                    document.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                var sheetReader = reader.GetSheet("Data");
+
+                object?[,] automatic = sheetReader.ReadRange("A1:C3");
+                object?[,] sequential = sheetReader.ReadRange("A1:C3", ExecutionMode.Sequential);
+                object?[,] parallel = sheetReader.ReadRange("A1:C3", ExecutionMode.Parallel);
+
+                AssertRangeEqual(automatic, sequential);
+                AssertRangeEqual(automatic, parallel);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRangeAsDataTable_ForcedExecutionModesReturnSameValues() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderDataTableExecutionModes.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Name");
+                    sheet.CellValue(1, 2, "Amount");
+                    sheet.CellValue(1, 3, "Active");
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellValue(2, 2, 12.5d);
+                    sheet.CellValue(3, 1, "Beta");
+                    sheet.CellValue(3, 3, true);
+                    document.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                var sheetReader = reader.GetSheet("Data");
+
+                DataTable automatic = sheetReader.ReadRangeAsDataTable("A1:C3");
+                DataTable sequential = sheetReader.ReadRangeAsDataTable("A1:C3", mode: ExecutionMode.Sequential);
+                DataTable parallel = sheetReader.ReadRangeAsDataTable("A1:C3", mode: ExecutionMode.Parallel);
+
+                AssertDataTablesEqual(automatic, sequential);
+                AssertDataTablesEqual(automatic, parallel);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRangeAsDataTable_WithoutHeadersPreservesAllRowsAndBlankCells() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderDataTableNoHeaders.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Alpha");
+                    sheet.CellValue(1, 3, 10);
+                    sheet.CellValue(2, 2, "Beta");
+                    document.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                DataTable table = reader.GetSheet("Data").ReadRangeAsDataTable("A1:C2", headersInFirstRow: false);
+
+                Assert.Equal(new[] { "Column1", "Column2", "Column3" }, table.Columns.Cast<DataColumn>().Select(c => c.ColumnName).ToArray());
+                Assert.Equal(2, table.Rows.Count);
+                Assert.Equal("Alpha", table.Rows[0]["Column1"]);
+                Assert.Equal(DBNull.Value, table.Rows[0]["Column2"]);
+                Assert.Equal(10d, table.Rows[0]["Column3"]);
+                Assert.Equal(DBNull.Value, table.Rows[1]["Column1"]);
+                Assert.Equal("Beta", table.Rows[1]["Column2"]);
+                Assert.Equal(DBNull.Value, table.Rows[1]["Column3"]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRangeAsDataTable_ReportsOwnExecutionDecision() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderDataTableDecision.xlsx");
+            var decisions = new List<(string Operation, int Items, ExecutionMode Mode)>();
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Name");
+                    sheet.CellValue(1, 2, "Value");
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellValue(2, 2, 1);
+                    document.Save();
+                }
+
+                var options = new ExcelReadOptions();
+                options.Execution.OperationThresholds["ReadRangeAsDataTable"] = 1;
+                options.Execution.OnDecision = (operation, items, mode) => decisions.Add((operation, items, mode));
+
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                DataTable table = reader.GetSheet("Data").ReadRangeAsDataTable("A1:B2");
+
+                Assert.Single(table.Rows);
+                var decision = Assert.Single(decisions);
+                Assert.Equal("ReadRangeAsDataTable", decision.Operation);
+                Assert.Equal(4, decision.Items);
+                Assert.Equal(ExecutionMode.Parallel, decision.Mode);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_TypedObjects_ReportsOwnExecutionDecision() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderTypedObjectsDecision.xlsx");
+            var decisions = new List<(string Operation, int Items, ExecutionMode Mode)>();
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Name");
+                    sheet.CellValue(1, 2, "Ignored");
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellValue(2, 2, "Value");
+                    document.Save();
+                }
+
+                var options = new ExcelReadOptions();
+                options.Execution.OperationThresholds["ReadObjectsAs"] = 1;
+                options.Execution.OnDecision = (operation, items, mode) => decisions.Add((operation, items, mode));
+
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                var row = Assert.Single(reader.GetSheet("Data").ReadObjects<StrictMappedRow>("A1:B2"));
+
+                Assert.Equal("Alpha", row.Name);
+                var decision = Assert.Single(decisions);
+                Assert.Equal("ReadObjectsAs", decision.Operation);
+                Assert.Equal(4, decision.Items);
+                Assert.Equal(ExecutionMode.Parallel, decision.Mode);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRange_PreservesRichSharedAndInlineStrings() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderRichStrings.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Shared");
+                    sheet.CellValue(1, 2, "Inline");
+                    sheet.CellValue(2, 1, "placeholder");
+                    sheet.CellValue(2, 2, "placeholder");
+                    document.Save();
+                }
+
+                using (var spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                    var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                    var sheetData = worksheetPart.Worksheet.GetFirstChild<SheetData>()!;
+                    var row = sheetData.Elements<Row>().First(r => r.RowIndex?.Value == 2);
+                    var sharedCell = row.Elements<Cell>().First(c => c.CellReference?.Value == "A2");
+                    var inlineCell = row.Elements<Cell>().First(c => c.CellReference?.Value == "B2");
+
+                    int sharedIndex = int.Parse(sharedCell.CellValue!.Text);
+                    var sharedTable = spreadsheet.WorkbookPart!.SharedStringTablePart!.SharedStringTable!;
+                    sharedTable.ReplaceChild(
+                        new SharedStringItem(
+                            new Run(new Text("Shared ")),
+                            new Run(new Text("Rich"))),
+                        sharedTable.Elements<SharedStringItem>().ElementAt(sharedIndex));
+
+                    inlineCell.CellValue = null;
+                    inlineCell.DataType = CellValues.InlineString;
+                    inlineCell.InlineString = new InlineString(
+                        new Run(new Text("Inline ")),
+                        new Run(new Text("Rich")));
+
+                    sharedTable.Save();
+                    worksheetPart.Worksheet.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                object?[,] values = reader.GetSheet("Data").ReadRange("A2:B2");
+
+                Assert.Equal("Shared Rich", values[0, 0]);
+                Assert.Equal("Inline Rich", values[0, 1]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Sheet_Rows_CanBeEnumeratedAfterReaderScopeDisposes() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderRowsMaterialized.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Name");
+                    sheet.CellValue(1, 2, "Amount");
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellValue(2, 2, 12.5d);
+                    document.Save();
+                }
+
+                IEnumerable<Dictionary<string, object?>> rows;
+                using (var document = ExcelDocument.Load(filePath)) {
+                    rows = document.GetSheet("Data").Rows("A1:B2");
+                }
+
+                var row = Assert.Single(rows);
+                Assert.Equal("Alpha", row["Name"]);
+                Assert.Equal(12.5d, row["Amount"]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Sheet_RowsAs_CanBeEnumeratedAfterReaderScopeDisposes() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderRowsAsMaterialized.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "First Name");
+                    sheet.CellValue(1, 2, "First Name");
+                    sheet.CellValue(1, 3, "Total Amount 2");
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellValue(2, 2, "Beta");
+                    sheet.CellValue(2, 3, 42);
+                    document.Save();
+                }
+
+                IEnumerable<FriendlyHeaderRow> rows;
+                using (var document = ExcelDocument.Load(filePath)) {
+                    rows = document.GetSheet("Data").RowsAs<FriendlyHeaderRow>("A1:C2");
+                }
+
+                var row = Assert.Single(rows);
+                Assert.Equal("Alpha", row.FirstName);
+                Assert.Equal("Beta", row.FirstName_2);
+                Assert.Equal(42, row.TotalAmount2);
             } finally {
                 if (File.Exists(filePath)) {
                     File.Delete(filePath);

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -353,6 +353,69 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Reader_ReadRangeSequential_DoesNotStopAtOutOfOrderRowsBeyondRange() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderOutOfOrderRows.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Header");
+                    sheet.CellValue(2, 1, "InRange");
+                    sheet.CellValue(5, 1, "Outside");
+                    document.Save();
+                }
+
+                using (var spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                    var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                    var sheetData = worksheetPart.Worksheet.GetFirstChild<SheetData>()!;
+                    var row2 = sheetData.Elements<Row>().First(r => r.RowIndex?.Value == 2U);
+                    row2.Remove();
+                    sheetData.Append(row2);
+                    worksheetPart.Worksheet.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                object?[,] values = reader.GetSheet("Data").ReadRange("A1:A2", ExecutionMode.Sequential);
+
+                Assert.Equal("Header", values[0, 0]);
+                Assert.Equal("InRange", values[1, 0]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRange_IgnoresMalformedCellReferenceWithoutRowNumber() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderMalformedCellReference.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "ShouldIgnore");
+                    document.Save();
+                }
+
+                using (var spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                    var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                    var cell = worksheetPart.Worksheet.Descendants<Cell>().First(c => c.CellReference?.Value == "A1");
+                    cell.CellReference = "A";
+                    worksheetPart.Worksheet.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                object?[,] values = reader.GetSheet("Data").ReadRange("A1:A1", ExecutionMode.Sequential);
+
+                Assert.Null(values[0, 0]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
         public void Sheet_Rows_CanBeEnumeratedAfterReaderScopeDisposes() {
             string filePath = Path.Combine(_directoryWithFiles, "ReaderRowsMaterialized.xlsx");
 

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -133,16 +133,24 @@ public class PdfReaderAndFooterRegressionTests {
 
         var spans = TextContentParser.Parse(
             content,
-            static (_, bytes) => bytes switch {
-                [0x00, 0x44] => "A",
-                [0x00, 0x45] => "B",
-                [0x00, 0x46] => "C",
-                [0x00] => "\0",
-                _ => string.Empty
-            },
+            static (_, bytes) => DecodeSyntheticCid(bytes),
             static (_, _) => 500);
 
         Assert.Equal("ABC", string.Concat(spans.Select(static span => span.Text)));
+
+        static string DecodeSyntheticCid(byte[] bytes) {
+            if (bytes.Length == 1 && bytes[0] == 0x00) {
+                return "\0";
+            }
+
+            if (bytes.Length == 2 && bytes[0] == 0x00) {
+                if (bytes[1] == 0x44) return "A";
+                if (bytes[1] == 0x45) return "B";
+                if (bytes[1] == 0x46) return "C";
+            }
+
+            return string.Empty;
+        }
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -128,6 +128,24 @@ public class PdfReaderAndFooterRegressionTests {
     }
 
     [Fact]
+    public void TextContentParser_UsesTwoByteCid_WhenSingleHighByteDecodesToNullGlyph() {
+        const string content = "BT /F1 12 Tf 0 0 Td <004400450046> Tj ET";
+
+        var spans = TextContentParser.Parse(
+            content,
+            static (_, bytes) => bytes switch {
+                [0x00, 0x44] => "A",
+                [0x00, 0x45] => "B",
+                [0x00, 0x46] => "C",
+                [0x00] => "\0",
+                _ => string.Empty
+            },
+            static (_, _) => 500);
+
+        Assert.Equal("ABC", string.Concat(spans.Select(static span => span.Text)));
+    }
+
+    [Fact]
     public void PdfTextExtractor_ExtractAllText_ReadsPagesWithContentStreamArrays() {
         byte[] bytes = BuildPdfWithContentStreamArray();
 

--- a/Website/data/benchmarks.json
+++ b/Website/data/benchmarks.json
@@ -20,44 +20,44 @@
     {
       "name": "Excel: Write report (2,500 rows)",
       "library": "OfficeIMO.Excel",
-      "result": "258.0 ms avg",
-      "notes": "5-sample snapshot dated 2026-04-05. Median 244.9 ms. Insert objects, table, and AutoFit on a single worksheet."
+      "result": "114.9 ms avg",
+      "notes": "5-sample snapshot dated 2026-05-12. Median 114.3 ms. Insert objects, table, and AutoFit on a single worksheet."
     },
     {
       "name": "Excel: Write report (2,500 rows)",
       "library": "ClosedXML",
-      "result": "273.3 ms avg",
-      "notes": "5-sample snapshot dated 2026-04-05. Median 323.4 ms. Insert table and adjust columns on a single worksheet."
+      "result": "271.8 ms avg",
+      "notes": "5-sample snapshot dated 2026-05-12. Median 244.3 ms. Insert table and adjust columns on a single worksheet."
     },
     {
       "name": "Excel: Read objects (2,500 rows)",
       "library": "OfficeIMO.Excel",
-      "result": "118.3 ms avg",
-      "notes": "5-sample snapshot dated 2026-04-05. Median 120.6 ms. Reader path materializing dictionary-style rows."
+      "result": "84.3 ms avg",
+      "notes": "5-sample snapshot dated 2026-05-12. Median 86.1 ms. Reader path materializing dictionary-style rows."
     },
     {
       "name": "Excel: Read DataTable (2,500 rows)",
       "library": "OfficeIMO.Excel",
-      "result": "139.1 ms avg",
-      "notes": "5-sample snapshot dated 2026-04-05. Median 140.2 ms. Reader path materializing a DataTable from the same workbook."
+      "result": "85.7 ms avg",
+      "notes": "5-sample snapshot dated 2026-05-12. Median 82.3 ms. Reader path materializing a DataTable from the same workbook."
     },
     {
       "name": "Excel: Read rows (2,500 rows)",
       "library": "ClosedXML",
-      "result": "99.9 ms avg",
-      "notes": "5-sample snapshot dated 2026-04-05. Median 104.8 ms. Worksheet row iteration over the same workbook payload."
+      "result": "119.3 ms avg",
+      "notes": "5-sample snapshot dated 2026-05-12. Median 126.3 ms. Worksheet row iteration over the same workbook payload."
     },
     {
       "name": "Excel: Load/edit/save (2,500 rows)",
       "library": "OfficeIMO.Excel",
-      "result": "123.6 ms avg",
-      "notes": "5-sample snapshot dated 2026-04-05. Median 123.4 ms. Load workbook, add review column, save to memory."
+      "result": "108.4 ms avg",
+      "notes": "5-sample snapshot dated 2026-05-12. Median 106.0 ms. Load workbook, add review column, save to memory."
     },
     {
       "name": "Excel: Load/edit/save (2,500 rows)",
       "library": "ClosedXML",
-      "result": "149.9 ms avg",
-      "notes": "5-sample snapshot dated 2026-04-05. Median 135.5 ms. Load workbook, add review column, save to memory."
+      "result": "124.7 ms avg",
+      "notes": "5-sample snapshot dated 2026-05-12. Median 117.0 ms. Load workbook, add review column, save to memory."
     },
     {
       "name": "Markdown: Build 500 blocks",


### PR DESCRIPTION
## Summary
- Improves OfficeIMO.Excel write hot paths by reducing repeated reference construction and avoiding unnecessary AutoFit saves in benchmark/report generation flows.
- Improves Excel reader performance with allocation-light A1 parsing, direct range/DataTable/object materialization, richer shared/inline string handling, and cleaner execution-policy diagnostics.
- Adds read/write benchmark commands and persisted benchmark artifacts, including typed object read profiles and updated website benchmark data.
- Fixes OfficeIMO.Pdf text decoding for two-byte CID glyph mappings, which improves downstream PDF text extraction used by reusable consumers such as CivicIntel.

## Why
The Excel layer should be faster and more predictable on realistic report/read workloads while preserving compatibility for existing workbook edge cases, including recoverable content-type normalization.

The PDF reader fix keeps OfficeIMO.Reader more useful as a generic document extraction provider for public/civic documents where Polish public-sector PDFs can rely on CID font mappings.

## Validation
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~Reader_TypedObjects|FullyQualifiedName~Sheet_RowsAs|FullyQualifiedName~Reader_ReadObjects"`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~Reader_BlankGeneratedHeaders|FullyQualifiedName~Reader_ShiftedRange|FullyQualifiedName~Reader_NormalizeHeadersFalse|FullyQualifiedName~Reader_ReadObjects|FullyQualifiedName~Sheet_Rows|FullyQualifiedName~Compatibility_Corpus"`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~Test_ReaderOpen|FullyQualifiedName~Compatibility_Corpus_RecoverableContentTypes|FullyQualifiedName~Reader_ReadRangeAsDataTable|FullyQualifiedName~PowerShellRoundTrip"`
- PDF CID regression coverage updated for `net472` compatibility.
- `dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release`
- `dotnet build .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -c Release --framework net8.0`
- `git diff --check`

## Benchmark Notes
Latest 2,500-row read profile repeat showed:
- `ReadObjectsAs` automatic median: `52.0 ms`
- `ReadObjectsAs.Sequential`: `44.9 ms`
- `ReadObjectsAs.Parallel`: `46.7 ms`
- `ReadObjects.Parallel`: `62.1 ms`
- `ReadRangeAsDataTable`: `49.9 ms`
- ClosedXML row iteration: `84.0 ms`