### PR TITLE
Add DataTable append support for Excel tables

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.DataTable.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.cs
@@ -196,8 +196,7 @@ namespace OfficeIMO.Excel {
             }
 
             bool hasHeaderRow = (table.HeaderRowCount?.Value ?? 1U) > 0U;
-            bool hasSyntheticHeaders = HasSyntheticTableColumnNames(tableColumnNames);
-            DataTable appendTable = BuildAppendDataTable(dataTable, tableColumnNames, matchColumnsByHeader && hasHeaderRow && !hasSyntheticHeaders);
+            DataTable appendTable = BuildAppendDataTable(dataTable, tableColumnNames, matchColumnsByHeader && hasHeaderRow);
             if (appendTable.Rows.Count == 0) {
                 return currentRange!;
             }
@@ -293,20 +292,6 @@ namespace OfficeIMO.Excel {
             }
 
             return ordered;
-        }
-
-        private static bool HasSyntheticTableColumnNames(IReadOnlyList<string> tableColumnNames) {
-            if (tableColumnNames.Count == 0) {
-                return false;
-            }
-
-            for (int i = 0; i < tableColumnNames.Count; i++) {
-                if (!string.Equals(tableColumnNames[i], $"Column{i + 1}", StringComparison.OrdinalIgnoreCase)) {
-                    return false;
-                }
-            }
-
-            return true;
         }
 
         private static bool HasActiveTotalsRow(Table table) {

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.cs
@@ -196,7 +196,8 @@ namespace OfficeIMO.Excel {
             }
 
             bool hasHeaderRow = (table.HeaderRowCount?.Value ?? 1U) > 0U;
-            DataTable appendTable = BuildAppendDataTable(dataTable, tableColumnNames, matchColumnsByHeader && hasHeaderRow);
+            bool useHeaderMapping = matchColumnsByHeader && ShouldMapAppendColumnsByHeader(dataTable, tableColumnNames, hasHeaderRow);
+            DataTable appendTable = BuildAppendDataTable(dataTable, tableColumnNames, useHeaderMapping);
             if (appendTable.Rows.Count == 0) {
                 return currentRange!;
             }
@@ -292,6 +293,43 @@ namespace OfficeIMO.Excel {
             }
 
             return ordered;
+        }
+
+        private static bool ShouldMapAppendColumnsByHeader(DataTable source, IReadOnlyList<string> tableColumnNames, bool hasHeaderRow) {
+            if (hasHeaderRow) {
+                return true;
+            }
+
+            if (SourceContainsTableColumns(source, tableColumnNames)) {
+                return true;
+            }
+
+            return !HasDefaultHeaderlessColumnNames(tableColumnNames);
+        }
+
+        private static bool SourceContainsTableColumns(DataTable source, IReadOnlyList<string> tableColumnNames) {
+            var sourceColumnNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (DataColumn column in source.Columns) {
+                sourceColumnNames.Add(column.ColumnName);
+            }
+
+            foreach (string tableColumnName in tableColumnNames) {
+                if (!sourceColumnNames.Contains(tableColumnName)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool HasDefaultHeaderlessColumnNames(IReadOnlyList<string> tableColumnNames) {
+            for (int i = 0; i < tableColumnNames.Count; i++) {
+                if (!string.Equals(tableColumnNames[i], "Column" + (i + 1), StringComparison.OrdinalIgnoreCase)) {
+                    return false;
+                }
+            }
+
+            return tableColumnNames.Count > 0;
         }
 
         private static bool HasActiveTotalsRow(Table table) {

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.cs
@@ -183,7 +183,7 @@ namespace OfficeIMO.Excel {
                 throw new InvalidOperationException($"Table '{tableName}' does not have a valid range.");
             }
 
-            if (table.TotalsRowShown?.Value == true) {
+            if (HasActiveTotalsRow(table)) {
                 throw new InvalidOperationException($"Table '{tableName}' has a totals row. Appending before totals rows is not supported yet.");
             }
 
@@ -307,6 +307,11 @@ namespace OfficeIMO.Excel {
             }
 
             return true;
+        }
+
+        private static bool HasActiveTotalsRow(Table table) {
+            uint? totalsRowCount = table.TotalsRowCount?.Value;
+            return totalsRowCount.HasValue && totalsRowCount.Value > 0U;
         }
 
         private void EnsureAppendTargetIsEmpty(int startRow, int endRow, int startColumn, int endColumn, string tableName) {

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.cs
@@ -195,7 +195,8 @@ namespace OfficeIMO.Excel {
                 throw new InvalidOperationException($"Table '{tableName}' column metadata does not match its range.");
             }
 
-            DataTable appendTable = BuildAppendDataTable(dataTable, tableColumnNames, matchColumnsByHeader);
+            bool hasHeaderRow = (table.HeaderRowCount?.Value ?? 1U) > 0U;
+            DataTable appendTable = BuildAppendDataTable(dataTable, tableColumnNames, matchColumnsByHeader && hasHeaderRow);
             if (appendTable.Rows.Count == 0) {
                 return currentRange!;
             }
@@ -298,19 +299,39 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
-            foreach (Cell cell in WorksheetRoot.Descendants<Cell>()) {
-                string? reference = cell.CellReference?.Value;
-                if (string.IsNullOrEmpty(reference)) {
+            var sheetData = WorksheetRoot.GetFirstChild<SheetData>();
+            if (sheetData == null) {
+                return;
+            }
+
+            foreach (Row rowElement in sheetData.Elements<Row>()) {
+                if (rowElement.RowIndex == null) {
                     continue;
                 }
 
-                var (row, column) = A1.ParseCellRef(reference!);
-                if (row < startRow || row > endRow || column < startColumn || column > endColumn) {
+                int rowIndex = (int)rowElement.RowIndex.Value;
+                if (rowIndex < startRow) {
                     continue;
                 }
 
-                if (CellHasContent(cell)) {
-                    throw new InvalidOperationException($"Cannot append to table '{tableName}' because cell {reference} already contains data.");
+                if (rowIndex > endRow) {
+                    break;
+                }
+
+                foreach (Cell cell in rowElement.Elements<Cell>()) {
+                    string? reference = cell.CellReference?.Value;
+                    if (string.IsNullOrEmpty(reference)) {
+                        continue;
+                    }
+
+                    int columnIndex = A1.ParseColumnIndexFromCellReference(reference!);
+                    if (columnIndex < startColumn || columnIndex > endColumn) {
+                        continue;
+                    }
+
+                    if (CellHasContent(cell)) {
+                        throw new InvalidOperationException($"Cannot append to table '{tableName}' because cell {reference} already contains data.");
+                    }
                 }
             }
         }

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.cs
@@ -296,7 +296,11 @@ namespace OfficeIMO.Excel {
 
         private static bool HasActiveTotalsRow(Table table) {
             uint? totalsRowCount = table.TotalsRowCount?.Value;
-            return totalsRowCount.HasValue && totalsRowCount.Value > 0U;
+            if (totalsRowCount.HasValue) {
+                return totalsRowCount.Value > 0U;
+            }
+
+            return table.TotalsRowShown?.Value == true;
         }
 
         private void EnsureAppendTargetIsEmpty(int startRow, int endRow, int startColumn, int endColumn, string tableName) {

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System.Data;
 using System.Globalization;
@@ -147,6 +148,187 @@ namespace OfficeIMO.Excel {
             // Create the Table with optional AutoFilter and style
             AddTable(range, includeHeaders, tableName ?? string.Empty, style, includeAutoFilter);
             return range;
+        }
+
+        /// <summary>
+        /// Appends rows from a <see cref="DataTable"/> to an existing Excel table and expands the table range.
+        /// </summary>
+        /// <param name="dataTable">Source DataTable containing rows to append.</param>
+        /// <param name="tableName">Existing table name or display name.</param>
+        /// <param name="matchColumnsByHeader">When true, DataTable columns are matched to table columns by header text. When false, columns are appended by position.</param>
+        /// <param name="mode">Optional execution mode override.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>The updated A1 range of the table.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="dataTable"/> or <paramref name="tableName"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the source columns cannot be mapped to the existing table.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the table cannot be found or cannot be safely expanded.</exception>
+        public string AppendDataTableToTable(
+            DataTable dataTable,
+            string tableName,
+            bool matchColumnsByHeader = true,
+            ExecutionMode? mode = null,
+            CancellationToken ct = default) {
+            if (dataTable == null) throw new ArgumentNullException(nameof(dataTable));
+            if (tableName == null) throw new ArgumentNullException(nameof(tableName));
+            if (string.IsNullOrWhiteSpace(tableName)) throw new ArgumentException("Table name cannot be empty.", nameof(tableName));
+
+            var tableDefinitionPart = FindTableDefinitionPart(tableName);
+            var table = tableDefinitionPart?.Table;
+            if (table == null) {
+                throw new InvalidOperationException($"Table '{tableName}' was not found on worksheet '{Name}'.");
+            }
+
+            string? currentRange = table.Reference?.Value;
+            if (string.IsNullOrWhiteSpace(currentRange) || !A1.TryParseRange(currentRange!, out int startRow, out int startColumn, out int endRow, out int endColumn)) {
+                throw new InvalidOperationException($"Table '{tableName}' does not have a valid range.");
+            }
+
+            if (table.TotalsRowShown?.Value == true) {
+                throw new InvalidOperationException($"Table '{tableName}' has a totals row. Appending before totals rows is not supported yet.");
+            }
+
+            var tableColumnNames = table.TableColumns?.Elements<TableColumn>()
+                .Select(column => column.Name?.Value ?? string.Empty)
+                .ToList() ?? new List<string>();
+            int tableColumnCount = endColumn - startColumn + 1;
+            if (tableColumnNames.Count != tableColumnCount) {
+                throw new InvalidOperationException($"Table '{tableName}' column metadata does not match its range.");
+            }
+
+            DataTable appendTable = BuildAppendDataTable(dataTable, tableColumnNames, matchColumnsByHeader);
+            if (appendTable.Rows.Count == 0) {
+                return currentRange!;
+            }
+
+            int appendStartRow = endRow + 1;
+            int appendEndRow = endRow + appendTable.Rows.Count;
+            if (appendEndRow > A1.MaxRows) {
+                throw new InvalidOperationException($"Appending {appendTable.Rows.Count} rows would exceed the Excel row limit.");
+            }
+
+            EnsureAppendTargetIsEmpty(appendStartRow, appendEndRow, startColumn, endColumn, tableName);
+
+            InsertDataTable(appendTable, appendStartRow, startColumn, includeHeaders: false, mode, ct);
+
+            string updatedRange = A1.CellReference(startRow, startColumn) + ":" + A1.CellReference(appendEndRow, endColumn);
+            WriteLock(() => {
+                table.Reference = updatedRange;
+                var autoFilter = table.GetFirstChild<AutoFilter>();
+                if (autoFilter != null) {
+                    autoFilter.Reference = updatedRange;
+                }
+
+                table.Save();
+                WorksheetRoot.Save();
+            });
+
+            return updatedRange;
+        }
+
+        private TableDefinitionPart? FindTableDefinitionPart(string tableName) {
+            return _worksheetPart.TableDefinitionParts
+                .FirstOrDefault(part => {
+                    var table = part.Table;
+                    if (table == null) {
+                        return false;
+                    }
+
+                    string? name = table.Name?.Value;
+                    string? displayName = table.DisplayName?.Value;
+                    return string.Equals(name, tableName, StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(displayName, tableName, StringComparison.OrdinalIgnoreCase);
+                });
+        }
+
+        private static DataTable BuildAppendDataTable(DataTable source, IReadOnlyList<string> tableColumnNames, bool matchColumnsByHeader) {
+            if (source.Columns.Count != tableColumnNames.Count) {
+                throw new ArgumentException($"Source table has {source.Columns.Count} columns, but the Excel table has {tableColumnNames.Count} columns.", nameof(source));
+            }
+
+            if (!matchColumnsByHeader) {
+                return source;
+            }
+
+            var sourceColumns = new Dictionary<string, DataColumn>(StringComparer.OrdinalIgnoreCase);
+            foreach (DataColumn column in source.Columns) {
+                if (sourceColumns.ContainsKey(column.ColumnName)) {
+                    throw new ArgumentException($"Source table contains duplicate column '{column.ColumnName}'.", nameof(source));
+                }
+
+                sourceColumns.Add(column.ColumnName, column);
+            }
+
+            var orderedColumns = new DataColumn[tableColumnNames.Count];
+            var matchedSourceNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < tableColumnNames.Count; i++) {
+                string tableColumnName = tableColumnNames[i];
+                if (!sourceColumns.TryGetValue(tableColumnName, out DataColumn? sourceColumn)) {
+                    throw new ArgumentException($"Source table is missing column '{tableColumnName}'.", nameof(source));
+                }
+
+                orderedColumns[i] = sourceColumn;
+                matchedSourceNames.Add(sourceColumn.ColumnName);
+            }
+
+            foreach (DataColumn column in source.Columns) {
+                if (!matchedSourceNames.Contains(column.ColumnName)) {
+                    throw new ArgumentException($"Source table column '{column.ColumnName}' does not exist in the Excel table.", nameof(source));
+                }
+            }
+
+            var ordered = new DataTable(source.TableName);
+            foreach (DataColumn sourceColumn in orderedColumns) {
+                ordered.Columns.Add(sourceColumn.ColumnName, sourceColumn.DataType);
+            }
+
+            foreach (DataRow sourceRow in source.Rows) {
+                DataRow row = ordered.NewRow();
+                for (int i = 0; i < orderedColumns.Length; i++) {
+                    row[i] = sourceRow[orderedColumns[i]];
+                }
+
+                ordered.Rows.Add(row);
+            }
+
+            return ordered;
+        }
+
+        private void EnsureAppendTargetIsEmpty(int startRow, int endRow, int startColumn, int endColumn, string tableName) {
+            if (startRow > endRow) {
+                return;
+            }
+
+            foreach (Cell cell in WorksheetRoot.Descendants<Cell>()) {
+                string? reference = cell.CellReference?.Value;
+                if (string.IsNullOrEmpty(reference)) {
+                    continue;
+                }
+
+                var (row, column) = A1.ParseCellRef(reference!);
+                if (row < startRow || row > endRow || column < startColumn || column > endColumn) {
+                    continue;
+                }
+
+                if (CellHasContent(cell)) {
+                    throw new InvalidOperationException($"Cannot append to table '{tableName}' because cell {reference} already contains data.");
+                }
+            }
+        }
+
+        private static bool CellHasContent(Cell cell) {
+            if (cell.CellFormula != null) {
+                return true;
+            }
+
+            if (cell.CellValue != null && !string.IsNullOrEmpty(cell.CellValue.Text)) {
+                return true;
+            }
+
+            if (cell.InlineString != null) {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.cs
@@ -196,7 +196,8 @@ namespace OfficeIMO.Excel {
             }
 
             bool hasHeaderRow = (table.HeaderRowCount?.Value ?? 1U) > 0U;
-            DataTable appendTable = BuildAppendDataTable(dataTable, tableColumnNames, matchColumnsByHeader && hasHeaderRow);
+            bool hasSyntheticHeaders = HasSyntheticTableColumnNames(tableColumnNames);
+            DataTable appendTable = BuildAppendDataTable(dataTable, tableColumnNames, matchColumnsByHeader && hasHeaderRow && !hasSyntheticHeaders);
             if (appendTable.Rows.Count == 0) {
                 return currentRange!;
             }
@@ -292,6 +293,20 @@ namespace OfficeIMO.Excel {
             }
 
             return ordered;
+        }
+
+        private static bool HasSyntheticTableColumnNames(IReadOnlyList<string> tableColumnNames) {
+            if (tableColumnNames.Count == 0) {
+                return false;
+            }
+
+            for (int i = 0; i < tableColumnNames.Count; i++) {
+                if (!string.Equals(tableColumnNames[i], $"Column{i + 1}", StringComparison.OrdinalIgnoreCase)) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private void EnsureAppendTargetIsEmpty(int startRow, int endRow, int startColumn, int endColumn, string tableName) {

--- a/OfficeIMO.Excel/README.md
+++ b/OfficeIMO.Excel/README.md
@@ -58,6 +58,22 @@ stream.Position = 0;
 File.WriteAllBytes("out.xlsx", stream.ToArray());
 ```
 
+Append to an existing table
+
+```csharp
+using var doc = ExcelDocument.Load(path);
+var sheet = doc["Sales"];
+
+var rows = new DataTable();
+rows.Columns.Add("Revenue", typeof(decimal));
+rows.Columns.Add("Region", typeof(string));
+rows.Rows.Add(150m, "APAC");
+
+// Columns are matched by table header by default, so source order can differ.
+sheet.AppendDataTableToTable(rows, "SalesTable");
+doc.Save();
+```
+
 What to expect
 
 - Noticeable wins on:

--- a/OfficeIMO.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Tests/Excel.DataTableInsert.cs
@@ -277,23 +277,23 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void Test_AppendDataTableToTable_SyntheticHeadersUsePositionalMapping() {
-            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableSyntheticHeaders.xlsx");
+        public void Test_AppendDataTableToTable_ColumnLikeHeadersUseHeaderMapping() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableColumnLikeHeaders.xlsx");
 
             using (var document = ExcelDocument.Create(filePath)) {
                 var sheet = document.AddWorkSheet("Sales");
                 sheet.CellValue(1, 1, "Column1");
                 sheet.CellValue(1, 2, "Column2");
-                sheet.CellValue(2, 1, "NA");
-                sheet.CellValue(2, 2, 100);
-                sheet.AddTable("A1:B2", true, "SyntheticSales", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                sheet.CellValue(2, 1, "first");
+                sheet.CellValue(2, 2, "second");
+                sheet.AddTable("A1:B2", true, "ColumnNamedSales", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
 
                 var append = new DataTable();
-                append.Columns.Add("Region", typeof(string));
-                append.Columns.Add("Revenue", typeof(int));
-                append.Rows.Add("APAC", 150);
+                append.Columns.Add("Column2", typeof(string));
+                append.Columns.Add("Column1", typeof(string));
+                append.Rows.Add("fourth", "third");
 
-                Assert.Equal("A1:B3", sheet.AppendDataTableToTable(append, "SyntheticSales"));
+                Assert.Equal("A1:B3", sheet.AppendDataTableToTable(append, "ColumnNamedSales"));
                 document.Save();
             }
 
@@ -301,8 +301,8 @@ namespace OfficeIMO.Tests {
                 WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 TableDefinitionPart tablePart = worksheetPart.TableDefinitionParts.First();
                 Assert.Equal("A1:B3", tablePart.Table.Reference!.Value);
-                Assert.Equal("APAC", GetCellText(spreadsheet, worksheetPart, "A3"));
-                Assert.Equal("150", GetCellText(spreadsheet, worksheetPart, "B3"));
+                Assert.Equal("third", GetCellText(spreadsheet, worksheetPart, "A3"));
+                Assert.Equal("fourth", GetCellText(spreadsheet, worksheetPart, "B3"));
             }
 
             File.Delete(filePath);

--- a/OfficeIMO.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Tests/Excel.DataTableInsert.cs
@@ -209,6 +209,31 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AppendDataTableToTable_ThrowsWhenColumnCountDoesNotMatch() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableColumnCountMismatch.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+                sheet.InsertDataTableAsTable(table, tableName: "SalesTable");
+
+                var append = new DataTable();
+                append.Columns.Add("Region", typeof(string));
+                append.Rows.Add("APAC");
+
+                var exception = Assert.Throws<ArgumentException>(() => sheet.AppendDataTableToTable(append, "SalesTable"));
+                Assert.Contains("1 columns", exception.Message);
+                Assert.Contains("2 columns", exception.Message);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_AppendDataTableToTable_HeaderlessTableUsesPositionalMapping() {
             string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableHeaderless.xlsx");
 
@@ -252,6 +277,38 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AppendDataTableToTable_SyntheticHeadersUsePositionalMapping() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableSyntheticHeaders.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sales");
+                sheet.CellValue(1, 1, "Column1");
+                sheet.CellValue(1, 2, "Column2");
+                sheet.CellValue(2, 1, "NA");
+                sheet.CellValue(2, 2, 100);
+                sheet.AddTable("A1:B2", true, "SyntheticSales", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+
+                var append = new DataTable();
+                append.Columns.Add("Region", typeof(string));
+                append.Columns.Add("Revenue", typeof(int));
+                append.Rows.Add("APAC", 150);
+
+                Assert.Equal("A1:B3", sheet.AppendDataTableToTable(append, "SyntheticSales"));
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                TableDefinitionPart tablePart = worksheetPart.TableDefinitionParts.First();
+                Assert.Equal("A1:B3", tablePart.Table.Reference!.Value);
+                Assert.Equal("APAC", GetCellText(spreadsheet, worksheetPart, "A3"));
+                Assert.Equal("150", GetCellText(spreadsheet, worksheetPart, "B3"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_AppendDataTableToTable_EmptyTableKeepsExistingRange() {
             string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableEmpty.xlsx");
 
@@ -277,6 +334,33 @@ namespace OfficeIMO.Tests {
                 WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 TableDefinitionPart tablePart = worksheetPart.TableDefinitionParts.First();
                 Assert.Equal("A1:B2", tablePart.Table.Reference!.Value);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Test_AppendDataTableToTable_ThrowsWhenFormulaExistsBelowTable() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableFormulaBelow.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+                sheet.InsertDataTableAsTable(table, tableName: "SalesTable");
+
+                sheet.CellFormula(3, 2, "SUM(B2:B2)");
+
+                var append = new DataTable();
+                append.Columns.Add("Region", typeof(string));
+                append.Columns.Add("Revenue", typeof(int));
+                append.Rows.Add("APAC", 150);
+
+                var exception = Assert.Throws<InvalidOperationException>(() => sheet.AppendDataTableToTable(append, "SalesTable"));
+                Assert.Contains("B3", exception.Message);
             }
 
             File.Delete(filePath);

--- a/OfficeIMO.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Tests/Excel.DataTableInsert.cs
@@ -277,6 +277,49 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AppendDataTableToTable_HiddenHeadersUseMatchingColumnNames() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableHiddenHeaders.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+                sheet.InsertDataTableAsTable(table, tableName: "HiddenHeaderSales");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                Table table = spreadsheet.WorkbookPart!.WorksheetParts.First().TableDefinitionParts.First().Table;
+                table.HeaderRowCount = 0U;
+                table.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var append = new DataTable();
+                append.Columns.Add("Revenue", typeof(int));
+                append.Columns.Add("Region", typeof(string));
+                append.Rows.Add(150, "APAC");
+
+                Assert.Equal("A1:B3", document.Sheets[0].AppendDataTableToTable(append, "HiddenHeaderSales"));
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                TableDefinitionPart tablePart = worksheetPart.TableDefinitionParts.First();
+                Assert.Equal((uint)0, tablePart.Table.HeaderRowCount!.Value);
+                Assert.Equal("A1:B3", tablePart.Table.Reference!.Value);
+                Assert.Equal("APAC", GetCellText(spreadsheet, worksheetPart, "A3"));
+                Assert.Equal("150", GetCellText(spreadsheet, worksheetPart, "B3"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_AppendDataTableToTable_ColumnLikeHeadersUseHeaderMapping() {
             string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableColumnLikeHeaders.xlsx");
 

--- a/OfficeIMO.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Tests/Excel.DataTableInsert.cs
@@ -445,6 +445,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AppendDataTableToTable_ThrowsWhenTotalsRowShownWithoutCount() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableTotalsShownNoCount.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+                sheet.InsertDataTableAsTable(table, tableName: "SalesTable");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                Table table = spreadsheet.WorkbookPart!.WorksheetParts.First().TableDefinitionParts.First().Table;
+                table.TotalsRowShown = true;
+                table.TotalsRowCount = null;
+                table.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var append = new DataTable();
+                append.Columns.Add("Region", typeof(string));
+                append.Columns.Add("Revenue", typeof(int));
+                append.Rows.Add("APAC", 150);
+
+                var exception = Assert.Throws<InvalidOperationException>(() => document.Sheets[0].AppendDataTableToTable(append, "SalesTable"));
+                Assert.Contains("totals row", exception.Message);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_AppendDataTableToTable_ThrowsWhenCellsBelowTableContainData() {
             string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableOccupiedCells.xlsx");
 

--- a/OfficeIMO.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Tests/Excel.DataTableInsert.cs
@@ -136,5 +136,103 @@ namespace OfficeIMO.Tests {
 
             File.Delete(filePath);
         }
+
+        [Fact]
+        public void Test_AppendDataTableToTable_ExtendsTableAndMapsColumnsByHeader() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTable.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+                table.Rows.Add("EMEA", 120);
+
+                Assert.Equal("A1:B3", sheet.InsertDataTableAsTable(table, tableName: "SalesTable"));
+
+                var append = new DataTable();
+                append.Columns.Add("Revenue", typeof(int));
+                append.Columns.Add("Region", typeof(string));
+                append.Rows.Add(150, "APAC");
+                append.Rows.Add(175, "LATAM");
+
+                Assert.Equal("A1:B5", sheet.AppendDataTableToTable(append, "SalesTable"));
+                Assert.Equal("A1:B5", sheet.GetTableRange("SalesTable"));
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                TableDefinitionPart tablePart = worksheetPart.TableDefinitionParts.First();
+                Assert.Equal("A1:B5", tablePart.Table.Reference!.Value);
+                Assert.Equal("A1:B5", tablePart.Table.GetFirstChild<AutoFilter>()!.Reference!.Value);
+
+                Assert.Equal("APAC", GetCellText(spreadsheet, worksheetPart, "A4"));
+                Assert.Equal("150", GetCellText(spreadsheet, worksheetPart, "B4"));
+                Assert.Equal("LATAM", GetCellText(spreadsheet, worksheetPart, "A5"));
+                Assert.Equal("175", GetCellText(spreadsheet, worksheetPart, "B5"));
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+                Assert.Equal("A1:B5", document.Sheets[0].GetTableRange("SalesTable"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Test_AppendDataTableToTable_ThrowsWhenColumnIsMissing() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableMissingColumn.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+                sheet.InsertDataTableAsTable(table, tableName: "SalesTable");
+
+                var append = new DataTable();
+                append.Columns.Add("Region", typeof(string));
+                append.Columns.Add("Amount", typeof(int));
+                append.Rows.Add("APAC", 150);
+
+                var exception = Assert.Throws<ArgumentException>(() => sheet.AppendDataTableToTable(append, "SalesTable"));
+                Assert.Contains("Revenue", exception.Message);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Test_AppendDataTableToTable_ThrowsWhenCellsBelowTableContainData() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableOccupiedCells.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+                sheet.InsertDataTableAsTable(table, tableName: "SalesTable");
+
+                sheet.CellValue(3, 1, "Existing");
+
+                var append = new DataTable();
+                append.Columns.Add("Region", typeof(string));
+                append.Columns.Add("Revenue", typeof(int));
+                append.Rows.Add("APAC", 150);
+
+                var exception = Assert.Throws<InvalidOperationException>(() => sheet.AppendDataTableToTable(append, "SalesTable"));
+                Assert.Contains("A3", exception.Message);
+            }
+
+            File.Delete(filePath);
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Tests/Excel.DataTableInsert.cs
@@ -209,6 +209,80 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AppendDataTableToTable_HeaderlessTableUsesPositionalMapping() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableHeaderless.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+
+                Assert.Equal("A1:B1", sheet.InsertDataTableAsTable(table, includeHeaders: false, tableName: "HeaderlessSales"));
+
+                var append = new DataTable();
+                append.Columns.Add("Region", typeof(string));
+                append.Columns.Add("Revenue", typeof(int));
+                append.Rows.Add("APAC", 150);
+                append.Rows.Add("EMEA", 200);
+
+                Assert.Equal("A1:B3", sheet.AppendDataTableToTable(append, "HeaderlessSales"));
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                TableDefinitionPart tablePart = worksheetPart.TableDefinitionParts.First();
+                Assert.Equal((uint)0, tablePart.Table.HeaderRowCount!.Value);
+                Assert.Equal("A1:B3", tablePart.Table.Reference!.Value);
+
+                Assert.Equal("APAC", GetCellText(spreadsheet, worksheetPart, "A2"));
+                Assert.Equal("150", GetCellText(spreadsheet, worksheetPart, "B2"));
+                Assert.Equal("EMEA", GetCellText(spreadsheet, worksheetPart, "A3"));
+                Assert.Equal("200", GetCellText(spreadsheet, worksheetPart, "B3"));
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Test_AppendDataTableToTable_EmptyTableKeepsExistingRange() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableEmpty.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+
+                sheet.InsertDataTableAsTable(table, tableName: "SalesTable");
+
+                var append = new DataTable();
+                append.Columns.Add("Revenue", typeof(int));
+                append.Columns.Add("Region", typeof(string));
+
+                Assert.Equal("A1:B2", sheet.AppendDataTableToTable(append, "SalesTable"));
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                TableDefinitionPart tablePart = worksheetPart.TableDefinitionParts.First();
+                Assert.Equal("A1:B2", tablePart.Table.Reference!.Value);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_AppendDataTableToTable_ThrowsWhenCellsBelowTableContainData() {
             string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableOccupiedCells.xlsx");
 

--- a/OfficeIMO.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Tests/Excel.DataTableInsert.cs
@@ -367,6 +367,84 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AppendDataTableToTable_AllowsHistoricalTotalsRowShownFlag() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableHistoricalTotals.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+                sheet.InsertDataTableAsTable(table, tableName: "SalesTable");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                Table table = spreadsheet.WorkbookPart!.WorksheetParts.First().TableDefinitionParts.First().Table;
+                table.TotalsRowShown = true;
+                table.TotalsRowCount = 0U;
+                table.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var append = new DataTable();
+                append.Columns.Add("Region", typeof(string));
+                append.Columns.Add("Revenue", typeof(int));
+                append.Rows.Add("APAC", 150);
+
+                Assert.Equal("A1:B3", document.Sheets[0].AppendDataTableToTable(append, "SalesTable"));
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                TableDefinitionPart tablePart = worksheetPart.TableDefinitionParts.First();
+                Assert.Equal("A1:B3", tablePart.Table.Reference!.Value);
+                Assert.Equal("APAC", GetCellText(spreadsheet, worksheetPart, "A3"));
+                Assert.Equal("150", GetCellText(spreadsheet, worksheetPart, "B3"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Test_AppendDataTableToTable_ThrowsWhenTotalsRowIsActive() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableActiveTotals.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sales");
+
+                var table = new DataTable();
+                table.Columns.Add("Region", typeof(string));
+                table.Columns.Add("Revenue", typeof(int));
+                table.Rows.Add("NA", 100);
+                sheet.InsertDataTableAsTable(table, tableName: "SalesTable");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                Table table = spreadsheet.WorkbookPart!.WorksheetParts.First().TableDefinitionParts.First().Table;
+                table.TotalsRowShown = true;
+                table.TotalsRowCount = 1U;
+                table.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var append = new DataTable();
+                append.Columns.Add("Region", typeof(string));
+                append.Columns.Add("Revenue", typeof(int));
+                append.Rows.Add("APAC", 150);
+
+                var exception = Assert.Throws<InvalidOperationException>(() => document.Sheets[0].AppendDataTableToTable(append, "SalesTable"));
+                Assert.Contains("totals row", exception.Message);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_AppendDataTableToTable_ThrowsWhenCellsBelowTableContainData() {
             string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTableOccupiedCells.xlsx");
 


### PR DESCRIPTION
## Summary
- add ExcelSheet.AppendDataTableToTable for expanding existing Excel tables from DataTable rows
- map appended data by table headers and update table/autofilter ranges
- guard against missing columns, totals rows, row-limit overflow, and occupied cells below the table
- document the new append workflow in the Excel README

## Validation
- dotnet build OfficeIMO.Excel\OfficeIMO.Excel.csproj --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --no-build --filter "FullyQualifiedName~Test_AppendDataTableToTable|FullyQualifiedName~Test_InsertDataTable"
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --no-build --filter "FullyQualifiedName~Test_AppendDataTableToTable|FullyQualifiedName~Test_InsertDataTable"
- git diff --check