### PR TITLE
Preserve typed numeric reads for date-styled cells

### DIFF
--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
@@ -77,6 +77,7 @@ namespace OfficeIMO.Excel {
                 result.Add(new T());
             }
 
+            bool hasCustomConverters = _opt.CellValueConverter != null || _opt.TypeConverter != null;
             for (int i = 0; i < rawCells.Count; i++) {
                 if (canCancel && (i & 1023) == 0) {
                     ct.ThrowIfCancellationRequested();
@@ -99,6 +100,13 @@ namespace OfficeIMO.Excel {
                 }
 
                 object? converted = TryChangeType(cell.TypedValue, binding, _opt.Culture);
+                if (converted is null
+                    && !hasCustomConverters
+                    && ShouldRetryRawDateStyledNumericBinding(cell, binding)
+                    && TryConvertRawForBinding(cell, binding, out object? rawConverted)) {
+                    converted = rawConverted;
+                }
+
                 if (canCancel) {
                     ct.ThrowIfCancellationRequested();
                 }
@@ -854,6 +862,28 @@ namespace OfficeIMO.Excel {
             }
 
             return TryConvertNumericTextForBinding(raw.RawText, binding, out converted);
+        }
+
+        private bool ShouldRetryRawDateStyledNumericBinding<TTarget>(
+            CellRaw raw,
+            TypedPropertyBinding<TTarget> binding) {
+            if (!_opt.TreatDatesUsingNumberFormat
+                || binding.NeedsDateStyleConversion
+                || !IsNumericBindingDestination(binding.DestinationType)
+                || raw.RawText == null
+                || raw.StyleIndex is null
+                || !_styles.IsDateLike(raw.StyleIndex.Value)) {
+                return false;
+            }
+
+            return double.TryParse(raw.RawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out _);
+        }
+
+        private static bool IsNumericBindingDestination(Type destinationType) {
+            return destinationType == typeof(int)
+                || destinationType == typeof(long)
+                || destinationType == typeof(double)
+                || destinationType == typeof(decimal);
         }
 
         private bool TryConvertNumericTextForBinding<TTarget>(

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Data;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -55,6 +56,12 @@ namespace OfficeIMO.Tests {
             public bool? Active { get; set; }
             public DateTime? CreatedOn { get; set; }
             public double? Amount { get; set; }
+        }
+
+        private sealed class DateStyledNumericTypedRow {
+            public double NumericValue { get; set; }
+            public DateTime DateValue { get; set; }
+            public string? TextValue { get; set; }
         }
 
         private static void AssertRangeEqual(object?[,] expected, object?[,] actual) {
@@ -958,6 +965,107 @@ namespace OfficeIMO.Tests {
                 Assert.Null(rows[1].Active);
                 Assert.Null(rows[1].CreatedOn);
                 Assert.Null(rows[1].Amount);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_TypedObjects_ParallelKeepsDateStyledNumericTargetsNumeric() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderDateStyledNumericTypedHeaders.xlsx");
+            const double serialValue = 1.5d;
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "NumericValue");
+                    sheet.CellValue(1, 2, "DateValue");
+                    sheet.CellValue(1, 3, "TextValue");
+                    sheet.CellValue(2, 1, serialValue);
+                    sheet.CellValue(2, 2, serialValue);
+                    sheet.CellValue(2, 3, serialValue);
+                    sheet.ColumnStyleByHeader("NumericValue").NumberFormat("[h]:mm");
+                    sheet.ColumnStyleByHeader("DateValue").NumberFormat("[h]:mm");
+                    sheet.ColumnStyleByHeader("TextValue").NumberFormat("[h]:mm");
+                    document.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                var row = Assert.Single(reader.GetSheet("Data").ReadObjects<DateStyledNumericTypedRow>("A1:C2", ExecutionMode.Parallel));
+
+                Assert.Equal(serialValue, row.NumericValue);
+                Assert.Equal(DateTime.FromOADate(serialValue), row.DateValue);
+                Assert.Equal(DateTime.FromOADate(serialValue).ToString(CultureInfo.InvariantCulture), row.TextValue);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_TypedObjects_ParallelHonorsHandledNullTypeConverterForDateStyledNumeric() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderDateStyledNumericTypeConverter.xlsx");
+            const double serialValue = 1.5d;
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "NumericValue");
+                    sheet.CellValue(2, 1, serialValue);
+                    sheet.ColumnStyleByHeader("NumericValue").NumberFormat("[h]:mm");
+                    document.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    TypeConverter = (value, targetType, culture) =>
+                        targetType == typeof(double) ? (true, null) : (false, null)
+                };
+
+                using var sequentialReader = ExcelDocumentReader.Open(filePath, options);
+                using var parallelReader = ExcelDocumentReader.Open(filePath, options);
+                var sequentialRow = Assert.Single(sequentialReader.GetSheet("Data").ReadObjects<DateStyledNumericTypedRow>("A1:A2", ExecutionMode.Sequential));
+                var row = Assert.Single(parallelReader.GetSheet("Data").ReadObjects<DateStyledNumericTypedRow>("A1:A2", ExecutionMode.Parallel));
+
+                Assert.Equal(sequentialRow.NumericValue, row.NumericValue);
+                Assert.Equal(0d, row.NumericValue);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_TypedObjects_ParallelHonorsHandledCellConverterForDateStyledNumeric() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderDateStyledNumericCellConverter.xlsx");
+            const double serialValue = 1.5d;
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "NumericValue");
+                    sheet.CellValue(2, 1, serialValue);
+                    sheet.ColumnStyleByHeader("NumericValue").NumberFormat("[h]:mm");
+                    document.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    CellValueConverter = context =>
+                        context.RawText == serialValue.ToString(CultureInfo.InvariantCulture)
+                            ? new ExcelCellValue("not-a-number")
+                            : ExcelCellValue.NotHandled
+                };
+
+                using var sequentialReader = ExcelDocumentReader.Open(filePath, options);
+                using var parallelReader = ExcelDocumentReader.Open(filePath, options);
+                var sequentialRow = Assert.Single(sequentialReader.GetSheet("Data").ReadObjects<DateStyledNumericTypedRow>("A1:A2", ExecutionMode.Sequential));
+                var row = Assert.Single(parallelReader.GetSheet("Data").ReadObjects<DateStyledNumericTypedRow>("A1:A2", ExecutionMode.Parallel));
+
+                Assert.Equal(sequentialRow.NumericValue, row.NumericValue);
+                Assert.Equal(0d, row.NumericValue);
             } finally {
                 if (File.Exists(filePath)) {
                     File.Delete(filePath);


### PR DESCRIPTION
## Summary
- preserve numeric typed bindings when date-styled numeric cells are read through the forced-parallel `ReadObjects<T>` path
- add a regression test covering numeric, DateTime, and string bindings over the same date-like number format

## Validation
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release -f net8.0 --filter "FullyQualifiedName~Reader_TypedObjects_ParallelKeepsDateStyledNumericTargetsNumeric|FullyQualifiedName~ReadObjects|FullyQualifiedName~ReaderNumberFormats"
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release -f net8.0 --filter "FullyQualifiedName~ReadObjects|FullyQualifiedName~ReadRowsAs|FullyQualifiedName~ReadRangeAs|FullyQualifiedName~ReaderNumberFormats|FullyQualifiedName~Reader_ReadRange"
- dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- compare --rows 2500 --scenario read-objects --warmup 1 --iterations 3 --skip-legacy-epplus

## Notes
- The benchmark JSON output was restored and is not part of this PR.
