### PR TITLE
Add Excel tabular ingestion primitives

### DIFF
--- a/OfficeIMO.Excel/ExcelDataSetImportResult.cs
+++ b/OfficeIMO.Excel/ExcelDataSetImportResult.cs
@@ -1,0 +1,29 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Describes a worksheet created while importing a <see cref="System.Data.DataSet"/>.
+    /// </summary>
+    public sealed class ExcelDataSetImportResult {
+        internal ExcelDataSetImportResult(string sheetName, string? tableName, string range, int rowCount, int columnCount) {
+            SheetName = sheetName;
+            TableName = tableName;
+            Range = range;
+            RowCount = rowCount;
+            ColumnCount = columnCount;
+        }
+
+        /// <summary>Worksheet name used for the imported table.</summary>
+        public string SheetName { get; }
+
+        /// <summary>Actual Excel table name, when a table was created.</summary>
+        public string? TableName { get; }
+
+        /// <summary>A1 range occupied by the imported data.</summary>
+        public string Range { get; }
+
+        /// <summary>Number of source data rows imported.</summary>
+        public int RowCount { get; }
+
+        /// <summary>Number of source columns imported.</summary>
+        public int ColumnCount { get; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.DataSet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DataSet.cs
@@ -1,0 +1,83 @@
+using System.Data;
+using System.Threading;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        /// <summary>
+        /// Imports a <see cref="DataSet"/> into the workbook with one worksheet per source <see cref="DataTable"/>.
+        /// </summary>
+        /// <param name="dataSet">Source dataset.</param>
+        /// <param name="createTables">Create an Excel table over each imported DataTable.</param>
+        /// <param name="tableStyle">Excel table style to use when <paramref name="createTables"/> is true.</param>
+        /// <param name="includeHeaders">Write source column names as the first row.</param>
+        /// <param name="includeAutoFilter">Include table AutoFilter dropdowns when creating tables.</param>
+        /// <param name="autoFit">Auto-fit imported columns after each sheet is created.</param>
+        /// <param name="mode">Optional execution mode override for DataTable writes.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>Import results describing the created worksheets and ranges.</returns>
+        public IReadOnlyList<ExcelDataSetImportResult> InsertDataSet(
+            DataSet dataSet,
+            bool createTables = true,
+            TableStyle tableStyle = TableStyle.TableStyleMedium2,
+            bool includeHeaders = true,
+            bool includeAutoFilter = true,
+            bool autoFit = false,
+            ExecutionMode? mode = null,
+            CancellationToken ct = default) {
+            if (dataSet == null) throw new ArgumentNullException(nameof(dataSet));
+
+            var results = new List<ExcelDataSetImportResult>();
+            int tableIndex = 1;
+            foreach (DataTable table in dataSet.Tables) {
+                ct.ThrowIfCancellationRequested();
+
+                string requestedSheetName = string.IsNullOrWhiteSpace(table.TableName)
+                    ? "Table" + tableIndex.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    : table.TableName;
+                ExcelSheet sheet = AddWorkSheet(requestedSheetName, SheetNameValidationMode.Sanitize);
+                string? requestedTableName = createTables ? requestedSheetName : null;
+                string? actualTableName = null;
+                string range;
+                if (createTables) {
+                    range = sheet.InsertDataTableAsTable(
+                        table,
+                        includeHeaders: includeHeaders,
+                        tableName: requestedTableName,
+                        style: tableStyle,
+                        includeAutoFilter: includeAutoFilter,
+                        mode: mode,
+                        ct: ct);
+                    actualTableName = GetImportedTableName(sheet);
+                } else {
+                    sheet.InsertDataTable(table, includeHeaders: includeHeaders, mode: mode, ct: ct);
+                    range = BuildImportedRange(table.Rows.Count, table.Columns.Count, includeHeaders);
+                }
+
+                if (autoFit && table.Columns.Count > 0) {
+                    sheet.AutoFitColumnsFor(Enumerable.Range(1, table.Columns.Count));
+                }
+
+                results.Add(new ExcelDataSetImportResult(sheet.Name, actualTableName, range, table.Rows.Count, table.Columns.Count));
+                tableIndex++;
+            }
+
+            return results;
+        }
+
+        private static string? GetImportedTableName(ExcelSheet sheet) {
+            return sheet.WorksheetPart.TableDefinitionParts
+                .Select(part => part.Table?.Name?.Value ?? part.Table?.DisplayName?.Value)
+                .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name));
+        }
+
+        private static string BuildImportedRange(int rowCount, int columnCount, bool includeHeaders) {
+            int rows = rowCount + (includeHeaders ? 1 : 0);
+            int columns = Math.Max(1, columnCount);
+            if (rows < 1) {
+                rows = 1;
+            }
+
+            return A1.CellReference(1, 1) + ":" + A1.CellReference(rows, columns);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.DataReader.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataReader.cs
@@ -1,0 +1,151 @@
+using System.Data;
+using System.Globalization;
+using System.Threading;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Streams rows from an <see cref="IDataReader"/> (including provider-owned DbDataReader implementations) into the worksheet and optionally creates an Excel table.
+        /// The caller owns the connection, command, query, and provider.
+        /// </summary>
+        /// <param name="reader">Open data reader positioned before the first row.</param>
+        /// <param name="startRow">1-based start row.</param>
+        /// <param name="startColumn">1-based start column.</param>
+        /// <param name="includeHeaders">Write field names as the first row.</param>
+        /// <param name="tableName">Optional Excel table name.</param>
+        /// <param name="style">Excel table style to use when <paramref name="createTable"/> is true.</param>
+        /// <param name="includeAutoFilter">Include table AutoFilter dropdowns when creating a table.</param>
+        /// <param name="createTable">Create an Excel table over the imported range.</param>
+        /// <param name="autoFit">Auto-fit imported columns after rows are written.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>A1 range occupied by the imported reader data.</returns>
+        public string InsertDataReader(
+            IDataReader reader,
+            int startRow = 1,
+            int startColumn = 1,
+            bool includeHeaders = true,
+            string? tableName = null,
+            TableStyle style = TableStyle.TableStyleMedium2,
+            bool includeAutoFilter = true,
+            bool createTable = true,
+            bool autoFit = false,
+            CancellationToken ct = default) {
+            if (reader == null) throw new ArgumentNullException(nameof(reader));
+            if (startRow < 1) throw new ArgumentOutOfRangeException(nameof(startRow));
+            if (startColumn < 1) throw new ArgumentOutOfRangeException(nameof(startColumn));
+            if (reader.FieldCount < 1) throw new ArgumentException("Data reader must expose at least one field.", nameof(reader));
+
+            string[] headers = BuildReaderHeaders(reader);
+            Type[] fieldTypes = BuildReaderFieldTypes(reader);
+            int row = startRow;
+            if (includeHeaders) {
+                for (int i = 0; i < headers.Length; i++) {
+                    CellValue(row, startColumn + i, headers[i]);
+                }
+
+                row++;
+            }
+
+            int dataRows = 0;
+            while (reader.Read()) {
+                ct.ThrowIfCancellationRequested();
+                for (int i = 0; i < headers.Length; i++) {
+                    object? value = reader.IsDBNull(i) ? null : reader.GetValue(i);
+                    int column = startColumn + i;
+                    CellValue(row, column, value);
+
+                    string? numberFormat = GetReaderNumberFormat(fieldTypes[i], value);
+                    if (!string.IsNullOrWhiteSpace(numberFormat)) {
+                        FormatCell(row, column, numberFormat!);
+                    }
+                }
+
+                row++;
+                dataRows++;
+            }
+
+            int occupiedRows = dataRows + (includeHeaders ? 1 : 0);
+            if (occupiedRows == 0) {
+                occupiedRows = 1;
+            }
+
+            string range = A1.CellReference(startRow, startColumn) + ":" +
+                A1.CellReference(startRow + occupiedRows - 1, startColumn + headers.Length - 1);
+
+            if (createTable) {
+                AddTable(range, includeHeaders, tableName ?? string.Empty, style, includeAutoFilter);
+            }
+
+            if (autoFit) {
+                AutoFitColumnsFor(Enumerable.Range(startColumn, headers.Length));
+            }
+
+            return range;
+        }
+
+        private static string[] BuildReaderHeaders(IDataReader reader) {
+            var headers = new List<string>(reader.FieldCount);
+            for (int i = 0; i < reader.FieldCount; i++) {
+                string name;
+                try {
+                    name = reader.GetName(i);
+                } catch (Exception) {
+                    name = string.Empty;
+                }
+
+                if (string.IsNullOrWhiteSpace(name)) {
+                    name = "Column" + (i + 1).ToString(CultureInfo.InvariantCulture);
+                }
+
+                headers.Add(name);
+            }
+
+            EnsureUniqueReaderHeaders(headers);
+            return headers.ToArray();
+        }
+
+        private static Type[] BuildReaderFieldTypes(IDataReader reader) {
+            var types = new Type[reader.FieldCount];
+            for (int i = 0; i < reader.FieldCount; i++) {
+                try {
+                    types[i] = reader.GetFieldType(i) ?? typeof(object);
+                } catch (Exception) {
+                    types[i] = typeof(object);
+                }
+            }
+
+            return types;
+        }
+
+        private static void EnsureUniqueReaderHeaders(IList<string> headers) {
+            var seen = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < headers.Count; i++) {
+                string baseName = string.IsNullOrWhiteSpace(headers[i])
+                    ? "Column" + (i + 1).ToString(CultureInfo.InvariantCulture)
+                    : headers[i].Trim();
+                if (!seen.TryGetValue(baseName, out int count)) {
+                    seen[baseName] = 1;
+                    headers[i] = baseName;
+                    continue;
+                }
+
+                count++;
+                seen[baseName] = count;
+                headers[i] = baseName + " (" + count.ToString(CultureInfo.InvariantCulture) + ")";
+            }
+        }
+
+        private static string? GetReaderNumberFormat(Type fieldType, object? value) {
+            Type type = Nullable.GetUnderlyingType(fieldType) ?? fieldType;
+            if (type == typeof(DateTime) || type == typeof(DateTimeOffset) || value is DateTime || value is DateTimeOffset) {
+                return "yyyy-mm-dd hh:mm";
+            }
+
+            if (type == typeof(TimeSpan) || value is TimeSpan) {
+                return "[h]:mm:ss";
+            }
+
+            return null;
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Tests/Excel.DataTableInsert.cs
@@ -138,6 +138,157 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_InsertDataSet_CreatesWorksheetPerTableWithSafeNames() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataSetImport.xlsx");
+
+            var dataSet = new DataSet("HtmlTables");
+            var sales = new DataTable("Sales:2026");
+            sales.Columns.Add("Region", typeof(string));
+            sales.Columns.Add("Revenue", typeof(decimal));
+            sales.Rows.Add("North", 12.5m);
+            dataSet.Tables.Add(sales);
+
+            var details = new DataTable("Details");
+            details.Columns.Add("Name", typeof(string));
+            details.Rows.Add("A");
+            dataSet.Tables.Add(details);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var results = document.InsertDataSet(dataSet, autoFit: true);
+
+                Assert.Equal(2, results.Count);
+                Assert.Equal("Sales_2026", results[0].SheetName);
+                Assert.Equal("Sales_2026", results[0].TableName);
+                Assert.Equal("A1:B2", results[0].Range);
+                Assert.Equal(1, results[0].RowCount);
+                Assert.Equal(2, results[0].ColumnCount);
+                Assert.Equal("Details", results[1].SheetName);
+                Assert.Equal("Details", results[1].TableName);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var sheets = spreadsheet.WorkbookPart!.Workbook.Sheets!.Elements<Sheet>().ToList();
+                Assert.Contains(sheets, sheet => sheet.Name?.Value == "Sales_2026");
+                Assert.Contains(sheets, sheet => sheet.Name?.Value == "Details");
+
+                var tableReferences = spreadsheet.WorkbookPart.WorksheetParts
+                    .SelectMany(part => part.TableDefinitionParts)
+                    .Select(part => part.Table?.Reference?.Value)
+                    .ToList();
+                Assert.Contains("A1:B2", tableReferences);
+                Assert.Contains("A1:A2", tableReferences);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Test_InsertDataSet_ReturnsActualUniqueTableNames() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataSetImportUniqueTables.xlsx");
+
+            var dataSet = new DataSet("DuplicateTables");
+            var first = new DataTable("Sales:2026");
+            first.Columns.Add("Region", typeof(string));
+            first.Rows.Add("North");
+            dataSet.Tables.Add(first);
+
+            var second = new DataTable("Sales/2026");
+            second.Columns.Add("Region", typeof(string));
+            second.Rows.Add("South");
+            dataSet.Tables.Add(second);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var results = document.InsertDataSet(dataSet);
+
+                Assert.Equal("Sales_2026", results[0].SheetName);
+                Assert.Equal("Sales_2026", results[0].TableName);
+                Assert.Equal("Sales_2026 (2)", results[1].SheetName);
+                Assert.Equal("Sales_20262", results[1].TableName);
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                var tables = document.GetTables().OrderBy(table => table.SheetIndex).ToList();
+                Assert.Equal(new[] { "Sales_2026", "Sales_20262" }, tables.Select(table => table.Name).ToArray());
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Test_InsertDataSet_CanImportPlainRangesWithoutTables() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataSetImportPlainRanges.xlsx");
+
+            var dataSet = new DataSet("PlainRanges");
+            var first = new DataTable("One");
+            first.Columns.Add("Name", typeof(string));
+            first.Rows.Add("Alpha");
+            dataSet.Tables.Add(first);
+
+            var second = new DataTable();
+            second.Columns.Add("Amount", typeof(int));
+            second.Rows.Add(5);
+            dataSet.Tables.Add(second);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var results = document.InsertDataSet(dataSet, createTables: false, includeHeaders: false);
+
+                Assert.Equal(2, results.Count);
+                Assert.Equal("One", results[0].SheetName);
+                Assert.Null(results[0].TableName);
+                Assert.Equal("A1:A1", results[0].Range);
+                Assert.Equal("Table1", results[1].SheetName);
+                Assert.Null(results[1].TableName);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                Assert.Empty(spreadsheet.WorkbookPart!.WorksheetParts.SelectMany(part => part.TableDefinitionParts));
+
+                var sheets = spreadsheet.WorkbookPart.Workbook.Sheets!.Elements<Sheet>().ToList();
+                Assert.Contains(sheets, sheet => sheet.Name?.Value == "One");
+                Assert.Contains(sheets, sheet => sheet.Name?.Value == "Table1");
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Test_InsertDataReader_StreamsRowsAndCreatesTable() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataReaderImport.xlsx");
+
+            var source = new DataTable("ReaderData");
+            source.Columns.Add("Name", typeof(string));
+            source.Columns.Add("Amount", typeof(decimal));
+            source.Columns.Add("When", typeof(DateTime));
+            source.Rows.Add("Alpha", 10.25m, new DateTime(2026, 1, 2, 3, 4, 0));
+            source.Rows.Add("Beta", 20.50m, new DateTime(2026, 1, 3, 4, 5, 0));
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Reader");
+                using IDataReader reader = source.CreateDataReader();
+                string range = sheet.InsertDataReader(reader, tableName: "ReaderTable", autoFit: true);
+
+                Assert.Equal("A1:C3", range);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                var table = worksheetPart.TableDefinitionParts.Single().Table!;
+                Assert.Equal("A1:C3", table.Reference?.Value);
+                Assert.Equal("ReaderTable", table.Name?.Value);
+
+                Cell dateCell = worksheetPart.Worksheet.Descendants<Cell>().First(cell => cell.CellReference == "C2");
+                Assert.True(dateCell.DataType == null || dateCell.DataType.Value == CellValues.Number);
+                Assert.Equal(new DateTime(2026, 1, 2, 3, 4, 0).ToOADate().ToString(CultureInfo.InvariantCulture), dateCell.CellValue!.Text);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_AppendDataTableToTable_ExtendsTableAndMapsColumnsByHeader() {
             string filePath = Path.Combine(_directoryWithFiles, "DataTableAppendTable.xlsx");
 


### PR DESCRIPTION
## Summary
- add ExcelDocument DataSet import with one worksheet per DataTable, safe names, table/no-table modes, autofit/header/filter options
- add ExcelSheet IDataReader import without SQL/OleDb/provider dependencies
- return actual sanitized/unique worksheet/table import metadata

## Validation
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~Test_InsertDataSet_CreatesWorksheetPerTableWithSafeNames|FullyQualifiedName~Test_InsertDataSet_ReturnsActualUniqueTableNames|FullyQualifiedName~Test_InsertDataSet_CanImportPlainRangesWithoutTables|FullyQualifiedName~Test_InsertDataReader_StreamsRowsAndCreatesTable"
- dotnet build OfficeIMO.Excel/OfficeIMO.Excel.csproj --framework net8.0
- dotnet build OfficeIMO.Excel/OfficeIMO.Excel.csproj --framework net472
- git diff --check
