### PR TITLE
[codex] Improve PowerPoint native authoring

### DIFF
--- a/OfficeIMO.PowerPoint/ImagePartType.cs
+++ b/OfficeIMO.PowerPoint/ImagePartType.cs
@@ -13,6 +13,8 @@ namespace OfficeIMO.PowerPoint {
         Bmp,
         /// <summary>Tagged Image File Format image.</summary>
         Tiff,
+        /// <summary>Scalable Vector Graphics image.</summary>
+        Svg,
         /// <summary>Enhanced Metafile image.</summary>
         Emf,
         /// <summary>Windows Metafile image.</summary>

--- a/OfficeIMO.PowerPoint/ImagePartTypeExtensions.cs
+++ b/OfficeIMO.PowerPoint/ImagePartTypeExtensions.cs
@@ -10,6 +10,7 @@ namespace OfficeIMO.PowerPoint {
             ImagePartType.Gif => OpenXmlImagePartType.Gif,
             ImagePartType.Bmp => OpenXmlImagePartType.Bmp,
             ImagePartType.Tiff => OpenXmlImagePartType.Tiff,
+            ImagePartType.Svg => OpenXmlImagePartType.Svg,
             ImagePartType.Emf => OpenXmlImagePartType.Emf,
             ImagePartType.Wmf => OpenXmlImagePartType.Wmf,
             ImagePartType.Icon => OpenXmlImagePartType.Icon,

--- a/OfficeIMO.PowerPoint/PowerPointApplicationProperties.cs
+++ b/OfficeIMO.PowerPoint/PowerPointApplicationProperties.cs
@@ -1,0 +1,111 @@
+using System;
+using DocumentFormat.OpenXml.ExtendedProperties;
+using DocumentFormat.OpenXml.Packaging;
+using Ap = DocumentFormat.OpenXml.ExtendedProperties;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Provides access to extended application properties for a PowerPoint presentation.
+    /// </summary>
+    public sealed class PowerPointApplicationProperties {
+        private readonly PresentationDocument _presentationDocument;
+
+        internal PowerPointApplicationProperties(PresentationDocument presentationDocument) {
+            _presentationDocument = presentationDocument ?? throw new ArgumentNullException(nameof(presentationDocument));
+        }
+
+        /// <summary>
+        ///     Gets or sets the application name that created the presentation.
+        /// </summary>
+        public string Application {
+            get => GetProperties().Application?.Text ?? string.Empty;
+            set {
+                Ap.Properties properties = GetProperties();
+                properties.Application ??= new Application();
+                properties.Application.Text = value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets or sets the application version that created the presentation.
+        /// </summary>
+        public string ApplicationVersion {
+            get => GetProperties().ApplicationVersion?.Text ?? string.Empty;
+            set {
+                Ap.Properties properties = GetProperties();
+                properties.ApplicationVersion ??= new ApplicationVersion();
+                properties.ApplicationVersion.Text = value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets or sets the company associated with the presentation.
+        /// </summary>
+        public string Company {
+            get => GetProperties().Company?.Text ?? string.Empty;
+            set {
+                Ap.Properties properties = GetProperties();
+                properties.Company ??= new Company();
+                properties.Company.Text = value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets or sets the manager associated with the presentation.
+        /// </summary>
+        public string Manager {
+            get => GetProperties().Manager?.Text ?? string.Empty;
+            set {
+                Ap.Properties properties = GetProperties();
+                properties.Manager ??= new Manager();
+                properties.Manager.Text = value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets or sets the presentation format description.
+        /// </summary>
+        public string PresentationFormat {
+            get => GetProperties().PresentationFormat?.Text ?? string.Empty;
+            set {
+                Ap.Properties properties = GetProperties();
+                properties.PresentationFormat ??= new PresentationFormat();
+                properties.PresentationFormat.Text = value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets the stored slide count.
+        /// </summary>
+        public string Slides => GetProperties().Slides?.Text ?? string.Empty;
+
+        /// <summary>
+        ///     Gets the stored notes count.
+        /// </summary>
+        public string Notes => GetProperties().Notes?.Text ?? string.Empty;
+
+        /// <summary>
+        ///     Gets the stored hidden-slide count.
+        /// </summary>
+        public string HiddenSlides => GetProperties().HiddenSlides?.Text ?? string.Empty;
+
+        /// <summary>
+        ///     Gets or sets the stored total editing time.
+        /// </summary>
+        public string TotalTime {
+            get => GetProperties().TotalTime?.Text ?? string.Empty;
+            set {
+                Ap.Properties properties = GetProperties();
+                properties.TotalTime ??= new TotalTime();
+                properties.TotalTime.Text = value;
+            }
+        }
+
+        private Ap.Properties GetProperties() {
+            ExtendedFilePropertiesPart part = _presentationDocument.ExtendedFilePropertiesPart
+                ?? _presentationDocument.AddExtendedFilePropertiesPart();
+            part.Properties ??= new Ap.Properties();
+            return part.Properties;
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointBuiltinDocumentProperties.cs
+++ b/OfficeIMO.PowerPoint/PowerPointBuiltinDocumentProperties.cs
@@ -1,0 +1,111 @@
+using System;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Provides access to the built-in package properties for a PowerPoint presentation.
+    /// </summary>
+    public sealed class PowerPointBuiltinDocumentProperties {
+        private readonly PresentationDocument _presentationDocument;
+
+        internal PowerPointBuiltinDocumentProperties(PresentationDocument presentationDocument) {
+            _presentationDocument = presentationDocument ?? throw new ArgumentNullException(nameof(presentationDocument));
+        }
+
+        /// <summary>
+        ///     Gets or sets the presentation creator.
+        /// </summary>
+        public string? Creator {
+            get => _presentationDocument.PackageProperties.Creator;
+            set => _presentationDocument.PackageProperties.Creator = value;
+        }
+
+        /// <summary>
+        ///     Gets or sets the presentation title.
+        /// </summary>
+        public string? Title {
+            get => _presentationDocument.PackageProperties.Title;
+            set => _presentationDocument.PackageProperties.Title = value;
+        }
+
+        /// <summary>
+        ///     Gets or sets the presentation description.
+        /// </summary>
+        public string? Description {
+            get => _presentationDocument.PackageProperties.Description;
+            set => _presentationDocument.PackageProperties.Description = value;
+        }
+
+        /// <summary>
+        ///     Gets or sets the presentation category.
+        /// </summary>
+        public string? Category {
+            get => _presentationDocument.PackageProperties.Category;
+            set => _presentationDocument.PackageProperties.Category = value;
+        }
+
+        /// <summary>
+        ///     Gets or sets keywords used for searching and indexing.
+        /// </summary>
+        public string? Keywords {
+            get => _presentationDocument.PackageProperties.Keywords;
+            set => _presentationDocument.PackageProperties.Keywords = value;
+        }
+
+        /// <summary>
+        ///     Gets or sets the presentation subject.
+        /// </summary>
+        public string? Subject {
+            get => _presentationDocument.PackageProperties.Subject;
+            set => _presentationDocument.PackageProperties.Subject = value;
+        }
+
+        /// <summary>
+        ///     Gets or sets the revision number.
+        /// </summary>
+        public string? Revision {
+            get => _presentationDocument.PackageProperties.Revision;
+            set => _presentationDocument.PackageProperties.Revision = value;
+        }
+
+        /// <summary>
+        ///     Gets or sets the last user who modified the presentation.
+        /// </summary>
+        public string? LastModifiedBy {
+            get => _presentationDocument.PackageProperties.LastModifiedBy;
+            set => _presentationDocument.PackageProperties.LastModifiedBy = value;
+        }
+
+        /// <summary>
+        ///     Gets or sets the presentation version.
+        /// </summary>
+        public string? Version {
+            get => _presentationDocument.PackageProperties.Version;
+            set => _presentationDocument.PackageProperties.Version = value;
+        }
+
+        /// <summary>
+        ///     Gets or sets the creation date.
+        /// </summary>
+        public DateTime? Created {
+            get => _presentationDocument.PackageProperties.Created;
+            set => _presentationDocument.PackageProperties.Created = value;
+        }
+
+        /// <summary>
+        ///     Gets or sets the last modification date.
+        /// </summary>
+        public DateTime? Modified {
+            get => _presentationDocument.PackageProperties.Modified;
+            set => _presentationDocument.PackageProperties.Modified = value;
+        }
+
+        /// <summary>
+        ///     Gets or sets the last print date.
+        /// </summary>
+        public DateTime? LastPrinted {
+            get => _presentationDocument.PackageProperties.LastPrinted;
+            set => _presentationDocument.PackageProperties.LastPrinted = value;
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointMedia.cs
+++ b/OfficeIMO.PowerPoint/PowerPointMedia.cs
@@ -1,0 +1,89 @@
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using A = DocumentFormat.OpenXml.Drawing;
+using P14 = DocumentFormat.OpenXml.Office2010.PowerPoint;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Represents an embedded audio or video media frame on a slide.
+    /// </summary>
+    public class PowerPointMedia : PowerPointPicture {
+        internal PowerPointMedia(Picture picture, SlidePart slidePart, PowerPointMediaKind kind) : base(picture, slidePart) {
+            Kind = kind;
+        }
+
+        /// <summary>
+        ///     Gets the media kind represented by this shape.
+        /// </summary>
+        public PowerPointMediaKind Kind { get; }
+
+        /// <summary>
+        ///     Gets the MIME content type of the embedded media part.
+        /// </summary>
+        public string? MediaContentType {
+            get {
+                MediaDataPart? mediaPart = GetMediaDataPart();
+                return mediaPart?.ContentType;
+            }
+        }
+
+        /// <summary>
+        ///     Gets the relationship id used by the audio/video file reference.
+        /// </summary>
+        public string? MediaReferenceId {
+            get {
+                Picture picture = (Picture)Element;
+                ApplicationNonVisualDrawingProperties? properties =
+                    picture.NonVisualPictureProperties?.ApplicationNonVisualDrawingProperties;
+                return Kind == PowerPointMediaKind.Audio
+                    ? properties?.GetFirstChild<A.AudioFromFile>()?.Link?.Value
+                    : properties?.GetFirstChild<A.VideoFromFile>()?.Link?.Value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets the p14 media relationship id used by PowerPoint playback metadata.
+        /// </summary>
+        public string? PlaybackReferenceId {
+            get {
+                Picture picture = (Picture)Element;
+                return picture.NonVisualPictureProperties?
+                    .ApplicationNonVisualDrawingProperties?
+                    .Descendants<P14.Media>()
+                    .FirstOrDefault()?
+                    .Embed?
+                    .Value;
+            }
+        }
+
+        internal static bool TryGetMediaKind(Picture picture, out PowerPointMediaKind kind) {
+            ApplicationNonVisualDrawingProperties? properties =
+                picture.NonVisualPictureProperties?.ApplicationNonVisualDrawingProperties;
+
+            if (properties?.GetFirstChild<A.AudioFromFile>() != null) {
+                kind = PowerPointMediaKind.Audio;
+                return true;
+            }
+
+            if (properties?.GetFirstChild<A.VideoFromFile>() != null) {
+                kind = PowerPointMediaKind.Video;
+                return true;
+            }
+
+            kind = default;
+            return false;
+        }
+
+        private MediaDataPart? GetMediaDataPart() {
+            string? relationshipId = MediaReferenceId;
+            if (string.IsNullOrWhiteSpace(relationshipId)) {
+                return null;
+            }
+
+            return SlidePart.DataPartReferenceRelationships
+                .FirstOrDefault(rel => rel.Id == relationshipId)?
+                .DataPart as MediaDataPart;
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointMediaKind.cs
+++ b/OfficeIMO.PowerPoint/PowerPointMediaKind.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Identifies the embedded media kind represented by a slide shape.
+    /// </summary>
+    public enum PowerPointMediaKind {
+        /// <summary>
+        ///     An audio media shape.
+        /// </summary>
+        Audio,
+
+        /// <summary>
+        ///     A video media shape.
+        /// </summary>
+        Video
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointPartFactory.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPartFactory.cs
@@ -162,6 +162,7 @@ namespace OfficeIMO.PowerPoint {
                 ImagePartType.Gif => ".gif",
                 ImagePartType.Bmp => ".bmp",
                 ImagePartType.Tiff => ".tiff",
+                ImagePartType.Svg => ".svg",
                 ImagePartType.Emf => ".emf",
                 ImagePartType.Wmf => ".wmf",
                 ImagePartType.Icon => ".ico",

--- a/OfficeIMO.PowerPoint/PowerPointPicture.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPicture.cs
@@ -15,6 +15,8 @@ namespace OfficeIMO.PowerPoint {
             _slidePart = slidePart;
         }
 
+        internal SlidePart SlidePart => _slidePart;
+
         private Picture Picture => (Picture)Element;
 
         /// <summary>
@@ -196,6 +198,7 @@ namespace OfficeIMO.PowerPoint {
                 ".gif" => ImagePartType.Gif,
                 ".bmp" => ImagePartType.Bmp,
                 ".tif" or ".tiff" => ImagePartType.Tiff,
+                ".svg" => ImagePartType.Svg,
                 ".emf" => ImagePartType.Emf,
                 ".wmf" => ImagePartType.Wmf,
                 ".ico" => ImagePartType.Icon,

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.cs
@@ -50,6 +50,8 @@ namespace OfficeIMO.PowerPoint {
             _document = document;
             _filePath = filePath;
             _presentationPart = document.PresentationPart ?? document.AddPresentationPart();
+            BuiltinDocumentProperties = new PowerPointBuiltinDocumentProperties(document);
+            ApplicationProperties = new PowerPointApplicationProperties(document);
             if (isNewPresentation || _presentationPart.Presentation == null) {
                 // New presentation - create with required initial structure
                 PresentationRoot = new Presentation();
@@ -102,6 +104,16 @@ namespace OfficeIMO.PowerPoint {
                 return _slides;
             }
         }
+
+        /// <summary>
+        ///     Built-in package properties for the presentation.
+        /// </summary>
+        public PowerPointBuiltinDocumentProperties BuiltinDocumentProperties { get; }
+
+        /// <summary>
+        ///     Extended application properties for the presentation.
+        /// </summary>
+        public PowerPointApplicationProperties ApplicationProperties { get; }
 
         /// <summary>
         ///     Slide size information for the presentation.
@@ -964,6 +976,45 @@ namespace OfficeIMO.PowerPoint {
         }
 
         /// <summary>
+        ///     Ensures a native footer placeholder exists on the specified slide layout.
+        /// </summary>
+        public PowerPointTextBox EnsureLayoutFooterPlaceholderTextBox(int masterIndex = 0, int layoutIndex = 0,
+            string? text = null, PowerPointLayoutBox? bounds = null, uint? index = null) {
+            return EnsureLayoutHeaderFooterPlaceholderTextBox(masterIndex, layoutIndex, PlaceholderValues.Footer,
+                text, bounds, index ?? 10U, "Footer Placeholder");
+        }
+
+        /// <summary>
+        ///     Ensures a native date/time placeholder exists on the specified slide layout.
+        /// </summary>
+        public PowerPointTextBox EnsureLayoutDateTimePlaceholderTextBox(int masterIndex = 0, int layoutIndex = 0,
+            string? text = null, PowerPointLayoutBox? bounds = null, uint? index = null) {
+            return EnsureLayoutHeaderFooterPlaceholderTextBox(masterIndex, layoutIndex, PlaceholderValues.DateAndTime,
+                text, bounds, index ?? 11U, "Date Placeholder");
+        }
+
+        /// <summary>
+        ///     Ensures a native slide-number placeholder exists on the specified slide layout.
+        /// </summary>
+        public PowerPointTextBox EnsureLayoutSlideNumberPlaceholderTextBox(int masterIndex = 0, int layoutIndex = 0,
+            string? text = null, PowerPointLayoutBox? bounds = null, uint? index = null) {
+            return EnsureLayoutHeaderFooterPlaceholderTextBox(masterIndex, layoutIndex, PlaceholderValues.SlideNumber,
+                text, bounds, index ?? 12U, "Slide Number Placeholder");
+        }
+
+        /// <summary>
+        ///     Ensures native footer, date/time, and slide-number placeholders exist on the specified slide layout.
+        /// </summary>
+        public IReadOnlyList<PowerPointTextBox> EnsureLayoutHeaderFooterPlaceholders(int masterIndex = 0, int layoutIndex = 0,
+            string? footerText = null, string? dateTimeText = null, string? slideNumberText = null) {
+            return new[] {
+                EnsureLayoutFooterPlaceholderTextBox(masterIndex, layoutIndex, footerText),
+                EnsureLayoutDateTimePlaceholderTextBox(masterIndex, layoutIndex, dateTimeText),
+                EnsureLayoutSlideNumberPlaceholderTextBox(masterIndex, layoutIndex, slideNumberText)
+            };
+        }
+
+        /// <summary>
         ///     Replaces text across all slides.
         /// </summary>
         public int ReplaceText(string oldValue, string newValue, bool includeTables = true, bool includeNotes = false) {
@@ -1279,6 +1330,12 @@ namespace OfficeIMO.PowerPoint {
             PresentationRoot.Save();
         }
 
+        private void ValidateSlideIndex(int index) {
+            if (index < 0 || index >= _slides.Count) {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+        }
+
         /// <summary>
         ///     Moves a slide from one index to another.
         /// </summary>
@@ -1566,6 +1623,42 @@ namespace OfficeIMO.PowerPoint {
             if (destination.CanSeek) {
                 destination.Seek(0, SeekOrigin.Begin);
             }
+        }
+
+        /// <summary>
+        ///     Exports a single slide as a standalone one-slide PowerPoint presentation.
+        /// </summary>
+        /// <param name="slideIndex">Zero-based index of the slide to export.</param>
+        /// <param name="filePath">Destination .pptx path.</param>
+        public void ExportSlide(int slideIndex, string filePath) {
+            ThrowIfDisposed();
+            if (filePath == null) throw new ArgumentNullException(nameof(filePath));
+            if (string.IsNullOrWhiteSpace(filePath)) throw new ArgumentException("File path cannot be empty.", nameof(filePath));
+
+            ValidateSlideIndex(slideIndex);
+            string? directory = Path.GetDirectoryName(Path.GetFullPath(filePath));
+            if (!string.IsNullOrWhiteSpace(directory)) {
+                Directory.CreateDirectory(directory);
+            }
+
+            using FileStream stream = new(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+            ExportSlide(slideIndex, stream);
+        }
+
+        /// <summary>
+        ///     Exports a single slide as a standalone one-slide PowerPoint presentation.
+        /// </summary>
+        /// <param name="slideIndex">Zero-based index of the slide to export.</param>
+        /// <param name="destination">Writable destination stream.</param>
+        public void ExportSlide(int slideIndex, Stream destination) {
+            ThrowIfDisposed();
+            if (destination == null) throw new ArgumentNullException(nameof(destination));
+            if (!destination.CanWrite) throw new ArgumentException("Destination stream must be writable.", nameof(destination));
+
+            ValidateSlideIndex(slideIndex);
+            using PowerPointPresentation exported = Create(destination, autoSave: false);
+            exported.ImportSlide(this, slideIndex);
+            exported.Save(destination);
         }
 
         /// <summary>
@@ -2687,6 +2780,77 @@ namespace OfficeIMO.PowerPoint {
                 return new PowerPointLayoutBox(838200L, 2174875L, 7772400L, 1470025L);
             }
             return new PowerPointLayoutBox(838200L, 2174875L, 7772400L, 3962400L);
+        }
+
+        private PowerPointTextBox EnsureLayoutHeaderFooterPlaceholderTextBox(int masterIndex, int layoutIndex,
+            PlaceholderValues placeholderType, string? text, PowerPointLayoutBox? bounds, uint index, string name) {
+            ThrowIfDisposed();
+
+            SlideLayoutPart layoutPart = GetSlideLayoutPart(masterIndex, layoutIndex);
+            SetHeaderFooterFlag(layoutPart, placeholderType, true);
+
+            PowerPointTextBox textBox = EnsureLayoutPlaceholderTextBox(masterIndex, layoutIndex, placeholderType,
+                index, bounds ?? GetDefaultHeaderFooterBounds(placeholderType), name);
+            if (text != null) {
+                textBox.Text = text;
+            }
+
+            return textBox;
+        }
+
+        private PowerPointLayoutBox GetDefaultHeaderFooterBounds(PlaceholderValues placeholderType) {
+            long slideWidth = SlideSize.WidthEmus;
+            long slideHeight = SlideSize.HeightEmus;
+            long margin = PowerPointUnits.FromCentimeters(0.6);
+            long footerTop = slideHeight - PowerPointUnits.FromCentimeters(0.8);
+            long footerHeight = PowerPointUnits.FromCentimeters(0.45);
+            long sideWidth = Math.Max(PowerPointUnits.FromCentimeters(2.0), slideWidth / 5);
+            long centerWidth = Math.Max(PowerPointUnits.FromCentimeters(4.0), slideWidth / 3);
+
+            if (placeholderType == PlaceholderValues.DateAndTime) {
+                return new PowerPointLayoutBox(margin, footerTop, sideWidth, footerHeight);
+            }
+
+            if (placeholderType == PlaceholderValues.SlideNumber) {
+                return new PowerPointLayoutBox(slideWidth - margin - sideWidth, footerTop, sideWidth, footerHeight);
+            }
+
+            return new PowerPointLayoutBox((slideWidth - centerWidth) / 2, footerTop, centerWidth, footerHeight);
+        }
+
+        private static void SetHeaderFooterFlag(SlideLayoutPart layoutPart, PlaceholderValues placeholderType, bool visible) {
+            HeaderFooter headerFooter = EnsureHeaderFooter(layoutPart);
+            if (placeholderType == PlaceholderValues.Footer) {
+                headerFooter.Footer = visible;
+                return;
+            }
+
+            if (placeholderType == PlaceholderValues.DateAndTime) {
+                headerFooter.DateTime = visible;
+                return;
+            }
+
+            if (placeholderType == PlaceholderValues.SlideNumber) {
+                headerFooter.SlideNumber = visible;
+            }
+        }
+
+        private static HeaderFooter EnsureHeaderFooter(SlideLayoutPart layoutPart) {
+            SlideLayout layout = layoutPart.SlideLayout ??= new SlideLayout();
+            HeaderFooter? headerFooter = layout.GetFirstChild<HeaderFooter>();
+            if (headerFooter != null) {
+                return headerFooter;
+            }
+
+            headerFooter = new HeaderFooter();
+            SlideLayoutExtensionList? extensionList = layout.GetFirstChild<SlideLayoutExtensionList>();
+            if (extensionList != null) {
+                layout.InsertBefore(headerFooter, extensionList);
+            } else {
+                layout.AppendChild(headerFooter);
+            }
+
+            return headerFooter;
         }
 
         private void ThrowIfDisposed() {

--- a/OfficeIMO.PowerPoint/PowerPointPreviewExportFormat.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPreviewExportFormat.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Slide preview/export formats supported by optional PowerPoint automation.
+    /// </summary>
+    public enum PowerPointPreviewExportFormat {
+        /// <summary>
+        ///     Export slides as PNG images.
+        /// </summary>
+        Png,
+
+        /// <summary>
+        ///     Export slides as JPEG images.
+        /// </summary>
+        Jpeg
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointPreviewExportResult.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPreviewExportResult.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Result of an optional slide preview/export attempt.
+    /// </summary>
+    public sealed class PowerPointPreviewExportResult {
+        internal PowerPointPreviewExportResult(bool succeeded, IReadOnlyList<string> files, string? message, Exception? exception) {
+            Succeeded = succeeded;
+            Files = files;
+            Message = message;
+            Exception = exception;
+        }
+
+        /// <summary>
+        ///     Gets a value indicating whether slide export completed.
+        /// </summary>
+        public bool Succeeded { get; }
+
+        /// <summary>
+        ///     Gets exported preview files discovered in the output directory.
+        /// </summary>
+        public IReadOnlyList<string> Files { get; }
+
+        /// <summary>
+        ///     Gets a human-readable status or failure message.
+        /// </summary>
+        public string? Message { get; }
+
+        /// <summary>
+        ///     Gets the caught exception when export failed after automation started.
+        /// </summary>
+        public Exception? Exception { get; }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointPreviewExporter.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPreviewExporter.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Optional slide preview/export boundary backed by installed Microsoft PowerPoint automation.
+    /// </summary>
+    public static class PowerPointPreviewExporter {
+        /// <summary>
+        ///     Returns true when this process can locate Microsoft PowerPoint automation.
+        /// </summary>
+        public static bool IsPowerPointAutomationAvailable() {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                   Type.GetTypeFromProgID("PowerPoint.Application") != null;
+        }
+
+        /// <summary>
+        ///     Attempts to export slides from a saved presentation to image files.
+        /// </summary>
+        public static bool TryExportSlides(
+            string presentationPath,
+            string outputDirectory,
+            out PowerPointPreviewExportResult result,
+            PowerPointPreviewExportFormat format = PowerPointPreviewExportFormat.Png,
+            int width = 0,
+            int height = 0) {
+            if (presentationPath == null) {
+                throw new ArgumentNullException(nameof(presentationPath));
+            }
+            if (outputDirectory == null) {
+                throw new ArgumentNullException(nameof(outputDirectory));
+            }
+            if (width < 0) {
+                throw new ArgumentOutOfRangeException(nameof(width));
+            }
+            if (height < 0) {
+                throw new ArgumentOutOfRangeException(nameof(height));
+            }
+            if (!File.Exists(presentationPath)) {
+                throw new FileNotFoundException("Presentation file not found.", presentationPath);
+            }
+
+            Type? powerPointType = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? Type.GetTypeFromProgID("PowerPoint.Application")
+                : null;
+            if (powerPointType == null) {
+                result = new PowerPointPreviewExportResult(false, Array.Empty<string>(),
+                    "Microsoft PowerPoint automation is not available on this host.", null);
+                return false;
+            }
+
+            Directory.CreateDirectory(outputDirectory);
+            string fullPresentationPath = Path.GetFullPath(presentationPath);
+            string fullOutputDirectory = Path.GetFullPath(outputDirectory);
+            object? application = null;
+            object? presentation = null;
+
+            try {
+                application = Activator.CreateInstance(powerPointType);
+                if (application == null) {
+                    throw new InvalidOperationException("PowerPoint automation could not be started.");
+                }
+
+                object presentations = InvokeGet(application, "Presentations");
+                presentation = Invoke(presentations, "Open", fullPresentationPath, -1, -1, 0);
+                if (presentation == null) {
+                    throw new InvalidOperationException("PowerPoint automation did not return an open presentation.");
+                }
+
+                Invoke(presentation, "Export", fullOutputDirectory, GetAutomationFormat(format), width, height);
+
+                IReadOnlyList<string> files = Directory
+                    .EnumerateFiles(fullOutputDirectory, "*." + GetFileExtension(format), SearchOption.TopDirectoryOnly)
+                    .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+                result = new PowerPointPreviewExportResult(true, files, "Slides exported successfully.", null);
+                return true;
+            } catch (Exception ex) {
+                result = new PowerPointPreviewExportResult(false, Array.Empty<string>(),
+                    "Slide export failed through Microsoft PowerPoint automation.", ex);
+                return false;
+            } finally {
+                if (presentation != null) {
+                    TryInvoke(presentation, "Close");
+                    ReleaseComObject(presentation);
+                }
+
+                if (application != null) {
+                    TryInvoke(application, "Quit");
+                    ReleaseComObject(application);
+                }
+            }
+        }
+
+        private static string GetAutomationFormat(PowerPointPreviewExportFormat format) {
+            return format switch {
+                PowerPointPreviewExportFormat.Jpeg => "JPG",
+                _ => "PNG"
+            };
+        }
+
+        private static string GetFileExtension(PowerPointPreviewExportFormat format) {
+            return format switch {
+                PowerPointPreviewExportFormat.Jpeg => "JPG",
+                _ => "PNG"
+            };
+        }
+
+        private static object InvokeGet(object target, string name) {
+            return target.GetType().InvokeMember(name, BindingFlags.GetProperty, null, target, null)
+                ?? throw new InvalidOperationException("PowerPoint automation returned null for " + name + ".");
+        }
+
+        private static object? Invoke(object target, string name, params object[] args) {
+            return target.GetType().InvokeMember(name, BindingFlags.InvokeMethod, null, target, args);
+        }
+
+        private static void TryInvoke(object target, string name) {
+            try {
+                Invoke(target, name);
+            } catch {
+                // Best effort cleanup for optional automation.
+            }
+        }
+
+        private static void ReleaseComObject(object target) {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Marshal.IsComObject(target)) {
+                Marshal.FinalReleaseComObject(target);
+            }
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointShape.cs
+++ b/OfficeIMO.PowerPoint/PowerPointShape.cs
@@ -2,6 +2,8 @@ using System;
 using System.Linq;
 using DocumentFormat.OpenXml.Presentation;
 using A = DocumentFormat.OpenXml.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+using Dgm = DocumentFormat.OpenXml.Drawing.Diagrams;
 
 namespace OfficeIMO.PowerPoint {
     /// <summary>
@@ -15,25 +17,123 @@ namespace OfficeIMO.PowerPoint {
         }
 
         internal OpenXmlElement Element { get; }
+        internal PowerPointSlide? OwnerSlide { get; private set; }
+
+        internal PowerPointShape AttachTo(PowerPointSlide slide) {
+            OwnerSlide = slide;
+            return this;
+        }
+
+        /// <summary>
+        ///     Numeric shape identifier stored in the PowerPoint non-visual drawing properties.
+        /// </summary>
+        public uint? Id {
+            get => GetNonVisualDrawingProperties(create: false)?.Id?.Value;
+        }
 
         /// <summary>
         ///     Name assigned to the shape.
         /// </summary>
         public string? Name {
-            get {
-                switch (Element) {
-                    case Shape s:
-                        return s.NonVisualShapeProperties?.NonVisualDrawingProperties?.Name?.Value;
-                    case Picture p:
-                        return p.NonVisualPictureProperties?.NonVisualDrawingProperties?.Name?.Value;
-                    case GraphicFrame g:
-                        return g.NonVisualGraphicFrameProperties?.NonVisualDrawingProperties?.Name?.Value;
-                    case GroupShape g:
-                        return g.NonVisualGroupShapeProperties?.NonVisualDrawingProperties?.Name?.Value;
-                    default:
-                        return null;
-                }
+            get => GetNonVisualDrawingProperties(create: false)?.Name?.Value;
+            set {
+                NonVisualDrawingProperties drawing = GetNonVisualDrawingProperties(create: true)
+                    ?? throw new NotSupportedException("This shape type does not expose non-visual drawing properties.");
+                drawing.Name = value ?? string.Empty;
             }
+        }
+
+        /// <summary>
+        ///     Alternative text description assigned to the shape.
+        /// </summary>
+        public string? AltText {
+            get => GetNonVisualDrawingProperties(create: false)?.Description?.Value;
+            set {
+                NonVisualDrawingProperties drawing = GetNonVisualDrawingProperties(create: true)
+                    ?? throw new NotSupportedException("This shape type does not expose non-visual drawing properties.");
+                drawing.Description = value;
+            }
+        }
+
+        /// <summary>
+        ///     Gets or sets whether the shape is hidden.
+        /// </summary>
+        public bool Hidden {
+            get => GetNonVisualDrawingProperties(create: false)?.Hidden?.Value == true;
+            set {
+                NonVisualDrawingProperties drawing = GetNonVisualDrawingProperties(create: true)
+                    ?? throw new NotSupportedException("This shape type does not expose non-visual drawing properties.");
+                drawing.Hidden = value ? true : null;
+            }
+        }
+
+        /// <summary>
+        ///     Placeholder type associated with the shape, if any.
+        /// </summary>
+        public PlaceholderValues? ShapePlaceholderType => GetPlaceholderShape()?.Type?.Value;
+
+        /// <summary>
+        ///     Placeholder index associated with the shape, if any.
+        /// </summary>
+        public uint? ShapePlaceholderIndex => GetPlaceholderShape()?.Index?.Value;
+
+        /// <summary>
+        ///     Primary content type represented by this shape wrapper.
+        /// </summary>
+        public PowerPointShapeContentType ShapeContentType => Element switch {
+            GroupShape => PowerPointShapeContentType.Group,
+            Picture p when IsMediaPicture(p) => PowerPointShapeContentType.Media,
+            Picture => PowerPointShapeContentType.Picture,
+            GraphicFrame g when g.Graphic?.GraphicData?.GetFirstChild<A.Table>() != null => PowerPointShapeContentType.Table,
+            GraphicFrame g when g.Graphic?.GraphicData?.GetFirstChild<C.ChartReference>() != null => PowerPointShapeContentType.Chart,
+            GraphicFrame g when g.Graphic?.GraphicData?.GetFirstChild<Dgm.RelationshipIds>() != null => PowerPointShapeContentType.SmartArt,
+            Shape s when s.TextBody != null => PowerPointShapeContentType.TextBox,
+            Shape => PowerPointShapeContentType.AutoShape,
+            _ => PowerPointShapeContentType.Unknown
+        };
+
+        /// <summary>
+        ///     Removes this shape from its owning slide or parent shape tree.
+        /// </summary>
+        public void Remove() {
+            if (OwnerSlide != null) {
+                OwnerSlide.RemoveShape(this);
+                return;
+            }
+
+            Element.Remove();
+        }
+
+        /// <summary>
+        ///     Duplicates this shape on its owning slide.
+        /// </summary>
+        public PowerPointShape Duplicate(long offsetX = 0L, long offsetY = 0L) {
+            if (OwnerSlide == null) {
+                throw new InvalidOperationException("Shape duplication requires a shape attached to a slide.");
+            }
+
+            return OwnerSlide.DuplicateShape(this, offsetX, offsetY);
+        }
+
+        /// <summary>
+        ///     Duplicates this shape on its owning slide and offsets it in centimeters.
+        /// </summary>
+        public PowerPointShape DuplicateCm(double offsetXCm, double offsetYCm) {
+            return Duplicate(PowerPointUnits.FromCentimeters(offsetXCm), PowerPointUnits.FromCentimeters(offsetYCm));
+        }
+
+        /// <summary>
+        ///     Duplicates this shape on its owning slide and offsets it in inches.
+        /// </summary>
+        public PowerPointShape DuplicateInches(double offsetXInches, double offsetYInches) {
+            return Duplicate(PowerPointUnits.FromInches(offsetXInches), PowerPointUnits.FromInches(offsetYInches));
+        }
+
+        /// <summary>
+        ///     Duplicates this shape on its owning slide and offsets it in points.
+        /// </summary>
+        public PowerPointShape DuplicatePoints(double offsetXPoints, double offsetYPoints) {
+            return Duplicate(PowerPointUnits.FromPoints(offsetXPoints), PowerPointUnits.FromPoints(offsetYPoints));
         }
 
         /// <summary>
@@ -928,6 +1028,73 @@ namespace OfficeIMO.PowerPoint {
                 default:
                     throw new NotSupportedException();
             }
+        }
+
+        private NonVisualDrawingProperties? GetNonVisualDrawingProperties(bool create) {
+            switch (Element) {
+                case Shape s: {
+                    if (create) {
+                        s.NonVisualShapeProperties ??= new NonVisualShapeProperties(
+                            new NonVisualDrawingProperties(),
+                            new NonVisualShapeDrawingProperties(new A.ShapeLocks { NoGrouping = true }),
+                            new ApplicationNonVisualDrawingProperties());
+                        s.NonVisualShapeProperties.NonVisualDrawingProperties ??= new NonVisualDrawingProperties();
+                    }
+
+                    return s.NonVisualShapeProperties?.NonVisualDrawingProperties;
+                }
+                case Picture p: {
+                    if (create) {
+                        p.NonVisualPictureProperties ??= new NonVisualPictureProperties(
+                            new NonVisualDrawingProperties(),
+                            new NonVisualPictureDrawingProperties(),
+                            new ApplicationNonVisualDrawingProperties());
+                        p.NonVisualPictureProperties.NonVisualDrawingProperties ??= new NonVisualDrawingProperties();
+                    }
+
+                    return p.NonVisualPictureProperties?.NonVisualDrawingProperties;
+                }
+                case GraphicFrame g: {
+                    if (create) {
+                        g.NonVisualGraphicFrameProperties ??= new NonVisualGraphicFrameProperties(
+                            new NonVisualDrawingProperties(),
+                            new NonVisualGraphicFrameDrawingProperties(),
+                            new ApplicationNonVisualDrawingProperties());
+                        g.NonVisualGraphicFrameProperties.NonVisualDrawingProperties ??= new NonVisualDrawingProperties();
+                    }
+
+                    return g.NonVisualGraphicFrameProperties?.NonVisualDrawingProperties;
+                }
+                case GroupShape g: {
+                    if (create) {
+                        g.NonVisualGroupShapeProperties ??= new NonVisualGroupShapeProperties(
+                            new NonVisualDrawingProperties(),
+                            new NonVisualGroupShapeDrawingProperties(),
+                            new ApplicationNonVisualDrawingProperties());
+                        g.NonVisualGroupShapeProperties.NonVisualDrawingProperties ??= new NonVisualDrawingProperties();
+                    }
+
+                    return g.NonVisualGroupShapeProperties?.NonVisualDrawingProperties;
+                }
+                default:
+                    return null;
+            }
+        }
+
+        private PlaceholderShape? GetPlaceholderShape() {
+            return Element switch {
+                Shape s => s.NonVisualShapeProperties?.ApplicationNonVisualDrawingProperties?.PlaceholderShape,
+                Picture p => p.NonVisualPictureProperties?.ApplicationNonVisualDrawingProperties?.PlaceholderShape,
+                GraphicFrame g => g.NonVisualGraphicFrameProperties?.ApplicationNonVisualDrawingProperties?.PlaceholderShape,
+                _ => null
+            };
+        }
+
+        private static bool IsMediaPicture(Picture picture) {
+            ApplicationNonVisualDrawingProperties? properties =
+                picture.NonVisualPictureProperties?.ApplicationNonVisualDrawingProperties;
+            return properties?.Descendants<A.AudioFromFile>().Any() == true ||
+                   properties?.Descendants<A.VideoFromFile>().Any() == true;
         }
 
         private A.Extents GetExtents() {

--- a/OfficeIMO.PowerPoint/PowerPointShapeContentType.cs
+++ b/OfficeIMO.PowerPoint/PowerPointShapeContentType.cs
@@ -1,0 +1,56 @@
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Describes the primary content carried by a PowerPoint shape wrapper.
+    /// </summary>
+    public enum PowerPointShapeContentType {
+        /// <summary>
+        ///     The shape content type could not be identified.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        ///     The shape is a regular drawing shape.
+        /// </summary>
+        AutoShape,
+
+        /// <summary>
+        ///     The shape is a text box.
+        /// </summary>
+        TextBox,
+
+        /// <summary>
+        ///     The shape is a picture.
+        /// </summary>
+        Picture,
+
+        /// <summary>
+        ///     The shape is a table.
+        /// </summary>
+        Table,
+
+        /// <summary>
+        ///     The shape is a chart.
+        /// </summary>
+        Chart,
+
+        /// <summary>
+        ///     The shape is a group of shapes.
+        /// </summary>
+        Group,
+
+        /// <summary>
+        ///     The shape represents embedded media, such as audio or video.
+        /// </summary>
+        Media,
+
+        /// <summary>
+        ///     The shape represents a SmartArt diagram.
+        /// </summary>
+        SmartArt,
+
+        /// <summary>
+        ///     The shape represents an embedded OLE object.
+        /// </summary>
+        OleObject
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Arrange.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Arrange.cs
@@ -7,6 +7,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using A = DocumentFormat.OpenXml.Drawing;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
+using Dgm = DocumentFormat.OpenXml.Drawing.Diagrams;
 
 namespace OfficeIMO.PowerPoint {
     public partial class PowerPointSlide {
@@ -45,7 +46,7 @@ namespace OfficeIMO.PowerPoint {
             }
 
             parent.InsertAfter(clone, shape.Element);
-            _shapes.Insert(index + 1, duplicate);
+            InsertTrackedShape(index + 1, duplicate);
             return duplicate;
         }
 
@@ -292,13 +293,17 @@ namespace OfficeIMO.PowerPoint {
                 case Shape s:
                     return s.TextBody != null ? new PowerPointTextBox(s, _slidePart) : new PowerPointAutoShape(s);
                 case Picture p:
-                    return new PowerPointPicture(p, _slidePart);
+                    return PowerPointMedia.TryGetMediaKind(p, out PowerPointMediaKind kind)
+                        ? new PowerPointMedia(p, _slidePart, kind)
+                        : new PowerPointPicture(p, _slidePart);
                 case GroupShape g:
                     return new PowerPointGroupShape(g);
                 case GraphicFrame g when g.Graphic?.GraphicData?.GetFirstChild<A.Table>() != null:
                     return new PowerPointTable(g, _slidePart);
                 case GraphicFrame g when g.Graphic?.GraphicData?.GetFirstChild<C.ChartReference>() != null:
                     return new PowerPointChart(g, _slidePart);
+                case GraphicFrame g when g.Graphic?.GraphicData?.GetFirstChild<Dgm.RelationshipIds>() != null:
+                    return new PowerPointSmartArt(g, _slidePart);
                 default:
                     return null;
             }

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Charts.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Charts.cs
@@ -875,8 +875,7 @@ namespace OfficeIMO.PowerPoint {
             CommonSlideData dataElement = SlideRoot.CommonSlideData ??= new CommonSlideData(new ShapeTree());
             ShapeTree tree = dataElement.ShapeTree ??= new ShapeTree();
             tree.AppendChild(frame);
-            PowerPointChart chart = new(frame, _slidePart);
-            _shapes.Add(chart);
+            PowerPointChart chart = TrackShape(new PowerPointChart(frame, _slidePart));
             return chart;
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Group.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Group.cs
@@ -64,7 +64,7 @@ namespace OfficeIMO.PowerPoint {
             }
 
             PowerPointGroupShape grouped = new PowerPointGroupShape(group);
-            _shapes.Insert(insertIndex, grouped);
+            InsertTrackedShape(insertIndex, grouped);
             return grouped;
         }
 
@@ -100,7 +100,7 @@ namespace OfficeIMO.PowerPoint {
             group.Remove();
 
             _shapes.RemoveAt(index);
-            _shapes.InsertRange(index, results);
+            InsertRangeTrackedShapes(index, results);
             return results;
         }
     }

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Media.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Media.cs
@@ -1,0 +1,277 @@
+using System;
+using System.IO;
+using System.Text;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using A = DocumentFormat.OpenXml.Drawing;
+using P14 = DocumentFormat.OpenXml.Office2010.PowerPoint;
+
+namespace OfficeIMO.PowerPoint {
+    public partial class PowerPointSlide {
+        /// <summary>
+        ///     Adds an embedded video file to the slide.
+        /// </summary>
+        public PowerPointMedia AddVideo(string videoPath, string? posterImagePath = null, long left = 0L, long top = 0L,
+            long width = 3657600L, long height = 2057400L) {
+            if (videoPath == null) {
+                throw new ArgumentNullException(nameof(videoPath));
+            }
+            if (!File.Exists(videoPath)) {
+                throw new FileNotFoundException("Video file not found.", videoPath);
+            }
+
+            using FileStream videoStream = new(videoPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            if (posterImagePath == null) {
+                return AddVideo(videoStream, GetVideoContentType(videoPath), Path.GetExtension(videoPath), left, top, width, height);
+            }
+
+            if (!File.Exists(posterImagePath)) {
+                throw new FileNotFoundException("Poster image file not found.", posterImagePath);
+            }
+
+            using FileStream posterStream = new(posterImagePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return AddVideo(videoStream, GetVideoContentType(videoPath), Path.GetExtension(videoPath), left, top, width, height,
+                posterStream, GetImagePartType(posterImagePath));
+        }
+
+        /// <summary>
+        ///     Adds an embedded video stream to the slide.
+        /// </summary>
+        public PowerPointMedia AddVideo(Stream video, string contentType, string extension, long left = 0L, long top = 0L,
+            long width = 3657600L, long height = 2057400L, Stream? posterImage = null,
+            ImagePartType posterImageType = ImagePartType.Png) {
+            return AddMedia(video, contentType, extension, PowerPointMediaKind.Video, left, top, width, height, posterImage,
+                posterImageType);
+        }
+
+        /// <summary>
+        ///     Adds an embedded audio file to the slide.
+        /// </summary>
+        public PowerPointMedia AddAudio(string audioPath, long left = 0L, long top = 0L, long width = 914400L,
+            long height = 914400L) {
+            if (audioPath == null) {
+                throw new ArgumentNullException(nameof(audioPath));
+            }
+            if (!File.Exists(audioPath)) {
+                throw new FileNotFoundException("Audio file not found.", audioPath);
+            }
+
+            using FileStream audioStream = new(audioPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return AddAudio(audioStream, GetAudioContentType(audioPath), Path.GetExtension(audioPath), left, top, width, height);
+        }
+
+        /// <summary>
+        ///     Adds an embedded audio stream to the slide.
+        /// </summary>
+        public PowerPointMedia AddAudio(Stream audio, string contentType, string extension, long left = 0L, long top = 0L,
+            long width = 914400L, long height = 914400L) {
+            return AddMedia(audio, contentType, extension, PowerPointMediaKind.Audio, left, top, width, height);
+        }
+
+        private PowerPointMedia AddMedia(Stream media, string contentType, string extension, PowerPointMediaKind kind,
+            long left, long top, long width, long height, Stream? posterImage = null,
+            ImagePartType posterImageType = ImagePartType.Png) {
+            if (media == null) {
+                throw new ArgumentNullException(nameof(media));
+            }
+            if (!media.CanRead) {
+                throw new ArgumentException("Media stream must be readable.", nameof(media));
+            }
+            if (string.IsNullOrWhiteSpace(contentType)) {
+                throw new ArgumentException("Media content type is required.", nameof(contentType));
+            }
+            if (string.IsNullOrWhiteSpace(extension)) {
+                throw new ArgumentException("Media extension is required.", nameof(extension));
+            }
+            if (width <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(width));
+            }
+            if (height <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(height));
+            }
+
+            MediaDataPart mediaPart = CreateMediaDataPart(media, contentType, extension);
+            string fileReferenceId = GetNextRelationshipId(_slidePart);
+            if (kind == PowerPointMediaKind.Audio) {
+                _slidePart.AddAudioReferenceRelationship(mediaPart, fileReferenceId);
+            } else {
+                _slidePart.AddVideoReferenceRelationship(mediaPart, fileReferenceId);
+            }
+            string playbackReferenceId = GetNextRelationshipId(_slidePart);
+            _slidePart.AddMediaReferenceRelationship(mediaPart, playbackReferenceId);
+
+            ImagePart posterPart = posterImage == null
+                ? AddGeneratedMediaPoster(kind)
+                : AddImagePartFromStream(posterImage, posterImageType);
+            string posterRelationshipId = _slidePart.GetIdOfPart(posterPart);
+
+            string name = GenerateUniqueName(kind == PowerPointMediaKind.Audio ? "Audio" : "Video");
+            uint shapeId = _nextShapeId++;
+            Picture picture = CreateMediaPicture(kind, shapeId, name, fileReferenceId, playbackReferenceId,
+                posterRelationshipId, left, top, width, height);
+
+            CommonSlideData data = SlideRoot.CommonSlideData ??= new CommonSlideData(new ShapeTree());
+            ShapeTree tree = data.ShapeTree ??= new ShapeTree();
+            tree.AppendChild(picture);
+            EnsureMediaTiming(shapeId, kind);
+
+            return TrackShape(new PowerPointMedia(picture, _slidePart, kind));
+        }
+
+        private MediaDataPart CreateMediaDataPart(Stream media, string contentType, string extension) {
+            if (_slidePart.OpenXmlPackage is not PresentationDocument document) {
+                throw new InvalidOperationException("Slide is not attached to a presentation document.");
+            }
+
+            string normalizedExtension = extension.Trim().TrimStart('.');
+            MediaDataPart mediaPart = document.CreateMediaDataPart(contentType, normalizedExtension);
+            if (media.CanSeek) {
+                media.Position = 0;
+            }
+            mediaPart.FeedData(media);
+            return mediaPart;
+        }
+
+        private ImagePart AddGeneratedMediaPoster(PowerPointMediaKind kind) {
+            string label = kind == PowerPointMediaKind.Audio ? "Audio" : "Video";
+            string glyph = kind == PowerPointMediaKind.Audio ? "♪" : "▶";
+            string svg = $"""
+                <svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360">
+                  <rect width="640" height="360" rx="20" fill="#1F2937"/>
+                  <circle cx="320" cy="164" r="72" fill="#F9FAFB" opacity="0.94"/>
+                  <text x="320" y="190" text-anchor="middle" font-family="Arial, sans-serif" font-size="78" fill="#111827">{glyph}</text>
+                  <text x="320" y="292" text-anchor="middle" font-family="Arial, sans-serif" font-size="34" fill="#F9FAFB">{label}</text>
+                </svg>
+                """;
+            using MemoryStream stream = new(Encoding.UTF8.GetBytes(svg));
+            return AddImagePartFromStream(stream, ImagePartType.Svg);
+        }
+
+        private ImagePart AddImagePartFromStream(Stream image, ImagePartType imageType) {
+            if (image == null) {
+                throw new ArgumentNullException(nameof(image));
+            }
+            if (!image.CanRead) {
+                throw new ArgumentException("Image stream must be readable.", nameof(image));
+            }
+
+            PartTypeInfo partTypeInfo = imageType.ToPartTypeInfo();
+            string imageExtension = PowerPointPartFactory.GetImageExtension(imageType);
+            string imagePartUri = PowerPointPartFactory.GetIndexedPartUri(
+                _slidePart.OpenXmlPackage,
+                "ppt/media",
+                "image",
+                imageExtension,
+                allowBaseWithoutIndex: false);
+            ImagePart imagePart = PowerPointPartFactory.CreatePart<ImagePart>(
+                _slidePart,
+                partTypeInfo.ContentType,
+                imagePartUri);
+            if (image.CanSeek) {
+                image.Position = 0;
+            }
+            imagePart.FeedData(image);
+            return imagePart;
+        }
+
+        private static Picture CreateMediaPicture(PowerPointMediaKind kind, uint shapeId, string name,
+            string fileReferenceId, string playbackReferenceId, string posterRelationshipId,
+            long left, long top, long width, long height) {
+            ApplicationNonVisualDrawingProperties appProperties = new();
+            if (kind == PowerPointMediaKind.Audio) {
+                appProperties.Append(new A.AudioFromFile { Link = fileReferenceId });
+            } else {
+                appProperties.Append(new A.VideoFromFile { Link = fileReferenceId });
+            }
+
+            P14.Media media = new() { Embed = playbackReferenceId };
+            media.AddNamespaceDeclaration("p14", P14Namespace);
+            ApplicationNonVisualDrawingPropertiesExtension extension =
+                new() { Uri = "{DAA4B4D4-6D71-4841-9C94-3DE7FCFB9230}" };
+            extension.Append(media);
+            appProperties.Append(new ApplicationNonVisualDrawingPropertiesExtensionList(extension));
+
+            NonVisualDrawingProperties drawingProperties = new() { Id = shapeId, Name = name };
+            drawingProperties.Append(new A.HyperlinkOnClick { Id = string.Empty, Action = "ppaction://media" });
+
+            return new Picture(
+                new NonVisualPictureProperties(
+                    drawingProperties,
+                    new NonVisualPictureDrawingProperties(new A.PictureLocks { NoChangeAspect = true }),
+                    appProperties),
+                new BlipFill(
+                    new A.Blip { Embed = posterRelationshipId },
+                    new A.Stretch(new A.FillRectangle())),
+                new ShapeProperties(
+                    new A.Transform2D(new A.Offset { X = left, Y = top }, new A.Extents { Cx = width, Cy = height }),
+                    new A.PresetGeometry(new A.AdjustValueList()) { Preset = A.ShapeTypeValues.Rectangle }));
+        }
+
+        private void EnsureMediaTiming(uint shapeId, PowerPointMediaKind kind) {
+            Timing timing = SlideRoot.Timing ??= new Timing();
+            TimeNodeList timeNodeList = timing.GetFirstChild<TimeNodeList>() ?? timing.AppendChild(new TimeNodeList());
+            ParallelTimeNode rootParallel = timeNodeList.GetFirstChild<ParallelTimeNode>() ?? timeNodeList.AppendChild(new ParallelTimeNode());
+            CommonTimeNode rootTimeNode = rootParallel.GetFirstChild<CommonTimeNode>() ??
+                rootParallel.AppendChild(new CommonTimeNode {
+                    Id = 1U,
+                    Duration = "indefinite",
+                    Restart = TimeNodeRestartValues.Never,
+                    NodeType = TimeNodeValues.TmingRoot
+                });
+            ChildTimeNodeList childNodes = rootTimeNode.GetFirstChild<ChildTimeNodeList>() ??
+                rootTimeNode.AppendChild(new ChildTimeNodeList());
+
+            OpenXmlCompositeElement mediaNode = kind == PowerPointMediaKind.Audio
+                ? new Audio()
+                : new Video();
+            mediaNode.Append(
+                new CommonMediaNode(
+                    new CommonTimeNode(
+                        new StartConditionList(new Condition { Delay = "indefinite" })) {
+                        Id = GetNextTimingId(),
+                        Fill = TimeNodeFillValues.Hold,
+                        Display = false
+                    },
+                    new TargetElement(new ShapeTarget { ShapeId = shapeId.ToString(System.Globalization.CultureInfo.InvariantCulture) })) {
+                    Volume = 80000
+                });
+            childNodes.Append(mediaNode);
+        }
+
+        private uint GetNextTimingId() {
+            uint maxId = 0;
+            foreach (CommonTimeNode node in SlideRoot.Descendants<CommonTimeNode>()) {
+                uint? id = node.Id?.Value;
+                if (id.HasValue && id.Value > maxId) {
+                    maxId = id.Value;
+                }
+            }
+
+            return maxId + 1;
+        }
+
+        private static string GetAudioContentType(string mediaPath) {
+            return Path.GetExtension(mediaPath).ToLowerInvariant() switch {
+                ".wav" => "audio/wav",
+                ".wma" => "audio/x-ms-wma",
+                ".ogg" or ".oga" => "audio/ogg",
+                ".m4a" => "audio/mp4",
+                ".mid" or ".midi" => "audio/midi",
+                ".aiff" or ".aif" => "audio/aiff",
+                _ => "audio/mpeg"
+            };
+        }
+
+        private static string GetVideoContentType(string mediaPath) {
+            return Path.GetExtension(mediaPath).ToLowerInvariant() switch {
+                ".avi" => "video/x-msvideo",
+                ".mpeg" => "video/mpeg",
+                ".mpg" => "video/mpg",
+                ".mov" => "video/quicktime",
+                ".wmv" => "video/x-ms-wmv",
+                ".ogv" => "video/ogg",
+                _ => "video/mp4"
+            };
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Pictures.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Pictures.cs
@@ -62,8 +62,7 @@ namespace OfficeIMO.PowerPoint {
             CommonSlideData data = SlideRoot.CommonSlideData ??= new CommonSlideData(new ShapeTree());
             ShapeTree tree = data.ShapeTree ??= new ShapeTree();
             tree.AppendChild(picture);
-            PowerPointPicture pic = new(picture, _slidePart);
-            _shapes.Add(pic);
+            PowerPointPicture pic = TrackShape(new PowerPointPicture(picture, _slidePart));
             return pic;
         }
 
@@ -129,8 +128,7 @@ namespace OfficeIMO.PowerPoint {
             CommonSlideData data = SlideRoot.CommonSlideData ??= new CommonSlideData(new ShapeTree());
             ShapeTree tree = data.ShapeTree ??= new ShapeTree();
             tree.AppendChild(picture);
-            PowerPointPicture pic = new(picture, _slidePart);
-            _shapes.Add(pic);
+            PowerPointPicture pic = TrackShape(new PowerPointPicture(picture, _slidePart));
             return pic;
         }
 
@@ -227,6 +225,7 @@ namespace OfficeIMO.PowerPoint {
                 ".gif" => ImagePartType.Gif,
                 ".bmp" => ImagePartType.Bmp,
                 ".tif" or ".tiff" => ImagePartType.Tiff,
+                ".svg" => ImagePartType.Svg,
                 ".emf" => ImagePartType.Emf,
                 ".wmf" => ImagePartType.Wmf,
                 ".ico" => ImagePartType.Icon,

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Shapes.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Shapes.cs
@@ -32,8 +32,7 @@ namespace OfficeIMO.PowerPoint {
             CommonSlideData data = SlideRoot.CommonSlideData ??= new CommonSlideData(new ShapeTree());
             ShapeTree tree = data.ShapeTree ??= new ShapeTree();
             tree.AppendChild(shape);
-            PowerPointAutoShape autoShape = new(shape);
-            _shapes.Add(autoShape);
+            PowerPointAutoShape autoShape = TrackShape(new PowerPointAutoShape(shape));
             return autoShape;
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointSlide.SmartArt.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.SmartArt.cs
@@ -1,0 +1,184 @@
+using System;
+using System.IO;
+using System.Text;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using A = DocumentFormat.OpenXml.Drawing;
+using Dgm = DocumentFormat.OpenXml.Drawing.Diagrams;
+
+namespace OfficeIMO.PowerPoint {
+    public partial class PowerPointSlide {
+        /// <summary>
+        ///     Adds a native SmartArt diagram to the slide.
+        /// </summary>
+        public PowerPointSmartArt AddSmartArt(PowerPointSmartArtType type = PowerPointSmartArtType.BasicProcess,
+            long left = 0L, long top = 0L, long width = 5486400L, long height = 3200400L) {
+            if (width <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(width));
+            }
+            if (height <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(height));
+            }
+
+            var (layoutRelId, colorsRelId, styleRelId, dataRelId) = AddSmartArtParts(type);
+            string name = GenerateUniqueName("SmartArt");
+            GraphicFrame frame = CreateSmartArtFrame(_nextShapeId++, name, layoutRelId, colorsRelId, styleRelId,
+                dataRelId, left, top, width, height);
+
+            CommonSlideData data = SlideRoot.CommonSlideData ??= new CommonSlideData(new ShapeTree());
+            ShapeTree tree = data.ShapeTree ??= new ShapeTree();
+            tree.Append(frame);
+
+            return TrackShape(new PowerPointSmartArt(frame, _slidePart));
+        }
+
+        /// <summary>
+        ///     Adds a native SmartArt diagram to the slide using a layout box.
+        /// </summary>
+        public PowerPointSmartArt AddSmartArt(PowerPointSmartArtType type, PowerPointLayoutBox layout) {
+            return AddSmartArt(type, layout.Left, layout.Top, layout.Width, layout.Height);
+        }
+
+        private (string layoutRelId, string colorsRelId, string styleRelId, string dataRelId) AddSmartArtParts(
+            PowerPointSmartArtType type) {
+            switch (type) {
+                case PowerPointSmartArtType.BasicProcess:
+                default:
+                    return AddBasicProcessSmartArtParts();
+            }
+        }
+
+        private (string layoutRelId, string colorsRelId, string styleRelId, string dataRelId)
+            AddBasicProcessSmartArtParts() {
+            DiagramLayoutDefinitionPart layoutPart = _slidePart.AddNewPart<DiagramLayoutDefinitionPart>();
+            PopulateBasicProcessLayout(layoutPart);
+            DiagramColorsPart colorsPart = _slidePart.AddNewPart<DiagramColorsPart>();
+            PopulateSmartArtColors(colorsPart);
+            DiagramStylePart stylePart = _slidePart.AddNewPart<DiagramStylePart>();
+            PopulateSmartArtStyle(stylePart);
+            DiagramDataPart dataPart = _slidePart.AddNewPart<DiagramDataPart>();
+            PopulateBasicProcessData(dataPart);
+
+            return (
+                _slidePart.GetIdOfPart(layoutPart)!,
+                _slidePart.GetIdOfPart(colorsPart)!,
+                _slidePart.GetIdOfPart(stylePart)!,
+                _slidePart.GetIdOfPart(dataPart)!);
+        }
+
+        private static GraphicFrame CreateSmartArtFrame(uint id, string name, string layoutRelId, string colorsRelId,
+            string styleRelId, string dataRelId, long left, long top, long width, long height) {
+            return new GraphicFrame(
+                new NonVisualGraphicFrameProperties(
+                    new NonVisualDrawingProperties { Id = id, Name = name },
+                    new NonVisualGraphicFrameDrawingProperties(new A.GraphicFrameLocks { NoChangeAspect = true }),
+                    new ApplicationNonVisualDrawingProperties()),
+                new Transform(new A.Offset { X = left, Y = top }, new A.Extents { Cx = width, Cy = height }),
+                new A.Graphic(
+                    new A.GraphicData(
+                        new Dgm.RelationshipIds {
+                            LayoutPart = layoutRelId,
+                            StylePart = styleRelId,
+                            ColorPart = colorsRelId,
+                            DataPart = dataRelId
+                        }) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/diagram" }));
+        }
+
+        private static void PopulateBasicProcessLayout(DiagramLayoutDefinitionPart part) {
+            Dgm.LayoutDefinition layout = new() {
+                UniqueId = "urn:microsoft.com/office/officeart/2005/8/layout/default"
+            };
+            layout.AddNamespaceDeclaration("dgm", "http://schemas.openxmlformats.org/drawingml/2006/diagram");
+            layout.AddNamespaceDeclaration("a", "http://schemas.openxmlformats.org/drawingml/2006/main");
+            layout.Append(new Dgm.Title { Val = string.Empty });
+            layout.Append(new Dgm.Description { Val = string.Empty });
+            layout.Append(new Dgm.CategoryList(new Dgm.Category { Type = "list", Priority = 400U }));
+
+            Dgm.LayoutNode layoutNode = new() { Name = "diagram" };
+            Dgm.Shape shape = new() { Blip = string.Empty };
+            shape.AddNamespaceDeclaration("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+            shape.Append(new Dgm.AdjustList());
+            layoutNode.Append(shape);
+
+            Dgm.ForEach forEach = new() {
+                Name = "nodes",
+                Axis = new ListValue<EnumValue<Dgm.AxisValues>> { InnerText = "ch" },
+                PointType = new ListValue<EnumValue<Dgm.ElementValues>> { InnerText = "node" }
+            };
+            Dgm.LayoutNode node = new() { Name = "node" };
+            Dgm.Shape nodeShape = new() { Type = "rect", Blip = string.Empty };
+            nodeShape.AddNamespaceDeclaration("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+            nodeShape.Append(new Dgm.AdjustList());
+            node.Append(nodeShape);
+            forEach.Append(node);
+            layoutNode.Append(forEach);
+            layout.Append(layoutNode);
+            part.LayoutDefinition = layout;
+        }
+
+        private static void PopulateBasicProcessData(DiagramDataPart part) {
+            string docId = "{" + Guid.NewGuid().ToString().ToUpperInvariant() + "}";
+            string childId = "{" + Guid.NewGuid().ToString().ToUpperInvariant() + "}";
+            string connectionId = "{" + Guid.NewGuid().ToString().ToUpperInvariant() + "}";
+
+            string xml = $"""
+                <dgm:dataModel xmlns:dgm="http://schemas.openxmlformats.org/drawingml/2006/diagram" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                  <dgm:ptLst>
+                    <dgm:pt modelId="{docId}" type="doc">
+                      <dgm:prSet loTypeId="urn:microsoft.com/office/officeart/2005/8/layout/default" loCatId="list" qsTypeId="urn:microsoft.com/office/officeart/2005/8/quickstyle/simple1" qsCatId="simple" csTypeId="urn:microsoft.com/office/officeart/2005/8/colors/accent1_2" csCatId="accent1" phldr="0" />
+                      <dgm:spPr />
+                      <dgm:txBody><a:bodyPr /><a:lstStyle /><a:p><a:endParaRPr lang="en-US" /></a:p></dgm:txBody>
+                    </dgm:pt>
+                    <dgm:pt modelId="{childId}">
+                      <dgm:prSet phldr="1" phldrT="[Text]" />
+                      <dgm:spPr />
+                      <dgm:txBody><a:bodyPr /><a:lstStyle /><a:p><a:r><a:t>[Text]</a:t></a:r><a:endParaRPr lang="en-US" /></a:p></dgm:txBody>
+                    </dgm:pt>
+                  </dgm:ptLst>
+                  <dgm:cxnLst>
+                    <dgm:cxn modelId="{connectionId}" srcId="{docId}" destId="{childId}" srcOrd="0" destOrd="0" />
+                  </dgm:cxnLst>
+                  <dgm:bg />
+                  <dgm:whole />
+                </dgm:dataModel>
+                """;
+            using MemoryStream stream = new(Encoding.UTF8.GetBytes(xml));
+            part.FeedData(stream);
+        }
+
+        private static void PopulateSmartArtColors(DiagramColorsPart part) {
+            string xml = """
+                <dgm:colorsDef uniqueId="urn:microsoft.com/office/officeart/2005/8/colors/accent1_2" xmlns:dgm="http://schemas.openxmlformats.org/drawingml/2006/diagram" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                  <dgm:title val="" />
+                  <dgm:desc val="" />
+                  <dgm:catLst><dgm:cat type="accent1" pri="11200" /></dgm:catLst>
+                  <dgm:styleLbl name="node0"><dgm:fillClrLst meth="repeat"><a:schemeClr val="accent1" /></dgm:fillClrLst><dgm:linClrLst meth="repeat"><a:schemeClr val="lt1" /></dgm:linClrLst><dgm:effectClrLst /><dgm:txLinClrLst /><dgm:txFillClrLst /><dgm:txEffectClrLst /></dgm:styleLbl>
+                  <dgm:styleLbl name="lnNode1"><dgm:fillClrLst meth="repeat"><a:schemeClr val="accent1" /></dgm:fillClrLst><dgm:linClrLst meth="repeat"><a:schemeClr val="lt1" /></dgm:linClrLst><dgm:effectClrLst /><dgm:txLinClrLst /><dgm:txFillClrLst /><dgm:txEffectClrLst /></dgm:styleLbl>
+                  <dgm:styleLbl name="alignNode1"><dgm:fillClrLst meth="repeat"><a:schemeClr val="accent1" /></dgm:fillClrLst><dgm:linClrLst meth="repeat"><a:schemeClr val="accent1" /></dgm:linClrLst><dgm:effectClrLst /><dgm:txLinClrLst /><dgm:txFillClrLst /><dgm:txEffectClrLst /></dgm:styleLbl>
+                </dgm:colorsDef>
+                """;
+            using MemoryStream stream = new(Encoding.UTF8.GetBytes(xml));
+            part.FeedData(stream);
+        }
+
+        private static void PopulateSmartArtStyle(DiagramStylePart part) {
+            string xml = """
+                <dgm:styleDef uniqueId="urn:microsoft.com/office/officeart/2005/8/quickstyle/simple1" xmlns:dgm="http://schemas.openxmlformats.org/drawingml/2006/diagram" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                  <dgm:title val="" />
+                  <dgm:desc val="" />
+                  <dgm:catLst><dgm:cat type="simple" pri="10100" /></dgm:catLst>
+                  <dgm:styleLbl name="node">
+                    <dgm:style>
+                      <a:lnRef idx="2"><a:schemeClr val="accent1" /></a:lnRef>
+                      <a:fillRef idx="1"><a:schemeClr val="accent1" /></a:fillRef>
+                      <a:effectRef idx="0"><a:schemeClr val="accent1" /></a:effectRef>
+                      <a:fontRef idx="minor"><a:schemeClr val="lt1" /></a:fontRef>
+                    </dgm:style>
+                  </dgm:styleLbl>
+                </dgm:styleDef>
+                """;
+            using MemoryStream stream = new(Encoding.UTF8.GetBytes(xml));
+            part.FeedData(stream);
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Tables.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Tables.cs
@@ -90,7 +90,7 @@ namespace OfficeIMO.PowerPoint {
             PowerPointTable tbl = new(frame, _slidePart);
             tbl.SetColumnWidthsEvenly();
             tbl.SetRowHeightsEvenly();
-            _shapes.Add(tbl);
+            TrackShape(tbl);
             return tbl;
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointSlide.Text.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.Text.cs
@@ -34,8 +34,7 @@ namespace OfficeIMO.PowerPoint {
             CommonSlideData data = SlideRoot.CommonSlideData ??= new CommonSlideData(new ShapeTree());
             ShapeTree tree = data.ShapeTree ??= new ShapeTree();
             tree.AppendChild(shape);
-            PowerPointTextBox textBox = new(shape, _slidePart);
-            _shapes.Add(textBox);
+            PowerPointTextBox textBox = TrackShape(new PowerPointTextBox(shape, _slidePart));
             return textBox;
         }
 
@@ -111,8 +110,7 @@ namespace OfficeIMO.PowerPoint {
             CommonSlideData data = SlideRoot.CommonSlideData ??= new CommonSlideData(new ShapeTree());
             ShapeTree tree = data.ShapeTree ??= new ShapeTree();
             tree.AppendChild(shape);
-            PowerPointTextBox textBox = new(shape, _slidePart);
-            _shapes.Add(textBox);
+            PowerPointTextBox textBox = TrackShape(new PowerPointTextBox(shape, _slidePart));
             return textBox;
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointSlide.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.cs
@@ -45,6 +45,11 @@ namespace OfficeIMO.PowerPoint {
         public IEnumerable<PowerPointPicture> Pictures => _shapes.OfType<PowerPointPicture>();
 
         /// <summary>
+        ///     Enumerates all embedded audio and video media shapes on the slide.
+        /// </summary>
+        public IEnumerable<PowerPointMedia> Media => _shapes.OfType<PowerPointMedia>();
+
+        /// <summary>
         ///     Enumerates all table shapes on the slide.
         /// </summary>
         public IEnumerable<PowerPointTable> Tables => _shapes.OfType<PowerPointTable>();
@@ -53,6 +58,11 @@ namespace OfficeIMO.PowerPoint {
         ///     Enumerates all charts on the slide.
         /// </summary>
         public IEnumerable<PowerPointChart> Charts => _shapes.OfType<PowerPointChart>();
+
+        /// <summary>
+        ///     Enumerates all SmartArt diagrams on the slide.
+        /// </summary>
+        public IEnumerable<PowerPointSmartArt> SmartArts => _shapes.OfType<PowerPointSmartArt>();
 
         /// <summary>
         ///     Retrieves shapes that are within or intersect the provided bounds.
@@ -977,6 +987,55 @@ namespace OfficeIMO.PowerPoint {
         }
 
         /// <summary>
+        ///     Retrieves a shape by name, optionally using case-insensitive comparison.
+        /// </summary>
+        public PowerPointShape? GetShapeByName(string name, bool ignoreCase = false) {
+            if (name == null) {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            StringComparison comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            return _shapes.FirstOrDefault(shape => string.Equals(shape.Name, name, comparison));
+        }
+
+        /// <summary>
+        ///     Attempts to retrieve a shape by name.
+        /// </summary>
+        public bool TryGetShapeByName(string name, out PowerPointShape? shape, bool ignoreCase = false) {
+            shape = GetShapeByName(name, ignoreCase);
+            return shape != null;
+        }
+
+        /// <summary>
+        ///     Retrieves a typed shape by name, optionally using case-insensitive comparison.
+        /// </summary>
+        public T? GetShapeByName<T>(string name, bool ignoreCase = false) where T : PowerPointShape {
+            return GetShapeByName(name, ignoreCase) as T;
+        }
+
+        /// <summary>
+        ///     Attempts to retrieve a typed shape by name.
+        /// </summary>
+        public bool TryGetShapeByName<T>(string name, out T? shape, bool ignoreCase = false) where T : PowerPointShape {
+            shape = GetShapeByName<T>(name, ignoreCase);
+            return shape != null;
+        }
+
+        /// <summary>
+        ///     Retrieves a shape by its non-visual drawing identifier.
+        /// </summary>
+        public PowerPointShape? GetShapeById(uint id) {
+            return _shapes.FirstOrDefault(shape => shape.Id == id);
+        }
+
+        /// <summary>
+        ///     Retrieves a typed shape by its non-visual drawing identifier.
+        /// </summary>
+        public T? GetShapeById<T>(uint id) where T : PowerPointShape {
+            return GetShapeById(id) as T;
+        }
+
+        /// <summary>
         ///     Retrieves a textbox by its name.
         /// </summary>
         public PowerPointTextBox? GetTextBox(string name) {
@@ -1144,8 +1203,25 @@ namespace OfficeIMO.PowerPoint {
                 throw new ArgumentNullException(nameof(shape));
             }
 
+            EnsureShapeOnSlide(shape);
             shape.Element.Remove();
             _shapes.Remove(shape);
+        }
+
+        private T TrackShape<T>(T shape) where T : PowerPointShape {
+            shape.AttachTo(this);
+            _shapes.Add(shape);
+            return shape;
+        }
+
+        private void InsertTrackedShape(int index, PowerPointShape shape) {
+            shape.AttachTo(this);
+            _shapes.Insert(index, shape);
+        }
+
+        private void InsertRangeTrackedShapes(int index, IEnumerable<PowerPointShape> shapes) {
+            PowerPointShape[] tracked = shapes.Select(shape => shape.AttachTo(this)).ToArray();
+            _shapes.InsertRange(index, tracked);
         }
 
         private string GenerateUniqueName(string baseName) {
@@ -1250,7 +1326,7 @@ namespace OfficeIMO.PowerPoint {
 
                 PowerPointShape? shape = CreateShapeFromElement(element);
                 if (shape != null) {
-                    _shapes.Add(shape);
+                    TrackShape(shape);
                 }
             }
 

--- a/OfficeIMO.PowerPoint/PowerPointSmartArt.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSmartArt.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using Dgm = DocumentFormat.OpenXml.Drawing.Diagrams;
+
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Represents a SmartArt diagram on a PowerPoint slide.
+    /// </summary>
+    public class PowerPointSmartArt : PowerPointShape {
+        private readonly SlidePart _slidePart;
+
+        internal PowerPointSmartArt(GraphicFrame graphicFrame, SlidePart slidePart) : base(graphicFrame) {
+            _slidePart = slidePart;
+        }
+
+        private GraphicFrame GraphicFrame => (GraphicFrame)Element;
+
+        /// <summary>
+        ///     Gets the number of editable SmartArt nodes.
+        /// </summary>
+        public int NodeCount => LoadNodeParagraphsWithPart().paras.Count;
+
+        /// <summary>
+        ///     Gets the text of an editable SmartArt node.
+        /// </summary>
+        public string GetNodeText(int index) {
+            var (_, _, paras, _) = LoadNodeParagraphsWithPart();
+            if (index < 0 || index >= paras.Count) {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            XNamespace a = "http://schemas.openxmlformats.org/drawingml/2006/main";
+            return string.Concat(paras[index].Descendants(a + "t").Select(t => (string?)t ?? string.Empty));
+        }
+
+        /// <summary>
+        ///     Replaces the text of an editable SmartArt node.
+        /// </summary>
+        public void SetNodeText(int index, string text) {
+            var (xdoc, ns, paras, dataPart) = LoadNodeParagraphsWithPart();
+            if (index < 0 || index >= paras.Count) {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            XElement paragraph = paras[index];
+            paragraph.RemoveNodes();
+            paragraph.Add(new XElement(ns.a + "r",
+                new XElement(ns.a + "t", text ?? string.Empty)));
+            paragraph.Add(new XElement(ns.a + "endParaRPr", new XAttribute("lang", "en-US")));
+            SaveDiagramData(dataPart, xdoc);
+        }
+
+        private (XDocument xdoc, (XNamespace dgm, XNamespace a) ns, List<XElement> paras, DiagramDataPart dataPart)
+            LoadNodeParagraphsWithPart() {
+            DiagramDataPart dataPart = GetDiagramDataPart();
+            XDocument xdoc = LoadDiagramXDocument(dataPart);
+            XNamespace dgm = "http://schemas.openxmlformats.org/drawingml/2006/diagram";
+            XNamespace a = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
+            List<XElement> paras = xdoc
+                .Descendants(dgm + "pt")
+                .Where(point => point.Attribute("type") == null)
+                .Select(point => (point.Element(dgm + "t") ?? point.Element(dgm + "txBody"))?.Element(a + "p"))
+                .Where(paragraph => paragraph != null)
+                .Cast<XElement>()
+                .ToList();
+
+            return (xdoc, (dgm, a), paras, dataPart);
+        }
+
+        private DiagramDataPart GetDiagramDataPart() {
+            Dgm.RelationshipIds relationshipIds = GraphicFrame.Graphic?.GraphicData?.GetFirstChild<Dgm.RelationshipIds>()
+                ?? throw new InvalidOperationException("SmartArt relationship ids were not found.");
+            string? dataPartId = relationshipIds.DataPart?.Value;
+            if (string.IsNullOrWhiteSpace(dataPartId)) {
+                throw new InvalidOperationException("SmartArt data relationship was not found.");
+            }
+
+            return _slidePart.GetPartById(dataPartId!) as DiagramDataPart
+                ?? throw new InvalidOperationException("SmartArt diagram data part was not found.");
+        }
+
+        private static XDocument LoadDiagramXDocument(DiagramDataPart dataPart) {
+            using Stream stream = dataPart.GetStream(FileMode.Open, FileAccess.Read);
+            return XDocument.Load(stream);
+        }
+
+        private static void SaveDiagramData(DiagramDataPart dataPart, XDocument xdoc) {
+            using Stream stream = dataPart.GetStream(FileMode.Create, FileAccess.Write);
+            xdoc.Save(stream);
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointSmartArtType.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSmartArtType.cs
@@ -1,0 +1,11 @@
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     SmartArt layouts supported by OfficeIMO.PowerPoint.
+    /// </summary>
+    public enum PowerPointSmartArtType {
+        /// <summary>
+        ///     A basic process/list SmartArt diagram.
+        /// </summary>
+        BasicProcess
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointTextBox.Markdown.cs
+++ b/OfficeIMO.PowerPoint/PowerPointTextBox.Markdown.cs
@@ -1,0 +1,305 @@
+using System;
+using System.Collections.Generic;
+using DocumentFormat.OpenXml.Presentation;
+using A = DocumentFormat.OpenXml.Drawing;
+
+namespace OfficeIMO.PowerPoint {
+    public partial class PowerPointTextBox {
+        /// <summary>
+        ///     Replaces the textbox content with rich text parsed from a small Markdown subset.
+        /// </summary>
+        public IReadOnlyList<PowerPointParagraph> SetMarkdown(string markdown) {
+            if (markdown == null) {
+                throw new ArgumentNullException(nameof(markdown));
+            }
+
+            TextBody textBody = EnsureTextBody();
+            A.Paragraph? templateParagraph = textBody.Elements<A.Paragraph>().FirstOrDefault();
+            textBody.RemoveAllChildren<A.Paragraph>();
+            return AppendMarkdown(markdown, templateParagraph);
+        }
+
+        /// <summary>
+        ///     Appends rich text parsed from a small Markdown subset to the textbox.
+        /// </summary>
+        public IReadOnlyList<PowerPointParagraph> AddMarkdown(string markdown) {
+            if (markdown == null) {
+                throw new ArgumentNullException(nameof(markdown));
+            }
+
+            TextBody textBody = EnsureTextBody();
+            A.Paragraph? templateParagraph = textBody.Elements<A.Paragraph>().FirstOrDefault();
+            return AppendMarkdown(markdown, templateParagraph);
+        }
+
+        private IReadOnlyList<PowerPointParagraph> AppendMarkdown(string markdown, A.Paragraph? templateParagraph) {
+            TextBody textBody = EnsureTextBody();
+            string[] lines = markdown.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+            var results = new List<PowerPointParagraph>();
+
+            foreach (string rawLine in lines) {
+                string line = rawLine.TrimEnd();
+                if (line.Length == 0) {
+                    continue;
+                }
+
+                MarkdownParagraphKind kind = GetMarkdownParagraphKind(line, out string text, out int headingLevel,
+                    out int listStart);
+                PowerPointParagraph paragraph = AppendParagraph(textBody, string.Empty, templateParagraph);
+                ApplyMarkdownInline(paragraph, ParseMarkdownInline(text));
+                ApplyMarkdownParagraphKind(paragraph, kind, headingLevel, listStart);
+                results.Add(paragraph);
+            }
+
+            if (results.Count == 0 && textBody.Elements<A.Paragraph>().FirstOrDefault() == null) {
+                textBody.Append(CreateEmptyParagraph(templateParagraph));
+            }
+
+            return results;
+        }
+
+        private static MarkdownParagraphKind GetMarkdownParagraphKind(string line, out string text, out int headingLevel,
+            out int listStart) {
+            text = line;
+            headingLevel = 0;
+            listStart = 1;
+
+            int hashCount = CountLeading(line, '#');
+            if (hashCount is >= 1 and <= 6 && line.Length > hashCount && line[hashCount] == ' ') {
+                text = line.Substring(hashCount + 1).TrimStart();
+                headingLevel = hashCount;
+                return MarkdownParagraphKind.Heading;
+            }
+
+            string trimmed = line.TrimStart();
+            if (trimmed.Length > 2 && (trimmed[0] == '-' || trimmed[0] == '*' || trimmed[0] == '+') &&
+                trimmed[1] == ' ') {
+                text = trimmed.Substring(2).TrimStart();
+                return MarkdownParagraphKind.Bullet;
+            }
+
+            int dotIndex = trimmed.IndexOf('.');
+            if (dotIndex > 0 && dotIndex < 8 &&
+                dotIndex + 1 < trimmed.Length &&
+                trimmed[dotIndex + 1] == ' ' &&
+                int.TryParse(trimmed.Substring(0, dotIndex), out int parsedStart)) {
+                text = trimmed.Substring(dotIndex + 2).TrimStart();
+                listStart = parsedStart;
+                return MarkdownParagraphKind.Numbered;
+            }
+
+            return MarkdownParagraphKind.Normal;
+        }
+
+        private static int CountLeading(string value, char character) {
+            int count = 0;
+            while (count < value.Length && value[count] == character) {
+                count++;
+            }
+
+            return count;
+        }
+
+        private static void ApplyMarkdownParagraphKind(PowerPointParagraph paragraph, MarkdownParagraphKind kind,
+            int headingLevel, int listStart) {
+            if (kind == MarkdownParagraphKind.Bullet) {
+                paragraph.SetBullet();
+                return;
+            }
+
+            if (kind == MarkdownParagraphKind.Numbered) {
+                paragraph.SetNumbered(listStart);
+                return;
+            }
+
+            if (kind == MarkdownParagraphKind.Heading) {
+                int fontSize = headingLevel switch {
+                    1 => 28,
+                    2 => 24,
+                    3 => 20,
+                    _ => 18
+                };
+
+                foreach (PowerPointTextRun run in paragraph.Runs) {
+                    run.Bold = true;
+                    run.FontSize = fontSize;
+                }
+            }
+        }
+
+        private static void ApplyMarkdownInline(PowerPointParagraph paragraph, IReadOnlyList<MarkdownInlineRun> runs) {
+            if (runs.Count == 0) {
+                paragraph.Text = string.Empty;
+                return;
+            }
+
+            bool first = true;
+            foreach (MarkdownInlineRun inlineRun in runs) {
+                PowerPointTextRun run;
+                if (first) {
+                    paragraph.Text = inlineRun.Text;
+                    run = paragraph.Runs[0];
+                    first = false;
+                } else {
+                    run = paragraph.AddRun(inlineRun.Text);
+                }
+
+                ApplyMarkdownInlineStyle(run, inlineRun);
+            }
+        }
+
+        private static void ApplyMarkdownInlineStyle(PowerPointTextRun run, MarkdownInlineRun inlineRun) {
+            if (inlineRun.Bold) {
+                run.Bold = true;
+            }
+
+            if (inlineRun.Italic) {
+                run.Italic = true;
+            }
+
+            if (inlineRun.Code) {
+                run.FontName = "Consolas";
+                run.HighlightColor = "F2F2F2";
+            }
+
+            if (!string.IsNullOrWhiteSpace(inlineRun.Link)) {
+                run.SetHyperlink(inlineRun.Link!);
+                run.Underline = true;
+                run.Color = "0563C1";
+            }
+        }
+
+        private static IReadOnlyList<MarkdownInlineRun> ParseMarkdownInline(string text) {
+            var runs = new List<MarkdownInlineRun>();
+            int index = 0;
+            while (index < text.Length) {
+                if (TryParseDelimited(text, index, "**", out MarkdownInlineRun boldRun, bold: true)) {
+                    runs.Add(boldRun);
+                    index += boldRun.SourceLength;
+                    continue;
+                }
+
+                if (TryParseDelimited(text, index, "__", out MarkdownInlineRun underscoreBoldRun, bold: true)) {
+                    runs.Add(underscoreBoldRun);
+                    index += underscoreBoldRun.SourceLength;
+                    continue;
+                }
+
+                if (TryParseDelimited(text, index, "`", out MarkdownInlineRun codeRun, code: true)) {
+                    runs.Add(codeRun);
+                    index += codeRun.SourceLength;
+                    continue;
+                }
+
+                if (TryParseLink(text, index, out MarkdownInlineRun linkRun)) {
+                    runs.Add(linkRun);
+                    index += linkRun.SourceLength;
+                    continue;
+                }
+
+                if (TryParseDelimited(text, index, "*", out MarkdownInlineRun italicRun, italic: true)) {
+                    runs.Add(italicRun);
+                    index += italicRun.SourceLength;
+                    continue;
+                }
+
+                if (TryParseDelimited(text, index, "_", out MarkdownInlineRun underscoreItalicRun, italic: true)) {
+                    runs.Add(underscoreItalicRun);
+                    index += underscoreItalicRun.SourceLength;
+                    continue;
+                }
+
+                int next = FindNextMarkdownMarker(text, index + 1);
+                string plain = text.Substring(index, next - index);
+                runs.Add(new MarkdownInlineRun(plain, next - index));
+                index = next;
+            }
+
+            return runs;
+        }
+
+        private static bool TryParseDelimited(string text, int index, string delimiter, out MarkdownInlineRun run,
+            bool bold = false, bool italic = false, bool code = false) {
+            run = default;
+            if (!text.Substring(index).StartsWith(delimiter, StringComparison.Ordinal)) {
+                return false;
+            }
+
+            int contentStart = index + delimiter.Length;
+            int end = text.IndexOf(delimiter, contentStart, StringComparison.Ordinal);
+            if (end <= contentStart) {
+                return false;
+            }
+
+            string content = text.Substring(contentStart, end - contentStart);
+            run = new MarkdownInlineRun(content, end + delimiter.Length - index, bold, italic, code);
+            return true;
+        }
+
+        private static bool TryParseLink(string text, int index, out MarkdownInlineRun run) {
+            run = default;
+            if (text[index] != '[') {
+                return false;
+            }
+
+            int labelEnd = text.IndexOf("](", index, StringComparison.Ordinal);
+            if (labelEnd < 0) {
+                return false;
+            }
+
+            int urlStart = labelEnd + 2;
+            int urlEnd = text.IndexOf(')', urlStart);
+            if (urlEnd <= urlStart) {
+                return false;
+            }
+
+            string label = text.Substring(index + 1, labelEnd - index - 1);
+            string url = text.Substring(urlStart, urlEnd - urlStart);
+            run = new MarkdownInlineRun(label, urlEnd + 1 - index, link: url);
+            return true;
+        }
+
+        private static int FindNextMarkdownMarker(string text, int start) {
+            int next = text.Length;
+            foreach (char marker in new[] { '*', '_', '`', '[' }) {
+                int markerIndex = text.IndexOf(marker, start);
+                if (markerIndex >= 0 && markerIndex < next) {
+                    next = markerIndex;
+                }
+            }
+
+            return next;
+        }
+
+        private enum MarkdownParagraphKind {
+            Normal,
+            Heading,
+            Bullet,
+            Numbered
+        }
+
+        private readonly struct MarkdownInlineRun {
+            public MarkdownInlineRun(string text, int sourceLength, bool bold = false, bool italic = false,
+                bool code = false, string? link = null) {
+                Text = text;
+                SourceLength = sourceLength;
+                Bold = bold;
+                Italic = italic;
+                Code = code;
+                Link = link;
+            }
+
+            public string Text { get; }
+
+            public int SourceLength { get; }
+
+            public bool Bold { get; }
+
+            public bool Italic { get; }
+
+            public bool Code { get; }
+
+            public string? Link { get; }
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointTextBox.cs
+++ b/OfficeIMO.PowerPoint/PowerPointTextBox.cs
@@ -9,7 +9,7 @@ namespace OfficeIMO.PowerPoint {
     /// <summary>
     ///     Represents a textbox shape.
     /// </summary>
-    public class PowerPointTextBox : PowerPointShape {
+    public partial class PowerPointTextBox : PowerPointShape {
         private readonly SlidePart? _slidePart;
 
         internal PowerPointTextBox(Shape shape, SlidePart? slidePart = null) : base(shape) {

--- a/OfficeIMO.PowerPoint/README.md
+++ b/OfficeIMO.PowerPoint/README.md
@@ -376,6 +376,16 @@ box.ApplyTextStyle(PowerPointTextStyle.Body.WithColor("1F4E79"));
 box.ApplyAutoSpacing(lineSpacingMultiplier: 1.15, spaceAfterPoints: 2);
 ```
 
+### Markdown rich text
+```csharp
+var box = slide.AddTextBox(string.Empty);
+box.SetMarkdown("""
+    # Launch plan
+    - **Owner:** Platform
+    - Track `net472` and [docs](https://example.com)
+    """);
+```
+
 ### Text box layout (margins + autofit)
 ```csharp
 using A = DocumentFormat.OpenXml.Drawing;
@@ -395,6 +405,29 @@ slide.AddPicture("logo.png",
 using var logoStream = File.OpenRead("logo.png");
 slide.AddPicture(logoStream, ImagePartType.Png,
     PowerPointUnits.Cm(23), PowerPointUnits.Cm(1.2), PowerPointUnits.Cm(5), PowerPointUnits.Cm(2));
+
+slide.AddPicture("diagram.svg",
+    PowerPointUnits.Cm(2), PowerPointUnits.Cm(2), PowerPointUnits.Cm(8), PowerPointUnits.Cm(4));
+```
+
+### Embedded audio and video
+```csharp
+var video = slide.AddVideo("demo.mp4", posterImagePath: "poster.png",
+    left: PowerPointUnits.Cm(2), top: PowerPointUnits.Cm(3),
+    width: PowerPointUnits.Cm(12), height: PowerPointUnits.Cm(6.75));
+
+var audio = slide.AddAudio("voiceover.mp3",
+    left: PowerPointUnits.Cm(2), top: PowerPointUnits.Cm(11));
+
+var mediaFrames = slide.Media;
+```
+
+### SmartArt
+```csharp
+var smartArt = slide.AddSmartArt(PowerPointSmartArtType.BasicProcess,
+    left: PowerPointUnits.Cm(2), top: PowerPointUnits.Cm(3),
+    width: PowerPointUnits.Cm(12), height: PowerPointUnits.Cm(7));
+smartArt.SetNodeText(0, "OfficeIMO-native process");
 ```
 
 ### Create and edit with streams
@@ -596,6 +629,22 @@ slide.SendToBack(shape);
 var copy = slide.DuplicateShapeCm(shape, 0.5, 0.5);
 ```
 
+### Shape lookup + metadata
+```csharp
+var title = slide.AddTextBox("Quarterly update");
+title.Name = "Hero Title";
+title.AltText = "Main slide title";
+
+var found = slide.GetShapeByName<PowerPointTextBox>("Hero Title");
+var sameShape = slide.GetShapeById(found!.Id!.Value);
+
+var copy = found.DuplicateCm(0.4, 0.4);
+copy.Name = "Hero Title Copy";
+
+found.Hidden = true;
+copy.Remove();
+```
+
 ### Slide properties
 ```csharp
 ppt.BuiltinDocumentProperties.Title = "Contoso Review";
@@ -607,6 +656,22 @@ ppt.ApplicationProperties.Company = "Contoso";
 var duplicate = ppt.DuplicateSlide(0);
 duplicate.Hidden = true;
 ```
+
+### Single-slide export and optional previews
+```csharp
+ppt.ExportSlide(0, "slide-preview-source.pptx");
+
+if (PowerPointPreviewExporter.TryExportSlides(
+        "slide-preview-source.pptx",
+        "preview",
+        out var preview,
+        PowerPointPreviewExportFormat.Png)) {
+    var pngFiles = preview.Files;
+}
+```
+
+Preview export is optional and host-dependent. OfficeIMO creates the `.pptx` with Open XML; `PowerPointPreviewExporter`
+uses installed Microsoft PowerPoint automation only when the caller explicitly asks for rendered PNG/JPEG slide previews.
 
 ### Slide layouts + theme helpers
 ```csharp
@@ -868,6 +933,13 @@ if (titleBounds != null) {
     var aligned = slide.AddTextBox("Aligned to layout");
     titleBounds.Value.ApplyTo(aligned);
 }
+
+int textLayout = ppt.GetLayoutIndex(SlideLayoutValues.Text);
+ppt.EnsureLayoutHeaderFooterPlaceholders(
+    layoutIndex: textLayout,
+    footerText: "Confidential",
+    dateTimeText: "2026-05-16",
+    slideNumberText: "#");
 ```
 
 ### Replace text
@@ -889,25 +961,30 @@ var sections = ppt.GetSections();
 - Slides: add, import, duplicate, reorder, hide, edit, and section slides
 - Sections: add, rename, and list sections
 - Shapes: basic rectangles/ellipses/lines with fill/stroke, line styles, shadows/glow/soft edges/blur/reflection; align/distribute; z-order + duplicate
-- Images: add images from file/stream (PNG/JPEG/GIF/BMP/TIFF/EMF/WMF/ICO/PCX)   
+- Images: add images from file/stream (PNG/JPEG/GIF/BMP/TIFF/SVG/EMF/WMF/ICO/PCX)
+- Media: embed audio/video with playback relationships and generated or supplied poster frames
+- SmartArt: add native Basic Process SmartArt and edit node text
 - Properties: set built‑in and application properties
 - Themes & transitions: default theme/table styles + slide transitions
 - Guides & grid: snap, spacing, and guide helpers
-- Text boxes: margins, auto-fit, vertical alignment
+- Text boxes: markdown rich text, margins, auto-fit, vertical alignment
 - Tables: styling + merged cells + sizing helpers
 - Placeholders: read/update layout placeholders
 - Backgrounds: set background images
 - Text replacement: find/replace across slides
 - Charts: add + format titles/legend/labels/series/markers
+- Export: save a slide as a standalone .pptx and optionally render previews through installed PowerPoint automation
 
 ## Feature Matrix (scope today)
 
 - 📽️ Slides
-  - ✅ Add slides; ✅ import/duplicate/reorder; ✅ hide/show; ✅ sections; ✅ set title; ✅ add text boxes; ✅ basic bullets
+  - ✅ Add slides; ✅ import/duplicate/reorder; ✅ hide/show; ✅ sections; ✅ set title; ✅ add text boxes; ✅ markdown/bullets
 - 🖼️ Media & Shapes
-  - ✅ Insert images; ✅ basic shapes (rect/ellipse/line) with fill/stroke + line styles + shadows/glow/soft edges/blur/reflection; ✅ align/distribute/arrange
+  - ✅ Insert images including SVG; ✅ embed audio/video; ✅ basic shapes (rect/ellipse/line) with fill/stroke + effects; ✅ align/distribute/arrange
 - 🗒️ Notes & Layout
-  - ✅ Speaker notes; ✅ guides/grid helpers; ⚠️ basic layout selection
+  - ✅ Speaker notes; ✅ guides/grid helpers; ✅ native footer/date/slide-number layout placeholders; ⚠️ basic layout selection
+- 🧩 SmartArt
+  - ✅ Native Basic Process diagram parts; ✅ editable node text
 - 📋 Tables
   - ⚠️ Basic styling + merged cells
 - 📊 Charts
@@ -919,8 +996,8 @@ var sections = ppt.GetSections();
 
 ## Why OfficeIMO.PowerPoint (today)
 
-- Cross‑platform, pure Open XML — no Office automation
-- Simple API surface to add slides, titles, text, bullets, and images without repair prompts
+- Cross‑platform Open XML authoring; optional PowerPoint automation is isolated to preview export
+- Simple API surface to add slides, titles, text, bullets, images, media, and SmartArt without repair prompts
 - Fluent helpers available for quick demos and templated decks
 
 ## Measurements

--- a/OfficeIMO.Tests/PowerPoint.Export.cs
+++ b/OfficeIMO.Tests/PowerPoint.Export.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Linq;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointExportTests {
+        [Fact]
+        public void CanExportSingleSlideAsStandalonePresentation() {
+            string filePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string exportedPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide first = presentation.AddSlide();
+                    first.AddTitle("Keep me");
+                    PowerPointSlide second = presentation.AddSlide();
+                    second.AddTitle("Export me");
+                    second.AddSmartArt().SetNodeText(0, "Preview boundary");
+                    presentation.Save();
+
+                    presentation.ExportSlide(1, exportedPath);
+                }
+
+                using PowerPointPresentation exported = PowerPointPresentation.Open(exportedPath);
+                Assert.Single(exported.Slides);
+                Assert.Contains(exported.Slides[0].TextBoxes, box => box.Text == "Export me");
+                PowerPointSmartArt smartArt = Assert.Single(exported.Slides[0].SmartArts);
+                Assert.Equal("Preview boundary", smartArt.GetNodeText(0));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+                if (File.Exists(exportedPath)) {
+                    File.Delete(exportedPath);
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/PowerPoint.LayoutPlaceholders.cs
+++ b/OfficeIMO.Tests/PowerPoint.LayoutPlaceholders.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
 using OfficeIMO.PowerPoint;
 using Xunit;
@@ -24,6 +26,62 @@ namespace OfficeIMO.Tests {
                 PowerPointLayoutBox? bodyBounds = slide.GetLayoutPlaceholderBounds(PlaceholderValues.Body);
                 Assert.NotNull(bodyBounds);
                 Assert.True(bodyBounds!.Value.Height > 0);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanCreateNativeLayoutHeaderFooterPlaceholders() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    int layoutIndex = presentation.GetLayoutIndex(SlideLayoutValues.Text);
+                    PowerPointSlide slide = presentation.AddSlide(SlideLayoutValues.Text);
+
+                    var placeholders = presentation.EnsureLayoutHeaderFooterPlaceholders(
+                        layoutIndex: layoutIndex,
+                        footerText: "Confidential",
+                        dateTimeText: "2026-05-16",
+                        slideNumberText: "#");
+
+                    Assert.Equal(3, placeholders.Count);
+                    Assert.NotNull(slide.GetLayoutPlaceholder(PlaceholderValues.Footer, 10U));
+                    Assert.NotNull(slide.GetLayoutPlaceholder(PlaceholderValues.DateAndTime, 11U));
+                    Assert.NotNull(slide.GetLayoutPlaceholder(PlaceholderValues.SlideNumber, 12U));
+                    Assert.Equal("Confidential", placeholders[0].Text);
+
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    SlidePart slidePart = document.PresentationPart!.SlideParts.First();
+                    SlideLayoutPart layoutPart = slidePart.SlideLayoutPart!;
+                    HeaderFooter headerFooter = Assert.Single(layoutPart.SlideLayout!.Elements<HeaderFooter>());
+
+                    Assert.True(headerFooter.Footer!.Value);
+                    Assert.True(headerFooter.DateTime!.Value);
+                    Assert.True(headerFooter.SlideNumber!.Value);
+
+                    var placeholderTypes = layoutPart.SlideLayout.CommonSlideData!.ShapeTree!
+                        .Descendants<PlaceholderShape>()
+                        .Select(placeholder => placeholder.Type?.Value)
+                        .ToArray();
+
+                    Assert.Contains(PlaceholderValues.Footer, placeholderTypes);
+                    Assert.Contains(PlaceholderValues.DateAndTime, placeholderTypes);
+                    Assert.Contains(PlaceholderValues.SlideNumber, placeholderTypes);
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                    PowerPointSlide slide = presentation.Slides[0];
+
+                    Assert.NotNull(slide.GetLayoutPlaceholder(PlaceholderValues.Footer, 10U));
+                    Assert.NotNull(slide.GetLayoutPlaceholder(PlaceholderValues.DateAndTime, 11U));
+                    Assert.NotNull(slide.GetLayoutPlaceholder(PlaceholderValues.SlideNumber, 12U));
+                }
             } finally {
                 if (File.Exists(filePath)) {
                     File.Delete(filePath);

--- a/OfficeIMO.Tests/PowerPoint.Markdown.cs
+++ b/OfficeIMO.Tests/PowerPoint.Markdown.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Drawing;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointMarkdownTests {
+        [Fact]
+        public void CanApplyMarkdownToTextBoxRichTextRuns() {
+            string filePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using PowerPointPresentation presentation = PowerPointPresentation.Create(filePath);
+                PowerPointSlide slide = presentation.AddSlide();
+                PowerPointTextBox textBox = slide.AddTextBox(string.Empty);
+
+                var paragraphs = textBox.SetMarkdown("""
+                    # Heading
+                    - **Bold** and *italic* with `code`
+                    3. Visit [OfficeIMO](https://example.com)
+                    """);
+
+                Assert.Equal(3, paragraphs.Count);
+                Assert.True(paragraphs[0].Runs[0].Bold);
+                Assert.Equal(28, paragraphs[0].Runs[0].FontSize);
+                Assert.NotNull(paragraphs[1].Paragraph.ParagraphProperties?.GetFirstChild<CharacterBullet>());
+                Assert.True(paragraphs[1].Runs[0].Bold);
+                Assert.True(paragraphs[1].Runs[2].Italic);
+                Assert.Equal("Consolas", paragraphs[1].Runs[4].FontName);
+                Assert.NotNull(paragraphs[2].Paragraph.ParagraphProperties?.GetFirstChild<AutoNumberedBullet>());
+                Assert.Equal(new Uri("https://example.com"), paragraphs[2].Runs.Last().Hyperlink);
+
+                presentation.Save();
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/PowerPoint.Media.cs
+++ b/OfficeIMO.Tests/PowerPoint.Media.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using OfficeIMO.PowerPoint;
+using Xunit;
+using A = DocumentFormat.OpenXml.Drawing;
+using P14 = DocumentFormat.OpenXml.Office2010.PowerPoint;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointMediaTests {
+        [Fact]
+        public void CanAddEmbeddedVideoAndReloadAsMediaShape() {
+            string filePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    using MemoryStream videoStream = new(new byte[] { 0, 0, 0, 24, 102, 116, 121, 112, 109, 112, 52, 50 });
+
+                    PowerPointMedia media = slide.AddVideo(videoStream, "video/mp4", ".mp4");
+
+                    Assert.Equal(PowerPointMediaKind.Video, media.Kind);
+                    Assert.Equal(PowerPointShapeContentType.Media, media.ShapeContentType);
+                    Assert.Equal("video/mp4", media.MediaContentType);
+                    Assert.NotNull(media.MediaReferenceId);
+                    Assert.NotNull(media.PlaybackReferenceId);
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    SlidePart slidePart = document.PresentationPart!.SlideParts.Single();
+                    Assert.Single(slidePart.DataPartReferenceRelationships.OfType<VideoReferenceRelationship>());
+                    Assert.Single(slidePart.DataPartReferenceRelationships.OfType<MediaReferenceRelationship>());
+
+                    Picture picture = slidePart.Slide.Descendants<Picture>().Single();
+                    ApplicationNonVisualDrawingProperties appProperties =
+                        picture.NonVisualPictureProperties!.ApplicationNonVisualDrawingProperties!;
+                    Assert.NotNull(appProperties.GetFirstChild<A.VideoFromFile>());
+                    Assert.NotNull(appProperties.Descendants<P14.Media>().SingleOrDefault());
+                    Assert.NotNull(slidePart.Slide.Timing?.Descendants<Video>().SingleOrDefault());
+                }
+
+                using (PowerPointPresentation reloaded = PowerPointPresentation.Open(filePath)) {
+                    PowerPointMedia media = Assert.IsType<PowerPointMedia>(reloaded.Slides[0].Shapes.Single());
+                    Assert.Equal(PowerPointMediaKind.Video, media.Kind);
+                    Assert.Equal("video/mp4", media.MediaContentType);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanAddEmbeddedAudioAndReloadAsMediaShape() {
+            string filePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    using MemoryStream audioStream = new(new byte[] { 73, 68, 51, 4, 0, 0, 0, 0, 0, 0 });
+
+                    PowerPointMedia media = slide.AddAudio(audioStream, "audio/mpeg", ".mp3");
+
+                    Assert.Equal(PowerPointMediaKind.Audio, media.Kind);
+                    Assert.Equal(PowerPointShapeContentType.Media, media.ShapeContentType);
+                    Assert.Equal("audio/mpeg", media.MediaContentType);
+                    Assert.NotNull(media.MediaReferenceId);
+                    Assert.NotNull(media.PlaybackReferenceId);
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    SlidePart slidePart = document.PresentationPart!.SlideParts.Single();
+                    Assert.Single(slidePart.DataPartReferenceRelationships.OfType<AudioReferenceRelationship>());
+                    Assert.Single(slidePart.DataPartReferenceRelationships.OfType<MediaReferenceRelationship>());
+
+                    Picture picture = slidePart.Slide.Descendants<Picture>().Single();
+                    ApplicationNonVisualDrawingProperties appProperties =
+                        picture.NonVisualPictureProperties!.ApplicationNonVisualDrawingProperties!;
+                    Assert.NotNull(appProperties.GetFirstChild<A.AudioFromFile>());
+                    Assert.NotNull(appProperties.Descendants<P14.Media>().SingleOrDefault());
+                    Assert.NotNull(slidePart.Slide.Timing?.Descendants<Audio>().SingleOrDefault());
+                }
+
+                using (PowerPointPresentation reloaded = PowerPointPresentation.Open(filePath)) {
+                    PowerPointMedia media = Assert.IsType<PowerPointMedia>(reloaded.Slides[0].Shapes.Single());
+                    Assert.Equal(PowerPointMediaKind.Audio, media.Kind);
+                    Assert.Equal("audio/mpeg", media.MediaContentType);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/PowerPoint.PreviewExport.cs
+++ b/OfficeIMO.Tests/PowerPoint.PreviewExport.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointPreviewExportTests {
+        [Fact]
+        public void PreviewExporterValidatesInputBeforeAutomation() {
+            string outputDirectory = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
+            string existingPresentation = System.IO.Path.Combine(outputDirectory, "existing.pptx");
+
+            try {
+                Directory.CreateDirectory(outputDirectory);
+                File.WriteAllBytes(existingPresentation, Array.Empty<byte>());
+
+                Assert.Throws<FileNotFoundException>(() =>
+                    PowerPointPreviewExporter.TryExportSlides(
+                        System.IO.Path.Combine(outputDirectory, "missing.pptx"),
+                        outputDirectory,
+                        out _));
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                    PowerPointPreviewExporter.TryExportSlides(
+                        existingPresentation,
+                        outputDirectory,
+                        out _,
+                        width: -1));
+            } finally {
+                if (Directory.Exists(outputDirectory)) {
+                    Directory.Delete(outputDirectory, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        public void PreviewExporterReportsAvailabilityWithoutThrowing() {
+            bool available = PowerPointPreviewExporter.IsPowerPointAutomationAvailable();
+            Assert.IsType<bool>(available);
+        }
+    }
+}

--- a/OfficeIMO.Tests/PowerPoint.Properties.cs
+++ b/OfficeIMO.Tests/PowerPoint.Properties.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointPropertiesTests {
+        [Fact]
+        public void CanRoundTripBuiltinAndApplicationProperties() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    presentation.BuiltinDocumentProperties.Title = "Roundtrip deck";
+                    presentation.BuiltinDocumentProperties.Creator = "OfficeIMO Tests";
+                    presentation.BuiltinDocumentProperties.Keywords = "officeimo,powerpoint";
+                    presentation.BuiltinDocumentProperties.Subject = "Properties";
+                    presentation.BuiltinDocumentProperties.Category = "Testing";
+                    presentation.ApplicationProperties.Company = "Evotec";
+                    presentation.ApplicationProperties.Manager = "Automation";
+                    presentation.ApplicationProperties.Application = "OfficeIMO.PowerPoint";
+                    presentation.ApplicationProperties.ApplicationVersion = "1.0";
+
+                    presentation.AddSlide().AddTitle("Properties");
+                    presentation.Save();
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                    Assert.Equal("Roundtrip deck", presentation.BuiltinDocumentProperties.Title);
+                    Assert.Equal("OfficeIMO Tests", presentation.BuiltinDocumentProperties.Creator);
+                    Assert.Equal("officeimo,powerpoint", presentation.BuiltinDocumentProperties.Keywords);
+                    Assert.Equal("Properties", presentation.BuiltinDocumentProperties.Subject);
+                    Assert.Equal("Testing", presentation.BuiltinDocumentProperties.Category);
+                    Assert.Equal("Evotec", presentation.ApplicationProperties.Company);
+                    Assert.Equal("Automation", presentation.ApplicationProperties.Manager);
+                    Assert.Equal("OfficeIMO.PowerPoint", presentation.ApplicationProperties.Application);
+                    Assert.Equal("1.0", presentation.ApplicationProperties.ApplicationVersion);
+                    Assert.Equal("1", presentation.ApplicationProperties.Slides);
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    Assert.Equal("Roundtrip deck", document.PackageProperties.Title);
+                    Assert.Equal("Evotec", document.ExtendedFilePropertiesPart!.Properties!.Company!.Text);
+                    Assert.Equal("Automation", document.ExtendedFilePropertiesPart.Properties.Manager!.Text);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/PowerPoint.ShapesManagement.cs
+++ b/OfficeIMO.Tests/PowerPoint.ShapesManagement.cs
@@ -35,5 +35,137 @@ namespace OfficeIMO.Tests {
 
             File.Delete(filePath);
         }
+
+        [Fact]
+        public void CanLookupAndPersistShapeIdentityMetadata() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    PowerPointTextBox textBox = slide.AddTextBox("Quarterly update");
+                    PowerPointAutoShape rectangle = slide.AddRectangle(1000, 1000, 2000, 1000);
+                    PowerPointTable table = slide.AddTable(2, 2);
+
+                    textBox.Name = "Hero Title";
+                    textBox.AltText = "Main slide title";
+                    textBox.Hidden = true;
+                    table.Name = "Metrics Table";
+
+                    Assert.NotNull(textBox.Id);
+                    Assert.NotNull(rectangle.Id);
+                    Assert.NotNull(table.Id);
+                    Assert.Equal(PowerPointShapeContentType.TextBox, textBox.ShapeContentType);
+                    Assert.Equal(PowerPointShapeContentType.AutoShape, rectangle.ShapeContentType);
+                    Assert.Equal(PowerPointShapeContentType.Table, table.ShapeContentType);
+                    Assert.Same(textBox, slide.GetShapeByName("Hero Title"));
+                    Assert.Same(textBox, slide.GetShapeByName("hero title", ignoreCase: true));
+                    Assert.True(slide.TryGetShapeByName("Hero Title", out PowerPointShape? found));
+                    Assert.Same(textBox, found);
+                    Assert.Same(textBox, slide.GetShapeByName<PowerPointTextBox>("Hero Title"));
+                    Assert.Same(table, slide.GetShapeById<PowerPointTable>(table.Id!.Value));
+                    Assert.Null(slide.GetShapeByName("Missing"));
+
+                    presentation.Save();
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                    PowerPointSlide slide = presentation.Slides[0];
+                    PowerPointTextBox? loadedTextBox = slide.GetShapeByName<PowerPointTextBox>("Hero Title");
+                    PowerPointTable? loadedTable = slide.GetShapeByName<PowerPointTable>("Metrics Table");
+
+                    Assert.NotNull(loadedTextBox);
+                    Assert.NotNull(loadedTable);
+                    Assert.Equal("Main slide title", loadedTextBox!.AltText);
+                    Assert.True(loadedTextBox.Hidden);
+                    Assert.NotNull(slide.GetShapeById(loadedTextBox.Id!.Value));
+                    Assert.Equal(PowerPointShapeContentType.TextBox, loadedTextBox.ShapeContentType);
+                    Assert.Equal(PowerPointShapeContentType.Table, loadedTable!.ShapeContentType);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void ShapeConvenienceDuplicateAndRemoveKeepSlideCollectionInSync() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    PowerPointAutoShape original = slide.AddRectangle(1000, 2000, 3000, 4000);
+                    original.Name = "Source Shape";
+
+                    PowerPointShape duplicate = original.Duplicate(offsetX: 500, offsetY: 600);
+                    duplicate.Name = "Duplicated Shape";
+
+                    Assert.Equal(2, slide.Shapes.Count);
+                    Assert.NotEqual(original.Id, duplicate.Id);
+                    Assert.Equal(original.Left + 500, duplicate.Left);
+                    Assert.Equal(original.Top + 600, duplicate.Top);
+                    Assert.Same(duplicate, slide.GetShapeByName("Duplicated Shape"));
+
+                    original.Remove();
+
+                    Assert.Single(slide.Shapes);
+                    Assert.Null(slide.GetShapeByName("Source Shape"));
+                    Assert.Same(duplicate, slide.GetShapeByName("Duplicated Shape"));
+
+                    presentation.Save();
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                    PowerPointSlide slide = presentation.Slides[0];
+
+                    Assert.Single(slide.Shapes);
+                    Assert.Null(slide.GetShapeByName("Source Shape"));
+                    Assert.NotNull(slide.GetShapeByName("Duplicated Shape"));
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void CanAddSvgPictureAndReloadContentType() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            string svgPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".svg");
+
+            try {
+                File.WriteAllText(svgPath,
+                    "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"120\" height=\"80\" viewBox=\"0 0 120 80\"><rect width=\"120\" height=\"80\" fill=\"#1f4e79\"/><circle cx=\"60\" cy=\"40\" r=\"24\" fill=\"#f4b183\"/></svg>");
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    PowerPointPicture picture = slide.AddPicture(svgPath, left: 1000, top: 1000, width: 2000, height: 1200);
+                    picture.Name = "Vector Logo";
+
+                    Assert.Equal("image/svg+xml", picture.ContentType);
+                    Assert.Equal(PowerPointShapeContentType.Picture, picture.ShapeContentType);
+
+                    presentation.Save();
+                }
+
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(filePath)) {
+                    PowerPointPicture? picture = presentation.Slides[0].GetShapeByName<PowerPointPicture>("Vector Logo");
+
+                    Assert.NotNull(picture);
+                    Assert.Equal("image/svg+xml", picture!.ContentType);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+
+                if (File.Exists(svgPath)) {
+                    File.Delete(svgPath);
+                }
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/PowerPoint.SmartArt.cs
+++ b/OfficeIMO.Tests/PowerPoint.SmartArt.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Drawing.Diagrams;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using OfficeIMO.PowerPoint;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class PowerPointSmartArtTests {
+        [Fact]
+        public void CanAddSmartArtAndEditNodeText() {
+            string filePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(filePath)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    PowerPointSmartArt smartArt = slide.AddSmartArt();
+
+                    Assert.Equal(PowerPointShapeContentType.SmartArt, smartArt.ShapeContentType);
+                    Assert.Equal(1, smartArt.NodeCount);
+                    smartArt.SetNodeText(0, "OfficeIMO-native process");
+                    Assert.Equal("OfficeIMO-native process", smartArt.GetNodeText(0));
+                    presentation.Save();
+                }
+
+                using (PresentationDocument document = PresentationDocument.Open(filePath, false)) {
+                    SlidePart slidePart = document.PresentationPart!.SlideParts.Single();
+                    Assert.Single(slidePart.DiagramDataParts);
+                    Assert.Single(slidePart.DiagramLayoutDefinitionParts);
+                    Assert.Single(slidePart.DiagramStyleParts);
+                    Assert.Single(slidePart.DiagramColorsParts);
+
+                    GraphicFrame frame = slidePart.Slide.Descendants<GraphicFrame>().Single();
+                    RelationshipIds relationships = frame.Graphic!.GraphicData!.GetFirstChild<RelationshipIds>()!;
+                    Assert.False(string.IsNullOrWhiteSpace(relationships.LayoutPart));
+                    Assert.False(string.IsNullOrWhiteSpace(relationships.StylePart));
+                    Assert.False(string.IsNullOrWhiteSpace(relationships.ColorPart));
+                    Assert.False(string.IsNullOrWhiteSpace(relationships.DataPart));
+
+                    DiagramLayoutDefinitionPart layoutPart =
+                        (DiagramLayoutDefinitionPart)slidePart.GetPartById(relationships.LayoutPart!);
+                    Assert.Equal("urn:microsoft.com/office/officeart/2005/8/layout/default",
+                        layoutPart.LayoutDefinition!.UniqueId!.Value);
+                }
+
+                using (PowerPointPresentation reloaded = PowerPointPresentation.Open(filePath)) {
+                    PowerPointSmartArt smartArt = Assert.IsType<PowerPointSmartArt>(reloaded.Slides[0].Shapes.Single());
+                    Assert.Equal("OfficeIMO-native process", smartArt.GetNodeText(0));
+                    Assert.Single(reloaded.Slides[0].SmartArts);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add richer OfficeIMO.PowerPoint shape identity, lookup, duplicate, and removal APIs
- add SVG, embedded audio/video, Basic Process SmartArt, markdown rich text, and presentation properties support
- add native layout header/footer placeholders plus single-slide export and optional PowerPoint automation preview export
- document the new APIs and cover them with focused PowerPoint tests

## Validation
- dotnet build OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj -c Debug --no-restore
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Debug --filter "FullyQualifiedName~PowerPointShapesManagement|FullyQualifiedName~PowerPointShapeArrange|FullyQualifiedName~PowerPointLayoutPlaceholderTests|FullyQualifiedName~PowerPointPropertiesTests|FullyQualifiedName~PowerPointMarkdownTests|FullyQualifiedName~PowerPointMediaTests|FullyQualifiedName~PowerPointSmartArtTests|FullyQualifiedName~PowerPointExportTests|FullyQualifiedName~PowerPointPreviewExportTests" --no-restore --logger "console;verbosity=minimal"