### PR TITLE
Fix Excel pivot review follow-ups

### DIFF
--- a/OfficeIMO.Excel/ExcelPivotDataField.cs
+++ b/OfficeIMO.Excel/ExcelPivotDataField.cs
@@ -13,6 +13,20 @@ namespace OfficeIMO.Excel {
         /// <param name="function">Aggregation function (Sum, Count, Average, ...).</param>
         /// <param name="displayName">Optional display name for the data field.</param>
         /// <param name="numberFormatId">Optional number format id to apply to the data field.</param>
+        public ExcelPivotDataField(string fieldName,
+            DataConsolidateFunctionValues? function,
+            string? displayName,
+            uint? numberFormatId)
+            : this(fieldName, function, displayName, numberFormatId, null) {
+        }
+
+        /// <summary>
+        /// Creates a pivot data field definition.
+        /// </summary>
+        /// <param name="fieldName">Header name from the source range.</param>
+        /// <param name="function">Aggregation function (Sum, Count, Average, ...).</param>
+        /// <param name="displayName">Optional display name for the data field.</param>
+        /// <param name="numberFormatId">Optional number format id to apply to the data field.</param>
         /// <param name="numberFormat">Optional number format code to apply to the data field.</param>
         public ExcelPivotDataField(string fieldName,
             DataConsolidateFunctionValues? function = null,

--- a/OfficeIMO.Excel/ExcelPivotDataFieldInfo.cs
+++ b/OfficeIMO.Excel/ExcelPivotDataFieldInfo.cs
@@ -8,7 +8,14 @@ namespace OfficeIMO.Excel {
         /// <summary>
         /// Creates a data field info instance.
         /// </summary>
-        public ExcelPivotDataFieldInfo(string fieldName, DataConsolidateFunctionValues function, string? displayName, uint? numberFormatId = null) {
+        public ExcelPivotDataFieldInfo(string fieldName, DataConsolidateFunctionValues function, string? displayName)
+            : this(fieldName, function, displayName, null) {
+        }
+
+        /// <summary>
+        /// Creates a data field info instance.
+        /// </summary>
+        public ExcelPivotDataFieldInfo(string fieldName, DataConsolidateFunctionValues function, string? displayName, uint? numberFormatId) {
             FieldName = fieldName;
             Function = function;
             DisplayName = displayName;

--- a/OfficeIMO.Excel/ExcelPivotTableInfo.cs
+++ b/OfficeIMO.Excel/ExcelPivotTableInfo.cs
@@ -22,6 +22,33 @@ namespace OfficeIMO.Excel {
             bool? showEmptyRows,
             bool? showEmptyColumns,
             bool? showDrill,
+            IReadOnlyList<string> rowFields,
+            IReadOnlyList<string> columnFields,
+            IReadOnlyList<string> pageFields,
+            IReadOnlyList<ExcelPivotDataFieldInfo> dataFields)
+            : this(name, cacheId, location, sourceSheet, sourceRange, sheetName, sheetIndex, pivotStyle,
+                layout, dataOnRows, showHeaders, showEmptyRows, showEmptyColumns, showDrill,
+                null, null, null, null, null, null, null, null, null, null, null, null, null,
+                rowFields, columnFields, pageFields, dataFields, null) {
+        }
+
+        /// <summary>
+        /// Creates a pivot table info instance.
+        /// </summary>
+        public ExcelPivotTableInfo(string name,
+            uint cacheId,
+            string? location,
+            string? sourceSheet,
+            string? sourceRange,
+            string sheetName,
+            int sheetIndex,
+            string? pivotStyle,
+            ExcelPivotLayout layout,
+            bool? dataOnRows,
+            bool? showHeaders,
+            bool? showEmptyRows,
+            bool? showEmptyColumns,
+            bool? showDrill,
             bool? rowGrandTotals,
             bool? columnGrandTotals,
             string? rowHeaderCaption,

--- a/OfficeIMO.Excel/ExcelSheet.PivotTables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PivotTables.cs
@@ -91,6 +91,73 @@ namespace OfficeIMO.Excel {
         /// <param name="showEmptyRows">Whether to show empty rows.</param>
         /// <param name="showEmptyColumns">Whether to show empty columns.</param>
         /// <param name="showDrill">Whether to show drill indicators.</param>
+        public void AddPivotTable(
+            string sourceRange,
+            string destinationCell,
+            string? name,
+            IEnumerable<string>? rowFields,
+            IEnumerable<string>? columnFields,
+            IEnumerable<string>? pageFields,
+            IEnumerable<ExcelPivotDataField>? dataFields,
+            bool showRowGrandTotals,
+            bool showColumnGrandTotals,
+            string? pivotStyleName,
+            ExcelPivotLayout layout,
+            bool? dataOnRows,
+            bool? showHeaders,
+            bool? showEmptyRows,
+            bool? showEmptyColumns,
+            bool? showDrill) {
+            AddPivotTable(
+                sourceRange,
+                destinationCell,
+                name,
+                rowFields,
+                columnFields,
+                pageFields,
+                dataFields,
+                showRowGrandTotals,
+                showColumnGrandTotals,
+                pivotStyleName,
+                layout,
+                dataOnRows,
+                showHeaders,
+                showEmptyRows,
+                showEmptyColumns,
+                showDrill,
+                fieldOptions: null,
+                rowHeaderCaption: null,
+                columnHeaderCaption: null,
+                grandTotalCaption: null,
+                missingCaption: null,
+                errorCaption: null,
+                showDataDropDown: null,
+                showDropZones: null,
+                showDataTips: null,
+                showMemberPropertyTips: null,
+                fieldListSortAscending: null,
+                customListSort: null);
+        }
+
+        /// <summary>
+        /// Adds a basic pivot table based on a source range and places it at a destination cell.
+        /// </summary>
+        /// <param name="sourceRange">Source data range (including header row), e.g. "A1:D100".</param>
+        /// <param name="destinationCell">Top-left cell for the pivot table (e.g. "F2").</param>
+        /// <param name="name">Optional pivot table name. Defaults to "PivotTable1" style.</param>
+        /// <param name="rowFields">Optional row fields (header names).</param>
+        /// <param name="columnFields">Optional column fields (header names).</param>
+        /// <param name="pageFields">Optional page fields (header names) used as filters.</param>
+        /// <param name="dataFields">Optional data field definitions. Defaults to last column with Sum.</param>
+        /// <param name="showRowGrandTotals">Show row grand totals.</param>
+        /// <param name="showColumnGrandTotals">Show column grand totals.</param>
+        /// <param name="pivotStyleName">Optional pivot table style name.</param>
+        /// <param name="layout">Layout mode (Compact, Outline, Tabular).</param>
+        /// <param name="dataOnRows">Whether to show data fields on rows instead of columns.</param>
+        /// <param name="showHeaders">Whether to show field headers.</param>
+        /// <param name="showEmptyRows">Whether to show empty rows.</param>
+        /// <param name="showEmptyColumns">Whether to show empty columns.</param>
+        /// <param name="showDrill">Whether to show drill indicators.</param>
         /// <param name="fieldOptions">Optional formatting and display options for source fields.</param>
         /// <param name="rowHeaderCaption">Optional row header caption.</param>
         /// <param name="columnHeaderCaption">Optional column header caption.</param>
@@ -424,11 +491,7 @@ namespace OfficeIMO.Excel {
                 var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 int column = firstColumn + field;
                 for (int row = firstDataRow; row <= lastDataRow; row++) {
-                    if (!TryGetCellText(row, column, out string text) || string.IsNullOrWhiteSpace(text)) {
-                        continue;
-                    }
-
-                    text = text.Trim();
+                    string text = TryGetCellText(row, column, out string cellText) ? cellText.Trim() : string.Empty;
                     if (seen.Add(text)) {
                         values.Add(text);
                     }
@@ -441,13 +504,19 @@ namespace OfficeIMO.Excel {
         }
 
         private static SharedItems BuildSharedItems(IReadOnlyList<string> values) {
+            bool hasBlank = values.Any(string.IsNullOrEmpty);
             var sharedItems = new SharedItems {
                 Count = (uint)values.Count,
-                ContainsString = values.Count > 0
+                ContainsString = values.Any(value => !string.IsNullOrEmpty(value)),
+                ContainsBlank = hasBlank
             };
 
             foreach (string value in values) {
-                sharedItems.Append(new StringItem { Val = value });
+                if (string.IsNullOrEmpty(value)) {
+                    sharedItems.Append(new MissingItem());
+                } else {
+                    sharedItems.Append(new StringItem { Val = value });
+                }
             }
 
             return sharedItems;

--- a/OfficeIMO.Tests/Excel.PivotTables.cs
+++ b/OfficeIMO.Tests/Excel.PivotTables.cs
@@ -72,6 +72,62 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_PivotPublicCompatibilityOverloadsRemainAvailable() {
+            Assert.NotNull(typeof(ExcelPivotDataField).GetConstructor(new[] {
+                typeof(string),
+                typeof(DataConsolidateFunctionValues?),
+                typeof(string),
+                typeof(uint?)
+            }));
+
+            Assert.NotNull(typeof(ExcelPivotDataFieldInfo).GetConstructor(new[] {
+                typeof(string),
+                typeof(DataConsolidateFunctionValues),
+                typeof(string)
+            }));
+
+            Assert.NotNull(typeof(ExcelPivotTableInfo).GetConstructor(new[] {
+                typeof(string),
+                typeof(uint),
+                typeof(string),
+                typeof(string),
+                typeof(string),
+                typeof(string),
+                typeof(int),
+                typeof(string),
+                typeof(ExcelPivotLayout),
+                typeof(bool?),
+                typeof(bool?),
+                typeof(bool?),
+                typeof(bool?),
+                typeof(bool?),
+                typeof(IReadOnlyList<string>),
+                typeof(IReadOnlyList<string>),
+                typeof(IReadOnlyList<string>),
+                typeof(IReadOnlyList<ExcelPivotDataFieldInfo>)
+            }));
+
+            Assert.NotNull(typeof(ExcelSheet).GetMethod("AddPivotTable", new[] {
+                typeof(string),
+                typeof(string),
+                typeof(string),
+                typeof(IEnumerable<string>),
+                typeof(IEnumerable<string>),
+                typeof(IEnumerable<string>),
+                typeof(IEnumerable<ExcelPivotDataField>),
+                typeof(bool),
+                typeof(bool),
+                typeof(string),
+                typeof(ExcelPivotLayout),
+                typeof(bool?),
+                typeof(bool?),
+                typeof(bool?),
+                typeof(bool?),
+                typeof(bool?)
+            }));
+        }
+
+        [Fact]
         public void Test_AddPivotTable_AppliesFieldOptionsAndNumberFormats() {
             var filePath = Path.Combine(_directoryWithFiles, "ExcelPivotTableFieldOptions.xlsx");
 
@@ -94,8 +150,11 @@ namespace OfficeIMO.Tests {
                 sheet.CellValue(4, 2, "B");
                 sheet.CellValue(4, 3, 7.75);
 
+                sheet.CellValue(5, 2, "C");
+                sheet.CellValue(5, 3, 3.5);
+
                 sheet.AddPivotTable(
-                    sourceRange: "A1:C4",
+                    sourceRange: "A1:C5",
                     destinationCell: "E2",
                     name: "SalesPivot",
                     rowFields: new[] { "Region" },
@@ -137,6 +196,11 @@ namespace OfficeIMO.Tests {
                 var pivotPart = workbookPart.WorksheetParts.SelectMany(part => part.PivotTableParts).Single();
                 var pivotDefinition = pivotPart.PivotTableDefinition!;
 
+                var cacheField = pivotPart.PivotTableCacheDefinitionPart!.PivotCacheDefinition!.CacheFields!.Elements<CacheField>().ElementAt(0);
+                var sharedItems = cacheField.SharedItems!.ChildElements;
+                Assert.Equal(3, sharedItems.Count);
+                Assert.IsType<MissingItem>(sharedItems[2]);
+
                 var regionField = pivotDefinition.PivotFields!.Elements<PivotField>().ElementAt(0);
                 Assert.Equal(FieldSortValues.Ascending, regionField.SortType!.Value);
                 Assert.False(regionField.DefaultSubtotal!.Value);
@@ -151,9 +215,10 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Region subtotal", regionField.SubtotalCaption!.Value);
 
                 var regionItems = regionField.Items!.Elements<Item>().ToList();
-                Assert.Equal(2, regionItems.Count);
+                Assert.Equal(3, regionItems.Count);
                 Assert.False(regionItems[0].Hidden?.Value ?? false);
                 Assert.True(regionItems[1].Hidden!.Value);
+                Assert.False(regionItems[2].Hidden?.Value ?? false);
 
                 var pageField = pivotDefinition.PageFields!.Elements<PageField>().Single();
                 Assert.Equal(1, pageField.Field!.Value);


### PR DESCRIPTION
## Summary
- restore binary-compatible Excel pivot public overloads while keeping the new metadata-aware APIs
- include blank pivot cache items so hidden item indexes stay aligned with Excel shared items
- add regression coverage for compatibility overloads and blank pivot cache entries

## Validation
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --filter "Test_PivotPublicCompatibilityOverloadsRemainAvailable|Test_AddPivotTable_AppliesFieldOptionsAndNumberFormats" --no-restore
- git diff --check