### PR TITLE
Improve Excel import and export performance

### DIFF
--- a/OfficeIMO.Excel.Benchmarks.LegacyEpPlus/Program.cs
+++ b/OfficeIMO.Excel.Benchmarks.LegacyEpPlus/Program.cs
@@ -22,6 +22,7 @@ int measuredIterations = ParsePositiveOption(args, "--iterations", "--measured-i
 var scenarioFilter = BuildScenarioFilter(ParseOptionValues(args, "--scenario", "--scenarios"));
 
 var rows = CreateSalesRecords(rowCount);
+var salesDataSet = CreateSalesDataSet(rows);
 int topDataRows = Math.Min(rowCount, 100);
 byte[] workbookBytes = CreateWorkbookBytes(rows);
 byte[] formulaWorkbookBytes = CreateFormulaWorkbookBytes(rowCount);
@@ -30,6 +31,7 @@ byte[] sparseWorkbookBytes = CreateSparseWorkbookBytes(SparseLastRow);
 var scenarios = new List<LegacyComparisonScenario>();
 
 AddScenario(scenarios, scenarioFilter, "write-bulk-report", LibraryName, "EPPlus 4.x manual row population, add table, autofit, save.", () => WriteBulkReport(rows), warmupIterations, measuredIterations);
+AddScenario(scenarios, scenarioFilter, "write-dataset-tables", LibraryName, "EPPlus 4.x import prepared DataTables as two styled worksheet tables and save.", () => WriteDataSetTables(salesDataSet), warmupIterations, measuredIterations);
 AddScenario(scenarios, scenarioFilter, "append-plain-rows", LibraryName, "EPPlus 4.x append equivalent row/cell values.", () => AppendPlainRows(rows), warmupIterations, measuredIterations);
 AddScenario(scenarios, scenarioFilter, "read-range", LibraryName, "EPPlus 4.x iterate used data cells from workbook.", () => ReadRange(workbookBytes), warmupIterations, measuredIterations);
 AddScenario(scenarios, scenarioFilter, "read-top-range", LibraryName, "EPPlus 4.x read the first 100 data rows from a larger sheet.", () => ReadRange(workbookBytes, topDataRows), warmupIterations, measuredIterations);
@@ -150,6 +152,20 @@ static int WriteBulkReport(IReadOnlyList<SalesRecord> rows) {
     using (var package = new ExcelPackage(stream)) {
         var worksheet = package.Workbook.Worksheets.Add("Data");
         PopulateWorksheet(worksheet, rows, includeTable: true, autoFit: true);
+        package.Save();
+    }
+
+    return checked((int)stream.Length);
+}
+
+static int WriteDataSetTables(DataSet dataSet) {
+    using var stream = new MemoryStream();
+    using (var package = new ExcelPackage(stream)) {
+        foreach (DataTable dataTable in dataSet.Tables) {
+            var worksheet = package.Workbook.Worksheets.Add(dataTable.TableName);
+            worksheet.Cells["A1"].LoadFromDataTable(dataTable, true, TableStyles.Medium2);
+        }
+
         package.Save();
     }
 
@@ -395,7 +411,8 @@ static void PopulateWorksheet(ExcelWorksheet worksheet, IReadOnlyList<SalesRecor
     }
 
     if (includeTable) {
-        var table = worksheet.Tables.Add(worksheet.Cells[1, 1, rows.Count + 1, 8], "SalesData");
+        string tableName = string.Equals(worksheet.Name, "Data", StringComparison.OrdinalIgnoreCase) ? "SalesData" : worksheet.Name;
+        var table = worksheet.Tables.Add(worksheet.Cells[1, 1, rows.Count + 1, 8], tableName);
         table.TableStyle = TableStyles.Medium2;
     }
 
@@ -501,6 +518,23 @@ static DataTable CreateSalesDataTable() {
     table.Columns.Add("Units", typeof(int));
     table.Columns.Add("Active", typeof(bool));
     table.Columns.Add("Notes", typeof(string));
+    return table;
+}
+
+static DataSet CreateSalesDataSet(IReadOnlyList<SalesRecord> rows) {
+    var dataSet = new DataSet("Sales") { Locale = CultureInfo.InvariantCulture };
+    dataSet.Tables.Add(CreateSalesDataTableFromRows(rows.Take(rows.Count / 2), "SalesA"));
+    dataSet.Tables.Add(CreateSalesDataTableFromRows(rows.Skip(rows.Count / 2), "SalesB"));
+    return dataSet;
+}
+
+static DataTable CreateSalesDataTableFromRows(IEnumerable<SalesRecord> rows, string tableName) {
+    var table = CreateSalesDataTable();
+    table.TableName = tableName;
+    foreach (var row in rows) {
+        table.Rows.Add(row.Id, row.Region, row.Owner, row.CreatedOn, row.Amount, row.Units, row.Active, row.Notes);
+    }
+
     return table;
 }
 

--- a/OfficeIMO.Excel.Benchmarks/ExcelLibraryComparisonRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelLibraryComparisonRunner.cs
@@ -46,6 +46,9 @@ internal static class ExcelLibraryComparisonRunner {
         var scenarioFilter = BuildScenarioFilter(scenarioFilters);
 
         var rows = ExcelBenchmarkScenarioFactory.CreateSalesRecords(rowCount);
+        var firstTableRows = rows.Take(rowCount / 2).ToList();
+        var secondTableRows = rows.Skip(rowCount / 2).ToList();
+        var salesDataSet = CreateSalesDataSet(firstTableRows, secondTableRows);
         byte[] officeImoWorkbookBytes = ExcelBenchmarkScenarioFactory.CreateWorkbookBytes(rows);
         byte[] closedXmlWorkbookBytes = CreateClosedXmlWorkbookBytes(rows);
         byte[] epPlusWorkbookBytes = CreateEpPlusWorkbookBytes(rows);
@@ -62,6 +65,12 @@ internal static class ExcelLibraryComparisonRunner {
             new LibraryComparisonCase("OfficeIMO.Excel", "Insert objects, add table, autofit, save.", () => OfficeImoWriteBulkReport(rows)),
             new LibraryComparisonCase("ClosedXML", "Insert table, apply table style, autofit, save.", () => ClosedXmlWriteBulkReport(rows)),
             new LibraryComparisonCase("EPPlus", "Manual row population, add table, autofit, save.", () => EpPlusWriteBulkReport(rows))
+        ]);
+
+        AddScenarioGroup(scenarios, scenarioFilter, "write-dataset-tables", warmupIterations, measuredIterations, [
+            new LibraryComparisonCase("OfficeIMO.Excel", "Write a prepared DataSet directly as two styled worksheet tables.", () => OfficeImoWriteDataSetTables(salesDataSet)),
+            new LibraryComparisonCase("ClosedXML", "Import prepared DataTables as two styled worksheet tables and save.", () => ClosedXmlWriteDataSetTables(salesDataSet)),
+            new LibraryComparisonCase("EPPlus", "Import prepared DataTables as two styled worksheet tables and save.", () => EpPlusWriteDataSetTables(salesDataSet))
         ]);
 
         AddScenarioGroup(scenarios, scenarioFilter, "append-plain-rows", warmupIterations, measuredIterations, [
@@ -371,6 +380,42 @@ internal static class ExcelLibraryComparisonRunner {
         using (var package = new ExcelPackage(stream)) {
             var worksheet = package.Workbook.Worksheets.Add("Data");
             PopulateEpPlusWorksheet(worksheet, rows, includeTable: true, autoFit: true);
+            package.Save();
+        }
+
+        return checked((int)stream.Length);
+    }
+
+    private static int OfficeImoWriteDataSetTables(DataSet dataSet) {
+        using var stream = new MemoryStream();
+        ExcelDocument.WriteDataSet(stream, dataSet);
+
+        return checked((int)stream.Length);
+    }
+
+    private static int ClosedXmlWriteDataSetTables(DataSet dataSet) {
+        using var stream = new MemoryStream();
+        using (var workbook = new XLWorkbook()) {
+            foreach (DataTable dataTable in dataSet.Tables) {
+                var worksheet = workbook.Worksheets.Add(dataTable.TableName);
+                var table = worksheet.Cell(1, 1).InsertTable(dataTable, dataTable.TableName, true);
+                ExcelBenchmarkScenarioFactory.StyleClosedXmlTable(table);
+            }
+
+            workbook.SaveAs(stream);
+        }
+
+        return checked((int)stream.Length);
+    }
+
+    private static int EpPlusWriteDataSetTables(DataSet dataSet) {
+        using var stream = new MemoryStream();
+        using (var package = new ExcelPackage(stream)) {
+            foreach (DataTable dataTable in dataSet.Tables) {
+                var worksheet = package.Workbook.Worksheets.Add(dataTable.TableName);
+                worksheet.Cells["A1"].LoadFromDataTable(dataTable, true, TableStyles.Medium2);
+            }
+
             package.Save();
         }
 
@@ -972,7 +1017,8 @@ internal static class ExcelLibraryComparisonRunner {
         }
 
         if (includeTable) {
-            var table = worksheet.Tables.Add(worksheet.Cells[1, 1, rows.Count + 1, 8], "SalesData");
+            string tableName = string.Equals(worksheet.Name, "Data", StringComparison.OrdinalIgnoreCase) ? "SalesData" : worksheet.Name;
+            var table = worksheet.Tables.Add(worksheet.Cells[1, 1, rows.Count + 1, 8], tableName);
             table.TableStyle = TableStyles.Medium2;
         }
 
@@ -1040,6 +1086,25 @@ internal static class ExcelLibraryComparisonRunner {
         table.Columns.Add("Units", typeof(int));
         table.Columns.Add("Active", typeof(bool));
         table.Columns.Add("Notes", typeof(string));
+        return table;
+    }
+
+    private static DataSet CreateSalesDataSet(
+        IReadOnlyList<ExcelBenchmarkScenarioFactory.SalesRecord> first,
+        IReadOnlyList<ExcelBenchmarkScenarioFactory.SalesRecord> second) {
+        var dataSet = new DataSet("Sales") { Locale = CultureInfo.InvariantCulture };
+        dataSet.Tables.Add(CreateSalesDataTable(first, "SalesA"));
+        dataSet.Tables.Add(CreateSalesDataTable(second, "SalesB"));
+        return dataSet;
+    }
+
+    private static DataTable CreateSalesDataTable(IEnumerable<ExcelBenchmarkScenarioFactory.SalesRecord> rows, string tableName) {
+        var table = CreateSalesDataTable();
+        table.TableName = tableName;
+        foreach (var row in rows) {
+            table.Rows.Add(row.Id, row.Region, row.Owner, row.CreatedOn, row.Amount, row.Units, row.Active, row.Notes);
+        }
+
         return table;
     }
 

--- a/OfficeIMO.Excel/ApplicationProperties.cs
+++ b/OfficeIMO.Excel/ApplicationProperties.cs
@@ -28,19 +28,19 @@ namespace OfficeIMO.Excel {
         /// <summary>Company property stored in the Extended File Properties part.</summary>
         public string Company {
             get => _spreadsheetDocument.ExtendedFilePropertiesPart?.Properties?.Company?.Text ?? string.Empty;
-            set { var p = EnsureProperties(); p.Company ??= new Company(); p.Company.Text = value; }
+            set { var p = EnsureProperties(); p.Company ??= new Company(); p.Company.Text = value; _document.MarkPackagePropertiesDirty(); }
         }
 
         /// <summary>Manager property stored in the Extended File Properties part.</summary>
         public string Manager {
             get => _spreadsheetDocument.ExtendedFilePropertiesPart?.Properties?.Manager?.Text ?? string.Empty;
-            set { var p = EnsureProperties(); p.Manager ??= new Manager(); p.Manager.Text = value; }
+            set { var p = EnsureProperties(); p.Manager ??= new Manager(); p.Manager.Text = value; _document.MarkPackagePropertiesDirty(); }
         }
 
         /// <summary>Application name (producer) stored in the Extended File Properties part.</summary>
         public string ApplicationName {
             get => _spreadsheetDocument.ExtendedFilePropertiesPart?.Properties?.Application?.Text ?? string.Empty;
-            set { var p = EnsureProperties(); p.Application ??= new Application(); p.Application.Text = value; }
+            set { var p = EnsureProperties(); p.Application ??= new Application(); p.Application.Text = value; _document.MarkPackagePropertiesDirty(); }
         }
     }
 }

--- a/OfficeIMO.Excel/BuiltinDocumentProperties.cs
+++ b/OfficeIMO.Excel/BuiltinDocumentProperties.cs
@@ -32,73 +32,73 @@ namespace OfficeIMO.Excel {
         /// <summary>The document creator/author.</summary>
         public string? Creator {
             get { return _spreadsheetDocument.PackageProperties.Creator; }
-            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Creator = value; }
+            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Creator = value; _document.MarkPackagePropertiesDirty(); }
         }
 
         /// <summary>Document title.</summary>
         public string? Title {
             get { return _spreadsheetDocument.PackageProperties.Title; }
-            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Title = value; }
+            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Title = value; _document.MarkPackagePropertiesDirty(); }
         }
 
         /// <summary>Document description/summary.</summary>
         public string? Description {
             get { return _spreadsheetDocument.PackageProperties.Description; }
-            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Description = value; }
+            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Description = value; _document.MarkPackagePropertiesDirty(); }
         }
 
         /// <summary>Document category.</summary>
         public string? Category {
             get { return _spreadsheetDocument.PackageProperties.Category; }
-            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Category = value; }
+            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Category = value; _document.MarkPackagePropertiesDirty(); }
         }
 
         /// <summary>Comma- or space-separated keywords.</summary>
         public string? Keywords {
             get { return _spreadsheetDocument.PackageProperties.Keywords; }
-            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Keywords = value; }
+            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Keywords = value; _document.MarkPackagePropertiesDirty(); }
         }
 
         /// <summary>Document subject.</summary>
         public string? Subject {
             get { return _spreadsheetDocument.PackageProperties.Subject; }
-            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Subject = value; }
+            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Subject = value; _document.MarkPackagePropertiesDirty(); }
         }
 
         /// <summary>Revision number.</summary>
         public string? Revision {
             get { return _spreadsheetDocument.PackageProperties.Revision; }
-            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Revision = value; }
+            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Revision = value; _document.MarkPackagePropertiesDirty(); }
         }
 
         /// <summary>Last modified by user.</summary>
         public string? LastModifiedBy {
             get { return _spreadsheetDocument.PackageProperties.LastModifiedBy; }
-            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.LastModifiedBy = value; }
+            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.LastModifiedBy = value; _document.MarkPackagePropertiesDirty(); }
         }
 
         /// <summary>Document version.</summary>
         public string? Version {
             get { return _spreadsheetDocument.PackageProperties.Version; }
-            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Version = value; }
+            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Version = value; _document.MarkPackagePropertiesDirty(); }
         }
 
         /// <summary>Creation timestamp (UTC).</summary>
         public DateTime? Created {
             get { return _spreadsheetDocument.PackageProperties.Created; }
-            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Created = value; }
+            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Created = value; _document.MarkPackagePropertiesDirty(); }
         }
 
         /// <summary>Last modified timestamp (UTC).</summary>
         public DateTime? Modified {
             get { return _spreadsheetDocument.PackageProperties.Modified; }
-            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Modified = value; }
+            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.Modified = value; _document.MarkPackagePropertiesDirty(); }
         }
 
         /// <summary>Last printed timestamp (UTC).</summary>
         public DateTime? LastPrinted {
             get { return _spreadsheetDocument.PackageProperties.LastPrinted; }
-            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.LastPrinted = value; }
+            set { EnsureCorePropertiesPart(); _spreadsheetDocument.PackageProperties.LastPrinted = value; _document.MarkPackagePropertiesDirty(); }
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelDocument.CalculationAndProtection.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CalculationAndProtection.cs
@@ -53,6 +53,7 @@ namespace OfficeIMO.Excel {
                 protection.RemoveAttribute("workbookPassword", string.Empty);
             }
             workbook.Save();
+            MarkPackageDirty();
         }
 
         /// <summary>
@@ -64,6 +65,7 @@ namespace OfficeIMO.Excel {
             if (protection != null) {
                 workbook.RemoveChild(protection);
                 workbook.Save();
+                MarkPackageDirty();
             }
         }
 
@@ -115,6 +117,7 @@ namespace OfficeIMO.Excel {
             properties.ForceFullCalculation = true;
             properties.FullCalculationOnLoad = true;
             workbook.Save();
+            MarkPackageDirty();
         }
 
         private static void InsertCalculationPropertiesInSchemaOrder(Workbook workbook, CalculationProperties properties) {

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
@@ -169,6 +169,9 @@ namespace OfficeIMO.Excel {
         }
 
         private static class DirectDataSetWorkbookWriter {
+            private const long MaxSafeInteger = 9007199254740991L;
+            private const ulong MaxSafeUnsignedInteger = 9007199254740991UL;
+
             internal static void Write(Stream stream, DirectDataSetWorkbookModel model, CancellationToken ct) {
                 using var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true);
                 WriteContentTypes(archive, model.Sheets);
@@ -370,9 +373,7 @@ namespace OfficeIMO.Excel {
                         builder.Append(" t=\"str\"><v></v></c>");
                         return;
                     case string stringValue:
-                        builder.Append(" t=\"str\"><v>");
-                        AppendEscaped(builder, Utilities.ExcelSanitizer.SanitizeString(stringValue));
-                        builder.Append("</v></c>");
+                        AppendStringCell(builder, stringValue);
                         return;
                     case bool boolValue:
                         builder.Append(" t=\"b\"><v>");
@@ -388,18 +389,61 @@ namespace OfficeIMO.Excel {
                     case TimeSpan timeSpan:
                         text = timeSpan.TotalDays.ToString(CultureInfo.InvariantCulture);
                         break;
-                    case IFormattable formattable:
-                        text = formattable.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty;
+                    case double doubleValue:
+                        text = doubleValue.ToString(CultureInfo.InvariantCulture);
                         break;
+                    case float floatValue:
+                        text = floatValue.ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case decimal decimalValue:
+                        text = decimalValue.ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case sbyte sbyteValue:
+                        text = sbyteValue.ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case byte byteValue:
+                        text = byteValue.ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case short shortValue:
+                        text = shortValue.ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case ushort ushortValue:
+                        text = ushortValue.ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case int intValue:
+                        text = intValue.ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case uint uintValue:
+                        text = uintValue.ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case long longValue when longValue >= -MaxSafeInteger && longValue <= MaxSafeInteger:
+                        text = longValue.ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case ulong ulongValue when ulongValue <= MaxSafeUnsignedInteger:
+                        text = ulongValue.ToString(CultureInfo.InvariantCulture);
+                        break;
+#if NET6_0_OR_GREATER
+                    case DateOnly dateOnly:
+                        text = dateOnly.ToDateTime(TimeOnly.MinValue).ToOADate().ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case TimeOnly timeOnly:
+                        text = timeOnly.ToTimeSpan().TotalDays.ToString(CultureInfo.InvariantCulture);
+                        break;
+#endif
                     default:
-                        builder.Append(" t=\"str\"><v>");
-                        AppendEscaped(builder, Utilities.ExcelSanitizer.SanitizeString(value.ToString() ?? string.Empty));
-                        builder.Append("</v></c>");
+                        AppendStringCell(builder, value.ToString() ?? string.Empty);
                         return;
                 }
 
                 builder.Append("><v>");
                 AppendEscaped(builder, text);
+                builder.Append("</v></c>");
+            }
+
+            private static void AppendStringCell(StringBuilder builder, string text) {
+                CoerceValueHelper.ValidateSharedStringLength(text, "value");
+                builder.Append(" t=\"str\"><v>");
+                AppendEscaped(builder, Utilities.ExcelSanitizer.SanitizeString(text));
                 builder.Append("</v></c>");
             }
 

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
@@ -1,0 +1,438 @@
+using System.Data;
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+using System.Threading;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        /// <summary>
+        /// Writes a DataSet directly to an XLSX package, using one worksheet and one Excel table per DataTable.
+        /// This path is intended for export workloads where the caller does not need to keep editing the workbook object.
+        /// </summary>
+        public static IReadOnlyList<ExcelDataSetImportResult> WriteDataSet(
+            Stream stream,
+            DataSet dataSet,
+            TableStyle tableStyle = TableStyle.TableStyleMedium2,
+            bool includeHeaders = true,
+            bool includeAutoFilter = true,
+            CancellationToken ct = default) {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            if (!stream.CanWrite) throw new ArgumentException("The destination stream must be writable.", nameof(stream));
+            if (dataSet == null) throw new ArgumentNullException(nameof(dataSet));
+
+            var model = DirectDataSetWorkbookModel.Create(dataSet, tableStyle, includeHeaders, includeAutoFilter, ct);
+            if (stream.CanSeek) {
+                PrepareDestinationStreamForWrite(stream);
+            }
+
+            DirectDataSetWorkbookWriter.Write(stream, model, ct);
+            if (stream.CanSeek) {
+                stream.Seek(0, SeekOrigin.Begin);
+            }
+
+            return model.Results;
+        }
+
+        private sealed class DirectDataSetWorkbookModel {
+            private DirectDataSetWorkbookModel(IReadOnlyList<DirectDataSetSheetModel> sheets, IReadOnlyList<ExcelDataSetImportResult> results) {
+                Sheets = sheets;
+                Results = results;
+            }
+
+            internal IReadOnlyList<DirectDataSetSheetModel> Sheets { get; }
+
+            internal IReadOnlyList<ExcelDataSetImportResult> Results { get; }
+
+            internal static DirectDataSetWorkbookModel Create(
+                DataSet dataSet,
+                TableStyle tableStyle,
+                bool includeHeaders,
+                bool includeAutoFilter,
+                CancellationToken ct) {
+                var sheets = new List<DirectDataSetSheetModel>();
+                var results = new List<ExcelDataSetImportResult>();
+                var usedSheetNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var usedTableNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                int index = 1;
+                foreach (DataTable table in dataSet.Tables) {
+                    ct.ThrowIfCancellationRequested();
+                    string requestedName = string.IsNullOrWhiteSpace(table.TableName)
+                        ? "Table" + index.ToString(CultureInfo.InvariantCulture)
+                        : table.TableName;
+                    string sheetName = GetUniqueName(SanitizeSheetName(requestedName), usedSheetNames, 31);
+                    string tableName = GetUniqueName(SanitizeTableName(requestedName), usedTableNames, 255);
+                    int rowCount = table.Rows.Count + (includeHeaders ? 1 : 0);
+                    string range = table.Columns.Count == 0 || rowCount == 0
+                        ? string.Empty
+                        : "A1:" + A1.CellReference(rowCount, table.Columns.Count);
+
+                    var sheet = new DirectDataSetSheetModel(index, sheetName, tableName, range, table, tableStyle, includeHeaders, includeAutoFilter);
+                    sheets.Add(sheet);
+                    results.Add(new ExcelDataSetImportResult(sheetName, range.Length == 0 ? null : tableName, range, table.Rows.Count, table.Columns.Count));
+                    index++;
+                }
+
+                return new DirectDataSetWorkbookModel(sheets, results);
+            }
+
+            private static string GetUniqueName(string baseName, HashSet<string> used, int maxLength) {
+                string trimmed = string.IsNullOrWhiteSpace(baseName) ? "Table" : baseName;
+                if (trimmed.Length > maxLength) {
+                    trimmed = trimmed.Substring(0, maxLength);
+                }
+
+                if (used.Add(trimmed)) {
+                    return trimmed;
+                }
+
+                int suffix = 2;
+                while (true) {
+                    string suffixText = suffix.ToString(CultureInfo.InvariantCulture);
+                    int prefixLength = Math.Max(1, maxLength - suffixText.Length);
+                    string candidate = trimmed.Length > prefixLength
+                        ? trimmed.Substring(0, prefixLength) + suffixText
+                        : trimmed + suffixText;
+                    if (used.Add(candidate)) {
+                        return candidate;
+                    }
+
+                    suffix++;
+                }
+            }
+
+            private static string SanitizeSheetName(string name) {
+                var builder = new StringBuilder(name.Length);
+                foreach (char ch in name) {
+                    builder.Append(ch is ':' or '\\' or '/' or '?' or '*' or '[' or ']' ? '_' : ch);
+                }
+
+                string value = builder.ToString().Trim('\'');
+                return string.IsNullOrWhiteSpace(value) ? "Table" : value;
+            }
+
+            private static string SanitizeTableName(string name) {
+                var builder = new StringBuilder(name.Length + 1);
+                foreach (char ch in name) {
+                    builder.Append(char.IsLetterOrDigit(ch) || ch == '_' ? ch : '_');
+                }
+
+                string value = builder.ToString();
+                if (string.IsNullOrWhiteSpace(value)) {
+                    value = "Table";
+                }
+
+                if (!char.IsLetter(value[0]) && value[0] != '_') {
+                    value = "_" + value;
+                }
+
+                return value;
+            }
+        }
+
+        private sealed class DirectDataSetSheetModel {
+            internal DirectDataSetSheetModel(
+                int index,
+                string sheetName,
+                string tableName,
+                string range,
+                DataTable table,
+                TableStyle tableStyle,
+                bool includeHeaders,
+                bool includeAutoFilter) {
+                Index = index;
+                SheetName = sheetName;
+                TableName = tableName;
+                Range = range;
+                Table = table;
+                TableStyle = tableStyle;
+                IncludeHeaders = includeHeaders;
+                IncludeAutoFilter = includeAutoFilter;
+            }
+
+            internal int Index { get; }
+
+            internal string SheetName { get; }
+
+            internal string TableName { get; }
+
+            internal string Range { get; }
+
+            internal DataTable Table { get; }
+
+            internal TableStyle TableStyle { get; }
+
+            internal bool IncludeHeaders { get; }
+
+            internal bool IncludeAutoFilter { get; }
+        }
+
+        private static class DirectDataSetWorkbookWriter {
+            internal static void Write(Stream stream, DirectDataSetWorkbookModel model, CancellationToken ct) {
+                using var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true);
+                WriteContentTypes(archive, model.Sheets);
+                WriteTextEntry(archive, "_rels/.rels",
+                    "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                    "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
+                    "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>" +
+                    "</Relationships>");
+                WriteWorkbook(archive, model.Sheets);
+                WriteWorkbookRelationships(archive, model.Sheets.Count);
+                WriteStyles(archive);
+                foreach (var sheet in model.Sheets) {
+                    ct.ThrowIfCancellationRequested();
+                    WriteWorksheet(archive, sheet, ct);
+                    if (sheet.Range.Length > 0) {
+                        WriteTextEntry(archive, $"xl/worksheets/_rels/sheet{sheet.Index}.xml.rels",
+                            "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                            "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
+                            $"<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/table\" Target=\"../tables/table{sheet.Index}.xml\"/>" +
+                            "</Relationships>");
+                        WriteTable(archive, sheet);
+                    }
+                }
+            }
+
+            private static void WriteContentTypes(ZipArchive archive, IReadOnlyList<DirectDataSetSheetModel> sheets) {
+                var builder = new StringBuilder(1024 + sheets.Count * 260);
+                builder.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+                builder.Append("<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">");
+                builder.Append("<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>");
+                builder.Append("<Default Extension=\"xml\" ContentType=\"application/xml\"/>");
+                builder.Append("<Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>");
+                builder.Append("<Override PartName=\"/xl/styles.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\"/>");
+                foreach (var sheet in sheets) {
+                    builder.Append("<Override PartName=\"/xl/worksheets/sheet");
+                    builder.Append(sheet.Index.ToString(CultureInfo.InvariantCulture));
+                    builder.Append(".xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>");
+                    if (sheet.Range.Length > 0) {
+                        builder.Append("<Override PartName=\"/xl/tables/table");
+                        builder.Append(sheet.Index.ToString(CultureInfo.InvariantCulture));
+                        builder.Append(".xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml\"/>");
+                    }
+                }
+
+                builder.Append("</Types>");
+                WriteTextEntry(archive, "[Content_Types].xml", builder.ToString());
+            }
+
+            private static void WriteWorkbook(ZipArchive archive, IReadOnlyList<DirectDataSetSheetModel> sheets) {
+                var builder = new StringBuilder(256 + sheets.Count * 120);
+                builder.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+                builder.Append("<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"><sheets>");
+                foreach (var sheet in sheets) {
+                    builder.Append("<sheet name=\"");
+                    AppendEscaped(builder, sheet.SheetName);
+                    builder.Append("\" sheetId=\"");
+                    builder.Append(sheet.Index.ToString(CultureInfo.InvariantCulture));
+                    builder.Append("\" r:id=\"rId");
+                    builder.Append(sheet.Index.ToString(CultureInfo.InvariantCulture));
+                    builder.Append("\"/>");
+                }
+
+                builder.Append("</sheets></workbook>");
+                WriteTextEntry(archive, "xl/workbook.xml", builder.ToString());
+            }
+
+            private static void WriteWorkbookRelationships(ZipArchive archive, int sheetCount) {
+                var builder = new StringBuilder(384 + sheetCount * 160);
+                builder.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+                builder.Append("<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">");
+                for (int i = 1; i <= sheetCount; i++) {
+                    builder.Append("<Relationship Id=\"rId");
+                    builder.Append(i.ToString(CultureInfo.InvariantCulture));
+                    builder.Append("\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet");
+                    builder.Append(i.ToString(CultureInfo.InvariantCulture));
+                    builder.Append(".xml\"/>");
+                }
+
+                builder.Append("<Relationship Id=\"rId");
+                builder.Append((sheetCount + 1).ToString(CultureInfo.InvariantCulture));
+                builder.Append("\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\" Target=\"styles.xml\"/>");
+                builder.Append("</Relationships>");
+                WriteTextEntry(archive, "xl/_rels/workbook.xml.rels", builder.ToString());
+            }
+
+            private static void WriteStyles(ZipArchive archive) {
+                WriteTextEntry(archive, "xl/styles.xml",
+                    "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                    "<styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">" +
+                    "<numFmts count=\"2\"><numFmt numFmtId=\"164\" formatCode=\"yyyy-mm-dd hh:mm\"/><numFmt numFmtId=\"165\" formatCode=\"[h]:mm:ss\"/></numFmts>" +
+                    "<fonts count=\"1\"><font><sz val=\"11\"/><color theme=\"1\"/><name val=\"Calibri\"/><family val=\"2\"/><scheme val=\"minor\"/></font></fonts>" +
+                    "<fills count=\"2\"><fill><patternFill patternType=\"none\"/></fill><fill><patternFill patternType=\"gray125\"/></fill></fills>" +
+                    "<borders count=\"1\"><border><left/><right/><top/><bottom/><diagonal/></border></borders>" +
+                    "<cellStyleXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/></cellStyleXfs>" +
+                    "<cellXfs count=\"3\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/><xf numFmtId=\"164\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyNumberFormat=\"1\"/><xf numFmtId=\"165\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyNumberFormat=\"1\"/></cellXfs>" +
+                    "<cellStyles count=\"1\"><cellStyle name=\"Normal\" xfId=\"0\" builtinId=\"0\"/></cellStyles>" +
+                    "<tableStyles count=\"0\" defaultTableStyle=\"TableStyleMedium2\" defaultPivotStyle=\"PivotStyleLight16\"/>" +
+                    "</styleSheet>");
+            }
+
+            private static void WriteWorksheet(ZipArchive archive, DirectDataSetSheetModel sheet, CancellationToken ct) {
+                var builder = new StringBuilder(Math.Max(4096, (sheet.Table.Rows.Count + 1) * Math.Max(1, sheet.Table.Columns.Count) * 40));
+                builder.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+                builder.Append("<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">");
+                builder.Append("<dimension ref=\"");
+                AppendEscaped(builder, sheet.Range.Length == 0 ? "A1" : sheet.Range);
+                builder.Append("\"/><sheetData>");
+                int rowIndex = 1;
+                if (sheet.IncludeHeaders) {
+                    builder.Append("<row r=\"1\">");
+                    for (int c = 0; c < sheet.Table.Columns.Count; c++) {
+                        AppendCell(builder, 1, c + 1, sheet.Table.Columns[c].ColumnName, null);
+                    }
+
+                    builder.Append("</row>");
+                    rowIndex++;
+                }
+
+                foreach (DataRow row in sheet.Table.Rows) {
+                    ct.ThrowIfCancellationRequested();
+                    builder.Append("<row r=\"");
+                    builder.Append(rowIndex.ToString(CultureInfo.InvariantCulture));
+                    builder.Append("\">");
+                    for (int c = 0; c < sheet.Table.Columns.Count; c++) {
+                        object? value = row.IsNull(c) ? null : row[c];
+                        AppendCell(builder, rowIndex, c + 1, value, GetStyleIndex(sheet.Table.Columns[c].DataType));
+                    }
+
+                    builder.Append("</row>");
+                    rowIndex++;
+                }
+
+                builder.Append("</sheetData>");
+                if (sheet.Range.Length > 0) {
+                    builder.Append("<tableParts count=\"1\"><tablePart r:id=\"rId1\"/></tableParts>");
+                }
+
+                builder.Append("</worksheet>");
+                WriteTextEntry(archive, $"xl/worksheets/sheet{sheet.Index}.xml", builder.ToString());
+            }
+
+            private static void WriteTable(ZipArchive archive, DirectDataSetSheetModel sheet) {
+                var builder = new StringBuilder(512 + sheet.Table.Columns.Count * 80);
+                builder.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+                builder.Append("<table xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" id=\"");
+                builder.Append(sheet.Index.ToString(CultureInfo.InvariantCulture));
+                builder.Append("\" name=\"");
+                AppendEscaped(builder, sheet.TableName);
+                builder.Append("\" displayName=\"");
+                AppendEscaped(builder, sheet.TableName);
+                builder.Append("\" ref=\"");
+                AppendEscaped(builder, sheet.Range);
+                builder.Append("\" headerRowCount=\"");
+                builder.Append(sheet.IncludeHeaders ? "1" : "0");
+                builder.Append("\" totalsRowShown=\"0\">");
+                if (sheet.IncludeAutoFilter && sheet.IncludeHeaders) {
+                    builder.Append("<autoFilter ref=\"");
+                    AppendEscaped(builder, sheet.Range);
+                    builder.Append("\"/>");
+                }
+
+                builder.Append("<tableColumns count=\"");
+                builder.Append(sheet.Table.Columns.Count.ToString(CultureInfo.InvariantCulture));
+                builder.Append("\">");
+                for (int i = 0; i < sheet.Table.Columns.Count; i++) {
+                    builder.Append("<tableColumn id=\"");
+                    builder.Append((i + 1).ToString(CultureInfo.InvariantCulture));
+                    builder.Append("\" name=\"");
+                    AppendEscaped(builder, string.IsNullOrWhiteSpace(sheet.Table.Columns[i].ColumnName) ? "Column" + (i + 1).ToString(CultureInfo.InvariantCulture) : sheet.Table.Columns[i].ColumnName);
+                    builder.Append("\"/>");
+                }
+
+                builder.Append("</tableColumns><tableStyleInfo name=\"");
+                builder.Append(sheet.TableStyle.ToString());
+                builder.Append("\" showFirstColumn=\"0\" showLastColumn=\"0\" showRowStripes=\"1\" showColumnStripes=\"0\"/></table>");
+                WriteTextEntry(archive, $"xl/tables/table{sheet.Index}.xml", builder.ToString());
+            }
+
+            private static uint? GetStyleIndex(Type dataType) {
+                if (dataType == typeof(DateTime) || dataType == typeof(DateTimeOffset)) return 1U;
+                if (dataType == typeof(TimeSpan)) return 2U;
+                return null;
+            }
+
+            private static void AppendCell(StringBuilder builder, int row, int column, object? value, uint? styleIndex) {
+                builder.Append("<c r=\"");
+                builder.Append(A1.CellReference(row, column));
+                builder.Append('"');
+                if (styleIndex.HasValue) {
+                    builder.Append(" s=\"");
+                    builder.Append(styleIndex.Value.ToString(CultureInfo.InvariantCulture));
+                    builder.Append('"');
+                }
+
+                string text;
+                switch (value) {
+                    case null:
+                    case DBNull:
+                        builder.Append(" t=\"str\"><v></v></c>");
+                        return;
+                    case string stringValue:
+                        builder.Append(" t=\"str\"><v>");
+                        AppendEscaped(builder, Utilities.ExcelSanitizer.SanitizeString(stringValue));
+                        builder.Append("</v></c>");
+                        return;
+                    case bool boolValue:
+                        builder.Append(" t=\"b\"><v>");
+                        builder.Append(boolValue ? "1" : "0");
+                        builder.Append("</v></c>");
+                        return;
+                    case DateTime dateTime:
+                        text = dateTime.ToOADate().ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case DateTimeOffset dateTimeOffset:
+                        text = dateTimeOffset.LocalDateTime.ToOADate().ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case TimeSpan timeSpan:
+                        text = timeSpan.TotalDays.ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case IFormattable formattable:
+                        text = formattable.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty;
+                        break;
+                    default:
+                        builder.Append(" t=\"str\"><v>");
+                        AppendEscaped(builder, Utilities.ExcelSanitizer.SanitizeString(value.ToString() ?? string.Empty));
+                        builder.Append("</v></c>");
+                        return;
+                }
+
+                builder.Append("><v>");
+                AppendEscaped(builder, text);
+                builder.Append("</v></c>");
+            }
+
+            private static void WriteTextEntry(ZipArchive archive, string path, string text) {
+                var entry = archive.CreateEntry(path, CompressionLevel.Fastest);
+                using var stream = entry.Open();
+                using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                writer.Write(text);
+            }
+
+            private static void AppendEscaped(StringBuilder builder, string value) {
+                foreach (char ch in value) {
+                    switch (ch) {
+                        case '&':
+                            builder.Append("&amp;");
+                            break;
+                        case '<':
+                            builder.Append("&lt;");
+                            break;
+                        case '>':
+                            builder.Append("&gt;");
+                            break;
+                        case '"':
+                            builder.Append("&quot;");
+                            break;
+                        case '\'':
+                            builder.Append("&apos;");
+                            break;
+                        default:
+                            builder.Append(ch);
+                            break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
@@ -20,6 +20,7 @@ namespace OfficeIMO.Excel {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (!stream.CanWrite) throw new ArgumentException("The destination stream must be writable.", nameof(stream));
             if (dataSet == null) throw new ArgumentNullException(nameof(dataSet));
+            if (dataSet.Tables.Count == 0) throw new ArgumentException("The DataSet must contain at least one DataTable.", nameof(dataSet));
 
             var model = DirectDataSetWorkbookModel.Create(dataSet, tableStyle, includeHeaders, includeAutoFilter, ct);
             if (stream.CanSeek) {

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
@@ -353,6 +353,10 @@ namespace OfficeIMO.Excel {
             private static uint? GetStyleIndex(Type dataType) {
                 if (dataType == typeof(DateTime) || dataType == typeof(DateTimeOffset)) return 1U;
                 if (dataType == typeof(TimeSpan)) return 2U;
+#if NET6_0_OR_GREATER
+                if (dataType == typeof(DateOnly)) return 1U;
+                if (dataType == typeof(TimeOnly)) return 2U;
+#endif
                 return null;
             }
 
@@ -384,7 +388,11 @@ namespace OfficeIMO.Excel {
                         text = dateTime.ToOADate().ToString(CultureInfo.InvariantCulture);
                         break;
                     case DateTimeOffset dateTimeOffset:
-                        text = dateTimeOffset.LocalDateTime.ToOADate().ToString(CultureInfo.InvariantCulture);
+                        if (!TryFormatDateTimeOffsetSerial(dateTimeOffset, out text)) {
+                            AppendStringCell(builder, dateTimeOffset.ToString("o", CultureInfo.InvariantCulture));
+                            return;
+                        }
+
                         break;
                     case TimeSpan timeSpan:
                         text = timeSpan.TotalDays.ToString(CultureInfo.InvariantCulture);
@@ -438,6 +446,25 @@ namespace OfficeIMO.Excel {
                 builder.Append("><v>");
                 AppendEscaped(builder, text);
                 builder.Append("</v></c>");
+            }
+
+            private static bool TryFormatDateTimeOffsetSerial(DateTimeOffset value, out string text) {
+                try {
+                    var excelEpoch = DateTime.FromOADate(0);
+                    if (value.UtcDateTime < excelEpoch) {
+                        text = string.Empty;
+                        return false;
+                    }
+
+                    text = value.LocalDateTime.ToOADate().ToString(CultureInfo.InvariantCulture);
+                    return true;
+                } catch (ArgumentException) {
+                    text = string.Empty;
+                    return false;
+                } catch (OverflowException) {
+                    text = string.Empty;
+                    return false;
+                }
             }
 
             private static void AppendStringCell(StringBuilder builder, string text) {

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
@@ -64,6 +64,7 @@ namespace OfficeIMO.Excel {
                     string sheetName = GetUniqueName(SanitizeSheetName(requestedName), usedSheetNames, 31);
                     string tableName = GetUniqueName(SanitizeTableName(requestedName), usedTableNames, 255);
                     int rowCount = table.Rows.Count + (includeHeaders ? 1 : 0);
+                    ValidateWorksheetBounds(table, rowCount);
                     string range = table.Columns.Count == 0 || rowCount == 0
                         ? string.Empty
                         : "A1:" + A1.CellReference(rowCount, table.Columns.Count);
@@ -75,6 +76,16 @@ namespace OfficeIMO.Excel {
                 }
 
                 return new DirectDataSetWorkbookModel(sheets, results);
+            }
+
+            private static void ValidateWorksheetBounds(DataTable table, int rowCount) {
+                if (table.Columns.Count > A1.MaxColumns) {
+                    throw new ArgumentException($"DataTable '{table.TableName}' has {table.Columns.Count.ToString(CultureInfo.InvariantCulture)} columns, exceeding Excel's maximum of {A1.MaxColumns.ToString(CultureInfo.InvariantCulture)} columns.", nameof(table));
+                }
+
+                if (rowCount > A1.MaxRows) {
+                    throw new ArgumentException($"DataTable '{table.TableName}' has {rowCount.ToString(CultureInfo.InvariantCulture)} worksheet rows including headers, exceeding Excel's maximum of {A1.MaxRows.ToString(CultureInfo.InvariantCulture)} rows.", nameof(table));
+                }
             }
 
             private static string GetUniqueName(string baseName, HashSet<string> used, int maxLength) {

--- a/OfficeIMO.Excel/ExcelDocument.FastPackage.cs
+++ b/OfficeIMO.Excel/ExcelDocument.FastPackage.cs
@@ -104,6 +104,10 @@ namespace OfficeIMO.Excel {
                     return false;
                 }
 
+                if (workbookPart.Workbook.ChildElements.Any(child => child is not DocumentFormat.OpenXml.Spreadsheet.Sheets)) {
+                    return false;
+                }
+
                 if (workbookPart.GetPartsOfType<ThemePart>().Any()) {
                     return false;
                 }
@@ -113,6 +117,10 @@ namespace OfficeIMO.Excel {
                 int tableIndex = 1;
                 for (int sheetIndex = 0; sheetIndex < sheets.Count; sheetIndex++) {
                     var sheet = sheets[sheetIndex];
+                    if (sheet.State != null) {
+                        return false;
+                    }
+
                     if (workbookPart.GetPartById(sheet.Id!) is not WorksheetPart worksheetPart) {
                         return false;
                     }
@@ -147,13 +155,16 @@ namespace OfficeIMO.Excel {
 
                 var sharedStrings = workbookPart.SharedStringTablePart?.SharedStringTable?
                     .Elements<SharedStringItem>()
-                    .Select(item => item.InnerText ?? string.Empty)
+                    .Select(item => item.HasChildren && item.Elements<Run>().Any() ? null : item.InnerText ?? string.Empty)
                     .ToList();
+                if (sharedStrings != null && sharedStrings.Any(item => item == null)) {
+                    return false;
+                }
 
                 model = new FastWorkbookPackageModel(
                     worksheets,
                     workbookPart.WorkbookStylesPart?.Stylesheet,
-                    sharedStrings,
+                    sharedStrings!,
                     tables);
                 return true;
             }

--- a/OfficeIMO.Excel/ExcelDocument.FastPackage.cs
+++ b/OfficeIMO.Excel/ExcelDocument.FastPackage.cs
@@ -1,0 +1,612 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using System.Globalization;
+using System.IO.Compression;
+using System.Xml;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        private bool TryWriteSimpleWorkbookPackage(Stream destination) {
+            if (destination == null || !destination.CanWrite || !destination.CanSeek) {
+                return false;
+            }
+
+            if (!FastWorkbookPackageModel.TryCreate(_spreadSheetDocument, out var model)) {
+                return false;
+            }
+
+            PrepareDestinationStreamForWrite(destination);
+            FastWorkbookPackageWriter.Write(destination, model);
+
+            destination.Flush();
+            destination.Seek(0, SeekOrigin.Begin);
+            _packageDirty = false;
+            _packagePropertiesDirty = false;
+            _requiresSavePreflight = false;
+            _unchangedPackageBytes = null;
+            return true;
+        }
+
+        private static class FastWorkbookPackageWriter {
+            internal static void Write(Stream destination, FastWorkbookPackageModel model) {
+                using (var archive = new ZipArchive(destination, ZipArchiveMode.Create, leaveOpen: true)) {
+                    WriteContentTypesEntry(archive, model.HasStyles, model.Worksheets.Count, model.Tables.Count);
+                    WriteTextEntry(archive, "_rels/.rels",
+                        "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                        "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
+                        "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>" +
+                        "</Relationships>");
+                    WriteWorkbookEntry(archive, model.Worksheets);
+                    WriteWorkbookRelationshipsEntry(archive, model.Worksheets, model.HasStyles);
+                    if (model.Stylesheet != null) {
+                        WriteTextEntry(archive, "xl/styles.xml", "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + model.Stylesheet.OuterXml);
+                    }
+
+                    foreach (var worksheet in model.Worksheets) {
+                        WriteWorksheetEntry(archive, worksheet, model.SharedStrings);
+                        if (worksheet.TablePartPaths.Count > 0) {
+                            WriteWorksheetRelationshipsEntry(archive, worksheet.RelationshipsPath, worksheet.TablePartPaths);
+                        }
+                    }
+
+                    for (int i = 0; i < model.Tables.Count; i++) {
+                        WriteTextEntry(
+                            archive,
+                            string.Format(CultureInfo.InvariantCulture, "xl/tables/table{0}.xml", i + 1),
+                            "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + model.Tables[i].OuterXml);
+                    }
+                }
+            }
+        }
+
+        private sealed class FastWorkbookPackageModel {
+            private FastWorkbookPackageModel(
+                IReadOnlyList<FastWorksheetPackageModel> worksheets,
+                Stylesheet? stylesheet,
+                IReadOnlyList<string>? sharedStrings,
+                IReadOnlyList<Table> tables) {
+                Worksheets = worksheets;
+                Stylesheet = stylesheet;
+                SharedStrings = sharedStrings;
+                Tables = tables;
+            }
+
+            internal IReadOnlyList<FastWorksheetPackageModel> Worksheets { get; }
+
+            internal Stylesheet? Stylesheet { get; }
+
+            internal bool HasStyles => Stylesheet != null;
+
+            internal IReadOnlyList<string>? SharedStrings { get; }
+
+            internal IReadOnlyList<Table> Tables { get; }
+
+            internal static bool TryCreate(SpreadsheetDocument document, out FastWorkbookPackageModel model) {
+                model = null!;
+
+                var workbookPart = document.WorkbookPart;
+                if (workbookPart?.Workbook?.Sheets == null) {
+                    return false;
+                }
+
+                var sheets = workbookPart.Workbook.Sheets.OfType<Sheet>().ToList();
+                if (sheets.Count == 0 || sheets.Any(sheet => sheet.Id == null)) {
+                    return false;
+                }
+
+                if (workbookPart.Workbook.Descendants<DefinedName>().Any()
+                    || workbookPart.CalculationChainPart != null) {
+                    return false;
+                }
+
+                if (workbookPart.GetPartsOfType<ThemePart>().Any()) {
+                    return false;
+                }
+
+                var worksheets = new List<FastWorksheetPackageModel>(sheets.Count);
+                var tables = new List<Table>();
+                int tableIndex = 1;
+                for (int sheetIndex = 0; sheetIndex < sheets.Count; sheetIndex++) {
+                    var sheet = sheets[sheetIndex];
+                    if (workbookPart.GetPartById(sheet.Id!) is not WorksheetPart worksheetPart) {
+                        return false;
+                    }
+
+                    var worksheet = worksheetPart.Worksheet;
+                    if (worksheet == null || !CanWriteWorksheet(worksheetPart, worksheet)) {
+                        return false;
+                    }
+
+                    var tablePartPaths = new Dictionary<string, string>(StringComparer.Ordinal);
+                    foreach (var tableDefinition in worksheetPart.TableDefinitionParts) {
+                        var table = tableDefinition.Table;
+                        if (table == null) {
+                            return false;
+                        }
+
+                        tables.Add(table);
+                        string relId = worksheetPart.GetIdOfPart(tableDefinition);
+                        tablePartPaths[relId] = string.Format(CultureInfo.InvariantCulture, "../tables/table{0}.xml", tableIndex);
+                        tableIndex++;
+                    }
+
+                    worksheets.Add(new FastWorksheetPackageModel(
+                        sheet.Name?.Value ?? "Sheet" + (sheetIndex + 1).ToString(CultureInfo.InvariantCulture),
+                        sheet.SheetId?.Value ?? (uint)(sheetIndex + 1),
+                        "rId" + (sheetIndex + 1).ToString(CultureInfo.InvariantCulture),
+                        string.Format(CultureInfo.InvariantCulture, "xl/worksheets/sheet{0}.xml", sheetIndex + 1),
+                        string.Format(CultureInfo.InvariantCulture, "xl/worksheets/_rels/sheet{0}.xml.rels", sheetIndex + 1),
+                        worksheet,
+                        tablePartPaths));
+                }
+
+                var sharedStrings = workbookPart.SharedStringTablePart?.SharedStringTable?
+                    .Elements<SharedStringItem>()
+                    .Select(item => item.InnerText ?? string.Empty)
+                    .ToList();
+
+                model = new FastWorkbookPackageModel(
+                    worksheets,
+                    workbookPart.WorkbookStylesPart?.Stylesheet,
+                    sharedStrings,
+                    tables);
+                return true;
+            }
+
+            private static bool CanWriteWorksheet(WorksheetPart worksheetPart, Worksheet worksheet) {
+                return CanWriteSimpleWorksheet(worksheetPart, worksheet);
+            }
+        }
+
+        private sealed class FastWorksheetPackageModel {
+            internal FastWorksheetPackageModel(
+                string sheetName,
+                uint sheetId,
+                string workbookRelationshipId,
+                string worksheetPath,
+                string relationshipsPath,
+                Worksheet worksheet,
+                IReadOnlyDictionary<string, string> tablePartPaths) {
+                SheetName = sheetName;
+                SheetId = sheetId;
+                WorkbookRelationshipId = workbookRelationshipId;
+                WorksheetPath = worksheetPath;
+                RelationshipsPath = relationshipsPath;
+                Worksheet = worksheet;
+                TablePartPaths = tablePartPaths;
+            }
+
+            internal string SheetName { get; }
+
+            internal uint SheetId { get; }
+
+            internal string WorkbookRelationshipId { get; }
+
+            internal string WorksheetPath { get; }
+
+            internal string RelationshipsPath { get; }
+
+            internal Worksheet Worksheet { get; }
+
+            internal IReadOnlyDictionary<string, string> TablePartPaths { get; }
+        }
+
+        private static bool CanWriteSimpleWorksheet(WorksheetPart worksheetPart, Worksheet worksheet) {
+            if (worksheetPart.DrawingsPart != null
+                || worksheetPart.WorksheetCommentsPart != null
+                || worksheetPart.HyperlinkRelationships.Any()
+                || worksheetPart.ExternalRelationships.Any()) {
+                return false;
+            }
+
+            foreach (var child in worksheet.ChildElements) {
+                if (child is not SheetProperties
+                    && child is not SheetDimension
+                    && child is not SheetViews
+                    && child is not SheetFormatProperties
+                    && child is not Columns
+                    && child is not SheetData
+                    && child is not SheetProtection
+                    && child is not AutoFilter
+                    && child is not SortState
+                    && child is not MergeCells
+                    && child is not DocumentFormat.OpenXml.Spreadsheet.ConditionalFormatting
+                    && child is not DataValidations
+                    && child is not TableParts) {
+                    return false;
+                }
+
+                if (child.Descendants<DocumentFormat.OpenXml.OpenXmlUnknownElement>().Any()) {
+                    return false;
+                }
+            }
+
+            var tableParts = worksheet.Elements<TableParts>().ToList();
+            if (tableParts.Count > 1) {
+                return false;
+            }
+
+            var tableDefinitionParts = worksheetPart.TableDefinitionParts.ToList();
+            var relationshipIds = new HashSet<string>(tableDefinitionParts.Select(worksheetPart.GetIdOfPart), StringComparer.Ordinal);
+            var worksheetTablePartIds = tableParts.Count == 0
+                ? new List<string>()
+                : tableParts[0].Elements<TablePart>()
+                    .Select(part => part.Id?.Value)
+                    .Where(id => !string.IsNullOrEmpty(id))
+                    .Select(id => id!)
+                    .ToList();
+
+            if (worksheetTablePartIds.Count != tableDefinitionParts.Count
+                || worksheetTablePartIds.Any(id => !relationshipIds.Contains(id))) {
+                return false;
+            }
+
+            foreach (var tableDefinitionPart in tableDefinitionParts) {
+                var table = tableDefinitionPart.Table;
+                if (table == null
+                    || table.Reference == null
+                    || table.TableColumns == null
+                    || table.Descendants<DocumentFormat.OpenXml.OpenXmlUnknownElement>().Any()) {
+                    return false;
+                }
+            }
+
+            var sheetData = worksheet.GetFirstChild<SheetData>();
+            if (sheetData == null) {
+                return true;
+            }
+
+            foreach (var row in sheetData.Elements<Row>()) {
+                if (row.CustomFormat?.Value == true || row.StyleIndex != null) {
+                    return false;
+                }
+
+                foreach (var cell in row.Elements<Cell>()) {
+                    if (cell.CellFormula != null || cell.InlineString != null) {
+                        return false;
+                    }
+
+                    var dataType = cell.DataType?.Value;
+                    if (dataType != null
+                        && dataType != CellValues.Number
+                        && dataType != CellValues.SharedString
+                        && dataType != CellValues.String
+                        && dataType != CellValues.Boolean) {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private static void WriteContentTypesEntry(ZipArchive archive, bool hasStyles, int worksheetCount, int tableCount) {
+            var builder = new System.Text.StringBuilder(512 + worksheetCount * 160 + tableCount * 160);
+            builder.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+            builder.Append("<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">");
+            builder.Append("<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>");
+            builder.Append("<Default Extension=\"xml\" ContentType=\"application/xml\"/>");
+            builder.Append("<Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>");
+            for (int i = 1; i <= worksheetCount; i++) {
+                builder.Append("<Override PartName=\"/xl/worksheets/sheet");
+                builder.Append(i.ToString(CultureInfo.InvariantCulture));
+                builder.Append(".xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>");
+            }
+
+            if (hasStyles) {
+                builder.Append("<Override PartName=\"/xl/styles.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\"/>");
+            }
+
+            for (int i = 1; i <= tableCount; i++) {
+                builder.Append("<Override PartName=\"/xl/tables/table");
+                builder.Append(i.ToString(CultureInfo.InvariantCulture));
+                builder.Append(".xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml\"/>");
+            }
+
+            builder.Append("</Types>");
+            WriteTextEntry(archive, "[Content_Types].xml", builder.ToString());
+        }
+
+        private static void WriteWorkbookEntry(ZipArchive archive, IReadOnlyList<FastWorksheetPackageModel> worksheets) {
+            var entry = archive.CreateEntry("xl/workbook.xml", CompressionLevel.Fastest);
+            using var stream = entry.Open();
+            using var writer = CreateFastXmlWriter(stream);
+            writer.WriteStartDocument();
+            writer.WriteStartElement("workbook", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+            writer.WriteAttributeString("xmlns", "r", null, "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+            writer.WriteStartElement("sheets");
+            foreach (var worksheet in worksheets) {
+                writer.WriteStartElement("sheet");
+                writer.WriteAttributeString("name", worksheet.SheetName);
+                writer.WriteAttributeString("sheetId", worksheet.SheetId.ToString(CultureInfo.InvariantCulture));
+                writer.WriteAttributeString("r", "id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships", worksheet.WorkbookRelationshipId);
+                writer.WriteEndElement();
+            }
+
+            writer.WriteEndElement();
+            writer.WriteEndElement();
+        }
+
+        private static void WriteWorkbookRelationshipsEntry(ZipArchive archive, IReadOnlyList<FastWorksheetPackageModel> worksheets, bool hasStyles) {
+            var builder = new System.Text.StringBuilder(384 + worksheets.Count * 180);
+            builder.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+            builder.Append("<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">");
+            foreach (var worksheet in worksheets) {
+                builder.Append("<Relationship Id=\"");
+                AppendXmlEscaped(builder, worksheet.WorkbookRelationshipId);
+                builder.Append("\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"");
+                AppendXmlEscaped(builder, worksheet.WorksheetPath.Substring("xl/".Length));
+                builder.Append("\"/>");
+            }
+
+            if (hasStyles) {
+                builder.Append("<Relationship Id=\"rId");
+                builder.Append((worksheets.Count + 1).ToString(CultureInfo.InvariantCulture));
+                builder.Append("\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\" Target=\"styles.xml\"/>");
+            }
+
+            builder.Append("</Relationships>");
+            WriteTextEntry(archive, "xl/_rels/workbook.xml.rels", builder.ToString());
+        }
+
+        private static void WriteWorksheetRelationshipsEntry(ZipArchive archive, string relationshipsPath, IReadOnlyDictionary<string, string> tablePartPaths) {
+            var builder = new System.Text.StringBuilder(160 + tablePartPaths.Count * 180);
+            builder.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+            builder.Append("<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">");
+            foreach (var item in tablePartPaths.OrderBy(static item => item.Key, StringComparer.Ordinal)) {
+                builder.Append("<Relationship Id=\"");
+                AppendXmlEscaped(builder, item.Key);
+                builder.Append("\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/table\" Target=\"");
+                AppendXmlEscaped(builder, item.Value);
+                builder.Append("\"/>");
+            }
+
+            builder.Append("</Relationships>");
+            WriteTextEntry(archive, relationshipsPath, builder.ToString());
+        }
+
+        private static void WriteWorksheetEntry(ZipArchive archive, FastWorksheetPackageModel model, IReadOnlyList<string>? sharedStrings) {
+            var entry = archive.CreateEntry(model.WorksheetPath, CompressionLevel.Fastest);
+            var worksheet = model.Worksheet;
+            string dimension = worksheet.SheetDimension?.Reference?.Value ?? ExcelSheet.ComputeSheetDimensionReference(worksheet);
+            var builder = new System.Text.StringBuilder(4096);
+            builder.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+            builder.Append("<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"");
+            if (model.TablePartPaths.Count > 0) {
+                builder.Append(" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"");
+            }
+
+            builder.Append(">");
+            AppendOptionalElement(builder, worksheet.GetFirstChild<SheetProperties>());
+
+            builder.Append("<dimension ref=\"");
+            AppendXmlEscaped(builder, dimension);
+            builder.Append("\"/>");
+
+            AppendOptionalElement(builder, worksheet.GetFirstChild<SheetViews>());
+            AppendOptionalElement(builder, worksheet.GetFirstChild<SheetFormatProperties>());
+
+            var columns = worksheet.GetFirstChild<Columns>();
+            if (columns != null) {
+                AppendColumns(builder, columns);
+            }
+
+            builder.Append("<sheetData>");
+
+            var sheetData = worksheet.GetFirstChild<SheetData>();
+            if (sheetData != null) {
+                foreach (var row in sheetData.Elements<Row>()) {
+                    builder.Append("<row");
+                    if (row.RowIndex != null) {
+                        builder.Append(" r=\"");
+                        builder.Append(row.RowIndex.Value.ToString(CultureInfo.InvariantCulture));
+                        builder.Append('"');
+                    }
+
+                    builder.Append('>');
+
+                    foreach (var cell in row.Elements<Cell>()) {
+                        AppendSimpleCell(builder, cell, sharedStrings);
+                    }
+
+                    builder.Append("</row>");
+                }
+            }
+
+            builder.Append("</sheetData>");
+            AppendOptionalElement(builder, worksheet.GetFirstChild<SheetProtection>());
+
+            var autoFilter = worksheet.GetFirstChild<AutoFilter>();
+            if (autoFilter != null) {
+                builder.Append(autoFilter.OuterXml);
+            }
+
+            AppendOptionalElement(builder, worksheet.GetFirstChild<SortState>());
+            AppendOptionalElement(builder, worksheet.GetFirstChild<MergeCells>());
+            AppendOptionalElements<DocumentFormat.OpenXml.Spreadsheet.ConditionalFormatting>(builder, worksheet);
+            AppendOptionalElement(builder, worksheet.GetFirstChild<DataValidations>());
+
+            var tableParts = worksheet.GetFirstChild<TableParts>();
+            if (tableParts != null && model.TablePartPaths.Count > 0) {
+                builder.Append("<tableParts count=\"");
+                builder.Append(model.TablePartPaths.Count.ToString(CultureInfo.InvariantCulture));
+                builder.Append("\">");
+                foreach (var tablePart in tableParts.Elements<TablePart>()) {
+                    string? id = tablePart.Id?.Value;
+                    if (id == null || !model.TablePartPaths.ContainsKey(id)) {
+                        continue;
+                    }
+
+                    builder.Append("<tablePart r:id=\"");
+                    AppendXmlEscaped(builder, id);
+                    builder.Append("\"/>");
+                }
+
+                builder.Append("</tableParts>");
+            }
+
+            builder.Append("</worksheet>");
+            using var stream = entry.Open();
+            using var writer = new StreamWriter(stream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            writer.Write(builder.ToString());
+        }
+
+        private static void AppendOptionalElement(System.Text.StringBuilder builder, OpenXmlElement? element) {
+            if (element != null) {
+                builder.Append(element.OuterXml);
+            }
+        }
+
+        private static void AppendOptionalElements<TElement>(System.Text.StringBuilder builder, OpenXmlElement parent)
+            where TElement : OpenXmlElement {
+            foreach (var element in parent.Elements<TElement>()) {
+                builder.Append(element.OuterXml);
+            }
+        }
+
+        private static void AppendColumns(System.Text.StringBuilder builder, Columns columns) {
+            builder.Append("<cols>");
+            foreach (var column in columns.Elements<Column>()) {
+                builder.Append("<col");
+                AppendUIntAttribute(builder, "min", column.Min);
+                AppendUIntAttribute(builder, "max", column.Max);
+                if (column.Width != null) {
+                    builder.Append(" width=\"");
+                    builder.Append(column.Width.Value.ToString(CultureInfo.InvariantCulture));
+                    builder.Append('"');
+                }
+
+                AppendBooleanAttribute(builder, "bestFit", column.BestFit);
+                AppendBooleanAttribute(builder, "customWidth", column.CustomWidth);
+                AppendBooleanAttribute(builder, "hidden", column.Hidden);
+                AppendUIntAttribute(builder, "style", column.Style);
+                AppendByteAttribute(builder, "outlineLevel", column.OutlineLevel);
+                AppendBooleanAttribute(builder, "collapsed", column.Collapsed);
+                builder.Append("/>");
+            }
+
+            builder.Append("</cols>");
+        }
+
+        private static void AppendSimpleCell(System.Text.StringBuilder builder, Cell cell, IReadOnlyList<string>? sharedStrings) {
+            string? text = cell.CellValue?.Text;
+            var dataType = cell.DataType?.Value;
+            if (dataType == CellValues.SharedString) {
+                text = TryResolveSharedString(text, sharedStrings);
+                dataType = CellValues.String;
+            }
+
+            builder.Append("<c");
+            if (cell.CellReference != null) {
+                builder.Append(" r=\"");
+                AppendXmlEscaped(builder, cell.CellReference.Value ?? string.Empty);
+                builder.Append('"');
+            }
+
+            if (cell.StyleIndex != null) {
+                builder.Append(" s=\"");
+                builder.Append(cell.StyleIndex.Value.ToString(CultureInfo.InvariantCulture));
+                builder.Append('"');
+            }
+
+            if (dataType == CellValues.String) {
+                builder.Append(" t=\"str\"");
+            } else if (dataType == CellValues.Boolean) {
+                builder.Append(" t=\"b\"");
+            }
+
+            builder.Append("><v>");
+            AppendXmlEscaped(builder, text ?? string.Empty);
+            builder.Append("</v></c>");
+        }
+
+        private static string TryResolveSharedString(string? rawIndex, IReadOnlyList<string>? sharedStrings) {
+            if (sharedStrings != null
+                && int.TryParse(rawIndex, NumberStyles.Integer, CultureInfo.InvariantCulture, out int index)
+                && index >= 0
+                && index < sharedStrings.Count) {
+                return sharedStrings[index];
+            }
+
+            return rawIndex ?? string.Empty;
+        }
+
+        private static void WriteTextEntry(ZipArchive archive, string path, string text) {
+            var entry = archive.CreateEntry(path, CompressionLevel.Fastest);
+            using var stream = entry.Open();
+            using var writer = new StreamWriter(stream, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            writer.Write(text);
+        }
+
+        private static void AppendUIntAttribute(System.Text.StringBuilder builder, string name, UInt32Value? value) {
+            if (value == null) {
+                return;
+            }
+
+            builder.Append(' ');
+            builder.Append(name);
+            builder.Append("=\"");
+            builder.Append(value.Value.ToString(CultureInfo.InvariantCulture));
+            builder.Append('"');
+        }
+
+        private static void AppendByteAttribute(System.Text.StringBuilder builder, string name, ByteValue? value) {
+            if (value == null) {
+                return;
+            }
+
+            builder.Append(' ');
+            builder.Append(name);
+            builder.Append("=\"");
+            builder.Append(value.Value.ToString(CultureInfo.InvariantCulture));
+            builder.Append('"');
+        }
+
+        private static void AppendBooleanAttribute(System.Text.StringBuilder builder, string name, BooleanValue? value) {
+            if (value == null) {
+                return;
+            }
+
+            builder.Append(' ');
+            builder.Append(name);
+            builder.Append("=\"");
+            builder.Append(value.Value ? '1' : '0');
+            builder.Append('"');
+        }
+
+        private static XmlWriter CreateFastXmlWriter(Stream stream) =>
+            XmlWriter.Create(stream, new XmlWriterSettings {
+                Encoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                CloseOutput = false,
+                Indent = false,
+                OmitXmlDeclaration = false
+            });
+
+        private static void AppendXmlEscaped(System.Text.StringBuilder builder, string text) {
+            for (int i = 0; i < text.Length; i++) {
+                char ch = text[i];
+                switch (ch) {
+                    case '&':
+                        builder.Append("&amp;");
+                        break;
+                    case '<':
+                        builder.Append("&lt;");
+                        break;
+                    case '>':
+                        builder.Append("&gt;");
+                        break;
+                    case '"':
+                        builder.Append("&quot;");
+                        break;
+                    case '\'':
+                        builder.Append("&apos;");
+                        break;
+                    default:
+                        builder.Append(ch);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.FastPackage.cs
+++ b/OfficeIMO.Excel/ExcelDocument.FastPackage.cs
@@ -12,6 +12,10 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
+            if (_packagePropertiesDirty || _unchangedPackageBytes != null || HasCalculationSaveWork()) {
+                return false;
+            }
+
             if (!FastWorkbookPackageModel.TryCreate(_spreadSheetDocument, out var model)) {
                 return false;
             }
@@ -258,7 +262,7 @@ namespace OfficeIMO.Excel {
             }
 
             foreach (var row in sheetData.Elements<Row>()) {
-                if (row.CustomFormat?.Value == true || row.StyleIndex != null) {
+                if (!IsSimpleRow(row)) {
                     return false;
                 }
 
@@ -279,6 +283,16 @@ namespace OfficeIMO.Excel {
             }
 
             return true;
+        }
+
+        private static bool IsSimpleRow(Row row) {
+            foreach (var attribute in row.GetAttributes()) {
+                if (!string.Equals(attribute.LocalName, "r", StringComparison.Ordinal)) {
+                    return false;
+                }
+            }
+
+            return row.CustomFormat?.Value != true && row.StyleIndex == null;
         }
 
         private static void WriteContentTypesEntry(ZipArchive archive, bool hasStyles, int worksheetCount, int tableCount) {

--- a/OfficeIMO.Excel/ExcelDocument.FastPackage.cs
+++ b/OfficeIMO.Excel/ExcelDocument.FastPackage.cs
@@ -508,6 +508,7 @@ namespace OfficeIMO.Excel {
                 AppendUIntAttribute(builder, "style", column.Style);
                 AppendByteAttribute(builder, "outlineLevel", column.OutlineLevel);
                 AppendBooleanAttribute(builder, "collapsed", column.Collapsed);
+                AppendBooleanAttribute(builder, "phonetic", column.Phonetic);
                 builder.Append("/>");
             }
 

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -1266,7 +1266,7 @@ namespace OfficeIMO.Excel {
         /// Closes the underlying spreadsheet document.
         /// </summary>
         public void Close() {
-            this._spreadSheetDocument.Dispose();
+            Dispose();
         }
 
         private static void EnsureDirectoryWritable(string path) {

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -663,7 +663,7 @@ namespace OfficeIMO.Excel {
             document._copyPackageToSourceOnDispose = copyPackageToSourceOnDispose && sourceStream != null;
             document._copyPackageToFilePathOnDispose = copyPackageToFilePathOnDispose && packageStream != null && !string.IsNullOrEmpty(filePath);
             document._leaveSourceStreamOpen = leaveSourceStreamOpen;
-            document._packageContentTypesKnownNormalized = true;
+            document._packageContentTypesKnownNormalized = false;
             document._requiresSavePreflight = true;
             document._packageDirty = true;
             document._packagePropertiesDirty = false;

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -166,6 +166,7 @@ namespace OfficeIMO.Excel {
         {
             _sheetCacheDirty = true;
             _cachedSheets = null;
+            MarkPackageDirty();
         }
 
         private List<Sheet> ReadSheetElements()

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -307,8 +307,30 @@ namespace OfficeIMO.Excel {
         private bool _copyPackageToSourceOnDispose;
         private bool _copyPackageToFilePathOnDispose;
         private bool _leaveSourceStreamOpen = true;
+        private bool _packageContentTypesKnownNormalized;
+        private bool _requiresSavePreflight;
+        private bool _packageDirty = true;
+        private bool _packagePropertiesDirty;
+        private byte[]? _unchangedPackageBytes;
 
         private const int StreamCopyBufferSize = 81920;
+
+        internal void MarkRequiresSavePreflight() {
+            _requiresSavePreflight = true;
+            MarkPackageDirty();
+        }
+
+        internal void MarkPackageDirty() {
+            _packageDirty = true;
+            _unchangedPackageBytes = null;
+        }
+
+        internal void MarkPackagePropertiesDirty() {
+            _packagePropertiesDirty = true;
+            MarkPackageDirty();
+        }
+
+        internal bool IsPackageDirty => _packageDirty;
 
         private static async Task<byte[]> ReadAllBytesCompatAsync(string path, CancellationToken ct) {
 #if NETSTANDARD2_0 || NET472 || NET48
@@ -516,6 +538,7 @@ namespace OfficeIMO.Excel {
                 int newIndex = sharedStringTable.Elements<SharedStringItem>().Count();
                 sharedStringTable.AppendChild(new SharedStringItem(new Text(text)));
                 _sharedStringTableDirty = true;
+                MarkPackageDirty();
                 _sharedStringCache[text] = newIndex;
 
                 return newIndex;
@@ -562,8 +585,8 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (changed) {
-                    sharedStringTable.Save();
-                    _sharedStringTableDirty = false;
+                    _sharedStringTableDirty = true;
+                    MarkPackageDirty();
                 }
 
                 return result;
@@ -610,7 +633,7 @@ namespace OfficeIMO.Excel {
                 ? new NonDisposingMemoryStream(StreamBufferSize)
                 : new MemoryStream(StreamBufferSize);
 
-            var spreadSheetDocument = SpreadsheetDocument.Create(packageStream, SpreadsheetDocumentType.Workbook, true);
+            var spreadSheetDocument = SpreadsheetDocument.Create(packageStream, SpreadsheetDocumentType.Workbook, false);
             return CreateNewDocument(spreadSheetDocument, filePath: null, packageStream, stream, autoSave, leaveSourceStreamOpen: true);
         }
 
@@ -640,6 +663,11 @@ namespace OfficeIMO.Excel {
             document._copyPackageToSourceOnDispose = copyPackageToSourceOnDispose && sourceStream != null;
             document._copyPackageToFilePathOnDispose = copyPackageToFilePathOnDispose && packageStream != null && !string.IsNullOrEmpty(filePath);
             document._leaveSourceStreamOpen = leaveSourceStreamOpen;
+            document._packageContentTypesKnownNormalized = true;
+            document._requiresSavePreflight = true;
+            document._packageDirty = true;
+            document._packagePropertiesDirty = false;
+            document._unchangedPackageBytes = null;
 
             // Initialize document property helpers
             document.BuiltinDocumentProperties = new BuiltinDocumentProperties(document);
@@ -655,7 +683,9 @@ namespace OfficeIMO.Excel {
             bool copyPackageToSourceOnDispose = false,
             bool leaveSourceStreamOpen = true,
             bool copyPackageToFilePathOnDispose = false,
-            Stream? ownedOpenStream = null) {
+            Stream? ownedOpenStream = null,
+            bool packageContentTypesKnownNormalized = false,
+            byte[]? unchangedPackageBytes = null) {
             bool keepPackageStream = copyPackageToSourceOnDispose || copyPackageToFilePathOnDispose;
             var document = new ExcelDocument {
                 FilePath = filePath ?? string.Empty,
@@ -667,6 +697,11 @@ namespace OfficeIMO.Excel {
                 _copyPackageToSourceOnDispose = copyPackageToSourceOnDispose && sourceStream != null,
                 _copyPackageToFilePathOnDispose = copyPackageToFilePathOnDispose && packageStream != null && !string.IsNullOrEmpty(filePath),
                 _leaveSourceStreamOpen = leaveSourceStreamOpen,
+                _packageContentTypesKnownNormalized = packageContentTypesKnownNormalized,
+                _requiresSavePreflight = false,
+                _packageDirty = false,
+                _packagePropertiesDirty = false,
+                _unchangedPackageBytes = packageContentTypesKnownNormalized ? unchangedPackageBytes : null,
             };
 
             document.BuiltinDocumentProperties = new BuiltinDocumentProperties(document);
@@ -718,8 +753,9 @@ namespace OfficeIMO.Excel {
                 normalizedStream.Write(bytes, 0, bytes.Length);
                 normalizedStream.Position = 0;
 
-                Utilities.ExcelPackageUtilities.NormalizeContentTypes(normalizedStream, leaveOpen: true);
+                bool normalizedContentTypes = Utilities.ExcelPackageUtilities.NormalizeContentTypes(normalizedStream, leaveOpen: true);
                 normalizedStream.Position = 0;
+                byte[] unchangedPackageBytes = normalizedContentTypes ? normalizedStream.ToArray() : bytes;
 
                 var memDoc = SpreadsheetDocument.Open(normalizedStream, !readOnly, effectiveOpenSettings);
                 return CreateDocument(
@@ -729,7 +765,9 @@ namespace OfficeIMO.Excel {
                     shouldCopyBack ? originalStream : null,
                     shouldCopyBack,
                     leaveOriginalStreamOpen,
-                    copyPackageToFilePathOnDispose: shouldCopyBackToFilePath);
+                    copyPackageToFilePathOnDispose: shouldCopyBackToFilePath,
+                    packageContentTypesKnownNormalized: true,
+                    unchangedPackageBytes: unchangedPackageBytes);
             } catch (Exception ex) when (ex is InvalidDataException || ex is OpenXmlPackageException || ex is XmlException) {
                 normalizedStream?.Dispose();
                 var contextMessage = filePath != null
@@ -759,7 +797,8 @@ namespace OfficeIMO.Excel {
                     shouldCopyBack ? originalStream : null,
                     shouldCopyBack,
                     leaveOriginalStreamOpen,
-                    copyPackageToFilePathOnDispose: shouldCopyBackToFilePath);
+                    copyPackageToFilePathOnDispose: shouldCopyBackToFilePath,
+                    packageContentTypesKnownNormalized: false);
             }
         }
 
@@ -1088,6 +1127,7 @@ namespace OfficeIMO.Excel {
                 string name = ValidateOrSanitizeSheetName(workSheetName, validationMode, currentSheetName: null);
                 ExcelSheet excelSheet = new ExcelSheet(this, _workBookPart, _spreadSheetDocument, name);
                 MarkSheetCacheDirty();
+                MarkRequiresSavePreflight();
                 return excelSheet;
             });
         }
@@ -1113,6 +1153,7 @@ namespace OfficeIMO.Excel {
                 target.Name = validatedName;
                 UpdateSheetNameReferences(currentName, validatedName);
                 WorkbookRoot.Save();
+                MarkRequiresSavePreflight();
             });
         }
 
@@ -1207,7 +1248,12 @@ namespace OfficeIMO.Excel {
         /// and header/footer references, and cleans up invalid table references.
         /// </summary>
         public void PreflightWorkbook() {
-            foreach (var sheet in Sheets) {
+            PreflightWorkbook(Sheets);
+            _requiresSavePreflight = false;
+        }
+
+        private void PreflightWorkbook(IEnumerable<ExcelSheet> sheets) {
+            foreach (var sheet in sheets) {
                 sheet.Preflight();
             }
             CleanupWorkbookViewArtifacts(save: true);
@@ -1453,15 +1499,18 @@ namespace OfficeIMO.Excel {
             if (destination == null) throw new ArgumentNullException(nameof(destination));
             if (!destination.CanWrite) throw new ArgumentException("Destination stream must be writable.", nameof(destination));
 
-            var payload = PreparePackageForSave(options);
+            if (TryWriteUnchangedPackageToStream(destination, options)) {
+                return;
+            }
+
+            var payload = PreparePackageForSave(options, closeDocument: false);
             try {
                 var finalizedBytes = FinalizePackageBytes(payload);
                 ThrowIfOpenXmlValidationFails(finalizedBytes, options);
                 PrepareDestinationStreamForWrite(destination);
                 destination.Write(finalizedBytes, 0, finalizedBytes.Length);
                 try { destination.Flush(); } catch (NotSupportedException) { }
-
-                ReloadFromBytes(finalizedBytes);
+                MarkPackageClean(finalizedBytes);
             } catch {
                 TryRestoreDocumentState(payload);
                 throw;
@@ -1479,12 +1528,16 @@ namespace OfficeIMO.Excel {
             if (password == null) throw new ArgumentNullException(nameof(password));
             if (!destination.CanWrite) throw new ArgumentException("Destination stream must be writable.", nameof(destination));
 
-            var payload = PreparePackageForSave(saveOptions);
+            if (CanUseUnchangedPackageFastPath(saveOptions) && _unchangedPackageBytes != null) {
+                OfficeEncryption.EncryptPackageToStream(_unchangedPackageBytes, password, destination);
+                return;
+            }
+
+            var payload = PreparePackageForSave(saveOptions, closeDocument: false);
             try {
                 var finalizedBytes = FinalizePackageBytes(payload);
                 ThrowIfOpenXmlValidationFails(finalizedBytes, saveOptions);
                 OfficeEncryption.EncryptPackageToStream(finalizedBytes, password, destination);
-                ReloadFromBytes(finalizedBytes);
             } catch {
                 TryRestoreDocumentState(payload);
                 throw;
@@ -1510,15 +1563,18 @@ namespace OfficeIMO.Excel {
             if (destination == null) throw new ArgumentNullException(nameof(destination));
             if (!destination.CanWrite) throw new ArgumentException("Destination stream must be writable.", nameof(destination));
 
-            var payload = PreparePackageForSave(options);
+            if (await TryWriteUnchangedPackageToStreamAsync(destination, options, cancellationToken).ConfigureAwait(false)) {
+                return;
+            }
+
+            var payload = PreparePackageForSave(options, closeDocument: false);
             try {
                 var finalizedBytes = FinalizePackageBytes(payload);
                 ThrowIfOpenXmlValidationFails(finalizedBytes, options);
                 PrepareDestinationStreamForWrite(destination);
                 await destination.WriteAsync(finalizedBytes, 0, finalizedBytes.Length, cancellationToken).ConfigureAwait(false);
                 try { await destination.FlushAsync(cancellationToken).ConfigureAwait(false); } catch (NotSupportedException) { }
-
-                ReloadFromBytes(finalizedBytes);
+                MarkPackageClean(finalizedBytes);
             } catch {
                 TryRestoreDocumentState(payload);
                 throw;
@@ -1543,18 +1599,26 @@ namespace OfficeIMO.Excel {
             return SaveAsync("", openExcel, cancellationToken);
         }
 
-        private SavePayload PreparePackageForSave(ExcelSaveOptions? options) {
+        private SavePayload PreparePackageForSave(ExcelSaveOptions? options, bool closeDocument = true) {
             // Ensure all worksheets have up-to-date dimensions and proper element ordering before saving
             ApplyCalculationPolicyBeforeSave();
 
-            foreach (var sheet in Sheets) {
+            var sheets = Sheets;
+            foreach (var sheet in sheets) {
+                if (!sheet.RequiresSavePreparation) {
+                    continue;
+                }
+
                 sheet.UpdateSheetDimension();
                 sheet.EnsureWorksheetElementOrder();
                 sheet.Commit();
             }
 
-            // Always preflight to remove orphaned/empty containers that can trigger Excel repairs
-            try { PreflightWorkbook(); } catch { }
+            // Run the heavier repair sweep only when workbook-level operations requested it.
+            if (_requiresSavePreflight || options?.SafePreflight == true) {
+                try { PreflightWorkbook(sheets); } catch { }
+                _requiresSavePreflight = false;
+            }
             if (options?.SafePreflight == true) {
                 // Already performed above; branch kept for semantic clarity
             }
@@ -1579,9 +1643,11 @@ namespace OfficeIMO.Excel {
 
             var packageBytes = snapshot.ToArray();
 
-            try { _spreadSheetDocument.Dispose(); } catch { }
+            if (closeDocument) {
+                try { _spreadSheetDocument.Dispose(); } catch { }
+            }
 
-            return new SavePayload(packageBytes, propertiesSnapshot);
+            return new SavePayload(packageBytes, propertiesSnapshot, closeDocument, normalizeContentTypes: !_packageContentTypesKnownNormalized, applyPackageProperties: _packagePropertiesDirty);
         }
 
         private static void PrepareDestinationStreamForWrite(Stream destination) {
@@ -1591,6 +1657,53 @@ namespace OfficeIMO.Excel {
 
             destination.Seek(0, SeekOrigin.Begin);
             destination.SetLength(0);
+        }
+
+        private bool TryWriteUnchangedPackageToStream(Stream destination, ExcelSaveOptions? options) {
+            if (!CanUseUnchangedPackageFastPath(options) || _unchangedPackageBytes == null) {
+                return false;
+            }
+
+            PrepareDestinationStreamForWrite(destination);
+            destination.Write(_unchangedPackageBytes, 0, _unchangedPackageBytes.Length);
+            try { destination.Flush(); } catch (NotSupportedException) { }
+            return true;
+        }
+
+        private async Task<bool> TryWriteUnchangedPackageToStreamAsync(Stream destination, ExcelSaveOptions? options, CancellationToken cancellationToken) {
+            if (!CanUseUnchangedPackageFastPath(options) || _unchangedPackageBytes == null) {
+                return false;
+            }
+
+            PrepareDestinationStreamForWrite(destination);
+            await destination.WriteAsync(_unchangedPackageBytes, 0, _unchangedPackageBytes.Length, cancellationToken).ConfigureAwait(false);
+            try { await destination.FlushAsync(cancellationToken).ConfigureAwait(false); } catch (NotSupportedException) { }
+            return true;
+        }
+
+        private bool CanUseUnchangedPackageFastPath(ExcelSaveOptions? options) {
+            return !_packageDirty
+                && _packageContentTypesKnownNormalized
+                && _unchangedPackageBytes != null
+                && !HasCalculationSaveWork()
+                && options?.SafePreflight != true
+                && options?.SafeRepairDefinedNames != true
+                && options?.ValidateOpenXml != true;
+        }
+
+        private bool HasCalculationSaveWork() {
+            return Calculation.EvaluateFormulasBeforeSave
+                || Calculation.ClearCachedFormulaResultsBeforeSave
+                || Calculation.MarkFormulasDirtyBeforeSave
+                || Calculation.ForceFullCalculationOnOpen;
+        }
+
+        private void MarkPackageClean(byte[] packageBytes) {
+            _packageDirty = false;
+            _packagePropertiesDirty = false;
+            _unchangedPackageBytes = packageBytes;
+            _packageContentTypesKnownNormalized = true;
+            _requiresSavePreflight = false;
         }
 
         private static string CreateTemporarySavePath(string targetPath) {
@@ -1705,6 +1818,10 @@ namespace OfficeIMO.Excel {
         }
 
         private void TryRestoreDocumentState(SavePayload payload) {
+            if (!payload.DocumentClosed) {
+                return;
+            }
+
             try {
                 ReloadFromBytes(payload.PackageBytes);
             } catch {
@@ -1727,6 +1844,7 @@ namespace OfficeIMO.Excel {
             _workBookPart = WorkbookPartRoot ?? throw new InvalidOperationException("WorkbookPart is null");
             _sharedStringTablePart = null;
             _packageStream = keepPackageStream ? mem : null;
+            MarkPackageClean(packageBytes);
 
             if (previousPackageStream != null && !ReferenceEquals(previousPackageStream, mem)) {
                 DisposeStream(previousPackageStream);
@@ -1738,6 +1856,15 @@ namespace OfficeIMO.Excel {
         }
 
         private static byte[] NormalizePackageBytes(byte[] packageBytes) {
+            using (var probe = new MemoryStream(packageBytes, writable: false)) {
+                try {
+                    if (!ExcelPackageUtilities.NeedsContentTypeNormalization(probe)) {
+                        return packageBytes;
+                    }
+                } catch {
+                }
+            }
+
             var working = new MemoryStream(packageBytes.Length + StreamBufferSize);
             working.Write(packageBytes, 0, packageBytes.Length);
             working.Position = 0;
@@ -1755,8 +1882,12 @@ namespace OfficeIMO.Excel {
         }
 
         private static byte[] FinalizePackageBytes(SavePayload payload) {
-            var withProperties = payload.Properties.ApplyTo(payload.PackageBytes);
-            return NormalizePackageBytes(withProperties);
+            var withProperties = payload.ApplyPackageProperties
+                ? payload.Properties.ApplyTo(payload.PackageBytes)
+                : payload.PackageBytes;
+            return payload.NormalizeContentTypes
+                ? NormalizePackageBytes(withProperties)
+                : withProperties;
         }
 
         private static void ThrowIfOpenXmlValidationFails(byte[] finalizedBytes, ExcelSaveOptions? options) {
@@ -1887,13 +2018,19 @@ namespace OfficeIMO.Excel {
         }
 
         private sealed class SavePayload {
-            public SavePayload(byte[] packageBytes, PackagePropertiesSnapshot properties) {
+            public SavePayload(byte[] packageBytes, PackagePropertiesSnapshot properties, bool documentClosed, bool normalizeContentTypes, bool applyPackageProperties) {
                 PackageBytes = packageBytes;
                 Properties = properties;
+                DocumentClosed = documentClosed;
+                NormalizeContentTypes = normalizeContentTypes;
+                ApplyPackageProperties = applyPackageProperties;
             }
 
             public byte[] PackageBytes { get; }
             public PackagePropertiesSnapshot Properties { get; }
+            public bool DocumentClosed { get; }
+            public bool NormalizeContentTypes { get; }
+            public bool ApplyPackageProperties { get; }
         }
 
         private bool _disposed;
@@ -1902,7 +2039,65 @@ namespace OfficeIMO.Excel {
         /// Releases resources used by the document.
         /// </summary>
         public void Dispose() {
-            DisposeAsync().GetAwaiter().GetResult();
+            if (_disposed) {
+                return;
+            }
+
+            Exception? persistenceFailure = null;
+
+            try {
+                if (this._spreadSheetDocument != null) {
+                    try {
+                        if (_copyPackageToSourceOnDispose && _sourceStream != null && !this._spreadSheetDocument.AutoSave) {
+                            if (!TryWriteSimpleWorkbookPackage(_sourceStream)) {
+                                Save(_sourceStream);
+                            }
+
+                            _copyPackageToSourceOnDispose = false;
+                        }
+
+                        if (this._spreadSheetDocument.AutoSave && this._spreadSheetDocument.FileOpenAccess != FileAccess.Read) {
+                            lock (_sharedStringLock) {
+                                if (_sharedStringTableDirty) {
+                                    _sharedStringTablePart?.SharedStringTable?.Save();
+                                    _sharedStringTableDirty = false;
+                                }
+                            }
+
+                            WorkbookRoot.Save();
+                        }
+
+                        this._spreadSheetDocument.Dispose();
+                    } catch (Exception ex) {
+                        persistenceFailure = ex;
+                    } finally {
+                        this._spreadSheetDocument = null!;
+                    }
+                }
+
+                try {
+                    PersistPackageToSourceIfNeeded();
+                } catch (Exception ex) {
+                    persistenceFailure ??= ex;
+                }
+            } finally {
+                if (_ownedOpenStream != null) {
+                    try {
+                        _ownedOpenStream.Dispose();
+                    } catch {
+                        // ignored
+                    }
+                    _ownedOpenStream = null;
+                }
+
+                _lock?.Dispose();
+                _disposed = true;
+                GC.SuppressFinalize(this);
+            }
+
+            if (persistenceFailure != null) {
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(persistenceFailure).Throw();
+            }
         }
 
         /// <summary>
@@ -1918,6 +2113,14 @@ namespace OfficeIMO.Excel {
             try {
                 if (this._spreadSheetDocument != null) {
                     try {
+                        if (_copyPackageToSourceOnDispose && _sourceStream != null && !this._spreadSheetDocument.AutoSave) {
+                            if (!TryWriteSimpleWorkbookPackage(_sourceStream)) {
+                                Save(_sourceStream);
+                            }
+
+                            _copyPackageToSourceOnDispose = false;
+                        }
+
                         if (this._spreadSheetDocument.AutoSave && this._spreadSheetDocument.FileOpenAccess != FileAccess.Read) {
                             lock (_sharedStringLock) {
                                 if (_sharedStringTableDirty) {

--- a/OfficeIMO.Excel/ExcelSheet.AutoFitText.cs
+++ b/OfficeIMO.Excel/ExcelSheet.AutoFitText.cs
@@ -221,6 +221,56 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        private static bool TryGetAutoFitDateSample(uint numberFormatId, string? formatCode, out string sample) {
+            sample = string.Empty;
+            if (numberFormatId == 46U || (formatCode?.IndexOf("[h]", StringComparison.OrdinalIgnoreCase) ?? -1) >= 0) {
+                return false;
+            }
+
+            switch (numberFormatId) {
+                case 14:
+                    sample = "12/31/9999";
+                    return true;
+                case 15:
+                    sample = "30-Sep-99";
+                    return true;
+                case 16:
+                    sample = "30-Sep";
+                    return true;
+                case 17:
+                    sample = "Sep-99";
+                    return true;
+                case 18:
+                    sample = "12:00 PM";
+                    return true;
+                case 19:
+                    sample = "12:00:00 PM";
+                    return true;
+                case 20:
+                    sample = "23:59";
+                    return true;
+                case 21:
+                    sample = "23:59:59";
+                    return true;
+                case 22:
+                    sample = "12/31/9999 23:59";
+                    return true;
+                case 45:
+                    sample = "59:59";
+                    return true;
+                case 47:
+                    sample = "59:59.0";
+                    return true;
+            }
+
+            if (string.IsNullOrWhiteSpace(formatCode)) {
+                return false;
+            }
+
+            sample = new DateTime(2099, 12, 31, 23, 59, 59).ToString(TranslateExcelDateFormat(formatCode!), CultureInfo.InvariantCulture);
+            return true;
+        }
+
         private static string TranslateExcelDateFormat(string formatCode) {
             string section = SelectNumberFormatSection(formatCode, 0);
             string normalized = StripNumberFormatDecorations(section);

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -243,6 +243,10 @@ namespace OfficeIMO.Excel {
         }
 
         private void ApplyAutomaticCellFormatting(Cell cell, object? value, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>? dataType) {
+            if (!RequiresAutomaticCellFormatting(value, dataType)) {
+                return;
+            }
+
             bool wroteNumber = dataType?.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.Number;
 
             // Automatically apply date format for DateTime values
@@ -260,6 +264,13 @@ namespace OfficeIMO.Excel {
             if (value is string s && (s.Contains("\n") || s.Contains("\r"))) {
                 ApplyWrapText(cell);
             }
+        }
+
+        private static bool RequiresAutomaticCellFormatting(object? value, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>? dataType) {
+            bool wroteNumber = dataType?.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.Number;
+            return (wroteNumber && (value is DateTime || value is DateTimeOffset))
+                || value is TimeSpan
+                || value is string s && (s.Contains("\n") || s.Contains("\r"));
         }
 
         private void ApplyAutomaticCellFormattingForAppendedCell(

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -214,6 +214,7 @@ namespace OfficeIMO.Excel {
 
         private void ClearHeaderCacheForPreparedAppend() {
             _hasWorksheetMutations = true;
+            _excelDocument.MarkPackageDirty();
             lock (_headerMapLock) {
                 _headerMapCache = null;
                 _headerMapSourceA1 = null;

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -284,7 +284,7 @@ namespace OfficeIMO.Excel {
             string end = A1.CellReference(maxRow, maxColumn);
             string reference = start == end ? start : start + ":" + end;
             if (dimension == null) {
-                worksheet.InsertAt(new SheetDimension { Reference = reference }, 0);
+                InsertSheetDimensionInSchemaOrder(worksheet, new SheetDimension { Reference = reference });
             } else {
                 dimension.Reference = reference;
             }

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -127,6 +127,10 @@ namespace OfficeIMO.Excel {
             int maxExistingRow = 0;
             int maxExistingColumn = 0;
             foreach (var existingRow in sheetData.Elements<Row>()) {
+                if (existingRow.RowIndex == null) {
+                    return false;
+                }
+
                 if (existingRow.RowIndex != null && existingRow.RowIndex.Value >= (uint)firstRow) {
                     return false;
                 }
@@ -444,6 +448,10 @@ namespace OfficeIMO.Excel {
 
             var sheetData = GetOrCreateSheetData();
             foreach (var existingRow in sheetData.Elements<Row>()) {
+                if (existingRow.RowIndex == null) {
+                    return false;
+                }
+
                 if (existingRow.RowIndex != null && existingRow.RowIndex.Value >= (uint)firstRow) {
                     return false;
                 }

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -34,6 +34,10 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
+            if (list.Count > DirectSequentialCellWriteLimit && TryApplyPlainCellsByAppendingRows(list, ct)) {
+                return;
+            }
+
             // Prepared buffers for parallel scenario
             var prepared = new (int Row, int Col, CellValue Val, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues> Type)[list.Count];
             var ssPlanner = new SharedStringPlanner();
@@ -99,6 +103,275 @@ namespace OfficeIMO.Excel {
                 },
                 dateTimeOffsetStrategy);
             return (cellValue, new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(cellType));
+        }
+
+        private bool TryApplyPlainCellsByAppendingRows(IList<(int Row, int Column, object Value)> source, CancellationToken ct) {
+            bool applied = false;
+            System.Threading.ReaderWriterLockSlim? lck = _excelDocument._lock;
+            if (lck == null) {
+                try { lck = _excelDocument.EnsureLock(); } catch { lck = null; }
+            }
+
+            Locking.ExecuteWrite(lck, () => applied = TryApplyPlainCellsByAppendingRowsCore(source, ct));
+            return applied;
+        }
+
+        private bool TryApplyPlainCellsByAppendingRowsCore(IList<(int Row, int Column, object Value)> source, CancellationToken ct) {
+            if (!TryGetPlainAppendLayout(source, out int firstRow, out int minColumn, out int maxColumn)) {
+                return false;
+            }
+
+            var sheetData = GetOrCreateSheetData();
+            int minExistingRow = int.MaxValue;
+            int minExistingColumn = int.MaxValue;
+            int maxExistingRow = 0;
+            int maxExistingColumn = 0;
+            foreach (var existingRow in sheetData.Elements<Row>()) {
+                if (existingRow.RowIndex != null && existingRow.RowIndex.Value >= (uint)firstRow) {
+                    return false;
+                }
+
+                if (!existingRow.HasChildren) {
+                    continue;
+                }
+
+                int existingRowIndex = checked((int)(existingRow.RowIndex?.Value ?? 0U));
+                if (existingRowIndex <= 0) {
+                    continue;
+                }
+
+                foreach (var existingCell in existingRow.Elements<Cell>()) {
+                    int existingColumnIndex = 0;
+                    string? reference = existingCell.CellReference?.Value;
+                    if (!string.IsNullOrEmpty(reference)) {
+                        existingColumnIndex = A1.ParseColumnIndexFromCellReference(reference!);
+                    }
+
+                    if (existingColumnIndex <= 0) {
+                        continue;
+                    }
+
+                    if (existingRowIndex < minExistingRow) minExistingRow = existingRowIndex;
+                    if (existingRowIndex > maxExistingRow) maxExistingRow = existingRowIndex;
+                    if (existingColumnIndex < minExistingColumn) minExistingColumn = existingColumnIndex;
+                    if (existingColumnIndex > maxExistingColumn) maxExistingColumn = existingColumnIndex;
+                }
+            }
+
+            var columnNames = new string[maxColumn + 1];
+            for (int column = 1; column <= maxColumn; column++) {
+                columnNames[column] = GetColumnName(column);
+            }
+
+            Dictionary<string, int>? sharedStringIndexes = null;
+            bool useDirectStringCells = source.Count >= 4096 && maxColumn > 1;
+            var appendedRows = new List<OpenXmlElement>(Math.Max(1, source.Count / Math.Max(maxColumn, 1)));
+            Row? row = null;
+            List<OpenXmlElement>? rowCells = null;
+            int rowIndex = 0;
+            string rowReference = string.Empty;
+
+            for (int i = 0; i < source.Count; i++) {
+                ct.ThrowIfCancellationRequested();
+                var item = source[i];
+
+                if (item.Row != rowIndex) {
+                    if (row != null) {
+                        row.Append(rowCells!);
+                        appendedRows.Add(row);
+                    }
+
+                    rowIndex = item.Row;
+                    rowReference = rowIndex.ToString(CultureInfo.InvariantCulture);
+                    row = new Row { RowIndex = (uint)rowIndex };
+                    rowCells = new List<OpenXmlElement>(Math.Min(maxColumn, 16));
+                }
+
+                var (cellValue, dataType) = CoercePlainAppendValue(item.Value, ref sharedStringIndexes, useDirectStringCells);
+                rowCells!.Add(new Cell {
+                    CellReference = columnNames[item.Column] + rowReference,
+                    CellValue = cellValue,
+                    DataType = dataType
+                });
+            }
+
+            if (row != null) {
+                row.Append(rowCells!);
+                appendedRows.Add(row);
+            }
+
+            sheetData.Append(appendedRows);
+            ClearHeaderCacheForPreparedAppend();
+            int lastRow = source[source.Count - 1].Row;
+            int dimensionMinRow = minExistingRow == int.MaxValue ? firstRow : Math.Min(minExistingRow, firstRow);
+            int dimensionMinColumn = minExistingColumn == int.MaxValue ? minColumn : Math.Min(minExistingColumn, minColumn);
+            int dimensionMaxRow = Math.Max(maxExistingRow, lastRow);
+            int dimensionMaxColumn = Math.Max(maxExistingColumn, maxColumn);
+            SetSheetDimensionReference(dimensionMinRow, dimensionMinColumn, dimensionMaxRow, dimensionMaxColumn);
+            _requiresSavePreparation = false;
+            return true;
+        }
+
+        private void ClearHeaderCacheForPreparedAppend() {
+            _hasWorksheetMutations = true;
+            lock (_headerMapLock) {
+                _headerMapCache = null;
+                _headerMapSourceA1 = null;
+            }
+        }
+
+        private bool TryGetPlainAppendLayout(
+            IList<(int Row, int Column, object Value)> source,
+            out int firstRow,
+            out int minColumn,
+            out int maxColumn) {
+            firstRow = source[0].Row;
+            minColumn = int.MaxValue;
+            maxColumn = 0;
+            int currentRow = 0;
+            int currentColumn = 0;
+
+            for (int i = 0; i < source.Count; i++) {
+                var item = source[i];
+                if (item.Row <= 0 || item.Column <= 0 || item.Column > A1.MaxColumns || item.Row < currentRow) {
+                    return false;
+                }
+
+                if (!CanAppendPlainValueDirectly(item.Value)) {
+                    return false;
+                }
+
+                if (item.Row != currentRow) {
+                    currentRow = item.Row;
+                    currentColumn = 0;
+                }
+
+                if (item.Column <= currentColumn) {
+                    return false;
+                }
+
+                currentColumn = item.Column;
+                if (item.Column < minColumn) {
+                    minColumn = item.Column;
+                }
+
+                if (item.Column > maxColumn) {
+                    maxColumn = item.Column;
+                }
+            }
+
+            if (minColumn == int.MaxValue) {
+                minColumn = 1;
+            }
+
+            return true;
+        }
+
+        private void SetSheetDimensionReference(int minRow, int minColumn, int maxRow, int maxColumn) {
+            var worksheet = WorksheetRoot;
+            var dimensions = worksheet.Elements<SheetDimension>().ToList();
+            SheetDimension? dimension = dimensions.FirstOrDefault();
+            foreach (var extraDimension in dimensions.Skip(1).ToList()) {
+                extraDimension.Remove();
+            }
+
+            string start = A1.CellReference(minRow, minColumn);
+            string end = A1.CellReference(maxRow, maxColumn);
+            string reference = start == end ? start : start + ":" + end;
+            if (dimension == null) {
+                worksheet.InsertAt(new SheetDimension { Reference = reference }, 0);
+            } else {
+                dimension.Reference = reference;
+            }
+        }
+
+        private static bool CanAppendPlainValueDirectly(object? value) {
+            switch (value) {
+                case null:
+                case DBNull:
+                case double:
+                case float:
+                case decimal:
+                case int:
+                case long:
+                case bool:
+                case uint:
+                case ulong:
+                case ushort:
+                case byte:
+                case sbyte:
+                case short:
+                case Guid:
+                case Enum:
+                case char:
+                case Uri:
+                    return true;
+                case string text:
+                    if (text.IndexOf('\r') >= 0 || text.IndexOf('\n') >= 0) {
+                        return false;
+                    }
+
+                    CoerceValueHelper.ValidateSharedStringLength(text, nameof(value));
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private (CellValue cellValue, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues> dataType) CoercePlainAppendValue(
+            object? value,
+            ref Dictionary<string, int>? sharedStringIndexes,
+            bool useDirectStringCells) {
+            (CellValue cellValue, DocumentFormat.OpenXml.Spreadsheet.CellValues cellType) = value switch {
+                null => CoerceValueHelper.HandleEmptyString(),
+                DBNull => CoerceValueHelper.HandleEmptyString(),
+                string text => useDirectStringCells
+                    ? (CreatePlainAppendStringValue(text), DocumentFormat.OpenXml.Spreadsheet.CellValues.String)
+                    : (CreatePlainAppendSharedStringValue(text, ref sharedStringIndexes), DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString),
+                double number => CoerceValueHelper.HandleNumber(number),
+                float number => CoerceValueHelper.HandleNumber(Convert.ToDouble(number)),
+                decimal number => CoerceValueHelper.HandleDecimal(number),
+                int number => CoerceValueHelper.HandleSignedInteger(number),
+                long number => CoerceValueHelper.HandleSignedInteger(number),
+                bool flag => CoerceValueHelper.HandleBoolean(flag),
+                uint number => CoerceValueHelper.HandleUnsignedInteger(number),
+                ulong number => CoerceValueHelper.HandleUnsignedInteger(number),
+                ushort number => CoerceValueHelper.HandleUnsignedInteger(number),
+                byte number => CoerceValueHelper.HandleUnsignedInteger(number),
+                sbyte number => CoerceValueHelper.HandleSignedInteger(number),
+                short number => CoerceValueHelper.HandleSignedInteger(number),
+                Guid guid => useDirectStringCells
+                    ? (CreatePlainAppendStringValue(guid.ToString()), DocumentFormat.OpenXml.Spreadsheet.CellValues.String)
+                    : (CreatePlainAppendSharedStringValue(guid.ToString(), ref sharedStringIndexes), DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString),
+                Enum enumValue => useDirectStringCells
+                    ? (CreatePlainAppendStringValue(enumValue.ToString()), DocumentFormat.OpenXml.Spreadsheet.CellValues.String)
+                    : (CreatePlainAppendSharedStringValue(enumValue.ToString(), ref sharedStringIndexes), DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString),
+                char character => useDirectStringCells
+                    ? (CreatePlainAppendStringValue(character.ToString()), DocumentFormat.OpenXml.Spreadsheet.CellValues.String)
+                    : (CreatePlainAppendSharedStringValue(character.ToString(), ref sharedStringIndexes), DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString),
+                Uri uri => useDirectStringCells
+                    ? (CreatePlainAppendStringValue(uri.ToString()), DocumentFormat.OpenXml.Spreadsheet.CellValues.String)
+                    : (CreatePlainAppendSharedStringValue(uri.ToString(), ref sharedStringIndexes), DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString),
+                _ => throw new InvalidOperationException("Unsupported direct append value.")
+            };
+
+            return (cellValue, new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(cellType));
+        }
+
+        private static CellValue CreatePlainAppendStringValue(string text) {
+            CoerceValueHelper.ValidateSharedStringLength(text, nameof(text));
+            return new CellValue(Utilities.ExcelSanitizer.SanitizeString(text));
+        }
+
+        private CellValue CreatePlainAppendSharedStringValue(string text, ref Dictionary<string, int>? sharedStringIndexes) {
+            string sanitized = Utilities.ExcelSanitizer.SanitizeString(text);
+            sharedStringIndexes ??= new Dictionary<string, int>(StringComparer.Ordinal);
+            if (!sharedStringIndexes.TryGetValue(sanitized, out int index)) {
+                index = _excelDocument.GetSharedStringIndex(sanitized);
+                sharedStringIndexes[sanitized] = index;
+            }
+
+            return new CellValue(index.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -175,12 +448,22 @@ namespace OfficeIMO.Excel {
                 }
             }
 
+            bool needsAutomaticFormatting = false;
+            for (int i = 0; i < source.Count; i++) {
+                if (RequiresAutomaticCellFormatting(source[i].Value, prepared[i].Type)) {
+                    needsAutomaticFormatting = true;
+                    break;
+                }
+            }
+
             var columnNames = new string[maxColumn + 1];
             for (int column = 1; column <= maxColumn; column++) {
                 columnNames[column] = GetColumnName(column);
             }
 
-            var baseStyleIndexes = GetAppendBaseStyleIndexes(sheetData, firstRow, maxColumn);
+            var baseStyleIndexes = needsAutomaticFormatting
+                ? GetAppendBaseStyleIndexes(sheetData, firstRow, maxColumn)
+                : null;
             Row? row = null;
             int rowIndex = 0;
             string rowReference = string.Empty;
@@ -203,14 +486,16 @@ namespace OfficeIMO.Excel {
                 };
 
                 row!.Append(cell);
-                ApplyAutomaticCellFormattingForAppendedCell(
-                    cell,
-                    source[i].Value,
-                    p.Type,
-                    baseStyleIndexes[p.Col] ?? 0U,
-                    ref appendedDateStyleIndexes,
-                    ref appendedDurationStyleIndexes,
-                    ref appendedWrapStyleIndexes);
+                if (needsAutomaticFormatting) {
+                    ApplyAutomaticCellFormattingForAppendedCell(
+                        cell,
+                        source[i].Value,
+                        p.Type,
+                        baseStyleIndexes![p.Col] ?? 0U,
+                        ref appendedDateStyleIndexes,
+                        ref appendedDurationStyleIndexes,
+                        ref appendedWrapStyleIndexes);
+                }
             }
 
             ClearHeaderCache();

--- a/OfficeIMO.Excel/ExcelSheet.ColumnsRows.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ColumnsRows.cs
@@ -15,6 +15,10 @@ namespace OfficeIMO.Excel {
         /// <param name="mode">Overrides how the auto-fit work is scheduled across columns.</param>
         /// <param name="ct">Cancels the auto-fit pass while widths are being measured or applied.</param>
         public void AutoFitColumns(ExecutionMode? mode = null, CancellationToken ct = default) {
+            if (CanSkipStableAutoFitColumns(null)) {
+                return;
+            }
+
             var planWatch = EffectiveExecution.OnTiming == null ? null : System.Diagnostics.Stopwatch.StartNew();
             var measurementPlan = BuildAutoFitMeasurementPlanForAllColumns(ct);
             if (planWatch != null) {
@@ -35,6 +39,10 @@ namespace OfficeIMO.Excel {
             if (columnIndexes == null) return;
             var list = columnIndexes.Where(i => i > 0).Distinct().OrderBy(i => i).ToList();
             if (list.Count == 0) return;
+            if (CanSkipStableAutoFitColumns(list)) {
+                return;
+            }
+
             AutoFitColumnsInternal(list, mode, ct);
         }
 
@@ -48,7 +56,116 @@ namespace OfficeIMO.Excel {
             var skip = new HashSet<int>(columnsToSkip ?? Array.Empty<int>());
             var remaining = GetAllColumnIndices().Where(i => i > 0 && !skip.Contains(i)).OrderBy(i => i).ToList();
             if (remaining.Count == 0) return;
+            if (CanSkipStableAutoFitColumns(remaining)) {
+                return;
+            }
+
             AutoFitColumnsInternal(remaining, mode, ct);
+        }
+
+        private bool CanSkipStableAutoFitColumns(IReadOnlyList<int>? requestedColumns) {
+            if (_hasWorksheetMutations) {
+                return false;
+            }
+
+            var worksheet = WorksheetRoot;
+            var columns = worksheet.GetFirstChild<Columns>();
+            if (columns == null) {
+                return false;
+            }
+
+            IEnumerable<int> targetColumns;
+            if (requestedColumns != null) {
+                targetColumns = requestedColumns;
+            } else if (TryGetDimensionColumnBounds(worksheet, out int firstColumn, out int lastColumn)) {
+                targetColumns = Enumerable.Range(firstColumn, lastColumn - firstColumn + 1);
+            } else if (TryGetSheetDataColumnBounds(worksheet, out firstColumn, out lastColumn)) {
+                targetColumns = Enumerable.Range(firstColumn, lastColumn - firstColumn + 1);
+            } else {
+                return false;
+            }
+
+            foreach (int columnIndex in targetColumns) {
+                bool hasStableWidth = false;
+                foreach (var column in columns.Elements<Column>()) {
+                    uint min = column.Min?.Value ?? 0U;
+                    uint max = column.Max?.Value ?? 0U;
+                    if (min <= (uint)columnIndex
+                        && max >= (uint)columnIndex
+                        && column.Width != null
+                        && column.CustomWidth?.Value == true
+                        && column.BestFit?.Value == true) {
+                        hasStableWidth = true;
+                        break;
+                    }
+                }
+
+                if (!hasStableWidth) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool TryGetDimensionColumnBounds(Worksheet worksheet, out int firstColumn, out int lastColumn) {
+            firstColumn = 0;
+            lastColumn = 0;
+            string? reference = worksheet.SheetDimension?.Reference?.Value;
+            if (string.IsNullOrWhiteSpace(reference)) {
+                return false;
+            }
+
+            if (reference!.IndexOf(':') >= 0) {
+                if (!A1.TryParseRange(reference, out _, out firstColumn, out _, out lastColumn)) {
+                    return false;
+                }
+            } else {
+                var parsed = A1.ParseCellRef(reference);
+                firstColumn = parsed.Col;
+                lastColumn = parsed.Col;
+            }
+
+            return firstColumn > 0 && lastColumn >= firstColumn;
+        }
+
+        private static bool TryGetSheetDataColumnBounds(Worksheet worksheet, out int firstColumn, out int lastColumn) {
+            firstColumn = int.MaxValue;
+            lastColumn = 0;
+
+            SheetData? sheetData = worksheet.GetFirstChild<SheetData>();
+            if (sheetData == null) {
+                firstColumn = 0;
+                return false;
+            }
+
+            foreach (var row in sheetData.Elements<Row>()) {
+                foreach (var cell in row.Elements<Cell>()) {
+                    string? reference = cell.CellReference?.Value;
+                    if (string.IsNullOrEmpty(reference)) {
+                        continue;
+                    }
+
+                    var parsed = A1.ParseCellRef(reference!);
+                    if (parsed.Col <= 0) {
+                        continue;
+                    }
+
+                    if (parsed.Col < firstColumn) {
+                        firstColumn = parsed.Col;
+                    }
+
+                    if (parsed.Col > lastColumn) {
+                        lastColumn = parsed.Col;
+                    }
+                }
+            }
+
+            if (firstColumn == int.MaxValue) {
+                firstColumn = 0;
+            }
+
+            return firstColumn > 0 && lastColumn >= firstColumn;
         }
 
         private void AutoFitColumnsInternal(IReadOnlyList<int> columnsList, ExecutionMode? mode, CancellationToken ct) {
@@ -92,6 +209,8 @@ namespace OfficeIMO.Excel {
                     if (EffectiveExecution.SaveWorksheetAfterAutoFit) {
                         worksheet.Save();
                     }
+                    MarkRequiresSavePreparation();
+                    _hasWorksheetMutations = false;
                     if (applyWatch != null) {
                         applyWatch.Stop();
                         EffectiveExecution.ReportTiming("AutoFitColumns.ApplyWidths", applyWatch.Elapsed);
@@ -114,6 +233,8 @@ namespace OfficeIMO.Excel {
                     if (EffectiveExecution.SaveWorksheetAfterAutoFit) {
                         worksheet.Save();
                     }
+                    MarkRequiresSavePreparation();
+                    _hasWorksheetMutations = false;
                     if (applyWatch != null) {
                         applyWatch.Stop();
                         EffectiveExecution.ReportTiming("AutoFitColumns.ApplyWidths", applyWatch.Elapsed);
@@ -163,6 +284,8 @@ namespace OfficeIMO.Excel {
             var targetColumns = new Dictionary<int, int>();
             var measurements = new List<AutoFitMeasurement>();
             var uniqueMeasurements = new HashSet<AutoFitMeasurementKey>();
+            var sharedStringMeasurements = new HashSet<(int TargetIndex, uint StyleIndex, int SharedStringId)>();
+            var simpleTextMaxLengths = new Dictionary<(int TargetIndex, uint StyleIndex), int>();
             var textContext = CreateAutoFitTextContext();
 
             foreach (var row in sheetData.Elements<Row>()) {
@@ -181,7 +304,7 @@ namespace OfficeIMO.Excel {
                         columnsList.Add(columnIndex);
                     }
 
-                    AddAutoFitMeasurement(cell, targetIndex, textContext, uniqueMeasurements, measurements);
+                    AddAutoFitMeasurement(cell, targetIndex, textContext, uniqueMeasurements, sharedStringMeasurements, simpleTextMaxLengths, measurements);
                 }
             }
 
@@ -217,6 +340,8 @@ namespace OfficeIMO.Excel {
 
             var measurements = new List<AutoFitMeasurement>();
             var uniqueMeasurements = new HashSet<AutoFitMeasurementKey>();
+            var sharedStringMeasurements = new HashSet<(int TargetIndex, uint StyleIndex, int SharedStringId)>();
+            var simpleTextMaxLengths = new Dictionary<(int TargetIndex, uint StyleIndex), int>();
             var textContext = CreateAutoFitTextContext();
             foreach (var row in sheetData.Elements<Row>()) {
                 ct.ThrowIfCancellationRequested();
@@ -232,7 +357,7 @@ namespace OfficeIMO.Excel {
                         continue;
                     }
 
-                    AddAutoFitMeasurement(cell, targetIndex, textContext, uniqueMeasurements, measurements);
+                    AddAutoFitMeasurement(cell, targetIndex, textContext, uniqueMeasurements, sharedStringMeasurements, simpleTextMaxLengths, measurements);
                 }
             }
 
@@ -244,17 +369,124 @@ namespace OfficeIMO.Excel {
             int targetIndex,
             AutoFitTextContext textContext,
             HashSet<AutoFitMeasurementKey> uniqueMeasurements,
+            HashSet<(int TargetIndex, uint StyleIndex, int SharedStringId)> sharedStringMeasurements,
+            Dictionary<(int TargetIndex, uint StyleIndex), int> simpleTextMaxLengths,
             List<AutoFitMeasurement> measurements) {
+            uint styleIndex = cell.StyleIndex?.Value ?? 0U;
+            if (cell.DataType?.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString
+                && TryGetSharedStringIndex(cell, out int sharedStringId)
+                && !sharedStringMeasurements.Add((targetIndex, styleIndex, sharedStringId))) {
+                return;
+            }
+
+            if (TryAddDateAutoFitSampleMeasurement(cell, targetIndex, styleIndex, textContext, uniqueMeasurements, measurements)) {
+                return;
+            }
+
+            if (CanSkipRawSimpleAutoFitMeasurement(cell, targetIndex, styleIndex, textContext, simpleTextMaxLengths)) {
+                return;
+            }
+
             string text = GetCellAutoFitText(cell, textContext);
             if (string.IsNullOrWhiteSpace(text)) {
                 return;
             }
 
-            uint styleIndex = cell.StyleIndex?.Value ?? 0U;
+            if (CanUseSimpleAutoFitLengthShortcut(cell, text)) {
+                var simpleKey = (targetIndex, styleIndex);
+                if (simpleTextMaxLengths.TryGetValue(simpleKey, out int maxLength) && text.Length <= maxLength) {
+                    return;
+                }
+
+                simpleTextMaxLengths[simpleKey] = text.Length;
+            }
+
             var runs = GetCellAutoFitRichTextRuns(cell, textContext);
             if (uniqueMeasurements.Add(new AutoFitMeasurementKey(targetIndex, styleIndex, text, runs))) {
                 measurements.Add(new AutoFitMeasurement(targetIndex, styleIndex, text, runs));
             }
+        }
+
+        private bool TryAddDateAutoFitSampleMeasurement(
+            Cell cell,
+            int targetIndex,
+            uint styleIndex,
+            AutoFitTextContext textContext,
+            HashSet<AutoFitMeasurementKey> uniqueMeasurements,
+            List<AutoFitMeasurement> measurements) {
+            var dataType = cell.DataType?.Value;
+            if (dataType != null && dataType != DocumentFormat.OpenXml.Spreadsheet.CellValues.Number) {
+                return false;
+            }
+
+            string raw = cell.CellValue?.InnerText ?? string.Empty;
+            if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out _)) {
+                return false;
+            }
+
+            uint numberFormatId = GetCellNumberFormatId(cell, textContext);
+            string? formatCode = GetNumberFormatCode(numberFormatId, textContext);
+            if (!IsDateNumberFormat(numberFormatId, formatCode)
+                || !TryGetAutoFitDateSample(numberFormatId, formatCode, out string sample)) {
+                return false;
+            }
+
+            if (uniqueMeasurements.Add(new AutoFitMeasurementKey(targetIndex, styleIndex, sample, null))) {
+                measurements.Add(new AutoFitMeasurement(targetIndex, styleIndex, sample, null));
+            }
+
+            return true;
+        }
+
+        private bool CanSkipRawSimpleAutoFitMeasurement(
+            Cell cell,
+            int targetIndex,
+            uint styleIndex,
+            AutoFitTextContext textContext,
+            Dictionary<(int TargetIndex, uint StyleIndex), int> simpleTextMaxLengths) {
+            var dataType = cell.DataType?.Value;
+            if (dataType != null && dataType != DocumentFormat.OpenXml.Spreadsheet.CellValues.Number) {
+                return false;
+            }
+
+            string raw = cell.CellValue?.InnerText ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(raw)) {
+                return false;
+            }
+
+            uint numberFormatId = GetCellNumberFormatId(cell, textContext);
+            string? formatCode = GetNumberFormatCode(numberFormatId, textContext);
+            if (numberFormatId != 0U
+                && !string.IsNullOrWhiteSpace(formatCode)
+                && !string.Equals(formatCode, "General", StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            for (int i = 0; i < raw.Length; i++) {
+                if (!IsSimpleAutoFitCharacter(raw[i])) {
+                    return false;
+                }
+            }
+
+            var simpleKey = (targetIndex, styleIndex);
+            return simpleTextMaxLengths.TryGetValue(simpleKey, out int maxLength) && raw.Length <= maxLength;
+        }
+
+        private static bool CanUseSimpleAutoFitLengthShortcut(Cell cell, string text) {
+            var dataType = cell.DataType?.Value;
+            if (dataType == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString
+                || dataType == DocumentFormat.OpenXml.Spreadsheet.CellValues.InlineString) {
+                return false;
+            }
+
+            for (int i = 0; i < text.Length; i++) {
+                char current = text[i];
+                if (current == '\n' || current == '\r' || !IsSimpleAutoFitCharacter(current)) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private double[] CalculateColumnWidths(IReadOnlyList<int> columnsList, CancellationToken ct) {

--- a/OfficeIMO.Excel/ExcelSheet.ColumnsRows.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ColumnsRows.cs
@@ -64,7 +64,7 @@ namespace OfficeIMO.Excel {
         }
 
         private bool CanSkipStableAutoFitColumns(IReadOnlyList<int>? requestedColumns) {
-            if (_hasWorksheetMutations) {
+            if (_hasWorksheetMutations || _excelDocument.IsPackageDirty) {
                 return false;
             }
 

--- a/OfficeIMO.Excel/ExcelSheet.Core.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Core.cs
@@ -30,6 +30,8 @@ namespace OfficeIMO.Excel {
         private readonly SpreadsheetDocument _spreadSheetDocument;
         private readonly ExcelDocument _excelDocument;
         private bool _isBatchOperation = false;
+        private bool _hasWorksheetMutations;
+        private bool _requiresSavePreparation;
         private readonly object _batchLock = new object();
         private static int _nextTableId = 1;
         private static readonly object _tableIdLock = new object();
@@ -86,6 +88,8 @@ namespace OfficeIMO.Excel {
             _excelDocument = excelDocument;
             _sheet = sheet;
             _spreadSheetDocument = spreadSheetDocument;
+            _hasWorksheetMutations = excelDocument.IsPackageDirty;
+            _requiresSavePreparation = excelDocument.IsPackageDirty;
 
             var workbookPart = spreadSheetDocument.WorkbookPart ?? throw new InvalidOperationException("WorkbookPart is null");
             _worksheetPart = (WorksheetPart)workbookPart.GetPartById(sheet.Id!);
@@ -103,6 +107,8 @@ namespace OfficeIMO.Excel {
         public ExcelSheet(ExcelDocument excelDocument, WorkbookPart workbookpart, SpreadsheetDocument spreadSheetDocument, string name) {
             _excelDocument = excelDocument;
             _spreadSheetDocument = spreadSheetDocument;
+            _hasWorksheetMutations = true;
+            _requiresSavePreparation = true;
 
             UInt32Value id = excelDocument.id.Max(v => v.Value) + 1;
             if (name == "") {
@@ -342,7 +348,10 @@ namespace OfficeIMO.Excel {
         }
 
         private void WriteLock(Action action) {
-            Locking.ExecuteWrite(_excelDocument.EnsureLock(), action);
+            Locking.ExecuteWrite(_excelDocument.EnsureLock(), () => {
+                action();
+                MarkRequiresSavePreparation();
+            });
         }
 
         private void WriteLockConditional(Action action) {
@@ -350,6 +359,7 @@ namespace OfficeIMO.Excel {
             // just execute the action directly
             if (_isBatchOperation || Locking.IsNoLock) {
                 action();
+                MarkRequiresSavePreparation();
             } else {
                 WriteLock(action);
             }
@@ -428,6 +438,14 @@ namespace OfficeIMO.Excel {
         /// </summary>
         internal void Commit() {
             _worksheetPart?.Worksheet?.Save();
+            _requiresSavePreparation = false;
+        }
+
+        internal bool RequiresSavePreparation => _requiresSavePreparation;
+
+        internal void MarkRequiresSavePreparation() {
+            _requiresSavePreparation = true;
+            _excelDocument.MarkRequiresSavePreflight();
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.cs
@@ -155,6 +155,10 @@ namespace OfficeIMO.Excel {
             int maxExistingRow = 0;
             int maxExistingColumn = 0;
             foreach (var existingRow in sheetData.Elements<Row>()) {
+                if (existingRow.RowIndex == null) {
+                    return false;
+                }
+
                 int existingRowIndex = checked((int)(existingRow.RowIndex?.Value ?? 0U));
                 if (existingRowIndex >= startRow) {
                     return false;

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.cs
@@ -24,6 +24,10 @@ namespace OfficeIMO.Excel {
             if (startRow < 1) throw new ArgumentOutOfRangeException(nameof(startRow));
             if (startColumn < 1) throw new ArgumentOutOfRangeException(nameof(startColumn));
 
+            if (mode != ExecutionMode.Parallel && TryInsertDataTableByAppendingRows(table, startRow, startColumn, includeHeaders, ct)) {
+                return;
+            }
+
             // Prepare a flat list of cells and optional number formats
             var cells = new List<(int Row, int Col, object? Val, string? NumFmt)>(
                 (table.Rows.Count + (includeHeaders ? 1 : 0)) * Math.Max(1, table.Columns.Count));
@@ -123,6 +127,210 @@ namespace OfficeIMO.Excel {
             );
         }
 
+        private bool TryInsertDataTableByAppendingRows(DataTable table, int startRow, int startColumn, bool includeHeaders, CancellationToken ct) {
+            int columnCount = table.Columns.Count;
+            int rowsCount = table.Rows.Count + (includeHeaders ? 1 : 0);
+            if (columnCount == 0 || rowsCount == 0) {
+                return true;
+            }
+
+            if (startColumn + columnCount - 1 > A1.MaxColumns || startRow + rowsCount - 1 > A1.MaxRows) {
+                return false;
+            }
+
+            bool applied = false;
+            System.Threading.ReaderWriterLockSlim? lck = _excelDocument._lock;
+            if (lck == null) {
+                try { lck = _excelDocument.EnsureLock(); } catch { lck = null; }
+            }
+
+            Locking.ExecuteWrite(lck, () => applied = TryInsertDataTableByAppendingRowsCore(table, startRow, startColumn, includeHeaders, ct));
+            return applied;
+        }
+
+        private bool TryInsertDataTableByAppendingRowsCore(DataTable table, int startRow, int startColumn, bool includeHeaders, CancellationToken ct) {
+            var sheetData = GetOrCreateSheetData();
+            int minExistingRow = int.MaxValue;
+            int minExistingColumn = int.MaxValue;
+            int maxExistingRow = 0;
+            int maxExistingColumn = 0;
+            foreach (var existingRow in sheetData.Elements<Row>()) {
+                int existingRowIndex = checked((int)(existingRow.RowIndex?.Value ?? 0U));
+                if (existingRowIndex >= startRow) {
+                    return false;
+                }
+
+                if (existingRowIndex <= 0 || !existingRow.HasChildren) {
+                    continue;
+                }
+
+                foreach (var existingCell in existingRow.Elements<Cell>()) {
+                    int existingColumnIndex = 0;
+                    string? reference = existingCell.CellReference?.Value;
+                    if (!string.IsNullOrEmpty(reference)) {
+                        existingColumnIndex = A1.ParseColumnIndexFromCellReference(reference!);
+                    }
+
+                    if (existingColumnIndex <= 0) {
+                        continue;
+                    }
+
+                    if (existingRowIndex < minExistingRow) minExistingRow = existingRowIndex;
+                    if (existingRowIndex > maxExistingRow) maxExistingRow = existingRowIndex;
+                    if (existingColumnIndex < minExistingColumn) minExistingColumn = existingColumnIndex;
+                    if (existingColumnIndex > maxExistingColumn) maxExistingColumn = existingColumnIndex;
+                }
+            }
+
+            int columnCount = table.Columns.Count;
+            var columnNames = new string[startColumn + columnCount];
+            for (int column = startColumn; column < startColumn + columnCount; column++) {
+                columnNames[column] = GetColumnName(column);
+            }
+
+            string?[] numberFormats = BuildDataTableNumberFormats(table);
+            var stylePlanner = new StylePlanner();
+            foreach (string? numberFormat in numberFormats) {
+                stylePlanner.NoteNumberFormat(numberFormat);
+            }
+
+            stylePlanner.ApplyTo(_excelDocument);
+            var styleIndexes = new uint?[numberFormats.Length];
+            for (int i = 0; i < numberFormats.Length; i++) {
+                if (stylePlanner.TryGetCellFormatIndex(numberFormats[i], out uint styleIndex)) {
+                    styleIndexes[i] = styleIndex;
+                }
+            }
+
+            int cellCount = (table.Rows.Count + (includeHeaders ? 1 : 0)) * columnCount;
+            bool useDirectStringCells = cellCount >= 4096 && columnCount > 1;
+            Dictionary<string, int>? sharedStringIndexes = null;
+            var appendedRows = new List<OpenXmlElement>(Math.Max(1, table.Rows.Count + (includeHeaders ? 1 : 0)));
+            int rowIndex = startRow;
+
+            if (includeHeaders) {
+                appendedRows.Add(CreateDataTableHeaderRow(rowIndex++, startColumn, columnNames, table, useDirectStringCells, ref sharedStringIndexes, ct));
+            }
+
+            foreach (DataRow dataRow in table.Rows) {
+                ct.ThrowIfCancellationRequested();
+                appendedRows.Add(CreateDataTableValueRow(rowIndex++, startColumn, columnNames, dataRow, styleIndexes, useDirectStringCells, ref sharedStringIndexes, ct));
+            }
+
+            sheetData.Append(appendedRows);
+            ClearHeaderCacheForPreparedAppend();
+            int lastRow = startRow + table.Rows.Count + (includeHeaders ? 1 : 0) - 1;
+            int lastColumn = startColumn + columnCount - 1;
+            int dimensionMinRow = minExistingRow == int.MaxValue ? startRow : Math.Min(minExistingRow, startRow);
+            int dimensionMinColumn = minExistingColumn == int.MaxValue ? startColumn : Math.Min(minExistingColumn, startColumn);
+            int dimensionMaxRow = Math.Max(maxExistingRow, lastRow);
+            int dimensionMaxColumn = Math.Max(maxExistingColumn, lastColumn);
+            SetSheetDimensionReference(dimensionMinRow, dimensionMinColumn, dimensionMaxRow, dimensionMaxColumn);
+            _requiresSavePreparation = false;
+            return true;
+        }
+
+        private Row CreateDataTableHeaderRow(
+            int rowIndex,
+            int startColumn,
+            IReadOnlyList<string> columnNames,
+            DataTable table,
+            bool useDirectStringCells,
+            ref Dictionary<string, int>? sharedStringIndexes,
+            CancellationToken ct) {
+            string rowReference = rowIndex.ToString(CultureInfo.InvariantCulture);
+            var cells = new List<OpenXmlElement>(table.Columns.Count);
+            for (int offset = 0; offset < table.Columns.Count; offset++) {
+                ct.ThrowIfCancellationRequested();
+                int column = startColumn + offset;
+                var (cellValue, cellType) = CoerceDataTableAppendValue(table.Columns[offset].ColumnName, useDirectStringCells, ref sharedStringIndexes);
+                var cell = new Cell {
+                    CellReference = columnNames[column] + rowReference,
+                    CellValue = cellValue,
+                    DataType = new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(cellType)
+                };
+
+                cells.Add(cell);
+            }
+
+            var row = new Row { RowIndex = (uint)rowIndex };
+            row.Append(cells);
+            return row;
+        }
+
+        private Row CreateDataTableValueRow(
+            int rowIndex,
+            int startColumn,
+            IReadOnlyList<string> columnNames,
+            DataRow dataRow,
+            IReadOnlyList<uint?> styleIndexes,
+            bool useDirectStringCells,
+            ref Dictionary<string, int>? sharedStringIndexes,
+            CancellationToken ct) {
+            string rowReference = rowIndex.ToString(CultureInfo.InvariantCulture);
+            int columnCount = dataRow.Table.Columns.Count;
+            var cells = new List<OpenXmlElement>(columnCount);
+            for (int offset = 0; offset < columnCount; offset++) {
+                ct.ThrowIfCancellationRequested();
+                object? value = dataRow.IsNull(offset) ? null : dataRow[offset];
+                int column = startColumn + offset;
+                var (cellValue, cellType) = CoerceDataTableAppendValue(value, useDirectStringCells, ref sharedStringIndexes);
+                var cell = new Cell {
+                    CellReference = columnNames[column] + rowReference,
+                    CellValue = cellValue,
+                    DataType = new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(cellType)
+                };
+
+                if (offset < styleIndexes.Count && styleIndexes[offset] is uint styleIndex) {
+                    cell.StyleIndex = styleIndex;
+                }
+
+                cells.Add(cell);
+            }
+
+            var row = new Row { RowIndex = (uint)rowIndex };
+            row.Append(cells);
+            return row;
+        }
+
+        private (CellValue cellValue, DocumentFormat.OpenXml.Spreadsheet.CellValues cellType) CoerceDataTableAppendValue(
+            object? value,
+            bool useDirectStringCells,
+            ref Dictionary<string, int>? sharedStringIndexes) {
+            var indexes = sharedStringIndexes;
+            CellValue HandleString(string text) {
+                return useDirectStringCells
+                    ? CreatePlainAppendStringValue(text)
+                    : CreatePlainAppendSharedStringValue(text, ref indexes);
+            }
+
+            var (cellValue, cellType) = CoerceValueHelper.Coerce(
+                value,
+                HandleString,
+                _excelDocument.DateTimeOffsetWriteStrategy);
+            sharedStringIndexes = indexes;
+
+            if (useDirectStringCells && cellType == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString) {
+                cellType = DocumentFormat.OpenXml.Spreadsheet.CellValues.String;
+            }
+
+            return (cellValue, cellType);
+        }
+
+        private static string?[] BuildDataTableNumberFormats(DataTable table) {
+            var formats = new string?[table.Columns.Count];
+            for (int i = 0; i < table.Columns.Count; i++) {
+                Type type = table.Columns[i].DataType;
+                if (type == typeof(DateTime) || type == typeof(DateTimeOffset)) {
+                    formats[i] = "yyyy-mm-dd hh:mm";
+                } else if (type == typeof(TimeSpan)) {
+                    formats[i] = "[h]:mm:ss";
+                }
+            }
+
+            return formats;
+        }
+
         /// <summary>
         /// Inserts a DataTable and immediately creates an Excel Table over the written range.
         /// Returns the A1-style range of the created table.
@@ -150,7 +358,7 @@ namespace OfficeIMO.Excel {
             string range = startRef + ":" + endRef;
 
             // Create the Table with optional AutoFilter and style
-            AddTable(range, includeHeaders, tableName ?? string.Empty, style, includeAutoFilter);
+            AddTableAndGetName(range, includeHeaders, tableName ?? string.Empty, style, includeAutoFilter, ensureRangeCellsExist: false);
             return range;
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.Dimension.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Dimension.cs
@@ -77,10 +77,20 @@ namespace OfficeIMO.Excel {
             string reference = ComputeSheetDimensionReference(ws);
 
             if (dimEl == null) {
-                ws.InsertAt(new SheetDimension { Reference = reference }, 0);
+                InsertSheetDimensionInSchemaOrder(ws, new SheetDimension { Reference = reference });
             } else {
                 dimEl.Reference = reference;
             }
+        }
+
+        private static void InsertSheetDimensionInSchemaOrder(Worksheet worksheet, SheetDimension dimension) {
+            var sheetProperties = worksheet.GetFirstChild<SheetProperties>();
+            if (sheetProperties != null) {
+                worksheet.InsertAfter(dimension, sheetProperties);
+                return;
+            }
+
+            worksheet.PrependChild(dimension);
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.Headers.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.cs
@@ -92,6 +92,8 @@ namespace OfficeIMO.Excel {
         /// Clears the cached header map.
         /// </summary>
         public void ClearHeaderCache() {
+            _hasWorksheetMutations = true;
+            MarkRequiresSavePreparation();
             lock (_headerMapLock) {
                 _headerMapCache = null;
                 _headerMapSourceA1 = null;

--- a/OfficeIMO.Excel/ExcelSheet.Preflight.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Preflight.cs
@@ -99,6 +99,7 @@ namespace OfficeIMO.Excel {
 
                 ws.Save();
             });
+            _requiresSavePreparation = false;
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Tables.cs
@@ -261,7 +261,7 @@ namespace OfficeIMO.Excel {
         /// <exception cref="ArgumentException">Thrown when <paramref name="range"/> is not in a valid format.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the specified range overlaps with an existing table.</exception>
         public void AddTable(string range, bool hasHeader, string name, TableStyle style) {
-            AddTableCore(range, hasHeader, name, style, includeAutoFilter: true);
+            AddTableCore(range, hasHeader, name, style, includeAutoFilter: true, ensureRangeCellsExist: true);
         }
 
         /// <summary>
@@ -300,14 +300,14 @@ namespace OfficeIMO.Excel {
         /// - Order doesn't matter — the final state will be consistent regardless of operation order.
         /// </remarks>
         public void AddTable(string range, bool hasHeader, string name, TableStyle style, bool includeAutoFilter, TableNameValidationMode validationMode = TableNameValidationMode.Sanitize) {
-            AddTableCore(range, hasHeader, name, style, includeAutoFilter, validationMode);
+            AddTableCore(range, hasHeader, name, style, includeAutoFilter, validationMode, ensureRangeCellsExist: true);
         }
 
-        internal string AddTableAndGetName(string range, bool hasHeader, string name, TableStyle style, bool includeAutoFilter, TableNameValidationMode validationMode = TableNameValidationMode.Sanitize) {
-            return AddTableCore(range, hasHeader, name, style, includeAutoFilter, validationMode);
+        internal string AddTableAndGetName(string range, bool hasHeader, string name, TableStyle style, bool includeAutoFilter, TableNameValidationMode validationMode = TableNameValidationMode.Sanitize, bool ensureRangeCellsExist = true) {
+            return AddTableCore(range, hasHeader, name, style, includeAutoFilter, validationMode, ensureRangeCellsExist);
         }
 
-        private string AddTableCore(string range, bool hasHeader, string name, TableStyle style, bool includeAutoFilter, TableNameValidationMode validationMode = TableNameValidationMode.Sanitize) {
+        private string AddTableCore(string range, bool hasHeader, string name, TableStyle style, bool includeAutoFilter, TableNameValidationMode validationMode = TableNameValidationMode.Sanitize, bool ensureRangeCellsExist = true) {
             if (string.IsNullOrEmpty(range)) {
                 throw new ArgumentNullException(nameof(range));
             }
@@ -355,7 +355,9 @@ namespace OfficeIMO.Excel {
                     }
                 }
 
-                EnsureRangeCellsExist(startRowIndex, endRowIndex, startColumnIndex, endColumnIndex);
+                if (ensureRangeCellsExist) {
+                    EnsureRangeCellsExist(startRowIndex, endRowIndex, startColumnIndex, endColumnIndex);
+                }
 
                 // Generate unique table ID atomically (must be unique across the entire workbook)
                 uint tableId;

--- a/OfficeIMO.Excel/Read/ExcelDocumentReader.Tables.cs
+++ b/OfficeIMO.Excel/Read/ExcelDocumentReader.Tables.cs
@@ -104,6 +104,7 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public IEnumerable<Dictionary<string, object?>> ReadTableObjects(string tableName, ExecutionMode? mode = null, CancellationToken ct = default) {
             var table = GetTable(tableName);
+            EnsureTableHasHeaderRow(table, nameof(ReadTableObjects));
             return GetSheet(table.SheetName).ReadObjects(table.Range, mode, ct);
         }
 
@@ -115,6 +116,7 @@ namespace OfficeIMO.Excel {
             ExecutionMode? mode = null,
             CancellationToken ct = default) where T : new() {
             var table = GetTable(tableName);
+            EnsureTableHasHeaderRow(table, nameof(ReadTableObjects));
             return GetSheet(table.SheetName).ReadObjects<T>(table.Range, mode, ct);
         }
 
@@ -125,7 +127,14 @@ namespace OfficeIMO.Excel {
             string tableName,
             CancellationToken ct = default) where T : new() {
             var table = GetTable(tableName);
+            EnsureTableHasHeaderRow(table, nameof(ReadTableObjectsStream));
             return GetSheet(table.SheetName).ReadObjectsStream<T>(table.Range, ct);
+        }
+
+        private static void EnsureTableHasHeaderRow(ExcelTableInfo table, string operationName) {
+            if (!table.HasHeaderRow) {
+                throw new InvalidOperationException($"{operationName} requires table '{table.Name}' to have a header row. Use ReadTableAsDataTable(..., headersInFirstRow: false) for headerless tables.");
+            }
         }
 
         private static string? GetOpenXmlAttributeValue(OpenXmlElement element, string localName) {

--- a/OfficeIMO.Excel/Read/ExcelDocumentReader.Tables.cs
+++ b/OfficeIMO.Excel/Read/ExcelDocumentReader.Tables.cs
@@ -1,0 +1,139 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+
+namespace OfficeIMO.Excel {
+    public sealed partial class ExcelDocumentReader {
+        /// <summary>
+        /// Returns all Excel tables defined in the workbook.
+        /// </summary>
+        public IReadOnlyList<ExcelTableInfo> GetTables() {
+            var workbook = WorkbookRoot;
+            var sheets = workbook.Sheets?.OfType<Sheet>().ToList() ?? new List<Sheet>();
+            var sheetLookup = new Dictionary<string, (string Name, int Index)>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < sheets.Count; i++) {
+                var sheet = sheets[i];
+                string? id = sheet.Id?.Value;
+                string? name = sheet.Name?.Value;
+                if (!string.IsNullOrWhiteSpace(id) && !string.IsNullOrWhiteSpace(name)) {
+                    sheetLookup[id!] = (name!, i);
+                }
+            }
+
+            var tables = new List<ExcelTableInfo>();
+            foreach (var worksheetPart in WorkbookPartRoot.WorksheetParts) {
+                string relId = WorkbookPartRoot.GetIdOfPart(worksheetPart);
+                sheetLookup.TryGetValue(relId, out var sheetInfo);
+                string sheetName = sheetInfo.Name ?? string.Empty;
+                int sheetIndex = string.IsNullOrEmpty(sheetInfo.Name) ? -1 : sheetInfo.Index;
+
+                foreach (var tablePart in worksheetPart.TableDefinitionParts) {
+                    var table = tablePart.Table;
+                    if (table == null) {
+                        continue;
+                    }
+
+                    string name = table.Name?.Value ?? table.DisplayName?.Value ?? string.Empty;
+                    string displayName = table.DisplayName?.Value ?? name;
+                    string range = table.Reference?.Value ?? string.Empty;
+                    var columns = table.TableColumns?.Elements<TableColumn>()
+                        .Select((column, index) => new ExcelTableColumnInfo(
+                            index + 1,
+                            column.Name?.Value ?? string.Empty,
+                            GetOpenXmlAttributeValue(column, "totalsRowFunction")))
+                        .ToList() ?? new List<ExcelTableColumnInfo>();
+
+                    tables.Add(new ExcelTableInfo(
+                        name,
+                        displayName,
+                        range,
+                        sheetName,
+                        sheetIndex,
+                        table.TableStyleInfo?.Name?.Value,
+                        (table.HeaderRowCount?.Value ?? 1U) > 0U,
+                        (table.TotalsRowCount?.Value ?? 0U) > 0U,
+                        table.GetFirstChild<AutoFilter>() != null,
+                        columns));
+                }
+            }
+
+            return tables;
+        }
+
+        /// <summary>
+        /// Gets metadata for a table by name or display name.
+        /// </summary>
+        public ExcelTableInfo GetTable(string tableName) {
+            if (string.IsNullOrWhiteSpace(tableName)) throw new ArgumentNullException(nameof(tableName));
+
+            var table = GetTables()
+                .FirstOrDefault(item =>
+                    string.Equals(item.Name, tableName, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(item.DisplayName, tableName, StringComparison.OrdinalIgnoreCase));
+            if (table == null) {
+                throw new KeyNotFoundException($"Table '{tableName}' was not found.");
+            }
+
+            return table;
+        }
+
+        /// <summary>
+        /// Reads an Excel table by name into a dense matrix.
+        /// </summary>
+        public object?[,] ReadTable(string tableName) {
+            var table = GetTable(tableName);
+            return GetSheet(table.SheetName).ReadRange(table.Range);
+        }
+
+        /// <summary>
+        /// Reads an Excel table by name into a DataTable.
+        /// </summary>
+        public DataTable ReadTableAsDataTable(string tableName, bool? headersInFirstRow = null, ExecutionMode? mode = null, CancellationToken ct = default) {
+            var table = GetTable(tableName);
+            return GetSheet(table.SheetName).ReadRangeAsDataTable(table.Range, headersInFirstRow ?? table.HasHeaderRow, mode, ct);
+        }
+
+        /// <summary>
+        /// Reads an Excel table by name as dictionaries using the table header row.
+        /// </summary>
+        public IEnumerable<Dictionary<string, object?>> ReadTableObjects(string tableName, ExecutionMode? mode = null, CancellationToken ct = default) {
+            var table = GetTable(tableName);
+            return GetSheet(table.SheetName).ReadObjects(table.Range, mode, ct);
+        }
+
+        /// <summary>
+        /// Reads an Excel table by name and maps rows to objects using the table header row.
+        /// </summary>
+        public IEnumerable<T> ReadTableObjects<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+            string tableName,
+            ExecutionMode? mode = null,
+            CancellationToken ct = default) where T : new() {
+            var table = GetTable(tableName);
+            return GetSheet(table.SheetName).ReadObjects<T>(table.Range, mode, ct);
+        }
+
+        /// <summary>
+        /// Streams an Excel table by name and maps rows to objects using the table header row.
+        /// </summary>
+        public IEnumerable<T> ReadTableObjectsStream<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+            string tableName,
+            CancellationToken ct = default) where T : new() {
+            var table = GetTable(tableName);
+            return GetSheet(table.SheetName).ReadObjectsStream<T>(table.Range, ct);
+        }
+
+        private static string? GetOpenXmlAttributeValue(OpenXmlElement element, string localName) {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+            if (string.IsNullOrWhiteSpace(localName)) throw new ArgumentException("Attribute name is required.", nameof(localName));
+
+            var attribute = element.GetAttributes().FirstOrDefault(a => string.Equals(a.LocalName, localName, StringComparison.OrdinalIgnoreCase));
+            return string.IsNullOrWhiteSpace(attribute.Value) ? null : attribute.Value;
+        }
+    }
+}

--- a/OfficeIMO.Excel/Read/ExcelRead.cs
+++ b/OfficeIMO.Excel/Read/ExcelRead.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OfficeIMO.Excel {
     /// <summary>
@@ -49,6 +50,47 @@ namespace OfficeIMO.Excel {
         public static DataTable ReadRangeAsDataTable(string path, string sheetName, string a1Range, bool headersInFirstRow = true, ExcelReadOptions? options = null) {
             using var rdr = ExcelDocumentReader.Open(path, options ?? new ExcelReadOptions());
             return rdr.GetSheet(sheetName).ReadRangeAsDataTable(a1Range, headersInFirstRow);
+        }
+
+        /// <summary>
+        /// Reads a named Excel table into a DataTable.
+        /// </summary>
+        /// <param name="path">Path to the .xlsx file.</param>
+        /// <param name="tableName">Excel table name or display name.</param>
+        /// <param name="headersInFirstRow">Optional override for whether the first table row is treated as headers.</param>
+        /// <param name="options">Optional read options.</param>
+        /// <returns>DataTable containing values from the named Excel table.</returns>
+        public static DataTable ReadTableAsDataTable(string path, string tableName, bool? headersInFirstRow = null, ExcelReadOptions? options = null) {
+            using var rdr = ExcelDocumentReader.Open(path, options ?? new ExcelReadOptions());
+            return rdr.ReadTableAsDataTable(tableName, headersInFirstRow);
+        }
+
+        /// <summary>
+        /// Reads a named Excel table as dictionaries using the table header row.
+        /// </summary>
+        /// <param name="path">Path to the .xlsx file.</param>
+        /// <param name="tableName">Excel table name or display name.</param>
+        /// <param name="options">Optional read options.</param>
+        /// <returns>Materialized list of row dictionaries.</returns>
+        public static List<Dictionary<string, object?>> ReadTableObjects(string path, string tableName, ExcelReadOptions? options = null) {
+            using var rdr = ExcelDocumentReader.Open(path, options ?? new ExcelReadOptions());
+            return rdr.ReadTableObjects(tableName).ToList();
+        }
+
+        /// <summary>
+        /// Reads a named Excel table and maps rows to instances of <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">Target type whose writable properties receive row values.</typeparam>
+        /// <param name="path">Path to the .xlsx file.</param>
+        /// <param name="tableName">Excel table name or display name.</param>
+        /// <param name="options">Optional read options.</param>
+        /// <returns>Materialized list of <typeparamref name="T"/> populated from each table row.</returns>
+        public static List<T> ReadTableObjectsAs<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+            string path,
+            string tableName,
+            ExcelReadOptions? options = null) where T : new() {
+            using var rdr = ExcelDocumentReader.Open(path, options ?? new ExcelReadOptions());
+            return rdr.ReadTableObjects<T>(tableName).ToList();
         }
 
         /// <summary>

--- a/OfficeIMO.Excel/Read/ExcelReadOptions.cs
+++ b/OfficeIMO.Excel/Read/ExcelReadOptions.cs
@@ -42,6 +42,12 @@ namespace OfficeIMO.Excel {
         public bool NumericAsDecimal { get; set; } = false;
 
         /// <summary>
+        /// When true, DataTable reads infer stable column types from the materialized range.
+        /// Mixed-type columns stay object-typed.
+        /// </summary>
+        public bool InferDataTableColumnTypes { get; set; } = true;
+
+        /// <summary>
         /// When true, typed object readers throw if selected headers cannot be mapped
         /// deterministically to writable properties.
         /// </summary>
@@ -63,11 +69,11 @@ namespace OfficeIMO.Excel {
         /// Initializes reading defaults and per-operation thresholds.
         /// </summary>
         public ExcelReadOptions() {
-            Execution.OperationThresholds["ReadRange"] = 10_000;
-            Execution.OperationThresholds["ReadRangeAsDataTable"] = 10_000;
+            Execution.OperationThresholds["ReadRange"] = 100_000;
+            Execution.OperationThresholds["ReadRangeAsDataTable"] = 100_000;
             Execution.OperationThresholds["ReadObjects"] = 10_000;
-            Execution.OperationThresholds["ReadObjectsAs"] = 10_000;
-            Execution.OperationThresholds["ReadRangeStream"] = 1_024;
+            Execution.OperationThresholds["ReadObjectsAs"] = 100_000;
+            Execution.OperationThresholds["ReadRangeStream"] = 100_000;
             Execution.OperationThresholds["ReadRows"] = 20_000;
         }
     }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
@@ -35,6 +35,10 @@ namespace OfficeIMO.Excel {
             }
 
             if (decided != OfficeIMO.Excel.ExecutionMode.Parallel) {
+                if (TryReadObjectsFromFastRange<T>(a1Range, r1, c1, rows, cols, ct, out var rangeResult)) {
+                    return rangeResult;
+                }
+
                 if (TryReadObjectsSequentialSinglePass<T>(a1Range, r1, c1, r2, c2, rows, cols, ct, out var fastResult)) {
                     return fastResult;
                 }
@@ -120,6 +124,70 @@ namespace OfficeIMO.Excel {
             return result;
         }
 
+        private bool TryReadObjectsFromFastRange<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+            string a1Range,
+            int r1,
+            int c1,
+            int rows,
+            int cols,
+            CancellationToken ct,
+            out List<T> result) where T : new() {
+            result = [];
+
+            if (_opt.CellValueConverter != null
+                || _opt.TypeConverter != null
+                || !CanUseXmlFastReader()) {
+                return false;
+            }
+
+            object?[,] values = ReadRange(a1Range, OfficeIMO.Excel.ExecutionMode.Sequential, ct);
+            var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => values[0, c]?.ToString(), _opt.NormalizeHeaders);
+            var headerBindings = GetTypedHeaderBindings<T>(headers, a1Range);
+            var bindings = headerBindings.Bindings;
+
+            int dataRowCount = rows - 1;
+            result = new List<T>(dataRowCount);
+            bool canCancel = ct.CanBeCanceled;
+            for (int r = 1; r < rows; r++) {
+                if (canCancel && (r & 1023) == 0) {
+                    ct.ThrowIfCancellationRequested();
+                }
+
+                var target = new T();
+                for (int c = 0; c < cols; c++) {
+                    var binding = bindings[c];
+                    if (binding == null) {
+                        continue;
+                    }
+
+                    object? value = values[r, c];
+                    if (value == null) {
+                        if (binding.IsNullable) {
+                            binding.SetValue(target, null);
+                        }
+
+                        continue;
+                    }
+
+                    if (_opt.TreatDatesUsingNumberFormat
+                        && value is DateTime
+                        && IsNumericBindingDestination(binding.DestinationType)) {
+                        result = [];
+                        return false;
+                    }
+
+                    object? converted = TryChangeType(value, binding, _opt.Culture);
+                    if (converted is not null || binding.IsNullable) {
+                        binding.SetValue(target, converted);
+                    }
+                }
+
+                result.Add(target);
+            }
+
+            return true;
+        }
+
         /// <summary>
         /// Streams a rectangular range and maps each data row into an instance of T without materializing the full result set first.
         /// Header cells are matched to public writable properties on T by name (case-insensitive).
@@ -135,7 +203,38 @@ namespace OfficeIMO.Excel {
                 return Array.Empty<T>();
             }
 
+            if (CanUseSequentialRangeFastPath("ReadObjectsAs", rows * cols, null)
+                && CanUseXmlFastReader()) {
+                return ReadObjectsStreamFastRangeIterator<T>(a1Range, r1, c1, r2, c2, rows, cols, ct);
+            }
+
             return ReadObjectsStreamIterator<T>(a1Range, r1, c1, r2, c2, cols, ct);
+        }
+
+        private IEnumerable<T> ReadObjectsStreamFastRangeIterator<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+            string a1Range,
+            int r1,
+            int c1,
+            int r2,
+            int c2,
+            int rows,
+            int cols,
+            CancellationToken ct) where T : new() {
+            if (TryReadObjectsFromFastRange<T>(a1Range, r1, c1, rows, cols, ct, out var result)) {
+                for (int i = 0; i < result.Count; i++) {
+                    if (ct.CanBeCanceled && (i & 1023) == 0) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
+                    yield return result[i];
+                }
+
+                yield break;
+            }
+
+            foreach (var item in ReadObjectsStreamIterator<T>(a1Range, r1, c1, r2, c2, cols, ct)) {
+                yield return item;
+            }
         }
 
         private IEnumerable<T> ReadObjectsStreamIterator<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
@@ -203,38 +203,7 @@ namespace OfficeIMO.Excel {
                 return Array.Empty<T>();
             }
 
-            if (CanUseSequentialRangeFastPath("ReadObjectsAs", rows * cols, null)
-                && CanUseXmlFastReader()) {
-                return ReadObjectsStreamFastRangeIterator<T>(a1Range, r1, c1, r2, c2, rows, cols, ct);
-            }
-
             return ReadObjectsStreamIterator<T>(a1Range, r1, c1, r2, c2, cols, ct);
-        }
-
-        private IEnumerable<T> ReadObjectsStreamFastRangeIterator<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
-            string a1Range,
-            int r1,
-            int c1,
-            int r2,
-            int c2,
-            int rows,
-            int cols,
-            CancellationToken ct) where T : new() {
-            if (TryReadObjectsFromFastRange<T>(a1Range, r1, c1, rows, cols, ct, out var result)) {
-                for (int i = 0; i < result.Count; i++) {
-                    if (ct.CanBeCanceled && (i & 1023) == 0) {
-                        ct.ThrowIfCancellationRequested();
-                    }
-
-                    yield return result[i];
-                }
-
-                yield break;
-            }
-
-            foreach (var item in ReadObjectsStreamIterator<T>(a1Range, r1, c1, r2, c2, cols, ct)) {
-                yield return item;
-            }
         }
 
         private IEnumerable<T> ReadObjectsStreamIterator<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
@@ -906,6 +906,11 @@ namespace OfficeIMO.Excel {
                 string? reference = rowReader.GetAttribute("r");
                 int columnIndex = A1.ParseColumnIndexFromCellReferenceFast(reference);
                 if (columnIndex <= 0) {
+                    if (!string.IsNullOrEmpty(reference)) {
+                        _ = ReadXmlCellValue(rowReader);
+                        continue;
+                    }
+
                     columnIndex = nextColumnIndex;
                 }
 
@@ -968,6 +973,10 @@ namespace OfficeIMO.Excel {
             }
 
             if (formulaText != null && !_opt.UseCachedFormulaResult) {
+                return formulaText;
+            }
+
+            if (formulaText != null && rawText == null) {
                 return formulaText;
             }
 

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
@@ -1,7 +1,10 @@
 using DocumentFormat.OpenXml.Spreadsheet;
 using System.Data;
+using System.Globalization;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 
 namespace OfficeIMO.Excel {
     /// <summary>
@@ -34,6 +37,10 @@ namespace OfficeIMO.Excel {
             int workload = height * width;
             if (decided == OfficeIMO.Excel.ExecutionMode.Automatic) decided = policy.Decide("ReadRange", workload);
             if (decided == OfficeIMO.Excel.ExecutionMode.Sequential) {
+                if (TryFillRangeXmlFast(result, r1, c1, r2, c2, ct)) {
+                    return result;
+                }
+
                 FillRangeSequential(result, r1, c1, r2, c2, ct);
                 return result;
             }
@@ -61,6 +68,10 @@ namespace OfficeIMO.Excel {
             int rows = r2 - r1 + 1;
             int cols = c2 - c1 + 1;
             if (CanUseSequentialRangeFastPath("ReadRangeAsDataTable", rows * cols, mode)) {
+                if (TryFillDataTableXmlFast(dt, r1, c1, r2, c2, rows, cols, headersInFirstRow, ct)) {
+                    return dt;
+                }
+
                 if (TryFillDataTableSequentialSinglePass(dt, r1, c1, r2, c2, rows, cols, headersInFirstRow, ct)) {
                     return dt;
                 }
@@ -70,6 +81,10 @@ namespace OfficeIMO.Excel {
             }
 
             var raw = SnapshotAndConvertRangeCells(r1, c1, r2, c2, "ReadRangeAsDataTable", mode, ct, rows * cols);
+
+            Type[]? columnTypes = _opt.InferDataTableColumnTypes
+                ? InferDataTableColumnTypesFromRaw(raw, r1, c1, cols, headersInFirstRow ? 1 : 0)
+                : null;
 
             if (headersInFirstRow && rows > 0) {
                 var headerValues = new object?[cols];
@@ -83,10 +98,10 @@ namespace OfficeIMO.Excel {
 
                 var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => headerValues[c]?.ToString(), _opt.NormalizeHeaders);
                 for (int c = 0; c < cols; c++) {
-                    dt.Columns.Add(headers[c], typeof(object));
+                    dt.Columns.Add(headers[c], columnTypes?[c] ?? typeof(object));
                 }
             } else {
-                for (int c = 0; c < cols; c++) dt.Columns.Add($"Column{c + 1}", typeof(object));
+                for (int c = 0; c < cols; c++) dt.Columns.Add($"Column{c + 1}", columnTypes?[c] ?? typeof(object));
             }
 
             int startRow = headersInFirstRow ? 1 : 0;
@@ -106,6 +121,68 @@ namespace OfficeIMO.Excel {
             }
 
             return dt;
+        }
+
+        private bool TryFillDataTableXmlFast(
+            DataTable dt,
+            int r1,
+            int c1,
+            int r2,
+            int c2,
+            int rows,
+            int cols,
+            bool headersInFirstRow,
+            CancellationToken ct) {
+            if (!CanUseXmlFastReader()) {
+                return false;
+            }
+
+            var values = new object?[rows, cols];
+            if (!TryFillRangeXmlFast(values, r1, c1, r2, c2, ct)) {
+                return false;
+            }
+
+            FillDataTableFromMatrix(dt, values, rows, cols, headersInFirstRow, ct);
+            return true;
+        }
+
+        private void FillDataTableFromMatrix(DataTable dt, object?[,] values, int rows, int cols, bool headersInFirstRow, CancellationToken ct) {
+            int startRow = headersInFirstRow ? 1 : 0;
+            int dataRowCount = Math.Max(0, rows - startRow);
+            Type[]? columnTypes = _opt.InferDataTableColumnTypes
+                ? InferDataTableColumnTypes(values, startRow, rows, cols)
+                : null;
+
+            if (headersInFirstRow && rows > 0) {
+                var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => values[0, c]?.ToString(), _opt.NormalizeHeaders);
+                for (int c = 0; c < cols; c++) {
+                    dt.Columns.Add(headers[c], columnTypes?[c] ?? typeof(object));
+                }
+            } else {
+                for (int c = 0; c < cols; c++) {
+                    dt.Columns.Add($"Column{c + 1}", columnTypes?[c] ?? typeof(object));
+                }
+            }
+
+            bool canCancel = ct.CanBeCanceled;
+            dt.BeginLoadData();
+            try {
+                for (int r = 0; r < dataRowCount; r++) {
+                    if (canCancel && (r & 1023) == 0) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
+                    int sourceRow = r + startRow;
+                    var rowValues = new object?[cols];
+                    for (int c = 0; c < cols; c++) {
+                        rowValues[c] = values[sourceRow, c] ?? DBNull.Value;
+                    }
+
+                    dt.Rows.Add(rowValues);
+                }
+            } finally {
+                dt.EndLoadData();
+            }
         }
 
         /// <summary>
@@ -212,15 +289,16 @@ namespace OfficeIMO.Excel {
                 var headerValues = new object?[cols];
                 FillSequentialBuffers(r1, c1, r2, c2, cols, startRow, headerValues, rowValues, ct);
                 var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => headerValues[c]?.ToString(), _opt.NormalizeHeaders);
+                Type[]? columnTypes = _opt.InferDataTableColumnTypes ? InferDataTableColumnTypes(rowValues, cols) : null;
                 for (int c = 0; c < cols; c++) {
-                    dt.Columns.Add(headers[c], typeof(object));
+                    dt.Columns.Add(headers[c], columnTypes?[c] ?? typeof(object));
                 }
             } else {
-                for (int c = 0; c < cols; c++) {
-                    dt.Columns.Add($"Column{c + 1}", typeof(object));
-                }
-
                 FillSequentialBuffers(r1, c1, r2, c2, cols, startRow, null, rowValues, ct);
+                Type[]? columnTypes = _opt.InferDataTableColumnTypes ? InferDataTableColumnTypes(rowValues, cols) : null;
+                for (int c = 0; c < cols; c++) {
+                    dt.Columns.Add($"Column{c + 1}", columnTypes?[c] ?? typeof(object));
+                }
             }
 
             for (int r = 0; r < dataRowCount; r++) {
@@ -244,6 +322,10 @@ namespace OfficeIMO.Excel {
             int cols,
             bool headersInFirstRow,
             CancellationToken ct) {
+            if (_opt.InferDataTableColumnTypes) {
+                return false;
+            }
+
             bool canCancel = ct.CanBeCanceled;
             bool columnsReady = false;
             int startRow = headersInFirstRow ? 1 : 0;
@@ -555,6 +637,79 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        private static Type[] InferDataTableColumnTypes(object?[][] rowValues, int cols) {
+            var types = new Type[cols];
+            for (int c = 0; c < cols; c++) {
+                Type? inferred = null;
+                for (int r = 0; r < rowValues.Length; r++) {
+                    object?[]? row = rowValues[r];
+                    if (row == null) {
+                        continue;
+                    }
+
+                    inferred = MergeDataTableColumnType(inferred, row[c]);
+                    if (inferred == typeof(object)) {
+                        break;
+                    }
+                }
+
+                types[c] = inferred ?? typeof(object);
+            }
+
+            return types;
+        }
+
+        private static Type[] InferDataTableColumnTypes(object?[,] values, int startRow, int rows, int cols) {
+            var types = new Type[cols];
+            for (int c = 0; c < cols; c++) {
+                Type? inferred = null;
+                for (int r = startRow; r < rows; r++) {
+                    inferred = MergeDataTableColumnType(inferred, values[r, c]);
+                    if (inferred == typeof(object)) {
+                        break;
+                    }
+                }
+
+                types[c] = inferred ?? typeof(object);
+            }
+
+            return types;
+        }
+
+        private static Type[] InferDataTableColumnTypesFromRaw(List<CellRaw> raw, int r1, int c1, int cols, int startRow) {
+            var types = new Type[cols];
+            Type?[] inferred = new Type?[cols];
+            for (int i = 0; i < raw.Count; i++) {
+                var cell = raw[i];
+                int rr = cell.Row - r1 - startRow;
+                int cc = cell.Col - c1;
+                if (rr < 0 || (uint)cc >= (uint)cols || inferred[cc] == typeof(object)) {
+                    continue;
+                }
+
+                inferred[cc] = MergeDataTableColumnType(inferred[cc], cell.TypedValue);
+            }
+
+            for (int c = 0; c < cols; c++) {
+                types[c] = inferred[c] ?? typeof(object);
+            }
+
+            return types;
+        }
+
+        private static Type? MergeDataTableColumnType(Type? current, object? value) {
+            if (value == null || value == DBNull.Value) {
+                return current;
+            }
+
+            Type next = value.GetType();
+            if (current == null || current == next) {
+                return next;
+            }
+
+            return typeof(object);
+        }
+
         private List<CellRaw> SnapshotAndConvertRangeCells(
             int r1,
             int c1,
@@ -667,6 +822,265 @@ namespace OfficeIMO.Excel {
                         result[rr, cc] = value;
                 }
             }
+        }
+
+        private bool TryFillRangeXmlFast(object?[,] result, int r1, int c1, int r2, int c2, CancellationToken ct) {
+            if (!CanUseXmlFastReader()) {
+                return false;
+            }
+
+            try {
+                using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
+                var settings = new XmlReaderSettings {
+                    DtdProcessing = DtdProcessing.Prohibit,
+                    IgnoreComments = true,
+                    IgnoreProcessingInstructions = true,
+                    IgnoreWhitespace = true,
+                    CloseInput = false
+                };
+
+                using var reader = XmlReader.Create(stream, settings);
+                bool canCancel = ct.CanBeCanceled;
+                int nextRowIndex = 1;
+                while (reader.Read()) {
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
+                    if (reader.NodeType != XmlNodeType.Element || reader.LocalName != "row") {
+                        continue;
+                    }
+
+                    int rowIndex = ParsePositiveIntAttribute(reader.GetAttribute("r"));
+                    if (rowIndex <= 0) {
+                        rowIndex = nextRowIndex;
+                    }
+
+                    nextRowIndex = rowIndex + 1;
+                    if (rowIndex < r1 || rowIndex > r2) {
+                        continue;
+                    }
+
+                    ReadXmlRowIntoRange(reader, result, rowIndex, r1, c1, c2, ct);
+                }
+
+                return true;
+            } catch (XmlException) {
+                return false;
+            } catch (IOException) {
+                return false;
+            } catch (UnauthorizedAccessException) {
+                return false;
+            } catch (ObjectDisposedException) {
+                return false;
+            }
+        }
+
+        private bool CanUseXmlFastReader() {
+            return _opt.CellValueConverter == null
+                && _opt.Culture == CultureInfo.InvariantCulture
+                && CanStreamWorksheetPart();
+        }
+
+        private void ReadXmlRowIntoRange(XmlReader rowReader, object?[,] result, int rowIndex, int r1, int c1, int c2, CancellationToken ct) {
+            if (rowReader.IsEmptyElement) {
+                return;
+            }
+
+            int depth = rowReader.Depth;
+            bool canCancel = ct.CanBeCanceled;
+            int nextColumnIndex = 1;
+            while (rowReader.Read()) {
+                if (canCancel) {
+                    ct.ThrowIfCancellationRequested();
+                }
+
+                if (rowReader.NodeType == XmlNodeType.EndElement && rowReader.Depth == depth && rowReader.LocalName == "row") {
+                    return;
+                }
+
+                if (rowReader.NodeType != XmlNodeType.Element || rowReader.LocalName != "c") {
+                    continue;
+                }
+
+                string? reference = rowReader.GetAttribute("r");
+                int columnIndex = A1.ParseColumnIndexFromCellReferenceFast(reference);
+                if (columnIndex <= 0) {
+                    columnIndex = nextColumnIndex;
+                }
+
+                nextColumnIndex = columnIndex + 1;
+                if (columnIndex < c1 || columnIndex > c2) {
+                    _ = ReadXmlCellValue(rowReader);
+                    continue;
+                }
+
+                int rr = rowIndex - r1;
+                int cc = columnIndex - c1;
+                if ((uint)rr >= (uint)result.GetLength(0) || (uint)cc >= (uint)result.GetLength(1)) {
+                    _ = ReadXmlCellValue(rowReader);
+                    continue;
+                }
+
+                result[rr, cc] = ReadXmlCellValue(rowReader);
+            }
+        }
+
+        private object? ReadXmlCellValue(XmlReader cellReader) {
+            string? type = cellReader.GetAttribute("t");
+            uint? styleIndex = TryParseUInt(cellReader.GetAttribute("s"), out uint parsedStyle) ? parsedStyle : null;
+
+            if (cellReader.IsEmptyElement) {
+                return _opt.FillBlanksInRanges ? null : null;
+            }
+
+            int depth = cellReader.Depth;
+            string? rawText = null;
+            string? inlineText = null;
+            string? formulaText = null;
+            bool hasNode = cellReader.Read();
+            while (hasNode) {
+                if (cellReader.NodeType == XmlNodeType.EndElement && cellReader.Depth == depth && cellReader.LocalName == "c") {
+                    break;
+                }
+
+                if (cellReader.NodeType == XmlNodeType.Element) {
+                    if (cellReader.LocalName == "v") {
+                        rawText = cellReader.ReadElementContentAsString();
+                        hasNode = true;
+                        continue;
+                    }
+
+                    if (cellReader.LocalName == "f") {
+                        formulaText = cellReader.ReadElementContentAsString();
+                        hasNode = true;
+                        continue;
+                    }
+
+                    if (cellReader.LocalName == "is") {
+                        inlineText = ReadXmlInlineString(cellReader);
+                        hasNode = true;
+                        continue;
+                    }
+                }
+
+                hasNode = cellReader.Read();
+            }
+
+            if (formulaText != null && !_opt.UseCachedFormulaResult) {
+                return formulaText;
+            }
+
+            if (type == "inlineStr") {
+                return inlineText;
+            }
+
+            if (type == "s") {
+                return TryParseSharedStringIndex(rawText, out int sstIndex) ? _sst.Get(sstIndex) : rawText;
+            }
+
+            if (type == "b" && rawText != null) {
+                return rawText == "1";
+            }
+
+            if (type == "str") {
+                return rawText ?? inlineText;
+            }
+
+            if (rawText == null) {
+                return inlineText;
+            }
+
+            if (_opt.TreatDatesUsingNumberFormat
+                && styleIndex is not null
+                && _styles.IsDateLike(styleIndex.Value)
+                && double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double oa)) {
+                return DateTime.FromOADate(oa);
+            }
+
+            return double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double number)
+                ? number
+                : rawText;
+        }
+
+        private static string ReadXmlInlineString(XmlReader inlineReader) {
+            if (inlineReader.IsEmptyElement) {
+                return string.Empty;
+            }
+
+            int depth = inlineReader.Depth;
+            string? first = null;
+            System.Text.StringBuilder? builder = null;
+            while (inlineReader.Read()) {
+                if (inlineReader.NodeType == XmlNodeType.EndElement && inlineReader.Depth == depth && inlineReader.LocalName == "is") {
+                    break;
+                }
+
+                if (inlineReader.NodeType != XmlNodeType.Element || inlineReader.LocalName != "t") {
+                    continue;
+                }
+
+                string text = inlineReader.ReadElementContentAsString();
+                if (builder != null) {
+                    builder.Append(text);
+                } else if (first == null) {
+                    first = text;
+                } else {
+                    builder = new System.Text.StringBuilder(first.Length + text.Length);
+                    builder.Append(first);
+                    builder.Append(text);
+                }
+            }
+
+            return builder?.ToString() ?? first ?? string.Empty;
+        }
+
+        private static int ParsePositiveIntAttribute(string? value) {
+            if (string.IsNullOrEmpty(value)) {
+                return 0;
+            }
+
+            string text = value!;
+            int result = 0;
+            for (int i = 0; i < text.Length; i++) {
+                int digit = text[i] - '0';
+                if ((uint)digit > 9U) {
+                    return 0;
+                }
+
+                if (result > (int.MaxValue - digit) / 10) {
+                    return 0;
+                }
+
+                result = (result * 10) + digit;
+            }
+
+            return result;
+        }
+
+        private static bool TryParseUInt(string? value, out uint result) {
+            result = 0;
+            if (string.IsNullOrEmpty(value)) {
+                return false;
+            }
+
+            string text = value!;
+            uint parsed = 0;
+            for (int i = 0; i < text.Length; i++) {
+                uint digit = (uint)(text[i] - '0');
+                if (digit > 9U) {
+                    return uint.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+                }
+
+                if (parsed > (uint.MaxValue - digit) / 10U) {
+                    return uint.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+                }
+
+                parsed = (parsed * 10U) + digit;
+            }
+
+            result = parsed;
+            return true;
         }
     }
 }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
@@ -344,6 +344,10 @@ namespace OfficeIMO.Excel {
                     ct.ThrowIfCancellationRequested();
                 }
 
+                if (row.RowIndex == null) {
+                    return false;
+                }
+
                 int rowIndex = checked((int)row.RowIndex!.Value);
                 if (rowIndex < r1) {
                     continue;
@@ -499,6 +503,10 @@ namespace OfficeIMO.Excel {
                     ct.ThrowIfCancellationRequested();
                 }
 
+                if (row.RowIndex == null) {
+                    return false;
+                }
+
                 int rowIndex = checked((int)row.RowIndex!.Value);
                 if (rowIndex < r1) {
                     continue;
@@ -597,13 +605,14 @@ namespace OfficeIMO.Excel {
             CancellationToken ct) {
             bool canCancel = ct.CanBeCanceled;
             int visitedCells = 0;
+            int inferredRowIndex = 0;
 
             foreach (var row in EnumerateWorksheetRows(ct)) {
                 if (canCancel) {
                     ct.ThrowIfCancellationRequested();
                 }
 
-                int rowIndex = checked((int)row.RowIndex!.Value);
+                int rowIndex = GetSequentialRowIndex(row, ref inferredRowIndex);
                 if (rowIndex < r1) continue;
                 if (rowIndex > r2) continue;
 
@@ -764,12 +773,13 @@ namespace OfficeIMO.Excel {
         private void SnapshotCellsInto(List<CellRaw> buffer, int r1, int c1, int r2, int c2, CancellationToken ct) {
             bool canCancel = ct.CanBeCanceled;
             int visitedCells = 0;
+            int inferredRowIndex = 0;
             foreach (var row in EnumerateWorksheetRows(ct)) {
                 if (canCancel) {
                     ct.ThrowIfCancellationRequested();
                 }
 
-                var rIndex = checked((int)row.RowIndex!.Value);
+                var rIndex = GetSequentialRowIndex(row, ref inferredRowIndex);
                 if (rIndex < r1) continue;
                 if (rIndex > r2) continue;
 
@@ -794,13 +804,14 @@ namespace OfficeIMO.Excel {
             int width = result.GetLength(1);
             bool canCancel = ct.CanBeCanceled;
             int visitedCells = 0;
+            int inferredRowIndex = 0;
 
             foreach (var row in EnumerateWorksheetRows(ct)) {
                 if (canCancel) {
                     ct.ThrowIfCancellationRequested();
                 }
 
-                var rIndex = checked((int)row.RowIndex!.Value);
+                var rIndex = GetSequentialRowIndex(row, ref inferredRowIndex);
                 if (rIndex < r1) continue;
                 if (rIndex > r2) continue;
 
@@ -822,6 +833,16 @@ namespace OfficeIMO.Excel {
                         result[rr, cc] = value;
                 }
             }
+        }
+
+        private static int GetSequentialRowIndex(Row row, ref int inferredRowIndex) {
+            if (row.RowIndex != null) {
+                inferredRowIndex = checked((int)row.RowIndex.Value);
+            } else {
+                inferredRowIndex++;
+            }
+
+            return inferredRowIndex;
         }
 
         private bool TryFillRangeXmlFast(object?[,] result, int r1, int c1, int r2, int c2, CancellationToken ct) {
@@ -992,6 +1013,12 @@ namespace OfficeIMO.Excel {
                 return rawText == "1";
             }
 
+            if (type == "d" && rawText != null) {
+                return DateTime.TryParse(rawText, _opt.Culture, DateTimeStyles.AssumeLocal, out var date)
+                    ? date
+                    : rawText;
+            }
+
             if (type == "str") {
                 return rawText ?? inlineText;
             }
@@ -1005,6 +1032,11 @@ namespace OfficeIMO.Excel {
                 && _styles.IsDateLike(styleIndex.Value)
                 && double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double oa)) {
                 return DateTime.FromOADate(oa);
+            }
+
+            if (_opt.NumericAsDecimal
+                && decimal.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, _opt.Culture, out decimal decimalNumber)) {
+                return decimalNumber;
             }
 
             return double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double number)

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Stream.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Stream.cs
@@ -38,6 +38,16 @@ namespace OfficeIMO.Excel {
             int nextToYield = 0;
             int chunkIndex = 0;
 
+            if (decided != OfficeIMO.Excel.ExecutionMode.Parallel
+                && estRows <= BufferedRangeStreamRowLimit
+                && CanUseXmlFastReader()) {
+                foreach (var chunk in ReadBufferedRangeStreamFromFastRange(a1Range, r1, c1, chunkRows, ct)) {
+                    yield return chunk;
+                }
+
+                yield break;
+            }
+
             if (estRows <= BufferedRangeStreamRowLimit) {
                 foreach (var chunk in ReadBufferedRows(EnumerateWorksheetRows(ct), r1, c1, r2, c2, decided, ct)) {
                     yield return chunk;
@@ -182,6 +192,32 @@ namespace OfficeIMO.Excel {
             int GetWindowIndex(int rowIndex) => (rowIndex - r1) / chunkRows;
 
             int GetWindowStartRow(int index) => r1 + (index * chunkRows);
+
+            IEnumerable<RangeChunk> ReadBufferedRangeStreamFromFastRange(string range, int firstRow, int firstColumn, int rowsPerChunk, CancellationToken token) {
+                object?[,] values = ReadRange(range, OfficeIMO.Excel.ExecutionMode.Sequential, token);
+                int height = values.GetLength(0);
+                int width = values.GetLength(1);
+                bool matrixCanCancel = token.CanBeCanceled;
+
+                for (int offset = 0; offset < height; offset += rowsPerChunk) {
+                    if (matrixCanCancel) {
+                        token.ThrowIfCancellationRequested();
+                    }
+
+                    int rowCount = Math.Min(rowsPerChunk, height - offset);
+                    var outRows = new object?[rowCount][];
+                    for (int r = 0; r < rowCount; r++) {
+                        var rowValues = new object?[width];
+                        for (int c = 0; c < width; c++) {
+                            rowValues[c] = values[offset + r, c];
+                        }
+
+                        outRows[r] = rowValues;
+                    }
+
+                    yield return new RangeChunk(firstRow + offset, rowCount, firstColumn, width, outRows);
+                }
+            }
 
             IEnumerable<RangeChunk> ReadBufferedRows(IEnumerable<Row> sourceRows, int rr1, int cc1, int rr2, int cc2, OfficeIMO.Excel.ExecutionMode executionMode, CancellationToken token) {
                 int windowCount = GetWindowIndex(rr2) + 1;

--- a/OfficeIMO.Excel/SharedStringPlanner.cs
+++ b/OfficeIMO.Excel/SharedStringPlanner.cs
@@ -1,6 +1,5 @@
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;
-using System.Collections.Concurrent;
 using System.Globalization;
 
 namespace OfficeIMO.Excel {
@@ -10,27 +9,36 @@ namespace OfficeIMO.Excel {
     /// and fixes up prepared cell values to reference shared string indices.
     /// </summary>
     internal sealed class SharedStringPlanner {
-        private readonly ConcurrentDictionary<string, byte> _distinct = new();
         private Dictionary<string, int>? _finalIndex;
 
         public string Note(string? s) {
             // Clamp and strip illegal XML control characters defensively
-            var safe = Utilities.ExcelSanitizer.SanitizeString(s);
-            _distinct.TryAdd(safe, 0);
-            return safe;
+            return Utilities.ExcelSanitizer.SanitizeString(s);
         }
 
         /// <summary>
         /// Apply collected strings to the document's SharedStringTable and build final index mapping.
         /// Must be called inside a serialized apply stage (under document write lock).
         /// </summary>
-        public void ApplyTo(ExcelDocument doc) {
-            if (_distinct.IsEmpty) {
+        public void ApplyTo(
+            (int Row, int Col, CellValue Val, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues> Type)[] prepared,
+            ExcelDocument doc) {
+            HashSet<string>? distinct = null;
+            for (int i = 0; i < prepared.Length; i++) {
+                if (prepared[i].Type?.Value != DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString) {
+                    continue;
+                }
+
+                distinct ??= new HashSet<string>(StringComparer.Ordinal);
+                distinct.Add(prepared[i].Val?.Text ?? string.Empty);
+            }
+
+            if (distinct == null || distinct.Count == 0) {
                 _finalIndex = new Dictionary<string, int>(0);
                 return;
             }
 
-            _finalIndex = doc.GetSharedStringIndices(_distinct.Keys);
+            _finalIndex = doc.GetSharedStringIndices(distinct);
         }
 
         /// <summary>
@@ -57,7 +65,7 @@ namespace OfficeIMO.Excel {
         /// Must be called inside serialized apply stage.
         /// </summary>
         public void ApplyAndFixup((int Row, int Col, CellValue Val, EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues> Type)[] prepared, ExcelDocument doc) {
-            ApplyTo(doc);
+            ApplyTo(prepared, doc);
             for (int i = 0; i < prepared.Length; i++) {
                 Fixup(ref prepared[i]);
             }

--- a/OfficeIMO.Excel/Utilities/ExcelPackageUtilities.cs
+++ b/OfficeIMO.Excel/Utilities/ExcelPackageUtilities.cs
@@ -23,6 +23,13 @@ namespace OfficeIMO.Excel.Utilities {
 
         internal static bool NormalizeContentTypes(Stream packageStream, bool leaveOpen = false) {
             if (packageStream == null || !packageStream.CanRead || !packageStream.CanSeek) return false;
+            long originalPosition = packageStream.Position;
+            if (!NeedsContentTypeNormalization(packageStream)) {
+                packageStream.Position = originalPosition;
+                return false;
+            }
+
+            packageStream.Position = originalPosition;
             using var archive = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: leaveOpen);
             var entry = archive.GetEntry(ContentTypesEntry);
             if (entry == null) {
@@ -117,6 +124,76 @@ namespace OfficeIMO.Excel.Utilities {
             document.Save(writer);
             writer.Flush();
             return true;
+        }
+
+        internal static bool NeedsContentTypeNormalization(Stream packageStream) {
+            try {
+                using var archive = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: true);
+                var entry = archive.GetEntry(ContentTypesEntry);
+                if (entry == null) {
+                    return true;
+                }
+
+                string xml;
+                using (var entryStream = entry.Open())
+                using (var reader = new StreamReader(entryStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: false)) {
+                    xml = reader.ReadToEnd();
+                }
+
+                if (string.IsNullOrWhiteSpace(xml)) {
+                    return true;
+                }
+
+                XDocument document;
+                try {
+                    document = XDocument.Parse(xml, LoadOptions.None);
+                } catch {
+                    return true;
+                }
+
+                var root = document.Root;
+                if (root == null) {
+                    return true;
+                }
+
+                XNamespace ns = root.Name.Namespace;
+                int xmlDefaultCount = 0;
+                bool xmlDefaultIsCorrect = false;
+                bool workbookOverrideIsCorrect = false;
+                bool appPropsOverrideIsCorrect = false;
+                bool corePropsOverrideIsCorrect = false;
+
+                foreach (var element in root.Elements()) {
+                    if (element.Name == ns + "Default"
+                        && string.Equals((string?)element.Attribute("Extension"), "xml", StringComparison.OrdinalIgnoreCase)) {
+                        xmlDefaultCount++;
+                        xmlDefaultIsCorrect = string.Equals((string?)element.Attribute("ContentType"), "application/xml", StringComparison.OrdinalIgnoreCase);
+                        continue;
+                    }
+
+                    if (element.Name != ns + "Override") {
+                        continue;
+                    }
+
+                    string? partName = (string?)element.Attribute("PartName");
+                    string? contentType = (string?)element.Attribute("ContentType");
+                    if (string.Equals(partName, WorkbookOverridePart, StringComparison.OrdinalIgnoreCase)) {
+                        workbookOverrideIsCorrect = string.Equals(contentType, WorkbookContentType, StringComparison.OrdinalIgnoreCase);
+                    } else if (string.Equals(partName, AppPropsOverridePart, StringComparison.OrdinalIgnoreCase)) {
+                        appPropsOverrideIsCorrect = string.Equals(contentType, AppPropsContentType, StringComparison.OrdinalIgnoreCase);
+                    } else if (string.Equals(partName, CorePropsOverridePart, StringComparison.OrdinalIgnoreCase)) {
+                        corePropsOverrideIsCorrect = string.Equals(contentType, CorePropsContentType, StringComparison.OrdinalIgnoreCase);
+                    }
+                }
+
+                return xmlDefaultCount != 1
+                    || !xmlDefaultIsCorrect
+                    || !workbookOverrideIsCorrect
+                    || !appPropsOverrideIsCorrect
+                    || !corePropsOverrideIsCorrect;
+            } catch {
+                return true;
+            }
         }
 
         internal static ContentTypesSummary GetContentTypesSummary(string packagePath) {

--- a/OfficeIMO.Tests/Excel.CreateStream.cs
+++ b/OfficeIMO.Tests/Excel.CreateStream.cs
@@ -1,7 +1,10 @@
+using System.Data;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using DocumentFormat.OpenXml.Validation;
 using OfficeIMO.Excel;
 using Xunit;
 
@@ -23,6 +26,372 @@ namespace OfficeIMO.Tests {
             var sheets = spreadsheet.WorkbookPart!.Workbook!.Sheets!.OfType<Sheet>().ToList();
             var sheetInfo = Assert.Single(sheets);
             Assert.Equal("StreamData", sheetInfo.Name?.Value);
+        }
+
+        [Fact]
+        public void Save_LoadedUnchangedStream_WritesReadablePackage() {
+            byte[] originalBytes = CreateStreamSaveWorkbookBytes();
+
+            using var input = new MemoryStream(originalBytes, writable: false);
+            using var output = new MemoryStream();
+            using (var document = ExcelDocument.Load(input)) {
+                document.Save(output);
+            }
+
+            using var reader = ExcelDocumentReader.Open(output.ToArray());
+            object?[,] values = reader.GetSheet("StreamData").ReadRange("A1:A1");
+            Assert.Equal("Hello Stream", values[0, 0]);
+        }
+
+        [Fact]
+        public void Save_LoadedStreamAfterCellEdit_WritesEditedPackage() {
+            byte[] originalBytes = CreateStreamSaveWorkbookBytes();
+
+            using var input = new MemoryStream(originalBytes, writable: false);
+            using var output = new MemoryStream();
+            using (var document = ExcelDocument.Load(input)) {
+                var sheet = document.GetSheet("StreamData");
+                sheet.CellValue(2, 1, "Edited");
+                document.Save(output);
+            }
+
+            using var reader = ExcelDocumentReader.Open(output.ToArray());
+            object?[,] values = reader.GetSheet("StreamData").ReadRange("A1:A2");
+            Assert.Equal("Hello Stream", values[0, 0]);
+            Assert.Equal("Edited", values[1, 0]);
+        }
+
+        [Fact]
+        public void Create_ToMemoryStream_WithTableAutoFitAndDate_WritesReadablePackage() {
+            var rows = new[] {
+                new StreamSalesRow(1, "North", new DateTime(2024, 1, 2), 123.45d),
+                new StreamSalesRow(2, "South", new DateTime(2024, 1, 3), 234.56d)
+            };
+
+            using var memory = new MemoryStream();
+            using (var document = ExcelDocument.Create(memory)) {
+                document.Execution.SaveWorksheetAfterAutoFit = false;
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertObjects(rows,
+                    ("Id", item => item.Id),
+                    ("Region", item => item.Region),
+                    ("CreatedOn", item => item.CreatedOn),
+                    ("Amount", item => item.Amount));
+                sheet.AddTable("A1:D3", hasHeader: true, name: "SalesData", style: OfficeIMO.Excel.TableStyle.TableStyleMedium2, includeAutoFilter: true);
+                sheet.AutoFitColumns();
+            }
+
+            Assert.True(memory.Length > 0);
+            memory.Position = 0;
+
+            using (var spreadsheet = SpreadsheetDocument.Open(memory, false)) {
+                var errors = new OpenXmlValidator().Validate(spreadsheet).ToList();
+                Assert.Empty(errors);
+
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                TableDefinitionPart tablePart = Assert.Single(wsPart.TableDefinitionParts);
+                Assert.Equal("SalesData", tablePart.Table.Name);
+                Assert.Equal("A1:D3", tablePart.Table.Reference!.Value);
+                Assert.NotNull(tablePart.Table.GetFirstChild<AutoFilter>());
+
+                var dateCell = wsPart.Worksheet.Descendants<Cell>().First(cell => cell.CellReference?.Value == "C2");
+                Assert.True(dateCell.DataType == null || dateCell.DataType.Value == CellValues.Number);
+                Assert.NotNull(dateCell.StyleIndex);
+                Assert.NotNull(wsPart.Worksheet.GetFirstChild<Columns>());
+            }
+
+            using var reader = ExcelDocumentReader.Open(memory.ToArray());
+            object?[,] values = reader.GetSheet("Data").ReadRange("A1:D3");
+            Assert.Equal("Region", values[0, 1]);
+            Assert.Equal("North", values[1, 1]);
+            Assert.Equal(123.45d, Assert.IsType<double>(values[1, 3]));
+        }
+
+        [Fact]
+        public void Create_ToMemoryStream_DataTableExportWithTableVisuals_WritesReadablePackage() {
+            DataTable orders = new DataTable("Orders");
+            orders.Columns.Add("Id", typeof(int));
+            orders.Columns.Add("Customer", typeof(string));
+            orders.Columns.Add("CreatedOn", typeof(DateTime));
+            orders.Columns.Add("Status", typeof(string));
+            orders.Columns.Add("Amount", typeof(double));
+            orders.Rows.Add(1, "Contoso", new DateTime(2024, 2, 1), "Open", 120.5d);
+            orders.Rows.Add(2, "Fabrikam", new DateTime(2024, 2, 2), "Closed", 250.75d);
+            orders.Rows.Add(3, "Northwind", new DateTime(2024, 2, 3), "Open", 87.25d);
+
+            using var memory = new MemoryStream();
+            using (var document = ExcelDocument.Create(memory)) {
+                document.Execution.SaveWorksheetAfterAutoFit = false;
+                var sheet = document.AddWorkSheet("Orders");
+                string range = sheet.InsertDataTableAsTable(
+                    orders,
+                    tableName: "OrdersExport",
+                    style: OfficeIMO.Excel.TableStyle.TableStyleMedium9,
+                    includeAutoFilter: true);
+                sheet.AddAutoFilter(range, new Dictionary<uint, IEnumerable<string>> {
+                    { 3U, new[] { "Open" } }
+                });
+                sheet.ValidationList("D2:D4", new[] { "Open", "Closed", "Hold" });
+                sheet.Freeze(topRows: 1, leftCols: 0);
+                sheet.AutoFitColumns();
+            }
+
+            Assert.True(memory.Length > 0);
+            memory.Position = 0;
+
+            using (var spreadsheet = SpreadsheetDocument.Open(memory, false)) {
+                var errors = new OpenXmlValidator().Validate(spreadsheet).ToList();
+                Assert.Empty(errors);
+
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Assert.NotNull(wsPart.Worksheet.GetFirstChild<SheetViews>());
+                Assert.NotNull(wsPart.Worksheet.GetFirstChild<DataValidations>());
+                Assert.NotNull(wsPart.Worksheet.GetFirstChild<Columns>());
+
+                TableDefinitionPart tablePart = Assert.Single(wsPart.TableDefinitionParts);
+                Assert.Equal("OrdersExport", tablePart.Table.Name);
+                Assert.Equal("TableStyleMedium9", tablePart.Table.TableStyleInfo?.Name?.Value);
+                AutoFilter tableFilter = Assert.Single(tablePart.Table.Elements<AutoFilter>());
+                FilterColumn filterColumn = Assert.Single(tableFilter.Elements<FilterColumn>());
+                Assert.Equal(3U, filterColumn.ColumnId?.Value);
+            }
+
+            using var reader = ExcelDocumentReader.Open(memory.ToArray());
+            object?[,] values = reader.GetSheet("Orders").ReadRange("A1:E4");
+            Assert.Equal("Customer", values[0, 1]);
+            Assert.Equal("Contoso", values[1, 1]);
+            Assert.Equal(250.75d, Assert.IsType<double>(values[2, 4]));
+        }
+
+        [Fact]
+        public void Create_ToMemoryStream_ObjectExportSortedFilteredAndFrozen_WritesReadablePackage() {
+            var rows = new[] {
+                new StreamSalesRow(1, "North", new DateTime(2024, 1, 2), 123.45d),
+                new StreamSalesRow(2, "West", new DateTime(2024, 1, 3), 345.67d),
+                new StreamSalesRow(3, "South", new DateTime(2024, 1, 4), 234.56d)
+            };
+
+            using var memory = new MemoryStream();
+            using (var document = ExcelDocument.Create(memory)) {
+                document.Execution.SaveWorksheetAfterAutoFit = false;
+                var sheet = document.AddWorkSheet("Sales");
+                sheet.InsertObjects(rows,
+                    ("Id", item => item.Id),
+                    ("Region", item => item.Region),
+                    ("CreatedOn", item => item.CreatedOn),
+                    ("Amount", item => item.Amount));
+                sheet.SortUsedRangeByHeader("Amount", ascending: false);
+                sheet.AddTable("A1:D4", hasHeader: true, name: "SalesExport", style: OfficeIMO.Excel.TableStyle.TableStyleMedium4, includeAutoFilter: true);
+                sheet.AddAutoFilter("A1:D4", new Dictionary<uint, IEnumerable<string>> {
+                    { 1U, new[] { "West", "South" } }
+                });
+                sheet.Freeze(topRows: 1, leftCols: 0);
+                sheet.AutoFitColumns();
+            }
+
+            Assert.True(memory.Length > 0);
+            memory.Position = 0;
+
+            using (var spreadsheet = SpreadsheetDocument.Open(memory, false)) {
+                var errors = new OpenXmlValidator().Validate(spreadsheet).ToList();
+                Assert.Empty(errors);
+
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Assert.NotNull(wsPart.Worksheet.GetFirstChild<SheetViews>());
+                TableDefinitionPart tablePart = Assert.Single(wsPart.TableDefinitionParts);
+                Assert.Equal("TableStyleMedium4", tablePart.Table.TableStyleInfo?.Name?.Value);
+                AutoFilter tableFilter = Assert.Single(tablePart.Table.Elements<AutoFilter>());
+                FilterColumn filterColumn = Assert.Single(tableFilter.Elements<FilterColumn>());
+                Assert.Equal(1U, filterColumn.ColumnId?.Value);
+            }
+
+            using var reader = ExcelDocumentReader.Open(memory.ToArray());
+            object?[,] values = reader.GetSheet("Sales").ReadRange("A1:D4");
+            Assert.Equal("West", values[1, 1]);
+            Assert.Equal(345.67d, Assert.IsType<double>(values[1, 3]));
+            Assert.Equal("South", values[2, 1]);
+        }
+
+        [Fact]
+        public void Create_ToMemoryStream_WithUnsupportedHyperlink_FallsBackToReadablePackage() {
+            using var memory = new MemoryStream();
+            using (var document = ExcelDocument.Create(memory)) {
+                var sheet = document.AddWorkSheet("Links");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(2, 1, "OfficeIMO");
+                sheet.SetHyperlink(2, 1, "https://github.com/evotecit/OfficeIMO", display: "OfficeIMO", style: false);
+            }
+
+            Assert.True(memory.Length > 0);
+            memory.Position = 0;
+
+            using (var spreadsheet = SpreadsheetDocument.Open(memory, false)) {
+                var errors = new OpenXmlValidator().Validate(spreadsheet).ToList();
+                Assert.Empty(errors);
+
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Hyperlinks hyperlinks = Assert.Single(wsPart.Worksheet.Elements<Hyperlinks>());
+                Hyperlink hyperlink = Assert.Single(hyperlinks.Elements<Hyperlink>());
+                Assert.Equal("A2", hyperlink.Reference?.Value);
+                Assert.Single(wsPart.HyperlinkRelationships);
+            }
+
+            using var reader = ExcelDocumentReader.Open(memory.ToArray());
+            object?[,] values = reader.GetSheet("Links").ReadRange("A1:A2");
+            Assert.Equal("OfficeIMO", values[1, 0]);
+        }
+
+        [Fact]
+        public void Create_ToMemoryStream_DataSetExportWithMultipleTables_ReadsBackByTableName() {
+            DataSet dataSet = new DataSet("Export");
+            DataTable orders = new DataTable("Orders");
+            orders.Columns.Add("Id", typeof(int));
+            orders.Columns.Add("Customer", typeof(string));
+            orders.Columns.Add("Amount", typeof(double));
+            orders.Rows.Add(1, "Contoso", 120.5d);
+            orders.Rows.Add(2, "Fabrikam", 250.75d);
+
+            DataTable customers = new DataTable("Customers");
+            customers.Columns.Add("Id", typeof(int));
+            customers.Columns.Add("Name", typeof(string));
+            customers.Columns.Add("Active", typeof(bool));
+            customers.Rows.Add(10, "Contoso", true);
+            customers.Rows.Add(20, "Fabrikam", false);
+
+            dataSet.Tables.Add(orders);
+            dataSet.Tables.Add(customers);
+
+            using var memory = new MemoryStream();
+            using (var document = ExcelDocument.Create(memory)) {
+                var results = document.InsertDataSet(dataSet, autoFit: true);
+                Assert.Equal(2, results.Count);
+                Assert.Equal("Orders", results[0].TableName);
+                Assert.Equal("Customers", results[1].TableName);
+            }
+
+            Assert.True(memory.Length > 0);
+            memory.Position = 0;
+
+            using (var package = new ZipArchive(memory, ZipArchiveMode.Read, leaveOpen: true)) {
+                Assert.NotNull(package.GetEntry("xl/worksheets/sheet1.xml"));
+                Assert.NotNull(package.GetEntry("xl/worksheets/sheet2.xml"));
+                Assert.NotNull(package.GetEntry("xl/tables/table1.xml"));
+                Assert.NotNull(package.GetEntry("xl/tables/table2.xml"));
+                Assert.Null(package.GetEntry("xl/sharedStrings.xml"));
+            }
+
+            memory.Position = 0;
+            using (var spreadsheet = SpreadsheetDocument.Open(memory, false)) {
+                var errors = new OpenXmlValidator().Validate(spreadsheet).ToList();
+                Assert.Empty(errors);
+                Assert.Equal(2, spreadsheet.WorkbookPart!.Workbook.Sheets!.Elements<Sheet>().Count());
+                Assert.Equal(2, spreadsheet.WorkbookPart.WorksheetParts.Sum(part => part.TableDefinitionParts.Count()));
+            }
+
+            using var reader = ExcelDocumentReader.Open(memory.ToArray());
+            var tables = reader.GetTables().OrderBy(table => table.Name).ToList();
+            Assert.Equal(new[] { "Customers", "Orders" }, tables.Select(table => table.Name).ToArray());
+
+            DataTable importedOrders = reader.ReadTableAsDataTable("Orders");
+            Assert.Equal(2, importedOrders.Rows.Count);
+            Assert.Equal("Customer", importedOrders.Columns[1].ColumnName);
+            Assert.Equal("Fabrikam", importedOrders.Rows[1]["Customer"]);
+
+            var importedCustomers = reader.ReadTableObjects<CustomerImportRow>("Customers").ToList();
+            Assert.Equal(2, importedCustomers.Count);
+            Assert.Equal(10, importedCustomers[0].Id);
+            Assert.Equal("Contoso", importedCustomers[0].Name);
+            Assert.True(importedCustomers[0].Active);
+
+            var streamedCustomers = reader.ReadTableObjectsStream<CustomerImportRow>("Customers").ToList();
+            Assert.Equal(importedCustomers.Count, streamedCustomers.Count);
+            Assert.Equal("Fabrikam", streamedCustomers[1].Name);
+        }
+
+        [Fact]
+        public void WriteDataSet_ToMemoryStream_DirectExport_ReadsBackByTableName() {
+            DataSet dataSet = new DataSet("Export");
+            DataTable orders = new DataTable("Orders");
+            orders.Columns.Add("Id", typeof(int));
+            orders.Columns.Add("Customer", typeof(string));
+            orders.Columns.Add("Amount", typeof(double));
+            orders.Rows.Add(1, "Contoso", 120.5d);
+            orders.Rows.Add(2, "Fabrikam", 250.75d);
+
+            DataTable customers = new DataTable("Customers");
+            customers.Columns.Add("Id", typeof(int));
+            customers.Columns.Add("Name", typeof(string));
+            customers.Columns.Add("Active", typeof(bool));
+            customers.Rows.Add(10, "Contoso", true);
+            customers.Rows.Add(20, "Fabrikam", false);
+
+            dataSet.Tables.Add(orders);
+            dataSet.Tables.Add(customers);
+
+            using var memory = new MemoryStream();
+            var results = ExcelDocument.WriteDataSet(memory, dataSet);
+            Assert.Equal(2, results.Count);
+            Assert.Equal("Orders", results[0].TableName);
+            Assert.Equal("Customers", results[1].TableName);
+
+            using (var package = new ZipArchive(memory, ZipArchiveMode.Read, leaveOpen: true)) {
+                Assert.NotNull(package.GetEntry("xl/worksheets/sheet1.xml"));
+                Assert.NotNull(package.GetEntry("xl/worksheets/sheet2.xml"));
+                Assert.NotNull(package.GetEntry("xl/tables/table1.xml"));
+                Assert.NotNull(package.GetEntry("xl/tables/table2.xml"));
+                Assert.Null(package.GetEntry("xl/sharedStrings.xml"));
+            }
+
+            memory.Position = 0;
+            using (var spreadsheet = SpreadsheetDocument.Open(memory, false)) {
+                var errors = new OpenXmlValidator().Validate(spreadsheet).ToList();
+                Assert.Empty(errors);
+            }
+
+            using var reader = ExcelDocumentReader.Open(memory.ToArray());
+            DataTable importedOrders = reader.ReadTableAsDataTable("Orders");
+            Assert.Equal(2, importedOrders.Rows.Count);
+            Assert.Equal("Fabrikam", importedOrders.Rows[1]["Customer"]);
+
+            var importedCustomers = reader.ReadTableObjects<CustomerImportRow>("Customers").ToList();
+            Assert.Equal(2, importedCustomers.Count);
+            Assert.True(importedCustomers[0].Active);
+        }
+
+        private static byte[] CreateStreamSaveWorkbookBytes() {
+            using var memory = new MemoryStream();
+            using (var document = ExcelDocument.Create(memory)) {
+                var sheet = document.AddWorkSheet("StreamData");
+                sheet.CellValue(1, 1, "Hello Stream");
+                sheet.AutoFitColumns();
+            }
+
+            return memory.ToArray();
+        }
+
+        private sealed class StreamSalesRow {
+            public StreamSalesRow(int id, string region, DateTime createdOn, double amount) {
+                Id = id;
+                Region = region;
+                CreatedOn = createdOn;
+                Amount = amount;
+            }
+
+            public int Id { get; }
+
+            public string Region { get; }
+
+            public DateTime CreatedOn { get; }
+
+            public double Amount { get; }
+        }
+
+        private sealed class CustomerImportRow {
+            public int Id { get; set; }
+
+            public string Name { get; set; } = string.Empty;
+
+            public bool Active { get; set; }
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.LoadExceptions.cs
+++ b/OfficeIMO.Tests/Excel.LoadExceptions.cs
@@ -135,10 +135,7 @@ namespace OfficeIMO.Tests {
             File.Copy(sourcePath, filePath, overwrite: true);
 
             RewriteContentTypes(filePath, root => {
-                XNamespace ns = root.Name.Namespace;
-                var appOverride = root.Elements(ns + "Override")
-                    .FirstOrDefault(e => string.Equals((string?)e.Attribute("PartName"), "/docProps/app.xml", StringComparison.OrdinalIgnoreCase))
-                    ?? throw new InvalidOperationException("Missing /docProps/app.xml override.");
+                var appOverride = GetOrAddAppPropertiesOverride(root);
                 appOverride.SetAttributeValue("ContentType", "application/xml");
             });
 
@@ -187,10 +184,7 @@ namespace OfficeIMO.Tests {
             File.Copy(sourcePath, filePath, overwrite: true);
 
             RewriteContentTypes(filePath, root => {
-                XNamespace ns = root.Name.Namespace;
-                var appOverride = root.Elements(ns + "Override")
-                    .FirstOrDefault(e => string.Equals((string?)e.Attribute("PartName"), "/docProps/app.xml", StringComparison.OrdinalIgnoreCase))
-                    ?? throw new InvalidOperationException("Missing /docProps/app.xml override.");
+                var appOverride = GetOrAddAppPropertiesOverride(root);
                 appOverride.SetAttributeValue("ContentType", "application/xml");
             });
 
@@ -206,10 +200,7 @@ namespace OfficeIMO.Tests {
             File.Copy(sourcePath, filePath, overwrite: true);
 
             RewriteContentTypes(filePath, root => {
-                XNamespace ns = root.Name.Namespace;
-                var appOverride = root.Elements(ns + "Override")
-                    .FirstOrDefault(e => string.Equals((string?)e.Attribute("PartName"), "/docProps/app.xml", StringComparison.OrdinalIgnoreCase))
-                    ?? throw new InvalidOperationException("Missing /docProps/app.xml override.");
+                var appOverride = GetOrAddAppPropertiesOverride(root);
                 appOverride.SetAttributeValue("ContentType", "application/xml");
             });
 
@@ -263,6 +254,21 @@ namespace OfficeIMO.Tests {
             using var writer = XmlWriter.Create(replacementStream, settings);
             document.Save(writer);
             writer.Flush();
+        }
+
+        private static XElement GetOrAddAppPropertiesOverride(XElement root) {
+            XNamespace ns = root.Name.Namespace;
+            var appOverride = root.Elements(ns + "Override")
+                .FirstOrDefault(e => string.Equals((string?)e.Attribute("PartName"), "/docProps/app.xml", StringComparison.OrdinalIgnoreCase));
+            if (appOverride != null) {
+                return appOverride;
+            }
+
+            appOverride = new XElement(ns + "Override",
+                new XAttribute("PartName", "/docProps/app.xml"),
+                new XAttribute("ContentType", "application/vnd.openxmlformats-officedocument.extended-properties+xml"));
+            root.Add(appOverride);
+            return appOverride;
         }
 
     }

--- a/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
+++ b/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
@@ -399,6 +399,64 @@ namespace OfficeIMO.Tests {
             Assert.Equal("Closed", text);
         }
 
+        [Fact]
+        public void PerformanceReview_StreamLoadCopyWorksheet_PersistsInsteadOfWritingUnchangedPackage() {
+            using var memory = new MemoryStream();
+
+            using (var document = ExcelDocument.Create(memory)) {
+                document.AddWorkSheet("Source").CellValue(1, 1, "Copied");
+            }
+
+            memory.Position = 0;
+            using (var document = ExcelDocument.Load(memory, autoSave: true)) {
+                document.CopyWorkSheet("Source", "Copy");
+            }
+
+            memory.Position = 0;
+            using var loaded = ExcelDocument.Load(memory, readOnly: true);
+            Assert.Contains(loaded.Sheets, sheet => sheet.Name == "Copy");
+        }
+
+        [Fact]
+        public void PerformanceReview_StreamFastPackage_PreservesColumnPhoneticAttribute() {
+            using var memory = new MemoryStream();
+
+            using (var document = ExcelDocument.Create(memory)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Value");
+                var worksheet = sheet.WorksheetPart.Worksheet;
+                var sheetData = worksheet.GetFirstChild<SheetData>()!;
+                var columns = new Columns(new Column {
+                    Min = 1U,
+                    Max = 1U,
+                    Width = 12D,
+                    CustomWidth = true,
+                    Phonetic = true
+                });
+                worksheet.InsertBefore(columns, sheetData);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var column = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.GetFirstChild<Columns>()!.Elements<Column>().Single();
+            Assert.True(column.Phonetic!.Value);
+        }
+
+        [Fact]
+        public void PerformanceReview_WriteDataSet_RejectsTooManyColumns() {
+            using var memory = new MemoryStream();
+            var dataSet = new DataSet();
+            var table = new DataTable("TooWide");
+            for (int i = 0; i <= A1.MaxColumns; i++) {
+                table.Columns.Add("Column" + i.ToString(CultureInfo.InvariantCulture));
+            }
+
+            dataSet.Tables.Add(table);
+
+            var exception = Assert.Throws<ArgumentException>(() => ExcelDocument.WriteDataSet(memory, dataSet));
+            Assert.Contains(A1.MaxColumns.ToString(CultureInfo.InvariantCulture), exception.Message);
+        }
+
         private static void RemoveFirstRowIndex(string filePath) {
             using var spreadsheet = SpreadsheetDocument.Open(filePath, true);
             var row = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.GetFirstChild<SheetData>()!.Elements<Row>().First();

--- a/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
+++ b/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
@@ -273,6 +273,38 @@ namespace OfficeIMO.Tests {
             Assert.Contains("at least one DataTable", exception.Message);
         }
 
+        [Fact]
+        public void PerformanceReview_WriteDataSet_SerializesNonNumericFormattableValuesAsText() {
+            using var memory = new MemoryStream();
+            var id = Guid.Parse("89f22c99-1d51-4de5-b3b4-b20c4a60164f");
+            var dataSet = new DataSet();
+            var table = new DataTable("Items");
+            table.Columns.Add("Id", typeof(Guid));
+            table.Rows.Add(id);
+            dataSet.Tables.Add(table);
+
+            ExcelDocument.WriteDataSet(memory, dataSet);
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var cell = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>().Single(c => c.CellReference?.Value == "A2");
+            Assert.Equal(CellValues.String, cell.DataType!.Value);
+            Assert.Equal(id.ToString(), cell.CellValue!.Text);
+        }
+
+        [Fact]
+        public void PerformanceReview_WriteDataSet_RejectsOversizedTextValues() {
+            using var memory = new MemoryStream();
+            var dataSet = new DataSet();
+            var table = new DataTable("Items");
+            table.Columns.Add("Notes", typeof(string));
+            table.Rows.Add(new string('A', 32768));
+            dataSet.Tables.Add(table);
+
+            var exception = Assert.Throws<ArgumentException>(() => ExcelDocument.WriteDataSet(memory, dataSet));
+            Assert.Contains("32,767", exception.Message);
+        }
+
         private static void RemoveFirstRowIndex(string filePath) {
             using var spreadsheet = SpreadsheetDocument.Open(filePath, true);
             var row = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.GetFirstChild<SheetData>()!.Elements<Row>().First();

--- a/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
+++ b/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using DocumentFormat.OpenXml.Validation;
 using OfficeIMO.Excel;
 using Xunit;
 
@@ -303,6 +305,98 @@ namespace OfficeIMO.Tests {
 
             var exception = Assert.Throws<ArgumentException>(() => ExcelDocument.WriteDataSet(memory, dataSet));
             Assert.Contains("32,767", exception.Message);
+        }
+
+        [Fact]
+        public void PerformanceReview_WriteDataSet_FallsBackForOutOfRangeDateTimeOffset() {
+            using var memory = new MemoryStream();
+            var value = DateTimeOffset.MinValue;
+            var dataSet = new DataSet();
+            var table = new DataTable("Items");
+            table.Columns.Add("When", typeof(DateTimeOffset));
+            table.Rows.Add(value);
+            dataSet.Tables.Add(table);
+
+            ExcelDocument.WriteDataSet(memory, dataSet);
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var cell = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>().Single(c => c.CellReference?.Value == "A2");
+            Assert.Equal(CellValues.String, cell.DataType!.Value);
+            Assert.Equal(value.ToString("o", CultureInfo.InvariantCulture), cell.CellValue!.Text);
+        }
+
+#if NET6_0_OR_GREATER
+        [Fact]
+        public void PerformanceReview_WriteDataSet_AppliesDateOnlyAndTimeOnlyStyles() {
+            using var memory = new MemoryStream();
+            var dataSet = new DataSet();
+            var table = new DataTable("Items");
+            table.Columns.Add("Date", typeof(DateOnly));
+            table.Columns.Add("Time", typeof(TimeOnly));
+            table.Rows.Add(new DateOnly(2026, 5, 17), new TimeOnly(14, 30, 0));
+            dataSet.Tables.Add(table);
+
+            ExcelDocument.WriteDataSet(memory, dataSet);
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>().ToDictionary(c => c.CellReference!.Value!);
+            Assert.Equal(1U, cells["A2"].StyleIndex!.Value);
+            Assert.Equal(2U, cells["B2"].StyleIndex!.Value);
+        }
+#endif
+
+        [Fact]
+        public void PerformanceReview_CellValuesAppend_InsertsMissingDimensionAfterSheetProperties() {
+            string filePath = Path.Combine(_directoryWithFiles, "PerformanceReview.DimensionOrder.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Existing");
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                var worksheet = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet;
+                worksheet.GetFirstChild<SheetDimension>()?.Remove();
+                if (worksheet.GetFirstChild<SheetProperties>() == null) {
+                    worksheet.PrependChild(new SheetProperties());
+                }
+
+                worksheet.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var cells = Enumerable.Range(2, 20)
+                    .Select(row => (row, 1, (object)("Row " + row.ToString(CultureInfo.InvariantCulture))))
+                    .ToList();
+                document.Sheets[0].CellValues(cells, ExecutionMode.Sequential);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var worksheet = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet;
+                var children = worksheet.ChildElements.ToList();
+                int propertiesIndex = children.FindIndex(element => element is SheetProperties);
+                int dimensionIndex = children.FindIndex(element => element is SheetDimension);
+                Assert.True(propertiesIndex >= 0);
+                Assert.True(dimensionIndex > propertiesIndex);
+                Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
+            }
+        }
+
+        [Fact]
+        public void PerformanceReview_StreamCreateClose_PersistsWorkbook() {
+            using var memory = new MemoryStream();
+
+            var document = ExcelDocument.Create(memory);
+            document.AddWorkSheet("Data").CellValue(1, 1, "Closed");
+            document.Close();
+
+            memory.Position = 0;
+            using var loaded = ExcelDocument.Load(memory, readOnly: true);
+            Assert.True(loaded.Sheets[0].TryGetCellText(1, 1, out string? text));
+            Assert.Equal("Closed", text);
         }
 
         private static void RemoveFirstRowIndex(string filePath) {

--- a/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
+++ b/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void PerformanceReview_LoadedWorkbookDirectAppend_PersistsAfterSave() {
+            string filePath = Path.Combine(_directoryWithFiles, "PerformanceReview.DirectAppendDirty.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Name");
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var sheet = document.Sheets[0];
+                var cells = Enumerable.Range(2, 20)
+                    .Select(row => (row, 1, (object)("Row " + row.ToString(System.Globalization.CultureInfo.InvariantCulture))))
+                    .ToList();
+                sheet.CellValues(cells, ExecutionMode.Sequential);
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.True(document.Sheets[0].TryGetCellText(21, 1, out string? text));
+                Assert.Equal("Row 21", text);
+            }
+        }
+
+        [Fact]
+        public void PerformanceReview_LoadedWorkbookProtection_PersistsAfterSave() {
+            string filePath = Path.Combine(_directoryWithFiles, "PerformanceReview.WorkbookProtectionDirty.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Value");
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                document.ProtectWorkbook(new ExcelWorkbookProtectionOptions {
+                    ProtectStructure = true,
+                    LegacyPasswordHash = "CAFE"
+                });
+                document.Save();
+            }
+
+            using var spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var protection = spreadsheet.WorkbookPart!.Workbook.GetFirstChild<WorkbookProtection>();
+            Assert.NotNull(protection);
+            Assert.True(protection!.LockStructure!.Value);
+            Assert.Equal("CAFE", protection.WorkbookPassword!.Value);
+        }
+
+        [Fact]
+        public void PerformanceReview_StreamSaveWithPackageProperties_PreservesProperties() {
+            using var memory = new MemoryStream();
+
+            using (var document = ExcelDocument.Create(memory)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Value");
+                document.BuiltinDocumentProperties.Title = "Performance Review";
+                document.ApplicationProperties.Company = "Evotec";
+            }
+
+            memory.Position = 0;
+            using var loaded = ExcelDocument.Load(memory, readOnly: true);
+            Assert.Equal("Performance Review", loaded.BuiltinDocumentProperties.Title);
+            Assert.Equal("Evotec", loaded.ApplicationProperties.Company);
+        }
+
+        [Fact]
+        public void PerformanceReview_StreamFastPackageFallback_PreservesRowMetadata() {
+            using var memory = new MemoryStream();
+
+            using (var document = ExcelDocument.Create(memory)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Hidden");
+                var row = sheet.WorksheetPart.Worksheet.GetFirstChild<SheetData>()!.Elements<Row>().First();
+                row.Hidden = true;
+                row.Height = 24D;
+                row.CustomHeight = true;
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var savedRow = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.GetFirstChild<SheetData>()!.Elements<Row>().First();
+            Assert.True(savedRow.Hidden!.Value);
+            Assert.Equal(24D, savedRow.Height!.Value);
+            Assert.True(savedRow.CustomHeight!.Value);
+        }
+
+        [Fact]
+        public void PerformanceReview_ReadRangeFormulaWithoutCachedValue_ReturnsFormulaText() {
+            string filePath = Path.Combine(_directoryWithFiles, "PerformanceReview.FormulaWithoutCache.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Formula");
+                sheet.CellFormula(1, 1, "SUM(1,2)");
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                var cell = worksheetPart.Worksheet.Descendants<Cell>().First(c => c.CellReference?.Value == "A1");
+                cell.CellValue = null;
+                worksheetPart.Worksheet.Save();
+            }
+
+            using var reader = ExcelDocumentReader.Open(filePath, new ExcelReadOptions { UseCachedFormulaResult = true });
+            object?[,] values = reader.GetSheet("Formula").ReadRange("A1:A1", ExecutionMode.Sequential);
+
+            Assert.Equal("SUM(1,2)", values[0, 0]);
+        }
+
+        [Fact]
+        public void PerformanceReview_HeaderlessTableObjectReaders_ThrowHelpfulError() {
+            string filePath = Path.Combine(_directoryWithFiles, "PerformanceReview.HeaderlessTableReaders.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Alpha");
+                sheet.CellValue(1, 2, 10d);
+                sheet.CellValue(2, 1, "Beta");
+                sheet.CellValue(2, 2, 20d);
+                sheet.AddTable("A1:B2", false, "HeaderlessData", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                document.Save();
+            }
+
+            using var reader = ExcelDocumentReader.Open(filePath);
+            var exception = Assert.Throws<InvalidOperationException>(() => reader.ReadTableObjects("HeaderlessData").ToList());
+            Assert.Contains("requires table 'HeaderlessData' to have a header row", exception.Message);
+
+            DataTable table = reader.ReadTableAsDataTable("HeaderlessData", headersInFirstRow: false);
+            Assert.Equal(2, table.Rows.Count);
+            Assert.Equal("Alpha", table.Rows[0][0]);
+            Assert.Equal(20d, table.Rows[1][1]);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
+++ b/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.IO;
 using System.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
@@ -142,6 +143,163 @@ namespace OfficeIMO.Tests {
             Assert.Equal(2, table.Rows.Count);
             Assert.Equal("Alpha", table.Rows[0][0]);
             Assert.Equal(20d, table.Rows[1][1]);
+        }
+
+        [Fact]
+        public void PerformanceReview_ReadObjectsSequential_FallsBackWhenRowsHaveImplicitIndex() {
+            string filePath = Path.Combine(_directoryWithFiles, "PerformanceReview.ImplicitRowIndexReadObjects.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Score");
+                sheet.CellValue(2, 1, "Alpha");
+                sheet.CellValue(2, 2, 10d);
+                document.Save();
+            }
+
+            RemoveFirstRowIndex(filePath);
+
+            using var reader = ExcelDocumentReader.Open(filePath);
+            var rows = reader.GetSheet("Data").ReadObjects("A1:B2", ExecutionMode.Sequential);
+
+            var row = Assert.Single(rows);
+            Assert.Equal("Alpha", row["Name"]);
+            Assert.Equal(10d, row["Score"]);
+        }
+
+        [Fact]
+        public void PerformanceReview_CellValuesAppend_FallsBackWhenExistingRowsHaveImplicitIndex() {
+            string filePath = Path.Combine(_directoryWithFiles, "PerformanceReview.ImplicitRowIndexCellValues.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Existing");
+                document.Save();
+            }
+
+            RemoveFirstRowIndex(filePath);
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var sheet = document.Sheets[0];
+                var cells = Enumerable.Range(2, 20)
+                    .Select(row => (row, 1, (object)("Row " + row.ToString(System.Globalization.CultureInfo.InvariantCulture))))
+                    .ToList();
+                sheet.CellValues(cells, ExecutionMode.Sequential);
+                document.Save();
+            }
+
+            AssertWorksheetHasUniqueCellReferences(filePath);
+            AssertWorksheetContainsCellReferences(filePath, "A1", "A21");
+        }
+
+        [Fact]
+        public void PerformanceReview_DataTableAppend_FallsBackWhenExistingRowsHaveImplicitIndex() {
+            string filePath = Path.Combine(_directoryWithFiles, "PerformanceReview.ImplicitRowIndexDataTable.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Existing");
+                document.Save();
+            }
+
+            RemoveFirstRowIndex(filePath);
+
+            var table = new DataTable();
+            table.Columns.Add("Name", typeof(string));
+            for (int i = 0; i < 20; i++) {
+                table.Rows.Add("Row " + i.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                document.Sheets[0].InsertDataTable(table, startRow: 2, startColumn: 1);
+                document.Save();
+            }
+
+            AssertWorksheetHasUniqueCellReferences(filePath);
+            AssertWorksheetContainsCellReferences(filePath, "A1", "A22");
+        }
+
+        [Fact]
+        public void PerformanceReview_ReadRangeSequential_HonorsTypedDatesAndDecimalOption() {
+            string filePath = Path.Combine(_directoryWithFiles, "PerformanceReview.TypedDateAndDecimal.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "placeholder");
+                sheet.CellValue(1, 2, 1d);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>().ToDictionary(c => c.CellReference!.Value!);
+                cells["A1"].DataType = CellValues.Date;
+                cells["A1"].CellValue = new CellValue("2024-01-02T03:04:05");
+                cells["B1"].DataType = CellValues.Number;
+                cells["B1"].CellValue = new CellValue("123.45");
+                spreadsheet.WorkbookPart.WorksheetParts.First().Worksheet.Save();
+            }
+
+            using var reader = ExcelDocumentReader.Open(filePath, new ExcelReadOptions { NumericAsDecimal = true });
+            object?[,] values = reader.GetSheet("Data").ReadRange("A1:B1", ExecutionMode.Sequential);
+
+            var date = Assert.IsType<DateTime>(values[0, 0]);
+            Assert.Equal(new DateTime(2024, 1, 2, 3, 4, 5), date);
+            var number = Assert.IsType<decimal>(values[0, 1]);
+            Assert.Equal(123.45m, number);
+        }
+
+        [Fact]
+        public void PerformanceReview_StreamFastPackageFallback_PreservesHiddenSheetState() {
+            using var memory = new MemoryStream();
+
+            using (var document = ExcelDocument.Create(memory)) {
+                document.AddWorkSheet("Visible").CellValue(1, 1, "Visible");
+                var hidden = document.AddWorkSheet("Hidden");
+                hidden.CellValue(1, 1, "Hidden");
+                hidden.SetHidden(true);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var hiddenSheet = spreadsheet.WorkbookPart!.Workbook.Sheets!.Elements<Sheet>().Single(sheet => sheet.Name == "Hidden");
+            Assert.Equal(SheetStateValues.Hidden, hiddenSheet.State!.Value);
+        }
+
+        [Fact]
+        public void PerformanceReview_WriteDataSet_RejectsEmptyDataSet() {
+            using var memory = new MemoryStream();
+            var dataSet = new DataSet();
+
+            var exception = Assert.Throws<ArgumentException>(() => ExcelDocument.WriteDataSet(memory, dataSet));
+            Assert.Contains("at least one DataTable", exception.Message);
+        }
+
+        private static void RemoveFirstRowIndex(string filePath) {
+            using var spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            var row = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.GetFirstChild<SheetData>()!.Elements<Row>().First();
+            row.RowIndex = null;
+            spreadsheet.WorkbookPart.WorksheetParts.First().Worksheet.Save();
+        }
+
+        private static void AssertWorksheetHasUniqueCellReferences(string filePath) {
+            using var spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var references = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>()
+                .Select(cell => cell.CellReference?.Value)
+                .Where(reference => !string.IsNullOrWhiteSpace(reference))
+                .ToList();
+
+            Assert.Equal(references.Count, references.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        }
+
+        private static void AssertWorksheetContainsCellReferences(string filePath, params string[] expectedReferences) {
+            using var spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var references = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>()
+                .Select(cell => cell.CellReference?.Value)
+                .Where(reference => !string.IsNullOrWhiteSpace(reference))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            foreach (string expectedReference in expectedReferences) {
+                Assert.Contains(expectedReference, references);
+            }
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -249,6 +249,68 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Reader_ReadRangeAsDataTable_InfersStableColumnTypes() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderDataTableTypedColumns.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Name");
+                    sheet.CellValue(1, 2, "Amount");
+                    sheet.CellValue(1, 3, "Created");
+                    sheet.CellValue(1, 4, "Active");
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellValue(2, 2, 12.5d);
+                    sheet.CellValue(2, 3, new DateTime(2024, 1, 2));
+                    sheet.CellValue(2, 4, true);
+                    sheet.CellValue(3, 1, "Beta");
+                    sheet.CellValue(3, 2, 25d);
+                    sheet.CellValue(3, 3, new DateTime(2024, 1, 3));
+                    sheet.CellValue(3, 4, false);
+                    document.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                DataTable table = reader.GetSheet("Data").ReadRangeAsDataTable("A1:D3");
+
+                Assert.Equal(typeof(string), table.Columns["Name"]!.DataType);
+                Assert.Equal(typeof(double), table.Columns["Amount"]!.DataType);
+                Assert.Equal(typeof(DateTime), table.Columns["Created"]!.DataType);
+                Assert.Equal(typeof(bool), table.Columns["Active"]!.DataType);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRangeAsDataTable_KeepsMixedColumnObjectTyped() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderDataTableMixedColumn.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Mixed");
+                    sheet.CellValue(2, 1, 10d);
+                    sheet.CellValue(3, 1, "Ten");
+                    document.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                DataTable table = reader.GetSheet("Data").ReadRangeAsDataTable("A1:A3");
+
+                Assert.Equal(typeof(object), table.Columns["Mixed"]!.DataType);
+                Assert.Equal(10d, table.Rows[0]["Mixed"]);
+                Assert.Equal("Ten", table.Rows[1]["Mixed"]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
         public void Reader_ReadRangeAsDataTable_ReportsOwnExecutionDecision() {
             string filePath = Path.Combine(_directoryWithFiles, "ReaderDataTableDecision.xlsx");
             var decisions = new List<(string Operation, int Items, ExecutionMode Mode)>();


### PR DESCRIPTION
## Summary
- add fast workbook package writing for multi-sheet Excel exports, including table relationships and automatic fallback when workbook features are outside the fast path
- add a direct DataSet export writer for database/HTML table/PowerShell object style scenarios where callers want a finished workbook stream without keeping an editable workbook object alive
- add table-name reader APIs and ExcelRead helpers for reading tables back as DataTable, object lists, typed objects, and streams
- expand benchmark coverage for DataSet/table exports against ClosedXML, current EPPlus, and EPPlus 4.x

## Performance evidence
2,500-row `write-dataset-tables` focused run:
- OfficeIMO.Excel: avg 6.35 ms, median 5.76 ms
- ClosedXML: avg 121.83 ms, median 116.53 ms
- EPPlus current: avg 57.74 ms, median 55.44 ms
- EPPlus 4.5.3.3: avg 40.40 ms, median 39.11 ms

Focused close-scenario rerun:
- `write-bulk-report`: OfficeIMO avg 94.50 ms vs EPPlus 4.5.3.3 avg 122.01 ms
- `append-plain-rows`: OfficeIMO avg 13.35 ms vs EPPlus 4.5.3.3 avg 23.31 ms

## Validation
- `dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --framework net8.0 --no-restore /nr:false`
- `dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --framework netstandard2.0 --no-restore /nr:false`
- `dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --framework net472 --no-restore /nr:false`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --filter "FullyQualifiedName~Create_ToMemoryStream|FullyQualifiedName~WriteDataSet_ToMemoryStream|FullyQualifiedName~DataTableInsert|FullyQualifiedName~Tables" /nr:false`
- `git diff --check`
