### PR TITLE
Improve Excel pivot formatting and pivot chart metadata

### DIFF
--- a/OfficeIMO.Excel/COMPATIBILITY.md
+++ b/OfficeIMO.Excel/COMPATIBILITY.md
@@ -16,7 +16,7 @@ It is intentionally honest. "Partial" means usable, not "done".
 | Tables and named ranges | Supported | Table creation and naming safeguards are in place, with worksheet/global named range helpers. |
 | Auto-fit and report ergonomics | Supported | Auto-fit, object insertion, and table/report helpers are a current strength. |
 | Charts | Partial | Common chart authoring is present, including axis titles/formats/scale/gridlines, series styling, trendlines, secondary-axis combo scenarios, and pivot-source chart metadata, but breadth and round-trip parity are still behind top-tier competitors. |
-| Pivot tables | Partial | Source-range pivot creation supports row/column/page/data fields, layouts, styles, display flags, data-field number formats, and field sort/subtotal/display options, but grouping and richer filtering remain parity targets. |
+| Pivot tables | Partial | Source-range pivot creation supports row/column/page/data fields, layouts, styles, display flags, captions, data-field number formats, field sort/subtotal/display options, field item visibility filters, and selected page-field items. Date/number grouping and advanced value/label filters remain parity targets. |
 | Formula/recalculation story | Partial | Formula authoring exists, but the package does not yet present a first-class recalculation/value-engine story comparable to EPPlus expectations. |
 | Worksheet/workbook protection | Partial | Protection helpers exist, but broader permission fidelity and compatibility proof are still needed. |
 | Encryption/password support | Roadmap | This remains a notable gap for enterprise-style workbook scenarios. |

--- a/OfficeIMO.Excel/COMPATIBILITY.md
+++ b/OfficeIMO.Excel/COMPATIBILITY.md
@@ -15,8 +15,8 @@ It is intentionally honest. "Partial" means usable, not "done".
 | Number/date import fidelity | Partial | Common formats work well; custom formats are better after the token-aware classifier, but the corpus still needs to grow. |
 | Tables and named ranges | Supported | Table creation and naming safeguards are in place, with worksheet/global named range helpers. |
 | Auto-fit and report ergonomics | Supported | Auto-fit, object insertion, and table/report helpers are a current strength. |
-| Charts | Partial | Common chart authoring is present, but breadth and round-trip parity are still behind top-tier competitors. |
-| Pivot tables | Partial | Basic support exists, but this is not yet a broad parity surface. |
+| Charts | Partial | Common chart authoring is present, including axis titles/formats/scale/gridlines, series styling, trendlines, secondary-axis combo scenarios, and pivot-source chart metadata, but breadth and round-trip parity are still behind top-tier competitors. |
+| Pivot tables | Partial | Source-range pivot creation supports row/column/page/data fields, layouts, styles, display flags, data-field number formats, and field sort/subtotal/display options, but grouping and richer filtering remain parity targets. |
 | Formula/recalculation story | Partial | Formula authoring exists, but the package does not yet present a first-class recalculation/value-engine story comparable to EPPlus expectations. |
 | Worksheet/workbook protection | Partial | Protection helpers exist, but broader permission fidelity and compatibility proof are still needed. |
 | Encryption/password support | Roadmap | This remains a notable gap for enterprise-style workbook scenarios. |

--- a/OfficeIMO.Excel/ExcelChart.cs
+++ b/OfficeIMO.Excel/ExcelChart.cs
@@ -44,6 +44,53 @@ namespace OfficeIMO.Excel {
         public ExcelChartDataRange? DataRange => _dataRange;
 
         /// <summary>
+        /// Gets whether the chart declares a pivot table source.
+        /// </summary>
+        public bool IsPivotChart => !string.IsNullOrWhiteSpace(PivotTableName);
+
+        /// <summary>
+        /// Gets the pivot table name used as this chart's pivot source, if present.
+        /// </summary>
+        public string? PivotTableName {
+            get {
+                ChartPart chartPart = GetChartPart();
+                return chartPart.ChartSpace?
+                    .GetFirstChild<C.PivotSource>()?
+                    .GetFirstChild<C.PivotTableName>()?
+                    .Text;
+            }
+        }
+
+        /// <summary>
+        /// Marks the chart as sourced from a pivot table.
+        /// </summary>
+        /// <param name="pivotTableName">Pivot table name to assign as the chart's pivot source.</param>
+        /// <param name="formatId">Pivot chart format id.</param>
+        public ExcelChart SetPivotSource(string pivotTableName, uint formatId = 0U) {
+            if (string.IsNullOrWhiteSpace(pivotTableName)) {
+                throw new ArgumentNullException(nameof(pivotTableName));
+            }
+
+            ChartPart chartPart = GetChartPart();
+            C.ChartSpace chartSpace = chartPart.ChartSpace ?? throw new InvalidOperationException("Chart space not found in chart part.");
+            chartSpace.RemoveAllChildren<C.PivotSource>();
+
+            var pivotSource = new C.PivotSource(
+                new C.PivotTableName { Text = pivotTableName.Trim() },
+                new C.FormatId { Val = formatId });
+
+            C.Chart? chart = chartSpace.GetFirstChild<C.Chart>();
+            if (chart != null) {
+                chartSpace.InsertBefore(pivotSource, chart);
+            } else {
+                chartSpace.Append(pivotSource);
+            }
+
+            Save();
+            return this;
+        }
+
+        /// <summary>
         /// Updates the chart data (series and categories).
         /// </summary>
         public ExcelChart UpdateData(ExcelChartData data, ExcelChartDataRange? dataRange = null, bool writeToSheet = true) {

--- a/OfficeIMO.Excel/ExcelPivotDataField.cs
+++ b/OfficeIMO.Excel/ExcelPivotDataField.cs
@@ -13,14 +13,17 @@ namespace OfficeIMO.Excel {
         /// <param name="function">Aggregation function (Sum, Count, Average, ...).</param>
         /// <param name="displayName">Optional display name for the data field.</param>
         /// <param name="numberFormatId">Optional number format id to apply to the data field.</param>
+        /// <param name="numberFormat">Optional number format code to apply to the data field.</param>
         public ExcelPivotDataField(string fieldName,
             DataConsolidateFunctionValues? function = null,
             string? displayName = null,
-            uint? numberFormatId = null) {
+            uint? numberFormatId = null,
+            string? numberFormat = null) {
             FieldName = fieldName ?? throw new ArgumentNullException(nameof(fieldName));
             Function = function ?? DataConsolidateFunctionValues.Sum;
             DisplayName = displayName;
             NumberFormatId = numberFormatId;
+            NumberFormat = numberFormat;
         }
 
         /// <summary>
@@ -42,5 +45,10 @@ namespace OfficeIMO.Excel {
         /// Gets the optional number format id for the data field.
         /// </summary>
         public uint? NumberFormatId { get; }
+
+        /// <summary>
+        /// Gets the optional number format code for the data field.
+        /// </summary>
+        public string? NumberFormat { get; }
     }
 }

--- a/OfficeIMO.Excel/ExcelPivotDataFieldInfo.cs
+++ b/OfficeIMO.Excel/ExcelPivotDataFieldInfo.cs
@@ -8,10 +8,11 @@ namespace OfficeIMO.Excel {
         /// <summary>
         /// Creates a data field info instance.
         /// </summary>
-        public ExcelPivotDataFieldInfo(string fieldName, DataConsolidateFunctionValues function, string? displayName) {
+        public ExcelPivotDataFieldInfo(string fieldName, DataConsolidateFunctionValues function, string? displayName, uint? numberFormatId = null) {
             FieldName = fieldName;
             Function = function;
             DisplayName = displayName;
+            NumberFormatId = numberFormatId;
         }
 
         /// <summary>
@@ -28,5 +29,10 @@ namespace OfficeIMO.Excel {
         /// Gets the display name for the data field.
         /// </summary>
         public string? DisplayName { get; }
+
+        /// <summary>
+        /// Gets the number format id applied to the data field.
+        /// </summary>
+        public uint? NumberFormatId { get; }
     }
 }

--- a/OfficeIMO.Excel/ExcelPivotFieldInfo.cs
+++ b/OfficeIMO.Excel/ExcelPivotFieldInfo.cs
@@ -1,0 +1,126 @@
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Describes a source field in an existing pivot table.
+    /// </summary>
+    public sealed class ExcelPivotFieldInfo {
+        /// <summary>
+        /// Creates pivot field readback information.
+        /// </summary>
+        public ExcelPivotFieldInfo(
+            string fieldName,
+            PivotTableAxisValues? axis = null,
+            FieldSortValues? sortType = null,
+            uint? numberFormatId = null,
+            bool? showAll = null,
+            bool? defaultSubtotal = null,
+            bool? subtotalTop = null,
+            bool? insertBlankRow = null,
+            bool? insertPageBreak = null,
+            bool? compact = null,
+            bool? outline = null,
+            bool? showDropDowns = null,
+            bool? multipleItemSelectionAllowed = null,
+            bool? includeNewItemsInFilter = null,
+            string? subtotalCaption = null,
+            IReadOnlyList<string>? hiddenItems = null) {
+            FieldName = fieldName;
+            Axis = axis;
+            SortType = sortType;
+            NumberFormatId = numberFormatId;
+            ShowAll = showAll;
+            DefaultSubtotal = defaultSubtotal;
+            SubtotalTop = subtotalTop;
+            InsertBlankRow = insertBlankRow;
+            InsertPageBreak = insertPageBreak;
+            Compact = compact;
+            Outline = outline;
+            ShowDropDowns = showDropDowns;
+            MultipleItemSelectionAllowed = multipleItemSelectionAllowed;
+            IncludeNewItemsInFilter = includeNewItemsInFilter;
+            SubtotalCaption = subtotalCaption;
+            HiddenItems = hiddenItems ?? Array.Empty<string>();
+        }
+
+        /// <summary>
+        /// Gets the source field name.
+        /// </summary>
+        public string FieldName { get; }
+
+        /// <summary>
+        /// Gets the pivot axis this field is assigned to, if any.
+        /// </summary>
+        public PivotTableAxisValues? Axis { get; }
+
+        /// <summary>
+        /// Gets the sort mode.
+        /// </summary>
+        public FieldSortValues? SortType { get; }
+
+        /// <summary>
+        /// Gets the field number format id.
+        /// </summary>
+        public uint? NumberFormatId { get; }
+
+        /// <summary>
+        /// Gets whether all items should be shown.
+        /// </summary>
+        public bool? ShowAll { get; }
+
+        /// <summary>
+        /// Gets whether the default subtotal is used.
+        /// </summary>
+        public bool? DefaultSubtotal { get; }
+
+        /// <summary>
+        /// Gets whether subtotals are shown at the top.
+        /// </summary>
+        public bool? SubtotalTop { get; }
+
+        /// <summary>
+        /// Gets whether a blank row is inserted after each item.
+        /// </summary>
+        public bool? InsertBlankRow { get; }
+
+        /// <summary>
+        /// Gets whether a page break is inserted after each item.
+        /// </summary>
+        public bool? InsertPageBreak { get; }
+
+        /// <summary>
+        /// Gets whether compact field layout is enabled.
+        /// </summary>
+        public bool? Compact { get; }
+
+        /// <summary>
+        /// Gets whether outline field layout is enabled.
+        /// </summary>
+        public bool? Outline { get; }
+
+        /// <summary>
+        /// Gets whether filter drop-downs are shown for the field.
+        /// </summary>
+        public bool? ShowDropDowns { get; }
+
+        /// <summary>
+        /// Gets whether multiple item selection is allowed.
+        /// </summary>
+        public bool? MultipleItemSelectionAllowed { get; }
+
+        /// <summary>
+        /// Gets whether new items are included in the filter by default.
+        /// </summary>
+        public bool? IncludeNewItemsInFilter { get; }
+
+        /// <summary>
+        /// Gets the custom subtotal caption.
+        /// </summary>
+        public string? SubtotalCaption { get; }
+
+        /// <summary>
+        /// Gets hidden item captions captured from the field item list.
+        /// </summary>
+        public IReadOnlyList<string> HiddenItems { get; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelPivotFieldOptions.cs
+++ b/OfficeIMO.Excel/ExcelPivotFieldOptions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.Excel {
@@ -17,6 +19,16 @@ namespace OfficeIMO.Excel {
         /// <param name="defaultSubtotal">Whether to use the default subtotal for the pivot field.</param>
         /// <param name="subtotalTop">Whether subtotals should be shown at the top.</param>
         /// <param name="insertBlankRow">Whether to insert a blank row after each item.</param>
+        /// <param name="insertPageBreak">Whether to insert a page break after each item.</param>
+        /// <param name="compact">Whether compact layout is enabled for this field.</param>
+        /// <param name="outline">Whether outline layout is enabled for this field.</param>
+        /// <param name="showDropDowns">Whether field drop-downs are shown.</param>
+        /// <param name="multipleItemSelectionAllowed">Whether multiple filter item selection is allowed.</param>
+        /// <param name="includeNewItemsInFilter">Whether new source items are included in the filter by default.</param>
+        /// <param name="subtotalCaption">Optional custom subtotal caption.</param>
+        /// <param name="hiddenItems">Optional source item captions to hide.</param>
+        /// <param name="visibleItems">Optional source item captions to show; other known items are hidden.</param>
+        /// <param name="selectedItem">Optional page-field item caption to select.</param>
         public ExcelPivotFieldOptions(
             string fieldName,
             FieldSortValues? sortType = null,
@@ -25,7 +37,17 @@ namespace OfficeIMO.Excel {
             bool? showAll = null,
             bool? defaultSubtotal = null,
             bool? subtotalTop = null,
-            bool? insertBlankRow = null) {
+            bool? insertBlankRow = null,
+            bool? insertPageBreak = null,
+            bool? compact = null,
+            bool? outline = null,
+            bool? showDropDowns = null,
+            bool? multipleItemSelectionAllowed = null,
+            bool? includeNewItemsInFilter = null,
+            string? subtotalCaption = null,
+            IEnumerable<string>? hiddenItems = null,
+            IEnumerable<string>? visibleItems = null,
+            string? selectedItem = null) {
             FieldName = fieldName ?? throw new ArgumentNullException(nameof(fieldName));
             SortType = sortType;
             NumberFormatId = numberFormatId;
@@ -34,6 +56,19 @@ namespace OfficeIMO.Excel {
             DefaultSubtotal = defaultSubtotal;
             SubtotalTop = subtotalTop;
             InsertBlankRow = insertBlankRow;
+            InsertPageBreak = insertPageBreak;
+            Compact = compact;
+            Outline = outline;
+            ShowDropDowns = showDropDowns;
+            MultipleItemSelectionAllowed = multipleItemSelectionAllowed;
+            IncludeNewItemsInFilter = includeNewItemsInFilter;
+            SubtotalCaption = subtotalCaption;
+            HiddenItems = NormalizeItems(hiddenItems);
+            VisibleItems = NormalizeItems(visibleItems);
+            SelectedItem = string.IsNullOrWhiteSpace(selectedItem) ? null : selectedItem!.Trim();
+            if (HiddenItems.Count > 0 && VisibleItems.Count > 0) {
+                throw new ArgumentException("Specify either hiddenItems or visibleItems, not both.");
+            }
         }
 
         /// <summary>
@@ -75,5 +110,64 @@ namespace OfficeIMO.Excel {
         /// Gets whether to insert a blank row after each item.
         /// </summary>
         public bool? InsertBlankRow { get; }
+
+        /// <summary>
+        /// Gets whether to insert a page break after each item.
+        /// </summary>
+        public bool? InsertPageBreak { get; }
+
+        /// <summary>
+        /// Gets whether compact layout is enabled for this field.
+        /// </summary>
+        public bool? Compact { get; }
+
+        /// <summary>
+        /// Gets whether outline layout is enabled for this field.
+        /// </summary>
+        public bool? Outline { get; }
+
+        /// <summary>
+        /// Gets whether field drop-downs are shown.
+        /// </summary>
+        public bool? ShowDropDowns { get; }
+
+        /// <summary>
+        /// Gets whether multiple item selection is allowed.
+        /// </summary>
+        public bool? MultipleItemSelectionAllowed { get; }
+
+        /// <summary>
+        /// Gets whether new source items are included in the filter by default.
+        /// </summary>
+        public bool? IncludeNewItemsInFilter { get; }
+
+        /// <summary>
+        /// Gets the optional custom subtotal caption.
+        /// </summary>
+        public string? SubtotalCaption { get; }
+
+        /// <summary>
+        /// Gets source item captions to hide.
+        /// </summary>
+        public IReadOnlyList<string> HiddenItems { get; }
+
+        /// <summary>
+        /// Gets source item captions to show; other known items are hidden.
+        /// </summary>
+        public IReadOnlyList<string> VisibleItems { get; }
+
+        /// <summary>
+        /// Gets the selected page-field item caption.
+        /// </summary>
+        public string? SelectedItem { get; }
+
+        private static IReadOnlyList<string> NormalizeItems(IEnumerable<string>? items) {
+            if (items == null) return Array.Empty<string>();
+            return items
+                .Where(item => !string.IsNullOrWhiteSpace(item))
+                .Select(item => item.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
     }
 }

--- a/OfficeIMO.Excel/ExcelPivotFieldOptions.cs
+++ b/OfficeIMO.Excel/ExcelPivotFieldOptions.cs
@@ -1,0 +1,79 @@
+using System;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Describes formatting and display options for a pivot source field.
+    /// </summary>
+    public sealed class ExcelPivotFieldOptions {
+        /// <summary>
+        /// Creates pivot field options for a source field.
+        /// </summary>
+        /// <param name="fieldName">Header name from the source range.</param>
+        /// <param name="sortType">Optional pivot field sort mode.</param>
+        /// <param name="numberFormatId">Optional number format id to apply to the pivot field.</param>
+        /// <param name="numberFormat">Optional number format code to apply to the pivot field.</param>
+        /// <param name="showAll">Whether to show all items for the pivot field.</param>
+        /// <param name="defaultSubtotal">Whether to use the default subtotal for the pivot field.</param>
+        /// <param name="subtotalTop">Whether subtotals should be shown at the top.</param>
+        /// <param name="insertBlankRow">Whether to insert a blank row after each item.</param>
+        public ExcelPivotFieldOptions(
+            string fieldName,
+            FieldSortValues? sortType = null,
+            uint? numberFormatId = null,
+            string? numberFormat = null,
+            bool? showAll = null,
+            bool? defaultSubtotal = null,
+            bool? subtotalTop = null,
+            bool? insertBlankRow = null) {
+            FieldName = fieldName ?? throw new ArgumentNullException(nameof(fieldName));
+            SortType = sortType;
+            NumberFormatId = numberFormatId;
+            NumberFormat = numberFormat;
+            ShowAll = showAll;
+            DefaultSubtotal = defaultSubtotal;
+            SubtotalTop = subtotalTop;
+            InsertBlankRow = insertBlankRow;
+        }
+
+        /// <summary>
+        /// Gets the source field name.
+        /// </summary>
+        public string FieldName { get; }
+
+        /// <summary>
+        /// Gets the optional pivot field sort mode.
+        /// </summary>
+        public FieldSortValues? SortType { get; }
+
+        /// <summary>
+        /// Gets the optional number format id.
+        /// </summary>
+        public uint? NumberFormatId { get; }
+
+        /// <summary>
+        /// Gets the optional number format code.
+        /// </summary>
+        public string? NumberFormat { get; }
+
+        /// <summary>
+        /// Gets whether all items should be shown for the field.
+        /// </summary>
+        public bool? ShowAll { get; }
+
+        /// <summary>
+        /// Gets whether the default subtotal should be used.
+        /// </summary>
+        public bool? DefaultSubtotal { get; }
+
+        /// <summary>
+        /// Gets whether subtotals should be shown at the top.
+        /// </summary>
+        public bool? SubtotalTop { get; }
+
+        /// <summary>
+        /// Gets whether to insert a blank row after each item.
+        /// </summary>
+        public bool? InsertBlankRow { get; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelPivotTableInfo.cs
+++ b/OfficeIMO.Excel/ExcelPivotTableInfo.cs
@@ -22,10 +22,24 @@ namespace OfficeIMO.Excel {
             bool? showEmptyRows,
             bool? showEmptyColumns,
             bool? showDrill,
+            bool? rowGrandTotals,
+            bool? columnGrandTotals,
+            string? rowHeaderCaption,
+            string? columnHeaderCaption,
+            string? grandTotalCaption,
+            string? missingCaption,
+            string? errorCaption,
+            bool? showDataDropDown,
+            bool? showDropZones,
+            bool? showDataTips,
+            bool? showMemberPropertyTips,
+            bool? fieldListSortAscending,
+            bool? customListSort,
             IReadOnlyList<string> rowFields,
             IReadOnlyList<string> columnFields,
             IReadOnlyList<string> pageFields,
-            IReadOnlyList<ExcelPivotDataFieldInfo> dataFields) {
+            IReadOnlyList<ExcelPivotDataFieldInfo> dataFields,
+            IReadOnlyList<ExcelPivotFieldInfo>? fields = null) {
             Name = name;
             CacheId = cacheId;
             Location = location;
@@ -40,10 +54,24 @@ namespace OfficeIMO.Excel {
             ShowEmptyRows = showEmptyRows;
             ShowEmptyColumns = showEmptyColumns;
             ShowDrill = showDrill;
+            RowGrandTotals = rowGrandTotals;
+            ColumnGrandTotals = columnGrandTotals;
+            RowHeaderCaption = rowHeaderCaption;
+            ColumnHeaderCaption = columnHeaderCaption;
+            GrandTotalCaption = grandTotalCaption;
+            MissingCaption = missingCaption;
+            ErrorCaption = errorCaption;
+            ShowDataDropDown = showDataDropDown;
+            ShowDropZones = showDropZones;
+            ShowDataTips = showDataTips;
+            ShowMemberPropertyTips = showMemberPropertyTips;
+            FieldListSortAscending = fieldListSortAscending;
+            CustomListSort = customListSort;
             RowFields = rowFields;
             ColumnFields = columnFields;
             PageFields = pageFields;
             DataFields = dataFields;
+            Fields = fields ?? Array.Empty<ExcelPivotFieldInfo>();
         }
 
         /// <summary>
@@ -117,6 +145,71 @@ namespace OfficeIMO.Excel {
         public bool? ShowDrill { get; }
 
         /// <summary>
+        /// Gets whether row grand totals are shown.
+        /// </summary>
+        public bool? RowGrandTotals { get; }
+
+        /// <summary>
+        /// Gets whether column grand totals are shown.
+        /// </summary>
+        public bool? ColumnGrandTotals { get; }
+
+        /// <summary>
+        /// Gets the row header caption.
+        /// </summary>
+        public string? RowHeaderCaption { get; }
+
+        /// <summary>
+        /// Gets the column header caption.
+        /// </summary>
+        public string? ColumnHeaderCaption { get; }
+
+        /// <summary>
+        /// Gets the grand total caption.
+        /// </summary>
+        public string? GrandTotalCaption { get; }
+
+        /// <summary>
+        /// Gets the missing-value caption.
+        /// </summary>
+        public string? MissingCaption { get; }
+
+        /// <summary>
+        /// Gets the error-value caption.
+        /// </summary>
+        public string? ErrorCaption { get; }
+
+        /// <summary>
+        /// Gets whether the data drop-down is shown.
+        /// </summary>
+        public bool? ShowDataDropDown { get; }
+
+        /// <summary>
+        /// Gets whether drop zones are shown.
+        /// </summary>
+        public bool? ShowDropZones { get; }
+
+        /// <summary>
+        /// Gets whether data tips are shown.
+        /// </summary>
+        public bool? ShowDataTips { get; }
+
+        /// <summary>
+        /// Gets whether member-property tips are shown.
+        /// </summary>
+        public bool? ShowMemberPropertyTips { get; }
+
+        /// <summary>
+        /// Gets whether the field list sorts ascending.
+        /// </summary>
+        public bool? FieldListSortAscending { get; }
+
+        /// <summary>
+        /// Gets whether custom-list sorting is enabled.
+        /// </summary>
+        public bool? CustomListSort { get; }
+
+        /// <summary>
         /// Gets row field names.
         /// </summary>
         public IReadOnlyList<string> RowFields { get; }
@@ -135,5 +228,10 @@ namespace OfficeIMO.Excel {
         /// Gets data fields.
         /// </summary>
         public IReadOnlyList<ExcelPivotDataFieldInfo> DataFields { get; }
+
+        /// <summary>
+        /// Gets detailed field metadata.
+        /// </summary>
+        public IReadOnlyList<ExcelPivotFieldInfo> Fields { get; }
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.Charts.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Charts.cs
@@ -138,6 +138,25 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
+        /// Adds a chart using an A1 range and marks it as sourced from an existing pivot table.
+        /// </summary>
+        public ExcelChart AddPivotChartFromRange(string pivotTableName, string dataRangeA1, int row, int column, int widthPixels = 640, int heightPixels = 360,
+            ExcelChartType type = ExcelChartType.ColumnClustered, bool hasHeaders = true, string? title = null, bool includeCachedData = true, uint formatId = 0U) {
+            if (string.IsNullOrWhiteSpace(pivotTableName)) throw new ArgumentNullException(nameof(pivotTableName));
+
+            string? resolvedName = GetPivotTables()
+                .FirstOrDefault(p => string.Equals(p.Name, pivotTableName, StringComparison.OrdinalIgnoreCase))
+                ?.Name;
+            if (string.IsNullOrWhiteSpace(resolvedName)) {
+                throw new InvalidOperationException($"Pivot table '{pivotTableName}' was not found on sheet '{Name}'.");
+            }
+
+            ExcelChart chart = AddChartFromRange(dataRangeA1, row, column, widthPixels, heightPixels, type, hasHeaders, title, includeCachedData);
+            chart.SetPivotSource(resolvedName!, formatId);
+            return chart;
+        }
+
+        /// <summary>
         /// Adds a scatter chart using explicit X/Y ranges.
         /// </summary>
         public ExcelChart AddScatterChartFromRanges(IEnumerable<ExcelChartSeriesRange> seriesRanges, int row, int column, int widthPixels = 640,

--- a/OfficeIMO.Excel/ExcelSheet.PivotTables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PivotTables.cs
@@ -76,6 +76,7 @@ namespace OfficeIMO.Excel {
         /// <param name="showEmptyRows">Whether to show empty rows.</param>
         /// <param name="showEmptyColumns">Whether to show empty columns.</param>
         /// <param name="showDrill">Whether to show drill indicators.</param>
+        /// <param name="fieldOptions">Optional formatting and display options for source fields.</param>
         public void AddPivotTable(
             string sourceRange,
             string destinationCell,
@@ -92,7 +93,8 @@ namespace OfficeIMO.Excel {
             bool? showHeaders = null,
             bool? showEmptyRows = null,
             bool? showEmptyColumns = null,
-            bool? showDrill = null) {
+            bool? showDrill = null,
+            IEnumerable<ExcelPivotFieldOptions>? fieldOptions = null) {
             if (string.IsNullOrWhiteSpace(sourceRange)) throw new ArgumentNullException(nameof(sourceRange));
             if (string.IsNullOrWhiteSpace(destinationCell)) throw new ArgumentNullException(nameof(destinationCell));
             if (!A1.TryParseRange(sourceRange, out int r1, out int c1, out int r2, out int c2)) {
@@ -145,6 +147,7 @@ namespace OfficeIMO.Excel {
 
                 var workbookPart = WorkbookPartRoot;
                 var workbook = workbookPart.Workbook ??= new Workbook();
+                var fieldOptionMap = BuildPivotFieldOptionMap(fieldOptions, headerIndex);
                 uint cacheId = NextPivotCacheId(workbookPart);
 
                 var cacheDefPart = workbookPart.AddNewPart<PivotTableCacheDefinitionPart>();
@@ -194,11 +197,13 @@ namespace OfficeIMO.Excel {
 
                 var pivotFields = new PivotFields { Count = (uint)headers.Count };
                 for (int i = 0; i < headers.Count; i++) {
-                    var pivotField = new PivotField { ShowAll = true };
+                    fieldOptionMap.TryGetValue(i, out var options);
+                    var pivotField = new PivotField { ShowAll = options?.ShowAll ?? true };
                     if (pageFieldIndices.Contains(i)) pivotField.Axis = PivotTableAxisValues.AxisPage;
                     if (rowFieldIndices.Contains(i)) pivotField.Axis = PivotTableAxisValues.AxisRow;
                     if (columnFieldIndices.Contains(i)) pivotField.Axis = PivotTableAxisValues.AxisColumn;
                     if (dataFieldIndices.Contains(i)) pivotField.DataField = true;
+                    ApplyPivotFieldOptions(pivotField, options, workbookPart);
                     pivotFields.Append(pivotField);
                 }
 
@@ -226,7 +231,8 @@ namespace OfficeIMO.Excel {
                         Field = (uint)idx,
                         Subtotal = df.Function
                     };
-                    if (df.NumberFormatId.HasValue) dataField.NumberFormatId = df.NumberFormatId.Value;
+                    uint? numberFormatId = ResolveNumberFormatId(workbookPart, df.NumberFormatId, df.NumberFormat);
+                    if (numberFormatId.HasValue) dataField.NumberFormatId = numberFormatId.Value;
                     dataFieldsElement.Append(dataField);
                 }
 
@@ -344,6 +350,68 @@ namespace OfficeIMO.Excel {
             return indices;
         }
 
+        private static Dictionary<int, ExcelPivotFieldOptions> BuildPivotFieldOptionMap(IEnumerable<ExcelPivotFieldOptions>? fieldOptions,
+            IDictionary<string, int> headerIndex) {
+            var map = new Dictionary<int, ExcelPivotFieldOptions>();
+            if (fieldOptions == null) return map;
+
+            foreach (var options in fieldOptions) {
+                if (options == null || string.IsNullOrWhiteSpace(options.FieldName)) continue;
+                int idx = ResolveFieldIndex(options.FieldName, headerIndex, nameof(fieldOptions));
+                map[idx] = options;
+            }
+
+            return map;
+        }
+
+        private static void ApplyPivotFieldOptions(PivotField pivotField, ExcelPivotFieldOptions? options, WorkbookPart workbookPart) {
+            if (options == null) return;
+
+            if (options.SortType.HasValue) pivotField.SortType = options.SortType.Value;
+            if (options.DefaultSubtotal.HasValue) pivotField.DefaultSubtotal = options.DefaultSubtotal.Value;
+            if (options.SubtotalTop.HasValue) pivotField.SubtotalTop = options.SubtotalTop.Value;
+            if (options.InsertBlankRow.HasValue) pivotField.InsertBlankRow = options.InsertBlankRow.Value;
+
+            uint? numberFormatId = ResolveNumberFormatId(workbookPart, options.NumberFormatId, options.NumberFormat);
+            if (numberFormatId.HasValue) pivotField.NumberFormatId = numberFormatId.Value;
+        }
+
+        private static uint? ResolveNumberFormatId(WorkbookPart workbookPart, uint? numberFormatId, string? numberFormat) {
+            if (numberFormatId.HasValue) return numberFormatId.Value;
+            if (string.IsNullOrWhiteSpace(numberFormat)) return null;
+            return GetOrCreateNumberFormatId(workbookPart, numberFormat!.Trim());
+        }
+
+        private static uint GetOrCreateNumberFormatId(WorkbookPart workbookPart, string numberFormat) {
+            WorkbookStylesPart? stylesPart = workbookPart.WorkbookStylesPart;
+            if (stylesPart == null) {
+                stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+            }
+
+            Stylesheet stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
+            EnsureDefaultStylePrimitives(stylesheet);
+
+            stylesheet.NumberingFormats ??= new NumberingFormats();
+            NumberingFormat? existingFormat = stylesheet.NumberingFormats.Elements<NumberingFormat>()
+                .FirstOrDefault(n => n.FormatCode != null && string.Equals(n.FormatCode.Value, numberFormat, StringComparison.Ordinal));
+
+            if (existingFormat?.NumberFormatId?.Value is uint existingId) {
+                return existingId;
+            }
+
+            uint formatId = stylesheet.NumberingFormats.Elements<NumberingFormat>().Any()
+                ? Math.Max(164U, stylesheet.NumberingFormats.Elements<NumberingFormat>().Max(n => n.NumberFormatId?.Value ?? 0U) + 1U)
+                : 164U;
+
+            stylesheet.NumberingFormats.Append(new NumberingFormat {
+                NumberFormatId = formatId,
+                FormatCode = StringValue.FromString(numberFormat)
+            });
+            stylesheet.NumberingFormats.Count = (uint)stylesheet.NumberingFormats.Count();
+            stylesPart.Stylesheet.Save();
+            return formatId;
+        }
+
         private static int ResolveFieldIndex(string field, IDictionary<string, int> headerIndex, string paramName) {
             var key = field.Trim();
             if (!headerIndex.TryGetValue(key, out int idx)) {
@@ -433,7 +501,7 @@ namespace OfficeIMO.Excel {
                 var name = ResolveFieldName(idx, cacheFields);
                 var fn = field.Subtotal?.Value ?? DataConsolidateFunctionValues.Sum;
                 var display = field.Name?.Value;
-                list.Add(new ExcelPivotDataFieldInfo(name, fn, display));
+                list.Add(new ExcelPivotDataFieldInfo(name, fn, display, field.NumberFormatId?.Value));
             }
             return list;
         }

--- a/OfficeIMO.Excel/ExcelSheet.PivotTables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PivotTables.cs
@@ -29,6 +29,7 @@ namespace OfficeIMO.Excel {
                     var columnFields = ResolveFieldNames(def.ColumnFields?.Elements<Field>(), cacheFields);
                     var pageFields = ResolvePageFieldNames(def.PageFields?.Elements<PageField>(), cacheFields);
                     var dataFields = ResolveDataFields(def.DataFields?.Elements<DataField>(), cacheFields);
+                    var fieldInfos = ResolveFieldInfos(def.PivotFields?.Elements<PivotField>(), cacheFields, BuildCacheFieldItems(cacheDef));
 
                     var layout = ResolveLayout(def.CompactData, def.OutlineData);
 
@@ -47,10 +48,24 @@ namespace OfficeIMO.Excel {
                         showEmptyRows: def.ShowEmptyRow?.Value,
                         showEmptyColumns: def.ShowEmptyColumn?.Value,
                         showDrill: def.ShowDrill?.Value,
+                        rowGrandTotals: def.RowGrandTotals?.Value,
+                        columnGrandTotals: def.ColumnGrandTotals?.Value,
+                        rowHeaderCaption: def.RowHeaderCaption?.Value,
+                        columnHeaderCaption: def.ColumnHeaderCaption?.Value,
+                        grandTotalCaption: def.GrandTotalCaption?.Value,
+                        missingCaption: def.MissingCaption?.Value,
+                        errorCaption: def.ErrorCaption?.Value,
+                        showDataDropDown: def.ShowDataDropDown?.Value,
+                        showDropZones: def.ShowDropZones?.Value,
+                        showDataTips: def.ShowDataTips?.Value,
+                        showMemberPropertyTips: def.ShowMemberPropertyTips?.Value,
+                        fieldListSortAscending: def.FieldListSortAscending?.Value,
+                        customListSort: def.CustomListSort?.Value,
                         rowFields: rowFields,
                         columnFields: columnFields,
                         pageFields: pageFields,
-                        dataFields: dataFields));
+                        dataFields: dataFields,
+                        fields: fieldInfos));
                 }
 
                 return list;
@@ -77,6 +92,17 @@ namespace OfficeIMO.Excel {
         /// <param name="showEmptyColumns">Whether to show empty columns.</param>
         /// <param name="showDrill">Whether to show drill indicators.</param>
         /// <param name="fieldOptions">Optional formatting and display options for source fields.</param>
+        /// <param name="rowHeaderCaption">Optional row header caption.</param>
+        /// <param name="columnHeaderCaption">Optional column header caption.</param>
+        /// <param name="grandTotalCaption">Optional grand total caption.</param>
+        /// <param name="missingCaption">Optional caption for missing values.</param>
+        /// <param name="errorCaption">Optional caption for error values.</param>
+        /// <param name="showDataDropDown">Whether to show the data drop-down.</param>
+        /// <param name="showDropZones">Whether to show drop zones.</param>
+        /// <param name="showDataTips">Whether to show data tips.</param>
+        /// <param name="showMemberPropertyTips">Whether to show member property tips.</param>
+        /// <param name="fieldListSortAscending">Whether field list sorting is ascending.</param>
+        /// <param name="customListSort">Whether custom-list sorting is enabled.</param>
         public void AddPivotTable(
             string sourceRange,
             string destinationCell,
@@ -94,7 +120,18 @@ namespace OfficeIMO.Excel {
             bool? showEmptyRows = null,
             bool? showEmptyColumns = null,
             bool? showDrill = null,
-            IEnumerable<ExcelPivotFieldOptions>? fieldOptions = null) {
+            IEnumerable<ExcelPivotFieldOptions>? fieldOptions = null,
+            string? rowHeaderCaption = null,
+            string? columnHeaderCaption = null,
+            string? grandTotalCaption = null,
+            string? missingCaption = null,
+            string? errorCaption = null,
+            bool? showDataDropDown = null,
+            bool? showDropZones = null,
+            bool? showDataTips = null,
+            bool? showMemberPropertyTips = null,
+            bool? fieldListSortAscending = null,
+            bool? customListSort = null) {
             if (string.IsNullOrWhiteSpace(sourceRange)) throw new ArgumentNullException(nameof(sourceRange));
             if (string.IsNullOrWhiteSpace(destinationCell)) throw new ArgumentNullException(nameof(destinationCell));
             if (!A1.TryParseRange(sourceRange, out int r1, out int c1, out int r2, out int c2)) {
@@ -148,6 +185,7 @@ namespace OfficeIMO.Excel {
                 var workbookPart = WorkbookPartRoot;
                 var workbook = workbookPart.Workbook ??= new Workbook();
                 var fieldOptionMap = BuildPivotFieldOptionMap(fieldOptions, headerIndex);
+                var fieldValueMap = BuildPivotFieldValueMap(headers.Count, r1 + 1, r2, c1);
                 uint cacheId = NextPivotCacheId(workbookPart);
 
                 var cacheDefPart = workbookPart.AddNewPart<PivotTableCacheDefinitionPart>();
@@ -165,9 +203,10 @@ namespace OfficeIMO.Excel {
                     SaveData = false
                 };
 
-                foreach (var header in headers) {
+                for (int i = 0; i < headers.Count; i++) {
+                    string header = headers[i];
                     var cacheField = new CacheField { Name = header };
-                    cacheField.SharedItems = new SharedItems { Count = 0U };
+                    cacheField.SharedItems = BuildSharedItems(fieldValueMap[i]);
                     cacheDef.CacheFields.Append(cacheField);
                 }
 
@@ -203,7 +242,7 @@ namespace OfficeIMO.Excel {
                     if (rowFieldIndices.Contains(i)) pivotField.Axis = PivotTableAxisValues.AxisRow;
                     if (columnFieldIndices.Contains(i)) pivotField.Axis = PivotTableAxisValues.AxisColumn;
                     if (dataFieldIndices.Contains(i)) pivotField.DataField = true;
-                    ApplyPivotFieldOptions(pivotField, options, workbookPart);
+                    ApplyPivotFieldOptions(pivotField, options, workbookPart, fieldValueMap[i]);
                     pivotFields.Append(pivotField);
                 }
 
@@ -219,7 +258,10 @@ namespace OfficeIMO.Excel {
 
                 var pageFieldsElement = pageFieldIndices.Count > 0 ? new PageFields { Count = (uint)pageFieldIndices.Count } : null;
                 if (pageFieldsElement != null) {
-                    foreach (int idx in pageFieldIndices) pageFieldsElement.Append(new PageField { Field = idx });
+                    foreach (int idx in pageFieldIndices) {
+                        fieldOptionMap.TryGetValue(idx, out var options);
+                        pageFieldsElement.Append(CreatePageField(idx, options, fieldValueMap[idx]));
+                    }
                 }
 
                 var dataFieldsElement = new DataFields { Count = (uint)dataFieldList.Count };
@@ -287,6 +329,17 @@ namespace OfficeIMO.Excel {
                 if (showEmptyRows.HasValue) pivotDefinition.ShowEmptyRow = showEmptyRows.Value;
                 if (showEmptyColumns.HasValue) pivotDefinition.ShowEmptyColumn = showEmptyColumns.Value;
                 if (showDrill.HasValue) pivotDefinition.ShowDrill = showDrill.Value;
+                if (!string.IsNullOrWhiteSpace(rowHeaderCaption)) pivotDefinition.RowHeaderCaption = rowHeaderCaption;
+                if (!string.IsNullOrWhiteSpace(columnHeaderCaption)) pivotDefinition.ColumnHeaderCaption = columnHeaderCaption;
+                if (!string.IsNullOrWhiteSpace(grandTotalCaption)) pivotDefinition.GrandTotalCaption = grandTotalCaption;
+                if (!string.IsNullOrWhiteSpace(missingCaption)) pivotDefinition.MissingCaption = missingCaption;
+                if (!string.IsNullOrWhiteSpace(errorCaption)) pivotDefinition.ErrorCaption = errorCaption;
+                if (showDataDropDown.HasValue) pivotDefinition.ShowDataDropDown = showDataDropDown.Value;
+                if (showDropZones.HasValue) pivotDefinition.ShowDropZones = showDropZones.Value;
+                if (showDataTips.HasValue) pivotDefinition.ShowDataTips = showDataTips.Value;
+                if (showMemberPropertyTips.HasValue) pivotDefinition.ShowMemberPropertyTips = showMemberPropertyTips.Value;
+                if (fieldListSortAscending.HasValue) pivotDefinition.FieldListSortAscending = fieldListSortAscending.Value;
+                if (customListSort.HasValue) pivotDefinition.CustomListSort = customListSort.Value;
 
                 pivotPart.PivotTableDefinition = pivotDefinition;
                 pivotPart.PivotTableDefinition.Save();
@@ -364,16 +417,118 @@ namespace OfficeIMO.Excel {
             return map;
         }
 
-        private static void ApplyPivotFieldOptions(PivotField pivotField, ExcelPivotFieldOptions? options, WorkbookPart workbookPart) {
+        private List<IReadOnlyList<string>> BuildPivotFieldValueMap(int fieldCount, int firstDataRow, int lastDataRow, int firstColumn) {
+            var maps = new List<IReadOnlyList<string>>(fieldCount);
+            for (int field = 0; field < fieldCount; field++) {
+                var values = new List<string>();
+                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                int column = firstColumn + field;
+                for (int row = firstDataRow; row <= lastDataRow; row++) {
+                    if (!TryGetCellText(row, column, out string text) || string.IsNullOrWhiteSpace(text)) {
+                        continue;
+                    }
+
+                    text = text.Trim();
+                    if (seen.Add(text)) {
+                        values.Add(text);
+                    }
+                }
+
+                maps.Add(values);
+            }
+
+            return maps;
+        }
+
+        private static SharedItems BuildSharedItems(IReadOnlyList<string> values) {
+            var sharedItems = new SharedItems {
+                Count = (uint)values.Count,
+                ContainsString = values.Count > 0
+            };
+
+            foreach (string value in values) {
+                sharedItems.Append(new StringItem { Val = value });
+            }
+
+            return sharedItems;
+        }
+
+        private static PageField CreatePageField(int fieldIndex, ExcelPivotFieldOptions? options, IReadOnlyList<string> values) {
+            var pageField = new PageField { Field = fieldIndex };
+            if (options == null || string.IsNullOrWhiteSpace(options.SelectedItem)) {
+                return pageField;
+            }
+
+            int selectedIndex = FindPivotItemIndex(options.SelectedItem!, values, options.FieldName, nameof(options.SelectedItem));
+            pageField.Item = (uint)selectedIndex;
+            return pageField;
+        }
+
+        private static void ApplyPivotFieldOptions(PivotField pivotField, ExcelPivotFieldOptions? options, WorkbookPart workbookPart,
+            IReadOnlyList<string> values) {
             if (options == null) return;
 
             if (options.SortType.HasValue) pivotField.SortType = options.SortType.Value;
             if (options.DefaultSubtotal.HasValue) pivotField.DefaultSubtotal = options.DefaultSubtotal.Value;
             if (options.SubtotalTop.HasValue) pivotField.SubtotalTop = options.SubtotalTop.Value;
             if (options.InsertBlankRow.HasValue) pivotField.InsertBlankRow = options.InsertBlankRow.Value;
+            if (options.InsertPageBreak.HasValue) pivotField.InsertPageBreak = options.InsertPageBreak.Value;
+            if (options.Compact.HasValue) pivotField.Compact = options.Compact.Value;
+            if (options.Outline.HasValue) pivotField.Outline = options.Outline.Value;
+            if (options.ShowDropDowns.HasValue) pivotField.ShowDropDowns = options.ShowDropDowns.Value;
+            if (options.MultipleItemSelectionAllowed.HasValue) pivotField.MultipleItemSelectionAllowed = options.MultipleItemSelectionAllowed.Value;
+            if (options.IncludeNewItemsInFilter.HasValue) pivotField.IncludeNewItemsInFilter = options.IncludeNewItemsInFilter.Value;
+            if (!string.IsNullOrWhiteSpace(options.SubtotalCaption)) pivotField.SubtotalCaption = options.SubtotalCaption;
 
             uint? numberFormatId = ResolveNumberFormatId(workbookPart, options.NumberFormatId, options.NumberFormat);
             if (numberFormatId.HasValue) pivotField.NumberFormatId = numberFormatId.Value;
+
+            ApplyPivotFieldItemFilters(pivotField, options, values);
+        }
+
+        private static void ApplyPivotFieldItemFilters(PivotField pivotField, ExcelPivotFieldOptions options, IReadOnlyList<string> values) {
+            if (options.HiddenItems.Count == 0 && options.VisibleItems.Count == 0) return;
+            if (values.Count == 0) {
+                throw new ArgumentException($"Field '{options.FieldName}' has no cache items to filter.", nameof(options));
+            }
+
+            var hidden = new HashSet<int>();
+            if (options.HiddenItems.Count > 0) {
+                foreach (string item in options.HiddenItems) {
+                    hidden.Add(FindPivotItemIndex(item, values, options.FieldName, nameof(options.HiddenItems)));
+                }
+            } else {
+                var visible = new HashSet<int>();
+                foreach (string item in options.VisibleItems) {
+                    visible.Add(FindPivotItemIndex(item, values, options.FieldName, nameof(options.VisibleItems)));
+                }
+
+                for (int i = 0; i < values.Count; i++) {
+                    if (!visible.Contains(i)) hidden.Add(i);
+                }
+            }
+
+            var items = new Items { Count = (uint)values.Count };
+            for (int i = 0; i < values.Count; i++) {
+                var item = new Item { Index = (uint)i };
+                if (hidden.Contains(i)) item.Hidden = true;
+                items.Append(item);
+            }
+
+            pivotField.Items = items;
+            if (options.ShowAll == null) {
+                pivotField.ShowAll = false;
+            }
+        }
+
+        private static int FindPivotItemIndex(string item, IReadOnlyList<string> values, string fieldName, string paramName) {
+            for (int i = 0; i < values.Count; i++) {
+                if (string.Equals(values[i], item, StringComparison.OrdinalIgnoreCase)) {
+                    return i;
+                }
+            }
+
+            throw new ArgumentException($"Item '{item}' was not found in pivot field '{fieldName}'.", paramName);
         }
 
         private static uint? ResolveNumberFormatId(WorkbookPart workbookPart, uint? numberFormatId, string? numberFormat) {
@@ -473,6 +628,33 @@ namespace OfficeIMO.Excel {
             return names;
         }
 
+        private static List<IReadOnlyList<string>> BuildCacheFieldItems(PivotCacheDefinition? cacheDef) {
+            var fields = new List<IReadOnlyList<string>>();
+            if (cacheDef?.CacheFields == null) return fields;
+
+            foreach (var field in cacheDef.CacheFields.Elements<CacheField>()) {
+                var values = new List<string>();
+                SharedItems? sharedItems = field.SharedItems;
+                if (sharedItems != null) {
+                    foreach (OpenXmlElement item in sharedItems.ChildElements) {
+                        string? text = item switch {
+                            StringItem stringItem => stringItem.Val?.Value,
+                            NumberItem numberItem => numberItem.Val?.Value.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                            DateTimeItem dateItem => dateItem.Val?.Value.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
+                            BooleanItem booleanItem => booleanItem.Val?.Value.ToString(),
+                            MissingItem => string.Empty,
+                            _ => item.InnerText
+                        };
+                        values.Add(text ?? string.Empty);
+                    }
+                }
+
+                fields.Add(values);
+            }
+
+            return fields;
+        }
+
         private static List<string> ResolveFieldNames(IEnumerable<Field>? fields, IReadOnlyList<string> cacheFields) {
             var list = new List<string>();
             if (fields == null) return list;
@@ -491,6 +673,50 @@ namespace OfficeIMO.Excel {
                 list.Add(ResolveFieldName(field.Field.Value, cacheFields));
             }
             return list;
+        }
+
+        private static List<ExcelPivotFieldInfo> ResolveFieldInfos(IEnumerable<PivotField>? fields, IReadOnlyList<string> cacheFields,
+            IReadOnlyList<IReadOnlyList<string>> cacheFieldItems) {
+            var list = new List<ExcelPivotFieldInfo>();
+            if (fields == null) return list;
+            int index = 0;
+            foreach (var field in fields) {
+                IReadOnlyList<string> itemValues = index < cacheFieldItems.Count ? cacheFieldItems[index] : Array.Empty<string>();
+                list.Add(new ExcelPivotFieldInfo(
+                    fieldName: ResolveFieldName(index, cacheFields),
+                    axis: field.Axis?.Value,
+                    sortType: field.SortType?.Value,
+                    numberFormatId: field.NumberFormatId?.Value,
+                    showAll: field.ShowAll?.Value,
+                    defaultSubtotal: field.DefaultSubtotal?.Value,
+                    subtotalTop: field.SubtotalTop?.Value,
+                    insertBlankRow: field.InsertBlankRow?.Value,
+                    insertPageBreak: field.InsertPageBreak?.Value,
+                    compact: field.Compact?.Value,
+                    outline: field.Outline?.Value,
+                    showDropDowns: field.ShowDropDowns?.Value,
+                    multipleItemSelectionAllowed: field.MultipleItemSelectionAllowed?.Value,
+                    includeNewItemsInFilter: field.IncludeNewItemsInFilter?.Value,
+                    subtotalCaption: field.SubtotalCaption?.Value,
+                    hiddenItems: ResolveHiddenItems(field.Items, itemValues)));
+                index++;
+            }
+
+            return list;
+        }
+
+        private static IReadOnlyList<string> ResolveHiddenItems(Items? items, IReadOnlyList<string> values) {
+            if (items == null || values.Count == 0) return Array.Empty<string>();
+            var hidden = new List<string>();
+            foreach (var item in items.Elements<Item>()) {
+                if (item.Hidden?.Value != true || item.Index == null) continue;
+                int idx = (int)item.Index.Value;
+                if (idx >= 0 && idx < values.Count) {
+                    hidden.Add(values[idx]);
+                }
+            }
+
+            return hidden;
         }
 
         private static List<ExcelPivotDataFieldInfo> ResolveDataFields(IEnumerable<DataField>? fields, IReadOnlyList<string> cacheFields) {

--- a/OfficeIMO.Excel/README.md
+++ b/OfficeIMO.Excel/README.md
@@ -271,6 +271,24 @@ chart.SetSeriesDataLabelTemplate(0, labelTemplate)
 ```
 
 ```csharp
+// Pivot table and pivot-source chart metadata
+sheet.AddPivotTable(
+    sourceRange: "A1:C100",
+    destinationCell: "F2",
+    name: "SalesPivot",
+    rowFields: new[] { "Region" },
+    dataFields: new[] {
+        new ExcelPivotDataField("Sales", DataConsolidateFunctionValues.Sum, "Total Sales", numberFormat: "$#,##0")
+    },
+    fieldOptions: new[] {
+        new ExcelPivotFieldOptions("Region", sortType: FieldSortValues.Ascending, defaultSubtotal: false)
+    });
+
+sheet.AddPivotChartFromRange("SalesPivot", "A1:C100", row: 12, column: 1,
+    type: ExcelChartType.ColumnClustered, title: "Sales Pivot");
+```
+
+```csharp
 // Combo chart with secondary axis
 var comboData = new ExcelChartData(
     new[] { "Q1", "Q2", "Q3", "Q4" },

--- a/OfficeIMO.Excel/README.md
+++ b/OfficeIMO.Excel/README.md
@@ -281,8 +281,16 @@ sheet.AddPivotTable(
         new ExcelPivotDataField("Sales", DataConsolidateFunctionValues.Sum, "Total Sales", numberFormat: "$#,##0")
     },
     fieldOptions: new[] {
-        new ExcelPivotFieldOptions("Region", sortType: FieldSortValues.Ascending, defaultSubtotal: false)
-    });
+        new ExcelPivotFieldOptions("Region",
+            sortType: FieldSortValues.Ascending,
+            defaultSubtotal: false,
+            hiddenItems: new[] { "Legacy" }),
+        new ExcelPivotFieldOptions("Product",
+            selectedItem: "Standard")
+    },
+    pageFields: new[] { "Product" },
+    rowHeaderCaption: "Region",
+    grandTotalCaption: "Total");
 
 sheet.AddPivotChartFromRange("SalesPivot", "A1:C100", row: 12, column: 1,
     type: ExcelChartType.ColumnClustered, title: "Sales Pivot");

--- a/OfficeIMO.Tests/Excel.PivotTables.cs
+++ b/OfficeIMO.Tests/Excel.PivotTables.cs
@@ -99,10 +99,35 @@ namespace OfficeIMO.Tests {
                     destinationCell: "E2",
                     name: "SalesPivot",
                     rowFields: new[] { "Region" },
+                    pageFields: new[] { "Product" },
                     dataFields: new[] { new ExcelPivotDataField("Sales", DataConsolidateFunctionValues.Sum, "Total Sales", numberFormat: "$#,##0.00") },
                     fieldOptions: new[] {
-                        new ExcelPivotFieldOptions("Region", sortType: FieldSortValues.Ascending, defaultSubtotal: false, subtotalTop: true, insertBlankRow: true)
-                    });
+                        new ExcelPivotFieldOptions("Region",
+                            sortType: FieldSortValues.Ascending,
+                            defaultSubtotal: false,
+                            subtotalTop: true,
+                            insertBlankRow: true,
+                            insertPageBreak: true,
+                            compact: false,
+                            outline: true,
+                            showDropDowns: true,
+                            multipleItemSelectionAllowed: true,
+                            includeNewItemsInFilter: true,
+                            subtotalCaption: "Region subtotal",
+                            hiddenItems: new[] { "West" }),
+                        new ExcelPivotFieldOptions("Product", selectedItem: "A")
+                    },
+                    rowHeaderCaption: "Rows",
+                    columnHeaderCaption: "Columns",
+                    grandTotalCaption: "Grand total",
+                    missingCaption: "(missing)",
+                    errorCaption: "(error)",
+                    showDataDropDown: false,
+                    showDropZones: true,
+                    showDataTips: true,
+                    showMemberPropertyTips: true,
+                    fieldListSortAscending: true,
+                    customListSort: false);
 
                 document.Save(false);
             }
@@ -117,6 +142,34 @@ namespace OfficeIMO.Tests {
                 Assert.False(regionField.DefaultSubtotal!.Value);
                 Assert.True(regionField.SubtotalTop!.Value);
                 Assert.True(regionField.InsertBlankRow!.Value);
+                Assert.True(regionField.InsertPageBreak!.Value);
+                Assert.False(regionField.Compact!.Value);
+                Assert.True(regionField.Outline!.Value);
+                Assert.True(regionField.ShowDropDowns!.Value);
+                Assert.True(regionField.MultipleItemSelectionAllowed!.Value);
+                Assert.True(regionField.IncludeNewItemsInFilter!.Value);
+                Assert.Equal("Region subtotal", regionField.SubtotalCaption!.Value);
+
+                var regionItems = regionField.Items!.Elements<Item>().ToList();
+                Assert.Equal(2, regionItems.Count);
+                Assert.False(regionItems[0].Hidden?.Value ?? false);
+                Assert.True(regionItems[1].Hidden!.Value);
+
+                var pageField = pivotDefinition.PageFields!.Elements<PageField>().Single();
+                Assert.Equal(1, pageField.Field!.Value);
+                Assert.Equal(0U, pageField.Item!.Value);
+
+                Assert.Equal("Rows", pivotDefinition.RowHeaderCaption!.Value);
+                Assert.Equal("Columns", pivotDefinition.ColumnHeaderCaption!.Value);
+                Assert.Equal("Grand total", pivotDefinition.GrandTotalCaption!.Value);
+                Assert.Equal("(missing)", pivotDefinition.MissingCaption!.Value);
+                Assert.Equal("(error)", pivotDefinition.ErrorCaption!.Value);
+                Assert.False(pivotDefinition.ShowDataDropDown!.Value);
+                Assert.True(pivotDefinition.ShowDropZones!.Value);
+                Assert.True(pivotDefinition.ShowDataTips!.Value);
+                Assert.True(pivotDefinition.ShowMemberPropertyTips!.Value);
+                Assert.True(pivotDefinition.FieldListSortAscending!.Value);
+                Assert.False(pivotDefinition.CustomListSort!.Value);
 
                 var dataField = pivotDefinition.DataFields!.Elements<DataField>().Single();
                 uint numberFormatId = dataField.NumberFormatId!.Value;
@@ -129,7 +182,25 @@ namespace OfficeIMO.Tests {
             }
 
             using (var document = ExcelDocument.Load(filePath)) {
-                var dataField = document.GetPivotTables().Single().DataFields.Single();
+                var pivot = document.GetPivotTables().Single();
+                Assert.True(pivot.RowGrandTotals);
+                Assert.True(pivot.ColumnGrandTotals);
+                Assert.Equal("Rows", pivot.RowHeaderCaption);
+                Assert.Equal("Columns", pivot.ColumnHeaderCaption);
+                Assert.Equal("Grand total", pivot.GrandTotalCaption);
+                Assert.False(pivot.ShowDataDropDown);
+                Assert.True(pivot.ShowDropZones);
+                Assert.Contains("Product", pivot.PageFields);
+
+                var region = pivot.Fields.Single(field => field.FieldName == "Region");
+                Assert.Equal(FieldSortValues.Ascending, region.SortType);
+                Assert.False(region.DefaultSubtotal);
+                Assert.True(region.InsertPageBreak);
+                Assert.False(region.Compact);
+                Assert.True(region.Outline);
+                Assert.Contains("West", region.HiddenItems);
+
+                var dataField = pivot.DataFields.Single();
                 Assert.True(dataField.NumberFormatId >= 164);
             }
 

--- a/OfficeIMO.Tests/Excel.PivotTables.cs
+++ b/OfficeIMO.Tests/Excel.PivotTables.cs
@@ -1,9 +1,11 @@
 using System;
 using System.IO;
 using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
 using Xunit;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
 
 namespace OfficeIMO.Tests {
     public partial class Excel {
@@ -62,6 +64,126 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Sales", dataField.FieldName);
                 Assert.Equal(DataConsolidateFunctionValues.Sum, dataField.Function);
                 Assert.Equal("Total Sales", dataField.DisplayName);
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_AddPivotTable_AppliesFieldOptionsAndNumberFormats() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelPivotTableFieldOptions.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(1, 2, "Product");
+                sheet.CellValue(1, 3, "Sales");
+
+                sheet.CellValue(2, 1, "East");
+                sheet.CellValue(2, 2, "A");
+                sheet.CellValue(2, 3, 10.25);
+
+                sheet.CellValue(3, 1, "West");
+                sheet.CellValue(3, 2, "A");
+                sheet.CellValue(3, 3, 12.5);
+
+                sheet.CellValue(4, 1, "East");
+                sheet.CellValue(4, 2, "B");
+                sheet.CellValue(4, 3, 7.75);
+
+                sheet.AddPivotTable(
+                    sourceRange: "A1:C4",
+                    destinationCell: "E2",
+                    name: "SalesPivot",
+                    rowFields: new[] { "Region" },
+                    dataFields: new[] { new ExcelPivotDataField("Sales", DataConsolidateFunctionValues.Sum, "Total Sales", numberFormat: "$#,##0.00") },
+                    fieldOptions: new[] {
+                        new ExcelPivotFieldOptions("Region", sortType: FieldSortValues.Ascending, defaultSubtotal: false, subtotalTop: true, insertBlankRow: true)
+                    });
+
+                document.Save(false);
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var workbookPart = spreadsheet.WorkbookPart!;
+                var pivotPart = workbookPart.WorksheetParts.SelectMany(part => part.PivotTableParts).Single();
+                var pivotDefinition = pivotPart.PivotTableDefinition!;
+
+                var regionField = pivotDefinition.PivotFields!.Elements<PivotField>().ElementAt(0);
+                Assert.Equal(FieldSortValues.Ascending, regionField.SortType!.Value);
+                Assert.False(regionField.DefaultSubtotal!.Value);
+                Assert.True(regionField.SubtotalTop!.Value);
+                Assert.True(regionField.InsertBlankRow!.Value);
+
+                var dataField = pivotDefinition.DataFields!.Elements<DataField>().Single();
+                uint numberFormatId = dataField.NumberFormatId!.Value;
+                Assert.True(numberFormatId >= 164);
+
+                var numberFormat = workbookPart.WorkbookStylesPart!.Stylesheet!.NumberingFormats!
+                    .Elements<NumberingFormat>()
+                    .Single(format => format.NumberFormatId!.Value == numberFormatId);
+                Assert.Equal("$#,##0.00", numberFormat.FormatCode!.Value);
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var dataField = document.GetPivotTables().Single().DataFields.Single();
+                Assert.True(dataField.NumberFormatId >= 164);
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_AddPivotChartFromRange_WritesPivotSource() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelPivotChart.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(1, 2, "Product");
+                sheet.CellValue(1, 3, "Sales");
+
+                sheet.CellValue(2, 1, "East");
+                sheet.CellValue(2, 2, "A");
+                sheet.CellValue(2, 3, 10);
+
+                sheet.CellValue(3, 1, "West");
+                sheet.CellValue(3, 2, "A");
+                sheet.CellValue(3, 3, 12);
+
+                sheet.CellValue(4, 1, "East");
+                sheet.CellValue(4, 2, "B");
+                sheet.CellValue(4, 3, 7);
+
+                sheet.AddPivotTable(
+                    sourceRange: "A1:C4",
+                    destinationCell: "E2",
+                    name: "SalesPivot",
+                    rowFields: new[] { "Region" },
+                    columnFields: new[] { "Product" },
+                    dataFields: new[] { new ExcelPivotDataField("Sales", DataConsolidateFunctionValues.Sum, "Total Sales") });
+
+                var chart = sheet.AddPivotChartFromRange("SalesPivot", "A1:C4", row: 7, column: 1, title: "Sales Pivot");
+                Assert.True(chart.IsPivotChart);
+                Assert.Equal("SalesPivot", chart.PivotTableName);
+
+                document.Save(false);
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First(part => part.DrawingsPart?.ChartParts.Any() == true);
+                var chartPart = worksheetPart.DrawingsPart!.ChartParts.Single();
+                var pivotSource = chartPart.ChartSpace!.GetFirstChild<C.PivotSource>();
+
+                Assert.NotNull(pivotSource);
+                Assert.Equal("SalesPivot", pivotSource!.GetFirstChild<C.PivotTableName>()!.Text);
+                Assert.Equal(0U, pivotSource.GetFirstChild<C.FormatId>()!.Val!.Value);
             }
 
             using (var document = ExcelDocument.Load(filePath, readOnly: true)) {


### PR DESCRIPTION
## Summary
- add pivot field options for sort, subtotal display, blank rows, show-all, and number formats
- allow pivot data fields to create/read number formats from format codes
- add pivot-chart metadata support through SetPivotSource and AddPivotChartFromRange
- update Excel docs and compatibility notes for pivot/chart coverage

## Validation
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --filter Test_AddPivot --no-restore
- git diff --check