### PR TITLE
Harden Excel import and worksheet copy edge cases

### DIFF
--- a/OfficeIMO.Excel/ExcelDataSetImportResult.cs
+++ b/OfficeIMO.Excel/ExcelDataSetImportResult.cs
@@ -17,7 +17,7 @@ namespace OfficeIMO.Excel {
         /// <summary>Actual Excel table name, when a table was created.</summary>
         public string? TableName { get; }
 
-        /// <summary>A1 range occupied by the imported data.</summary>
+        /// <summary>A1 range occupied by the imported data, or an empty string when no worksheet cells were written.</summary>
         public string Range { get; }
 
         /// <summary>Number of source data rows imported.</summary>

--- a/OfficeIMO.Excel/ExcelDocument.DataSet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DataSet.cs
@@ -39,15 +39,19 @@ namespace OfficeIMO.Excel {
                 string? actualTableName = null;
                 string range;
                 if (createTables) {
-                    range = sheet.InsertDataTableAsTable(
-                        table,
-                        includeHeaders: includeHeaders,
-                        tableName: requestedTableName,
-                        style: tableStyle,
-                        includeAutoFilter: includeAutoFilter,
-                        mode: mode,
-                        ct: ct);
-                    actualTableName = GetImportedTableName(sheet);
+                    if (DataTableWritesCells(table, includeHeaders)) {
+                        range = sheet.InsertDataTableAsTable(
+                            table,
+                            includeHeaders: includeHeaders,
+                            tableName: requestedTableName,
+                            style: tableStyle,
+                            includeAutoFilter: includeAutoFilter,
+                            mode: mode,
+                            ct: ct);
+                        actualTableName = GetImportedTableName(sheet);
+                    } else {
+                        range = string.Empty;
+                    }
                 } else {
                     sheet.InsertDataTable(table, includeHeaders: includeHeaders, mode: mode, ct: ct);
                     range = BuildImportedRange(table.Rows.Count, table.Columns.Count, includeHeaders);
@@ -70,14 +74,21 @@ namespace OfficeIMO.Excel {
                 .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name));
         }
 
+        private static bool DataTableWritesCells(DataTable table, bool includeHeaders) {
+            return table.Columns.Count > 0 && (includeHeaders || table.Rows.Count > 0);
+        }
+
         private static string BuildImportedRange(int rowCount, int columnCount, bool includeHeaders) {
-            int rows = rowCount + (includeHeaders ? 1 : 0);
-            int columns = Math.Max(1, columnCount);
-            if (rows < 1) {
-                rows = 1;
+            if (columnCount == 0) {
+                return string.Empty;
             }
 
-            return A1.CellReference(1, 1) + ":" + A1.CellReference(rows, columns);
+            int rows = rowCount + (includeHeaders ? 1 : 0);
+            if (rows == 0) {
+                return string.Empty;
+            }
+
+            return A1.CellReference(1, 1) + ":" + A1.CellReference(rows, columnCount);
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -2,7 +2,6 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System.Globalization;
-using System.Text.RegularExpressions;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
@@ -507,13 +506,75 @@ namespace OfficeIMO.Excel {
                 return formula ?? string.Empty;
             }
 
-            string rewritten = formula!;
-            foreach (var mapping in tableNameMap) {
-                string pattern = @"(?<![A-Za-z0-9_\\])" + Regex.Escape(mapping.Key) + @"(?=\[)";
-                rewritten = Regex.Replace(rewritten, pattern, mapping.Value, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+            var mappings = tableNameMap
+                .Where(mapping => !string.IsNullOrEmpty(mapping.Key))
+                .OrderByDescending(mapping => mapping.Key.Length)
+                .ToArray();
+            if (mappings.Length == 0) {
+                return formula!;
             }
 
-            return rewritten;
+            var rewritten = new System.Text.StringBuilder(formula!.Length);
+            bool inStringLiteral = false;
+            for (int index = 0; index < formula!.Length;) {
+                char current = formula[index];
+                if (current == '"') {
+                    rewritten.Append(current);
+                    if (inStringLiteral && index + 1 < formula.Length && formula[index + 1] == '"') {
+                        rewritten.Append(formula[index + 1]);
+                        index += 2;
+                        continue;
+                    }
+
+                    inStringLiteral = !inStringLiteral;
+                    index++;
+                    continue;
+                }
+
+                if (!inStringLiteral && TryRewriteStructuredReferenceAt(formula, index, mappings, out string? replacement, out int consumed)) {
+                    rewritten.Append(replacement);
+                    index += consumed;
+                    continue;
+                }
+
+                rewritten.Append(current);
+                index++;
+            }
+
+            return rewritten.ToString();
+        }
+
+        private static bool TryRewriteStructuredReferenceAt(
+            string formula,
+            int index,
+            KeyValuePair<string, string>[] mappings,
+            out string? replacement,
+            out int consumed) {
+            replacement = null;
+            consumed = 0;
+            foreach (var mapping in mappings) {
+                string tableName = mapping.Key;
+                if (index > 0) {
+                    char previous = formula[index - 1];
+                    if (char.IsLetterOrDigit(previous) || previous == '_' || previous == '\\') {
+                        continue;
+                    }
+                }
+
+                if (index + tableName.Length >= formula.Length || formula[index + tableName.Length] != '[') {
+                    continue;
+                }
+
+                if (string.Compare(formula, index, tableName, 0, tableName.Length, StringComparison.OrdinalIgnoreCase) != 0) {
+                    continue;
+                }
+
+                replacement = mapping.Value;
+                consumed = tableName.Length;
+                return true;
+            }
+
+            return false;
         }
 
         private static string MakeUnusedRelationshipId(WorksheetPart worksheetPart) {

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -2,6 +2,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
@@ -188,33 +189,42 @@ namespace OfficeIMO.Excel {
             bool skipHeader = options.SourceHasHeader && !options.IncludeSourceHeader && values.GetLength(0) > 0;
             int sourceRowOffset = skipHeader ? 1 : 0;
             int rowsToCopy = Math.Max(0, values.GetLength(0) - sourceRowOffset);
-            int[] columnMap = BuildMergeColumnMap(targetSheet, sourceBounds, values, options);
-            int columnsToCopy = columnMap.Length;
+            return Locking.ExecuteWrite(EnsureLock(), () => {
+                using (Locking.EnterNoLockScope()) {
+                    int[] columnMap = BuildMergeColumnMap(targetSheet, sourceBounds, values, options);
+                    int columnsToCopy = columnMap.Length;
 
-            int targetStartRow = options.TargetStartRow ?? GetAppendStartRow(targetSheet, options.BlankRowsBefore);
-            int targetStartColumn = GetMergeTargetStartColumn(targetSheet, sourceBounds, options);
-            if (targetStartRow < 1) throw new ArgumentOutOfRangeException(nameof(options.TargetStartRow));
-            if (targetStartColumn < 1) throw new ArgumentOutOfRangeException(nameof(options.TargetStartColumn));
+                    int targetStartRow = options.TargetStartRow ?? GetAppendStartRow(targetSheet, options.BlankRowsBefore);
+                    int targetStartColumn = GetMergeTargetStartColumn(targetSheet, sourceBounds, options);
+                    if (targetStartRow < 1) throw new ArgumentOutOfRangeException(nameof(options.TargetStartRow));
+                    if (targetStartColumn < 1) throw new ArgumentOutOfRangeException(nameof(options.TargetStartColumn));
 
-            EnsureMergeTargetCanWrite(targetSheet, targetStartRow, targetStartColumn, rowsToCopy, values, sourceRowOffset, columnMap, options);
+                    EnsureMergeTargetCanWrite(targetSheet, targetStartRow, targetStartColumn, rowsToCopy, values, sourceRowOffset, columnMap, options);
 
-            for (int rowOffset = 0; rowOffset < rowsToCopy; rowOffset++) {
-                for (int columnOffset = 0; columnOffset < columnsToCopy; columnOffset++) {
-                    object? value = values[rowOffset + sourceRowOffset, columnMap[columnOffset]];
-                    if (value == null) continue;
-                    targetSheet.CellValue(targetStartRow + rowOffset, targetStartColumn + columnOffset, value);
+                    var cells = new List<(int Row, int Column, object Value)>();
+                    for (int rowOffset = 0; rowOffset < rowsToCopy; rowOffset++) {
+                        for (int columnOffset = 0; columnOffset < columnsToCopy; columnOffset++) {
+                            object? value = values[rowOffset + sourceRowOffset, columnMap[columnOffset]];
+                            if (value == null) continue;
+                            cells.Add((targetStartRow + rowOffset, targetStartColumn + columnOffset, value));
+                        }
+                    }
+
+                    if (cells.Count > 0) {
+                        targetSheet.CellValues(cells);
+                    }
+
+                    string targetRange = BuildMergeTargetRange(targetStartRow, targetStartColumn, rowsToCopy, columnsToCopy);
+                    return new ExcelWorksheetMergeResult(
+                        sourceSheet.Name,
+                        targetSheet.Name,
+                        sourceRange,
+                        targetRange,
+                        rowsToCopy,
+                        columnsToCopy,
+                        skipHeader);
                 }
-            }
-
-            string targetRange = BuildMergeTargetRange(targetStartRow, targetStartColumn, rowsToCopy, columnsToCopy);
-            return new ExcelWorksheetMergeResult(
-                sourceSheet.Name,
-                targetSheet.Name,
-                sourceRange,
-                targetRange,
-                rowsToCopy,
-                columnsToCopy,
-                skipHeader);
+            });
         }
 
         /// <summary>
@@ -354,6 +364,8 @@ namespace OfficeIMO.Excel {
 
         private void CopyWorksheetTables(WorksheetPart sourcePart, WorksheetPart copiedPart) {
             TableParts? copiedTableParts = null;
+            var tableNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var copiedTables = new List<Table>();
             foreach (TableDefinitionPart sourceTablePart in sourcePart.TableDefinitionParts) {
                 Table? sourceTable = sourceTablePart.Table;
                 if (sourceTable == null) {
@@ -364,16 +376,32 @@ namespace OfficeIMO.Excel {
                 TableDefinitionPart copiedTablePart = copiedPart.AddNewPart<TableDefinitionPart>(relationshipId);
                 var copiedTable = (Table)sourceTable.CloneNode(true);
                 copiedTable.Id = GetNextUniqueTableId();
-                string tableName = CreateUniqueCopiedTableName(sourceTable.Name?.Value ?? sourceTable.DisplayName?.Value);
+                string? sourceTableName = sourceTable.Name?.Value ?? sourceTable.DisplayName?.Value;
+                string tableName = CreateUniqueCopiedTableName(sourceTableName);
                 copiedTable.Name = tableName;
                 copiedTable.DisplayName = tableName;
 
                 copiedTablePart.Table = copiedTable;
-                copiedTablePart.Table.Save();
                 ReserveTableName(tableName);
+                copiedTables.Add(copiedTable);
+                if (!string.IsNullOrWhiteSpace(sourceTableName)) {
+                    tableNameMap[sourceTableName!] = tableName;
+                }
 
                 copiedTableParts ??= EnsureTableParts(copiedPart.Worksheet!);
                 copiedTableParts.Append(new TablePart { Id = copiedPart.GetIdOfPart(copiedTablePart) });
+            }
+
+            if (tableNameMap.Count > 0) {
+                RewriteStructuredTableReferences(copiedPart.Worksheet!, tableNameMap);
+            }
+
+            foreach (Table copiedTable in copiedTables) {
+                if (tableNameMap.Count > 0) {
+                    RewriteStructuredTableReferences(copiedTable, tableNameMap);
+                }
+
+                copiedTable.Save();
             }
 
             if (copiedTableParts != null) {
@@ -448,8 +476,44 @@ namespace OfficeIMO.Excel {
             }
 
             tableParts = new TableParts();
-            worksheet.Append(tableParts);
+            WorksheetExtensionList? extensionList = worksheet.Elements<WorksheetExtensionList>().FirstOrDefault();
+            if (extensionList != null) {
+                worksheet.InsertBefore(tableParts, extensionList);
+            } else {
+                worksheet.Append(tableParts);
+            }
+
             return tableParts;
+        }
+
+        private static void RewriteStructuredTableReferences(Worksheet worksheet, IReadOnlyDictionary<string, string> tableNameMap) {
+            foreach (CellFormula formula in worksheet.Descendants<CellFormula>()) {
+                formula.Text = RewriteStructuredTableReferences(formula.Text, tableNameMap);
+            }
+        }
+
+        private static void RewriteStructuredTableReferences(Table table, IReadOnlyDictionary<string, string> tableNameMap) {
+            foreach (CalculatedColumnFormula formula in table.Descendants<CalculatedColumnFormula>()) {
+                formula.Text = RewriteStructuredTableReferences(formula.Text, tableNameMap);
+            }
+
+            foreach (TotalsRowFormula formula in table.Descendants<TotalsRowFormula>()) {
+                formula.Text = RewriteStructuredTableReferences(formula.Text, tableNameMap);
+            }
+        }
+
+        private static string RewriteStructuredTableReferences(string? formula, IReadOnlyDictionary<string, string> tableNameMap) {
+            if (string.IsNullOrEmpty(formula) || tableNameMap.Count == 0) {
+                return formula ?? string.Empty;
+            }
+
+            string rewritten = formula!;
+            foreach (var mapping in tableNameMap) {
+                string pattern = @"(?<![A-Za-z0-9_\\])" + Regex.Escape(mapping.Key) + @"(?=\[)";
+                rewritten = Regex.Replace(rewritten, pattern, mapping.Value, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+            }
+
+            return rewritten;
         }
 
         private static string MakeUnusedRelationshipId(WorksheetPart worksheetPart) {

--- a/OfficeIMO.Excel/ExcelSheet.DataReader.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataReader.cs
@@ -66,7 +66,7 @@ namespace OfficeIMO.Excel {
 
             int occupiedRows = dataRows + (includeHeaders ? 1 : 0);
             if (occupiedRows == 0) {
-                occupiedRows = 1;
+                return string.Empty;
             }
 
             string range = A1.CellReference(startRow, startColumn) + ":" +

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.cs
@@ -140,7 +140,11 @@ namespace OfficeIMO.Excel {
             InsertDataTable(table, startRow, startColumn, includeHeaders, mode, ct);
 
             int rowsCount = table.Rows.Count + (includeHeaders ? 1 : 0);
-            int colsCount = Math.Max(1, table.Columns.Count);
+            if (table.Columns.Count == 0 || rowsCount == 0) {
+                return string.Empty;
+            }
+
+            int colsCount = table.Columns.Count;
             string startRef = A1.CellReference(startRow, startColumn);
             string endRef = A1.CellReference(startRow + rowsCount - 1, startColumn + colsCount - 1);
             string range = startRef + ":" + endRef;

--- a/OfficeIMO.Tests/Excel.DataTableInsert.cs
+++ b/OfficeIMO.Tests/Excel.DataTableInsert.cs
@@ -255,6 +255,86 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_InsertDataSet_HeaderlessEmptyTable_DoesNotCreateTableOrFakeRange() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataSetImportHeaderlessEmpty.xlsx");
+
+            var dataSet = new DataSet("Empty");
+            var empty = new DataTable("EmptyTable");
+            empty.Columns.Add("Name", typeof(string));
+            dataSet.Tables.Add(empty);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var result = Assert.Single(document.InsertDataSet(dataSet, includeHeaders: false));
+
+                Assert.Equal("EmptyTable", result.SheetName);
+                Assert.Null(result.TableName);
+                Assert.Equal(string.Empty, result.Range);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.Single();
+                Assert.Empty(worksheetPart.TableDefinitionParts);
+                Assert.Empty(worksheetPart.Worksheet.Descendants<Cell>());
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Test_InsertDataSet_ZeroColumnPlainRange_ReturnsEmptyRange() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataSetImportZeroColumn.xlsx");
+
+            var dataSet = new DataSet("ZeroColumn");
+            var empty = new DataTable("NoColumns");
+            empty.Rows.Add(empty.NewRow());
+            dataSet.Tables.Add(empty);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var result = Assert.Single(document.InsertDataSet(dataSet, createTables: false));
+
+                Assert.Equal("NoColumns", result.SheetName);
+                Assert.Null(result.TableName);
+                Assert.Equal(string.Empty, result.Range);
+                Assert.Equal(1, result.RowCount);
+                Assert.Equal(0, result.ColumnCount);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.Single();
+                Assert.Empty(worksheetPart.TableDefinitionParts);
+                Assert.Empty(worksheetPart.Worksheet.Descendants<Cell>());
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Test_InsertDataSet_HeaderlessNoRowsPlainRange_ReturnsEmptyRange() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataSetImportHeaderlessNoRows.xlsx");
+
+            var dataSet = new DataSet("Headerless");
+            var empty = new DataTable("EmptyRange");
+            empty.Columns.Add("Name", typeof(string));
+            dataSet.Tables.Add(empty);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var result = Assert.Single(document.InsertDataSet(dataSet, createTables: false, includeHeaders: false));
+
+                Assert.Equal(string.Empty, result.Range);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.Single();
+                Assert.Empty(worksheetPart.Worksheet.Descendants<Cell>());
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_InsertDataReader_StreamsRowsAndCreatesTable() {
             string filePath = Path.Combine(_directoryWithFiles, "DataReaderImport.xlsx");
 
@@ -283,6 +363,32 @@ namespace OfficeIMO.Tests {
                 Cell dateCell = worksheetPart.Worksheet.Descendants<Cell>().First(cell => cell.CellReference == "C2");
                 Assert.True(dateCell.DataType == null || dateCell.DataType.Value == CellValues.Number);
                 Assert.Equal(new DateTime(2026, 1, 2, 3, 4, 0).ToOADate().ToString(CultureInfo.InvariantCulture), dateCell.CellValue!.Text);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Test_InsertDataReader_HeaderlessEmptyReader_ReturnsEmptyRangeAndNoTable() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataReaderImportHeaderlessEmpty.xlsx");
+
+            var source = new DataTable("ReaderData");
+            source.Columns.Add("Name", typeof(string));
+            source.Columns.Add("Amount", typeof(decimal));
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Reader");
+                using IDataReader reader = source.CreateDataReader();
+                string range = sheet.InsertDataReader(reader, includeHeaders: false, tableName: "ReaderTable");
+
+                Assert.Equal(string.Empty, range);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.Single();
+                Assert.Empty(worksheetPart.TableDefinitionParts);
+                Assert.Empty(worksheetPart.Worksheet.Descendants<Cell>());
             }
 
             File.Delete(filePath);

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -76,6 +76,7 @@ namespace OfficeIMO.Tests {
                 source.CellValue(3, 1, "EMEA");
                 source.CellValue(3, 2, 200);
                 source.AddTable("A1:B3", hasHeader: true, name: "SalesTable", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                source.CellFormula(4, 2, "SUM(SalesTable[Revenue])");
 
                 ExcelSheet copy = document.CopyWorkSheet(source, "Copy");
 
@@ -100,6 +101,38 @@ namespace OfficeIMO.Tests {
                 TableParts tableParts = Assert.Single(copiedPart.Worksheet.Elements<TableParts>());
                 TablePart tablePart = Assert.Single(tableParts.Elements<TablePart>());
                 Assert.NotNull(copiedPart.GetPartById(tablePart.Id!.Value!));
+
+                Cell formulaCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference == "B4");
+                Assert.Equal("SUM(SalesTable2[Revenue])", formulaCell.CellFormula?.Text);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetWithinWorkbook_InsertsTablePartsBeforeExtensionList() {
+            string filePath = Path.Combine(_directoryWithFiles, "WorksheetCopyTablePartsOrder.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet source = document.AddWorkSheet("Source");
+                source.CellValue(1, 1, "Name");
+                source.CellValue(2, 1, "Ada");
+                source.AddTable("A1:A2", hasHeader: true, name: "People", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                source.WorksheetPart.Worksheet.Append(new WorksheetExtensionList(new WorksheetExtension { Uri = "{00000000-0000-0000-0000-000000000001}" }));
+
+                document.CopyWorkSheet(source, "Copy");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Copy");
+                var children = copiedPart.Worksheet.ChildElements.ToList();
+                int tablePartsIndex = children.FindIndex(element => element is TableParts);
+                int extensionListIndex = children.FindIndex(element => element is WorksheetExtensionList);
+
+                Assert.True(tablePartsIndex >= 0);
+                Assert.True(extensionListIndex >= 0);
+                Assert.True(tablePartsIndex < extensionListIndex);
             }
 
             File.Delete(filePath);

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -139,6 +139,45 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CopyWorkSheetWithinWorkbook_RewritesStructuredReferencesAtomicallyOutsideStrings() {
+            string filePath = Path.Combine(_directoryWithFiles, "WorksheetCopyStructuredReferenceRewrite.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet source = document.AddWorkSheet("Source");
+                source.CellValue(1, 1, "Region");
+                source.CellValue(1, 2, "Revenue");
+                source.CellValue(2, 1, "NA");
+                source.CellValue(2, 2, 100);
+                source.CellValue(1, 4, "Region");
+                source.CellValue(1, 5, "Revenue");
+                source.CellValue(2, 4, "EMEA");
+                source.CellValue(2, 5, 200);
+                source.AddTable("A1:B2", hasHeader: true, name: "Sales", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                source.AddTable("D1:E2", hasHeader: true, name: "Sales2", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                source.CellFormula(4, 1, "SUM(Sales[Revenue])+SUM(Sales2[Revenue])+\"Sales[Revenue]\"");
+
+                document.CopyWorkSheet(source, "Copy");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Copy");
+                var tableNamesByRange = copiedPart.TableDefinitionParts
+                    .Select(part => part.Table)
+                    .Where(table => table?.Reference?.Value != null && table.Name?.Value != null)
+                    .ToDictionary(table => table!.Reference!.Value!, table => table!.Name!.Value!);
+
+                string firstCopiedTable = tableNamesByRange["A1:B2"];
+                string secondCopiedTable = tableNamesByRange["D1:E2"];
+                Cell formulaCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference == "A4");
+
+                Assert.Equal($"SUM({firstCopiedTable}[Revenue])+SUM({secondCopiedTable}[Revenue])+\"Sales[Revenue]\"", formulaCell.CellFormula?.Text);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_CopyWorkSheetFrom_CopiesValuesBetweenWorkbooks() {
             string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopySource.xlsx");
             string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyTarget.xlsx");


### PR DESCRIPTION
Summary: avoids fake ranges and tables for empty DataSet/DataReader/DataTable imports; rewrites structured table formulas when copied tables are renamed; keeps worksheet tableParts before extLst and holds one write lock during merge writes. Tests: dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter FullyQualifiedName~OfficeIMO.Tests.Excel; dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter FullyQualifiedName~OfficeIMO.Tests.Excel; dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter FullyQualifiedName~Test_CopyWorkSheetWithinWorkbook --no-restore; git diff --check.