### PR TITLE
Improve Excel sparkline range compatibility

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.Sparklines.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Sparklines.cs
@@ -3,6 +3,7 @@ using DocumentFormat.OpenXml.Spreadsheet;
 using DocumentFormat.OpenXml.Office2010.Excel;
 using OfficeFormula = DocumentFormat.OpenXml.Office.Excel.Formula;
 using OfficeReferenceSequence = DocumentFormat.OpenXml.Office.Excel.ReferenceSequence;
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace OfficeIMO.Excel {
@@ -76,11 +77,13 @@ namespace OfficeIMO.Excel {
                 ApplyColor(lastColor, rgb => group.LastMarkerColor = new LastMarkerColor { Rgb = rgb });
 
                 var sparklines = new Sparklines();
-                var sparkline = new Sparkline {
-                    Formula = new OfficeFormula(dataRange.Trim()),
-                    ReferenceSequence = new OfficeReferenceSequence(locationRange.Trim())
-                };
-                sparklines.Append(sparkline);
+                foreach (var sparklineReference in BuildSparklineReferences(dataRange, locationRange)) {
+                    var sparkline = new Sparkline {
+                        Formula = new OfficeFormula(sparklineReference.Formula),
+                        ReferenceSequence = new OfficeReferenceSequence(sparklineReference.Location)
+                    };
+                    sparklines.Append(sparkline);
+                }
                 group.Append(sparklines);
                 groups.Append(group);
 
@@ -172,6 +175,71 @@ namespace OfficeIMO.Excel {
             return new HexBinaryValue(value.ToUpperInvariant());
         }
 
+        private static IReadOnlyList<SparklineReference> BuildSparklineReferences(string dataRange, string locationRange) {
+            string data = dataRange.Trim();
+            string location = locationRange.Trim();
+
+            if (!TryParseSparklineRange(data, out var dataAddress) || !TryParseSparklineRange(location, out var locationAddress)) {
+                return new[] { new SparklineReference(data, location) };
+            }
+
+            if (locationAddress.RowCount == 1 && locationAddress.ColumnCount == 1) {
+                return new[] { new SparklineReference(data, location) };
+            }
+
+            var references = new List<SparklineReference>();
+            if (locationAddress.ColumnCount == 1 && dataAddress.RowCount == locationAddress.RowCount) {
+                for (int offset = 0; offset < locationAddress.RowCount; offset++) {
+                    int dataRow = dataAddress.Row1 + offset;
+                    int locationRow = locationAddress.Row1 + offset;
+                    references.Add(new SparklineReference(
+                        dataAddress.ToReference(dataRow, dataAddress.Column1, dataRow, dataAddress.Column2),
+                        locationAddress.ToReference(locationRow, locationAddress.Column1, locationRow, locationAddress.Column1)));
+                }
+
+                return references;
+            }
+
+            if (locationAddress.RowCount == 1 && dataAddress.ColumnCount == locationAddress.ColumnCount) {
+                for (int offset = 0; offset < locationAddress.ColumnCount; offset++) {
+                    int dataColumn = dataAddress.Column1 + offset;
+                    int locationColumn = locationAddress.Column1 + offset;
+                    references.Add(new SparklineReference(
+                        dataAddress.ToReference(dataAddress.Row1, dataColumn, dataAddress.Row2, dataColumn),
+                        locationAddress.ToReference(locationAddress.Row1, locationColumn, locationAddress.Row1, locationColumn)));
+                }
+
+                return references;
+            }
+
+            throw new ArgumentException(
+                "LocationRange spans multiple cells, but DataRange does not match by row or by column. " +
+                "Use a single destination cell, one data row per destination row, or one data column per destination column.",
+                nameof(locationRange));
+        }
+
+        private static bool TryParseSparklineRange(string text, out SparklineRange range) {
+            string trimmed = text.Trim();
+            int separator = trimmed.LastIndexOf('!');
+            string sheetPrefix = separator >= 0 ? trimmed.Substring(0, separator + 1) : string.Empty;
+            string reference = separator >= 0 ? trimmed.Substring(separator + 1) : trimmed;
+            reference = reference.Replace("$", string.Empty);
+
+            if (A1.TryParseRange(reference, out int r1, out int c1, out int r2, out int c2)) {
+                range = new SparklineRange(sheetPrefix, r1, c1, r2, c2);
+                return true;
+            }
+
+            var cell = A1.ParseCellRef(reference);
+            if (cell.Row > 0 && cell.Col > 0) {
+                range = new SparklineRange(sheetPrefix, cell.Row, cell.Col, cell.Row, cell.Col);
+                return true;
+            }
+
+            range = default;
+            return false;
+        }
+
         private static SparklineGroups GetOrCreateSparklineGroups(Worksheet ws) {
             const string SparklineUri = "{05C60535-1F16-4fd2-B633-F4F36F0B64E0}";
 
@@ -195,6 +263,50 @@ namespace OfficeIMO.Excel {
             }
 
             return groups;
+        }
+
+        private readonly struct SparklineReference {
+            internal SparklineReference(string formula, string location) {
+                Formula = formula;
+                Location = location;
+            }
+
+            internal string Formula { get; }
+
+            internal string Location { get; }
+        }
+
+        private readonly struct SparklineRange {
+            internal SparklineRange(string sheetPrefix, int row1, int column1, int row2, int column2) {
+                SheetPrefix = sheetPrefix;
+                Row1 = row1;
+                Column1 = column1;
+                Row2 = row2;
+                Column2 = column2;
+            }
+
+            internal string SheetPrefix { get; }
+
+            internal int Row1 { get; }
+
+            internal int Column1 { get; }
+
+            internal int Row2 { get; }
+
+            internal int Column2 { get; }
+
+            internal int RowCount => Row2 - Row1 + 1;
+
+            internal int ColumnCount => Column2 - Column1 + 1;
+
+            internal string ToReference(int row1, int column1, int row2, int column2) {
+                string start = SheetPrefix + A1.CellReference(row1, column1);
+                if (row1 == row2 && column1 == column2) {
+                    return start;
+                }
+
+                return start + ":" + A1.CellReference(row2, column2);
+            }
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.SheetRenameReferences.cs
+++ b/OfficeIMO.Tests/Excel.SheetRenameReferences.cs
@@ -92,7 +92,9 @@ namespace OfficeIMO.Tests {
                     .Select(f => f.Text)
                     .Where(f => !string.IsNullOrWhiteSpace(f))
                     .ToList();
-                Assert.Contains("'Renamed Data'!B2:B3", sparklineFormulas);
+                Assert.Contains("'Renamed Data'!B2", sparklineFormulas);
+                Assert.Contains("'Renamed Data'!B3", sparklineFormulas);
+                Assert.DoesNotContain(sparklineFormulas, f => f!.Contains("'Data'!", StringComparison.Ordinal));
 
                 var chartPart = worksheetPart.DrawingsPart!.ChartParts.First();
                 var chartFormulas = chartPart.ChartSpace!.Descendants<DocumentFormat.OpenXml.Drawing.Charts.Formula>()

--- a/OfficeIMO.Tests/Excel.WorksheetFeatures.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetFeatures.cs
@@ -6,6 +6,8 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using DocumentFormat.OpenXml.Office2010.Excel;
 using OfficeIMO.Excel;
+using OfficeFormula = DocumentFormat.OpenXml.Office.Excel.Formula;
+using OfficeReferenceSequence = DocumentFormat.OpenXml.Office.Excel.ReferenceSequence;
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -127,6 +129,9 @@ namespace OfficeIMO.Tests {
                     var group = groups.Elements<SparklineGroup>().FirstOrDefault();
                     Assert.NotNull(group);
                     Assert.Equal(SparklineTypeValues.Line, group!.Type?.Value);
+                    var sparkline = group.GetFirstChild<Sparklines>()!.Elements<Sparkline>().Single();
+                    Assert.Equal("B2:G2", sparkline.GetFirstChild<OfficeFormula>()!.Text);
+                    Assert.Equal("H2:H2", sparkline.GetFirstChild<OfficeReferenceSequence>()!.Text);
                 } else {
                     const string SparklineNamespace = "http://schemas.microsoft.com/office/excel/2009/9/main";
                     var unknown = wsPart.Worksheet.Descendants<OpenXmlUnknownElement>()
@@ -134,6 +139,90 @@ namespace OfficeIMO.Tests {
                         .FirstOrDefault(e => e.LocalName == "sparklineGroups" && e.NamespaceUri == SparklineNamespace);
                     Assert.NotNull(unknown);
                 }
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_WorksheetSparklines_MultiRowRangesExpandPerTargetCell() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelWorksheetSparklines.MultiRow.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sparklines");
+                for (int row = 2; row <= 4; row++) {
+                    sheet.CellValue(row, 3, (double)row);
+                    sheet.CellValue(row, 4, (double)(row + 10));
+                }
+
+                sheet.AddSparklines("C2:D4", "E2:E4", displayMarkers: true, seriesColor: "#FF0000");
+                document.Save(false);
+            }
+
+            using (var doc = SpreadsheetDocument.Open(filePath, false)) {
+                var wb = doc.WorkbookPart!;
+                var sheet = wb.Workbook.Sheets!.OfType<Sheet>().First(s => s.Name == "Sparklines");
+                var wsPart = (WorksheetPart)wb.GetPartById(sheet.Id!);
+                var group = wsPart.Worksheet.Descendants<SparklineGroup>().Single();
+                var sparklines = group.GetFirstChild<Sparklines>()!.Elements<Sparkline>().ToList();
+
+                Assert.Equal(3, sparklines.Count);
+                Assert.Equal(new[] { "C2:D2", "C3:D3", "C4:D4" },
+                    sparklines.Select(s => s.GetFirstChild<OfficeFormula>()!.Text).ToArray());
+                Assert.Equal(new[] { "E2", "E3", "E4" },
+                    sparklines.Select(s => s.GetFirstChild<OfficeReferenceSequence>()!.Text).ToArray());
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_WorksheetSparklines_MultiColumnRangesExpandPerTargetCell() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelWorksheetSparklines.MultiColumn.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sparklines");
+                for (int row = 2; row <= 4; row++) {
+                    sheet.CellValue(row, 3, (double)row);
+                    sheet.CellValue(row, 4, (double)(row + 10));
+                }
+
+                sheet.AddSparklines("C2:D4", "C5:D5", displayMarkers: true, seriesColor: "#FF0000");
+                document.Save(false);
+            }
+
+            using (var doc = SpreadsheetDocument.Open(filePath, false)) {
+                var wb = doc.WorkbookPart!;
+                var sheet = wb.Workbook.Sheets!.OfType<Sheet>().First(s => s.Name == "Sparklines");
+                var wsPart = (WorksheetPart)wb.GetPartById(sheet.Id!);
+                var group = wsPart.Worksheet.Descendants<SparklineGroup>().Single();
+                var sparklines = group.GetFirstChild<Sparklines>()!.Elements<Sparkline>().ToList();
+
+                Assert.Equal(2, sparklines.Count);
+                Assert.Equal(new[] { "C2:C4", "D2:D4" },
+                    sparklines.Select(s => s.GetFirstChild<OfficeFormula>()!.Text).ToArray());
+                Assert.Equal(new[] { "C5", "D5" },
+                    sparklines.Select(s => s.GetFirstChild<OfficeReferenceSequence>()!.Text).ToArray());
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_WorksheetSparklines_AmbiguousMultiCellLocationThrows() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelWorksheetSparklines.InvalidShape.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Sparklines");
+
+                var exception = Assert.Throws<ArgumentException>(() => sheet.AddSparklines("C2:D4", "E2:F4"));
+                Assert.Equal("locationRange", exception.ParamName);
             }
         }
 


### PR DESCRIPTION
## Summary
- expand multi-cell sparkline destinations into one sparkline per target cell for row-wise and column-wise ranges
- keep single-destination sparkline calls compatible, including existing range text
- add tests for row-wise, column-wise, ambiguous destination handling, OpenXML validation, and rename reference updates

## Validation
- dotnet build OfficeIMO.Excel\OfficeIMO.Excel.csproj -f net8.0 --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net8.0 --filter "FullyQualifiedName~OfficeIMO.Tests.Excel.Test_WorksheetSparklines|FullyQualifiedName~OfficeIMO.Tests.Excel.MixedFeatureWorkbookValidatesWithoutRepairSignals|FullyQualifiedName~OfficeIMO.Tests.Excel.Test_RenameWorkSheet_UpdatesChartsPivotsAndSparklines|FullyQualifiedName~OfficeIMO.Tests.Excel.Test_AddPivotTableAndReadBack" --no-restore