### PR TITLE
Polish Excel table metadata and helpers

### DIFF
--- a/OfficeIMO.Excel/ExcelDocument.Tables.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Tables.cs
@@ -44,8 +44,26 @@ namespace OfficeIMO.Excel {
                         }
 
                         var name = table.Name?.Value ?? table.DisplayName?.Value ?? string.Empty;
+                        var displayName = table.DisplayName?.Value ?? name;
                         var range = table.Reference?.Value ?? string.Empty;
-                        result.Add(new ExcelTableInfo(name, range, sheetName, sheetIndex));
+                        var columns = table.TableColumns?.Elements<TableColumn>()
+                            .Select((column, index) => new ExcelTableColumnInfo(
+                                index + 1,
+                                column.Name?.Value ?? string.Empty,
+                                GetOpenXmlAttributeValue(column, "totalsRowFunction")))
+                            .ToList() ?? new List<ExcelTableColumnInfo>();
+
+                        result.Add(new ExcelTableInfo(
+                            name,
+                            displayName,
+                            range,
+                            sheetName,
+                            sheetIndex,
+                            table.TableStyleInfo?.Name?.Value,
+                            (table.HeaderRowCount?.Value ?? 1U) > 0U,
+                            table.TotalsRowShown?.Value == true,
+                            table.GetFirstChild<AutoFilter>() != null,
+                            columns));
                     }
                 }
 

--- a/OfficeIMO.Excel/ExcelDocument.Tables.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Tables.cs
@@ -61,7 +61,7 @@ namespace OfficeIMO.Excel {
                             sheetIndex,
                             table.TableStyleInfo?.Name?.Value,
                             (table.HeaderRowCount?.Value ?? 1U) > 0U,
-                            table.TotalsRowShown?.Value == true,
+                            (table.TotalsRowCount?.Value ?? 0U) > 0U,
                             table.GetFirstChild<AutoFilter>() != null,
                             columns));
                     }

--- a/OfficeIMO.Excel/ExcelDocument.Tables.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Tables.cs
@@ -35,7 +35,7 @@ namespace OfficeIMO.Excel {
 
                     sheetLookup.TryGetValue(relId, out var sheetInfo);
                     var sheetName = sheetInfo.Name ?? string.Empty;
-                    var sheetIndex = sheetInfo.Name == null ? -1 : sheetInfo.Index;
+                    var sheetIndex = string.IsNullOrEmpty(sheetInfo.Name) ? -1 : sheetInfo.Index;
 
                     foreach (var tablePart in worksheetPart.TableDefinitionParts) {
                         var table = tablePart.Table;

--- a/OfficeIMO.Excel/ExcelSheet.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Tables.cs
@@ -82,7 +82,12 @@ namespace OfficeIMO.Excel {
                 var styleInfo = table.TableStyleInfo;
                 if (styleInfo == null) {
                     styleInfo = new TableStyleInfo();
-                    table.Append(styleInfo);
+                    var extensionList = table.GetFirstChild<TableExtensionList>();
+                    if (extensionList == null) {
+                        table.Append(styleInfo);
+                    } else {
+                        table.InsertBefore(styleInfo, extensionList);
+                    }
                 }
 
                 styleInfo.Name = style.ToString();
@@ -109,6 +114,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 table.TotalsRowShown = true;
+                table.TotalsRowCount = 1U;
                 var tableColumns = table.TableColumns ?? throw new InvalidOperationException("Table columns are missing.");
                 foreach (var tc in tableColumns.Elements<TableColumn>()) {
                     var name = tc.Name?.Value ?? string.Empty;

--- a/OfficeIMO.Excel/ExcelSheet.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Tables.cs
@@ -14,27 +14,121 @@ namespace OfficeIMO.Excel {
             if (string.IsNullOrWhiteSpace(range)) throw new System.ArgumentNullException(nameof(range));
             if (byHeader == null) throw new System.ArgumentNullException(nameof(byHeader));
 
-            var totalsByHeader = new System.Collections.Generic.Dictionary<string, DocumentFormat.OpenXml.Spreadsheet.TotalsRowFunctionValues>(byHeader, System.StringComparer.OrdinalIgnoreCase);
+            SetTableTotalsCore(range, byHeader, throwIfMissing: false);
+        }
+
+        /// <summary>
+        /// Enables a totals row for the named table and assigns per-column functions by header name.
+        /// </summary>
+        /// <param name="tableName">Table name or display name.</param>
+        /// <param name="byHeader">Mapping of table header names to totals functions.</param>
+        public void SetTableTotalsByName(string tableName, System.Collections.Generic.IDictionary<string, DocumentFormat.OpenXml.Spreadsheet.TotalsRowFunctionValues> byHeader) {
+            if (string.IsNullOrWhiteSpace(tableName)) throw new System.ArgumentNullException(nameof(tableName));
+            if (byHeader == null) throw new System.ArgumentNullException(nameof(byHeader));
+
+            SetTableTotalsCore(tableName, byHeader, throwIfMissing: true);
+        }
+
+        /// <summary>
+        /// Clears totals-row settings for the table identified by range, name, or display name.
+        /// </summary>
+        /// <param name="tableOrRange">Table range, name, or display name.</param>
+        public void ClearTableTotals(string tableOrRange) {
+            if (string.IsNullOrWhiteSpace(tableOrRange)) throw new System.ArgumentNullException(nameof(tableOrRange));
+
             WriteLock(() => {
-                foreach (var tdp in _worksheetPart.TableDefinitionParts) {
-                    var table = tdp.Table;
-                    if (table is null) continue;
-                    if (table.Reference?.Value != range) continue;
-                    table.TotalsRowShown = true;
-                    var tableColumns = table.TableColumns ?? throw new InvalidOperationException("Table columns are missing.");
-                    var headerNames = tableColumns.Elements<TableColumn>().Select(tc => tc.Name?.Value ?? string.Empty).ToList();
-                    int idx = 0;
-                    foreach (var tc in tableColumns.Elements<TableColumn>()) {
-                        var name = headerNames[idx++];
-                        if (totalsByHeader.TryGetValue(name, out var fn)) {
-                            tc.TotalsRowFunction = fn;
-                        }
-                    }
-                    table.Save();
-                    break;
+                var table = FindTableByRangeNameOrDisplayName(tableOrRange);
+                if (table == null) {
+                    throw new InvalidOperationException($"Table '{tableOrRange}' was not found on worksheet '{Name}'.");
                 }
+
+                table.TotalsRowShown = false;
+                table.TotalsRowCount = 0U;
+                foreach (var tableColumn in table.TableColumns?.Elements<TableColumn>() ?? Enumerable.Empty<TableColumn>()) {
+                    tableColumn.TotalsRowFunction = null;
+                    tableColumn.TotalsRowFormula = null;
+                    tableColumn.TotalsRowLabel = null;
+                }
+
+                table.Save();
                 WorksheetRoot.Save();
             });
+        }
+
+        /// <summary>
+        /// Updates the visual style flags for the table identified by range, name, or display name.
+        /// </summary>
+        /// <param name="tableOrRange">Table range, name, or display name.</param>
+        /// <param name="style">Table style to apply.</param>
+        /// <param name="showFirstColumn">Optional first-column emphasis flag.</param>
+        /// <param name="showLastColumn">Optional last-column emphasis flag.</param>
+        /// <param name="showRowStripes">Optional row stripe flag.</param>
+        /// <param name="showColumnStripes">Optional column stripe flag.</param>
+        public void SetTableStyle(
+            string tableOrRange,
+            TableStyle style,
+            bool? showFirstColumn = null,
+            bool? showLastColumn = null,
+            bool? showRowStripes = null,
+            bool? showColumnStripes = null) {
+            if (string.IsNullOrWhiteSpace(tableOrRange)) throw new System.ArgumentNullException(nameof(tableOrRange));
+
+            WriteLock(() => {
+                var table = FindTableByRangeNameOrDisplayName(tableOrRange);
+                if (table == null) {
+                    throw new InvalidOperationException($"Table '{tableOrRange}' was not found on worksheet '{Name}'.");
+                }
+
+                var styleInfo = table.TableStyleInfo;
+                if (styleInfo == null) {
+                    styleInfo = new TableStyleInfo();
+                    table.Append(styleInfo);
+                }
+
+                styleInfo.Name = style.ToString();
+                if (showFirstColumn.HasValue) styleInfo.ShowFirstColumn = showFirstColumn.Value;
+                if (showLastColumn.HasValue) styleInfo.ShowLastColumn = showLastColumn.Value;
+                if (showRowStripes.HasValue) styleInfo.ShowRowStripes = showRowStripes.Value;
+                if (showColumnStripes.HasValue) styleInfo.ShowColumnStripes = showColumnStripes.Value;
+
+                table.Save();
+                WorksheetRoot.Save();
+            });
+        }
+
+        private void SetTableTotalsCore(string tableOrRange, System.Collections.Generic.IDictionary<string, DocumentFormat.OpenXml.Spreadsheet.TotalsRowFunctionValues> byHeader, bool throwIfMissing) {
+            var totalsByHeader = new System.Collections.Generic.Dictionary<string, DocumentFormat.OpenXml.Spreadsheet.TotalsRowFunctionValues>(byHeader, System.StringComparer.OrdinalIgnoreCase);
+            WriteLock(() => {
+                var table = FindTableByRangeNameOrDisplayName(tableOrRange);
+                if (table == null) {
+                    if (throwIfMissing) {
+                        throw new InvalidOperationException($"Table '{tableOrRange}' was not found on worksheet '{Name}'.");
+                    }
+
+                    return;
+                }
+
+                table.TotalsRowShown = true;
+                var tableColumns = table.TableColumns ?? throw new InvalidOperationException("Table columns are missing.");
+                foreach (var tc in tableColumns.Elements<TableColumn>()) {
+                    var name = tc.Name?.Value ?? string.Empty;
+                    if (totalsByHeader.TryGetValue(name, out var fn)) {
+                        tc.TotalsRowFunction = fn;
+                    }
+                }
+
+                table.Save();
+                WorksheetRoot.Save();
+            });
+        }
+
+        private Table? FindTableByRangeNameOrDisplayName(string tableOrRange) {
+            return _worksheetPart.TableDefinitionParts
+                .Select(part => part.Table)
+                .FirstOrDefault(table => table != null && (
+                    string.Equals(table.Reference?.Value, tableOrRange, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(table.Name?.Value, tableOrRange, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(table.DisplayName?.Value, tableOrRange, StringComparison.OrdinalIgnoreCase)));
         }
         /// <summary>
         /// Adds an AutoFilter to the worksheet or table.

--- a/OfficeIMO.Excel/ExcelTableInfo.cs
+++ b/OfficeIMO.Excel/ExcelTableInfo.cs
@@ -1,4 +1,30 @@
+using System.Collections.Generic;
+
 namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Represents a column inside an Excel table.
+    /// </summary>
+    public sealed class ExcelTableColumnInfo {
+        /// <summary>Initializes a new instance of the <see cref="ExcelTableColumnInfo"/> class.</summary>
+        /// <param name="index">1-based column index inside the table.</param>
+        /// <param name="name">Column name.</param>
+        /// <param name="totalsRowFunction">Totals row function name, when one is assigned.</param>
+        public ExcelTableColumnInfo(int index, string name, string? totalsRowFunction = null) {
+            Index = index;
+            Name = name ?? string.Empty;
+            TotalsRowFunction = totalsRowFunction;
+        }
+
+        /// <summary>1-based column index inside the table.</summary>
+        public int Index { get; }
+
+        /// <summary>Column name.</summary>
+        public string Name { get; }
+
+        /// <summary>Totals row function name, when one is assigned.</summary>
+        public string? TotalsRowFunction { get; }
+    }
+
     /// <summary>
     /// Represents a table defined in an Excel workbook.
     /// </summary>
@@ -8,15 +34,38 @@ namespace OfficeIMO.Excel {
         /// <param name="range">Table range in A1 notation.</param>
         /// <param name="sheetName">Sheet name containing the table.</param>
         /// <param name="sheetIndex">0-based sheet index; -1 when unknown.</param>
-        public ExcelTableInfo(string name, string range, string sheetName, int sheetIndex) {
+        public ExcelTableInfo(string name, string range, string sheetName, int sheetIndex)
+            : this(name, name, range, sheetName, sheetIndex, null, hasHeaderRow: true, totalsRowShown: false, hasAutoFilter: false, columns: null) {
+        }
+
+        internal ExcelTableInfo(
+            string name,
+            string displayName,
+            string range,
+            string sheetName,
+            int sheetIndex,
+            string? styleName,
+            bool hasHeaderRow,
+            bool totalsRowShown,
+            bool hasAutoFilter,
+            IReadOnlyList<ExcelTableColumnInfo>? columns) {
             Name = name ?? string.Empty;
+            DisplayName = displayName ?? string.Empty;
             Range = range ?? string.Empty;
             SheetName = sheetName ?? string.Empty;
             SheetIndex = sheetIndex;
+            StyleName = styleName;
+            HasHeaderRow = hasHeaderRow;
+            TotalsRowShown = totalsRowShown;
+            HasAutoFilter = hasAutoFilter;
+            Columns = columns ?? System.Array.Empty<ExcelTableColumnInfo>();
         }
 
         /// <summary>Table name (or display name).</summary>
         public string Name { get; }
+
+        /// <summary>Table display name.</summary>
+        public string DisplayName { get; }
 
         /// <summary>Table range in A1 notation.</summary>
         public string Range { get; }
@@ -26,5 +75,20 @@ namespace OfficeIMO.Excel {
 
         /// <summary>0-based sheet index; -1 when unknown.</summary>
         public int SheetIndex { get; }
+
+        /// <summary>Table style name, when present.</summary>
+        public string? StyleName { get; }
+
+        /// <summary>Whether the table has a header row.</summary>
+        public bool HasHeaderRow { get; }
+
+        /// <summary>Whether the table shows a totals row.</summary>
+        public bool TotalsRowShown { get; }
+
+        /// <summary>Whether the table has a table-scoped AutoFilter.</summary>
+        public bool HasAutoFilter { get; }
+
+        /// <summary>Table columns in display order.</summary>
+        public IReadOnlyList<ExcelTableColumnInfo> Columns { get; }
     }
 }

--- a/OfficeIMO.Tests/Excel.TableCatalog.cs
+++ b/OfficeIMO.Tests/Excel.TableCatalog.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Collections.Generic;
 using OfficeIMO.Excel;
 using Xunit;
+using TotalsRowFunctionValues = DocumentFormat.OpenXml.Spreadsheet.TotalsRowFunctionValues;
 
 namespace OfficeIMO.Tests {
     public partial class Excel {
@@ -26,6 +28,10 @@ namespace OfficeIMO.Tests {
                 sheet2.CellValue(2, 2, 2d);
                 sheet2.CellValue(2, 3, 3);
                 sheet2.AddTable("A1:C2", true, "TableTwo", TableStyle.TableStyleMedium9);
+                sheet2.SetTableTotalsByName("TableTwo", new Dictionary<string, TotalsRowFunctionValues> {
+                    ["Value"] = TotalsRowFunctionValues.Sum,
+                    ["Count"] = TotalsRowFunctionValues.Sum,
+                });
 
                 document.Save();
             }
@@ -38,11 +44,19 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("A1:B2", tableOne.Range);
                 Assert.Equal("SheetOne", tableOne.SheetName);
                 Assert.Equal(0, tableOne.SheetIndex);
+                Assert.Equal("TableStyleMedium9", tableOne.StyleName);
+                Assert.True(tableOne.HasHeaderRow);
+                Assert.True(tableOne.HasAutoFilter);
+                Assert.False(tableOne.TotalsRowShown);
+                Assert.Equal(new[] { "Name", "Value" }, tableOne.Columns.Select(column => column.Name).ToArray());
 
                 var tableTwo = tables.Single(t => t.Name == "TableTwo");
                 Assert.Equal("A1:C2", tableTwo.Range);
                 Assert.Equal("SheetTwo", tableTwo.SheetName);
                 Assert.Equal(1, tableTwo.SheetIndex);
+                Assert.True(tableTwo.TotalsRowShown);
+                Assert.Equal("sum", tableTwo.Columns.Single(column => column.Name == "Value").TotalsRowFunction);
+                Assert.Equal("sum", tableTwo.Columns.Single(column => column.Name == "Count").TotalsRowFunction);
             }
 
             File.Delete(filePath);

--- a/OfficeIMO.Tests/Excel.Tables.cs
+++ b/OfficeIMO.Tests/Excel.Tables.cs
@@ -243,6 +243,71 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Test_SetTableTotalsByNameAndClearTableTotals() {
+            string filePath = Path.Combine(_directoryWithFiles, "Table.TotalsByName.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Amount");
+                sheet.CellValue(2, 1, "A");
+                sheet.CellValue(2, 2, 2d);
+                sheet.AddTable("A1:B2", true, "SalesTable", TableStyle.TableStyleMedium9);
+
+                sheet.SetTableTotalsByName("SalesTable", new Dictionary<string, TotalsRowFunctionValues> {
+                    ["Name"] = TotalsRowFunctionValues.Count,
+                    ["Amount"] = TotalsRowFunctionValues.Sum,
+                });
+
+                sheet.ClearTableTotals("SalesTable");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                TableDefinitionPart tablePart = wsPart.TableDefinitionParts.First();
+                var table = tablePart.Table;
+
+                Assert.False(table.TotalsRowShown?.Value ?? false);
+                Assert.Equal((uint)0, table.TotalsRowCount!.Value);
+                Assert.All(table.TableColumns!.Elements<TableColumn>(), column => Assert.Null(column.TotalsRowFunction));
+            }
+        }
+
+        [Fact]
+        public void Test_SetTableStyleUpdatesNamedTableVisualFlags() {
+            string filePath = Path.Combine(_directoryWithFiles, "Table.StyleByName.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Amount");
+                sheet.CellValue(2, 1, "A");
+                sheet.CellValue(2, 2, 2d);
+                sheet.AddTable("A1:B2", true, "SalesTable", TableStyle.TableStyleMedium9);
+
+                sheet.SetTableStyle(
+                    "SalesTable",
+                    TableStyle.TableStyleLight11,
+                    showFirstColumn: true,
+                    showLastColumn: true,
+                    showRowStripes: false,
+                    showColumnStripes: true);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                TableDefinitionPart tablePart = wsPart.TableDefinitionParts.First();
+                var styleInfo = tablePart.Table.TableStyleInfo!;
+
+                Assert.Equal("TableStyleLight11", styleInfo.Name!.Value);
+                Assert.True(styleInfo.ShowFirstColumn?.Value);
+                Assert.True(styleInfo.ShowLastColumn?.Value);
+                Assert.False(styleInfo.ShowRowStripes?.Value);
+                Assert.True(styleInfo.ShowColumnStripes?.Value);
+            }
+        }
+
         private static string GetCellText(SpreadsheetDocument document, WorksheetPart worksheetPart, string cellReference) {
             var cell = worksheetPart.Worksheet.Descendants<DocumentFormat.OpenXml.Spreadsheet.Cell>()
                 .First(item => item.CellReference?.Value == cellReference);

--- a/OfficeIMO.Tests/Excel.Tables.cs
+++ b/OfficeIMO.Tests/Excel.Tables.cs
@@ -7,6 +7,8 @@ using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Excel;
 using Xunit;
 using TableColumn = DocumentFormat.OpenXml.Spreadsheet.TableColumn;
+using TableExtensionList = DocumentFormat.OpenXml.Spreadsheet.TableExtensionList;
+using TableStyleInfo = DocumentFormat.OpenXml.Spreadsheet.TableStyleInfo;
 using TotalsRowFunctionValues = DocumentFormat.OpenXml.Spreadsheet.TotalsRowFunctionValues;
 
 namespace OfficeIMO.Tests {
@@ -275,6 +277,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_SetTableTotalsByNameRestoresTotalsRowCountAfterClear() {
+            string filePath = Path.Combine(_directoryWithFiles, "Table.TotalsRestore.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Amount");
+                sheet.CellValue(2, 1, "A");
+                sheet.CellValue(2, 2, 2d);
+                sheet.AddTable("A1:B2", true, "SalesTable", TableStyle.TableStyleMedium9);
+
+                sheet.SetTableTotalsByName("SalesTable", new Dictionary<string, TotalsRowFunctionValues> {
+                    ["Name"] = TotalsRowFunctionValues.Count,
+                    ["Amount"] = TotalsRowFunctionValues.Sum,
+                });
+                sheet.ClearTableTotals("SalesTable");
+                sheet.SetTableTotalsByName("SalesTable", new Dictionary<string, TotalsRowFunctionValues> {
+                    ["Amount"] = TotalsRowFunctionValues.Sum,
+                });
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                TableDefinitionPart tablePart = wsPart.TableDefinitionParts.First();
+                var table = tablePart.Table;
+                var columns = table.TableColumns!.Elements<TableColumn>().ToList();
+
+                Assert.True(table.TotalsRowShown?.Value);
+                Assert.Equal((uint)1, table.TotalsRowCount!.Value);
+                Assert.Null(columns[0].TotalsRowFunction);
+                Assert.Equal(TotalsRowFunctionValues.Sum, columns[1].TotalsRowFunction?.Value);
+            }
+        }
+
+        [Fact]
         public void Test_SetTableStyleUpdatesNamedTableVisualFlags() {
             string filePath = Path.Combine(_directoryWithFiles, "Table.StyleByName.xlsx");
             using (var document = ExcelDocument.Create(filePath)) {
@@ -305,6 +342,45 @@ namespace OfficeIMO.Tests {
                 Assert.True(styleInfo.ShowLastColumn?.Value);
                 Assert.False(styleInfo.ShowRowStripes?.Value);
                 Assert.True(styleInfo.ShowColumnStripes?.Value);
+            }
+        }
+
+        [Fact]
+        public void Test_SetTableStyleInsertsBeforeExtensionList() {
+            string filePath = Path.Combine(_directoryWithFiles, "Table.StyleBeforeExtensionList.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Amount");
+                sheet.CellValue(2, 1, "A");
+                sheet.CellValue(2, 2, 2d);
+                sheet.AddTable("A1:B2", true, "SalesTable", TableStyle.TableStyleMedium9);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                TableDefinitionPart tablePart = wsPart.TableDefinitionParts.First();
+                tablePart.Table.TableStyleInfo!.Remove();
+                tablePart.Table.Append(new TableExtensionList());
+                tablePart.Table.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                document.GetSheet("Data").SetTableStyle("SalesTable", TableStyle.TableStyleLight11);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                TableDefinitionPart tablePart = wsPart.TableDefinitionParts.First();
+                var children = tablePart.Table.ChildElements.ToList();
+                int styleIndex = children.FindIndex(child => child is TableStyleInfo);
+                int extensionIndex = children.FindIndex(child => child is TableExtensionList);
+
+                Assert.True(styleIndex >= 0);
+                Assert.True(extensionIndex >= 0);
+                Assert.True(styleIndex < extensionIndex);
             }
         }
 


### PR DESCRIPTION
Summary: expand Excel table catalog metadata with style, header, totals, autofilter, and column details; add table-name helpers for totals rows and table style flags; cover metadata, totals clearing, and style updates in tests. Tests: OfficeIMO.Excel net8.0 build; focused Excel table metadata tests; DataSet/IDataReader/table append tests; worksheet copy/reorder/merge/compare tests.