### PR TITLE
Add Excel ClosedXML gap APIs

### DIFF
--- a/OfficeIMO.Excel/ExcelCalculationOptions.cs
+++ b/OfficeIMO.Excel/ExcelCalculationOptions.cs
@@ -1,0 +1,144 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Controls how formula cells are treated before a workbook is saved.
+    /// </summary>
+    public sealed class ExcelCalculationOptions {
+        /// <summary>
+        /// When true, OfficeIMO evaluates supported formulas and writes cached values before saving.
+        /// Unsupported formulas are left intact and can still be recalculated by Excel.
+        /// </summary>
+        public bool EvaluateFormulasBeforeSave { get; set; }
+
+        /// <summary>
+        /// When true, formula cells are marked dirty so Excel-compatible applications recalculate them on open.
+        /// </summary>
+        public bool MarkFormulasDirtyBeforeSave { get; set; }
+
+        /// <summary>
+        /// When true, workbook calculation properties request a full recalculation when the file opens.
+        /// </summary>
+        public bool ForceFullCalculationOnOpen { get; set; }
+
+        /// <summary>
+        /// When true, cached formula results are removed before saving. Ignored when <see cref="EvaluateFormulasBeforeSave"/> is true.
+        /// </summary>
+        public bool ClearCachedFormulaResultsBeforeSave { get; set; }
+    }
+
+    /// <summary>
+    /// Options used when protecting the workbook structure.
+    /// </summary>
+    public sealed class ExcelWorkbookProtectionOptions {
+        /// <summary>
+        /// Protects the workbook structure, which prevents sheet add/delete/move/rename operations in Excel UI.
+        /// </summary>
+        public bool ProtectStructure { get; set; } = true;
+
+        /// <summary>
+        /// Protects workbook windows where supported by the consuming application.
+        /// </summary>
+        public bool ProtectWindows { get; set; }
+
+        /// <summary>
+        /// Optional workbook protection password. This is Excel UI protection, not package encryption.
+        /// </summary>
+        public string? Password { get; set; }
+
+        /// <summary>
+        /// Optional precomputed legacy workbook protection hash. When set, this value is written as-is.
+        /// </summary>
+        public string? LegacyPasswordHash { get; set; }
+    }
+
+    /// <summary>
+    /// Selects which cell parts are cleared by <see cref="ExcelRange.Clear"/>.
+    /// </summary>
+    [System.Flags]
+    public enum ExcelClearOptions {
+        /// <summary>Do not clear any cell data or metadata.</summary>
+        None = 0,
+        /// <summary>Clear literal cell values.</summary>
+        Values = 1,
+        /// <summary>Clear cell formulas.</summary>
+        Formulas = 2,
+        /// <summary>Clear cell style indexes.</summary>
+        Styles = 4,
+        /// <summary>Clear comments in the selected cells when supported.</summary>
+        Comments = 8,
+        /// <summary>Clear hyperlinks that overlap the range.</summary>
+        Hyperlinks = 16,
+        /// <summary>Clear data validation rules that overlap the range.</summary>
+        DataValidations = 32,
+        /// <summary>Clear conditional formatting rules that overlap the range.</summary>
+        ConditionalFormatting = 64,
+        /// <summary>Clear merged-cell definitions that overlap the range.</summary>
+        Merges = 128,
+        /// <summary>Clear sparklines whose target cells overlap the range.</summary>
+        Sparklines = 256,
+        /// <summary>Clear all supported cell data and range metadata.</summary>
+        All = Values | Formulas | Styles | Comments | Hyperlinks | DataValidations | ConditionalFormatting | Merges | Sparklines
+    }
+
+    /// <summary>
+    /// Kind of value stored in an <see cref="ExcelCellData"/>.
+    /// </summary>
+    public enum ExcelCellDataKind {
+        /// <summary>The cell has no value.</summary>
+        Blank,
+        /// <summary>The cell contains a Boolean value.</summary>
+        Boolean,
+        /// <summary>The cell contains a numeric value.</summary>
+        Number,
+        /// <summary>The cell contains text.</summary>
+        Text,
+        /// <summary>The cell contains an error value.</summary>
+        Error,
+        /// <summary>The cell contains a formula.</summary>
+        Formula
+    }
+
+    /// <summary>
+    /// A typed snapshot of a worksheet cell value.
+    /// </summary>
+    public sealed class ExcelCellData {
+        /// <summary>
+        /// Creates a snapshot for a worksheet cell value.
+        /// </summary>
+        public ExcelCellData(ExcelCellDataKind kind, object? value, string? formula = null, string? cachedText = null) {
+            Kind = kind;
+            Value = value;
+            Formula = formula;
+            CachedText = cachedText;
+        }
+
+        /// <summary>
+        /// Gets the value kind.
+        /// </summary>
+        public ExcelCellDataKind Kind { get; }
+
+        /// <summary>
+        /// Gets the typed value when one is available.
+        /// </summary>
+        public object? Value { get; }
+
+        /// <summary>
+        /// Gets the formula text for formula cells.
+        /// </summary>
+        public string? Formula { get; }
+
+        /// <summary>
+        /// Gets the cached text from the cell value.
+        /// </summary>
+        public string? CachedText { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the cell is blank.
+        /// </summary>
+        public bool IsBlank => Kind == ExcelCellDataKind.Blank;
+
+        /// <summary>
+        /// Gets a value indicating whether the cell contains a formula.
+        /// </summary>
+        public bool HasFormula => Kind == ExcelCellDataKind.Formula;
+    }
+}

--- a/OfficeIMO.Excel/ExcelCell.cs
+++ b/OfficeIMO.Excel/ExcelCell.cs
@@ -168,8 +168,10 @@ namespace OfficeIMO.Excel {
     public sealed class ExcelRange {
         internal ExcelRange(ExcelSheet sheet, string address) {
             Sheet = sheet ?? throw new ArgumentNullException(nameof(sheet));
-            Address = string.IsNullOrWhiteSpace(address) ? throw new ArgumentNullException(nameof(address)) : address;
-            var bounds = A1.ParseRange(Address);
+            if (string.IsNullOrWhiteSpace(address)) throw new ArgumentNullException(nameof(address));
+
+            var bounds = ParseRangeOrCell(address);
+            Address = ToRangeAddress(bounds.r1, bounds.c1, bounds.r2, bounds.c2);
             FirstRow = bounds.r1;
             FirstColumn = bounds.c1;
             LastRow = bounds.r2;
@@ -264,6 +266,25 @@ namespace OfficeIMO.Excel {
         public ExcelRange SetFillColor(string hexColor) {
             Sheet.FillRange(Address, hexColor);
             return this;
+        }
+
+        private static (int r1, int c1, int r2, int c2) ParseRangeOrCell(string address) {
+            if (A1.TryParseRange(address, out int r1, out int c1, out int r2, out int c2)) {
+                return (r1, c1, r2, c2);
+            }
+
+            var cell = A1.ParseCellRef(address);
+            if (cell.Row <= 0 || cell.Col <= 0) {
+                throw new ArgumentException($"Invalid A1 range or cell reference '{address}'.", nameof(address));
+            }
+
+            return (cell.Row, cell.Col, cell.Row, cell.Col);
+        }
+
+        private static string ToRangeAddress(int r1, int c1, int r2, int c2) {
+            string start = A1.CellReference(r1, c1);
+            string end = A1.CellReference(r2, c2);
+            return $"{start}:{end}";
         }
     }
 

--- a/OfficeIMO.Excel/ExcelCell.cs
+++ b/OfficeIMO.Excel/ExcelCell.cs
@@ -62,6 +62,9 @@ namespace OfficeIMO.Excel {
             } catch (OverflowException) {
                 value = default;
                 return false;
+            } catch (ArgumentException) {
+                value = default;
+                return false;
             }
         }
 

--- a/OfficeIMO.Excel/ExcelCell.cs
+++ b/OfficeIMO.Excel/ExcelCell.cs
@@ -269,11 +269,12 @@ namespace OfficeIMO.Excel {
         }
 
         private static (int r1, int c1, int r2, int c2) ParseRangeOrCell(string address) {
-            if (A1.TryParseRange(address, out int r1, out int c1, out int r2, out int c2)) {
+            string normalizedAddress = address.Replace("$", string.Empty);
+            if (A1.TryParseRange(normalizedAddress, out int r1, out int c1, out int r2, out int c2)) {
                 return (r1, c1, r2, c2);
             }
 
-            var cell = A1.ParseCellRef(address);
+            var cell = A1.ParseCellRef(normalizedAddress);
             if (cell.Row <= 0 || cell.Col <= 0) {
                 throw new ArgumentException($"Invalid A1 range or cell reference '{address}'.", nameof(address));
             }

--- a/OfficeIMO.Excel/ExcelCell.cs
+++ b/OfficeIMO.Excel/ExcelCell.cs
@@ -1,0 +1,367 @@
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Lightweight object model wrapper for a single worksheet cell.
+    /// </summary>
+    public sealed class ExcelCell {
+        internal ExcelCell(ExcelSheet sheet, int row, int column) {
+            Sheet = sheet ?? throw new ArgumentNullException(nameof(sheet));
+            Row = row;
+            Column = column;
+        }
+
+        /// <summary>Gets the worksheet that owns the cell.</summary>
+        public ExcelSheet Sheet { get; }
+        /// <summary>Gets the 1-based row index.</summary>
+        public int Row { get; }
+        /// <summary>Gets the 1-based column index.</summary>
+        public int Column { get; }
+        /// <summary>Gets the A1 cell address.</summary>
+        public string Address => A1.CellReference(Row, Column);
+
+        /// <summary>
+        /// Gets a typed snapshot of the cell value.
+        /// </summary>
+        public ExcelCellData GetValue() => Sheet.GetCellValueSnapshot(Row, Column);
+
+        /// <summary>
+        /// Gets formatted display text for the cell value.
+        /// </summary>
+        public string GetFormattedText(IFormatProvider? provider = null) => Sheet.GetCellFormattedText(Row, Column, provider);
+
+        /// <summary>
+        /// Gets the cell value converted to the requested type.
+        /// </summary>
+        public T? GetValue<T>() {
+            object? value = GetValue().Value;
+            if (value == null) {
+                return default;
+            }
+
+            if (value is T typed) {
+                return typed;
+            }
+
+            return (T?)Convert.ChangeType(value, typeof(T), System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Tries to get the cell value converted to the requested type.
+        /// </summary>
+        public bool TryGetValue<T>(out T? value) {
+            try {
+                value = GetValue<T>();
+                return true;
+            } catch (InvalidCastException) {
+                value = default;
+                return false;
+            } catch (FormatException) {
+                value = default;
+                return false;
+            } catch (OverflowException) {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Sets the cell value.
+        /// </summary>
+        public ExcelCell SetValue(object? value) {
+            Sheet.CellValue(Row, Column, value);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the cell formula.
+        /// </summary>
+        public ExcelCell SetFormula(string formula) {
+            Sheet.CellFormula(Row, Column, formula);
+            return this;
+        }
+
+        /// <summary>
+        /// Clears selected cell data and metadata.
+        /// </summary>
+        public ExcelCell Clear(ExcelClearOptions options = ExcelClearOptions.All) {
+            Sheet.ClearRange(Address + ":" + Address, options);
+            return this;
+        }
+
+        /// <summary>
+        /// Applies a number format to the cell.
+        /// </summary>
+        public ExcelCell SetNumberFormat(string numberFormat) {
+            Sheet.FormatCell(Row, Column, numberFormat);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets or clears bold font style.
+        /// </summary>
+        public ExcelCell SetBold(bool bold = true) {
+            Sheet.CellBold(Row, Column, bold);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets or clears italic font style.
+        /// </summary>
+        public ExcelCell SetItalic(bool italic = true) {
+            Sheet.CellItalic(Row, Column, italic);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets or clears underline font style.
+        /// </summary>
+        public ExcelCell SetUnderline(bool underline = true) {
+            Sheet.CellUnderline(Row, Column, underline);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the font color using a hex color value.
+        /// </summary>
+        public ExcelCell SetFontColor(string hexColor) {
+            Sheet.CellFontColor(Row, Column, hexColor);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the fill color using a hex color value.
+        /// </summary>
+        public ExcelCell SetFillColor(string hexColor) {
+            Sheet.CellBackground(Row, Column, hexColor);
+            return this;
+        }
+
+        /// <summary>
+        /// Applies a border style to the cell.
+        /// </summary>
+        public ExcelCell SetBorder(BorderStyleValues style, string? hexColor = null) {
+            Sheet.CellBorder(Row, Column, style, hexColor);
+            return this;
+        }
+
+        /// <summary>
+        /// Replaces the cell contents with rich inline text runs.
+        /// </summary>
+        public ExcelCell SetRichText(params ExcelRichTextRun[] runs) {
+            Sheet.SetRichText(Row, Column, runs);
+            return this;
+        }
+
+        /// <summary>
+        /// Gets rich inline text runs from the cell.
+        /// </summary>
+        public IReadOnlyList<ExcelRichTextRun> GetRichText() => Sheet.GetRichText(Row, Column);
+    }
+
+    /// <summary>
+    /// Lightweight object model wrapper for an A1 range.
+    /// </summary>
+    public sealed class ExcelRange {
+        internal ExcelRange(ExcelSheet sheet, string address) {
+            Sheet = sheet ?? throw new ArgumentNullException(nameof(sheet));
+            Address = string.IsNullOrWhiteSpace(address) ? throw new ArgumentNullException(nameof(address)) : address;
+            var bounds = A1.ParseRange(Address);
+            FirstRow = bounds.r1;
+            FirstColumn = bounds.c1;
+            LastRow = bounds.r2;
+            LastColumn = bounds.c2;
+        }
+
+        /// <summary>Gets the worksheet that owns the range.</summary>
+        public ExcelSheet Sheet { get; }
+        /// <summary>Gets the A1 range address.</summary>
+        public string Address { get; }
+        /// <summary>Gets the first row in the range.</summary>
+        public int FirstRow { get; }
+        /// <summary>Gets the first column in the range.</summary>
+        public int FirstColumn { get; }
+        /// <summary>Gets the last row in the range.</summary>
+        public int LastRow { get; }
+        /// <summary>Gets the last column in the range.</summary>
+        public int LastColumn { get; }
+
+        /// <summary>
+        /// Gets a wrapper for the top-left cell.
+        /// </summary>
+        public ExcelCell FirstCell => Sheet.CellAt(FirstRow, FirstColumn);
+
+        /// <summary>
+        /// Clears selected data and metadata from the range.
+        /// </summary>
+        public ExcelRange Clear(ExcelClearOptions options = ExcelClearOptions.All) {
+            Sheet.ClearRange(Address, options);
+            return this;
+        }
+
+        /// <summary>
+        /// Sorts the range by a 1-based column offset.
+        /// </summary>
+        public ExcelRange SortByColumn(int columnOffset, bool ascending = true, bool hasHeader = true) {
+            Sheet.SortRangeByColumn(Address, columnOffset, ascending, hasHeader);
+            return this;
+        }
+
+        /// <summary>
+        /// Applies AutoFilter to the range using optional zero-based column criteria.
+        /// </summary>
+        public ExcelRange ApplyAutoFilter(Dictionary<uint, IEnumerable<string>>? filterCriteria = null) {
+            Sheet.AddAutoFilter(Address, filterCriteria);
+            return this;
+        }
+
+        /// <summary>
+        /// Clears the worksheet AutoFilter.
+        /// </summary>
+        public ExcelRange ClearAutoFilter() {
+            Sheet.AutoFilterClear();
+            return this;
+        }
+
+        /// <summary>
+        /// Merges the range.
+        /// </summary>
+        public ExcelRange Merge() {
+            Sheet.MergeRange(Address);
+            return this;
+        }
+
+        /// <summary>
+        /// Removes merge definitions that overlap the range.
+        /// </summary>
+        public ExcelRange Unmerge() {
+            Sheet.UnmergeRange(Address);
+            return this;
+        }
+
+        /// <summary>
+        /// Creates an Excel table over the range.
+        /// </summary>
+        public ExcelTable CreateTable(string name, bool hasHeader = true, TableStyle style = TableStyle.TableStyleMedium2, bool includeAutoFilter = true) {
+            Sheet.AddTable(Address, hasHeader, name, style, includeAutoFilter);
+            return Sheet.Table(name);
+        }
+
+        /// <summary>
+        /// Applies a number format to every cell in the range.
+        /// </summary>
+        public ExcelRange SetNumberFormat(string numberFormat) {
+            Sheet.FormatRange(Address, numberFormat);
+            return this;
+        }
+
+        /// <summary>
+        /// Applies a fill color to every cell in the range.
+        /// </summary>
+        public ExcelRange SetFillColor(string hexColor) {
+            Sheet.FillRange(Address, hexColor);
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// Lightweight object model wrapper for an Excel table.
+    /// </summary>
+    public sealed class ExcelTable {
+        internal ExcelTable(ExcelSheet sheet, string nameOrRange) {
+            Sheet = sheet ?? throw new ArgumentNullException(nameof(sheet));
+            NameOrRange = string.IsNullOrWhiteSpace(nameOrRange) ? throw new ArgumentNullException(nameof(nameOrRange)) : nameOrRange;
+        }
+
+        /// <summary>Gets the worksheet that owns the table.</summary>
+        public ExcelSheet Sheet { get; }
+        /// <summary>Gets the table name, display name, or A1 range used to locate the table.</summary>
+        public string NameOrRange { get; }
+        /// <summary>Gets the table range when it can be resolved.</summary>
+        public string? Range => Sheet.GetTableRange(NameOrRange) ?? (A1.TryParseRange(NameOrRange, out _, out _, out _, out _) ? NameOrRange : null);
+
+        /// <summary>
+        /// Returns the table as a range wrapper.
+        /// </summary>
+        public ExcelRange AsRange() {
+            string? range = Range;
+            if (range == null) {
+                throw new InvalidOperationException($"Table '{NameOrRange}' was not found on worksheet '{Sheet.Name}'.");
+            }
+
+            return Sheet.Range(range);
+        }
+
+        /// <summary>
+        /// Applies a built-in table style and optional style flags.
+        /// </summary>
+        public ExcelTable SetStyle(TableStyle style, bool? showFirstColumn = null, bool? showLastColumn = null, bool? showRowStripes = null, bool? showColumnStripes = null) {
+            Sheet.SetTableStyle(NameOrRange, style, showFirstColumn, showLastColumn, showRowStripes, showColumnStripes);
+            return this;
+        }
+
+        /// <summary>
+        /// Applies totals row functions by header name.
+        /// </summary>
+        public ExcelTable SetTotals(IDictionary<string, TotalsRowFunctionValues> byHeader) {
+            Sheet.SetTableTotalsByName(NameOrRange, byHeader);
+            return this;
+        }
+
+        /// <summary>
+        /// Clears totals row settings from the table.
+        /// </summary>
+        public ExcelTable ClearTotals() {
+            Sheet.ClearTableTotals(NameOrRange);
+            return this;
+        }
+
+        /// <summary>
+        /// Appends rows from a data table to the Excel table.
+        /// </summary>
+        public ExcelTable AppendDataTable(System.Data.DataTable table) {
+            Sheet.AppendDataTableToTable(table, NameOrRange);
+            return this;
+        }
+
+        /// <summary>
+        /// Sorts table rows by a 1-based column offset.
+        /// </summary>
+        public ExcelTable SortByColumn(int columnOffset, bool ascending = true) {
+            AsRange().SortByColumn(columnOffset, ascending, hasHeader: true);
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// Describes a run of rich text inside a cell.
+    /// </summary>
+    public sealed class ExcelRichTextRun {
+        /// <summary>
+        /// Creates a rich text run with the supplied text.
+        /// </summary>
+        public ExcelRichTextRun(string text) {
+            Text = text ?? string.Empty;
+        }
+
+        /// <summary>Gets or sets the run text.</summary>
+        public string Text { get; set; }
+        /// <summary>Gets or sets whether the run is bold.</summary>
+        public bool Bold { get; set; }
+        /// <summary>Gets or sets whether the run is italic.</summary>
+        public bool Italic { get; set; }
+        /// <summary>Gets or sets whether the run is underlined.</summary>
+        public bool Underline { get; set; }
+        /// <summary>Gets or sets the run font color as a hex value.</summary>
+        public string? FontColor { get; set; }
+        /// <summary>Gets or sets the run font name.</summary>
+        public string? FontName { get; set; }
+        /// <summary>Gets or sets the run font size.</summary>
+        public double? FontSize { get; set; }
+
+        /// <summary>
+        /// Creates a plain rich text run.
+        /// </summary>
+        public static ExcelRichTextRun Plain(string text) => new ExcelRichTextRun(text);
+    }
+}

--- a/OfficeIMO.Excel/ExcelCell.cs
+++ b/OfficeIMO.Excel/ExcelCell.cs
@@ -248,8 +248,8 @@ namespace OfficeIMO.Excel {
         /// Creates an Excel table over the range.
         /// </summary>
         public ExcelTable CreateTable(string name, bool hasHeader = true, TableStyle style = TableStyle.TableStyleMedium2, bool includeAutoFilter = true) {
-            Sheet.AddTable(Address, hasHeader, name, style, includeAutoFilter);
-            return Sheet.Table(name);
+            string resolvedName = Sheet.AddTableAndGetName(Address, hasHeader, name, style, includeAutoFilter);
+            return Sheet.Table(resolvedName);
         }
 
         /// <summary>

--- a/OfficeIMO.Excel/ExcelDocument.CalculationAndProtection.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CalculationAndProtection.cs
@@ -29,7 +29,15 @@ namespace OfficeIMO.Excel {
                 protection = new WorkbookProtection();
                 var workbookViews = workbook.GetFirstChild<BookViews>();
                 if (workbookViews != null) {
-                    workbook.InsertAfter(protection, workbookViews);
+                    workbook.InsertBefore(protection, workbookViews);
+                } else if (workbook.GetFirstChild<Sheets>() is Sheets sheets) {
+                    workbook.InsertBefore(protection, sheets);
+                } else if (workbook.GetFirstChild<WorkbookProperties>() is WorkbookProperties workbookProperties) {
+                    workbook.InsertAfter(protection, workbookProperties);
+                } else if (workbook.GetFirstChild<FileSharing>() is FileSharing fileSharing) {
+                    workbook.InsertAfter(protection, fileSharing);
+                } else if (workbook.GetFirstChild<FileVersion>() is FileVersion fileVersion) {
+                    workbook.InsertAfter(protection, fileVersion);
                 } else {
                     workbook.InsertAt(protection, 0);
                 }

--- a/OfficeIMO.Excel/ExcelDocument.CalculationAndProtection.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CalculationAndProtection.cs
@@ -114,7 +114,6 @@ namespace OfficeIMO.Excel {
             InsertCalculationPropertiesInSchemaOrder(workbook, properties);
             properties.ForceFullCalculation = true;
             properties.FullCalculationOnLoad = true;
-            properties.CalculationMode = CalculateModeValues.Auto;
             workbook.Save();
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.CalculationAndProtection.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CalculationAndProtection.cs
@@ -107,13 +107,34 @@ namespace OfficeIMO.Excel {
             var properties = workbook.GetFirstChild<CalculationProperties>();
             if (properties == null) {
                 properties = new CalculationProperties();
-                workbook.Append(properties);
+            } else {
+                properties.Remove();
             }
 
+            InsertCalculationPropertiesInSchemaOrder(workbook, properties);
             properties.ForceFullCalculation = true;
             properties.FullCalculationOnLoad = true;
             properties.CalculationMode = CalculateModeValues.Auto;
             workbook.Save();
+        }
+
+        private static void InsertCalculationPropertiesInSchemaOrder(Workbook workbook, CalculationProperties properties) {
+            var laterChild = workbook.ChildElements.FirstOrDefault(child =>
+                string.Equals(child.LocalName, "oleSize", StringComparison.Ordinal)
+                || string.Equals(child.LocalName, "customWorkbookViews", StringComparison.Ordinal)
+                || string.Equals(child.LocalName, "pivotCaches", StringComparison.Ordinal)
+                || string.Equals(child.LocalName, "smartTagPr", StringComparison.Ordinal)
+                || string.Equals(child.LocalName, "smartTagTypes", StringComparison.Ordinal)
+                || string.Equals(child.LocalName, "webPublishing", StringComparison.Ordinal)
+                || string.Equals(child.LocalName, "fileRecoveryPr", StringComparison.Ordinal)
+                || string.Equals(child.LocalName, "webPublishObjects", StringComparison.Ordinal)
+                || string.Equals(child.LocalName, "extLst", StringComparison.Ordinal));
+
+            if (laterChild != null) {
+                workbook.InsertBefore(properties, laterChild);
+            } else {
+                workbook.Append(properties);
+            }
         }
 
         internal void ApplyCalculationPolicyBeforeSave() {

--- a/OfficeIMO.Excel/ExcelDocument.CalculationAndProtection.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CalculationAndProtection.cs
@@ -1,0 +1,127 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        /// <summary>
+        /// Formula calculation and cached-result policy used during save.
+        /// </summary>
+        public ExcelCalculationOptions Calculation { get; } = new ExcelCalculationOptions();
+
+        /// <summary>
+        /// Returns true when workbook-level structure or window protection is present.
+        /// </summary>
+        public bool IsWorkbookProtected {
+            get {
+                var protection = WorkbookRoot.GetFirstChild<WorkbookProtection>();
+                return protection != null && ((protection.LockStructure?.Value ?? false) || (protection.LockWindows?.Value ?? false));
+            }
+        }
+
+        /// <summary>
+        /// Protects workbook structure/window metadata. This is not file encryption.
+        /// </summary>
+        public void ProtectWorkbook(ExcelWorkbookProtectionOptions? options = null) {
+            var opts = options ?? new ExcelWorkbookProtectionOptions();
+            var workbook = WorkbookRoot;
+            var protection = workbook.GetFirstChild<WorkbookProtection>();
+            if (protection == null) {
+                protection = new WorkbookProtection();
+                var workbookViews = workbook.GetFirstChild<BookViews>();
+                if (workbookViews != null) {
+                    workbook.InsertAfter(protection, workbookViews);
+                } else {
+                    workbook.InsertAt(protection, 0);
+                }
+            }
+
+            protection.LockStructure = opts.ProtectStructure;
+            protection.LockWindows = opts.ProtectWindows;
+            string? hash = ExcelProtectionHash.ResolveLegacyHash(opts.Password, opts.LegacyPasswordHash);
+            if (hash != null) {
+                protection.WorkbookPassword = hash;
+            } else {
+                protection.WorkbookPassword = null;
+                protection.RemoveAttribute("workbookPassword", string.Empty);
+            }
+            workbook.Save();
+        }
+
+        /// <summary>
+        /// Removes workbook-level structure/window protection metadata.
+        /// </summary>
+        public void UnprotectWorkbook() {
+            var workbook = WorkbookRoot;
+            var protection = workbook.GetFirstChild<WorkbookProtection>();
+            if (protection != null) {
+                workbook.RemoveChild(protection);
+                workbook.Save();
+            }
+        }
+
+        /// <summary>
+        /// Marks all formulas dirty so Excel-compatible applications recalculate them on open.
+        /// </summary>
+        public void InvalidateFormulas() {
+            foreach (var sheet in Sheets) {
+                sheet.InvalidateFormulas();
+            }
+
+            ConfigureFullCalculationOnOpen();
+        }
+
+        /// <summary>
+        /// Removes cached values from all formula cells.
+        /// </summary>
+        public void ClearCachedFormulaResults() {
+            foreach (var sheet in Sheets) {
+                sheet.ClearCachedFormulaResults();
+            }
+        }
+
+        /// <summary>
+        /// Evaluates supported formulas and writes cached values.
+        /// </summary>
+        public int RecalculateSupportedFormulas() {
+            int count = 0;
+            foreach (var sheet in Sheets) {
+                count += sheet.RecalculateSupportedFormulas();
+            }
+
+            return count;
+        }
+
+        /// <summary>
+        /// Requests a full workbook recalculation when the file is opened.
+        /// </summary>
+        public void ConfigureFullCalculationOnOpen() {
+            var workbook = WorkbookRoot;
+            var properties = workbook.GetFirstChild<CalculationProperties>();
+            if (properties == null) {
+                properties = new CalculationProperties();
+                workbook.Append(properties);
+            }
+
+            properties.ForceFullCalculation = true;
+            properties.FullCalculationOnLoad = true;
+            properties.CalculationMode = CalculateModeValues.Auto;
+            workbook.Save();
+        }
+
+        internal void ApplyCalculationPolicyBeforeSave() {
+            if (Calculation.EvaluateFormulasBeforeSave) {
+                RecalculateSupportedFormulas();
+            } else if (Calculation.ClearCachedFormulaResultsBeforeSave) {
+                ClearCachedFormulaResults();
+            }
+
+            if (Calculation.MarkFormulasDirtyBeforeSave) {
+                InvalidateFormulas();
+            }
+
+            if (Calculation.ForceFullCalculationOnOpen) {
+                ConfigureFullCalculationOnOpen();
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.Inspection.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Inspection.cs
@@ -192,19 +192,19 @@ namespace OfficeIMO.Excel {
             }
 
             return new ExcelWorksheetProtectionSnapshot {
-                AllowSelectLockedCells = protection.SelectLockedCells?.Value == true,
-                AllowSelectUnlockedCells = protection.SelectUnlockedCells?.Value == true,
-                AllowFormatCells = protection.FormatCells?.Value == true,
-                AllowFormatColumns = protection.FormatColumns?.Value == true,
-                AllowFormatRows = protection.FormatRows?.Value == true,
-                AllowInsertColumns = protection.InsertColumns?.Value == true,
-                AllowInsertRows = protection.InsertRows?.Value == true,
-                AllowInsertHyperlinks = protection.InsertHyperlinks?.Value == true,
-                AllowDeleteColumns = protection.DeleteColumns?.Value == true,
-                AllowDeleteRows = protection.DeleteRows?.Value == true,
-                AllowSort = protection.Sort?.Value == true,
-                AllowAutoFilter = protection.AutoFilter?.Value == true,
-                AllowPivotTables = protection.PivotTables?.Value == true,
+                AllowSelectLockedCells = protection.SelectLockedCells?.Value != true,
+                AllowSelectUnlockedCells = protection.SelectUnlockedCells?.Value != true,
+                AllowFormatCells = protection.FormatCells?.Value != true,
+                AllowFormatColumns = protection.FormatColumns?.Value != true,
+                AllowFormatRows = protection.FormatRows?.Value != true,
+                AllowInsertColumns = protection.InsertColumns?.Value != true,
+                AllowInsertRows = protection.InsertRows?.Value != true,
+                AllowInsertHyperlinks = protection.InsertHyperlinks?.Value != true,
+                AllowDeleteColumns = protection.DeleteColumns?.Value != true,
+                AllowDeleteRows = protection.DeleteRows?.Value != true,
+                AllowSort = protection.Sort?.Value != true,
+                AllowAutoFilter = protection.AutoFilter?.Value != true,
+                AllowPivotTables = protection.PivotTables?.Value != true,
             };
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.Inspection.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Inspection.cs
@@ -192,20 +192,24 @@ namespace OfficeIMO.Excel {
             }
 
             return new ExcelWorksheetProtectionSnapshot {
-                AllowSelectLockedCells = protection.SelectLockedCells?.Value != true,
-                AllowSelectUnlockedCells = protection.SelectUnlockedCells?.Value != true,
-                AllowFormatCells = protection.FormatCells?.Value != true,
-                AllowFormatColumns = protection.FormatColumns?.Value != true,
-                AllowFormatRows = protection.FormatRows?.Value != true,
-                AllowInsertColumns = protection.InsertColumns?.Value != true,
-                AllowInsertRows = protection.InsertRows?.Value != true,
-                AllowInsertHyperlinks = protection.InsertHyperlinks?.Value != true,
-                AllowDeleteColumns = protection.DeleteColumns?.Value != true,
-                AllowDeleteRows = protection.DeleteRows?.Value != true,
-                AllowSort = protection.Sort?.Value != true,
-                AllowAutoFilter = protection.AutoFilter?.Value != true,
-                AllowPivotTables = protection.PivotTables?.Value != true,
+                AllowSelectLockedCells = IsProtectionActionAllowed(protection.SelectLockedCells, lockedWhenOmitted: false),
+                AllowSelectUnlockedCells = IsProtectionActionAllowed(protection.SelectUnlockedCells, lockedWhenOmitted: false),
+                AllowFormatCells = IsProtectionActionAllowed(protection.FormatCells, lockedWhenOmitted: true),
+                AllowFormatColumns = IsProtectionActionAllowed(protection.FormatColumns, lockedWhenOmitted: true),
+                AllowFormatRows = IsProtectionActionAllowed(protection.FormatRows, lockedWhenOmitted: true),
+                AllowInsertColumns = IsProtectionActionAllowed(protection.InsertColumns, lockedWhenOmitted: true),
+                AllowInsertRows = IsProtectionActionAllowed(protection.InsertRows, lockedWhenOmitted: true),
+                AllowInsertHyperlinks = IsProtectionActionAllowed(protection.InsertHyperlinks, lockedWhenOmitted: true),
+                AllowDeleteColumns = IsProtectionActionAllowed(protection.DeleteColumns, lockedWhenOmitted: true),
+                AllowDeleteRows = IsProtectionActionAllowed(protection.DeleteRows, lockedWhenOmitted: true),
+                AllowSort = IsProtectionActionAllowed(protection.Sort, lockedWhenOmitted: true),
+                AllowAutoFilter = IsProtectionActionAllowed(protection.AutoFilter, lockedWhenOmitted: true),
+                AllowPivotTables = IsProtectionActionAllowed(protection.PivotTables, lockedWhenOmitted: true),
             };
+        }
+
+        private static bool IsProtectionActionAllowed(BooleanValue? lockFlag, bool lockedWhenOmitted) {
+            return !(lockFlag?.Value ?? lockedWhenOmitted);
         }
 
         private static Dictionary<string, ExcelHyperlinkSnapshot> BuildHyperlinkMap(WorksheetPart worksheetPart) {

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -1545,6 +1545,8 @@ namespace OfficeIMO.Excel {
 
         private SavePayload PreparePackageForSave(ExcelSaveOptions? options) {
             // Ensure all worksheets have up-to-date dimensions and proper element ordering before saving
+            ApplyCalculationPolicyBeforeSave();
+
             foreach (var sheet in Sheets) {
                 sheet.UpdateSheetDimension();
                 sheet.EnsureWorksheetElementOrder();

--- a/OfficeIMO.Excel/ExcelProtectionHash.cs
+++ b/OfficeIMO.Excel/ExcelProtectionHash.cs
@@ -7,7 +7,12 @@ namespace OfficeIMO.Excel {
 
         internal static string? ResolveLegacyHash(string? password, string? legacyHash) {
             if (!string.IsNullOrWhiteSpace(legacyHash)) {
-                return legacyHash!.Trim().ToUpperInvariant();
+                string normalized = legacyHash!.Trim().ToUpperInvariant();
+                if (normalized.Length > 4 || normalized.Any(character => !Uri.IsHexDigit(character))) {
+                    throw new ArgumentException("Legacy protection hash must be a hexadecimal value up to four characters long.", nameof(legacyHash));
+                }
+
+                return normalized;
             }
 
             return string.IsNullOrEmpty(password) ? null : ComputeLegacyPasswordHash(password!);

--- a/OfficeIMO.Excel/ExcelProtectionHash.cs
+++ b/OfficeIMO.Excel/ExcelProtectionHash.cs
@@ -1,0 +1,33 @@
+using System.Globalization;
+
+namespace OfficeIMO.Excel {
+    internal static class ExcelProtectionHash {
+        // Excel's legacy worksheet/workbook protection hash salt.
+        private const int LegacyPasswordSalt = 0xCE4B;
+
+        internal static string? ResolveLegacyHash(string? password, string? legacyHash) {
+            if (!string.IsNullOrWhiteSpace(legacyHash)) {
+                return legacyHash!.Trim().ToUpperInvariant();
+            }
+
+            return string.IsNullOrEmpty(password) ? null : ComputeLegacyPasswordHash(password!);
+        }
+
+        internal static string ComputeLegacyPasswordHash(string password) {
+            int hash = 0;
+            for (int index = password.Length - 1; index >= 0; index--) {
+                hash = Rotate(hash);
+                hash ^= password[index];
+            }
+
+            hash = Rotate(hash);
+            hash ^= password.Length;
+            hash ^= LegacyPasswordSalt;
+            return (hash & 0xFFFF).ToString("X4", CultureInfo.InvariantCulture);
+        }
+
+        private static int Rotate(int value) {
+            return ((value >> 14) & 0x0001) | ((value << 1) & 0x7FFF);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelRuleInfo.cs
+++ b/OfficeIMO.Excel/ExcelRuleInfo.cs
@@ -1,0 +1,63 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Read-only snapshot of a conditional formatting rule.
+    /// </summary>
+    public sealed class ExcelConditionalFormattingInfo {
+        /// <summary>Gets or sets the A1 range covered by the rule.</summary>
+        public string Range { get; set; } = string.Empty;
+        /// <summary>Gets or sets the OpenXML conditional formatting type.</summary>
+        public string Type { get; set; } = string.Empty;
+        /// <summary>Gets or sets the OpenXML conditional formatting operator.</summary>
+        public string? Operator { get; set; }
+        /// <summary>Gets or sets the rule priority.</summary>
+        public int Priority { get; set; }
+        /// <summary>Gets or sets whether evaluation stops when the rule is true.</summary>
+        public bool StopIfTrue { get; set; }
+        /// <summary>Gets or sets formulas attached to the rule.</summary>
+        public IReadOnlyList<string> Formulas { get; set; } = Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// Read-only snapshot of a data validation rule.
+    /// </summary>
+    public sealed class ExcelDataValidationInfo {
+        /// <summary>Gets or sets the A1 range covered by the validation.</summary>
+        public string Range { get; set; } = string.Empty;
+        /// <summary>Gets or sets the OpenXML validation type.</summary>
+        public string Type { get; set; } = string.Empty;
+        /// <summary>Gets or sets the OpenXML validation operator.</summary>
+        public string? Operator { get; set; }
+        /// <summary>Gets or sets whether blank values are allowed.</summary>
+        public bool AllowBlank { get; set; }
+        /// <summary>Gets or sets the first validation formula.</summary>
+        public string? Formula1 { get; set; }
+        /// <summary>Gets or sets the second validation formula.</summary>
+        public string? Formula2 { get; set; }
+        /// <summary>Gets or sets the input prompt title.</summary>
+        public string? PromptTitle { get; set; }
+        /// <summary>Gets or sets the input prompt text.</summary>
+        public string? Prompt { get; set; }
+        /// <summary>Gets or sets the error title.</summary>
+        public string? ErrorTitle { get; set; }
+        /// <summary>Gets or sets the error text.</summary>
+        public string? Error { get; set; }
+    }
+
+    /// <summary>
+    /// User-facing prompt/error options for data validation.
+    /// </summary>
+    public sealed class ExcelDataValidationMessageOptions {
+        /// <summary>Gets or sets the input prompt title.</summary>
+        public string? PromptTitle { get; set; }
+        /// <summary>Gets or sets the input prompt text.</summary>
+        public string? Prompt { get; set; }
+        /// <summary>Gets or sets the validation error title.</summary>
+        public string? ErrorTitle { get; set; }
+        /// <summary>Gets or sets the validation error text.</summary>
+        public string? Error { get; set; }
+        /// <summary>Gets or sets whether Excel should show the input prompt.</summary>
+        public bool ShowInputMessage { get; set; }
+        /// <summary>Gets or sets whether Excel should show the validation error.</summary>
+        public bool ShowErrorMessage { get; set; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.cs
@@ -4,13 +4,18 @@ using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
+        private const int MaxSupportedFormulaLength = 8192;
+        private static readonly TimeSpan FormulaRegexTimeout = TimeSpan.FromMilliseconds(100);
+
         private static readonly Regex SimpleFunctionFormulaRegex = new Regex(
             @"^\s*=?\s*(SUM|AVERAGE|MIN|MAX|COUNT|COUNTA)\s*\(([^)]*)\)\s*$",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            FormulaRegexTimeout);
 
         private static readonly Regex SimpleBinaryFormulaRegex = new Regex(
             @"^\s*=?\s*([A-Z]+[0-9]+|-?\d+(?:\.\d+)?)\s*([+\-*/])\s*([A-Z]+[0-9]+|-?\d+(?:\.\d+)?)\s*$",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            RegexOptions.IgnoreCase | RegexOptions.Compiled,
+            FormulaRegexTimeout);
 
         /// <summary>
         /// Marks all formula cells on this sheet dirty.
@@ -128,55 +133,63 @@ namespace OfficeIMO.Excel {
 
         private bool TryEvaluateFormula(string formula, out double result) {
             result = 0;
-            var functionMatch = SimpleFunctionFormulaRegex.Match(formula);
-            if (functionMatch.Success) {
-                var values = ResolveFormulaArguments(functionMatch.Groups[2].Value).ToList();
-                string function = functionMatch.Groups[1].Value.ToUpperInvariant();
-                if (function == "COUNTA") {
-                    result = values.Count(v => v.HasValue || !string.IsNullOrEmpty(v.Text));
-                    return true;
-                }
-
-                var numbers = values.Where(v => v.Number.HasValue).Select(v => v.Number!.Value).ToList();
-                if (function == "COUNT") {
-                    result = numbers.Count;
-                    return true;
-                }
-
-                if (numbers.Count == 0) {
-                    return false;
-                }
-
-                if (function == "SUM") result = numbers.Sum();
-                else if (function == "AVERAGE") result = numbers.Average();
-                else if (function == "MIN") result = numbers.Min();
-                else if (function == "MAX") result = numbers.Max();
-                else return false;
-                return true;
+            if (string.IsNullOrWhiteSpace(formula) || formula.Length > MaxSupportedFormulaLength) {
+                return false;
             }
 
-            var binaryMatch = SimpleBinaryFormulaRegex.Match(formula);
-            if (binaryMatch.Success) {
-                if (!TryResolveNumericOperand(binaryMatch.Groups[1].Value, out double left)
-                    || !TryResolveNumericOperand(binaryMatch.Groups[3].Value, out double right)) {
-                    return false;
+            try {
+                var functionMatch = SimpleFunctionFormulaRegex.Match(formula);
+                if (functionMatch.Success) {
+                    var values = ResolveFormulaArguments(functionMatch.Groups[2].Value).ToList();
+                    string function = functionMatch.Groups[1].Value.ToUpperInvariant();
+                    if (function == "COUNTA") {
+                        result = values.Count(v => v.HasValue || !string.IsNullOrEmpty(v.Text));
+                        return true;
+                    }
+
+                    var numbers = values.Where(v => v.Number.HasValue).Select(v => v.Number!.Value).ToList();
+                    if (function == "COUNT") {
+                        result = numbers.Count;
+                        return true;
+                    }
+
+                    if (numbers.Count == 0) {
+                        return false;
+                    }
+
+                    if (function == "SUM") result = numbers.Sum();
+                    else if (function == "AVERAGE") result = numbers.Average();
+                    else if (function == "MIN") result = numbers.Min();
+                    else if (function == "MAX") result = numbers.Max();
+                    else return false;
+                    return true;
                 }
 
-                switch (binaryMatch.Groups[2].Value) {
-                    case "+":
-                        result = left + right;
-                        return true;
-                    case "-":
-                        result = left - right;
-                        return true;
-                    case "*":
-                        result = left * right;
-                        return true;
-                    case "/":
-                        if (Math.Abs(right) < double.Epsilon) return false;
-                        result = left / right;
-                        return true;
+                var binaryMatch = SimpleBinaryFormulaRegex.Match(formula);
+                if (binaryMatch.Success) {
+                    if (!TryResolveNumericOperand(binaryMatch.Groups[1].Value, out double left)
+                        || !TryResolveNumericOperand(binaryMatch.Groups[3].Value, out double right)) {
+                        return false;
+                    }
+
+                    switch (binaryMatch.Groups[2].Value) {
+                        case "+":
+                            result = left + right;
+                            return true;
+                        case "-":
+                            result = left - right;
+                            return true;
+                        case "*":
+                            result = left * right;
+                            return true;
+                        case "/":
+                            if (Math.Abs(right) < double.Epsilon) return false;
+                            result = left / right;
+                            return true;
+                    }
                 }
+            } catch (RegexMatchTimeoutException) {
+                return false;
             }
 
             return false;

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.cs
@@ -1,0 +1,261 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        private static readonly Regex SimpleFunctionFormulaRegex = new Regex(
+            @"^\s*=?\s*(SUM|AVERAGE|MIN|MAX|COUNT|COUNTA)\s*\(([^)]*)\)\s*$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex SimpleBinaryFormulaRegex = new Regex(
+            @"^\s*=?\s*([A-Z]+[0-9]+|-?\d+(?:\.\d+)?)\s*([+\-*/])\s*([A-Z]+[0-9]+|-?\d+(?:\.\d+)?)\s*$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        /// <summary>
+        /// Marks all formula cells on this sheet dirty.
+        /// </summary>
+        public void InvalidateFormulas() {
+            WriteLock(() => {
+                foreach (var formula in WorksheetRoot.Descendants<CellFormula>()) {
+                    formula.CalculateCell = true;
+                }
+                WorksheetRoot.Save();
+            });
+        }
+
+        /// <summary>
+        /// Removes cached values from formula cells on this sheet.
+        /// </summary>
+        public void ClearCachedFormulaResults() {
+            WriteLock(() => {
+                foreach (var cell in WorksheetRoot.Descendants<Cell>().Where(c => c.CellFormula != null)) {
+                    cell.CellValue = null;
+                }
+                WorksheetRoot.Save();
+            });
+        }
+
+        /// <summary>
+        /// Evaluates supported formulas on this sheet and writes cached results.
+        /// </summary>
+        public int RecalculateSupportedFormulas() {
+            int count = 0;
+            WriteLock(() => {
+                foreach (var cell in WorksheetRoot.Descendants<Cell>().Where(c => c.CellFormula != null).ToList()) {
+                    if (TryEvaluateFormula(cell.CellFormula!.Text ?? string.Empty, out double result)) {
+                        cell.CellValue = new CellValue(result.ToString(CultureInfo.InvariantCulture));
+                        cell.DataType = DocumentFormat.OpenXml.Spreadsheet.CellValues.Number;
+                        cell.CellFormula.CalculateCell = false;
+                        count++;
+                    }
+                }
+
+                WorksheetRoot.Save();
+            });
+
+            return count;
+        }
+
+        /// <summary>
+        /// Returns the formula text from a cell, if present.
+        /// </summary>
+        public string? GetFormulaText(int row, int column) {
+            return GetCell(row, column).CellFormula?.Text;
+        }
+
+        /// <summary>
+        /// Tries to return a formula cell's cached value.
+        /// </summary>
+        public bool TryGetCachedFormulaValue(int row, int column, out string? value) {
+            var cell = GetCell(row, column);
+            value = cell.CellFormula == null ? null : cell.CellValue?.Text;
+            return value != null;
+        }
+
+        /// <summary>
+        /// Sets a shared-free array formula over a range. The top-left cell owns the formula metadata.
+        /// </summary>
+        public void SetArrayFormula(string a1Range, string formula) {
+            if (string.IsNullOrWhiteSpace(formula)) throw new ArgumentNullException(nameof(formula));
+            var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
+            WriteLock(() => {
+                foreach (var cell in WorksheetRoot.Descendants<Cell>().Where(c => c.CellFormula?.FormulaType?.Value == CellFormulaValues.Array).ToList()) {
+                    string? reference = cell.CellFormula?.Reference?.Value;
+                    if (!string.IsNullOrWhiteSpace(reference) && RangesOverlapInclusive((r1, c1, r2, c2), A1.ParseRange(reference!))) {
+                        throw new InvalidOperationException($"Array formula range '{a1Range}' overlaps existing array formula range '{reference}'.");
+                    }
+                }
+
+                var topLeft = GetCell(r1, c1);
+                topLeft.CellFormula = new CellFormula(Utilities.ExcelSanitizer.SanitizeFormula(formula)) {
+                    FormulaType = CellFormulaValues.Array,
+                    Reference = a1Range
+                };
+                for (int row = r1; row <= r2; row++) {
+                    for (int column = c1; column <= c2; column++) {
+                        if (row == r1 && column == c1) continue;
+                        var cell = GetCell(row, column);
+                        cell.CellFormula = null;
+                        cell.CellValue = null;
+                    }
+                }
+
+                WorksheetRoot.Save();
+            });
+        }
+
+        /// <summary>
+        /// Clears an array formula whose reference overlaps the supplied range or cell.
+        /// </summary>
+        public void ClearArrayFormula(string a1RangeOrCell) {
+            var bounds = a1RangeOrCell.IndexOf(':') >= 0
+                ? A1.ParseRange(a1RangeOrCell)
+                : CellAsRange(a1RangeOrCell);
+
+            WriteLock(() => {
+                foreach (var cell in WorksheetRoot.Descendants<Cell>().Where(c => c.CellFormula?.FormulaType?.Value == CellFormulaValues.Array).ToList()) {
+                    string? reference = cell.CellFormula?.Reference?.Value;
+                    if (!string.IsNullOrWhiteSpace(reference) && RangesOverlapInclusive(bounds, A1.ParseRange(reference!))) {
+                        cell.CellFormula = null;
+                        cell.CellValue = null;
+                    }
+                }
+
+                WorksheetRoot.Save();
+            });
+        }
+
+        private bool TryEvaluateFormula(string formula, out double result) {
+            result = 0;
+            var functionMatch = SimpleFunctionFormulaRegex.Match(formula);
+            if (functionMatch.Success) {
+                var values = ResolveFormulaArguments(functionMatch.Groups[2].Value).ToList();
+                string function = functionMatch.Groups[1].Value.ToUpperInvariant();
+                if (function == "COUNTA") {
+                    result = values.Count(v => v.HasValue || !string.IsNullOrEmpty(v.Text));
+                    return true;
+                }
+
+                var numbers = values.Where(v => v.Number.HasValue).Select(v => v.Number!.Value).ToList();
+                if (function == "COUNT") {
+                    result = numbers.Count;
+                    return true;
+                }
+
+                if (numbers.Count == 0) {
+                    return false;
+                }
+
+                if (function == "SUM") result = numbers.Sum();
+                else if (function == "AVERAGE") result = numbers.Average();
+                else if (function == "MIN") result = numbers.Min();
+                else if (function == "MAX") result = numbers.Max();
+                else return false;
+                return true;
+            }
+
+            var binaryMatch = SimpleBinaryFormulaRegex.Match(formula);
+            if (binaryMatch.Success) {
+                if (!TryResolveNumericOperand(binaryMatch.Groups[1].Value, out double left)
+                    || !TryResolveNumericOperand(binaryMatch.Groups[3].Value, out double right)) {
+                    return false;
+                }
+
+                switch (binaryMatch.Groups[2].Value) {
+                    case "+":
+                        result = left + right;
+                        return true;
+                    case "-":
+                        result = left - right;
+                        return true;
+                    case "*":
+                        result = left * right;
+                        return true;
+                    case "/":
+                        if (Math.Abs(right) < double.Epsilon) return false;
+                        result = left / right;
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        private IEnumerable<FormulaArgumentValue> ResolveFormulaArguments(string args) {
+            foreach (var token in args.Split(',')) {
+                string trimmed = token.Trim();
+                if (trimmed.Length == 0) continue;
+                if (trimmed.IndexOf(':') >= 0) {
+                    var (r1, c1, r2, c2) = A1.ParseRange(trimmed.Replace("$", string.Empty));
+                    for (int row = r1; row <= r2; row++) {
+                        for (int column = c1; column <= c2; column++) {
+                            yield return ResolveCellArgument(row, column);
+                        }
+                    }
+                    continue;
+                }
+
+                if (TryParseFormulaCellReference(trimmed, out var cellRef)) {
+                    yield return ResolveCellArgument(cellRef.Row, cellRef.Col);
+                    continue;
+                }
+
+                if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out double numeric)) {
+                    yield return new FormulaArgumentValue(numeric, trimmed);
+                }
+            }
+        }
+
+        private bool TryResolveNumericOperand(string token, out double value) {
+            token = token.Trim().Replace("$", string.Empty);
+            if (double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out value)) {
+                return true;
+            }
+
+            if (!TryParseFormulaCellReference(token, out var cellRef)) {
+                return false;
+            }
+
+            var argument = ResolveCellArgument(cellRef.Row, cellRef.Col);
+            if (argument.Number.HasValue) {
+                value = argument.Number.Value;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryParseFormulaCellReference(string token, out (int Row, int Col) cellRef) {
+            cellRef = A1.ParseCellRef(token.Trim().Replace("$", string.Empty));
+            return cellRef.Row > 0
+                && cellRef.Col > 0
+                && cellRef.Row <= A1.MaxRows
+                && cellRef.Col <= A1.MaxColumns;
+        }
+
+        private FormulaArgumentValue ResolveCellArgument(int row, int column) {
+            var value = GetCellValueSnapshot(row, column);
+            if (value.Value is double d) {
+                return new FormulaArgumentValue(d, value.CachedText);
+            }
+
+            if (double.TryParse(value.CachedText, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed)) {
+                return new FormulaArgumentValue(parsed, value.CachedText);
+            }
+
+            return new FormulaArgumentValue(null, value.Value?.ToString());
+        }
+
+        private readonly struct FormulaArgumentValue {
+            internal FormulaArgumentValue(double? number, string? text) {
+                Number = number;
+                Text = text;
+            }
+
+            internal double? Number { get; }
+            internal string? Text { get; }
+            internal bool HasValue => Number.HasValue || Text != null;
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.cs
@@ -66,15 +66,15 @@ namespace OfficeIMO.Excel {
         /// Returns the formula text from a cell, if present.
         /// </summary>
         public string? GetFormulaText(int row, int column) {
-            return GetCell(row, column).CellFormula?.Text;
+            return TryGetExistingCell(row, column)?.CellFormula?.Text;
         }
 
         /// <summary>
         /// Tries to return a formula cell's cached value.
         /// </summary>
         public bool TryGetCachedFormulaValue(int row, int column, out string? value) {
-            var cell = GetCell(row, column);
-            value = cell.CellFormula == null ? null : cell.CellValue?.Text;
+            var cell = TryGetExistingCell(row, column);
+            value = cell?.CellFormula == null ? null : cell.CellValue?.Text;
             return value != null;
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.cs
@@ -124,10 +124,19 @@ namespace OfficeIMO.Excel {
                 foreach (var cell in WorksheetRoot.Descendants<Cell>().Where(c => c.CellFormula?.FormulaType?.Value == CellFormulaValues.Array).ToList()) {
                     string? reference = cell.CellFormula?.Reference?.Value;
                     if (!string.IsNullOrWhiteSpace(reference)
-                        && A1.TryParseRange(reference!, out int existingR1, out int existingC1, out int existingR2, out int existingC2)
+                        && A1.TryParseRange(reference!.Replace("$", string.Empty), out int existingR1, out int existingC1, out int existingR2, out int existingC2)
                         && RangesOverlapInclusive(bounds, (existingR1, existingC1, existingR2, existingC2))) {
-                        cell.CellFormula = null;
-                        cell.CellValue = null;
+                        for (int row = existingR1; row <= existingR2; row++) {
+                            for (int column = existingC1; column <= existingC2; column++) {
+                                var spillCell = TryGetExistingCell(row, column);
+                                if (spillCell == null) {
+                                    continue;
+                                }
+
+                                spillCell.CellFormula = null;
+                                spillCell.CellValue = null;
+                            }
+                        }
                     }
                 }
 

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.cs
@@ -87,7 +87,9 @@ namespace OfficeIMO.Excel {
             WriteLock(() => {
                 foreach (var cell in WorksheetRoot.Descendants<Cell>().Where(c => c.CellFormula?.FormulaType?.Value == CellFormulaValues.Array).ToList()) {
                     string? reference = cell.CellFormula?.Reference?.Value;
-                    if (!string.IsNullOrWhiteSpace(reference) && RangesOverlapInclusive((r1, c1, r2, c2), A1.ParseRange(reference!))) {
+                    if (!string.IsNullOrWhiteSpace(reference)
+                        && A1.TryParseRange(reference!, out int existingR1, out int existingC1, out int existingR2, out int existingC2)
+                        && RangesOverlapInclusive((r1, c1, r2, c2), (existingR1, existingC1, existingR2, existingC2))) {
                         throw new InvalidOperationException($"Array formula range '{a1Range}' overlaps existing array formula range '{reference}'.");
                     }
                 }
@@ -121,7 +123,9 @@ namespace OfficeIMO.Excel {
             WriteLock(() => {
                 foreach (var cell in WorksheetRoot.Descendants<Cell>().Where(c => c.CellFormula?.FormulaType?.Value == CellFormulaValues.Array).ToList()) {
                     string? reference = cell.CellFormula?.Reference?.Value;
-                    if (!string.IsNullOrWhiteSpace(reference) && RangesOverlapInclusive(bounds, A1.ParseRange(reference!))) {
+                    if (!string.IsNullOrWhiteSpace(reference)
+                        && A1.TryParseRange(reference!, out int existingR1, out int existingC1, out int existingR2, out int existingC2)
+                        && RangesOverlapInclusive(bounds, (existingR1, existingC1, existingR2, existingC2))) {
                         cell.CellFormula = null;
                         cell.CellValue = null;
                     }
@@ -140,7 +144,10 @@ namespace OfficeIMO.Excel {
             try {
                 var functionMatch = SimpleFunctionFormulaRegex.Match(formula);
                 if (functionMatch.Success) {
-                    var values = ResolveFormulaArguments(functionMatch.Groups[2].Value).ToList();
+                    if (!TryResolveFormulaArguments(functionMatch.Groups[2].Value, out var values)) {
+                        return false;
+                    }
+
                     string function = functionMatch.Groups[1].Value.ToUpperInvariant();
                     if (function == "COUNTA") {
                         result = values.Count(v => v.HasValue || !string.IsNullOrEmpty(v.Text));
@@ -195,29 +202,40 @@ namespace OfficeIMO.Excel {
             return false;
         }
 
-        private IEnumerable<FormulaArgumentValue> ResolveFormulaArguments(string args) {
+        private bool TryResolveFormulaArguments(string args, out List<FormulaArgumentValue> values) {
+            values = new List<FormulaArgumentValue>();
             foreach (var token in args.Split(',')) {
                 string trimmed = token.Trim();
                 if (trimmed.Length == 0) continue;
                 if (trimmed.IndexOf(':') >= 0) {
-                    var (r1, c1, r2, c2) = A1.ParseRange(trimmed.Replace("$", string.Empty));
+                    if (!A1.TryParseRange(trimmed.Replace("$", string.Empty), out int r1, out int c1, out int r2, out int c2)) {
+                        values.Clear();
+                        return false;
+                    }
+
                     for (int row = r1; row <= r2; row++) {
                         for (int column = c1; column <= c2; column++) {
-                            yield return ResolveCellArgument(row, column);
+                            values.Add(ResolveCellArgument(row, column));
                         }
                     }
                     continue;
                 }
 
                 if (TryParseFormulaCellReference(trimmed, out var cellRef)) {
-                    yield return ResolveCellArgument(cellRef.Row, cellRef.Col);
+                    values.Add(ResolveCellArgument(cellRef.Row, cellRef.Col));
                     continue;
                 }
 
                 if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out double numeric)) {
-                    yield return new FormulaArgumentValue(numeric, trimmed);
+                    values.Add(new FormulaArgumentValue(numeric, trimmed));
+                    continue;
                 }
+
+                values.Clear();
+                return false;
             }
+
+            return true;
         }
 
         private bool TryResolveNumericOperand(string token, out double value) {

--- a/OfficeIMO.Excel/ExcelSheet.ObjectModel.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectModel.cs
@@ -289,8 +289,8 @@ namespace OfficeIMO.Excel {
         /// Reads rich inline text runs from a cell.
         /// </summary>
         public IReadOnlyList<ExcelRichTextRun> GetRichText(int row, int column) {
-            var cell = GetCell(row, column);
-            if (cell.InlineString == null) {
+            var cell = TryGetExistingCell(row, column);
+            if (cell?.InlineString == null) {
                 return Array.Empty<ExcelRichTextRun>();
             }
 

--- a/OfficeIMO.Excel/ExcelSheet.ObjectModel.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectModel.cs
@@ -1,0 +1,430 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
+using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Returns a lightweight object wrapper for a single cell.
+        /// </summary>
+        public ExcelCell CellAt(int row, int column) => new ExcelCell(this, row, column);
+
+        /// <summary>
+        /// Returns a lightweight object wrapper for an A1 range.
+        /// </summary>
+        public ExcelRange Range(string a1Range) => new ExcelRange(this, a1Range);
+
+        /// <summary>
+        /// Returns a lightweight object wrapper for a table by name, display name, or range.
+        /// </summary>
+        public ExcelTable Table(string nameOrRange) => new ExcelTable(this, nameOrRange);
+
+        internal ExcelCellData GetCellValueSnapshot(int row, int column) {
+            var cell = GetCell(row, column);
+            string? cached = cell.CellValue?.Text;
+            if (cell.CellFormula != null) {
+                return new ExcelCellData(ExcelCellDataKind.Formula, cached, cell.CellFormula.Text, cached);
+            }
+
+            if (cell.CellValue == null && cell.InlineString == null) {
+                return new ExcelCellData(ExcelCellDataKind.Blank, null);
+            }
+
+            var type = cell.DataType?.Value;
+            if (type == DocumentFormat.OpenXml.Spreadsheet.CellValues.Boolean) {
+                return new ExcelCellData(ExcelCellDataKind.Boolean, cached == "1" || string.Equals(cached, "true", StringComparison.OrdinalIgnoreCase), cachedText: cached);
+            }
+
+            if (type == DocumentFormat.OpenXml.Spreadsheet.CellValues.Error) {
+                return new ExcelCellData(ExcelCellDataKind.Error, cached, cachedText: cached);
+            }
+
+            string text = GetCellText(cell);
+            if (type == DocumentFormat.OpenXml.Spreadsheet.CellValues.String
+                || type == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString
+                || type == DocumentFormat.OpenXml.Spreadsheet.CellValues.InlineString) {
+                return new ExcelCellData(ExcelCellDataKind.Text, text, cachedText: text);
+            }
+
+            if (double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double number)) {
+                return new ExcelCellData(ExcelCellDataKind.Number, number, cachedText: text);
+            }
+
+            return string.IsNullOrEmpty(text)
+                ? new ExcelCellData(ExcelCellDataKind.Blank, null)
+                : new ExcelCellData(ExcelCellDataKind.Text, text, cachedText: text);
+        }
+
+        internal string GetCellFormattedText(int row, int column, IFormatProvider? provider) {
+            var value = GetCellValueSnapshot(row, column);
+            if (value.Value is IFormattable formattable) {
+                return formattable.ToString(null, provider ?? CultureInfo.CurrentCulture) ?? string.Empty;
+            }
+
+            return Convert.ToString(value.Value, provider as CultureInfo ?? CultureInfo.CurrentCulture) ?? value.CachedText ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Applies a number format to every cell in the range.
+        /// </summary>
+        public void FormatRange(string a1Range, string numberFormat) {
+            var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
+            for (int row = r1; row <= r2; row++) {
+                for (int column = c1; column <= c2; column++) {
+                    FormatCell(row, column, numberFormat);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Applies a solid fill to every cell in the range.
+        /// </summary>
+        public void FillRange(string a1Range, string hexColor) {
+            var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
+            for (int row = r1; row <= r2; row++) {
+                for (int column = c1; column <= c2; column++) {
+                    CellBackground(row, column, hexColor);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clears selected parts of every cell and attached worksheet metadata in the range.
+        /// </summary>
+        public void ClearRange(string a1Range, ExcelClearOptions options = ExcelClearOptions.All) {
+            var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
+            WriteLock(() => {
+                var ws = WorksheetRoot;
+                for (int row = r1; row <= r2; row++) {
+                    for (int column = c1; column <= c2; column++) {
+                        var cell = GetCell(row, column);
+                        if (options.HasFlag(ExcelClearOptions.Values)) {
+                            cell.CellValue = null;
+                            cell.DataType = null;
+                            cell.InlineString = null;
+                        }
+
+                        if (options.HasFlag(ExcelClearOptions.Formulas)) {
+                            cell.CellFormula = null;
+                        }
+
+                        if (options.HasFlag(ExcelClearOptions.Styles)) {
+                            cell.StyleIndex = null;
+                        }
+                    }
+                }
+
+                if (options.HasFlag(ExcelClearOptions.Comments)) {
+                    ClearCommentsInRange(r1, c1, r2, c2);
+                }
+
+                if (options.HasFlag(ExcelClearOptions.Hyperlinks)) {
+                    ClearHyperlinksInRange(ws, a1Range);
+                }
+
+                if (options.HasFlag(ExcelClearOptions.DataValidations)) {
+                    RemoveDataValidationsCore(a1Range);
+                }
+
+                if (options.HasFlag(ExcelClearOptions.ConditionalFormatting)) {
+                    ClearConditionalFormattingCore(a1Range);
+                }
+
+                if (options.HasFlag(ExcelClearOptions.Merges)) {
+                    UnmergeRangeCore(a1Range);
+                }
+
+                if (options.HasFlag(ExcelClearOptions.Sparklines)) {
+                    ClearSparklinesInRange(a1Range);
+                }
+
+                ws.Save();
+                ClearHeaderCache();
+            });
+        }
+
+        /// <summary>
+        /// Sorts a rectangular range by a 1-based column offset while moving whole row cell nodes.
+        /// </summary>
+        public void SortRangeByColumn(string a1Range, int columnOffset, bool ascending = true, bool hasHeader = true) {
+            if (columnOffset < 1) throw new ArgumentOutOfRangeException(nameof(columnOffset));
+            var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
+            int targetColumn = c1 + columnOffset - 1;
+            if (targetColumn > c2) throw new ArgumentOutOfRangeException(nameof(columnOffset));
+
+            int firstDataRow = hasHeader ? r1 + 1 : r1;
+            if (firstDataRow >= r2) {
+                return;
+            }
+
+            WriteLock(() => {
+                var rows = new List<RowSnapshot>();
+                for (int row = firstDataRow; row <= r2; row++) {
+                    rows.Add(CaptureRow(row, c1, c2, targetColumn));
+                }
+
+                rows.Sort((left, right) => {
+                    int result = CompareSortValues(left.SortValue, right.SortValue);
+                    if (result == 0) {
+                        result = left.OriginalRow.CompareTo(right.OriginalRow);
+                    }
+                    return ascending ? result : -result;
+                });
+
+                for (int index = 0; index < rows.Count; index++) {
+                    WriteRowSnapshot(firstDataRow + index, c1, c2, rows[index]);
+                }
+
+                WorksheetRoot.Save();
+                ClearHeaderCache();
+            });
+        }
+
+        /// <summary>
+        /// Merges the specified A1 range.
+        /// </summary>
+        public void MergeRange(string a1Range) {
+            A1.ParseRange(a1Range);
+            WriteLock(() => {
+                var ws = WorksheetRoot;
+                var merges = ws.GetFirstChild<MergeCells>();
+                if (merges == null) {
+                    var customSheetViews = ws.GetFirstChild<CustomSheetViews>();
+                    merges = new MergeCells();
+                    if (customSheetViews != null) {
+                        ws.InsertBefore(merges, customSheetViews);
+                    } else {
+                        ws.Append(merges);
+                    }
+                }
+
+                if (!merges.Elements<MergeCell>().Any(m => string.Equals(m.Reference?.Value, a1Range, StringComparison.OrdinalIgnoreCase))) {
+                    merges.Append(new MergeCell { Reference = a1Range });
+                    merges.Count = (uint)merges.Elements<MergeCell>().Count();
+                }
+
+                ws.Save();
+            });
+        }
+
+        /// <summary>
+        /// Removes merge definitions that overlap the supplied A1 range.
+        /// </summary>
+        public void UnmergeRange(string a1Range) {
+            WriteLock(() => UnmergeRangeCore(a1Range));
+        }
+
+        private void UnmergeRangeCore(string a1Range) {
+            var bounds = A1.ParseRange(a1Range);
+            var merges = WorksheetRoot.GetFirstChild<MergeCells>();
+            if (merges == null) return;
+
+            foreach (var merge in merges.Elements<MergeCell>().ToList()) {
+                if (merge.Reference?.Value is string reference && RangesOverlapInclusive(bounds, A1.ParseRange(reference))) {
+                    merge.Remove();
+                }
+            }
+
+            merges.Count = (uint)merges.Elements<MergeCell>().Count();
+            WorksheetRoot.Save();
+        }
+
+        /// <summary>
+        /// Writes rich inline text runs into a cell.
+        /// </summary>
+        public void SetRichText(int row, int column, IEnumerable<ExcelRichTextRun> runs) {
+            if (runs == null) throw new ArgumentNullException(nameof(runs));
+            WriteLock(() => {
+                var cell = GetCell(row, column);
+                var inline = new InlineString();
+                foreach (var run in runs) {
+                    var text = new Text(run.Text ?? string.Empty) { Space = SpaceProcessingModeValues.Preserve };
+                    var properties = new RunProperties();
+                    if (run.Bold) properties.Append(new Bold());
+                    if (run.Italic) properties.Append(new Italic());
+                    if (run.Underline) properties.Append(new Underline());
+                    if (!string.IsNullOrWhiteSpace(run.FontColor)) properties.Append(new Color { Rgb = NormalizeHexColor(run.FontColor!) });
+                    if (!string.IsNullOrWhiteSpace(run.FontName)) properties.Append(new RunFont { Val = run.FontName });
+                    if (run.FontSize.HasValue) properties.Append(new FontSize { Val = run.FontSize.Value });
+
+                    var openXmlRun = new Run();
+                    if (properties.HasChildren) {
+                        openXmlRun.Append(properties);
+                    }
+                    openXmlRun.Append(text);
+                    inline.Append(openXmlRun);
+                }
+
+                cell.CellFormula = null;
+                cell.CellValue = null;
+                cell.DataType = DocumentFormat.OpenXml.Spreadsheet.CellValues.InlineString;
+                cell.InlineString = inline;
+                ClearHeaderCache();
+            });
+        }
+
+        /// <summary>
+        /// Reads rich inline text runs from a cell.
+        /// </summary>
+        public IReadOnlyList<ExcelRichTextRun> GetRichText(int row, int column) {
+            var cell = GetCell(row, column);
+            if (cell.InlineString == null) {
+                return Array.Empty<ExcelRichTextRun>();
+            }
+
+            var runs = new List<ExcelRichTextRun>();
+            foreach (var run in cell.InlineString.Elements<Run>()) {
+                var properties = run.RunProperties;
+                var text = run.Text?.Text ?? string.Empty;
+                runs.Add(new ExcelRichTextRun(text) {
+                    Bold = properties?.GetFirstChild<Bold>() != null,
+                    Italic = properties?.GetFirstChild<Italic>() != null,
+                    Underline = properties?.GetFirstChild<Underline>() != null,
+                    FontColor = properties?.GetFirstChild<Color>()?.Rgb?.Value,
+                    FontName = properties?.GetFirstChild<RunFont>()?.Val?.Value,
+                    FontSize = properties?.GetFirstChild<FontSize>()?.Val?.Value
+                });
+            }
+
+            return runs;
+        }
+
+        private void ClearCommentsInRange(int firstRow, int firstColumn, int lastRow, int lastColumn) {
+            var commentsPart = WorksheetCommentsPartRoot;
+            if (commentsPart?.Comments?.CommentList != null) {
+                foreach (var comment in commentsPart.Comments.CommentList.Elements<Comment>().ToList()) {
+                    if (comment.Reference?.Value is not string reference) {
+                        continue;
+                    }
+
+                    var (row, col) = A1.ParseCellRef(reference);
+                    if (row >= firstRow && row <= lastRow && col >= firstColumn && col <= lastColumn) {
+                        comment.Remove();
+                    }
+                }
+
+                commentsPart.Comments.Save();
+            }
+
+            for (int row = firstRow; row <= lastRow; row++) {
+                for (int column = firstColumn; column <= lastColumn; column++) {
+                    RemoveCommentVmlShape(row, column);
+                }
+            }
+
+            CleanupCommentArtifacts();
+        }
+
+        private RowSnapshot CaptureRow(int rowIndex, int firstColumn, int lastColumn, int sortColumn) {
+            var cells = new List<CellSnapshot>();
+            object? sortValue = null;
+            for (int column = firstColumn; column <= lastColumn; column++) {
+                var cell = GetCell(rowIndex, column);
+                var clone = (Cell)cell.CloneNode(true);
+                cells.Add(new CellSnapshot(column - firstColumn, clone));
+                if (column == sortColumn) {
+                    sortValue = GetCellValueSnapshot(rowIndex, column).Value;
+                }
+            }
+
+            return new RowSnapshot(rowIndex, cells, sortValue);
+        }
+
+        private void WriteRowSnapshot(int targetRow, int firstColumn, int lastColumn, RowSnapshot snapshot) {
+            for (int column = firstColumn; column <= lastColumn; column++) {
+                var cell = GetCell(targetRow, column);
+                cell.RemoveAllChildren();
+                cell.CellFormula = null;
+                cell.CellValue = null;
+                cell.DataType = null;
+                cell.StyleIndex = null;
+
+                var source = snapshot.Cells[column - firstColumn].Cell;
+                cell.DataType = source.DataType;
+                cell.StyleIndex = source.StyleIndex;
+                if (source.CellFormula != null) cell.CellFormula = (CellFormula)source.CellFormula.CloneNode(true);
+                if (source.CellValue != null) cell.CellValue = (CellValue)source.CellValue.CloneNode(true);
+                if (source.InlineString != null) cell.InlineString = (InlineString)source.InlineString.CloneNode(true);
+                foreach (var child in source.ChildElements.Where(c =>
+                    !(c is DocumentFormat.OpenXml.Spreadsheet.CellFormula)
+                    && !(c is DocumentFormat.OpenXml.Spreadsheet.CellValue)
+                    && !(c is InlineString))) {
+                    cell.Append(child.CloneNode(true));
+                }
+            }
+        }
+
+        private static int CompareSortValues(object? left, object? right) {
+            if (left == null && right == null) return 0;
+            if (left == null) return 1;
+            if (right == null) return -1;
+            if (left is double ld && right is double rd) return ld.CompareTo(rd);
+            if (left is IComparable comparable && left.GetType() == right.GetType()) return comparable.CompareTo(right);
+            return string.Compare(Convert.ToString(left, CultureInfo.InvariantCulture), Convert.ToString(right, CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool RangesOverlapInclusive((int r1, int c1, int r2, int c2) left, (int r1, int c1, int r2, int c2) right) {
+            return left.r1 <= right.r2 && left.r2 >= right.r1 && left.c1 <= right.c2 && left.c2 >= right.c1;
+        }
+
+        private void ClearHyperlinksInRange(Worksheet ws, string a1Range) {
+            var bounds = A1.ParseRange(a1Range);
+            var hyperlinks = ws.GetFirstChild<Hyperlinks>();
+            if (hyperlinks == null) return;
+
+            foreach (var link in hyperlinks.Elements<Hyperlink>().ToList()) {
+                if (link.Reference?.Value is string reference) {
+                    var linkBounds = reference.IndexOf(':') >= 0
+                        ? A1.ParseRange(reference)
+                        : CellAsRange(reference);
+                    if (RangesOverlapInclusive(bounds, linkBounds)) {
+                        link.Remove();
+                    }
+                }
+            }
+        }
+
+        private void ClearSparklinesInRange(string a1Range) {
+            var bounds = A1.ParseRange(a1Range);
+            foreach (var sparkline in WorksheetRoot.Descendants<DocumentFormat.OpenXml.Office2010.Excel.Sparkline>().ToList()) {
+                var reference = sparkline.ReferenceSequence?.Text;
+                if (!string.IsNullOrWhiteSpace(reference)) {
+                    var sparklineBounds = CellAsRange(reference!);
+                    if (RangesOverlapInclusive(bounds, sparklineBounds)) {
+                        sparkline.Remove();
+                    }
+                }
+            }
+        }
+
+        private static (int r1, int c1, int r2, int c2) CellAsRange(string cellRef) {
+            var parsed = A1.ParseCellRef(cellRef);
+            return (parsed.Row, parsed.Col, parsed.Row, parsed.Col);
+        }
+
+        private sealed class RowSnapshot {
+            internal RowSnapshot(int originalRow, List<CellSnapshot> cells, object? sortValue) {
+                OriginalRow = originalRow;
+                Cells = cells;
+                SortValue = sortValue;
+            }
+
+            internal int OriginalRow { get; }
+            internal List<CellSnapshot> Cells { get; }
+            internal object? SortValue { get; }
+        }
+
+        private sealed class CellSnapshot {
+            internal CellSnapshot(int offset, Cell cell) {
+                Offset = offset;
+                Cell = cell;
+            }
+
+            internal int Offset { get; }
+            internal Cell Cell { get; }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.ObjectModel.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectModel.cs
@@ -26,7 +26,10 @@ namespace OfficeIMO.Excel {
             var cell = GetCell(row, column);
             string? cached = cell.CellValue?.Text;
             if (cell.CellFormula != null) {
-                return new ExcelCellData(ExcelCellDataKind.Formula, cached, cell.CellFormula.Text, cached);
+                object? formulaValue = double.TryParse(cached, NumberStyles.Float, CultureInfo.InvariantCulture, out double cachedNumber)
+                    ? cachedNumber
+                    : cached;
+                return new ExcelCellData(ExcelCellDataKind.Formula, formulaValue, cell.CellFormula.Text, cached);
             }
 
             if (cell.CellValue == null && cell.InlineString == null) {
@@ -98,21 +101,27 @@ namespace OfficeIMO.Excel {
             var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
             WriteLock(() => {
                 var ws = WorksheetRoot;
-                for (int row = r1; row <= r2; row++) {
-                    for (int column = c1; column <= c2; column++) {
-                        var cell = GetCell(row, column);
-                        if (options.HasFlag(ExcelClearOptions.Values)) {
-                            cell.CellValue = null;
-                            cell.DataType = null;
-                            cell.InlineString = null;
-                        }
+                bool clearCellFields = options.HasFlag(ExcelClearOptions.Values)
+                    || options.HasFlag(ExcelClearOptions.Formulas)
+                    || options.HasFlag(ExcelClearOptions.Styles);
 
-                        if (options.HasFlag(ExcelClearOptions.Formulas)) {
-                            cell.CellFormula = null;
-                        }
+                if (clearCellFields) {
+                    for (int row = r1; row <= r2; row++) {
+                        for (int column = c1; column <= c2; column++) {
+                            var cell = GetCell(row, column);
+                            if (options.HasFlag(ExcelClearOptions.Values)) {
+                                cell.CellValue = null;
+                                cell.DataType = null;
+                                cell.InlineString = null;
+                            }
 
-                        if (options.HasFlag(ExcelClearOptions.Styles)) {
-                            cell.StyleIndex = null;
+                            if (options.HasFlag(ExcelClearOptions.Formulas)) {
+                                cell.CellFormula = null;
+                            }
+
+                            if (options.HasFlag(ExcelClearOptions.Styles)) {
+                                cell.StyleIndex = null;
+                            }
                         }
                     }
                 }
@@ -178,6 +187,7 @@ namespace OfficeIMO.Excel {
                     WriteRowSnapshot(firstDataRow + index, c1, c2, rows[index]);
                 }
 
+                RemapSortedRangeMetadata(rows, firstDataRow, r2, c1, c2);
                 WorksheetRoot.Save();
                 ClearHeaderCache();
             });
@@ -318,6 +328,99 @@ namespace OfficeIMO.Excel {
             CleanupCommentArtifacts();
         }
 
+        private void RemapSortedRangeMetadata(IReadOnlyList<RowSnapshot> rows, int firstRow, int lastRow, int firstColumn, int lastColumn) {
+            var rowMap = new Dictionary<int, int>();
+            for (int index = 0; index < rows.Count; index++) {
+                int targetRow = firstRow + index;
+                if (rows[index].OriginalRow != targetRow) {
+                    rowMap[rows[index].OriginalRow] = targetRow;
+                }
+            }
+
+            if (rowMap.Count == 0) {
+                return;
+            }
+
+            RemapSortedComments(rowMap, firstRow, lastRow, firstColumn, lastColumn);
+            RemapSortedHyperlinks(rowMap, firstRow, lastRow, firstColumn, lastColumn);
+            RemapSortedDataValidations(rowMap, firstRow, lastRow, firstColumn, lastColumn);
+            RemapSortedConditionalFormatting(rowMap, firstRow, lastRow, firstColumn, lastColumn);
+        }
+
+        private void RemapSortedComments(IReadOnlyDictionary<int, int> rowMap, int firstRow, int lastRow, int firstColumn, int lastColumn) {
+            var commentsPart = WorksheetCommentsPartRoot;
+            if (commentsPart?.Comments?.CommentList == null) {
+                return;
+            }
+
+            var moved = new List<((int Row, int Col) OldCell, (int Row, int Col) NewCell)>();
+            foreach (var comment in commentsPart.Comments.CommentList.Elements<Comment>()) {
+                if (comment.Reference?.Value is not string reference) {
+                    continue;
+                }
+
+                var cell = A1.ParseCellRef(reference);
+                if (cell.Row < firstRow || cell.Row > lastRow || cell.Col < firstColumn || cell.Col > lastColumn) {
+                    continue;
+                }
+
+                if (rowMap.TryGetValue(cell.Row, out int targetRow)) {
+                    comment.Reference = A1.CellReference(targetRow, cell.Col);
+                    moved.Add((cell, (targetRow, cell.Col)));
+                }
+            }
+
+            if (moved.Count == 0) {
+                return;
+            }
+
+            commentsPart.Comments.Save();
+            foreach (var pair in moved) {
+                RemoveCommentVmlShape(pair.OldCell.Row, pair.OldCell.Col);
+            }
+
+            foreach (var pair in moved) {
+                EnsureCommentVmlShape(pair.NewCell.Row, pair.NewCell.Col);
+            }
+        }
+
+        private void RemapSortedHyperlinks(IReadOnlyDictionary<int, int> rowMap, int firstRow, int lastRow, int firstColumn, int lastColumn) {
+            var hyperlinks = WorksheetRoot.GetFirstChild<Hyperlinks>();
+            if (hyperlinks == null) {
+                return;
+            }
+
+            foreach (var link in hyperlinks.Elements<Hyperlink>()) {
+                if (link.Reference?.Value is string reference
+                    && TryRemapReferenceForSortedRange(reference, rowMap, firstRow, lastRow, firstColumn, lastColumn, out string remapped)) {
+                    link.Reference = remapped;
+                }
+            }
+        }
+
+        private void RemapSortedDataValidations(IReadOnlyDictionary<int, int> rowMap, int firstRow, int lastRow, int firstColumn, int lastColumn) {
+            var validations = WorksheetRoot.GetFirstChild<DataValidations>();
+            if (validations == null) {
+                return;
+            }
+
+            foreach (var validation in validations.Elements<DataValidation>()) {
+                if (validation.SequenceOfReferences?.InnerText is string references
+                    && TryRemapReferenceListForSortedRange(references, rowMap, firstRow, lastRow, firstColumn, lastColumn, out string remapped)) {
+                    validation.SequenceOfReferences = new ListValue<StringValue> { InnerText = remapped };
+                }
+            }
+        }
+
+        private void RemapSortedConditionalFormatting(IReadOnlyDictionary<int, int> rowMap, int firstRow, int lastRow, int firstColumn, int lastColumn) {
+            foreach (var conditional in WorksheetRoot.Elements<ConditionalFormatting>()) {
+                if (conditional.SequenceOfReferences?.InnerText is string references
+                    && TryRemapReferenceListForSortedRange(references, rowMap, firstRow, lastRow, firstColumn, lastColumn, out string remapped)) {
+                    conditional.SequenceOfReferences = new ListValue<StringValue> { InnerText = remapped };
+                }
+            }
+        }
+
         private RowSnapshot CaptureRow(int rowIndex, int firstColumn, int lastColumn, int sortColumn) {
             var cells = new List<CellSnapshot>();
             object? sortValue = null;
@@ -370,6 +473,67 @@ namespace OfficeIMO.Excel {
             return left.r1 <= right.r2 && left.r2 >= right.r1 && left.c1 <= right.c2 && left.c2 >= right.c1;
         }
 
+        private static bool TryRemapReferenceListForSortedRange(string referenceList, IReadOnlyDictionary<int, int> rowMap, int firstRow, int lastRow, int firstColumn, int lastColumn, out string remapped) {
+            bool changed = false;
+            var parts = new List<string>();
+            foreach (string part in SplitReferenceList(referenceList)) {
+                if (TryRemapReferenceForSortedRange(part, rowMap, firstRow, lastRow, firstColumn, lastColumn, out string remappedPart)) {
+                    parts.Add(remappedPart);
+                    changed = true;
+                } else {
+                    parts.Add(part);
+                }
+            }
+
+            remapped = string.Join(" ", parts);
+            return changed;
+        }
+
+        private static bool TryRemapReferenceForSortedRange(string reference, IReadOnlyDictionary<int, int> rowMap, int firstRow, int lastRow, int firstColumn, int lastColumn, out string remapped) {
+            remapped = reference;
+            var bounds = TryParseReference(reference, out var parsed) ? parsed : default;
+            if (bounds == default
+                || bounds.r1 < firstRow
+                || bounds.r2 > lastRow
+                || bounds.c1 < firstColumn
+                || bounds.c2 > lastColumn) {
+                return false;
+            }
+
+            var remappedRows = new List<int>();
+            bool changed = false;
+            for (int row = bounds.r1; row <= bounds.r2; row++) {
+                if (rowMap.TryGetValue(row, out int targetRow)) {
+                    remappedRows.Add(targetRow);
+                    changed = true;
+                } else {
+                    remappedRows.Add(row);
+                }
+            }
+
+            if (!changed) {
+                return false;
+            }
+
+            remappedRows.Sort();
+            var parts = new List<string>();
+            int runStart = remappedRows[0];
+            int previous = remappedRows[0];
+            for (int index = 1; index < remappedRows.Count; index++) {
+                if (remappedRows[index] == previous + 1) {
+                    previous = remappedRows[index];
+                    continue;
+                }
+
+                parts.Add(ToReference(runStart, bounds.c1, previous, bounds.c2));
+                runStart = previous = remappedRows[index];
+            }
+
+            parts.Add(ToReference(runStart, bounds.c1, previous, bounds.c2));
+            remapped = string.Join(" ", parts);
+            return true;
+        }
+
         private void ClearHyperlinksInRange(Worksheet ws, string a1Range) {
             var bounds = A1.ParseRange(a1Range);
             var hyperlinks = ws.GetFirstChild<Hyperlinks>();
@@ -403,6 +567,28 @@ namespace OfficeIMO.Excel {
         private static (int r1, int c1, int r2, int c2) CellAsRange(string cellRef) {
             var parsed = A1.ParseCellRef(cellRef);
             return (parsed.Row, parsed.Col, parsed.Row, parsed.Col);
+        }
+
+        private static bool TryParseReference(string reference, out (int r1, int c1, int r2, int c2) bounds) {
+            string normalized = reference.Replace("$", string.Empty);
+            if (normalized.IndexOf(':') >= 0) {
+                return A1.TryParseRange(normalized, out bounds.r1, out bounds.c1, out bounds.r2, out bounds.c2);
+            }
+
+            var cell = A1.ParseCellRef(normalized);
+            if (cell.Row <= 0 || cell.Col <= 0) {
+                bounds = default;
+                return false;
+            }
+
+            bounds = (cell.Row, cell.Col, cell.Row, cell.Col);
+            return true;
+        }
+
+        private static string ToReference(int r1, int c1, int r2, int c2) {
+            string start = A1.CellReference(r1, c1);
+            string end = A1.CellReference(r2, c2);
+            return string.Equals(start, end, StringComparison.OrdinalIgnoreCase) ? start : $"{start}:{end}";
         }
 
         private sealed class RowSnapshot {

--- a/OfficeIMO.Excel/ExcelSheet.ObjectModel.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectModel.cs
@@ -23,7 +23,15 @@ namespace OfficeIMO.Excel {
         public ExcelTable Table(string nameOrRange) => new ExcelTable(this, nameOrRange);
 
         internal ExcelCellData GetCellValueSnapshot(int row, int column) {
-            var cell = GetCell(row, column);
+            var cell = TryGetExistingCell(row, column);
+            return GetCellValueSnapshot(cell);
+        }
+
+        private ExcelCellData GetCellValueSnapshot(Cell? cell) {
+            if (cell == null) {
+                return new ExcelCellData(ExcelCellDataKind.Blank, null);
+            }
+
             string? cached = cell.CellValue?.Text;
             if (cell.CellFormula != null) {
                 object? formulaValue = double.TryParse(cached, NumberStyles.Float, CultureInfo.InvariantCulture, out double cachedNumber)
@@ -183,11 +191,12 @@ namespace OfficeIMO.Excel {
                     return ascending ? result : -result;
                 });
 
+                var rowMap = BuildSortedRowMap(rows, firstDataRow);
                 for (int index = 0; index < rows.Count; index++) {
-                    WriteRowSnapshot(firstDataRow + index, c1, c2, rows[index]);
+                    WriteRowSnapshot(firstDataRow + index, c1, c2, rows[index], rowMap);
                 }
 
-                RemapSortedRangeMetadata(rows, firstDataRow, r2, c1, c2);
+                RemapSortedRangeMetadata(rowMap, firstDataRow, r2, c1, c2);
                 WorksheetRoot.Save();
                 ClearHeaderCache();
             });
@@ -328,7 +337,7 @@ namespace OfficeIMO.Excel {
             CleanupCommentArtifacts();
         }
 
-        private void RemapSortedRangeMetadata(IReadOnlyList<RowSnapshot> rows, int firstRow, int lastRow, int firstColumn, int lastColumn) {
+        private static Dictionary<int, int> BuildSortedRowMap(IReadOnlyList<RowSnapshot> rows, int firstRow) {
             var rowMap = new Dictionary<int, int>();
             for (int index = 0; index < rows.Count; index++) {
                 int targetRow = firstRow + index;
@@ -337,6 +346,10 @@ namespace OfficeIMO.Excel {
                 }
             }
 
+            return rowMap;
+        }
+
+        private void RemapSortedRangeMetadata(IReadOnlyDictionary<int, int> rowMap, int firstRow, int lastRow, int firstColumn, int lastColumn) {
             if (rowMap.Count == 0) {
                 return;
             }
@@ -439,30 +452,42 @@ namespace OfficeIMO.Excel {
             var cells = new List<CellSnapshot>();
             object? sortValue = null;
             for (int column = firstColumn; column <= lastColumn; column++) {
-                var cell = GetCell(rowIndex, column);
-                var clone = (Cell)cell.CloneNode(true);
+                var cell = TryGetExistingCell(rowIndex, column);
+                var clone = cell == null ? null : (Cell)cell.CloneNode(true);
                 cells.Add(new CellSnapshot(column - firstColumn, clone));
                 if (column == sortColumn) {
-                    sortValue = GetCellValueSnapshot(rowIndex, column).Value;
+                    sortValue = GetCellValueSnapshot(cell).Value;
                 }
             }
 
             return new RowSnapshot(rowIndex, cells, sortValue);
         }
 
-        private void WriteRowSnapshot(int targetRow, int firstColumn, int lastColumn, RowSnapshot snapshot) {
+        private void WriteRowSnapshot(int targetRow, int firstColumn, int lastColumn, RowSnapshot snapshot, IReadOnlyDictionary<int, int> rowMap) {
             for (int column = firstColumn; column <= lastColumn; column++) {
-                var cell = GetCell(targetRow, column);
+                var source = snapshot.Cells[column - firstColumn].Cell;
+                var cell = TryGetExistingCell(targetRow, column);
+                if (source == null) {
+                    cell?.Remove();
+                    continue;
+                }
+
+                cell ??= GetCell(targetRow, column);
                 cell.RemoveAllChildren();
                 cell.CellFormula = null;
                 cell.CellValue = null;
                 cell.DataType = null;
                 cell.StyleIndex = null;
 
-                var source = snapshot.Cells[column - firstColumn].Cell;
                 cell.DataType = source.DataType;
                 cell.StyleIndex = source.StyleIndex;
-                if (source.CellFormula != null) cell.CellFormula = (CellFormula)source.CellFormula.CloneNode(true);
+                if (source.CellFormula != null) {
+                    var formula = (CellFormula)source.CellFormula.CloneNode(true);
+                    if (!string.IsNullOrEmpty(formula.Text)) {
+                        formula.Text = RewriteSortedFormulaReferences(formula.Text, rowMap, firstColumn, lastColumn);
+                    }
+                    cell.CellFormula = formula;
+                }
                 if (source.CellValue != null) cell.CellValue = (CellValue)source.CellValue.CloneNode(true);
                 if (source.InlineString != null) cell.InlineString = (InlineString)source.InlineString.CloneNode(true);
                 foreach (var child in source.ChildElements.Where(c =>
@@ -555,11 +580,19 @@ namespace OfficeIMO.Excel {
 
             foreach (var link in hyperlinks.Elements<Hyperlink>().ToList()) {
                 if (link.Reference?.Value is string reference) {
-                    var linkBounds = reference.IndexOf(':') >= 0
-                        ? A1.ParseRange(reference)
-                        : CellAsRange(reference);
-                    if (RangesOverlapInclusive(bounds, linkBounds)) {
+                    var remaining = RemoveReferenceOverlap(reference, bounds);
+                    if (remaining.Count == 0) {
                         link.Remove();
+                        continue;
+                    }
+
+                    link.Reference = remaining[0];
+                    var insertAfter = link;
+                    for (int index = 1; index < remaining.Count; index++) {
+                        var clone = (Hyperlink)link.CloneNode(true);
+                        clone.Reference = remaining[index];
+                        hyperlinks.InsertAfter(clone, insertAfter);
+                        insertAfter = clone;
                     }
                 }
             }
@@ -605,6 +638,55 @@ namespace OfficeIMO.Excel {
             return string.Equals(start, end, StringComparison.OrdinalIgnoreCase) ? start : $"{start}:{end}";
         }
 
+        private Cell? TryGetExistingCell(int row, int column) {
+            if (row <= 0) throw new ArgumentOutOfRangeException(nameof(row));
+            if (column <= 0) throw new ArgumentOutOfRangeException(nameof(column));
+
+            var sheetData = WorksheetRoot.GetFirstChild<SheetData>();
+            if (sheetData == null) {
+                return null;
+            }
+
+            var rowElement = sheetData.Elements<Row>().FirstOrDefault(r => r.RowIndex?.Value == (uint)row);
+            if (rowElement == null) {
+                return null;
+            }
+
+            foreach (Cell cell in rowElement.Elements<Cell>()) {
+                if (cell.CellReference?.Value is string reference
+                    && GetColumnIndex(reference) == column) {
+                    return cell;
+                }
+            }
+
+            return null;
+        }
+
+        private static string RewriteSortedFormulaReferences(string formula, IReadOnlyDictionary<int, int> rowMap, int firstColumn, int lastColumn) {
+            if (rowMap.Count == 0 || string.IsNullOrEmpty(formula)) {
+                return formula;
+            }
+
+            return Regex.Replace(
+                formula,
+                @"(?<![A-Za-z0-9_\.!])(\$?)([A-Za-z]{1,3})(\$?)(\d{1,7})(?=[:),+\-*/^&=<> \t\r\n]|$)",
+                match => {
+                    bool rowAbsolute = match.Groups[3].Value == "$";
+                    if (rowAbsolute || !int.TryParse(match.Groups[4].Value, NumberStyles.None, CultureInfo.InvariantCulture, out int row)) {
+                        return match.Value;
+                    }
+
+                    var cell = A1.ParseCellRef(match.Groups[2].Value + row.ToString(CultureInfo.InvariantCulture));
+                    if (cell.Col < firstColumn || cell.Col > lastColumn || !rowMap.TryGetValue(row, out int targetRow)) {
+                        return match.Value;
+                    }
+
+                    return match.Groups[1].Value + match.Groups[2].Value + match.Groups[3].Value + targetRow.ToString(CultureInfo.InvariantCulture);
+                },
+                RegexOptions.CultureInvariant,
+                TimeSpan.FromMilliseconds(200));
+        }
+
         private sealed class RowSnapshot {
             internal RowSnapshot(int originalRow, List<CellSnapshot> cells, object? sortValue) {
                 OriginalRow = originalRow;
@@ -618,13 +700,13 @@ namespace OfficeIMO.Excel {
         }
 
         private sealed class CellSnapshot {
-            internal CellSnapshot(int offset, Cell cell) {
+            internal CellSnapshot(int offset, Cell? cell) {
                 Offset = offset;
                 Cell = cell;
             }
 
             internal int Offset { get; }
-            internal Cell Cell { get; }
+            internal Cell? Cell { get; }
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.ObjectModel.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectModel.cs
@@ -390,10 +390,24 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
-            foreach (var link in hyperlinks.Elements<Hyperlink>()) {
-                if (link.Reference?.Value is string reference
-                    && TryRemapReferenceForSortedRange(reference, rowMap, firstRow, lastRow, firstColumn, lastColumn, out string remapped)) {
-                    link.Reference = remapped;
+            foreach (var link in hyperlinks.Elements<Hyperlink>().ToList()) {
+                if (link.Reference?.Value is not string reference
+                    || !TryRemapReferenceForSortedRange(reference, rowMap, firstRow, lastRow, firstColumn, lastColumn, out string remapped)) {
+                    continue;
+                }
+
+                var references = SplitReferenceList(remapped);
+                if (references.Length == 0) {
+                    continue;
+                }
+
+                link.Reference = references[0];
+                var insertAfter = link;
+                for (int index = 1; index < references.Length; index++) {
+                    var clone = (Hyperlink)link.CloneNode(true);
+                    clone.Reference = references[index];
+                    hyperlinks.InsertAfter(clone, insertAfter);
+                    insertAfter = clone;
                 }
             }
         }

--- a/OfficeIMO.Excel/ExcelSheet.Protection.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Protection.cs
@@ -29,19 +29,19 @@ namespace OfficeIMO.Excel {
                 }
 
                 protection.Sheet = true;
-                protection.SelectLockedCells = opts.AllowSelectLockedCells;
-                protection.SelectUnlockedCells = opts.AllowSelectUnlockedCells;
-                protection.FormatCells = opts.AllowFormatCells;
-                protection.FormatColumns = opts.AllowFormatColumns;
-                protection.FormatRows = opts.AllowFormatRows;
-                protection.InsertColumns = opts.AllowInsertColumns;
-                protection.InsertRows = opts.AllowInsertRows;
-                protection.InsertHyperlinks = opts.AllowInsertHyperlinks;
-                protection.DeleteColumns = opts.AllowDeleteColumns;
-                protection.DeleteRows = opts.AllowDeleteRows;
-                protection.Sort = opts.AllowSort;
-                protection.AutoFilter = opts.AllowAutoFilter;
-                protection.PivotTables = opts.AllowPivotTables;
+                protection.SelectLockedCells = !opts.AllowSelectLockedCells;
+                protection.SelectUnlockedCells = !opts.AllowSelectUnlockedCells;
+                protection.FormatCells = !opts.AllowFormatCells;
+                protection.FormatColumns = !opts.AllowFormatColumns;
+                protection.FormatRows = !opts.AllowFormatRows;
+                protection.InsertColumns = !opts.AllowInsertColumns;
+                protection.InsertRows = !opts.AllowInsertRows;
+                protection.InsertHyperlinks = !opts.AllowInsertHyperlinks;
+                protection.DeleteColumns = !opts.AllowDeleteColumns;
+                protection.DeleteRows = !opts.AllowDeleteRows;
+                protection.Sort = !opts.AllowSort;
+                protection.AutoFilter = !opts.AllowAutoFilter;
+                protection.PivotTables = !opts.AllowPivotTables;
                 string? hash = ExcelProtectionHash.ResolveLegacyHash(opts.Password, opts.LegacyPasswordHash);
                 if (hash != null) {
                     protection.Password = hash;

--- a/OfficeIMO.Excel/ExcelSheet.Protection.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Protection.cs
@@ -42,6 +42,13 @@ namespace OfficeIMO.Excel {
                 protection.Sort = opts.AllowSort;
                 protection.AutoFilter = opts.AllowAutoFilter;
                 protection.PivotTables = opts.AllowPivotTables;
+                string? hash = ExcelProtectionHash.ResolveLegacyHash(opts.Password, opts.LegacyPasswordHash);
+                if (hash != null) {
+                    protection.Password = hash;
+                } else {
+                    protection.Password = null;
+                    protection.RemoveAttribute("password", string.Empty);
+                }
 
                 EnsureWorksheetElementOrder();
                 ws.Save();

--- a/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
@@ -164,10 +164,11 @@ namespace OfficeIMO.Excel {
                 var filter = A1.ParseRange(a1Range!);
                 foreach (var conditional in WorksheetRoot.Elements<ConditionalFormatting>().ToList()) {
                     string range = conditional.SequenceOfReferences?.InnerText ?? string.Empty;
-                    bool overlaps = SplitReferenceList(range)
-                        .Any(part => RangesOverlapInclusive(filter, part.IndexOf(':') >= 0 ? A1.ParseRange(part) : CellAsRange(part)));
-                    if (overlaps) {
+                    var remaining = RemoveReferenceOverlap(range, filter);
+                    if (remaining.Count == 0) {
                         conditional.Remove();
+                    } else if (!string.Equals(range, string.Join(" ", remaining), StringComparison.OrdinalIgnoreCase)) {
+                        conditional.SequenceOfReferences = new ListValue<StringValue> { InnerText = string.Join(" ", remaining) };
                     }
                 }
             }
@@ -185,10 +186,11 @@ namespace OfficeIMO.Excel {
                 var filter = A1.ParseRange(a1Range!);
                 foreach (var validation in validations.Elements<DataValidation>().ToList()) {
                     string range = validation.SequenceOfReferences?.InnerText ?? string.Empty;
-                    bool overlaps = SplitReferenceList(range)
-                        .Any(part => RangesOverlapInclusive(filter, part.IndexOf(':') >= 0 ? A1.ParseRange(part) : CellAsRange(part)));
-                    if (overlaps) {
+                    var remaining = RemoveReferenceOverlap(range, filter);
+                    if (remaining.Count == 0) {
                         validation.Remove();
+                    } else if (!string.Equals(range, string.Join(" ", remaining), StringComparison.OrdinalIgnoreCase)) {
+                        validation.SequenceOfReferences = new ListValue<StringValue> { InnerText = string.Join(" ", remaining) };
                     }
                 }
             }
@@ -221,6 +223,50 @@ namespace OfficeIMO.Excel {
 
         private static string[] SplitReferenceList(string referenceList) {
             return referenceList.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        private static List<string> RemoveReferenceOverlap(string referenceList, (int r1, int c1, int r2, int c2) filter) {
+            var remaining = new List<string>();
+            foreach (string part in SplitReferenceList(referenceList)) {
+                if (!TryParseReference(part, out var bounds)) {
+                    remaining.Add(part);
+                    continue;
+                }
+
+                foreach (var segment in SubtractRange(bounds, filter)) {
+                    remaining.Add(ToReference(segment.r1, segment.c1, segment.r2, segment.c2));
+                }
+            }
+
+            return remaining;
+        }
+
+        private static IEnumerable<(int r1, int c1, int r2, int c2)> SubtractRange((int r1, int c1, int r2, int c2) source, (int r1, int c1, int r2, int c2) remove) {
+            if (!RangesOverlapInclusive(source, remove)) {
+                yield return source;
+                yield break;
+            }
+
+            int ir1 = Math.Max(source.r1, remove.r1);
+            int ic1 = Math.Max(source.c1, remove.c1);
+            int ir2 = Math.Min(source.r2, remove.r2);
+            int ic2 = Math.Min(source.c2, remove.c2);
+
+            if (source.r1 < ir1) {
+                yield return (source.r1, source.c1, ir1 - 1, source.c2);
+            }
+
+            if (ir2 < source.r2) {
+                yield return (ir2 + 1, source.c1, source.r2, source.c2);
+            }
+
+            if (source.c1 < ic1) {
+                yield return (ir1, source.c1, ir2, ic1 - 1);
+            }
+
+            if (ic2 < source.c2) {
+                yield return (ir1, ic2 + 1, ir2, source.c2);
+            }
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
@@ -1,0 +1,226 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Lists conditional formatting rules on the worksheet.
+        /// </summary>
+        public IReadOnlyList<ExcelConditionalFormattingInfo> GetConditionalFormattingRules(string? a1Range = null) {
+            (int r1, int c1, int r2, int c2)? filter = string.IsNullOrWhiteSpace(a1Range) ? null : A1.ParseRange(a1Range!);
+            var list = new List<ExcelConditionalFormattingInfo>();
+            foreach (var conditional in WorksheetRoot.Elements<ConditionalFormatting>()) {
+                string range = conditional.SequenceOfReferences?.InnerText ?? string.Empty;
+                if (filter.HasValue && !string.IsNullOrWhiteSpace(range)) {
+                    bool overlaps = SplitReferenceList(range)
+                        .Any(part => RangesOverlapInclusive(filter.Value, part.IndexOf(':') >= 0 ? A1.ParseRange(part) : CellAsRange(part)));
+                    if (!overlaps) continue;
+                }
+
+                foreach (var rule in conditional.Elements<ConditionalFormattingRule>()) {
+                    list.Add(new ExcelConditionalFormattingInfo {
+                        Range = range,
+                        Type = rule.Type?.Value.ToString() ?? string.Empty,
+                        Operator = rule.Operator?.Value.ToString(),
+                        Priority = (int)(rule.Priority?.Value ?? 0),
+                        StopIfTrue = rule.StopIfTrue?.Value ?? false,
+                        Formulas = rule.Elements<Formula>().Select(f => f.Text ?? string.Empty).ToArray()
+                    });
+                }
+            }
+
+            return list;
+        }
+
+        /// <summary>
+        /// Clears conditional formatting rules, optionally restricted to a range.
+        /// </summary>
+        public void ClearConditionalFormatting(string? a1Range = null) {
+            WriteLock(() => ClearConditionalFormattingCore(a1Range));
+        }
+
+        /// <summary>
+        /// Adds a formula-based conditional formatting rule.
+        /// </summary>
+        public void AddConditionalFormulaRule(string range, string formula, bool stopIfTrue = false) {
+            AddConditionalRuleCore(range, ConditionalFormatValues.Expression, null, new[] { formula }, stopIfTrue);
+        }
+
+        /// <summary>
+        /// Adds a duplicate-values conditional formatting rule.
+        /// </summary>
+        public void AddConditionalDuplicateValuesRule(string range) {
+            AddConditionalRuleCore(range, ConditionalFormatValues.DuplicateValues, null, Array.Empty<string>(), stopIfTrue: false);
+        }
+
+        /// <summary>
+        /// Adds a top/bottom conditional formatting rule.
+        /// </summary>
+        public void AddConditionalTopBottomRule(string range, uint rank, bool bottom = false, bool percent = false) {
+            if (rank == 0) throw new ArgumentOutOfRangeException(nameof(rank));
+            AddConditionalRuleCore(range, ConditionalFormatValues.Top10, rule => {
+                rule.Rank = rank;
+                rule.Bottom = bottom;
+                rule.Percent = percent;
+            }, Array.Empty<string>(), stopIfTrue: false);
+        }
+
+        /// <summary>
+        /// Lists data validation rules on the worksheet.
+        /// </summary>
+        public IReadOnlyList<ExcelDataValidationInfo> GetDataValidations(string? a1Range = null) {
+            (int r1, int c1, int r2, int c2)? filter = string.IsNullOrWhiteSpace(a1Range) ? null : A1.ParseRange(a1Range!);
+            var result = new List<ExcelDataValidationInfo>();
+            var validations = WorksheetRoot.GetFirstChild<DataValidations>();
+            if (validations == null) return result;
+
+            foreach (var validation in validations.Elements<DataValidation>()) {
+                string range = validation.SequenceOfReferences?.InnerText ?? string.Empty;
+                if (filter.HasValue) {
+                    bool overlaps = SplitReferenceList(range)
+                        .Any(part => RangesOverlapInclusive(filter.Value, part.IndexOf(':') >= 0 ? A1.ParseRange(part) : CellAsRange(part)));
+                    if (!overlaps) continue;
+                }
+
+                result.Add(new ExcelDataValidationInfo {
+                    Range = range,
+                    Type = validation.Type?.Value.ToString() ?? string.Empty,
+                    Operator = validation.Operator?.Value.ToString(),
+                    AllowBlank = validation.AllowBlank?.Value ?? false,
+                    Formula1 = validation.GetFirstChild<Formula1>()?.Text,
+                    Formula2 = validation.GetFirstChild<Formula2>()?.Text,
+                    PromptTitle = validation.PromptTitle?.Value,
+                    Prompt = validation.Prompt?.Value,
+                    ErrorTitle = validation.ErrorTitle?.Value,
+                    Error = validation.Error?.Value
+                });
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Removes data validation rules, optionally restricted to a range.
+        /// </summary>
+        public void RemoveDataValidations(string? a1Range = null) {
+            WriteLock(() => RemoveDataValidationsCore(a1Range));
+        }
+
+        /// <summary>
+        /// Applies prompt/error-message metadata to existing validations that overlap the range.
+        /// </summary>
+        public void SetDataValidationMessages(string a1Range, ExcelDataValidationMessageOptions options) {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            var filter = A1.ParseRange(a1Range);
+            WriteLock(() => {
+                var validations = WorksheetRoot.GetFirstChild<DataValidations>();
+                if (validations == null) return;
+                foreach (var validation in validations.Elements<DataValidation>()) {
+                    string range = validation.SequenceOfReferences?.InnerText ?? string.Empty;
+                    bool overlaps = SplitReferenceList(range)
+                        .Any(part => RangesOverlapInclusive(filter, part.IndexOf(':') >= 0 ? A1.ParseRange(part) : CellAsRange(part)));
+                    if (!overlaps) continue;
+
+                    validation.PromptTitle = options.PromptTitle;
+                    validation.Prompt = options.Prompt;
+                    validation.ErrorTitle = options.ErrorTitle;
+                    validation.Error = options.Error;
+                    validation.ShowInputMessage = options.ShowInputMessage || !string.IsNullOrEmpty(options.Prompt) || !string.IsNullOrEmpty(options.PromptTitle);
+                    validation.ShowErrorMessage = options.ShowErrorMessage || !string.IsNullOrEmpty(options.Error) || !string.IsNullOrEmpty(options.ErrorTitle);
+                }
+
+                WorksheetRoot.Save();
+            });
+        }
+
+        private void AddConditionalRuleCore(string range, ConditionalFormatValues type, Action<ConditionalFormattingRule>? configure, IReadOnlyList<string> formulas, bool stopIfTrue) {
+            if (string.IsNullOrWhiteSpace(range)) throw new ArgumentNullException(nameof(range));
+            WriteLock(() => {
+                int priority = WorksheetRoot.Descendants<ConditionalFormattingRule>().Select(r => r.Priority?.Value ?? 0).DefaultIfEmpty(0).Max() + 1;
+                var conditional = new ConditionalFormatting {
+                    SequenceOfReferences = new ListValue<StringValue> { InnerText = range }
+                };
+                var rule = new ConditionalFormattingRule {
+                    Type = type,
+                    Priority = priority,
+                    StopIfTrue = stopIfTrue
+                };
+                configure?.Invoke(rule);
+                foreach (var formula in formulas) {
+                    rule.Append(new Formula(formula));
+                }
+                conditional.Append(rule);
+                InsertConditionalFormatting(conditional);
+                WorksheetRoot.Save();
+            });
+        }
+
+        private void ClearConditionalFormattingCore(string? a1Range) {
+            if (string.IsNullOrWhiteSpace(a1Range)) {
+                foreach (var conditional in WorksheetRoot.Elements<ConditionalFormatting>().ToList()) {
+                    conditional.Remove();
+                }
+            } else {
+                var filter = A1.ParseRange(a1Range!);
+                foreach (var conditional in WorksheetRoot.Elements<ConditionalFormatting>().ToList()) {
+                    string range = conditional.SequenceOfReferences?.InnerText ?? string.Empty;
+                    bool overlaps = SplitReferenceList(range)
+                        .Any(part => RangesOverlapInclusive(filter, part.IndexOf(':') >= 0 ? A1.ParseRange(part) : CellAsRange(part)));
+                    if (overlaps) {
+                        conditional.Remove();
+                    }
+                }
+            }
+
+            WorksheetRoot.Save();
+        }
+
+        private void RemoveDataValidationsCore(string? a1Range) {
+            var validations = WorksheetRoot.GetFirstChild<DataValidations>();
+            if (validations == null) return;
+
+            if (string.IsNullOrWhiteSpace(a1Range)) {
+                validations.RemoveAllChildren<DataValidation>();
+            } else {
+                var filter = A1.ParseRange(a1Range!);
+                foreach (var validation in validations.Elements<DataValidation>().ToList()) {
+                    string range = validation.SequenceOfReferences?.InnerText ?? string.Empty;
+                    bool overlaps = SplitReferenceList(range)
+                        .Any(part => RangesOverlapInclusive(filter, part.IndexOf(':') >= 0 ? A1.ParseRange(part) : CellAsRange(part)));
+                    if (overlaps) {
+                        validation.Remove();
+                    }
+                }
+            }
+
+            validations.Count = (uint)validations.Elements<DataValidation>().Count();
+            WorksheetRoot.Save();
+        }
+
+        private void InsertConditionalFormatting(ConditionalFormatting conditionalFormatting) {
+            var worksheet = WorksheetRoot;
+            var tableParts = worksheet.Elements<TableParts>().FirstOrDefault();
+            if (tableParts != null) {
+                worksheet.InsertBefore(conditionalFormatting, tableParts);
+                return;
+            }
+
+            var autoFilter = worksheet.Elements<AutoFilter>().FirstOrDefault();
+            if (autoFilter != null) {
+                worksheet.InsertAfter(conditionalFormatting, autoFilter);
+                return;
+            }
+
+            var sheetData = worksheet.GetFirstChild<SheetData>();
+            if (sheetData != null) {
+                worksheet.InsertAfter(conditionalFormatting, sheetData);
+            } else {
+                worksheet.Append(conditionalFormatting);
+            }
+        }
+
+        private static string[] SplitReferenceList(string referenceList) {
+            return referenceList.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Tables.cs
@@ -261,7 +261,7 @@ namespace OfficeIMO.Excel {
         /// <exception cref="ArgumentException">Thrown when <paramref name="range"/> is not in a valid format.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the specified range overlaps with an existing table.</exception>
         public void AddTable(string range, bool hasHeader, string name, TableStyle style) {
-            AddTable(range, hasHeader, name, style, includeAutoFilter: true);
+            AddTableCore(range, hasHeader, name, style, includeAutoFilter: true);
         }
 
         /// <summary>
@@ -300,10 +300,19 @@ namespace OfficeIMO.Excel {
         /// - Order doesn't matter — the final state will be consistent regardless of operation order.
         /// </remarks>
         public void AddTable(string range, bool hasHeader, string name, TableStyle style, bool includeAutoFilter, TableNameValidationMode validationMode = TableNameValidationMode.Sanitize) {
+            AddTableCore(range, hasHeader, name, style, includeAutoFilter, validationMode);
+        }
+
+        internal string AddTableAndGetName(string range, bool hasHeader, string name, TableStyle style, bool includeAutoFilter, TableNameValidationMode validationMode = TableNameValidationMode.Sanitize) {
+            return AddTableCore(range, hasHeader, name, style, includeAutoFilter, validationMode);
+        }
+
+        private string AddTableCore(string range, bool hasHeader, string name, TableStyle style, bool includeAutoFilter, TableNameValidationMode validationMode = TableNameValidationMode.Sanitize) {
             if (string.IsNullOrEmpty(range)) {
                 throw new ArgumentNullException(nameof(range));
             }
 
+            string resolvedName = string.Empty;
             WriteLock(() => {
                 var cells = range.Split(':');
                 if (cells.Length != 2) {
@@ -391,6 +400,7 @@ namespace OfficeIMO.Excel {
                 if (string.IsNullOrWhiteSpace(name)) {
                     throw new InvalidOperationException("Table name cannot be empty after validation.");
                 }
+                resolvedName = name;
                 // Reserve the final name in the workbook-level cache for fast uniqueness checks
                 _excelDocument.ReserveTableName(name);
 
@@ -491,6 +501,8 @@ namespace OfficeIMO.Excel {
 
                 WorksheetRoot.Save();
             });
+
+            return resolvedName;
         }
 
         /// <summary>

--- a/OfficeIMO.Excel/ExcelSheetProtectionOptions.cs
+++ b/OfficeIMO.Excel/ExcelSheetProtectionOptions.cs
@@ -29,5 +29,9 @@ namespace OfficeIMO.Excel {
         public bool AllowAutoFilter { get; set; }
         /// <summary>Allow PivotTables.</summary>
         public bool AllowPivotTables { get; set; }
+        /// <summary>Optional worksheet protection password. This is Excel UI protection, not package encryption.</summary>
+        public string? Password { get; set; }
+        /// <summary>Optional precomputed legacy worksheet protection hash. When set, this value is written as-is.</summary>
+        public string? LegacyPasswordHash { get; set; }
     }
 }

--- a/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
+++ b/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
@@ -143,6 +143,52 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ClosedXmlGap_Sort_SplitsNonContiguousHyperlinkRemaps() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.SortHyperlinkRemap.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Sort");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Score");
+                sheet.CellValue(2, 1, "Hundred");
+                sheet.CellValue(2, 2, 100d);
+                sheet.CellValue(3, 1, "Two");
+                sheet.CellValue(3, 2, 2d);
+                sheet.CellValue(4, 1, "Fifty");
+                sheet.CellValue(4, 2, 50d);
+                sheet.SetHyperlink(2, 1, "https://example.com", display: "Linked", style: false);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Hyperlink hyperlink = worksheetPart.Worksheet.Descendants<Hyperlink>().Single();
+                hyperlink.Reference = "A2:A3";
+                worksheetPart.Worksheet.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                ExcelSheet sheet = document.Sheets[0];
+                sheet.SortRangeByColumn("A1:B4", 2, ascending: true, hasHeader: true);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                string[] references = worksheetPart.Worksheet.Descendants<Hyperlink>()
+                    .Select(hyperlink => hyperlink.Reference?.Value ?? string.Empty)
+                    .OrderBy(reference => reference)
+                    .ToArray();
+
+                Assert.Equal(new[] { "A2", "A4" }, references);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
         public void Test_ClosedXmlGap_WorkbookAndWorksheetProtection_PreserveLegacyHashes() {
             string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.Protection.xlsx");
 
@@ -184,6 +230,60 @@ namespace OfficeIMO.Tests {
             using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
                 Assert.True(document.IsWorkbookProtected);
                 Assert.True(document.Sheets[0].IsProtected);
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_CalculationProperties_AreInsertedBeforeLaterWorkbookNodes() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.CalculationOrder.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Calc");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                Workbook workbook = spreadsheet.WorkbookPart!.Workbook;
+                workbook.Append(new PivotCaches());
+                workbook.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                document.ConfigureFullCalculationOnOpen();
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                Workbook workbook = spreadsheet.WorkbookPart!.Workbook;
+                var children = workbook.ChildElements.ToList();
+                int calculationIndex = children.FindIndex(element => element is CalculationProperties);
+                int pivotCachesIndex = children.FindIndex(element => element is PivotCaches);
+
+                Assert.True(calculationIndex >= 0);
+                Assert.True(pivotCachesIndex >= 0);
+                Assert.True(calculationIndex < pivotCachesIndex);
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_Range_AcceptsSingleCellAddress() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.SingleCellRange.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Range");
+                ExcelRange range = sheet.Range("A1");
+
+                Assert.Equal("A1:A1", range.Address);
+                range.FirstCell.SetValue("single");
+                Assert.Equal("single", range.FirstCell.GetValue<string>());
+
+                range.Clear(ExcelClearOptions.Values);
+                Assert.True(range.FirstCell.GetValue().IsBlank);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
                 Assert.Empty(document.ValidateOpenXml());
             }
         }

--- a/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
+++ b/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
@@ -267,6 +267,35 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ClosedXmlGap_FullCalculationOnOpen_PreservesManualCalculationMode() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.CalculationMode.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Manual");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                Workbook workbook = spreadsheet.WorkbookPart!.Workbook;
+                workbook.Append(new CalculationProperties { CalculationMode = CalculateModeValues.Manual });
+                workbook.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                document.ConfigureFullCalculationOnOpen();
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                CalculationProperties calculationProperties = spreadsheet.WorkbookPart!.Workbook.GetFirstChild<CalculationProperties>()!;
+
+                Assert.Equal(CalculateModeValues.Manual, calculationProperties.CalculationMode!.Value);
+                Assert.True(calculationProperties.ForceFullCalculation!.Value);
+                Assert.True(calculationProperties.FullCalculationOnLoad!.Value);
+            }
+        }
+
+        [Fact]
         public void Test_ClosedXmlGap_Range_AcceptsSingleCellAddress() {
             string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.SingleCellRange.xlsx");
 
@@ -340,6 +369,28 @@ namespace OfficeIMO.Tests {
                 Assert.False(worksheet.Protection.AllowFormatCells);
                 Assert.False(worksheet.Protection.AllowSort);
                 Assert.False(worksheet.Protection.AllowAutoFilter);
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_GetRichText_DoesNotMaterializeMissingCells() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.RichTextReadMissingCell.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("RichText");
+
+                Assert.Empty(sheet.CellAt(10, 3).GetRichText());
+
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                string[] references = worksheetPart.Worksheet.Descendants<Cell>()
+                    .Select(cell => cell.CellReference?.Value ?? string.Empty)
+                    .ToArray();
+
+                Assert.DoesNotContain("C10", references);
             }
         }
 
@@ -497,6 +548,47 @@ namespace OfficeIMO.Tests {
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
                 WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 Assert.Empty(worksheetPart.Worksheet.Descendants<Cell>());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_ClearArrayFormula_ClearsEntireSpillRange() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.ClearArraySpill.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Array");
+                sheet.CellValue(1, 1, 10d);
+                sheet.CellValue(1, 2, 20d);
+                sheet.CellValue(2, 1, 30d);
+                sheet.CellValue(2, 2, 40d);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Cell anchor = worksheetPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A1");
+                anchor.CellFormula = new CellFormula("SUM(C1:C2)") {
+                    FormulaType = CellFormulaValues.Array,
+                    Reference = "A1:B2"
+                };
+                worksheetPart.Worksheet.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                document.Sheets[0].ClearArrayFormula("B2");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Dictionary<string, Cell> cells = worksheetPart.Worksheet.Descendants<Cell>()
+                    .Where(cell => cell.CellReference?.Value is "A1" or "B1" or "A2" or "B2")
+                    .ToDictionary(cell => cell.CellReference!.Value!);
+
+                Assert.All(cells.Values, cell => {
+                    Assert.Null(cell.CellFormula);
+                    Assert.Null(cell.CellValue);
+                });
             }
         }
 

--- a/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
+++ b/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
@@ -1,0 +1,174 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+using ExcelTableStyle = OfficeIMO.Excel.TableStyle;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_ClosedXmlGap_ObjectModel_RichText_Sort_Table_And_Clear() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.ObjectModel.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+
+                sheet.CellAt(1, 1).SetValue("Name").SetBold().SetFillColor("FFF2CC");
+                sheet.CellAt(1, 2).SetValue("Score").SetBold().SetFillColor("FFF2CC");
+                sheet.CellAt(2, 1).SetValue("Charlie");
+                sheet.CellAt(2, 2).SetValue(30d);
+                sheet.CellAt(3, 1).SetValue("Alice");
+                sheet.CellAt(3, 2).SetValue(10d);
+                sheet.CellAt(4, 1).SetValue("Bob");
+                sheet.CellAt(4, 2).SetValue(20d);
+                sheet.SetComment(3, 1, "temporary comment", author: "Tester", initials: "TT");
+
+                sheet.Range("A1:B4").SortByColumn(2, ascending: true, hasHeader: true);
+                Assert.Equal("Alice", sheet.CellAt(2, 1).GetValue<string>());
+                Assert.Equal(10d, sheet.CellAt(2, 2).GetValue<double>());
+
+                sheet.Range("A1:B4").ApplyAutoFilter();
+                ExcelTable table = sheet.Range("A1:B4").CreateTable("Scores");
+                Assert.Equal("A1:B4", table.Range);
+                table.SetStyle(ExcelTableStyle.TableStyleMedium4);
+
+                sheet.Range("D1:E1").Merge().Unmerge();
+                sheet.CellAt(6, 1).SetRichText(
+                    new ExcelRichTextRun("Strong") { Bold = true, FontColor = "FF0000" },
+                    ExcelRichTextRun.Plain(" text"));
+
+                IReadOnlyList<ExcelRichTextRun> runs = sheet.CellAt(6, 1).GetRichText();
+                Assert.Equal(2, runs.Count);
+                Assert.True(runs[0].Bold);
+                Assert.Equal("Strong", runs[0].Text);
+
+                sheet.ClearRange("A2:A2", ExcelClearOptions.Values | ExcelClearOptions.Comments);
+                Assert.True(sheet.CellAt(2, 1).GetValue().IsBlank);
+                Assert.False(sheet.HasComment(2, 1));
+
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_CalculationPolicy_EvaluatesSupportedFormulasBeforeSave() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.Calculation.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Calc");
+                sheet.CellValue(1, 1, 2d);
+                sheet.CellValue(2, 1, 3d);
+                sheet.CellFormula(3, 1, "SUM(A1:A2)");
+                sheet.CellFormula(4, 1, "A1+A2");
+                document.Calculation.EvaluateFormulasBeforeSave = true;
+                document.Calculation.ForceFullCalculationOnOpen = true;
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Cell sumCell = worksheetPart.Worksheet.Descendants<Cell>().First(cell => cell.CellReference?.Value == "A3");
+                Cell binaryCell = worksheetPart.Worksheet.Descendants<Cell>().First(cell => cell.CellReference?.Value == "A4");
+
+                Assert.Equal("SUM(A1:A2)", sumCell.CellFormula!.Text);
+                Assert.Equal("5", sumCell.CellValue!.Text);
+                Assert.Equal("5", binaryCell.CellValue!.Text);
+                Assert.True(spreadsheet.WorkbookPart.Workbook.CalculationProperties!.ForceFullCalculation!.Value);
+                Assert.True(spreadsheet.WorkbookPart.Workbook.CalculationProperties!.FullCalculationOnLoad!.Value);
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_WorkbookAndWorksheetProtection_PreserveLegacyHashes() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.Protection.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Protected");
+                sheet.CellValue(1, 1, "locked");
+
+                document.ProtectWorkbook(new ExcelWorkbookProtectionOptions {
+                    ProtectStructure = true,
+                    ProtectWindows = true,
+                    LegacyPasswordHash = "CAFE"
+                });
+                sheet.Protect(new ExcelSheetProtectionOptions {
+                    AllowSort = true,
+                    LegacyPasswordHash = "BEEF"
+                });
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorkbookProtection workbookProtection = spreadsheet.WorkbookPart!.Workbook.GetFirstChild<WorkbookProtection>()!;
+                Assert.True(workbookProtection.LockStructure!.Value);
+                Assert.True(workbookProtection.LockWindows!.Value);
+                Assert.Equal("CAFE", workbookProtection.WorkbookPassword!.Value);
+
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                SheetProtection sheetProtection = worksheetPart.Worksheet.Elements<SheetProtection>().First();
+                Assert.True(sheetProtection.Sheet!.Value);
+                Assert.True(sheetProtection.Sort!.Value);
+                Assert.Equal("BEEF", sheetProtection.Password!.Value);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.True(document.IsWorkbookProtected);
+                Assert.True(document.Sheets[0].IsProtected);
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_ConditionalFormattingAndDataValidation_Management() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.Rules.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Rules");
+                sheet.CellValue(1, 1, "Value");
+                sheet.CellValue(2, 1, 10d);
+                sheet.CellValue(3, 1, 20d);
+                sheet.CellValue(4, 1, 20d);
+
+                sheet.AddConditionalFormulaRule("A2:A4", "A2>15", stopIfTrue: true);
+                sheet.AddConditionalDuplicateValuesRule("A2:A4");
+                sheet.AddConditionalTopBottomRule("A2:A4", 1);
+
+                IReadOnlyList<ExcelConditionalFormattingInfo> rules = sheet.GetConditionalFormattingRules("A2:A4");
+                Assert.Equal(3, rules.Count);
+                Assert.Contains(rules, rule => rule.Type == ConditionalFormatValues.Expression.ToString() && rule.StopIfTrue);
+                Assert.Contains(rules, rule => rule.Type == ConditionalFormatValues.DuplicateValues.ToString());
+                Assert.Contains(rules, rule => rule.Type == ConditionalFormatValues.Top10.ToString());
+
+                sheet.ValidationWholeNumber("B2:B4", DataValidationOperatorValues.Between, 1, 30);
+                sheet.SetDataValidationMessages("B2:B4", new ExcelDataValidationMessageOptions {
+                    PromptTitle = "Allowed",
+                    Prompt = "1-30 only",
+                    ErrorTitle = "Invalid",
+                    Error = "Choose a number between 1 and 30"
+                });
+
+                ExcelDataValidationInfo validation = Assert.Single(sheet.GetDataValidations("B3:B3"));
+                Assert.Equal("Allowed", validation.PromptTitle);
+                Assert.Equal("Invalid", validation.ErrorTitle);
+
+                sheet.RemoveDataValidations("B2:B4");
+                Assert.Empty(sheet.GetDataValidations("B2:B4"));
+                sheet.ClearConditionalFormatting("A2:A4");
+                Assert.Empty(sheet.GetConditionalFormattingRules("A2:A4"));
+
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
+++ b/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
@@ -223,7 +223,7 @@ namespace OfficeIMO.Tests {
                 WorksheetPart worksheetPart = spreadsheet.WorkbookPart.WorksheetParts.First();
                 SheetProtection sheetProtection = worksheetPart.Worksheet.Elements<SheetProtection>().First();
                 Assert.True(sheetProtection.Sheet!.Value);
-                Assert.True(sheetProtection.Sort!.Value);
+                Assert.False(sheetProtection.Sort!.Value);
                 Assert.Equal("BEEF", sheetProtection.Password!.Value);
             }
 
@@ -281,6 +281,132 @@ namespace OfficeIMO.Tests {
                 range.Clear(ExcelClearOptions.Values);
                 Assert.True(range.FirstCell.GetValue().IsBlank);
                 document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_RangeCreateTable_ReturnsResolvedTableName() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.ResolvedTableName.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Table");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Score");
+                sheet.CellValue(2, 1, "Alpha");
+                sheet.CellValue(2, 2, 10d);
+
+                ExcelTable table = sheet.Range("A1:B2").CreateTable("My Table");
+                Assert.Equal("My_Table", table.NameOrRange);
+                Assert.Equal("A1:B2", table.Range);
+                table.SetStyle(ExcelTableStyle.TableStyleMedium4);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_ClearHyperlinks_PreservesNonOverlappingRangeSegments() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.ClearHyperlinkSegments.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Links");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(2, 1, "One");
+                sheet.CellValue(3, 1, "Two");
+                sheet.CellValue(4, 1, "Three");
+                sheet.SetHyperlink(2, 1, "https://example.com", display: "Linked", style: false);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Hyperlink hyperlink = worksheetPart.Worksheet.Descendants<Hyperlink>().Single();
+                hyperlink.Reference = "A2:A4";
+                worksheetPart.Worksheet.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                document.Sheets[0].Range("A3").Clear(ExcelClearOptions.Hyperlinks);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                string[] references = worksheetPart.Worksheet.Descendants<Hyperlink>()
+                    .Select(hyperlink => hyperlink.Reference?.Value ?? string.Empty)
+                    .OrderBy(reference => reference)
+                    .ToArray();
+
+                Assert.Equal(new[] { "A2", "A4" }, references);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_Sort_RewritesRelativeFormulaRows() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.SortFormulaRows.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Sort");
+                sheet.CellValue(1, 1, "Value");
+                sheet.CellValue(1, 2, "Formula");
+                sheet.CellValue(2, 1, 2d);
+                sheet.CellValue(3, 1, 1d);
+                sheet.CellAt(2, 2).SetFormula("A2");
+                sheet.CellAt(3, 2).SetFormula("A3");
+
+                sheet.SortRangeByColumn("A1:B3", 1, ascending: true, hasHeader: true);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Dictionary<string, string?> formulas = worksheetPart.Worksheet.Descendants<Cell>()
+                    .Where(cell => cell.CellFormula != null)
+                    .ToDictionary(cell => cell.CellReference!.Value!, cell => cell.CellFormula?.Text);
+
+                Assert.Equal("A2", formulas["B2"]);
+                Assert.Equal("A3", formulas["B3"]);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_Sort_DoesNotMaterializeSparseBlankCells() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.SortSparse.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Sparse");
+                sheet.CellValue(1, 1, "Value");
+                sheet.CellValue(1, 2, "Blank");
+                sheet.CellValue(2, 1, 2d);
+                sheet.CellValue(3, 1, 1d);
+
+                sheet.SortRangeByColumn("A1:B3", 1, ascending: true, hasHeader: true);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                string[] references = worksheetPart.Worksheet.Descendants<Cell>()
+                    .Select(cell => cell.CellReference?.Value ?? string.Empty)
+                    .ToArray();
+
+                Assert.DoesNotContain("B2", references);
+                Assert.DoesNotContain("B3", references);
             }
 
             using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {

--- a/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
+++ b/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
@@ -29,6 +29,8 @@ namespace OfficeIMO.Tests {
                 sheet.Range("A1:B4").SortByColumn(2, ascending: true, hasHeader: true);
                 Assert.Equal("Alice", sheet.CellAt(2, 1).GetValue<string>());
                 Assert.Equal(10d, sheet.CellAt(2, 2).GetValue<double>());
+                Assert.True(sheet.HasComment(2, 1));
+                Assert.False(sheet.HasComment(3, 1));
 
                 sheet.Range("A1:B4").ApplyAutoFilter();
                 ExcelTable table = sheet.Range("A1:B4").CreateTable("Scores");
@@ -94,10 +96,43 @@ namespace OfficeIMO.Tests {
                 sheet.CellValue(1, 1, 2d);
                 sheet.CellFormula(2, 1, "VLOOKUP(A1,B1:C2,2,FALSE)");
                 sheet.CellFormula(3, 1, "SUM(" + new string('A', 9000) + ")");
+                sheet.CellFormula(4, 1, "SUM(Calc!A1:A2)");
 
                 Assert.Equal(0, document.RecalculateSupportedFormulas());
                 Assert.False(sheet.TryGetCachedFormulaValue(2, 1, out _));
                 Assert.False(sheet.TryGetCachedFormulaValue(3, 1, out _));
+                Assert.False(sheet.TryGetCachedFormulaValue(4, 1, out _));
+
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_Sort_UsesNumericFormulaCachesAndKeepsMetadata() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.SortFormulaCaches.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Sort");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Score");
+                sheet.CellValue(2, 1, "Hundred");
+                sheet.CellValue(2, 3, 100d);
+                sheet.CellFormula(2, 2, "C2+0");
+                sheet.CellValue(3, 1, "Two");
+                sheet.CellValue(3, 3, 2d);
+                sheet.CellFormula(3, 2, "C3+0");
+                sheet.SetComment(3, 1, "moves with Two", author: "Tester");
+
+                Assert.Equal(2, document.RecalculateSupportedFormulas());
+                sheet.SortRangeByColumn("A1:B3", 2, ascending: true, hasHeader: true);
+
+                Assert.Equal("Two", sheet.CellAt(2, 1).GetValue<string>());
+                Assert.True(sheet.HasComment(2, 1));
+                Assert.Equal("Hundred", sheet.CellAt(3, 1).GetValue<string>());
 
                 document.Save();
             }
@@ -127,6 +162,12 @@ namespace OfficeIMO.Tests {
                 document.Save();
             }
 
+            using (ExcelDocument document = ExcelDocument.Create(Path.Combine(_directoryWithFiles, "ClosedXmlGap.InvalidProtectionHash.xlsx"))) {
+                Assert.Throws<ArgumentException>(() => document.ProtectWorkbook(new ExcelWorkbookProtectionOptions {
+                    LegacyPasswordHash = "NOPE"
+                }));
+            }
+
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
                 WorkbookProtection workbookProtection = spreadsheet.WorkbookPart!.Workbook.GetFirstChild<WorkbookProtection>()!;
                 Assert.True(workbookProtection.LockStructure!.Value);
@@ -144,6 +185,60 @@ namespace OfficeIMO.Tests {
                 Assert.True(document.IsWorkbookProtected);
                 Assert.True(document.Sheets[0].IsProtected);
                 Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_WorkbookProtection_IsInsertedBeforeBookViews() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.ProtectionBookViews.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Protected");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                Workbook workbook = spreadsheet.WorkbookPart!.Workbook;
+                if (workbook.GetFirstChild<BookViews>() == null) {
+                    workbook.InsertBefore(new BookViews(new WorkbookView()), workbook.GetFirstChild<Sheets>());
+                    workbook.Save();
+                }
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                document.ProtectWorkbook(new ExcelWorkbookProtectionOptions { LegacyPasswordHash = "CAFE" });
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                Workbook workbook = spreadsheet.WorkbookPart!.Workbook;
+                var children = workbook.ChildElements.ToList();
+                int protectionIndex = children.FindIndex(element => element is WorkbookProtection);
+                int bookViewsIndex = children.FindIndex(element => element is BookViews);
+
+                Assert.True(protectionIndex >= 0);
+                Assert.True(bookViewsIndex >= 0);
+                Assert.True(protectionIndex < bookViewsIndex);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_ClearRange_None_DoesNotMaterializeCells() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.ClearNone.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Clear");
+                sheet.ClearRange("C5:D6", ExcelClearOptions.None);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Assert.Empty(worksheetPart.Worksheet.Descendants<Cell>());
             }
         }
 
@@ -180,8 +275,19 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Allowed", validation.PromptTitle);
                 Assert.Equal("Invalid", validation.ErrorTitle);
 
+                sheet.RemoveDataValidations("B3:B3");
+                Assert.Single(sheet.GetDataValidations("B2:B2"));
+                Assert.Empty(sheet.GetDataValidations("B3:B3"));
+                Assert.Single(sheet.GetDataValidations("B4:B4"));
+
                 sheet.RemoveDataValidations("B2:B4");
                 Assert.Empty(sheet.GetDataValidations("B2:B4"));
+
+                sheet.ClearConditionalFormatting("A3:A3");
+                Assert.Equal(3, sheet.GetConditionalFormattingRules("A2:A2").Count);
+                Assert.Empty(sheet.GetConditionalFormattingRules("A3:A3"));
+                Assert.Equal(3, sheet.GetConditionalFormattingRules("A4:A4").Count);
+
                 sheet.ClearConditionalFormatting("A2:A4");
                 Assert.Empty(sheet.GetConditionalFormattingRules("A2:A4"));
 

--- a/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
+++ b/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
@@ -86,6 +86,28 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ClosedXmlGap_CalculationPolicy_IgnoresUnsupportedOrOversizedFormulas() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.CalculationUnsupported.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Calc");
+                sheet.CellValue(1, 1, 2d);
+                sheet.CellFormula(2, 1, "VLOOKUP(A1,B1:C2,2,FALSE)");
+                sheet.CellFormula(3, 1, "SUM(" + new string('A', 9000) + ")");
+
+                Assert.Equal(0, document.RecalculateSupportedFormulas());
+                Assert.False(sheet.TryGetCachedFormulaValue(2, 1, out _));
+                Assert.False(sheet.TryGetCachedFormulaValue(3, 1, out _));
+
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
         public void Test_ClosedXmlGap_WorkbookAndWorksheetProtection_PreserveLegacyHashes() {
             string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.Protection.xlsx");
 

--- a/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
+++ b/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
@@ -273,8 +273,12 @@ namespace OfficeIMO.Tests {
             using (ExcelDocument document = ExcelDocument.Create(filePath)) {
                 ExcelSheet sheet = document.AddWorkSheet("Range");
                 ExcelRange range = sheet.Range("A1");
+                ExcelRange absoluteCellRange = sheet.Range("$B$2");
+                ExcelRange absoluteMultiCellRange = sheet.Range("$C$3:$D$4");
 
                 Assert.Equal("A1:A1", range.Address);
+                Assert.Equal("B2:B2", absoluteCellRange.Address);
+                Assert.Equal("C3:D4", absoluteMultiCellRange.Address);
                 range.FirstCell.SetValue("single");
                 Assert.Equal("single", range.FirstCell.GetValue<string>());
 
@@ -308,6 +312,34 @@ namespace OfficeIMO.Tests {
 
             using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
                 Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_Inspection_HonorsSheetProtectionDefaults() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.ProtectionDefaults.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Defaults");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                worksheetPart.Worksheet.Append(new SheetProtection { Sheet = true });
+                worksheetPart.Worksheet.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelWorkbookSnapshot snapshot = document.CreateInspectionSnapshot();
+                ExcelWorksheetSnapshot worksheet = Assert.Single(snapshot.Worksheets);
+
+                Assert.NotNull(worksheet.Protection);
+                Assert.True(worksheet.Protection!.AllowSelectLockedCells);
+                Assert.True(worksheet.Protection.AllowSelectUnlockedCells);
+                Assert.False(worksheet.Protection.AllowFormatCells);
+                Assert.False(worksheet.Protection.AllowSort);
+                Assert.False(worksheet.Protection.AllowAutoFilter);
             }
         }
 
@@ -465,6 +497,30 @@ namespace OfficeIMO.Tests {
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
                 WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 Assert.Empty(worksheetPart.Worksheet.Descendants<Cell>());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_FormulaReadApis_DoNotMaterializeMissingCells() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.FormulaReadMissingCell.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Formula");
+
+                Assert.Null(sheet.GetFormulaText(10, 3));
+                Assert.False(sheet.TryGetCachedFormulaValue(10, 3, out string? cachedValue));
+                Assert.Null(cachedValue);
+
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                string[] references = worksheetPart.Worksheet.Descendants<Cell>()
+                    .Select(cell => cell.CellReference?.Value ?? string.Empty)
+                    .ToArray();
+
+                Assert.DoesNotContain("C10", references);
             }
         }
 

--- a/OfficeIMO.Tests/Excel.WorksheetFeatures.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetFeatures.cs
@@ -80,11 +80,11 @@ namespace OfficeIMO.Tests {
                 var wsPart = (WorksheetPart)wb.GetPartById(sheet.Id!);
                 var protection = wsPart.Worksheet.Elements<SheetProtection>().FirstOrDefault();
                 Assert.NotNull(protection);
-                Assert.True(protection!.Sort?.Value ?? false);
-                Assert.True(protection.AutoFilter?.Value ?? false);
-                Assert.True(protection.InsertRows?.Value ?? false);
-                Assert.False(protection.SelectLockedCells?.Value ?? true);
-                Assert.False(protection.SelectUnlockedCells?.Value ?? true);
+                Assert.False(protection!.Sort?.Value ?? true);
+                Assert.False(protection.AutoFilter?.Value ?? true);
+                Assert.False(protection.InsertRows?.Value ?? true);
+                Assert.True(protection.SelectLockedCells?.Value ?? false);
+                Assert.True(protection.SelectUnlockedCells?.Value ?? false);
             }
 
             using (var document = ExcelDocument.Load(filePath)) {


### PR DESCRIPTION
## Summary
- Adds first-class OfficeIMO.Excel cell, range, table, and rich-text wrappers for the highest-value ClosedXML-style workflows.
- Adds workbook calculation policy hooks with a small supported-formula cached-value evaluator and dirty/full-recalc save options.
- Adds range sort and AutoFilter bridge APIs, workbook/worksheet protection hash support, conditional-formatting management, and data-validation inspection/message/removal helpers.
- Adds focused tests covering the new Excel gap features end to end.

## Validation
- `dotnet build OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Debug -f net8.0 /nr:false --no-restore`
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Debug -f net8.0 --no-build --filter "FullyQualifiedName~OfficeIMO.Tests.Excel"`

## Notes
- PR #1807 has already been merged into `master`, so this branch was rebased onto current `origin/master` before opening the PR.
