### PR TITLE
Improve OfficeIMO.Excel reader fast paths

### DIFF
--- a/OfficeIMO.Excel.Benchmarks/ExcelReadProfileRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelReadProfileRunner.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using System.Text.Json;
 using ClosedXML.Excel;
 
@@ -6,6 +7,9 @@ namespace OfficeIMO.Excel.Benchmarks;
 internal static class ExcelReadProfileRunner {
     private const int DefaultRowCount = 2500;
     private const int SparseLastRow = 100_001;
+    private const int HeaderLookupIterations = 10_000;
+    private const int HeaderOperationIterations = 100;
+    private const int LoadedTextLookupIterations = 20;
 #if DEBUG
     private const string BuildConfiguration = "Debug";
 #else
@@ -35,7 +39,18 @@ internal static class ExcelReadProfileRunner {
         var rows = ExcelBenchmarkScenarioFactory.CreateSalesRecords(rowCount);
         byte[] workbookBytes = ExcelBenchmarkScenarioFactory.CreateWorkbookBytes(rows);
         string dataRange = ExcelBenchmarkScenarioFactory.BuildDataRange(rowCount);
+        using var loadedHeaderDocument = ExcelDocument.Load(new MemoryStream(workbookBytes, writable: false), readOnly: true);
+        var loadedHeaderSheet = loadedHeaderDocument.GetSheet("Data");
+        using var loadedHeaderOpsStream = new MemoryStream();
+        loadedHeaderOpsStream.Write(workbookBytes, 0, workbookBytes.Length);
+        loadedHeaderOpsStream.Position = 0;
+        using var loadedHeaderOpsDocument = ExcelDocument.Load(loadedHeaderOpsStream);
+        var loadedHeaderOpsSheet = loadedHeaderOpsDocument.GetSheet("Data");
+        byte[] mixedTypeWorkbookBytes = CreateMixedTypeWorkbookBytes(rowCount);
         byte[] sparseWorkbookBytes = CreateSparseWorkbookBytes(SparseLastRow);
+        byte[] sharedStringHeavyWorkbookBytes = CreateSharedStringHeavyWorkbookBytes(rowCount);
+        using var loadedSharedStringHeaderDocument = ExcelDocument.Load(new MemoryStream(sharedStringHeavyWorkbookBytes, writable: false), readOnly: true);
+        var loadedSharedStringHeaderSheet = loadedSharedStringHeaderDocument.GetSheet("Data");
         string sparseRange = $"A1:A{SparseLastRow}";
 
         List<ExcelReadProfileScenario> scenarios = [];
@@ -47,9 +62,15 @@ internal static class ExcelReadProfileRunner {
         scenarios.AddRange(MeasureGroup("OfficeIMO.Excel", [
             new ReadProfileCase("ReadObjectsAs", "Typed object materialization with automatic execution policy.", () => OfficeImoReadObjectsAs(workbookBytes, dataRange, null)),
             new ReadProfileCase("ReadObjectsAs.Sequential", "Typed object materialization with forced sequential range conversion.", () => OfficeImoReadObjectsAs(workbookBytes, dataRange, ExecutionMode.Sequential)),
-            new ReadProfileCase("ReadObjectsAs.Parallel", "Typed object materialization with forced parallel range conversion.", () => OfficeImoReadObjectsAs(workbookBytes, dataRange, ExecutionMode.Parallel))
+            new ReadProfileCase("ReadObjectsAs.Parallel", "Typed object materialization with forced parallel range conversion.", () => OfficeImoReadObjectsAs(workbookBytes, dataRange, ExecutionMode.Parallel)),
+            new ReadProfileCase("ReadObjectsAs.CustomConverterFallback", "Typed object materialization through a custom converter hook that falls back to built-in conversion.", () => OfficeImoReadObjectsAsCustomConverterFallback(workbookBytes, dataRange)),
+            new ReadProfileCase("ReadObjectsAs.CustomConverterCultureFallback", "Typed object materialization through a custom converter fallback with non-invariant culture.", () => OfficeImoReadObjectsAsCustomConverterCultureFallback(workbookBytes, dataRange))
         ], warmupIterations, measuredIterations));
-        scenarios.Add(Measure("OfficeIMO.Excel", "ReadObjectsStreamAs", "Streaming typed object materialization without full result buffering.", () => OfficeImoReadObjectsStreamAs(workbookBytes, dataRange), warmupIterations, measuredIterations));
+        scenarios.AddRange(MeasureGroup("OfficeIMO.Excel", [
+            new ReadProfileCase("ReadObjectsStreamAs", "Streaming typed object materialization without full result buffering.", () => OfficeImoReadObjectsStreamAs(workbookBytes, dataRange)),
+            new ReadProfileCase("ReadObjectsStreamAs.CustomConverterFallback", "Streaming typed object materialization through a custom converter hook that falls back to built-in conversion.", () => OfficeImoReadObjectsStreamAsCustomConverterFallback(workbookBytes, dataRange)),
+            new ReadProfileCase("ReadObjectsStreamAs.CustomConverterCultureFallback", "Streaming typed object materialization through a custom converter fallback with non-invariant culture.", () => OfficeImoReadObjectsStreamAsCustomConverterCultureFallback(workbookBytes, dataRange))
+        ], warmupIterations, measuredIterations));
         scenarios.AddRange(MeasureGroup("OfficeIMO.Excel", [
             new ReadProfileCase("ReadRange", "Dense 2D array read with automatic execution policy.", () => OfficeImoReadRange(workbookBytes, dataRange, null)),
             new ReadProfileCase("ReadRange.Sequential", "Dense 2D array read with forced sequential conversion.", () => OfficeImoReadRange(workbookBytes, dataRange, ExecutionMode.Sequential)),
@@ -58,14 +79,41 @@ internal static class ExcelReadProfileRunner {
         scenarios.AddRange(MeasureGroup("OfficeIMO.Excel", [
             new ReadProfileCase("ReadRangeAsDataTable", "Automatic execution policy.", () => OfficeImoReadDataTable(workbookBytes, dataRange, null)),
             new ReadProfileCase("ReadRangeAsDataTable.Sequential", "Forced sequential range conversion.", () => OfficeImoReadDataTable(workbookBytes, dataRange, ExecutionMode.Sequential)),
-            new ReadProfileCase("ReadRangeAsDataTable.Parallel", "Forced parallel range conversion.", () => OfficeImoReadDataTable(workbookBytes, dataRange, ExecutionMode.Parallel))
+            new ReadProfileCase("ReadRangeAsDataTable.Parallel", "Forced parallel range conversion.", () => OfficeImoReadDataTable(workbookBytes, dataRange, ExecutionMode.Parallel)),
+            new ReadProfileCase("ReadRangeAsDataTable.HeadersNoInference", "Header row with type inference disabled.", () => OfficeImoReadDataTableHeadersNoInference(workbookBytes, dataRange)),
+            new ReadProfileCase("ReadRangeAsDataTable.NoHeadersNoInference", "Generated columns with type inference disabled.", () => OfficeImoReadDataTableNoHeadersNoInference(workbookBytes, dataRange)),
+            new ReadProfileCase("ReadRangeAsDataTable.MixedTypeInference", "Infer object columns from mixed-type data.", () => OfficeImoReadDataTable(mixedTypeWorkbookBytes, dataRange, ExecutionMode.Sequential)),
+            new ReadProfileCase("ReadRangeAsDataTable.CustomConverterFallback", "Sequential DataTable read through a custom converter hook that falls back to built-in conversion.", () => OfficeImoReadDataTableCustomConverterFallback(workbookBytes, dataRange)),
+            new ReadProfileCase("ReadRangeAsDataTable.CustomConverterCultureFallback", "Sequential DataTable read through a custom converter fallback with non-invariant culture.", () => OfficeImoReadDataTableCustomConverterCultureFallback(workbookBytes, dataRange))
         ], warmupIterations, measuredIterations));
         scenarios.AddRange(MeasureGroup("OfficeIMO.Excel", [
             new ReadProfileCase("ReadRangeStream", "Streaming row chunks with automatic execution policy.", () => OfficeImoReadRangeStream(workbookBytes, dataRange, null)),
             new ReadProfileCase("ReadRangeStream.Sequential", "Streaming row chunks with forced sequential conversion.", () => OfficeImoReadRangeStream(workbookBytes, dataRange, ExecutionMode.Sequential)),
-            new ReadProfileCase("ReadRangeStream.Parallel", "Streaming row chunks with forced parallel conversion.", () => OfficeImoReadRangeStream(workbookBytes, dataRange, ExecutionMode.Parallel))
+            new ReadProfileCase("ReadRangeStream.Parallel", "Streaming row chunks with forced parallel conversion.", () => OfficeImoReadRangeStream(workbookBytes, dataRange, ExecutionMode.Parallel)),
+            new ReadProfileCase("ReadRangeStream.CustomConverterFallback", "Streaming row chunks through a custom converter hook that falls back to built-in conversion.", () => OfficeImoReadRangeStreamCustomConverterFallback(workbookBytes, dataRange)),
+            new ReadProfileCase("ReadRangeStream.CustomConverterCultureFallback", "Streaming row chunks through a custom converter fallback with non-invariant culture.", () => OfficeImoReadRangeStreamCustomConverterCultureFallback(workbookBytes, dataRange))
         ], warmupIterations, measuredIterations));
-        scenarios.Add(Measure("OfficeIMO.Excel", "ReadColumn.LargeSparse", "Sparse A1:A100001 read with only the first and last rows populated.", () => OfficeImoReadSparseColumn(sparseWorkbookBytes, sparseRange, SparseLastRow), warmupIterations, measuredIterations));
+        scenarios.AddRange(MeasureGroup("OfficeIMO.Excel", [
+            new ReadProfileCase("ReadRows.Dense", "Dense row enumeration over the same workbook payload.", () => OfficeImoReadRowsDense(workbookBytes, dataRange)),
+            new ReadProfileCase("ReadRows.Dense.CustomConverterFallback", "Dense row enumeration through a custom converter hook that falls back to built-in conversion.", () => OfficeImoReadRowsDenseCustomConverterFallback(workbookBytes, dataRange)),
+            new ReadProfileCase("ReadRows.Dense.CustomConverterCultureFallback", "Dense row enumeration through a custom converter fallback with non-invariant culture.", () => OfficeImoReadRowsDenseCustomConverterCultureFallback(workbookBytes, dataRange))
+        ], warmupIterations, measuredIterations));
+        scenarios.AddRange(MeasureGroup("OfficeIMO.Excel", [
+            new ReadProfileCase("ReadColumn.Dense", "Dense single-column enumeration over the same workbook payload.", () => OfficeImoReadDenseColumn(workbookBytes, $"A1:A{rowCount + 1}")),
+            new ReadProfileCase("ReadColumn.Dense.CustomConverterFallback", "Dense single-column enumeration through a custom converter hook that falls back to built-in conversion.", () => OfficeImoReadDenseColumnCustomConverterFallback(workbookBytes, $"A1:A{rowCount + 1}")),
+            new ReadProfileCase("ReadColumn.Dense.CustomConverterCultureFallback", "Dense single-column enumeration through a custom converter fallback with non-invariant culture.", () => OfficeImoReadDenseColumnCustomConverterCultureFallback(workbookBytes, $"A1:A{rowCount + 1}"))
+        ], warmupIterations, measuredIterations));
+        scenarios.Add(Measure("OfficeIMO.Excel", "GetHeaderMap.LargeUsedRange", "Build the header lookup map from the first used row of a larger worksheet.", () => OfficeImoGetHeaderMap(workbookBytes), warmupIterations, measuredIterations));
+        scenarios.Add(Measure("OfficeIMO.Excel", "GetHeaderMap.LoadedRebuild", "Rebuild the header lookup map on an already loaded worksheet after cache invalidation.", () => OfficeImoGetHeaderMapLoadedRebuild(loadedHeaderSheet), warmupIterations, measuredIterations));
+        scenarios.Add(Measure("OfficeIMO.Excel", "GetHeaderMap.LoadedSharedStrings", "Rebuild headers when the worksheet has many unique shared strings below the header row.", () => OfficeImoGetHeaderMapLoadedRebuild(loadedSharedStringHeaderSheet), warmupIterations, measuredIterations));
+        scenarios.Add(Measure("OfficeIMO.Excel", "TryGetColumnIndexByHeader.Cached", "Repeated cached header lookup without exposing the mutable header map.", () => OfficeImoTryGetHeaderLookupLoaded(loadedHeaderSheet), warmupIterations, measuredIterations));
+        scenarios.Add(Measure("OfficeIMO.Excel", "LoadedText.FindFirst.SharedStrings", "Repeated loaded-sheet text search over cells backed by many shared strings.", () => OfficeImoFindFirstSharedStringLoaded(loadedSharedStringHeaderSheet, rowCount), warmupIterations, measuredIterations));
+        scenarios.Add(Measure("OfficeIMO.Excel", "LoadedText.ReplaceAll.SharedStrings", "Batch replacement over a loaded worksheet with many shared-string cells.", () => OfficeImoReplaceAllSharedStrings(sharedStringHeavyWorkbookBytes, rowCount), warmupIterations, measuredIterations));
+        scenarios.Add(Measure("OfficeIMO.Excel", "HeaderOps.AutoFilterByHeaders.BatchMap", "Repeated multi-header AutoFilter updates using one internal cached header map per operation.", () => OfficeImoAutoFilterByHeadersLoaded(loadedHeaderOpsSheet), warmupIterations, measuredIterations));
+        scenarios.AddRange(MeasureGroup("OfficeIMO.Excel", [
+            new ReadProfileCase("ReadColumn.LargeSparse", "Sparse A1:A100001 read with only the first and last rows populated.", () => OfficeImoReadSparseColumn(sparseWorkbookBytes, sparseRange, SparseLastRow)),
+            new ReadProfileCase("ReadColumn.LargeSparse.CustomConverterFallback", "Sparse A1:A100001 read through a custom converter hook that falls back to built-in conversion.", () => OfficeImoReadSparseColumnCustomConverterFallback(sparseWorkbookBytes, sparseRange, SparseLastRow))
+        ], warmupIterations, measuredIterations));
         scenarios.Add(Measure("OfficeIMO.Excel", "ReadRows.LargeSparse", "Sparse A1:A100001 row read with only the first and last rows populated.", () => OfficeImoReadSparseRows(sparseWorkbookBytes, sparseRange, SparseLastRow), warmupIterations, measuredIterations));
         scenarios.Add(Measure("ClosedXML", "ReadRows", "Worksheet row iteration over the same workbook payload.", () => ClosedXmlReadRows(workbookBytes), warmupIterations, measuredIterations));
 
@@ -157,8 +205,42 @@ internal static class ExcelReadProfileRunner {
         return reader.GetSheet("Data").ReadObjects<ReadSalesRecord>(dataRange, mode).Count();
     }
 
+    private static int OfficeImoReadObjectsAsCustomConverterFallback(byte[] workbookBytes, string dataRange) {
+        var options = new ExcelReadOptions {
+            CellValueConverter = static _ => ExcelCellValue.NotHandled
+        };
+        using var reader = ExcelDocumentReader.Open(workbookBytes, options);
+        return reader.GetSheet("Data").ReadObjects<ReadSalesRecord>(dataRange, ExecutionMode.Sequential).Count();
+    }
+
+    private static int OfficeImoReadObjectsAsCustomConverterCultureFallback(byte[] workbookBytes, string dataRange) {
+        var options = new ExcelReadOptions {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("pl-PL"),
+            CellValueConverter = static _ => ExcelCellValue.NotHandled
+        };
+        using var reader = ExcelDocumentReader.Open(workbookBytes, options);
+        return reader.GetSheet("Data").ReadObjects<ReadSalesRecord>(dataRange, ExecutionMode.Sequential).Count();
+    }
+
     private static int OfficeImoReadObjectsStreamAs(byte[] workbookBytes, string dataRange) {
         using var reader = ExcelDocumentReader.Open(workbookBytes);
+        return reader.GetSheet("Data").ReadObjectsStream<ReadSalesRecord>(dataRange).Count();
+    }
+
+    private static int OfficeImoReadObjectsStreamAsCustomConverterFallback(byte[] workbookBytes, string dataRange) {
+        var options = new ExcelReadOptions {
+            CellValueConverter = static _ => ExcelCellValue.NotHandled
+        };
+        using var reader = ExcelDocumentReader.Open(workbookBytes, options);
+        return reader.GetSheet("Data").ReadObjectsStream<ReadSalesRecord>(dataRange).Count();
+    }
+
+    private static int OfficeImoReadObjectsStreamAsCustomConverterCultureFallback(byte[] workbookBytes, string dataRange) {
+        var options = new ExcelReadOptions {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("pl-PL"),
+            CellValueConverter = static _ => ExcelCellValue.NotHandled
+        };
+        using var reader = ExcelDocumentReader.Open(workbookBytes, options);
         return reader.GetSheet("Data").ReadObjectsStream<ReadSalesRecord>(dataRange).Count();
     }
 
@@ -173,21 +255,234 @@ internal static class ExcelReadProfileRunner {
         return reader.GetSheet("Data").ReadRangeAsDataTable(dataRange, headersInFirstRow: true, mode: mode).Rows.Count;
     }
 
+    private static int OfficeImoReadDataTableHeadersNoInference(byte[] workbookBytes, string dataRange) {
+        using var reader = ExcelDocumentReader.Open(workbookBytes, new ExcelReadOptions { InferDataTableColumnTypes = false });
+        DataTable table = reader.GetSheet("Data").ReadRangeAsDataTable(dataRange, headersInFirstRow: true, mode: ExecutionMode.Sequential);
+        return table.Rows.Count + table.Columns.Count;
+    }
+
+    private static int OfficeImoReadDataTableNoHeadersNoInference(byte[] workbookBytes, string dataRange) {
+        using var reader = ExcelDocumentReader.Open(workbookBytes, new ExcelReadOptions { InferDataTableColumnTypes = false });
+        DataTable table = reader.GetSheet("Data").ReadRangeAsDataTable(dataRange, headersInFirstRow: false, mode: ExecutionMode.Sequential);
+        return table.Rows.Count + table.Columns.Count;
+    }
+
+    private static int OfficeImoReadDataTableCustomConverterFallback(byte[] workbookBytes, string dataRange) {
+        var options = new ExcelReadOptions {
+            CellValueConverter = static _ => ExcelCellValue.NotHandled
+        };
+        using var reader = ExcelDocumentReader.Open(workbookBytes, options);
+        DataTable table = reader.GetSheet("Data").ReadRangeAsDataTable(dataRange, headersInFirstRow: true, mode: ExecutionMode.Sequential);
+        return table.Rows.Count + table.Columns.Count;
+    }
+
+    private static int OfficeImoReadDataTableCustomConverterCultureFallback(byte[] workbookBytes, string dataRange) {
+        var options = new ExcelReadOptions {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("pl-PL"),
+            CellValueConverter = static _ => ExcelCellValue.NotHandled
+        };
+        using var reader = ExcelDocumentReader.Open(workbookBytes, options);
+        DataTable table = reader.GetSheet("Data").ReadRangeAsDataTable(dataRange, headersInFirstRow: true, mode: ExecutionMode.Sequential);
+        return table.Rows.Count + table.Columns.Count;
+    }
+
     private static int OfficeImoReadRangeStream(byte[] workbookBytes, string dataRange, ExecutionMode? mode) {
         using var reader = ExcelDocumentReader.Open(workbookBytes);
+        return CountRangeStreamRows(reader.GetSheet("Data"), dataRange, mode);
+    }
+
+    private static int OfficeImoReadRangeStreamCustomConverterFallback(byte[] workbookBytes, string dataRange) {
+        var options = new ExcelReadOptions {
+            CellValueConverter = static _ => ExcelCellValue.NotHandled
+        };
+        using var reader = ExcelDocumentReader.Open(workbookBytes, options);
+        return CountRangeStreamRows(reader.GetSheet("Data"), dataRange, ExecutionMode.Sequential);
+    }
+
+    private static int OfficeImoReadRangeStreamCustomConverterCultureFallback(byte[] workbookBytes, string dataRange) {
+        var options = new ExcelReadOptions {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("pl-PL"),
+            CellValueConverter = static _ => ExcelCellValue.NotHandled
+        };
+        using var reader = ExcelDocumentReader.Open(workbookBytes, options);
+        return CountRangeStreamRows(reader.GetSheet("Data"), dataRange, ExecutionMode.Sequential);
+    }
+
+    private static int CountRangeStreamRows(ExcelSheetReader sheet, string dataRange, ExecutionMode? mode) {
         int rows = 0;
-        foreach (var chunk in reader.GetSheet("Data").ReadRangeStream(dataRange, chunkRows: 512, mode: mode)) {
+        foreach (var chunk in sheet.ReadRangeStream(dataRange, chunkRows: 512, mode: mode)) {
             rows += chunk.RowCount;
         }
 
         return rows;
     }
 
+    private static int OfficeImoReadRowsDense(byte[] workbookBytes, string dataRange) {
+        using var reader = ExcelDocumentReader.Open(workbookBytes);
+        return CountDenseRows(reader.GetSheet("Data"), dataRange);
+    }
+
+    private static int OfficeImoReadRowsDenseCustomConverterFallback(byte[] workbookBytes, string dataRange) {
+        var options = new ExcelReadOptions {
+            CellValueConverter = static _ => ExcelCellValue.NotHandled
+        };
+        using var reader = ExcelDocumentReader.Open(workbookBytes, options);
+        return CountDenseRows(reader.GetSheet("Data"), dataRange);
+    }
+
+    private static int OfficeImoReadRowsDenseCustomConverterCultureFallback(byte[] workbookBytes, string dataRange) {
+        var options = new ExcelReadOptions {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("pl-PL"),
+            CellValueConverter = static _ => ExcelCellValue.NotHandled
+        };
+        using var reader = ExcelDocumentReader.Open(workbookBytes, options);
+        return CountDenseRows(reader.GetSheet("Data"), dataRange);
+    }
+
+    private static int CountDenseRows(ExcelSheetReader sheet, string dataRange) {
+        int rows = 0;
+        int populatedCells = 0;
+        foreach (object?[]? row in sheet.ReadRows(dataRange)) {
+            rows++;
+            if (row == null) {
+                continue;
+            }
+
+            for (int i = 0; i < row.Length; i++) {
+                if (row[i] != null) {
+                    populatedCells++;
+                }
+            }
+        }
+
+        return rows + populatedCells;
+    }
+
+    private static int OfficeImoReadDenseColumn(byte[] workbookBytes, string columnRange) {
+        using var reader = ExcelDocumentReader.Open(workbookBytes);
+        return CountColumnValues(reader.GetSheet("Data"), columnRange);
+    }
+
+    private static int OfficeImoReadDenseColumnCustomConverterFallback(byte[] workbookBytes, string columnRange) {
+        var options = new ExcelReadOptions {
+            CellValueConverter = static _ => ExcelCellValue.NotHandled
+        };
+        using var reader = ExcelDocumentReader.Open(workbookBytes, options);
+        return CountColumnValues(reader.GetSheet("Data"), columnRange);
+    }
+
+    private static int OfficeImoReadDenseColumnCustomConverterCultureFallback(byte[] workbookBytes, string columnRange) {
+        var options = new ExcelReadOptions {
+            Culture = System.Globalization.CultureInfo.GetCultureInfo("pl-PL"),
+            CellValueConverter = static _ => ExcelCellValue.NotHandled
+        };
+        using var reader = ExcelDocumentReader.Open(workbookBytes, options);
+        return CountColumnValues(reader.GetSheet("Data"), columnRange);
+    }
+
+    private static int CountColumnValues(ExcelSheetReader sheet, string columnRange) {
+        int rows = 0;
+        int populated = 0;
+        foreach (object? value in sheet.ReadColumn(columnRange)) {
+            rows++;
+            if (value != null) {
+                populated++;
+            }
+        }
+
+        return rows + populated;
+    }
+
+    private static int OfficeImoGetHeaderMap(byte[] workbookBytes) {
+        using var stream = new MemoryStream(workbookBytes, writable: false);
+        using var document = ExcelDocument.Load(stream, readOnly: true);
+        var map = document.GetSheet("Data").GetHeaderMap();
+        return map.Count + map["Id"];
+    }
+
+    private static int OfficeImoGetHeaderMapLoadedRebuild(ExcelSheet sheet) {
+        sheet.ClearHeaderCache();
+        var map = sheet.GetHeaderMap();
+        return map.Count + map["Id"];
+    }
+
+    private static int OfficeImoTryGetHeaderLookupLoaded(ExcelSheet sheet) {
+        _ = sheet.GetHeaderMap();
+        int total = 0;
+        for (int i = 0; i < HeaderLookupIterations; i++) {
+            if (sheet.TryGetColumnIndexByHeader("Amount", out int columnIndex)) {
+                total += columnIndex;
+            }
+        }
+
+        return total;
+    }
+
+    private static int OfficeImoFindFirstSharedStringLoaded(ExcelSheet sheet, int rowCount) {
+        string expectedAddress = $"D{rowCount + 1}";
+        string expectedText = $"Unique note payload {rowCount - 1:000000}";
+        int total = 0;
+        for (int i = 0; i < LoadedTextLookupIterations; i++) {
+            string? address = sheet.FindFirst(expectedText);
+            if (!string.Equals(address, expectedAddress, StringComparison.Ordinal)) {
+                throw new InvalidOperationException($"Expected {expectedAddress}, got {address ?? "<null>"}.");
+            }
+
+            total += expectedAddress.Length;
+        }
+
+        return total;
+    }
+
+    private static int OfficeImoReplaceAllSharedStrings(byte[] workbookBytes, int rowCount) {
+        using var stream = new MemoryStream();
+        stream.Write(workbookBytes, 0, workbookBytes.Length);
+        stream.Position = 0;
+
+        using var document = ExcelDocument.Load(stream);
+        int replaced = document.GetSheet("Data").ReplaceAll("Unique note payload", "Processed note payload");
+        if (replaced != rowCount) {
+            throw new InvalidOperationException($"Expected {rowCount} replacements, got {replaced}.");
+        }
+
+        return replaced;
+    }
+
+    private static int OfficeImoAutoFilterByHeadersLoaded(ExcelSheet sheet) {
+        int appliedFilters = 0;
+        for (int i = 0; i < HeaderOperationIterations; i++) {
+            sheet.AutoFilterByHeadersEquals(
+                ("Id", new[] { "1" }),
+                ("Region", new[] { "North" }),
+                ("Owner", new[] { "Owner 1", "Owner 2" }),
+                ("CreatedOn", new[] { "2024-01-01" }),
+                ("Amount", new[] { "100" }),
+                ("Units", new[] { "3" }),
+                ("Active", new[] { "TRUE" }),
+                ("Notes", new[] { "Note 1" }));
+            appliedFilters += 8;
+        }
+
+        return appliedFilters;
+    }
+
     private static int OfficeImoReadSparseColumn(byte[] workbookBytes, string sparseRange, int expectedRows) {
         using var reader = ExcelDocumentReader.Open(workbookBytes);
+        return CountSparseColumn(reader.GetSheet("Data"), sparseRange, expectedRows);
+    }
+
+    private static int OfficeImoReadSparseColumnCustomConverterFallback(byte[] workbookBytes, string sparseRange, int expectedRows) {
+        var options = new ExcelReadOptions {
+            CellValueConverter = static _ => ExcelCellValue.NotHandled
+        };
+        using var reader = ExcelDocumentReader.Open(workbookBytes, options);
+        return CountSparseColumn(reader.GetSheet("Data"), sparseRange, expectedRows);
+    }
+
+    private static int CountSparseColumn(ExcelSheetReader sheet, string sparseRange, int expectedRows) {
         int rowIndex = 0;
 
-        foreach (object? value in reader.GetSheet("Data").ReadColumn(sparseRange)) {
+        foreach (object? value in sheet.ReadColumn(sparseRange)) {
             rowIndex++;
             ValidateSparseCell(rowIndex, expectedRows, value);
         }
@@ -237,6 +532,57 @@ internal static class ExcelReadProfileRunner {
             var sheet = document.AddWorkSheet("Data");
             sheet.CellValue(1, 1, "Header");
             sheet.CellValue(lastRow, 1, "Tail");
+        }
+
+        return stream.ToArray();
+    }
+
+    private static byte[] CreateMixedTypeWorkbookBytes(int rowCount) {
+        using var stream = new MemoryStream();
+        using (var document = ExcelDocument.Create(stream)) {
+            var sheet = document.AddWorkSheet("Data");
+            sheet.CellValue(1, 1, "Id");
+            sheet.CellValue(1, 2, "Region");
+            sheet.CellValue(1, 3, "Owner");
+            sheet.CellValue(1, 4, "CreatedOn");
+            sheet.CellValue(1, 5, "Amount");
+            sheet.CellValue(1, 6, "Units");
+            sheet.CellValue(1, 7, "Active");
+            sheet.CellValue(1, 8, "Notes");
+
+            for (int i = 0; i < rowCount; i++) {
+                int row = i + 2;
+                bool even = (i & 1) == 0;
+                sheet.CellValue(row, 1, even ? i + 1 : $"ID-{i + 1}");
+                sheet.CellValue(row, 2, even ? "North" : i);
+                sheet.CellValue(row, 3, even ? $"Owner {i % 13}" : i + 1000);
+                sheet.CellValue(row, 4, even ? new DateTime(2024, 1, 1).AddDays(i) : $"2024-{(i % 12) + 1:00}");
+                sheet.CellValue(row, 5, even ? i * 1.25D : $"Amount {i}");
+                sheet.CellValue(row, 6, even ? i % 17 : $"Units {i % 17}");
+                sheet.CellValue(row, 7, even ? i % 2 == 0 : $"Active {i % 2}");
+                sheet.CellValue(row, 8, even ? $"Note {i}" : i * 2.0D);
+            }
+        }
+
+        return stream.ToArray();
+    }
+
+    private static byte[] CreateSharedStringHeavyWorkbookBytes(int rowCount) {
+        using var stream = new MemoryStream();
+        using (var document = ExcelDocument.Create(stream)) {
+            var sheet = document.AddWorkSheet("Data");
+            sheet.CellValue(1, 1, "Id");
+            sheet.CellValue(1, 2, "Region");
+            sheet.CellValue(1, 3, "Owner");
+            sheet.CellValue(1, 4, "Notes");
+
+            for (int i = 0; i < rowCount; i++) {
+                int row = i + 2;
+                sheet.CellValue(row, 1, $"ID-{i + 1:000000}");
+                sheet.CellValue(row, 2, $"Region {i:000000}");
+                sheet.CellValue(row, 3, $"Owner {i:000000}");
+                sheet.CellValue(row, 4, $"Unique note payload {i:000000}");
+            }
         }
 
         return stream.ToArray();

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -626,20 +626,27 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        internal Dictionary<string, int> GetSharedStringIndices(IEnumerable<string> texts) {
+        internal Dictionary<string, int> GetSharedStringIndices(IEnumerable<string> texts, bool assumeDistinct = false) {
             if (texts == null) {
                 throw new ArgumentNullException(nameof(texts));
+            }
+
+            int capacity = texts is ICollection<string> collection ? collection.Count : 0;
+            if (capacity == 0 && texts is ICollection<string>) {
+                return new Dictionary<string, int>(0, StringComparer.Ordinal);
             }
 
             lock (_sharedStringLock) {
                 var sharedStringTable = SharedStringTablePart.SharedStringTable ??= new SharedStringTable();
                 int tableCount = EnsureSharedStringCacheAndCount(sharedStringTable);
 
-                var result = new Dictionary<string, int>(StringComparer.Ordinal);
+                var result = capacity > 0
+                    ? new Dictionary<string, int>(capacity, StringComparer.Ordinal)
+                    : new Dictionary<string, int>(StringComparer.Ordinal);
                 bool changed = false;
 
                 foreach (string text in texts) {
-                    if (result.ContainsKey(text)) {
+                    if (!assumeDistinct && result.ContainsKey(text)) {
                         continue;
                     }
 

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -482,7 +482,7 @@ namespace OfficeIMO.Excel {
                 // Resolve shared string if needed
                 if (cell.DataType != null && cell.DataType.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString) {
                     if (TryParseCellTextSharedStringIndex(cell.InnerText, out int ssid)) {
-                        string? sharedText = GetCellTextSharedStringCache().Get(ssid);
+                        string? sharedText = BuildCellTextSharedStringSnapshot().Get(ssid);
                         if (sharedText != null) {
                             text = sharedText;
                             return true;

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -82,13 +82,16 @@ namespace OfficeIMO.Excel {
             int sharedStringIndex = _excelDocument.GetSharedStringIndex(value);
 
             var cell = GetCell(row, column);
+            SetExistingCellSharedStringValue(cell, value, sharedStringIndex);
+            ClearHeaderCache();
+        }
+
+        private void SetExistingCellSharedStringValue(Cell cell, string value, int sharedStringIndex) {
             cell.CellValue = new CellValue(sharedStringIndex.ToString(CultureInfo.InvariantCulture));
             cell.DataType = DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString;
             if (value.Contains("\n") || value.Contains("\r")) {
                 ApplyWrapText(cell);
             }
-
-            ClearHeaderCache();
         }
 
         private void CellDoubleValueCore(int row, int column, double value) {
@@ -478,14 +481,13 @@ namespace OfficeIMO.Excel {
                 if (cell == null) return false;
                 // Resolve shared string if needed
                 if (cell.DataType != null && cell.DataType.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString) {
-                    if (int.TryParse(cell.InnerText, System.Globalization.NumberStyles.Integer, CultureInfo.InvariantCulture, out int ssid)) {
-                        var wb = _excelDocument.WorkbookPartRoot;
-                        var sst = wb?.SharedStringTablePart?.SharedStringTable;
-                        var si = sst?.Elements<SharedStringItem>().ElementAtOrDefault(ssid);
-                        if (si != null) {
-                            text = si.InnerText ?? string.Empty;
+                    if (TryParseCellTextSharedStringIndex(cell.InnerText, out int ssid)) {
+                        string? sharedText = GetCellTextSharedStringCache().Get(ssid);
+                        if (sharedText != null) {
+                            text = sharedText;
                             return true;
                         }
+
                         return false;
                     }
                 }

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -674,6 +674,7 @@ namespace OfficeIMO.Excel {
         private void ClearHeaderCacheForPreparedAppend() {
             _hasWorksheetMutations = true;
             _excelDocument.MarkPackageDirty();
+            ClearCellTextSharedStringCache();
             lock (_headerMapLock) {
                 _headerMapCache = null;
                 _headerMapSourceA1 = null;

--- a/OfficeIMO.Excel/ExcelSheet.Core.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Core.cs
@@ -40,11 +40,6 @@ namespace OfficeIMO.Excel {
         private int _lastAccessedCellRowIndex;
         private int _lastAccessedCellColumnIndex;
         private SheetData? _sheetDataCache;
-        private SharedStringCache? _cellTextSharedStringCache;
-        private readonly object _findFirstCacheLock = new object();
-        private string? _findFirstCacheText;
-        private string? _findFirstCacheAddress;
-        private bool _findFirstCacheHasValue;
         private static int _instancesCreated;
 
         internal static int InstancesCreatedForTests => Volatile.Read(ref _instancesCreated);
@@ -393,7 +388,7 @@ namespace OfficeIMO.Excel {
             if (cell.DataType?.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString) {
                 var raw = cell.CellValue?.InnerText;
                 if (!string.IsNullOrEmpty(raw) && TryParseCellTextSharedStringIndex(raw, out int id)) {
-                    return GetCellTextSharedStringCache().Get(id) ?? string.Empty;
+                    return BuildCellTextSharedStringSnapshot().Get(id) ?? string.Empty;
                 }
 
                 return string.Empty;
@@ -419,48 +414,11 @@ namespace OfficeIMO.Excel {
             return cell.CellValue?.InnerText ?? string.Empty;
         }
 
-        private SharedStringCache GetCellTextSharedStringCache() {
-            var cache = Volatile.Read(ref _cellTextSharedStringCache);
-            if (cache != null) {
-                return cache;
-            }
-
-            cache = SharedStringCache.Build(_spreadSheetDocument);
-            var existing = Interlocked.CompareExchange(ref _cellTextSharedStringCache, cache, null);
-            return existing ?? cache;
+        private SharedStringCache BuildCellTextSharedStringSnapshot() {
+            return SharedStringCache.Build(_spreadSheetDocument);
         }
 
         private void ClearCellTextSharedStringCache() {
-            Volatile.Write(ref _cellTextSharedStringCache, null);
-            ClearFindFirstCache();
-        }
-
-        private bool TryGetFindFirstCache(string text, out string? address) {
-            lock (_findFirstCacheLock) {
-                if (_findFirstCacheHasValue && string.Equals(_findFirstCacheText, text, StringComparison.Ordinal)) {
-                    address = _findFirstCacheAddress;
-                    return true;
-                }
-            }
-
-            address = null;
-            return false;
-        }
-
-        private void SetFindFirstCache(string text, string? address) {
-            lock (_findFirstCacheLock) {
-                _findFirstCacheText = text;
-                _findFirstCacheAddress = address;
-                _findFirstCacheHasValue = true;
-            }
-        }
-
-        private void ClearFindFirstCache() {
-            lock (_findFirstCacheLock) {
-                _findFirstCacheText = null;
-                _findFirstCacheAddress = null;
-                _findFirstCacheHasValue = false;
-            }
         }
 
         private static bool TryParseCellTextSharedStringIndex(string? text, out int index) {

--- a/OfficeIMO.Excel/ExcelSheet.Core.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Core.cs
@@ -40,6 +40,11 @@ namespace OfficeIMO.Excel {
         private int _lastAccessedCellRowIndex;
         private int _lastAccessedCellColumnIndex;
         private SheetData? _sheetDataCache;
+        private SharedStringCache? _cellTextSharedStringCache;
+        private readonly object _findFirstCacheLock = new object();
+        private string? _findFirstCacheText;
+        private string? _findFirstCacheAddress;
+        private bool _findFirstCacheHasValue;
         private static int _instancesCreated;
 
         internal static int InstancesCreatedForTests => Volatile.Read(ref _instancesCreated);
@@ -387,23 +392,10 @@ namespace OfficeIMO.Excel {
             // Shared string lookup
             if (cell.DataType?.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString) {
                 var raw = cell.CellValue?.InnerText;
-                if (!string.IsNullOrEmpty(raw) && int.TryParse(raw, out int id)) {
-                    var sst = _excelDocument.SharedStringTablePart?.SharedStringTable;
-                    if (sst != null) {
-                        var item = sst.Elements<SharedStringItem>().ElementAtOrDefault(id);
-                        if (item != null) {
-                            // Prefer direct Text element when present; otherwise concatenate run texts
-                            if (item.Text != null) {
-                                return item.Text.Text ?? string.Empty;
-                            }
-                            var sb = new StringBuilder();
-                            foreach (var t in item.Descendants<Text>()) {
-                                sb.Append(t.Text);
-                            }
-                            return sb.ToString();
-                        }
-                    }
+                if (!string.IsNullOrEmpty(raw) && TryParseCellTextSharedStringIndex(raw, out int id)) {
+                    return GetCellTextSharedStringCache().Get(id) ?? string.Empty;
                 }
+
                 return string.Empty;
             }
 
@@ -425,6 +417,70 @@ namespace OfficeIMO.Excel {
 
             // Default: take cell value as-is (numbers, booleans, etc.)
             return cell.CellValue?.InnerText ?? string.Empty;
+        }
+
+        private SharedStringCache GetCellTextSharedStringCache() {
+            var cache = Volatile.Read(ref _cellTextSharedStringCache);
+            if (cache != null) {
+                return cache;
+            }
+
+            cache = SharedStringCache.Build(_spreadSheetDocument);
+            var existing = Interlocked.CompareExchange(ref _cellTextSharedStringCache, cache, null);
+            return existing ?? cache;
+        }
+
+        private void ClearCellTextSharedStringCache() {
+            Volatile.Write(ref _cellTextSharedStringCache, null);
+            ClearFindFirstCache();
+        }
+
+        private bool TryGetFindFirstCache(string text, out string? address) {
+            lock (_findFirstCacheLock) {
+                if (_findFirstCacheHasValue && string.Equals(_findFirstCacheText, text, StringComparison.Ordinal)) {
+                    address = _findFirstCacheAddress;
+                    return true;
+                }
+            }
+
+            address = null;
+            return false;
+        }
+
+        private void SetFindFirstCache(string text, string? address) {
+            lock (_findFirstCacheLock) {
+                _findFirstCacheText = text;
+                _findFirstCacheAddress = address;
+                _findFirstCacheHasValue = true;
+            }
+        }
+
+        private void ClearFindFirstCache() {
+            lock (_findFirstCacheLock) {
+                _findFirstCacheText = null;
+                _findFirstCacheAddress = null;
+                _findFirstCacheHasValue = false;
+            }
+        }
+
+        private static bool TryParseCellTextSharedStringIndex(string? text, out int index) {
+            index = 0;
+            if (string.IsNullOrEmpty(text)) {
+                return false;
+            }
+
+            int parsed = 0;
+            for (int i = 0; i < text!.Length; i++) {
+                int digit = text[i] - '0';
+                if ((uint)digit > 9U || parsed > (int.MaxValue - digit) / 10) {
+                    return int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out index);
+                }
+
+                parsed = (parsed * 10) + digit;
+            }
+
+            index = parsed;
+            return true;
         }
 
         private void WriteLock(Action action) {

--- a/OfficeIMO.Excel/ExcelSheet.DataOperations.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataOperations.cs
@@ -288,22 +288,18 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public string? FindFirst(string text) {
             if (string.IsNullOrEmpty(text)) return null;
-            if (TryGetFindFirstCache(text, out var cachedAddress)) {
-                return cachedAddress;
-            }
 
             var ws = WorksheetRoot;
             var sd = ws.GetFirstChild<SheetData>();
             if (sd == null) return null;
 
-            var sharedStringCache = GetCellTextSharedStringCache();
+            var sharedStringCache = BuildCellTextSharedStringSnapshot();
             var sharedStringMatches = sharedStringCache.FindIndexesContaining(text, StringComparison.OrdinalIgnoreCase);
             foreach (var row in sd.Elements<Row>()) {
                 foreach (var cell in row.Elements<Cell>()) {
                     if (TryGetSharedStringCellIndex(cell, out int sharedStringIndex)) {
                         if (sharedStringMatches != null && sharedStringMatches.Contains(sharedStringIndex)) {
                             string? address = cell.CellReference?.Value;
-                            SetFindFirstCache(text, address);
                             return address;
                         }
 
@@ -313,13 +309,11 @@ namespace OfficeIMO.Excel {
                     var t = GetCellText(cell);
                     if (!string.IsNullOrEmpty(t) && t.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0) {
                         string? address = cell.CellReference?.Value;
-                        SetFindFirstCache(text, address);
                         return address;
                     }
                 }
             }
 
-            SetFindFirstCache(text, null);
             return null;
         }
 
@@ -335,7 +329,7 @@ namespace OfficeIMO.Excel {
                 var sd = ws.GetFirstChild<SheetData>();
                 if (sd == null) return;
 
-                var sharedStringCache = GetCellTextSharedStringCache();
+                var sharedStringCache = BuildCellTextSharedStringSnapshot();
                 var sharedStringMatches = sharedStringCache.FindIndexesContaining(oldText, StringComparison.OrdinalIgnoreCase);
                 int replacementCapacity = sharedStringMatches?.Count ?? 0;
                 var replacements = replacementCapacity > 0

--- a/OfficeIMO.Excel/ExcelSheet.DataOperations.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataOperations.cs
@@ -89,9 +89,10 @@ namespace OfficeIMO.Excel {
             if (filters == null || filters.Length == 0) throw new ArgumentException("At least one filter must be provided.", nameof(filters));
             WriteLock(() => {
                 var toApply = new List<(int ColumnIndex, IEnumerable<string> Values)>();
+                var headerMap = GetHeaderMapCached(DefaultHeaderReadOptions);
                 foreach (var (header, values) in filters) {
                     if (string.IsNullOrWhiteSpace(header)) continue;
-                    if (!TryGetColumnIndexByHeader(header, out var colIndex)) continue;
+                    if (!headerMap.TryGetValue(header, out var colIndex)) continue;
                     toApply.Add((colIndex, values ?? Array.Empty<string>()));
                 }
                 if (toApply.Count == 0) return;
@@ -105,25 +106,73 @@ namespace OfficeIMO.Excel {
                 }
 
                 var (r1, c1, r2, c2) = A1.ParseRange(af.Reference!);
+                var existingColumns = new Dictionary<uint, FilterColumn>();
+                foreach (var existing in af.Elements<FilterColumn>()) {
+                    if (existing.ColumnId?.Value is uint existingColumnId) {
+                        existingColumns[existingColumnId] = existing;
+                    }
+                }
 
+                bool changed = false;
                 foreach (var (colIndex, values) in toApply) {
                     if (colIndex < c1 || colIndex > c2) continue;
                     uint columnId = (uint)(colIndex - c1);
+                    var filterValues = BuildDistinctFilterValues(values);
 
-                    var existingColumn = af.Elements<FilterColumn>().FirstOrDefault(fc => fc.ColumnId?.Value == columnId);
-                    existingColumn?.Remove();
+                    if (existingColumns.TryGetValue(columnId, out var existingColumn)) {
+                        if (FilterColumnMatchesValues(existingColumn, filterValues)) {
+                            continue;
+                        }
+
+                        existingColumn.Remove();
+                    }
 
                     var fcNew = new FilterColumn { ColumnId = columnId };
                     var filtersNode = new Filters();
-                    foreach (var v in values.Distinct(StringComparer.OrdinalIgnoreCase)) {
-                        if (v == null) continue;
+                    foreach (var v in filterValues) {
                         filtersNode.Append(new Filter { Val = v });
                     }
                     fcNew.Append(filtersNode);
                     af.Append(fcNew);
+                    existingColumns[columnId] = fcNew;
+                    changed = true;
                 }
-                ws.Save();
+                if (changed) {
+                    ws.Save();
+                }
             });
+        }
+
+        private static List<string> BuildDistinctFilterValues(IEnumerable<string> values) {
+            var result = new List<string>();
+            HashSet<string>? seen = null;
+            foreach (var value in values) {
+                if (value == null) continue;
+                seen ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                if (seen.Add(value)) {
+                    result.Add(value);
+                }
+            }
+
+            return result;
+        }
+
+        private static bool FilterColumnMatchesValues(FilterColumn filterColumn, IReadOnlyList<string> values) {
+            var filtersNode = filterColumn.GetFirstChild<Filters>();
+            if (filtersNode == null || filterColumn.GetFirstChild<CustomFilters>() != null) {
+                return false;
+            }
+
+            int index = 0;
+            foreach (var filter in filtersNode.Elements<Filter>()) {
+                if ((uint)index >= (uint)values.Count || !string.Equals(filter.Val?.Value, values[index], StringComparison.Ordinal)) {
+                    return false;
+                }
+
+                index++;
+            }
+
+            return index == values.Count;
         }
 
         /// <summary>
@@ -239,17 +288,38 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public string? FindFirst(string text) {
             if (string.IsNullOrEmpty(text)) return null;
+            if (TryGetFindFirstCache(text, out var cachedAddress)) {
+                return cachedAddress;
+            }
+
             var ws = WorksheetRoot;
             var sd = ws.GetFirstChild<SheetData>();
             if (sd == null) return null;
 
+            var sharedStringCache = GetCellTextSharedStringCache();
+            var sharedStringMatches = sharedStringCache.FindIndexesContaining(text, StringComparison.OrdinalIgnoreCase);
             foreach (var row in sd.Elements<Row>()) {
                 foreach (var cell in row.Elements<Cell>()) {
+                    if (TryGetSharedStringCellIndex(cell, out int sharedStringIndex)) {
+                        if (sharedStringMatches != null && sharedStringMatches.Contains(sharedStringIndex)) {
+                            string? address = cell.CellReference?.Value;
+                            SetFindFirstCache(text, address);
+                            return address;
+                        }
+
+                        continue;
+                    }
+
                     var t = GetCellText(cell);
-                    if (!string.IsNullOrEmpty(t) && t.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0)
-                        return cell.CellReference?.Value;
+                    if (!string.IsNullOrEmpty(t) && t.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0) {
+                        string? address = cell.CellReference?.Value;
+                        SetFindFirstCache(text, address);
+                        return address;
+                    }
                 }
             }
+
+            SetFindFirstCache(text, null);
             return null;
         }
 
@@ -265,22 +335,64 @@ namespace OfficeIMO.Excel {
                 var sd = ws.GetFirstChild<SheetData>();
                 if (sd == null) return;
 
+                var sharedStringCache = GetCellTextSharedStringCache();
+                var sharedStringMatches = sharedStringCache.FindIndexesContaining(oldText, StringComparison.OrdinalIgnoreCase);
+                int replacementCapacity = sharedStringMatches?.Count ?? 0;
+                var replacements = replacementCapacity > 0
+                    ? new List<(Cell Cell, string Text)>(replacementCapacity)
+                    : new List<(Cell Cell, string Text)>();
+                var distinctReplacementTexts = replacementCapacity > 0
+                    ? new List<string>(replacementCapacity)
+                    : new List<string>();
+                var distinctReplacementLookup = new HashSet<string>(StringComparer.Ordinal);
                 foreach (var row in sd.Elements<Row>()) {
                     foreach (var cell in row.Elements<Cell>()) {
-                        var current = GetCellText(cell);
+                        string? current;
+                        bool currentContainsOldText;
+                        if (TryGetSharedStringCellIndex(cell, out int sharedStringIndex)) {
+                            if (sharedStringMatches == null || !sharedStringMatches.Contains(sharedStringIndex)) {
+                                continue;
+                            }
+
+                            current = sharedStringCache.Get(sharedStringIndex);
+                            currentContainsOldText = true;
+                        } else {
+                            current = GetCellText(cell);
+                            currentContainsOldText = !string.IsNullOrEmpty(current)
+                                && current!.IndexOf(oldText, StringComparison.OrdinalIgnoreCase) >= 0;
+                        }
+
                         if (string.IsNullOrEmpty(current)) continue;
-                        if (current.IndexOf(oldText, StringComparison.OrdinalIgnoreCase) >= 0) {
-                            var replaced = ReplaceIgnoreCase(current, oldText, newText);
-                            // write back
-                            var (r, c) = A1.ParseCellRef(cell.CellReference?.Value ?? "");
-                            CellValue(r, c, replaced);
-                            count++;
+                        string currentText = current!;
+                        if (currentContainsOldText) {
+                            var replaced = ReplaceIgnoreCase(currentText, oldText, newText);
+                            if (distinctReplacementLookup.Add(replaced)) {
+                                CoerceValueHelper.ValidateSharedStringLength(replaced, nameof(newText));
+                                distinctReplacementTexts.Add(replaced);
+                            }
+
+                            replacements.Add((cell, replaced));
                         }
                     }
                 }
-                ws.Save();
+                if (replacements.Count > 0) {
+                    var replacementIndexes = _excelDocument.GetSharedStringIndices(distinctReplacementTexts, assumeDistinct: true);
+                    foreach (var replacement in replacements) {
+                        SetExistingCellSharedStringValue(replacement.Cell, replacement.Text, replacementIndexes[replacement.Text]);
+                    }
+
+                    count = replacements.Count;
+                    ClearHeaderCache();
+                    ws.Save();
+                }
             });
             return count;
+        }
+
+        private static bool TryGetSharedStringCellIndex(Cell cell, out int index) {
+            index = 0;
+            return cell.DataType?.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString
+                && TryParseCellTextSharedStringIndex(cell.CellValue?.InnerText ?? cell.InnerText, out index);
         }
 
         private static string ReplaceIgnoreCase(string input, string oldValue, string newValue) {
@@ -659,9 +771,10 @@ namespace OfficeIMO.Excel {
 
             // Resolve column indices and validate
             var cols = new List<(int Index, bool Asc)>();
+            var headerMap = GetHeaderMapCached(DefaultHeaderReadOptions);
             foreach (var k in keys) {
                 if (string.IsNullOrWhiteSpace(k.Header)) continue;
-                if (!TryGetColumnIndexByHeader(k.Header, out var col)) continue;
+                if (!headerMap.TryGetValue(k.Header, out var col)) continue;
                 if (col < c1 || col > c2) continue;
                 cols.Add((col - c1, k.Ascending));
             }

--- a/OfficeIMO.Excel/ExcelSheet.Dimension.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Dimension.cs
@@ -30,8 +30,7 @@ namespace OfficeIMO.Excel {
                     int resolvedCol = 0;
 
                     var cref = cell.CellReference?.Value;
-                    if (!string.IsNullOrEmpty(cref)) {
-                        var (parsedRow, parsedCol) = A1.ParseCellRef(cref!);
+                    if (A1.TryParseCellReferenceFast(cref, out int parsedRow, out int parsedCol)) {
                         if (parsedRow > 0) {
                             resolvedRow = parsedRow;
                         }
@@ -39,7 +38,6 @@ namespace OfficeIMO.Excel {
                             resolvedCol = parsedCol;
                         }
                     }
-
                     if (resolvedCol <= 0) {
                         resolvedCol = cellOrdinal;
                     }

--- a/OfficeIMO.Excel/ExcelSheet.Headers.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.cs
@@ -280,12 +280,6 @@ namespace OfficeIMO.Excel {
             }
 
             var opt = options ?? DefaultHeaderReadOptions;
-            lock (_headerMapLock) {
-                if (_headerMapCache != null && _headerMapNormalize == opt.NormalizeHeaders) {
-                    return _headerMapCache.TryGetValue(header, out columnIndex);
-                }
-            }
-
             var map = GetHeaderMapCached(opt);
             return map.TryGetValue(header, out columnIndex);
         }

--- a/OfficeIMO.Excel/ExcelSheet.Headers.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.cs
@@ -23,12 +23,6 @@ namespace OfficeIMO.Excel {
         }
 
         private Dictionary<string, int> GetHeaderMapCached(ExcelReadOptions opt) {
-            lock (_headerMapLock) {
-                if (_headerMapCache != null && _headerMapNormalize == opt.NormalizeHeaders) {
-                    return _headerMapCache;
-                }
-            }
-
             string reference = ExcelSheet.ComputeSheetDimensionReference(WorksheetRoot);
             var a1Used = reference.IndexOf(":", StringComparison.Ordinal) >= 0 ? reference : reference + ":" + reference;
             lock (_headerMapLock) {
@@ -150,6 +144,10 @@ namespace OfficeIMO.Excel {
                     }
                 }
 
+                if (options.TreatDatesUsingNumberFormat && HeaderCellsNeedReaderDateConversion(headerCells)) {
+                    return false;
+                }
+
                 List<string>? sharedStrings = maxSharedStringIndex >= 0
                     ? LoadSharedStringTextsFromDom(maxSharedStringIndex)
                     : null;
@@ -178,6 +176,28 @@ namespace OfficeIMO.Excel {
             }
 
             return true;
+        }
+
+        private bool HeaderCellsNeedReaderDateConversion(Cell?[] headerCells) {
+            StylesCache? styles = null;
+            for (int i = 0; i < headerCells.Length; i++) {
+                Cell? cell = headerCells[i];
+                if (cell?.StyleIndex == null || !HeaderCellCanUseDateStyle(cell)) {
+                    continue;
+                }
+
+                styles ??= StylesCache.Build(_spreadSheetDocument);
+                if (styles.HasDateStyles && styles.IsDateLike(cell.StyleIndex.Value)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HeaderCellCanUseDateStyle(Cell cell) {
+            OpenXmlCellValues? type = cell.DataType?.Value;
+            return type == null || type == OpenXmlCellValues.Number;
         }
 
         private object? ConvertHeaderCellFromDom(Cell cell, List<string>? sharedStrings) {

--- a/OfficeIMO.Excel/ExcelSheet.Headers.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.cs
@@ -1,3 +1,7 @@
+using DocumentFormat.OpenXml.Spreadsheet;
+using System.Globalization;
+using OpenXmlCellValues = DocumentFormat.OpenXml.Spreadsheet.CellValues;
+
 namespace OfficeIMO.Excel {
     /// <summary>
     /// Header-based helpers for addressing cells and columns by header name.
@@ -7,33 +11,53 @@ namespace OfficeIMO.Excel {
         private string? _headerMapSourceA1;
         private bool _headerMapNormalize;
         private readonly object _headerMapLock = new object();
+        private static readonly ExcelReadOptions DefaultHeaderReadOptions = new ExcelReadOptions();
 
         /// <summary>
         /// Builds or returns a cached case-insensitive map of header name to 1-based column index using the first row of UsedRange.
         /// Cache is keyed by UsedRange A1 and NormalizeHeaders option.
         /// </summary>
         public Dictionary<string, int> GetHeaderMap(ExcelReadOptions? options = null) {
-            var opt = options ?? new ExcelReadOptions();
-            var a1Used = GetUsedRangeA1();
+            var opt = options ?? DefaultHeaderReadOptions;
+            return new Dictionary<string, int>(GetHeaderMapCached(opt), StringComparer.OrdinalIgnoreCase);
+        }
+
+        private Dictionary<string, int> GetHeaderMapCached(ExcelReadOptions opt) {
+            lock (_headerMapLock) {
+                if (_headerMapCache != null && _headerMapNormalize == opt.NormalizeHeaders) {
+                    return _headerMapCache;
+                }
+            }
+
+            string reference = ExcelSheet.ComputeSheetDimensionReference(WorksheetRoot);
+            var a1Used = reference.IndexOf(":", StringComparison.Ordinal) >= 0 ? reference : reference + ":" + reference;
             lock (_headerMapLock) {
                 if (_headerMapCache != null && string.Equals(_headerMapSourceA1, a1Used, StringComparison.Ordinal) && _headerMapNormalize == opt.NormalizeHeaders) {
-                    return new Dictionary<string, int>(_headerMapCache, StringComparer.OrdinalIgnoreCase);
+                    return _headerMapCache;
                 }
+                var (r1, c1, _, c2) = A1.ParseRange(a1Used);
+                if (TryBuildHeaderMapFromWorksheetDom(r1, c1, c2, opt, out var directMap)) {
+                    _headerMapCache = directMap;
+                    _headerMapSourceA1 = a1Used;
+                    _headerMapNormalize = opt.NormalizeHeaders;
+                    return _headerMapCache;
+                }
+
                 using var rdr = _excelDocument.CreateReader(opt);
                 var sh = rdr.GetSheet(this.Name);
-                var values = sh.ReadRange(a1Used);
+                string headerRange = A1.CellReference(r1, c1) + ":" + A1.CellReference(r1, c2);
+                var values = sh.ReadRange(headerRange);
 
                 if (values.GetLength(0) == 0 || values.GetLength(1) == 0) {
                     var empty = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
                     _headerMapCache = empty;
                     _headerMapSourceA1 = a1Used;
                     _headerMapNormalize = opt.NormalizeHeaders;
-                    return new Dictionary<string, int>(_headerMapCache, StringComparer.OrdinalIgnoreCase);
+                    return _headerMapCache;
                 }
 
                 int cols = values.GetLength(1);
                 var map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-                var (_, c1, _, _) = A1.ParseRange(a1Used);
                 bool anyHeader = false;
                 for (int c = 0; c < cols; c++) {
                     if (!string.IsNullOrEmpty(ExcelHeaderNameHelper.NormalizeHeader(values[0, c]?.ToString(), opt.NormalizeHeaders))) {
@@ -46,7 +70,7 @@ namespace OfficeIMO.Excel {
                     _headerMapCache = map;
                     _headerMapSourceA1 = a1Used;
                     _headerMapNormalize = opt.NormalizeHeaders;
-                    return new Dictionary<string, int>(_headerMapCache, StringComparer.OrdinalIgnoreCase);
+                    return _headerMapCache;
                 }
 
                 var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => values[0, c]?.ToString(), opt.NormalizeHeaders);
@@ -57,8 +81,172 @@ namespace OfficeIMO.Excel {
                 _headerMapCache = map;
                 _headerMapSourceA1 = a1Used;
                 _headerMapNormalize = opt.NormalizeHeaders;
-                return new Dictionary<string, int>(_headerMapCache, StringComparer.OrdinalIgnoreCase);
+                return _headerMapCache;
             }
+        }
+
+        private bool TryBuildHeaderMapFromWorksheetDom(int headerRowIndex, int firstColumn, int lastColumn, ExcelReadOptions options, out Dictionary<string, int> map) {
+            map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            if (options.CellValueConverter != null
+                || options.Culture != CultureInfo.InvariantCulture
+                || options.NumericAsDecimal
+                || !options.UseCachedFormulaResult) {
+                return false;
+            }
+
+            var sheetData = WorksheetRoot.GetFirstChild<SheetData>();
+            if (sheetData == null) {
+                return true;
+            }
+
+            Row? headerRow = null;
+            int inferredRow = 0;
+            foreach (var row in sheetData.Elements<Row>()) {
+                int rowIndex;
+                if (row.RowIndex != null) {
+                    rowIndex = checked((int)row.RowIndex.Value);
+                    inferredRow = rowIndex;
+                } else {
+                    rowIndex = ++inferredRow;
+                }
+
+                if (rowIndex < headerRowIndex) {
+                    continue;
+                }
+
+                if (rowIndex == headerRowIndex) {
+                    headerRow = row;
+                }
+
+                break;
+            }
+
+            int columnCount = lastColumn - firstColumn + 1;
+            var headerValues = new object?[columnCount];
+            if (headerRow != null) {
+                int nextColumnIndex = 1;
+                var headerCells = new Cell?[columnCount];
+                int maxSharedStringIndex = -1;
+                foreach (var cell in headerRow.Elements<Cell>()) {
+                    int columnIndex = A1.ParseColumnIndexFromCellReferenceFast(cell.CellReference?.Value);
+                    if (columnIndex <= 0) {
+                        columnIndex = string.IsNullOrEmpty(cell.CellReference?.Value) ? nextColumnIndex : 0;
+                    }
+
+                    if (columnIndex > 0) {
+                        nextColumnIndex = columnIndex + 1;
+                    }
+
+                    if (columnIndex < firstColumn || columnIndex > lastColumn) {
+                        continue;
+                    }
+
+                    int offset = columnIndex - firstColumn;
+                    headerCells[offset] = cell;
+                    if (cell.DataType?.Value == OpenXmlCellValues.SharedString
+                        && TryParseSharedStringIndex(cell.CellValue?.InnerText, out int sharedStringIndex)
+                        && sharedStringIndex > maxSharedStringIndex) {
+                        maxSharedStringIndex = sharedStringIndex;
+                    }
+                }
+
+                List<string>? sharedStrings = maxSharedStringIndex >= 0
+                    ? LoadSharedStringTextsFromDom(maxSharedStringIndex)
+                    : null;
+                for (int c = 0; c < headerCells.Length; c++) {
+                    if (headerCells[c] != null) {
+                        headerValues[c] = ConvertHeaderCellFromDom(headerCells[c]!, sharedStrings);
+                    }
+                }
+            }
+
+            bool anyHeader = false;
+            for (int c = 0; c < columnCount; c++) {
+                if (!string.IsNullOrEmpty(ExcelHeaderNameHelper.NormalizeHeader(headerValues[c]?.ToString(), options.NormalizeHeaders))) {
+                    anyHeader = true;
+                    break;
+                }
+            }
+
+            if (!anyHeader) {
+                return true;
+            }
+
+            var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(columnCount, c => headerValues[c]?.ToString(), options.NormalizeHeaders);
+            for (int c = 0; c < columnCount; c++) {
+                map[headers[c]] = firstColumn + c;
+            }
+
+            return true;
+        }
+
+        private object? ConvertHeaderCellFromDom(Cell cell, List<string>? sharedStrings) {
+            OpenXmlCellValues? type = cell.DataType?.Value;
+            string? rawText = cell.CellValue?.InnerText;
+            if (type == OpenXmlCellValues.SharedString) {
+                if (!TryParseSharedStringIndex(rawText, out int index)) {
+                    return rawText;
+                }
+
+                return sharedStrings != null && (uint)index < (uint)sharedStrings.Count ? sharedStrings[index] : rawText;
+            }
+
+            if (type == OpenXmlCellValues.InlineString || cell.InlineString != null) {
+                if (cell.InlineString?.Text?.Text != null) {
+                    return cell.InlineString.Text.Text;
+                }
+
+                return cell.InlineString?.HasChildren == true ? SharedStringCache.GetRunText(cell.InlineString) : rawText;
+            }
+
+            if (type == OpenXmlCellValues.Boolean && rawText != null) {
+                return rawText == "1";
+            }
+
+            return rawText;
+        }
+
+        private List<string> LoadSharedStringTextsFromDom(int maxIndex) {
+            var table = _spreadSheetDocument.WorkbookPart?.SharedStringTablePart?.SharedStringTable;
+            if (table == null || maxIndex < 0) {
+                return new List<string>();
+            }
+
+            int capacity = maxIndex + 1;
+            if (table.Count?.Value is uint declaredCount && declaredCount < (uint)capacity) {
+                capacity = (int)declaredCount;
+            }
+
+            var values = new List<string>(capacity);
+            foreach (var item in table.Elements<SharedStringItem>()) {
+                values.Add(item.Text?.Text ?? (item.HasChildren ? SharedStringCache.GetRunText(item) : string.Empty));
+                if (values.Count > maxIndex) {
+                    break;
+                }
+            }
+
+            return values;
+        }
+
+        private static bool TryParseSharedStringIndex(string? rawText, out int index) {
+            index = 0;
+            if (string.IsNullOrEmpty(rawText)) {
+                return false;
+            }
+
+            string text = rawText!;
+            int parsed = 0;
+            for (int i = 0; i < text.Length; i++) {
+                int digit = text[i] - '0';
+                if ((uint)digit > 9U || parsed > (int.MaxValue - digit) / 10) {
+                    return int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out index);
+                }
+
+                parsed = (parsed * 10) + digit;
+            }
+
+            index = parsed;
+            return true;
         }
 
         /// <summary>
@@ -70,7 +258,15 @@ namespace OfficeIMO.Excel {
                 columnIndex = 0;
                 return false;
             }
-            var map = GetHeaderMap(options);
+
+            var opt = options ?? DefaultHeaderReadOptions;
+            lock (_headerMapLock) {
+                if (_headerMapCache != null && _headerMapNormalize == opt.NormalizeHeaders) {
+                    return _headerMapCache.TryGetValue(header, out columnIndex);
+                }
+            }
+
+            var map = GetHeaderMapCached(opt);
             return map.TryGetValue(header, out columnIndex);
         }
 
@@ -94,6 +290,7 @@ namespace OfficeIMO.Excel {
         public void ClearHeaderCache() {
             _hasWorksheetMutations = true;
             MarkRequiresSavePreparation();
+            ClearCellTextSharedStringCache();
             lock (_headerMapLock) {
                 _headerMapCache = null;
                 _headerMapSourceA1 = null;

--- a/OfficeIMO.Excel/ExcelSheet.Headers.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.cs
@@ -23,6 +23,10 @@ namespace OfficeIMO.Excel {
         }
 
         private Dictionary<string, int> GetHeaderMapCached(ExcelReadOptions opt) {
+            if (!_excelDocument.IsMaterializingDeferredDataSetImport) {
+                _excelDocument.MaterializeDeferredDataSetImport();
+            }
+
             string reference = ExcelSheet.ComputeSheetDimensionReference(WorksheetRoot);
             var a1Used = reference.IndexOf(":", StringComparison.Ordinal) >= 0 ? reference : reference + ":" + reference;
             lock (_headerMapLock) {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Columns.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Columns.cs
@@ -17,7 +17,7 @@ namespace OfficeIMO.Excel {
 
             bool canCancel = ct.CanBeCanceled;
             int height = r2 - r1 + 1;
-            if (CanUseXmlFastReader()) {
+            if (CanUseColumnXmlReader()) {
                 if (TryReadColumnXmlFast(r1, c1, r2, height, ct, out var xmlValues)) {
                     for (int i = 0; i < height; i++) {
                         if (canCancel) {
@@ -111,17 +111,10 @@ namespace OfficeIMO.Excel {
             try {
                 using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
                 RewindWorksheetStream(stream);
-                var settings = new XmlReaderSettings {
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    IgnoreComments = true,
-                    IgnoreProcessingInstructions = true,
-                    IgnoreWhitespace = true,
-                    CloseInput = false
-                };
-
-                using var reader = XmlReader.Create(stream, settings);
+                using var reader = OpenWorksheetXmlReader(stream);
                 bool canCancel = ct.CanBeCanceled;
                 int nextRowIndex = 1;
+                var seenRows = CreateCompletedRowTracker(height);
                 while (reader.Read()) {
                     if (canCancel) {
                         ct.ThrowIfCancellationRequested();
@@ -138,6 +131,10 @@ namespace OfficeIMO.Excel {
 
                     nextRowIndex = rowIndex + 1;
                     if (rowIndex < r1 || rowIndex > r2) {
+                        if (rowIndex > r2 && seenRows.AllRowsSeen) {
+                            break;
+                        }
+
                         SkipXmlElement(reader, "row");
                         continue;
                     }
@@ -149,6 +146,7 @@ namespace OfficeIMO.Excel {
                     }
 
                     ReadXmlColumnValue(reader, values, rowOffset, columnIndex, ct);
+                    seenRows.MarkSeen(rowOffset);
                 }
 
                 return true;
@@ -184,18 +182,12 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                string? reference = rowReader.GetAttribute("r");
-                int columnIndex = A1.ParseColumnIndexFromCellReferenceWithKnownRowFast(reference);
+                int columnIndex = GetXmlCellColumnIndex(rowReader, ref nextColumnIndex);
                 if (columnIndex <= 0) {
-                    if (!string.IsNullOrEmpty(reference)) {
-                        SkipXmlElement(rowReader, "c");
-                        continue;
-                    }
-
-                    columnIndex = nextColumnIndex;
+                    SkipXmlElement(rowReader, "c");
+                    continue;
                 }
 
-                nextColumnIndex = columnIndex + 1;
                 if (columnIndex != targetColumnIndex) {
                     SkipXmlElement(rowReader, "c");
                     continue;
@@ -205,6 +197,11 @@ namespace OfficeIMO.Excel {
                 SkipXmlElementContent(rowReader, depth, "row");
                 return;
             }
+        }
+
+        private bool CanUseColumnXmlReader() {
+            return (_opt.CellValueConverter != null || _opt.Culture == System.Globalization.CultureInfo.InvariantCulture)
+                && CanStreamWorksheetPart();
         }
     }
 }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
@@ -671,10 +671,11 @@ namespace OfficeIMO.Excel {
 
         private CellRaw ReadXmlCellRaw<TTarget>(XmlReader cellReader, int rowIndex, int columnIndex, TypedPropertyBinding<TTarget> binding) {
             XmlCellKind cellKind = ParseXmlCellKind(cellReader.GetAttribute("t"));
-            bool readStyleIndex = _opt.TreatDatesUsingNumberFormat
+            bool readStyleIndex = _opt.CellValueConverter != null
+                || (_opt.TreatDatesUsingNumberFormat
                 && _styles.HasDateStyles
                 && binding.NeedsDateStyleConversion
-                && CellKindCanUseDateStyle(cellKind);
+                && CellKindCanUseDateStyle(cellKind));
             return ReadXmlCellRaw(cellReader, rowIndex, columnIndex, cellKind, readStyleIndex);
         }
 

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
@@ -686,12 +686,12 @@ namespace OfficeIMO.Excel {
                 TypeHint = ToCellValueType(cellKind)
             };
 
-            if (cellReader.IsEmptyElement) {
-                return raw;
-            }
-
             if (readStyleIndex && TryParseUInt(cellReader.GetAttribute("s"), out uint parsedStyle)) {
                 raw.StyleIndex = parsedStyle;
+            }
+
+            if (cellReader.IsEmptyElement) {
+                return raw;
             }
 
             int depth = cellReader.Depth;
@@ -1717,15 +1717,6 @@ namespace OfficeIMO.Excel {
             CellRaw raw,
             TypedPropertyBinding<TTarget> binding,
             TTarget target) {
-            if (raw.RawText == null && raw.InlineText == null && raw.FormulaText == null) {
-                if (binding.IsNullable) {
-                    binding.SetValue(target, null);
-                    return true;
-                }
-
-                return false;
-            }
-
             if (_opt.CellValueConverter != null || _opt.TypeConverter != null) {
                 object? typedValue = ConvertRaw(raw).TypedValue;
                 if (typedValue is null) {
@@ -1740,6 +1731,15 @@ namespace OfficeIMO.Excel {
                 object? converted = TryChangeType(typedValue, binding, _opt.Culture);
                 if (converted is not null || binding.IsNullable) {
                     binding.SetValue(target, converted);
+                    return true;
+                }
+
+                return false;
+            }
+
+            if (raw.RawText == null && raw.InlineText == null && raw.FormulaText == null) {
+                if (binding.IsNullable) {
+                    binding.SetValue(target, null);
                     return true;
                 }
 

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
@@ -149,10 +149,7 @@ namespace OfficeIMO.Excel {
             out List<T> result) where T : new() {
             result = [];
 
-            if (_opt.TypeConverter != null
-                || _opt.CellValueConverter != null
-                || _opt.Culture != CultureInfo.InvariantCulture
-                || !_canStreamWorksheetPart) {
+            if (!CanStreamWorksheetPart()) {
                 return false;
             }
 
@@ -164,21 +161,14 @@ namespace OfficeIMO.Excel {
 
             using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
             RewindWorksheetStream(stream);
-            var settings = new XmlReaderSettings {
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    IgnoreComments = true,
-                    IgnoreProcessingInstructions = true,
-                    IgnoreWhitespace = true,
-                    CloseInput = false
-                };
-
-                using var reader = XmlReader.Create(stream, settings);
+            using var reader = OpenWorksheetXmlReader(stream);
             bool canCancel = ct.CanBeCanceled;
             TypedPropertyBinding<T>?[]? bindings = null;
             bool canTrackMappedColumns = false;
             ulong mappedColumns = 0;
             int nextRowIndex = 1;
             bool sawRow = false;
+            var seenRows = CreateCompletedRowTracker(rows);
 
             while (reader.Read()) {
                 if (canCancel) {
@@ -197,6 +187,10 @@ namespace OfficeIMO.Excel {
 
                 nextRowIndex = rowIndex + 1;
                 if (rowIndex < r1 || rowIndex > r2) {
+                    if (rowIndex > r2 && seenRows.AllRowsSeen) {
+                        break;
+                    }
+
                     SkipXmlElement(reader, "row");
                     continue;
                 }
@@ -206,6 +200,7 @@ namespace OfficeIMO.Excel {
                     var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => headerValues[c]?.ToString(), _opt.NormalizeHeaders);
                     bindings = GetTypedHeaderBindings<T>(headers, a1Range).Bindings;
                     canTrackMappedColumns = TryGetMappedColumnMask(bindings, out mappedColumns);
+                    seenRows.MarkSeen(0);
                     continue;
                 }
 
@@ -221,6 +216,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 ReadXmlRowIntoTypedObject(reader, rowIndex, c1, c2, bindings, canTrackMappedColumns, mappedColumns, result[resultIndex], ct);
+                seenRows.MarkSeen(rowIndex - r1);
             }
 
             if (!sawRow) {
@@ -314,8 +310,12 @@ namespace OfficeIMO.Excel {
                 return Array.Empty<T>();
             }
 
-            if (_opt.TypeConverter == null
-                && CanUseXmlFastReader()) {
+            if (CanUseTypedObjectXmlReader()) {
+                if (rows <= BufferedRangeStreamRowLimit
+                    && TryReadObjectsStreamOrderedXmlFast<T>(a1Range, r1, c1, r2, c2, rows, cols, ct, out var mediumRows)) {
+                    return mediumRows;
+                }
+
                 if (rows > BufferedRangeStreamRowLimit
                     && ShouldUseOrderedBufferedXmlStream(rows, c1, c2)
                     && TryReadObjectsStreamOrderedXmlFast<T>(a1Range, r1, c1, r2, c2, rows, cols, ct, out var orderedRows)) {
@@ -328,6 +328,10 @@ namespace OfficeIMO.Excel {
             }
 
             return ReadObjectsStreamIterator<T>(a1Range, r1, c1, r2, c2, cols, ct);
+        }
+
+        private bool CanUseTypedObjectXmlReader() {
+            return CanStreamWorksheetPart();
         }
 
         private bool TryReadObjectsStreamOrderedXmlFast<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
@@ -355,17 +359,10 @@ namespace OfficeIMO.Excel {
             try {
                 using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
                 RewindWorksheetStream(stream);
-                var settings = new XmlReaderSettings {
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    IgnoreComments = true,
-                    IgnoreProcessingInstructions = true,
-                    IgnoreWhitespace = true,
-                    CloseInput = false
-                };
-
-                using var reader = XmlReader.Create(stream, settings);
+                using var reader = OpenWorksheetXmlReader(stream);
                 bool canCancel = ct.CanBeCanceled;
                 int nextRowIndex = 1;
+                var seenRows = CreateCompletedRowTracker(rows);
                 while (reader.Read()) {
                     if (canCancel) {
                         ct.ThrowIfCancellationRequested();
@@ -382,6 +379,10 @@ namespace OfficeIMO.Excel {
 
                     nextRowIndex = rowIndex + 1;
                     if (rowIndex < r1 || rowIndex > r2) {
+                        if (rowIndex > r2 && seenRows.AllRowsSeen) {
+                            break;
+                        }
+
                         SkipXmlElement(reader, "row");
                         continue;
                     }
@@ -397,6 +398,7 @@ namespace OfficeIMO.Excel {
                         bindings = GetTypedHeaderBindings<T>(headers, a1Range).Bindings;
                         canTrackMappedColumns = TryGetMappedColumnMask(bindings, out mappedColumns);
                         sawHeader = true;
+                        seenRows.MarkSeen(0);
                         continue;
                     }
 
@@ -415,6 +417,7 @@ namespace OfficeIMO.Excel {
                     ReadXmlRowIntoTypedObject(reader, rowIndex, c1, c2, bindings, canTrackMappedColumns, mappedColumns, target, ct);
                     results[dataRowOffset] = target;
                     assignedRows[dataRowOffset] = true;
+                    seenRows.MarkSeen(rowIndex - r1);
                 }
 
                 for (int i = 0; i < results.Length; i++) {
@@ -449,15 +452,7 @@ namespace OfficeIMO.Excel {
             CancellationToken ct) where T : new() {
             using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
             RewindWorksheetStream(stream);
-            var settings = new XmlReaderSettings {
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    IgnoreComments = true,
-                    IgnoreProcessingInstructions = true,
-                    IgnoreWhitespace = true,
-                    CloseInput = false
-                };
-
-                using var reader = XmlReader.Create(stream, settings);
+            using var reader = OpenWorksheetXmlReader(stream);
             bool canCancel = ct.CanBeCanceled;
             TypedPropertyBinding<T>?[]? bindings = null;
             bool canTrackMappedColumns = false;
@@ -535,13 +530,20 @@ namespace OfficeIMO.Excel {
 
         private object?[] ReadXmlRowValues(XmlReader rowReader, int rowIndex, int c1, int c2, int cols, CancellationToken ct) {
             var values = new object?[cols];
+            ReadXmlRowValuesInto(rowReader, rowIndex, c1, c2, values, ct);
+            return values;
+        }
+
+        private void ReadXmlRowValuesInto(XmlReader rowReader, int rowIndex, int c1, int c2, object?[] values, CancellationToken ct) {
             if (rowReader.IsEmptyElement) {
-                return values;
+                return;
             }
 
             int depth = rowReader.Depth;
             bool canCancel = ct.CanBeCanceled;
             int nextColumnIndex = 1;
+            int cols = values.Length;
+            bool canTrackColumns = cols <= 64;
             ulong seenColumns = 0;
             while (rowReader.Read()) {
                 if (canCancel) {
@@ -549,7 +551,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (rowReader.NodeType == XmlNodeType.EndElement && rowReader.Depth == depth && rowReader.LocalName == "row") {
-                    return values;
+                    return;
                 }
 
                 if (rowReader.NodeType != XmlNodeType.Element || rowReader.LocalName != "c") {
@@ -564,13 +566,11 @@ namespace OfficeIMO.Excel {
 
                 CellRaw raw = ReadXmlCellRaw(rowReader, rowIndex, columnIndex);
                 values[columnIndex - c1] = ConvertRaw(raw).TypedValue;
-                if (MarkRequestedColumnSeen(columnIndex - c1, cols, ref seenColumns)) {
+                if (canTrackColumns && MarkRequestedColumnSeen(columnIndex - c1, cols, ref seenColumns)) {
                     SkipXmlElementContent(rowReader, depth, "row");
-                    return values;
+                    return;
                 }
             }
-
-            return values;
         }
 
         private void ReadXmlRowIntoTypedObject<T>(
@@ -617,7 +617,7 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                CellRaw raw = ReadXmlCellRaw(rowReader, rowIndex, columnIndex);
+                CellRaw raw = ReadXmlCellRaw(rowReader, rowIndex, columnIndex, binding);
                 TrySetRawCellForBinding(raw, binding, target);
                 if (canTrackMappedColumns) {
                     seenMappedColumns |= 1UL << (columnIndex - c1);
@@ -662,17 +662,35 @@ namespace OfficeIMO.Excel {
         }
 
         private CellRaw ReadXmlCellRaw(XmlReader cellReader, int rowIndex, int columnIndex) {
-            CellValues? typeHint = ParseXmlCellType(cellReader.GetAttribute("t"));
-            uint? styleIndex = TryParseUInt(cellReader.GetAttribute("s"), out uint parsedStyle) ? parsedStyle : null;
+            XmlCellKind cellKind = ParseXmlCellKind(cellReader.GetAttribute("t"));
+            bool readStyleIndex = _opt.TreatDatesUsingNumberFormat
+                && _styles.HasDateStyles
+                && CellKindCanUseDateStyle(cellKind);
+            return ReadXmlCellRaw(cellReader, rowIndex, columnIndex, cellKind, readStyleIndex);
+        }
+
+        private CellRaw ReadXmlCellRaw<TTarget>(XmlReader cellReader, int rowIndex, int columnIndex, TypedPropertyBinding<TTarget> binding) {
+            XmlCellKind cellKind = ParseXmlCellKind(cellReader.GetAttribute("t"));
+            bool readStyleIndex = _opt.TreatDatesUsingNumberFormat
+                && _styles.HasDateStyles
+                && binding.NeedsDateStyleConversion
+                && CellKindCanUseDateStyle(cellKind);
+            return ReadXmlCellRaw(cellReader, rowIndex, columnIndex, cellKind, readStyleIndex);
+        }
+
+        private CellRaw ReadXmlCellRaw(XmlReader cellReader, int rowIndex, int columnIndex, XmlCellKind cellKind, bool readStyleIndex) {
             var raw = new CellRaw {
                 Row = rowIndex,
                 Col = columnIndex,
-                TypeHint = typeHint,
-                StyleIndex = styleIndex
+                TypeHint = ToCellValueType(cellKind)
             };
 
             if (cellReader.IsEmptyElement) {
                 return raw;
+            }
+
+            if (readStyleIndex && TryParseUInt(cellReader.GetAttribute("s"), out uint parsedStyle)) {
+                raw.StyleIndex = parsedStyle;
             }
 
             int depth = cellReader.Depth;
@@ -724,17 +742,6 @@ namespace OfficeIMO.Excel {
             raw.InlineText = preferFormulaText ? null : inlineText;
             return raw;
         }
-
-        private static CellValues? ParseXmlCellType(string? type)
-            => type switch {
-                "b" => CellValues.Boolean,
-                "d" => CellValues.Date,
-                "inlineStr" => CellValues.InlineString,
-                "n" => CellValues.Number,
-                "s" => CellValues.SharedString,
-                "str" => CellValues.String,
-                _ => null
-            };
 
         private static void SkipXmlElement(XmlReader reader, string localName) {
             if (reader.IsEmptyElement) {
@@ -1464,14 +1471,15 @@ namespace OfficeIMO.Excel {
 
         private object? TryChangeType<TTarget>(object value, TypedPropertyBinding<TTarget> binding, CultureInfo culture) {
             if (value == null) return null;
-            var srcType = value.GetType();
-            if (binding.PropertyType.IsAssignableFrom(srcType)) return value;
 
             var hook = _opt.TypeConverter;
             if (hook != null) {
                 var (ok, v) = hook(value, binding.DestinationType, culture);
                 if (ok) return v;
             }
+
+            var srcType = value.GetType();
+            if (binding.PropertyType.IsAssignableFrom(srcType)) return value;
 
             return binding.ConvertValue(value, culture);
         }
@@ -1711,6 +1719,26 @@ namespace OfficeIMO.Excel {
             if (raw.RawText == null && raw.InlineText == null && raw.FormulaText == null) {
                 if (binding.IsNullable) {
                     binding.SetValue(target, null);
+                    return true;
+                }
+
+                return false;
+            }
+
+            if (_opt.CellValueConverter != null || _opt.TypeConverter != null) {
+                object? typedValue = ConvertRaw(raw).TypedValue;
+                if (typedValue is null) {
+                    if (binding.IsNullable) {
+                        binding.SetValue(target, null);
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                object? converted = TryChangeType(typedValue, binding, _opt.Culture);
+                if (converted is not null || binding.IsNullable) {
+                    binding.SetValue(target, converted);
                     return true;
                 }
 
@@ -2261,8 +2289,6 @@ namespace OfficeIMO.Excel {
 
         private object? TryChangeType(object value, Type targetType, CultureInfo culture) {
             if (value == null) return null;
-            var srcType = value.GetType();
-            if (targetType.IsAssignableFrom(srcType)) return value;
 
             var nullable = Nullable.GetUnderlyingType(targetType);
             var destType = nullable ?? targetType;
@@ -2272,6 +2298,9 @@ namespace OfficeIMO.Excel {
                 var (ok, v) = hook(value, destType, culture);
                 if (ok) return v;
             }
+
+            var srcType = value.GetType();
+            if (targetType.IsAssignableFrom(srcType)) return value;
 
             return ConvertToDestinationType(value, destType, culture);
         }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
@@ -12,6 +12,7 @@ namespace OfficeIMO.Excel {
     /// </summary>
     public sealed partial class ExcelSheetReader {
         private const int DenseSnapshotCapacityLimit = 100_000;
+        private const int XmlFastCompletedRowTrackingLimit = 4096;
 
         /// <summary>
         /// Returns the used range of the worksheet as an A1 string (e.g., "A1:C10").
@@ -78,6 +79,10 @@ namespace OfficeIMO.Excel {
             }
 
             if (decided == OfficeIMO.Excel.ExecutionMode.Sequential) {
+                if (TryFillDataTableXmlBufferedSinglePass(dt, r1, c1, r2, c2, rows, cols, headersInFirstRow, workload, ct)) {
+                    return dt;
+                }
+
                 if (TryFillDataTableXmlFast(dt, r1, c1, r2, c2, rows, cols, headersInFirstRow, ct)) {
                     return dt;
                 }
@@ -133,6 +138,218 @@ namespace OfficeIMO.Excel {
             return dt;
         }
 
+        private bool TryFillDataTableXmlBufferedSinglePass(
+            DataTable dt,
+            int r1,
+            int c1,
+            int r2,
+            int c2,
+            int rows,
+            int cols,
+            bool headersInFirstRow,
+            int workload,
+            CancellationToken ct) {
+            if (!_opt.InferDataTableColumnTypes
+                || workload > DenseSnapshotCapacityLimit
+                || !CanUseDataTableXmlBufferedReader()) {
+                return false;
+            }
+
+            int startRow = headersInFirstRow ? 1 : 0;
+            int dataRowCount = Math.Max(0, rows - startRow);
+            var headerValues = headersInFirstRow ? new object?[cols] : null;
+            var rowValues = new object?[dataRowCount][];
+            var inferredTypes = new Type?[cols];
+
+            try {
+                using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
+                RewindWorksheetStream(stream);
+                using var reader = OpenWorksheetXmlReader(stream);
+                bool canCancel = ct.CanBeCanceled;
+                int nextRowIndex = 1;
+                var seenRows = CreateCompletedRowTracker(rows);
+                while (reader.Read()) {
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
+                    if (reader.NodeType != XmlNodeType.Element || reader.LocalName != "row") {
+                        continue;
+                    }
+
+                    int rowIndex = ParsePositiveIntAttribute(reader.GetAttribute("r"));
+                    if (rowIndex <= 0) {
+                        rowIndex = nextRowIndex;
+                    }
+
+                    nextRowIndex = rowIndex + 1;
+                    if (rowIndex < r1 || rowIndex > r2) {
+                        if (rowIndex > r2 && seenRows.AllRowsSeen) {
+                            break;
+                        }
+
+                        SkipXmlElement(reader, "row");
+                        continue;
+                    }
+
+                    if (headersInFirstRow && rowIndex == r1) {
+                        ReadXmlRowIntoDataTableBuffer(reader, c1, c2, cols, headerValues, null, null, ct);
+                        seenRows.MarkSeen(0);
+                        continue;
+                    }
+
+                    int rr = rowIndex - r1 - startRow;
+                    if ((uint)rr >= (uint)dataRowCount) {
+                        SkipXmlElement(reader, "row");
+                        continue;
+                    }
+
+                    object?[] values = rowValues[rr] ??= new object?[cols];
+                    ReadXmlRowIntoDataTableBuffer(reader, c1, c2, cols, null, values, inferredTypes, ct);
+                    seenRows.MarkSeen(rowIndex - r1);
+                }
+
+                Type[] columnTypes = new Type[cols];
+                for (int c = 0; c < cols; c++) {
+                    columnTypes[c] = inferredTypes[c] ?? typeof(object);
+                }
+
+                if (headersInFirstRow && rows > 0) {
+                    var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => headerValues?[c]?.ToString(), _opt.NormalizeHeaders);
+                    for (int c = 0; c < cols; c++) {
+                        dt.Columns.Add(headers[c], columnTypes[c]);
+                    }
+                } else {
+                    for (int c = 0; c < cols; c++) {
+                        dt.Columns.Add($"Column{c + 1}", columnTypes[c]);
+                    }
+                }
+
+                dt.MinimumCapacity = Math.Max(dt.MinimumCapacity, dataRowCount);
+                dt.BeginLoadData();
+                try {
+                    AddBufferedRowsToDataTable(dt, rowValues, dataRowCount, cols, ct);
+                } finally {
+                    dt.EndLoadData();
+                }
+
+                return true;
+            } catch (XmlException) {
+                dt.Clear();
+                dt.Columns.Clear();
+                return false;
+            } catch (IOException) {
+                dt.Clear();
+                dt.Columns.Clear();
+                return false;
+            } catch (UnauthorizedAccessException) {
+                dt.Clear();
+                dt.Columns.Clear();
+                return false;
+            } catch (ObjectDisposedException) {
+                dt.Clear();
+                dt.Columns.Clear();
+                return false;
+            }
+        }
+
+        private static void AddBufferedRowsToDataTable(DataTable dt, object?[][] rowValues, int dataRowCount, int cols, CancellationToken ct) {
+            bool canCancel = ct.CanBeCanceled;
+            object[]? blankRow = null;
+            for (int r = 0; r < dataRowCount; r++) {
+                if (canCancel && (r & 1023) == 0) {
+                    ct.ThrowIfCancellationRequested();
+                }
+
+                object?[]? source = rowValues[r];
+                if (source == null) {
+                    blankRow ??= CreateDbNullRow(cols);
+                    dt.Rows.Add(blankRow);
+                    continue;
+                }
+
+                for (int c = 0; c < cols; c++) {
+                    source[c] ??= DBNull.Value;
+                }
+
+                dt.Rows.Add(source);
+            }
+        }
+
+        private static object[] CreateDbNullRow(int cols) {
+            var values = new object[cols];
+            for (int i = 0; i < values.Length; i++) {
+                values[i] = DBNull.Value;
+            }
+
+            return values;
+        }
+
+        private void ReadXmlRowIntoDataTableBuffer(
+            XmlReader rowReader,
+            int c1,
+            int c2,
+            int cols,
+            object?[]? headerValues,
+            object?[]? rowValues,
+            Type?[]? inferredTypes,
+            CancellationToken ct) {
+            if (rowReader.IsEmptyElement) {
+                return;
+            }
+
+            int depth = rowReader.Depth;
+            bool canCancel = ct.CanBeCanceled;
+            int nextColumnIndex = 1;
+            bool canTrackColumns = cols <= 64;
+            ulong seenColumns = 0;
+            while (rowReader.Read()) {
+                if (canCancel) {
+                    ct.ThrowIfCancellationRequested();
+                }
+
+                if (rowReader.NodeType == XmlNodeType.EndElement && rowReader.Depth == depth && rowReader.LocalName == "row") {
+                    return;
+                }
+
+                if (rowReader.NodeType != XmlNodeType.Element || rowReader.LocalName != "c") {
+                    continue;
+                }
+
+                int columnIndex = GetXmlCellColumnIndex(rowReader, ref nextColumnIndex);
+                if (columnIndex <= 0) {
+                    SkipXmlElement(rowReader, "c");
+                    continue;
+                }
+
+                if (columnIndex < c1 || columnIndex > c2) {
+                    SkipXmlElement(rowReader, "c");
+                    continue;
+                }
+
+                int cc = columnIndex - c1;
+                if ((uint)cc >= (uint)cols) {
+                    SkipXmlElement(rowReader, "c");
+                    continue;
+                }
+
+                object? value = ReadXmlCellValue(rowReader);
+                if (headerValues != null) {
+                    headerValues[cc] = value;
+                } else if (rowValues != null) {
+                    rowValues[cc] = value;
+                    if (inferredTypes != null && inferredTypes[cc] != typeof(object)) {
+                        inferredTypes[cc] = MergeDataTableColumnType(inferredTypes[cc], value);
+                    }
+                }
+
+                if (canTrackColumns && MarkRequestedColumnSeen(cc, cols, ref seenColumns)) {
+                    SkipXmlElementContent(rowReader, depth, "row");
+                    return;
+                }
+            }
+        }
+
         private bool TryFillDataTableXmlFast(
             DataTable dt,
             int r1,
@@ -184,21 +401,20 @@ namespace OfficeIMO.Excel {
             headerValues = headersInFirstRow ? new object?[cols] : null;
             columnTypes = null;
             Type?[]? inferredTypes = _opt.InferDataTableColumnTypes ? new Type?[cols] : null;
+            if (headerValues == null && inferredTypes == null) {
+                return true;
+            }
 
             try {
                 using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
                 RewindWorksheetStream(stream);
-                var settings = new XmlReaderSettings {
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    IgnoreComments = true,
-                    IgnoreProcessingInstructions = true,
-                    IgnoreWhitespace = true,
-                    CloseInput = false
-                };
-
-                using var reader = XmlReader.Create(stream, settings);
+                using var reader = OpenWorksheetXmlReader(stream);
                 bool canCancel = ct.CanBeCanceled;
                 int nextRowIndex = 1;
+                int rowCount = r2 - r1 + 1;
+                var seenRows = CreateCompletedRowTracker(rowCount);
+                bool headerRead = !headersInFirstRow;
+                int unresolvedInferredTypes = inferredTypes?.Length ?? 0;
                 while (reader.Read()) {
                     if (canCancel) {
                         ct.ThrowIfCancellationRequested();
@@ -215,6 +431,10 @@ namespace OfficeIMO.Excel {
 
                     nextRowIndex = rowIndex + 1;
                     if (rowIndex < r1 || rowIndex > r2) {
+                        if (rowIndex > r2 && seenRows.AllRowsSeen) {
+                            break;
+                        }
+
                         SkipXmlElement(reader, "row");
                         continue;
                     }
@@ -226,7 +446,15 @@ namespace OfficeIMO.Excel {
                         continue;
                     }
 
-                    ReadXmlRowIntoDataTableMetadata(reader, c1, c2, headerValues, inferredTypes, isHeaderRow, inferFromRow, ct);
+                    ReadXmlRowIntoDataTableMetadata(reader, c1, c2, headerValues, inferredTypes, isHeaderRow, inferFromRow, ct, ref unresolvedInferredTypes);
+                    seenRows.MarkSeen(rowIndex - r1);
+                    if (isHeaderRow) {
+                        headerRead = true;
+                    }
+
+                    if (headerRead && (inferredTypes == null || unresolvedInferredTypes == 0)) {
+                        return true;
+                    }
                 }
 
                 if (inferredTypes != null) {
@@ -256,7 +484,8 @@ namespace OfficeIMO.Excel {
             Type?[]? inferredTypes,
             bool isHeaderRow,
             bool inferFromRow,
-            CancellationToken ct) {
+            CancellationToken ct,
+            ref int unresolvedInferredTypes) {
             if (rowReader.IsEmptyElement) {
                 return;
             }
@@ -265,6 +494,7 @@ namespace OfficeIMO.Excel {
             bool canCancel = ct.CanBeCanceled;
             int nextColumnIndex = 1;
             int columnCount = c2 - c1 + 1;
+            bool canTrackColumns = columnCount <= 64;
             ulong seenColumns = 0;
             while (rowReader.Read()) {
                 if (canCancel) {
@@ -279,18 +509,12 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                string? reference = rowReader.GetAttribute("r");
-                int columnIndex = A1.ParseColumnIndexFromCellReferenceWithKnownRowFast(reference);
+                int columnIndex = GetXmlCellColumnIndex(rowReader, ref nextColumnIndex);
                 if (columnIndex <= 0) {
-                    if (!string.IsNullOrEmpty(reference)) {
-                        SkipXmlElement(rowReader, "c");
-                        continue;
-                    }
-
-                    columnIndex = nextColumnIndex;
+                    SkipXmlElement(rowReader, "c");
+                    continue;
                 }
 
-                nextColumnIndex = columnIndex + 1;
                 if (columnIndex < c1 || columnIndex > c2) {
                     SkipXmlElement(rowReader, "c");
                     continue;
@@ -303,10 +527,15 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (inferFromRow && inferredTypes![cc] != typeof(object)) {
-                    inferredTypes[cc] = MergeDataTableColumnType(inferredTypes[cc], value);
+                    Type? previous = inferredTypes[cc];
+                    Type? inferred = MergeDataTableColumnType(previous, value);
+                    inferredTypes[cc] = inferred;
+                    if (previous != typeof(object) && inferred == typeof(object)) {
+                        unresolvedInferredTypes--;
+                    }
                 }
 
-                if (MarkRequestedColumnSeen(cc, columnCount, ref seenColumns)) {
+                if (canTrackColumns && MarkRequestedColumnSeen(cc, columnCount, ref seenColumns)) {
                     SkipXmlElementContent(rowReader, depth, "row");
                     return;
                 }
@@ -329,25 +558,15 @@ namespace OfficeIMO.Excel {
                 return true;
             }
 
-            var dataRows = new DataRow[dataRowCount];
-            for (int r = 0; r < dataRowCount; r++) {
-                dataRows[r] = dt.NewRow();
-            }
+            var rowValues = new object?[dataRowCount][];
 
             try {
                 using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
                 RewindWorksheetStream(stream);
-                var settings = new XmlReaderSettings {
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    IgnoreComments = true,
-                    IgnoreProcessingInstructions = true,
-                    IgnoreWhitespace = true,
-                    CloseInput = false
-                };
-
-                using var reader = XmlReader.Create(stream, settings);
+                using var reader = OpenWorksheetXmlReader(stream);
                 bool canCancel = ct.CanBeCanceled;
                 int nextRowIndex = 1;
+                var seenRows = CreateCompletedRowTracker(rows);
                 while (reader.Read()) {
                     if (canCancel) {
                         ct.ThrowIfCancellationRequested();
@@ -364,34 +583,35 @@ namespace OfficeIMO.Excel {
 
                     nextRowIndex = rowIndex + 1;
                     if (rowIndex < r1 || rowIndex > r2) {
+                        if (rowIndex > r2 && seenRows.AllRowsSeen) {
+                            break;
+                        }
+
                         SkipXmlElement(reader, "row");
                         continue;
                     }
 
                     if (headersInFirstRow && rowIndex == r1) {
+                        seenRows.MarkSeen(0);
                         SkipXmlElement(reader, "row");
                         continue;
                     }
 
                     int rr = rowIndex - r1 - startRow;
-                    if ((uint)rr >= (uint)dataRows.Length) {
+                    if ((uint)rr >= (uint)rowValues.Length) {
                         SkipXmlElement(reader, "row");
                         continue;
                     }
 
-                    ReadXmlRowIntoDataRow(reader, dataRows[rr], c1, c2, cols, ct);
+                    object?[] values = rowValues[rr] ??= new object?[cols];
+                    ReadXmlRowIntoDataTableBuffer(reader, c1, c2, cols, null, values, null, ct);
+                    seenRows.MarkSeen(rowIndex - r1);
                 }
 
                 dt.MinimumCapacity = Math.Max(dt.MinimumCapacity, dataRowCount);
                 dt.BeginLoadData();
                 try {
-                    for (int r = 0; r < dataRows.Length; r++) {
-                        if (canCancel && (r & 1023) == 0) {
-                            ct.ThrowIfCancellationRequested();
-                        }
-
-                        dt.Rows.Add(dataRows[r]);
-                    }
+                    AddBufferedRowsToDataTable(dt, rowValues, dataRowCount, cols, ct);
                 } finally {
                     dt.EndLoadData();
                 }
@@ -405,59 +625,6 @@ namespace OfficeIMO.Excel {
                 return false;
             } catch (ObjectDisposedException) {
                 return false;
-            }
-        }
-
-        private void ReadXmlRowIntoDataRow(XmlReader rowReader, DataRow dataRow, int c1, int c2, int cols, CancellationToken ct) {
-            if (rowReader.IsEmptyElement) {
-                return;
-            }
-
-            int depth = rowReader.Depth;
-            bool canCancel = ct.CanBeCanceled;
-            int nextColumnIndex = 1;
-            ulong seenColumns = 0;
-            while (rowReader.Read()) {
-                if (canCancel) {
-                    ct.ThrowIfCancellationRequested();
-                }
-
-                if (rowReader.NodeType == XmlNodeType.EndElement && rowReader.Depth == depth && rowReader.LocalName == "row") {
-                    return;
-                }
-
-                if (rowReader.NodeType != XmlNodeType.Element || rowReader.LocalName != "c") {
-                    continue;
-                }
-
-                string? reference = rowReader.GetAttribute("r");
-                int columnIndex = A1.ParseColumnIndexFromCellReferenceWithKnownRowFast(reference);
-                if (columnIndex <= 0) {
-                    if (!string.IsNullOrEmpty(reference)) {
-                        SkipXmlElement(rowReader, "c");
-                        continue;
-                    }
-
-                    columnIndex = nextColumnIndex;
-                }
-
-                nextColumnIndex = columnIndex + 1;
-                if (columnIndex < c1 || columnIndex > c2) {
-                    SkipXmlElement(rowReader, "c");
-                    continue;
-                }
-
-                int cc = columnIndex - c1;
-                if ((uint)cc >= (uint)cols) {
-                    SkipXmlElement(rowReader, "c");
-                    continue;
-                }
-
-                dataRow[cc] = ReadXmlCellValue(rowReader) ?? DBNull.Value;
-                if (MarkRequestedColumnSeen(cc, cols, ref seenColumns)) {
-                    SkipXmlElementContent(rowReader, depth, "row");
-                    return;
-                }
             }
         }
 
@@ -511,6 +678,11 @@ namespace OfficeIMO.Excel {
             int cols = c2 - c1 + 1;
             if (rows <= 1 || cols == 0) {
                 return Array.Empty<Dictionary<string, object?>>();
+            }
+
+            if (CanUseReadObjectsXmlFastPath(mode)
+                && TryReadObjectsDictionaryXmlFast(r1, c1, r2, c2, rows, cols, ct, out var xmlResult)) {
+                return xmlResult;
             }
 
             if (CanUseSequentialRangeFastPath("ReadObjects", rows * cols, mode)) {
@@ -616,14 +788,12 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            for (int r = 0; r < dataRowCount; r++) {
-                var source = rowValues[r];
-                DataRow row = dt.NewRow();
-                for (int c = 0; c < cols; c++) {
-                    row[c] = source?[c] ?? DBNull.Value;
-                }
-
-                dt.Rows.Add(row);
+            dt.MinimumCapacity = Math.Max(dt.MinimumCapacity, dataRowCount);
+            dt.BeginLoadData();
+            try {
+                AddBufferedRowsToDataTable(dt, rowValues, dataRowCount, cols, ct);
+            } finally {
+                dt.EndLoadData();
             }
         }
 
@@ -791,6 +961,135 @@ namespace OfficeIMO.Excel {
             }
 
             return result;
+        }
+
+        private bool CanUseReadObjectsXmlFastPath(OfficeIMO.Excel.ExecutionMode? mode) {
+            var policy = _opt.Execution;
+            var decided = mode ?? policy.Mode;
+            if (decided == OfficeIMO.Excel.ExecutionMode.Parallel) {
+                return false;
+            }
+
+            return policy.OnDecision == null && CanUseXmlFastReader();
+        }
+
+        private bool TryReadObjectsDictionaryXmlFast(
+            int r1,
+            int c1,
+            int r2,
+            int c2,
+            int rows,
+            int cols,
+            CancellationToken ct,
+            out List<Dictionary<string, object?>> result) {
+            result = [];
+            int dataRowCount = rows - 1;
+            var headerValues = new object?[cols];
+            var rowValues = dataRowCount == 0 ? Array.Empty<object?[]>() : new object?[dataRowCount][];
+
+            try {
+                using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
+                RewindWorksheetStream(stream);
+                using var reader = OpenWorksheetXmlReader(stream);
+                bool canCancel = ct.CanBeCanceled;
+                int nextRowIndex = 1;
+                var seenRows = CreateCompletedRowTracker(rows);
+
+                while (reader.Read()) {
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
+                    if (reader.NodeType != XmlNodeType.Element || reader.LocalName != "row") {
+                        continue;
+                    }
+
+                    int rowIndex = ParsePositiveIntAttribute(reader.GetAttribute("r"));
+                    if (rowIndex <= 0) {
+                        rowIndex = nextRowIndex;
+                    }
+
+                    nextRowIndex = rowIndex + 1;
+                    if (rowIndex < r1 || rowIndex > r2) {
+                        if (rowIndex > r2 && seenRows.AllRowsSeen) {
+                            break;
+                        }
+
+                        SkipXmlElement(reader, "row");
+                        continue;
+                    }
+
+                    if (rowIndex == r1) {
+                        ReadXmlRowValuesInto(reader, rowIndex, c1, c2, headerValues, ct);
+                        seenRows.MarkSeen(0);
+                        continue;
+                    }
+
+                    int rowOffset = rowIndex - r1 - 1;
+                    if ((uint)rowOffset >= (uint)rowValues.Length) {
+                        continue;
+                    }
+
+                    object?[] values = ReadXmlRowValues(reader, rowIndex, c1, c2, cols, ct);
+                    object?[]? existing = rowValues[rowOffset];
+                    if (existing == null) {
+                        rowValues[rowOffset] = values;
+                    } else {
+                        MergeRowValues(existing, values);
+                    }
+
+                    seenRows.MarkSeen(rowIndex - r1);
+                }
+
+                var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => headerValues[c]?.ToString(), _opt.NormalizeHeaders);
+                result = new List<Dictionary<string, object?>>(dataRowCount);
+                for (int r = 0; r < dataRowCount; r++) {
+                    if (canCancel && (r & 1023) == 0) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
+                    result.Add(CreateDictionaryRow(headers, rowValues[r], cols));
+                }
+
+                return true;
+            } catch (XmlException) {
+                result = [];
+                return false;
+            } catch (IOException) {
+                result = [];
+                return false;
+            } catch (UnauthorizedAccessException) {
+                result = [];
+                return false;
+            } catch (ObjectDisposedException) {
+                result = [];
+                return false;
+            }
+
+            static void MergeRowValues(object?[] target, object?[] source) {
+                for (int i = 0; i < source.Length; i++) {
+                    if (source[i] != null) {
+                        target[i] = source[i];
+                    }
+                }
+            }
+
+            static Dictionary<string, object?> CreateDictionaryRow(string[] headers, object?[]? values, int columnCount) {
+                var dict = new Dictionary<string, object?>(columnCount, StringComparer.OrdinalIgnoreCase);
+                if (values == null) {
+                    for (int c = 0; c < columnCount; c++) {
+                        dict.Add(headers[c], null);
+                    }
+
+                    return dict;
+                }
+
+                for (int c = 0; c < columnCount; c++) {
+                    dict.Add(headers[c], values[c]);
+                }
+
+                return dict;
+            }
         }
 
         private bool TryReadObjectsSequentialSinglePass(
@@ -1168,18 +1467,12 @@ namespace OfficeIMO.Excel {
             try {
                 using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
                 RewindWorksheetStream(stream);
-                var settings = new XmlReaderSettings {
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    IgnoreComments = true,
-                    IgnoreProcessingInstructions = true,
-                    IgnoreWhitespace = true,
-                    CloseInput = false
-                };
-
-                using var reader = XmlReader.Create(stream, settings);
+                using var reader = OpenWorksheetXmlReader(stream);
                 bool canCancel = ct.CanBeCanceled;
                 int nextRowIndex = 1;
                 int width = result.GetLength(1);
+                int height = result.GetLength(0);
+                var seenRows = CreateCompletedRowTracker(height);
                 while (reader.Read()) {
                     if (canCancel) {
                         ct.ThrowIfCancellationRequested();
@@ -1196,11 +1489,16 @@ namespace OfficeIMO.Excel {
 
                     nextRowIndex = rowIndex + 1;
                     if (rowIndex < r1 || rowIndex > r2) {
+                        if (rowIndex > r2 && seenRows.AllRowsSeen) {
+                            break;
+                        }
+
                         SkipXmlElement(reader, "row");
                         continue;
                     }
 
                     ReadXmlRowIntoRange(reader, result, rowIndex, r1, c1, c2, width, ct);
+                    seenRows.MarkSeen(rowIndex - r1);
                 }
 
                 return true;
@@ -1219,6 +1517,62 @@ namespace OfficeIMO.Excel {
             return _opt.CellValueConverter == null
                 && _opt.Culture == CultureInfo.InvariantCulture
                 && CanStreamWorksheetPart();
+        }
+
+        private bool CanUseDataTableXmlBufferedReader() {
+            return (_opt.CellValueConverter != null || _opt.Culture == CultureInfo.InvariantCulture)
+                && CanStreamWorksheetPart();
+        }
+
+        private static CompletedRowTracker CreateCompletedRowTracker(int rowCount) {
+            return new CompletedRowTracker(rowCount);
+        }
+
+        private struct CompletedRowTracker {
+            private readonly int _rowCount;
+            private bool[]? _seenRows;
+            private ulong _seenRowMask;
+            private int _seenRowCount;
+
+            internal CompletedRowTracker(int rowCount) {
+                if (rowCount <= 0 || rowCount > XmlFastCompletedRowTrackingLimit) {
+                    _rowCount = 0;
+                    _seenRows = null;
+                    _seenRowMask = 0;
+                    _seenRowCount = 0;
+                    return;
+                }
+
+                _rowCount = rowCount;
+                _seenRows = rowCount > 64 ? new bool[rowCount] : null;
+                _seenRowMask = 0;
+                _seenRowCount = 0;
+            }
+
+            internal readonly bool AllRowsSeen => _rowCount > 0 && _seenRowCount == _rowCount;
+
+            internal void MarkSeen(int rowOffset) {
+                if ((uint)rowOffset >= (uint)_rowCount) {
+                    return;
+                }
+
+                if (_seenRows == null) {
+                    ulong rowBit = 1UL << rowOffset;
+                    if ((_seenRowMask & rowBit) != 0) {
+                        return;
+                    }
+
+                    _seenRowMask |= rowBit;
+                } else {
+                    if (_seenRows[rowOffset]) {
+                        return;
+                    }
+
+                    _seenRows[rowOffset] = true;
+                }
+
+                _seenRowCount++;
+            }
         }
 
         private static bool MarkRequestedColumnSeen(int columnOffset, int columnCount, ref ulong seenColumns) {
@@ -1245,6 +1599,7 @@ namespace OfficeIMO.Excel {
             int depth = rowReader.Depth;
             bool canCancel = ct.CanBeCanceled;
             int nextColumnIndex = 1;
+            bool canTrackColumns = width <= 64;
             ulong seenColumns = 0;
             while (rowReader.Read()) {
                 if (canCancel) {
@@ -1259,18 +1614,12 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                string? reference = rowReader.GetAttribute("r");
-                int columnIndex = A1.ParseColumnIndexFromCellReferenceWithKnownRowFast(reference);
+                int columnIndex = GetXmlCellColumnIndex(rowReader, ref nextColumnIndex);
                 if (columnIndex <= 0) {
-                    if (!string.IsNullOrEmpty(reference)) {
-                        SkipXmlElement(rowReader, "c");
-                        continue;
-                    }
-
-                    columnIndex = nextColumnIndex;
+                    SkipXmlElement(rowReader, "c");
+                    continue;
                 }
 
-                nextColumnIndex = columnIndex + 1;
                 if (columnIndex < c1 || columnIndex > c2) {
                     SkipXmlElement(rowReader, "c");
                     continue;
@@ -1283,7 +1632,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 result[rr, cc] = ReadXmlCellValue(rowReader);
-                if (MarkRequestedColumnSeen(cc, width, ref seenColumns)) {
+                if (canTrackColumns && MarkRequestedColumnSeen(cc, width, ref seenColumns)) {
                     SkipXmlElementContent(rowReader, depth, "row");
                     return;
                 }
@@ -1291,19 +1640,22 @@ namespace OfficeIMO.Excel {
         }
 
         private object? ReadXmlCellValue(XmlReader cellReader) {
-            string? type = cellReader.GetAttribute("t");
-            string? styleAttribute = _opt.TreatDatesUsingNumberFormat
-                && type != "s"
-                && type != "b"
-                && type != "inlineStr"
-                && type != "d"
-                && type != "str"
-                ? cellReader.GetAttribute("s")
-                : null;
+            XmlCellKind cellKind = ParseXmlCellKind(cellReader.GetAttribute("t"));
 
             if (cellReader.IsEmptyElement) {
                 return _opt.FillBlanksInRanges ? null : null;
             }
+
+            if (_opt.CellValueConverter != null) {
+                CellRaw raw = ReadXmlCellRaw(cellReader, 0, 0, cellKind, readStyleIndex: true);
+                return ConvertRaw(raw).TypedValue;
+            }
+
+            string? styleAttribute = _opt.TreatDatesUsingNumberFormat
+                && _styles.HasDateStyles
+                && CellKindCanUseDateStyle(cellKind)
+                ? cellReader.GetAttribute("s")
+                : null;
 
             int depth = cellReader.Depth;
             string? rawText = null;
@@ -1351,25 +1703,25 @@ namespace OfficeIMO.Excel {
                 return formulaText;
             }
 
-            if (type == "inlineStr") {
+            if (cellKind == XmlCellKind.InlineString) {
                 return inlineText;
             }
 
-            if (type == "s") {
+            if (cellKind == XmlCellKind.SharedString) {
                 return TryParseSharedStringIndex(rawText, out int sstIndex) ? _sst.Get(sstIndex) : rawText;
             }
 
-            if (type == "b" && rawText != null) {
+            if (cellKind == XmlCellKind.Boolean && rawText != null) {
                 return rawText == "1";
             }
 
-            if (type == "d" && rawText != null) {
+            if (cellKind == XmlCellKind.Date && rawText != null) {
                 return DateTime.TryParse(rawText, _opt.Culture, DateTimeStyles.AssumeLocal, out var date)
                     ? date
                     : rawText;
             }
 
-            if (type == "str") {
+            if (cellKind == XmlCellKind.String) {
                 return rawText ?? inlineText;
             }
 
@@ -1378,6 +1730,8 @@ namespace OfficeIMO.Excel {
             }
 
             if (_opt.TreatDatesUsingNumberFormat
+                && _styles.HasDateStyles
+                && CellKindCanUseDateStyle(cellKind)
                 && TryParseUInt(styleAttribute, out uint styleIndex)
                 && _styles.IsDateLike(styleIndex)
                 && (TryParseInvariantDoubleFast(rawText, out double oa)

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Rows.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Rows.cs
@@ -28,18 +28,31 @@ namespace OfficeIMO.Excel {
             bool canCancel = ct.CanBeCanceled;
             int height = r2 - r1 + 1;
             int width = c2 - c1 + 1;
-            if (height > DenseSnapshotCapacityLimit
-                && CanUseXmlFastReader()
-                && RowsAreSortedWithinRangeXmlFast(r1, r2, ct)) {
-                foreach (var row in ReadRowsXmlFast(r1, c1, r2, c2, width, ct)) {
-                    if (canCancel) {
-                        ct.ThrowIfCancellationRequested();
+            if (CanUseRowsXmlReader()) {
+                if (ShouldUseOrderedBufferedXmlStream(height, c1, c2)
+                    && TryReadRowsOrderedBufferedXmlFast(r1, c1, r2, c2, width, height, ct, out var orderedRows)) {
+                    for (int r = 0; r < orderedRows.Length; r++) {
+                        if (canCancel) {
+                            ct.ThrowIfCancellationRequested();
+                        }
+
+                        yield return orderedRows[r];
                     }
 
-                    yield return row;
+                    yield break;
                 }
 
-                yield break;
+                if (height > DenseSnapshotCapacityLimit && RowsAreSortedWithinRangeXmlFast(r1, r2, ct)) {
+                    foreach (var row in ReadRowsXmlFast(r1, c1, r2, c2, width, ct)) {
+                        if (canCancel) {
+                            ct.ThrowIfCancellationRequested();
+                        }
+
+                        yield return row;
+                    }
+
+                    yield break;
+                }
             }
 
             if (height > DenseSnapshotCapacityLimit && RowsAreSortedWithinRange(r1, r2, ct)) {
@@ -101,8 +114,7 @@ namespace OfficeIMO.Excel {
             }
 
             object?[]? ReadRowValue(Row row, int firstColumn, int lastColumn, int rowWidth, CancellationToken token) {
-                var arr = new object?[rowWidth];
-                bool hasCells = false;
+                object?[]? arr = null;
                 bool canCancelCell = token.CanBeCanceled;
 
                 foreach (var cell in row.Elements<Cell>()) {
@@ -112,28 +124,88 @@ namespace OfficeIMO.Excel {
 
                     int cc = A1.ParseColumnIndexFromCellReferenceFast(cell.CellReference?.Value);
                     if (cc < firstColumn || cc > lastColumn) continue;
-                    hasCells = true;
+                    arr ??= new object?[rowWidth];
                     if (TryConvertCell(cell, out object? value)) {
                         arr[cc - firstColumn] = value ?? arr[cc - firstColumn];
                     }
                 }
 
-                return hasCells ? arr : null;
+                return arr;
+            }
+        }
+
+        private bool TryReadRowsOrderedBufferedXmlFast(
+            int r1,
+            int c1,
+            int r2,
+            int c2,
+            int width,
+            int height,
+            CancellationToken ct,
+            out object?[]?[] rows) {
+            rows = new object?[height][];
+
+            try {
+                using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
+                RewindWorksheetStream(stream);
+                using var reader = OpenWorksheetXmlReader(stream);
+                bool canCancel = ct.CanBeCanceled;
+                int nextRowIndex = 1;
+                var seenRows = CreateCompletedRowTracker(height);
+                while (reader.Read()) {
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
+                    if (reader.NodeType != XmlNodeType.Element || reader.LocalName != "row") {
+                        continue;
+                    }
+
+                    int rowIndex = ParsePositiveIntAttribute(reader.GetAttribute("r"));
+                    if (rowIndex <= 0) {
+                        rowIndex = nextRowIndex;
+                    }
+
+                    nextRowIndex = rowIndex + 1;
+                    if (rowIndex < r1 || rowIndex > r2) {
+                        if (rowIndex > r2 && seenRows.AllRowsSeen) {
+                            break;
+                        }
+
+                        SkipXmlElement(reader, "row");
+                        continue;
+                    }
+
+                    int rowOffset = rowIndex - r1;
+                    if ((uint)rowOffset >= (uint)rows.Length) {
+                        SkipXmlElement(reader, "row");
+                        continue;
+                    }
+
+                    rows[rowOffset] = ReadXmlRowValue(reader, c1, c2, width, ct);
+                    seenRows.MarkSeen(rowOffset);
+                }
+
+                return true;
+            } catch (XmlException) {
+                rows = Array.Empty<object?[]>();
+                return false;
+            } catch (IOException) {
+                rows = Array.Empty<object?[]>();
+                return false;
+            } catch (UnauthorizedAccessException) {
+                rows = Array.Empty<object?[]>();
+                return false;
+            } catch (ObjectDisposedException) {
+                rows = Array.Empty<object?[]>();
+                return false;
             }
         }
 
         private IEnumerable<object?[]?> ReadRowsXmlFast(int r1, int c1, int r2, int c2, int width, CancellationToken ct) {
             using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
             RewindWorksheetStream(stream);
-            var settings = new XmlReaderSettings {
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    IgnoreComments = true,
-                    IgnoreProcessingInstructions = true,
-                    IgnoreWhitespace = true,
-                    CloseInput = false
-                };
-
-                using var reader = XmlReader.Create(stream, settings);
+            using var reader = OpenWorksheetXmlReader(stream);
             bool canCancel = ct.CanBeCanceled;
             int nextRowIndex = 1;
             int nextRequestedRow = r1;
@@ -190,11 +262,11 @@ namespace OfficeIMO.Excel {
                 return null;
             }
 
-            var values = new object?[width];
-            bool hasCells = false;
+            object?[]? values = null;
             int depth = rowReader.Depth;
             bool canCancel = ct.CanBeCanceled;
             int nextColumnIndex = 1;
+            bool canTrackColumns = width <= 64;
             ulong seenColumns = 0;
             while (rowReader.Read()) {
                 if (canCancel) {
@@ -202,25 +274,19 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (rowReader.NodeType == XmlNodeType.EndElement && rowReader.Depth == depth && rowReader.LocalName == "row") {
-                    return hasCells ? values : null;
+                    return values;
                 }
 
                 if (rowReader.NodeType != XmlNodeType.Element || rowReader.LocalName != "c") {
                     continue;
                 }
 
-                string? reference = rowReader.GetAttribute("r");
-                int columnIndex = A1.ParseColumnIndexFromCellReferenceWithKnownRowFast(reference);
+                int columnIndex = GetXmlCellColumnIndex(rowReader, ref nextColumnIndex);
                 if (columnIndex <= 0) {
-                    if (!string.IsNullOrEmpty(reference)) {
-                        SkipXmlElement(rowReader, "c");
-                        continue;
-                    }
-
-                    columnIndex = nextColumnIndex;
+                    SkipXmlElement(rowReader, "c");
+                    continue;
                 }
 
-                nextColumnIndex = columnIndex + 1;
                 if (columnIndex < c1 || columnIndex > c2) {
                     SkipXmlElement(rowReader, "c");
                     continue;
@@ -232,15 +298,20 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
+                values ??= new object?[width];
                 values[offset] = ReadXmlCellValue(rowReader);
-                hasCells = true;
-                if (MarkRequestedColumnSeen(offset, width, ref seenColumns)) {
+                if (canTrackColumns && MarkRequestedColumnSeen(offset, width, ref seenColumns)) {
                     SkipXmlElementContent(rowReader, depth, "row");
                     return values;
                 }
             }
 
-            return hasCells ? values : null;
+            return values;
+        }
+
+        private bool CanUseRowsXmlReader() {
+            return (_opt.CellValueConverter != null || _opt.Culture == System.Globalization.CultureInfo.InvariantCulture)
+                && CanStreamWorksheetPart();
         }
     }
 }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Stream.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Stream.cs
@@ -44,6 +44,15 @@ namespace OfficeIMO.Excel {
                     yield break;
                 }
 
+                if (estRows <= BufferedRangeStreamRowLimit
+                    && TryReadBufferedRangeStreamXmlFast(r1, c1, r2, c2, chunkRows, estRows, ct, out var bufferedChunks)) {
+                    foreach (var chunk in bufferedChunks) {
+                        yield return chunk;
+                    }
+
+                    yield break;
+                }
+
                 if (ShouldUseOrderedBufferedXmlStream(estRows, c1, c2)
                     && TryReadOrderedBufferedRangeStreamXmlFast(r1, c1, r2, c2, chunkRows, estRows, ct, out var automaticChunks)) {
                     foreach (var chunk in automaticChunks) {
@@ -72,7 +81,7 @@ namespace OfficeIMO.Excel {
 
             if (decided != OfficeIMO.Excel.ExecutionMode.Parallel
                 && estRows <= BufferedRangeStreamRowLimit
-                && CanUseXmlFastReader()) {
+                && CanUseRangeStreamXmlReader()) {
                 if (chunkRows >= estRows) {
                     foreach (var chunk in ReadRangeStreamXmlFast(r1, c1, r2, c2, chunkRows, ct)) {
                         yield return chunk;
@@ -105,7 +114,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (decided != OfficeIMO.Excel.ExecutionMode.Parallel
-                && CanUseXmlFastReader()
+                && CanUseRangeStreamXmlReader()
                 && RowsAreSortedWithinRangeXmlFast(r1, r2, ct)) {
                 foreach (var chunk in ReadRangeStreamXmlFast(r1, c1, r2, c2, chunkRows, ct)) {
                     yield return chunk;
@@ -417,27 +426,26 @@ namespace OfficeIMO.Excel {
         private bool CanUseAutomaticXmlStreamFastPath(bool automaticDecision, OfficeIMO.Excel.ExecutionMode decided) {
             return automaticDecision
                 && decided != OfficeIMO.Excel.ExecutionMode.Parallel
-                && CanUseXmlFastReader();
+                && CanUseRangeStreamXmlReader();
+        }
+
+        private bool CanUseRangeStreamXmlReader() {
+            return (_opt.CellValueConverter != null || _opt.Culture == System.Globalization.CultureInfo.InvariantCulture)
+                && CanStreamWorksheetPart();
         }
 
         private IEnumerable<RangeChunk> ReadRangeStreamXmlFast(int r1, int c1, int r2, int c2, int chunkRows, CancellationToken ct) {
             using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
             RewindWorksheetStream(stream);
-            var settings = new XmlReaderSettings {
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    IgnoreComments = true,
-                    IgnoreProcessingInstructions = true,
-                    IgnoreWhitespace = true,
-                    CloseInput = false
-                };
-
-                using var reader = XmlReader.Create(stream, settings);
+            using var reader = OpenWorksheetXmlReader(stream);
             bool canCancel = ct.CanBeCanceled;
             int width = c2 - c1 + 1;
             int currentWindow = -1;
             int currentStartRow = 0;
             object?[][]? currentRows = null;
             int nextRowIndex = 1;
+            int requestedRowCount = r2 - r1 + 1;
+            var seenRows = CreateCompletedRowTracker(requestedRowCount);
 
             while (reader.Read()) {
                 if (canCancel) {
@@ -455,6 +463,10 @@ namespace OfficeIMO.Excel {
 
                 nextRowIndex = rowIndex + 1;
                 if (rowIndex < r1 || rowIndex > r2) {
+                    if (rowIndex > r2 && seenRows.AllRowsSeen) {
+                        break;
+                    }
+
                     SkipXmlElement(reader, "row");
                     continue;
                 }
@@ -476,6 +488,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 ReadXmlRowIntoChunk(reader, currentRows, rowIndex, currentStartRow, c1, c2, ct);
+                seenRows.MarkSeen(rowIndex - r1);
             }
 
             if (currentRows != null) {
@@ -499,17 +512,10 @@ namespace OfficeIMO.Excel {
             try {
                 using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
                 RewindWorksheetStream(stream);
-                var settings = new XmlReaderSettings {
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    IgnoreComments = true,
-                    IgnoreProcessingInstructions = true,
-                    IgnoreWhitespace = true,
-                    CloseInput = false
-                };
-
-                using var reader = XmlReader.Create(stream, settings);
+                using var reader = OpenWorksheetXmlReader(stream);
                 bool canCancel = ct.CanBeCanceled;
                 int nextRowIndex = 1;
+                var seenRows = CreateCompletedRowTracker(estimatedRows);
                 while (reader.Read()) {
                     if (canCancel) {
                         ct.ThrowIfCancellationRequested();
@@ -526,6 +532,10 @@ namespace OfficeIMO.Excel {
 
                     nextRowIndex = rowIndex + 1;
                     if (rowIndex < r1 || rowIndex > r2) {
+                        if (rowIndex > r2 && seenRows.AllRowsSeen) {
+                            break;
+                        }
+
                         SkipXmlElement(reader, "row");
                         continue;
                     }
@@ -544,6 +554,7 @@ namespace OfficeIMO.Excel {
                     }
 
                     ReadXmlRowIntoChunk(reader, chunk.Rows, rowIndex, chunk.StartRow, c1, c2, ct);
+                    seenRows.MarkSeen(rowIndex - r1);
                 }
 
                 if (chunkMap.Count == 0) {
@@ -598,17 +609,10 @@ namespace OfficeIMO.Excel {
             try {
                 using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
                 RewindWorksheetStream(stream);
-                var settings = new XmlReaderSettings {
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    IgnoreComments = true,
-                    IgnoreProcessingInstructions = true,
-                    IgnoreWhitespace = true,
-                    CloseInput = false
-                };
-
-                using var reader = XmlReader.Create(stream, settings);
+                using var reader = OpenWorksheetXmlReader(stream);
                 bool canCancel = ct.CanBeCanceled;
                 int nextRowIndex = 1;
+                var seenRows = CreateCompletedRowTracker(estimatedRows);
                 while (reader.Read()) {
                     if (canCancel) {
                         ct.ThrowIfCancellationRequested();
@@ -625,6 +629,10 @@ namespace OfficeIMO.Excel {
 
                     nextRowIndex = rowIndex + 1;
                     if (rowIndex < r1 || rowIndex > r2) {
+                        if (rowIndex > r2 && seenRows.AllRowsSeen) {
+                            break;
+                        }
+
                         SkipXmlElement(reader, "row");
                         continue;
                     }
@@ -637,6 +645,7 @@ namespace OfficeIMO.Excel {
 
                     var chunk = chunks[window];
                     ReadXmlRowIntoChunk(reader, chunk.Rows, rowIndex, chunk.StartRow, c1, c2, ct);
+                    seenRows.MarkSeen(rowIndex - r1);
                 }
 
                 return true;
@@ -669,6 +678,7 @@ namespace OfficeIMO.Excel {
             int depth = rowReader.Depth;
             bool canCancel = ct.CanBeCanceled;
             int nextColumnIndex = 1;
+            bool canTrackColumns = rowValues.Length <= 64;
             ulong seenColumns = 0;
             while (rowReader.Read()) {
                 if (canCancel) {
@@ -683,18 +693,12 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                string? reference = rowReader.GetAttribute("r");
-                int columnIndex = A1.ParseColumnIndexFromCellReferenceWithKnownRowFast(reference);
+                int columnIndex = GetXmlCellColumnIndex(rowReader, ref nextColumnIndex);
                 if (columnIndex <= 0) {
-                    if (!string.IsNullOrEmpty(reference)) {
-                        SkipXmlElement(rowReader, "c");
-                        continue;
-                    }
-
-                    columnIndex = nextColumnIndex;
+                    SkipXmlElement(rowReader, "c");
+                    continue;
                 }
 
-                nextColumnIndex = columnIndex + 1;
                 if (columnIndex < c1 || columnIndex > c2) {
                     SkipXmlElement(rowReader, "c");
                     continue;
@@ -707,7 +711,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 rowValues[columnOffset] = ReadXmlCellValue(rowReader);
-                if (MarkRequestedColumnSeen(columnOffset, rowValues.Length, ref seenColumns)) {
+                if (canTrackColumns && MarkRequestedColumnSeen(columnOffset, rowValues.Length, ref seenColumns)) {
                     SkipXmlElementContent(rowReader, depth, "row");
                     return;
                 }
@@ -718,20 +722,14 @@ namespace OfficeIMO.Excel {
             try {
                 using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
                 RewindWorksheetStream(stream);
-                var settings = new XmlReaderSettings {
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    IgnoreComments = true,
-                    IgnoreProcessingInstructions = true,
-                    IgnoreWhitespace = true,
-                    CloseInput = false
-                };
-
-                using var reader = XmlReader.Create(stream, settings);
+                using var reader = OpenWorksheetXmlReader(stream);
                 bool canCancel = token.CanBeCanceled;
                 bool hasPrevious = false;
                 bool sawRowAfterRange = false;
                 int previous = 0;
                 int nextRowIndex = 1;
+                int rowCount = lastRow - firstRow + 1;
+                var seenRows = CreateCompletedRowTracker(rowCount);
 
                 while (reader.Read()) {
                     if (canCancel) {
@@ -754,6 +752,10 @@ namespace OfficeIMO.Excel {
                     }
 
                     if (rowIndex > lastRow) {
+                        if (seenRows.AllRowsSeen) {
+                            return true;
+                        }
+
                         sawRowAfterRange = true;
                         SkipXmlElement(reader, "row");
                         continue;
@@ -769,6 +771,7 @@ namespace OfficeIMO.Excel {
 
                     previous = rowIndex;
                     hasPrevious = true;
+                    seenRows.MarkSeen(rowIndex - firstRow);
                 }
 
                 return true;
@@ -788,6 +791,8 @@ namespace OfficeIMO.Excel {
             bool hasPrevious = false;
             bool sawRowAfterRange = false;
             int previous = 0;
+            int rowCount = lastRow - firstRow + 1;
+            var seenRows = CreateCompletedRowTracker(rowCount);
 
             foreach (var row in data.Elements<Row>()) {
                 if (canCancel) {
@@ -797,6 +802,10 @@ namespace OfficeIMO.Excel {
                 int rowIndex = checked((int)row.RowIndex!.Value);
                 if (rowIndex < firstRow) continue;
                 if (rowIndex > lastRow) {
+                    if (seenRows.AllRowsSeen) {
+                        return true;
+                    }
+
                     sawRowAfterRange = true;
                     continue;
                 }
@@ -810,6 +819,7 @@ namespace OfficeIMO.Excel {
 
                 previous = rowIndex;
                 hasPrevious = true;
+                seenRows.MarkSeen(rowIndex - firstRow);
             }
 
             return true;
@@ -820,6 +830,8 @@ namespace OfficeIMO.Excel {
             bool hasPrevious = false;
             bool sawRowAfterRange = false;
             int previous = 0;
+            int rowCount = lastRow - firstRow + 1;
+            var seenRows = CreateCompletedRowTracker(rowCount);
 
             foreach (var row in EnumerateWorksheetRows(token)) {
                 if (canCancel) {
@@ -829,6 +841,10 @@ namespace OfficeIMO.Excel {
                 int rowIndex = checked((int)row.RowIndex!.Value);
                 if (rowIndex < firstRow) continue;
                 if (rowIndex > lastRow) {
+                    if (seenRows.AllRowsSeen) {
+                        return true;
+                    }
+
                     sawRowAfterRange = true;
                     continue;
                 }
@@ -842,6 +858,7 @@ namespace OfficeIMO.Excel {
 
                 previous = rowIndex;
                 hasPrevious = true;
+                seenRows.MarkSeen(rowIndex - firstRow);
             }
 
             return true;

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.cs
@@ -5,6 +5,7 @@ using System.Data;
 using System.Globalization;
 using System.IO;
 using System.Threading;
+using System.Xml;
 
 namespace OfficeIMO.Excel {
     /// <summary>
@@ -18,6 +19,7 @@ namespace OfficeIMO.Excel {
         private readonly ExcelReadOptions _opt;
         private readonly bool _canStreamWorksheetPart;
         private bool? _hasWorksheetPartStreamContent;
+        private static readonly XmlReaderSettings WorksheetXmlReaderSettings = CreateWorksheetXmlReaderSettings();
 
         internal ExcelSheetReader(string sheetName, WorksheetPart wsPart, SharedStringCache sst, StylesCache styles, ExcelReadOptions opt, bool canStreamWorksheetPart) {
             _sheetName = sheetName;
@@ -132,6 +134,20 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        private static XmlReader OpenWorksheetXmlReader(Stream stream) {
+            return XmlReader.Create(stream, WorksheetXmlReaderSettings);
+        }
+
+        private static XmlReaderSettings CreateWorksheetXmlReaderSettings() {
+            return new XmlReaderSettings {
+                DtdProcessing = DtdProcessing.Prohibit,
+                IgnoreComments = true,
+                IgnoreProcessingInstructions = true,
+                IgnoreWhitespace = true,
+                CloseInput = false
+            };
+        }
+
         private static string? ExtractFormulaText(Cell cell) {
             return cell.CellFormula?.Text;
         }
@@ -197,11 +213,54 @@ namespace OfficeIMO.Excel {
         private bool NeedsStyleForConversion(CellValues? typeHint, string? rawText) {
             return rawText != null
                 && _opt.TreatDatesUsingNumberFormat
+                && _styles.HasDateStyles
                 && typeHint != CellValues.SharedString
                 && typeHint != CellValues.Boolean
                 && typeHint != CellValues.String
                 && typeHint != CellValues.InlineString
                 && typeHint != CellValues.Date;
+        }
+
+        private static XmlCellKind ParseXmlCellKind(string? type) {
+            if (string.IsNullOrEmpty(type)) {
+                return XmlCellKind.Default;
+            }
+
+            string text = type!;
+            switch (text.Length) {
+                case 1:
+                    return text[0] switch {
+                        'b' => XmlCellKind.Boolean,
+                        'd' => XmlCellKind.Date,
+                        'n' => XmlCellKind.Number,
+                        's' => XmlCellKind.SharedString,
+                        _ => XmlCellKind.Unknown
+                    };
+                case 3:
+                    return text == "str" ? XmlCellKind.String : XmlCellKind.Unknown;
+                case 9:
+                    return text == "inlineStr" ? XmlCellKind.InlineString : XmlCellKind.Unknown;
+                default:
+                    return XmlCellKind.Unknown;
+            }
+        }
+
+        private static bool CellKindCanUseDateStyle(XmlCellKind kind) {
+            return kind == XmlCellKind.Default
+                || kind == XmlCellKind.Number
+                || kind == XmlCellKind.Unknown;
+        }
+
+        private static CellValues? ToCellValueType(XmlCellKind kind) {
+            return kind switch {
+                XmlCellKind.Boolean => CellValues.Boolean,
+                XmlCellKind.Date => CellValues.Date,
+                XmlCellKind.InlineString => CellValues.InlineString,
+                XmlCellKind.Number => CellValues.Number,
+                XmlCellKind.SharedString => CellValues.SharedString,
+                XmlCellKind.String => CellValues.String,
+                _ => null
+            };
         }
 
         private CellRaw SnapshotCell(Cell cell, int row = 0, int col = 0) {
@@ -509,6 +568,17 @@ namespace OfficeIMO.Excel {
             public string? RawText;
             public string? InlineText;
             public object? TypedValue;
+        }
+
+        private enum XmlCellKind {
+            Default,
+            Boolean,
+            Date,
+            InlineString,
+            Number,
+            SharedString,
+            String,
+            Unknown
         }
     }
 }

--- a/OfficeIMO.Excel/Read/Helpers/A1.cs
+++ b/OfficeIMO.Excel/Read/Helpers/A1.cs
@@ -199,6 +199,69 @@ namespace OfficeIMO.Excel {
             return hasNonZeroRowDigit ? col : 0;
         }
 
+        internal static bool TryParseCellReferenceFast(string? cellRef, out int row, out int col) {
+            row = 0;
+            col = 0;
+            if (string.IsNullOrEmpty(cellRef)) return false;
+
+            string text = cellRef!;
+            int length = text.Length;
+            char first = text[0];
+            char last = text[length - 1];
+            if (!char.IsWhiteSpace(first) && last >= '0' && last <= '9') {
+                int index = 0;
+                for (; index < length; index++) {
+                    char ch = ToUpperAscii(text[index]);
+                    if (ch < 'A' || ch > 'Z') {
+                        break;
+                    }
+
+                    int value = ch - 'A' + 1;
+                    if (col > (int.MaxValue - value) / 26) {
+                        row = 0;
+                        col = 0;
+                        return false;
+                    }
+
+                    col = (col * 26) + value;
+                }
+
+                if (index == 0 || index == length) {
+                    row = 0;
+                    col = 0;
+                    return false;
+                }
+
+                for (; index < length; index++) {
+                    char ch = text[index];
+                    if (ch < '0' || ch > '9') {
+                        row = 0;
+                        col = 0;
+                        return false;
+                    }
+
+                    int digit = ch - '0';
+                    if (row > (int.MaxValue - digit) / 10) {
+                        row = 0;
+                        col = 0;
+                        return false;
+                    }
+
+                    row = (row * 10) + digit;
+                }
+
+                if (row <= 0 || col <= 0) {
+                    row = 0;
+                    col = 0;
+                    return false;
+                }
+
+                return true;
+            }
+
+            return TryParseCellRef(cellRef, 0, length, out row, out col);
+        }
+
         internal static int ParseColumnIndexFromCellReferenceWithKnownRowFast(string? cellRef) {
             if (string.IsNullOrEmpty(cellRef)) return 0;
 

--- a/OfficeIMO.Excel/Read/Helpers/SharedStringCache.cs
+++ b/OfficeIMO.Excel/Read/Helpers/SharedStringCache.cs
@@ -9,10 +9,13 @@ using System.Xml;
 namespace OfficeIMO.Excel {
     internal sealed class SharedStringCache {
         private const int MinimumInitialCapacity = 1024;
+        private static readonly XmlReaderSettings SharedStringXmlReaderSettings = CreateSharedStringXmlReaderSettings();
 
         private readonly SharedStringTablePart? _part;
         private readonly bool _preferDom;
         private readonly Lazy<List<string>> _items;
+        private readonly object _containsCacheLock = new object();
+        private Dictionary<(string Text, StringComparison Comparison), HashSet<int>?>? _containsCache;
 
         private SharedStringCache(SharedStringTablePart? part, bool preferDom) {
             _part = part;
@@ -59,15 +62,7 @@ namespace OfficeIMO.Excel {
 
             try {
                 using var stream = _part!.GetStream(FileMode.Open, FileAccess.Read);
-                var settings = new XmlReaderSettings {
-                    DtdProcessing = DtdProcessing.Prohibit,
-                    IgnoreComments = true,
-                    IgnoreProcessingInstructions = true,
-                    IgnoreWhitespace = true,
-                    CloseInput = false
-                };
-
-                using var reader = XmlReader.Create(stream, settings);
+                using var reader = XmlReader.Create(stream, SharedStringXmlReaderSettings);
                 while (reader.Read()) {
                     if (reader.NodeType != XmlNodeType.Element) {
                         continue;
@@ -105,6 +100,16 @@ namespace OfficeIMO.Excel {
                 items = null!;
                 return false;
             }
+        }
+
+        private static XmlReaderSettings CreateSharedStringXmlReaderSettings() {
+            return new XmlReaderSettings {
+                DtdProcessing = DtdProcessing.Prohibit,
+                IgnoreComments = true,
+                IgnoreProcessingInstructions = true,
+                IgnoreWhitespace = true,
+                CloseInput = false
+            };
         }
 
         private static string ReadSharedStringItemXml(XmlReader reader) {
@@ -187,6 +192,39 @@ namespace OfficeIMO.Excel {
             var items = _items.Value;
             if ((uint)index < (uint)items.Count) return items[index];
             return null;
+        }
+
+        internal HashSet<int>? FindIndexesContaining(string text, StringComparison comparison) {
+            if (string.IsNullOrEmpty(text)) {
+                return null;
+            }
+
+            var key = (text, comparison);
+            lock (_containsCacheLock) {
+                if (_containsCache != null && _containsCache.TryGetValue(key, out var cachedIndexes)) {
+                    return cachedIndexes;
+                }
+            }
+
+            var items = _items.Value;
+            HashSet<int>? indexes = null;
+            for (int i = 0; i < items.Count; i++) {
+                if (items[i].IndexOf(text, comparison) >= 0) {
+                    indexes ??= new HashSet<int>();
+                    indexes.Add(i);
+                }
+            }
+
+            lock (_containsCacheLock) {
+                _containsCache ??= new Dictionary<(string Text, StringComparison Comparison), HashSet<int>?>();
+                if (_containsCache.Count >= 32) {
+                    _containsCache.Clear();
+                }
+
+                _containsCache[key] = indexes;
+            }
+
+            return indexes;
         }
 
         private static int ParsePositiveIntAttribute(string? value) {

--- a/OfficeIMO.Excel/Read/Helpers/StylesCache.cs
+++ b/OfficeIMO.Excel/Read/Helpers/StylesCache.cs
@@ -8,6 +8,8 @@ namespace OfficeIMO.Excel {
 
         private StylesCache() { }
 
+        public bool HasDateStyles { get; private set; }
+
         public static StylesCache Build(SpreadsheetDocument doc) {
             var cache = new StylesCache();
             var sp = doc.WorkbookPart!.WorkbookStylesPart;
@@ -37,7 +39,10 @@ namespace OfficeIMO.Excel {
                     var cf = cellFormats[idx];
                     var nId = (uint)(cf.NumberFormatId?.Value ?? 0);
                     bool dateLike = IsBuiltInDate(nId) || (nf.TryGetValue(nId, out var code) && ExcelNumberFormatClassifier.LooksLikeDateFormat(code));
-                    if (dateLike) cache._dateStyleIndexes[idx] = true;
+                    if (dateLike) {
+                        cache._dateStyleIndexes[idx] = true;
+                        cache.HasDateStyles = true;
+                    }
                 }
             }
 

--- a/OfficeIMO.Excel/SharedStringPlanner.cs
+++ b/OfficeIMO.Excel/SharedStringPlanner.cs
@@ -38,7 +38,7 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
-            _finalIndex = doc.GetSharedStringIndices(distinct);
+            _finalIndex = doc.GetSharedStringIndices(distinct, assumeDistinct: true);
         }
 
         /// <summary>

--- a/OfficeIMO.Tests/Excel.AutoFilter.cs
+++ b/OfficeIMO.Tests/Excel.AutoFilter.cs
@@ -87,6 +87,59 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AutoFilterByHeadersEquals_BatchesAndReplacesExistingFilters() {
+            string filePath = Path.Combine(_directoryWithFiles, "AutoFilter.BatchHeaders.xlsx");
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(1, 2, "Department");
+                sheet.CellValue(1, 3, "Score");
+                sheet.CellValue(1, 4, "Notes");
+                sheet.CellValue(2, 1, "North");
+                sheet.CellValue(2, 2, "Finance");
+                sheet.CellValue(2, 3, 20d);
+                sheet.CellValue(2, 4, "keep");
+                sheet.CellValue(3, 1, "South");
+                sheet.CellValue(3, 2, "Operations");
+                sheet.CellValue(3, 3, 30d);
+                sheet.CellValue(3, 4, "review");
+                sheet.AutoFilterAdd("A1:D3");
+                sheet.AutoFilterByHeaderEquals("Region", new[] { "Old" });
+                sheet.AutoFilterByHeadersEquals(
+                    ("Region", new[] { "North", "north", "South" }),
+                    ("Missing", new[] { "Ignored" }),
+                    ("Score", new[] { "20", "20", "30" }),
+                    ("Region", new[] { "East" }));
+                sheet.AutoFilterByHeadersEquals(
+                    ("Region", new[] { "East" }),
+                    ("Score", new[] { "20", "30" }));
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                AutoFilter autoFilter = Assert.Single(wsPart.Worksheet.Elements<AutoFilter>());
+                Assert.Equal("A1:D3", autoFilter.Reference!.Value);
+
+                var filterColumns = autoFilter.Elements<FilterColumn>().OrderBy(fc => fc.ColumnId?.Value ?? 0U).ToList();
+                Assert.Equal(2, filterColumns.Count);
+
+                Assert.Equal(0U, filterColumns[0].ColumnId!.Value);
+                var regionFilters = Assert.Single(filterColumns[0].Elements<Filters>());
+                Filter regionFilter = Assert.Single(regionFilters.Elements<Filter>());
+                Assert.Equal("East", regionFilter.Val!.Value);
+
+                Assert.Equal(2U, filterColumns[1].ColumnId!.Value);
+                var scoreFilters = Assert.Single(filterColumns[1].Elements<Filters>());
+                Assert.Equal(new[] { "20", "30" }, scoreFilters.Elements<Filter>().Select(filter => filter.Val!.Value).ToArray());
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
         public void Test_CustomAutoFilterHelpersPersistExpectedOperators() {
             string filePath = Path.Combine(_directoryWithFiles, "AutoFilter.CustomHelpers.xlsx");
             using (ExcelDocument document = ExcelDocument.Create(filePath)) {

--- a/OfficeIMO.Tests/Excel.CellAndRange.cs
+++ b/OfficeIMO.Tests/Excel.CellAndRange.cs
@@ -119,6 +119,13 @@ namespace OfficeIMO.Tests {
             Assert.Equal(0, A1.ParseColumnIndexFromCellReferenceFast("A2147483648"));
             Assert.Equal(0, A1.ParseColumnIndexFromCellReferenceFast("AB12X"));
             Assert.Equal(0, A1.ParseColumnIndexFromCellReferenceFast("TOTAL"));
+            Assert.True(A1.TryParseCellReferenceFast("ab12", out int fastRow, out int fastCol));
+            Assert.Equal((12, 28), (fastRow, fastCol));
+            Assert.True(A1.TryParseCellReferenceFast(" AB12 ", out fastRow, out fastCol));
+            Assert.Equal((12, 28), (fastRow, fastCol));
+            Assert.False(A1.TryParseCellReferenceFast("A0", out _, out _));
+            Assert.False(A1.TryParseCellReferenceFast("AB12X", out _, out _));
+            Assert.False(A1.TryParseCellReferenceFast("A2147483648", out _, out _));
             Assert.Equal("A", A1.ColumnIndexToLetters(0));
             Assert.Equal("A", A1.ColumnIndexToLetters(1));
             Assert.Equal("Z", A1.ColumnIndexToLetters(26));

--- a/OfficeIMO.Tests/Excel.CellValues.cs
+++ b/OfficeIMO.Tests/Excel.CellValues.cs
@@ -95,5 +95,62 @@ namespace OfficeIMO.Tests {
 
             File.Delete(filePath);
         }
+
+        [Fact]
+        public void Test_TryGetCellText_UsesFreshSharedStringsAfterMutation() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesSharedStringCache.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Alpha");
+                sheet.CellValue(2, 1, "Beta");
+
+                Assert.True(sheet.TryGetCellText(1, 1, out var first));
+                Assert.Equal("Alpha", first);
+                Assert.Equal("A2", sheet.FindFirst("Beta"));
+
+                sheet.CellValue(3, 1, "Gamma");
+
+                Assert.True(sheet.TryGetCellText(3, 1, out var appended));
+                Assert.Equal("Gamma", appended);
+                Assert.Equal("A3", sheet.FindFirst("Gamma"));
+                Assert.Equal("A2", sheet.FindFirst("Beta"));
+                sheet.CellValue(2, 1, "Delta");
+                Assert.Null(sheet.FindFirst("Beta"));
+                Assert.Equal("A2", sheet.FindFirst("Delta"));
+                sheet.CellValue(4, 1, "Beta");
+                Assert.Equal("A4", sheet.FindFirst("Beta"));
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_FindFirstAndReplaceAll_HandleSharedStrings() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesSharedStringFindReplace.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Status New");
+                sheet.CellValue(2, 1, "Status Old");
+                sheet.CellValue(3, 1, "Status New");
+                sheet.CellValue(4, 1, 123);
+
+                Assert.Equal("A2", sheet.FindFirst("old"));
+                Assert.Equal(2, sheet.ReplaceAll("new", "Processed"));
+                Assert.True(sheet.TryGetCellText(1, 1, out var first));
+                Assert.True(sheet.TryGetCellText(3, 1, out var third));
+                Assert.Equal("Status Processed", first);
+                Assert.Equal("Status Processed", third);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.CellValues.cs
+++ b/OfficeIMO.Tests/Excel.CellValues.cs
@@ -129,6 +129,64 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_TryGetCellText_UsesFreshSharedStringsAfterDirectOpenXmlMutation() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesSharedStringDirectMutation.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Alpha");
+
+                Assert.True(sheet.TryGetCellText(1, 1, out var first));
+                Assert.Equal("Alpha", first);
+
+                var sharedString = document._spreadSheetDocument.WorkbookPart!.SharedStringTablePart!.SharedStringTable!
+                    .Elements<SharedStringItem>()
+                    .First();
+                sharedString.Text!.Text = "Omega";
+
+                Assert.True(sheet.TryGetCellText(1, 1, out var refreshed));
+                Assert.Equal("Omega", refreshed);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Test_FindFirst_UsesFreshWorksheetStateAfterDirectOpenXmlMutation() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesFindFirstDirectMutation.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Alpha");
+                sheet.CellValue(2, 1, "Beta");
+
+                Assert.Equal("A2", sheet.FindFirst("Beta"));
+                Assert.Null(sheet.FindFirst("Gamma"));
+
+                var worksheet = document._spreadSheetDocument.WorkbookPart!.WorksheetParts.First().Worksheet;
+                var betaCell = worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A2");
+                betaCell.DataType = CellValues.InlineString;
+                betaCell.CellValue = null;
+                betaCell.InlineString = new InlineString(new Text("Delta"));
+
+                var sheetData = worksheet.GetFirstChild<SheetData>()!;
+                var row = new Row { RowIndex = 3 };
+                row.Append(new Cell {
+                    CellReference = "A3",
+                    DataType = CellValues.InlineString,
+                    InlineString = new InlineString(new Text("Gamma"))
+                });
+                sheetData.Append(row);
+
+                Assert.Null(sheet.FindFirst("Beta"));
+                Assert.Equal("A2", sheet.FindFirst("Delta"));
+                Assert.Equal("A3", sheet.FindFirst("Gamma"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Test_FindFirstAndReplaceAll_HandleSharedStrings() {
             string filePath = Path.Combine(_directoryWithFiles, "CellValuesSharedStringFindReplace.xlsx");
 

--- a/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
+++ b/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
@@ -1750,6 +1750,27 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PerformanceReview_DataTableDeferredHeaderMap_MaterializesBeforeDomHeaderFastPath() {
+            using var memory = new MemoryStream();
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertDataTable(CreateSingleColumnDataTable("Items", "Alpha"));
+
+                Assert.True(sheet.TryGetColumnIndexByHeader("Name", out int columnIndex));
+                Assert.Equal(1, columnIndex);
+
+                document.Save(memory);
+                Assert.NotEqual(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+            }
+
+            memory.Position = 0;
+            using var loaded = ExcelDocument.Load(memory, readOnly: true);
+            Assert.True(loaded.Sheets[0].TryGetCellText(2, 1, out string? value));
+            Assert.Equal("Alpha", value);
+        }
+
+        [Fact]
         public void PerformanceReview_DataTableDeferredThenParallelWrite_MaterializesBeforeFallbackSave() {
             using var memory = new MemoryStream();
 

--- a/OfficeIMO.Tests/Excel.ReadRowsEmptyRows.cs
+++ b/OfficeIMO.Tests/Excel.ReadRowsEmptyRows.cs
@@ -69,6 +69,34 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ReadRows_ReturnsNullForRowsWithoutCellsInRequestedColumns() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReadRowsOutsideRequestedColumns.xlsx");
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Header");
+                    sheet.CellValue(2, 2, "Outside");
+                    sheet.CellValue(3, 1, "Value");
+                    document.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                var rows = reader.GetSheet("Data").ReadRows("A1:A3").ToList();
+
+                Assert.Equal(3, rows.Count);
+                Assert.NotNull(rows[0]);
+                Assert.Equal("Header", rows[0]![0]);
+                Assert.Null(rows[1]);
+                Assert.NotNull(rows[2]);
+                Assert.Equal("Value", rows[2]![0]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
         public void ReadRowsAs_ThrowsForRowsWithoutCells() {
             string filePath = Path.Combine(_directoryWithFiles, "ReadRowsAsEmptyRows.xlsx");
             try {

--- a/OfficeIMO.Tests/Excel.Reader.cs
+++ b/OfficeIMO.Tests/Excel.Reader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -327,6 +328,104 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Reader_DataTable_NoHeadersNoInference_UsesGeneratedObjectColumns() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderDataTableNoHeadersNoInference.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Name");
+                    sheet.CellValue(1, 2, "Count");
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellValue(2, 2, 42);
+                    document.Save();
+                }
+
+                var options = new ExcelReadOptions { InferDataTableColumnTypes = false };
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                var table = reader.GetSheet("Data").ReadRangeAsDataTable("A1:B2", headersInFirstRow: false, mode: ExecutionMode.Sequential);
+
+                Assert.Equal(new[] { "Column1", "Column2" }, table.Columns.Cast<DataColumn>().Select(column => column.ColumnName).ToArray());
+                Assert.All(table.Columns.Cast<DataColumn>(), column => Assert.Equal(typeof(object), column.DataType));
+                Assert.Equal("Name", table.Rows[0][0]);
+                Assert.Equal("Count", table.Rows[0][1]);
+                Assert.Equal("Alpha", table.Rows[1][0]);
+                Assert.Equal(42D, table.Rows[1][1]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_DataTable_HeadersNoInference_UsesHeaderObjectColumns() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderDataTableHeadersNoInference.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Name");
+                    sheet.CellValue(1, 2, "Count");
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellValue(2, 2, 42);
+                    sheet.CellValue(3, 1, "Beta");
+                    sheet.CellValue(3, 2, 7);
+                    document.Save();
+                }
+
+                var options = new ExcelReadOptions { InferDataTableColumnTypes = false };
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                var table = reader.GetSheet("Data").ReadRangeAsDataTable("A1:B3", headersInFirstRow: true, mode: ExecutionMode.Sequential);
+
+                Assert.Equal(new[] { "Name", "Count" }, table.Columns.Cast<DataColumn>().Select(column => column.ColumnName).ToArray());
+                Assert.All(table.Columns.Cast<DataColumn>(), column => Assert.Equal(typeof(object), column.DataType));
+                Assert.Equal(2, table.Rows.Count);
+                Assert.Equal("Alpha", table.Rows[0][0]);
+                Assert.Equal(42D, table.Rows[0][1]);
+                Assert.Equal("Beta", table.Rows[1][0]);
+                Assert.Equal(7D, table.Rows[1][1]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_DataTable_MixedTypeInference_ResolvesObjectColumns() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderDataTableMixedTypeInference.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Key");
+                    sheet.CellValue(1, 2, "Value");
+                    sheet.CellValue(2, 1, 1);
+                    sheet.CellValue(2, 2, "Open");
+                    sheet.CellValue(3, 1, "Two");
+                    sheet.CellValue(3, 2, 7);
+                    document.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                var table = reader.GetSheet("Data").ReadRangeAsDataTable("A1:B3", headersInFirstRow: true, mode: ExecutionMode.Sequential);
+
+                Assert.Equal(new[] { "Key", "Value" }, table.Columns.Cast<DataColumn>().Select(column => column.ColumnName).ToArray());
+                Assert.All(table.Columns.Cast<DataColumn>(), column => Assert.Equal(typeof(object), column.DataType));
+                Assert.Equal(2, table.Rows.Count);
+                Assert.Equal(1D, table.Rows[0][0]);
+                Assert.Equal("Open", table.Rows[0][1]);
+                Assert.Equal("Two", table.Rows[1][0]);
+                Assert.Equal(7D, table.Rows[1][1]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
         public void Reader_RowReaders_HandleLargeSortedSparseRanges() {
             string filePath = Path.Combine(_directoryWithFiles, "ReaderRowReadersLargeSortedSparseRanges.xlsx");
 
@@ -334,6 +433,7 @@ namespace OfficeIMO.Tests {
                 using (var document = ExcelDocument.Create(filePath)) {
                     var sheet = document.AddWorkSheet("Data");
                     sheet.CellValue(1, 1, "Header");
+                    sheet.CellValue(2, 2, "OutsideRequestedColumn");
                     sheet.CellValue(100001, 1, "Tail");
                     document.Save();
                 }
@@ -352,6 +452,367 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Header", rows[0]![0]);
                 Assert.Null(rows[1]);
                 Assert.Equal("Tail", rows[100000]![0]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRows_LargeSparseOutOfOrderRowsRemainOrdered() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderRowsLargeSparseOutOfOrderRows.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Header");
+                    sheet.CellValue(2, 2, "OutsideRequestedColumn");
+                    sheet.CellValue(100001, 1, "Tail");
+                    document.Save();
+                }
+
+                MoveWorksheetRowToEnd(filePath, 1U);
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                var rows = reader.GetSheet("Data").ReadRows("A1:A100001").ToArray();
+
+                Assert.Equal(100001, rows.Length);
+                Assert.Equal("Header", rows[0]![0]);
+                Assert.Null(rows[1]);
+                Assert.Equal("Tail", rows[100000]![0]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadObjects_SequentialOutOfOrderRowsRemainOrdered() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderObjectsOutOfOrderRows.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Name");
+                    sheet.CellValue(1, 2, "Count");
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellValue(2, 2, 42);
+                    sheet.CellValue(4, 1, "Omega");
+                    sheet.CellValue(4, 2, 99);
+                    document.Save();
+                }
+
+                MoveWorksheetRowToEnd(filePath, 1U);
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                var rows = reader.GetSheet("Data").ReadObjects("A1:B4", ExecutionMode.Sequential).ToList();
+
+                Assert.Equal(3, rows.Count);
+                Assert.Equal("Alpha", rows[0]["Name"]);
+                Assert.Equal(42D, rows[0]["Count"]);
+                Assert.Null(rows[1]["Name"]);
+                Assert.Null(rows[1]["Count"]);
+                Assert.Equal("Omega", rows[2]["Name"]);
+                Assert.Equal(99D, rows[2]["Count"]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadObjects_SequentialHonorsCellValueConverter() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderObjectsCellValueConverter.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Name");
+                    sheet.CellValue(1, 2, "Count");
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellValue(2, 2, 42);
+                    document.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    CellValueConverter = context => context.RawText == "42" ? new ExcelCellValue("forty-two") : ExcelCellValue.NotHandled
+                };
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                var row = Assert.Single(reader.GetSheet("Data").ReadObjects("A1:B2", ExecutionMode.Sequential));
+
+                Assert.Equal("Alpha", row["Name"]);
+                Assert.Equal("forty-two", row["Count"]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRows_HonorsCellValueConverter() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderRowsCellValueConverter.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Name");
+                    sheet.CellValue(1, 2, "Count");
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellValue(2, 2, 42);
+                    document.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    CellValueConverter = context => context.RawText == "42" ? new ExcelCellValue("forty-two") : ExcelCellValue.NotHandled
+                };
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                var row = Assert.Single(reader.GetSheet("Data").ReadRows("A2:B2"));
+
+                Assert.Equal("Alpha", row![0]);
+                Assert.Equal("forty-two", row[1]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadColumn_HonorsCellValueConverter() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderColumnCellValueConverter.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Name");
+                    sheet.CellValue(2, 1, 42);
+                    document.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    CellValueConverter = context => context.RawText == "42" ? new ExcelCellValue("forty-two") : ExcelCellValue.NotHandled
+                };
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                var column = reader.GetSheet("Data").ReadColumn("A1:A2").ToList();
+
+                Assert.Equal("Name", column[0]);
+                Assert.Equal("forty-two", column[1]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadColumn_CellValueConverterFallbackUsesConfiguredCulture() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderColumnConverterCultureFallback.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, 1d);
+                    sheet.CellValue(2, 1, 2d);
+                    document.Save();
+                }
+
+                using (var spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                    var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>().ToDictionary(c => c.CellReference!.Value!);
+                    cells["A1"].DataType = CellValues.Number;
+                    cells["A1"].CellValue = new CellValue("1,23");
+                    cells["A2"].DataType = CellValues.Number;
+                    cells["A2"].CellValue = new CellValue("123.45");
+                    spreadsheet.WorkbookPart.WorksheetParts.First().Worksheet.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    Culture = CultureInfo.GetCultureInfo("pl-PL"),
+                    CellValueConverter = static _ => ExcelCellValue.NotHandled
+                };
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                var column = reader.GetSheet("Data").ReadColumn("A1:A2").ToList();
+
+                Assert.Equal(1.23d, Assert.IsType<double>(column[0]), precision: 2);
+                Assert.Equal(123.45d, Assert.IsType<double>(column[1]), precision: 2);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRows_CellValueConverterFallbackUsesConfiguredCulture() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderRowsConverterCultureFallback.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, 1d);
+                    sheet.CellValue(2, 1, 2d);
+                    document.Save();
+                }
+
+                using (var spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                    var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>().ToDictionary(c => c.CellReference!.Value!);
+                    cells["A1"].DataType = CellValues.Number;
+                    cells["A1"].CellValue = new CellValue("1,23");
+                    cells["A2"].DataType = CellValues.Number;
+                    cells["A2"].CellValue = new CellValue("123.45");
+                    spreadsheet.WorkbookPart.WorksheetParts.First().Worksheet.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    Culture = CultureInfo.GetCultureInfo("pl-PL"),
+                    CellValueConverter = static _ => ExcelCellValue.NotHandled
+                };
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                var rows = reader.GetSheet("Data").ReadRows("A1:A2").ToList();
+
+                Assert.Equal(1.23d, Assert.IsType<double>(rows[0]![0]), precision: 2);
+                Assert.Equal(123.45d, Assert.IsType<double>(rows[1]![0]), precision: 2);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRangeStream_HonorsCellValueConverter() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderRangeStreamCellValueConverter.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Name");
+                    sheet.CellValue(1, 2, "Count");
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellValue(2, 2, 42);
+                    document.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    CellValueConverter = context => context.RawText == "42" ? new ExcelCellValue("forty-two") : ExcelCellValue.NotHandled
+                };
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                var chunks = reader.GetSheet("Data").ReadRangeStream("A1:B2", chunkRows: 1, mode: ExecutionMode.Sequential).ToList();
+
+                Assert.Equal(2, chunks.Count);
+                Assert.Equal("Alpha", chunks[1].Rows[0][0]);
+                Assert.Equal("forty-two", chunks[1].Rows[0][1]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRangeStream_CellValueConverterFallbackUsesConfiguredCulture() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderRangeStreamConverterCultureFallback.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, 1d);
+                    sheet.CellValue(2, 1, 2d);
+                    document.Save();
+                }
+
+                using (var spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                    var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>().ToDictionary(c => c.CellReference!.Value!);
+                    cells["A1"].DataType = CellValues.Number;
+                    cells["A1"].CellValue = new CellValue("1,23");
+                    cells["A2"].DataType = CellValues.Number;
+                    cells["A2"].CellValue = new CellValue("123.45");
+                    spreadsheet.WorkbookPart.WorksheetParts.First().Worksheet.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    Culture = CultureInfo.GetCultureInfo("pl-PL"),
+                    CellValueConverter = static _ => ExcelCellValue.NotHandled
+                };
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                var chunk = Assert.Single(reader.GetSheet("Data").ReadRangeStream("A1:A2", chunkRows: 2, mode: ExecutionMode.Sequential));
+
+                Assert.Equal(1.23d, Assert.IsType<double>(chunk.Rows[0][0]), precision: 2);
+                Assert.Equal(123.45d, Assert.IsType<double>(chunk.Rows[1][0]), precision: 2);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRangeAsDataTable_SequentialHonorsCellValueConverter() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderDataTableCellValueConverter.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Name");
+                    sheet.CellValue(1, 2, "Count");
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellValue(2, 2, 42);
+                    sheet.CellValue(3, 1, "Beta");
+                    sheet.CellValue(3, 2, 7);
+                    document.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    CellValueConverter = context => context.RawText == "42" ? new ExcelCellValue("forty-two") : ExcelCellValue.NotHandled
+                };
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                DataTable table = reader.GetSheet("Data").ReadRangeAsDataTable("A1:B3", mode: ExecutionMode.Sequential);
+
+                Assert.Equal("Alpha", table.Rows[0]["Name"]);
+                Assert.Equal("forty-two", table.Rows[0]["Count"]);
+                Assert.Equal("Beta", table.Rows[1]["Name"]);
+                Assert.Equal(7d, table.Rows[1]["Count"]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRangeAsDataTable_CellValueConverterFallbackUsesConfiguredCulture() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderDataTableConverterCultureFallback.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Amount");
+                    sheet.CellValue(2, 1, 1d);
+                    sheet.CellValue(3, 1, 2d);
+                    document.Save();
+                }
+
+                using (var spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                    var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>().ToDictionary(c => c.CellReference!.Value!);
+                    cells["A2"].DataType = CellValues.Number;
+                    cells["A2"].CellValue = new CellValue("1,23");
+                    cells["A3"].DataType = CellValues.Number;
+                    cells["A3"].CellValue = new CellValue("123.45");
+                    spreadsheet.WorkbookPart.WorksheetParts.First().Worksheet.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    Culture = CultureInfo.GetCultureInfo("pl-PL"),
+                    CellValueConverter = static _ => ExcelCellValue.NotHandled
+                };
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                DataTable table = reader.GetSheet("Data").ReadRangeAsDataTable("A1:A3", mode: ExecutionMode.Sequential);
+
+                Assert.Equal(1.23d, Assert.IsType<double>(table.Rows[0]["Amount"]), precision: 2);
+                Assert.Equal(123.45d, Assert.IsType<double>(table.Rows[1]["Amount"]), precision: 2);
             } finally {
                 if (File.Exists(filePath)) {
                     File.Delete(filePath);

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -1094,6 +1094,9 @@ namespace OfficeIMO.Tests {
                     InlineString = new InlineString(new Text("Value"))
                 });
 
+                Assert.True(loadedSheet.TryGetColumnIndexByHeader("Value", out int valueColumn));
+                Assert.Equal(2, valueColumn);
+
                 var refreshedMap = loadedSheet.GetHeaderMap();
                 Assert.Equal(1, refreshedMap["Status"]);
                 Assert.Equal(2, refreshedMap["Value"]);
@@ -1806,6 +1809,45 @@ namespace OfficeIMO.Tests {
                 var options = new ExcelReadOptions {
                     CellValueConverter = context =>
                         context.RawText == "42" && context.StyleIndex != null
+                            ? new ExcelCellValue("100")
+                            : ExcelCellValue.NotHandled
+                };
+
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                var row = Assert.Single(reader.GetSheet("Data").ReadObjects<NullableTypedRow>("A1:A2", ExecutionMode.Sequential));
+
+                Assert.Equal(100, row.Score);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_TypedObjects_HonorsCellValueConverterStyleContextForEmptyXmlCells() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderTypedObjectsEmptyCellConverterStyleContext.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Score");
+                    sheet.CellValue(2, 1, 42);
+                    sheet.CellAt(2, 1).SetNumberFormat("0.00");
+                    document.Save();
+                }
+
+                using (var spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                    var worksheet = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet;
+                    var cell = worksheet.Descendants<Cell>().Single(c => c.CellReference?.Value == "A2");
+                    cell.CellValue = null;
+                    cell.DataType = null;
+                    worksheet.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    CellValueConverter = context =>
+                        context.RawText == null && context.StyleIndex != null
                             ? new ExcelCellValue("100")
                             : ExcelCellValue.NotHandled
                 };

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -1118,17 +1118,18 @@ namespace OfficeIMO.Tests {
                     document.Save();
                 }
 
-                string? expectedHeader;
+                object? readerHeader;
                 using (var reader = ExcelDocumentReader.Open(filePath)) {
-                    expectedHeader = reader.GetSheet("Data").ReadRange("A1:A1")[0, 0]?.ToString();
+                    readerHeader = reader.GetSheet("Data").ReadRange("A1:A1")[0, 0];
                 }
 
                 using var loadedDocument = ExcelDocument.Load(filePath);
                 var loadedSheet = loadedDocument.GetSheet("Data");
                 var map = loadedSheet.GetHeaderMap();
 
-                Assert.False(string.IsNullOrEmpty(expectedHeader));
-                Assert.True(map.ContainsKey(expectedHeader));
+                Assert.IsType<DateTime>(readerHeader);
+                Assert.Single(map);
+                Assert.Equal(1, map.Values.Single());
                 Assert.False(map.ContainsKey(serialValue.ToString(CultureInfo.InvariantCulture)));
             } finally {
                 if (File.Exists(filePath)) {

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -1122,7 +1122,7 @@ namespace OfficeIMO.Tests {
                 var loadedSheet = loadedDocument.GetSheet("Data");
                 var map = loadedSheet.GetHeaderMap();
 
-                string expectedHeader = DateTime.FromOADate(serialValue).ToString();
+                string expectedHeader = DateTime.FromOADate(serialValue).ToString(CultureInfo.InvariantCulture);
                 Assert.True(map.ContainsKey(expectedHeader));
                 Assert.False(map.ContainsKey(serialValue.ToString(CultureInfo.InvariantCulture)));
             } finally {

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -1068,6 +1068,71 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Sheet_HeaderMapCache_RevalidatesUsedRangeAfterOpenXmlMutation() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderHeaderCacheOpenXmlUsedRangeShift.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Status");
+                    document.Save();
+                }
+
+                using var loadedDocument = ExcelDocument.Load(filePath);
+                var loadedSheet = loadedDocument.GetSheet("Data");
+
+                var initialMap = loadedSheet.GetHeaderMap();
+                Assert.Equal(1, initialMap["Status"]);
+
+                var workbookPart = loadedDocument._spreadSheetDocument.WorkbookPart!;
+                var sheetElement = workbookPart.Workbook.Sheets!.Elements<Sheet>().Single(sheet => sheet.Name == "Data");
+                var worksheetPart = (WorksheetPart)workbookPart.GetPartById(sheetElement.Id!);
+                var firstRow = worksheetPart.Worksheet.GetFirstChild<SheetData>()!.Elements<Row>().Single(row => row.RowIndex?.Value == 1U);
+                firstRow.Append(new Cell {
+                    CellReference = "B1",
+                    DataType = CellValues.InlineString,
+                    InlineString = new InlineString(new Text("Value"))
+                });
+
+                var refreshedMap = loadedSheet.GetHeaderMap();
+                Assert.Equal(1, refreshedMap["Status"]);
+                Assert.Equal(2, refreshedMap["Value"]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Sheet_HeaderMap_UsesReaderForDateStyledNumericHeaders() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderHeaderMapDateStyledNumericHeader.xlsx");
+            const double serialValue = 45292d;
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, serialValue);
+                    sheet.CellValue(2, 1, "Alpha");
+                    sheet.CellAt(1, 1).SetNumberFormat("yyyy-mm-dd");
+                    document.Save();
+                }
+
+                using var loadedDocument = ExcelDocument.Load(filePath);
+                var loadedSheet = loadedDocument.GetSheet("Data");
+                var map = loadedSheet.GetHeaderMap();
+
+                string expectedHeader = DateTime.FromOADate(serialValue).ToString();
+                Assert.True(map.ContainsKey(expectedHeader));
+                Assert.False(map.ContainsKey(serialValue.ToString(CultureInfo.InvariantCulture)));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
         public void Sheet_HeaderMap_ReadsOnlyFirstUsedRow() {
             string filePath = Path.Combine(_directoryWithFiles, "ReaderHeaderMapFirstUsedRowOnly.xlsx");
 
@@ -1706,6 +1771,37 @@ namespace OfficeIMO.Tests {
 
                 var options = new ExcelReadOptions {
                     CellValueConverter = context => context.RawText == "42" ? new ExcelCellValue("100") : ExcelCellValue.NotHandled
+                };
+
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                var row = Assert.Single(reader.GetSheet("Data").ReadObjects<NullableTypedRow>("A1:A2", ExecutionMode.Sequential));
+
+                Assert.Equal(100, row.Score);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_TypedObjects_HonorsCellValueConverterStyleContextOnXmlPath() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderTypedObjectsCellConverterStyleContext.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Score");
+                    sheet.CellValue(2, 1, 42);
+                    sheet.CellAt(2, 1).SetNumberFormat("0.00");
+                    document.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    CellValueConverter = context =>
+                        context.RawText == "42" && context.StyleIndex != null
+                            ? new ExcelCellValue("100")
+                            : ExcelCellValue.NotHandled
                 };
 
                 using var reader = ExcelDocumentReader.Open(filePath, options);

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -999,6 +999,39 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Sheet_HeaderMap_ReturnedMapDoesNotMutateCachedLookup() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderHeaderCacheDefensiveCopy.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Status");
+                    sheet.CellValue(1, 2, "Value");
+                    document.Save();
+                }
+
+                using var loadedDocument = ExcelDocument.Load(filePath);
+                var loadedSheet = loadedDocument.GetSheet("Data");
+
+                var map = loadedSheet.GetHeaderMap();
+                map["Status"] = 99;
+                map["Injected"] = 3;
+
+                Assert.True(loadedSheet.TryGetColumnIndexByHeader("Status", out int statusColumn));
+                Assert.Equal(1, statusColumn);
+                Assert.False(loadedSheet.TryGetColumnIndexByHeader("Injected", out _));
+
+                var secondMap = loadedSheet.GetHeaderMap();
+                Assert.Equal(1, secondMap["Status"]);
+                Assert.False(secondMap.ContainsKey("Injected"));
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
         public void Sheet_HeaderMapCache_RebuildsWhenUsedRangeShiftsAfterWrite() {
             string filePath = Path.Combine(_directoryWithFiles, "ReaderHeaderCacheUsedRangeShift.xlsx");
 
@@ -1027,6 +1060,46 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(1, refreshedMap["Id"]);
                 Assert.Equal(2, refreshedMap["Region"]);
                 Assert.Equal(3, refreshedMap["Amount"]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Sheet_HeaderMap_ReadsOnlyFirstUsedRow() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderHeaderMapFirstUsedRowOnly.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Id");
+                    sheet.CellValue(1, 2, "Value");
+                    for (int row = 2; row <= 1000; row++) {
+                        sheet.CellValue(row, 1, (double)(row - 1));
+                        sheet.CellValue(row, 2, 10d);
+                    }
+
+                    document.Save();
+                }
+
+                using var loadedDocument = ExcelDocument.Load(filePath);
+                var loadedSheet = loadedDocument.GetSheet("Data");
+                var options = new ExcelReadOptions {
+                    CellValueConverter = context => {
+                        if (context.TypeHint is null && context.RawText == "10") {
+                            throw new InvalidOperationException("Header map should not read data rows.");
+                        }
+
+                        return ExcelCellValue.NotHandled;
+                    }
+                };
+
+                var map = loadedSheet.GetHeaderMap(options);
+
+                Assert.Equal(1, map["Id"]);
+                Assert.Equal(2, map["Value"]);
             } finally {
                 if (File.Exists(filePath)) {
                     File.Delete(filePath);
@@ -1560,6 +1633,85 @@ namespace OfficeIMO.Tests {
                 Assert.True(row.Active);
                 Assert.Equal(expectedDate, row.CreatedOn);
                 Assert.Equal(123.45, row.Amount);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_TypedObjectsStream_HonorsCellValueConverter() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderTypedObjectsStreamCellConverter.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Score");
+                    sheet.CellValue(2, 1, 42);
+                    document.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    CellValueConverter = context => context.RawText == "42" ? new ExcelCellValue("100") : ExcelCellValue.NotHandled
+                };
+
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                var row = Assert.Single(reader.GetSheet("Data").ReadObjectsStream<NullableTypedRow>("A1:A2"));
+
+                Assert.Equal(100, row.Score);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_TypedObjectsStream_ParsesDoubleTextWithConfiguredCultureFirst() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderTypedObjectsStreamCultureDoubleTyped.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Amount");
+                    sheet.CellValue(2, 1, "1,23");
+                    document.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath, new ExcelReadOptions {
+                    Culture = CultureInfo.GetCultureInfo("pl-PL")
+                });
+                var row = Assert.Single(reader.GetSheet("Data").ReadObjectsStream<CultureDoubleTypedRow>("A1:A2"));
+
+                Assert.Equal(1.23d, row.Amount, precision: 10);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_TypedObjects_HonorsCellValueConverter() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderTypedObjectsCellConverter.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Score");
+                    sheet.CellValue(2, 1, 42);
+                    document.Save();
+                }
+
+                var options = new ExcelReadOptions {
+                    CellValueConverter = context => context.RawText == "42" ? new ExcelCellValue("100") : ExcelCellValue.NotHandled
+                };
+
+                using var reader = ExcelDocumentReader.Open(filePath, options);
+                var row = Assert.Single(reader.GetSheet("Data").ReadObjects<NullableTypedRow>("A1:A2", ExecutionMode.Sequential));
+
+                Assert.Equal(100, row.Score);
             } finally {
                 if (File.Exists(filePath)) {
                     File.Delete(filePath);

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -1118,11 +1118,16 @@ namespace OfficeIMO.Tests {
                     document.Save();
                 }
 
+                string? expectedHeader;
+                using (var reader = ExcelDocumentReader.Open(filePath)) {
+                    expectedHeader = reader.GetSheet("Data").ReadRange("A1:A1")[0, 0]?.ToString();
+                }
+
                 using var loadedDocument = ExcelDocument.Load(filePath);
                 var loadedSheet = loadedDocument.GetSheet("Data");
                 var map = loadedSheet.GetHeaderMap();
 
-                string expectedHeader = DateTime.FromOADate(serialValue).ToString(CultureInfo.InvariantCulture);
+                Assert.False(string.IsNullOrEmpty(expectedHeader));
                 Assert.True(map.ContainsKey(expectedHeader));
                 Assert.False(map.ContainsKey(serialValue.ToString(CultureInfo.InvariantCulture)));
             } finally {


### PR DESCRIPTION
## Summary

This PR improves OfficeIMO.Excel reader performance across several real-world paths while keeping the existing API behavior intact. The changes expand internal XML fast paths and cached/shared helpers instead of adding public path-selection knobs.

Highlights:
- expands converter-aware XML routing for typed object reads, typed streams, row reads, column reads, range streams, and DataTable reads
- improves header/cache/shared-string paths used by loaded worksheets, AutoFilter by headers, FindFirst, and ReplaceAll
- adds lower-level parsing/cache helpers for A1, shared strings, styles, and completed-row tracking
- extends the read-profile runner with converter, culture, dense, sparse, header, and loaded-sheet scenarios
- adds regression tests for converter semantics, culture fallback, ordering, sparse rows, header behavior, and loaded shared-string text operations

## Validation

- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~OfficeIMO.Tests.Excel"`
  - net8.0: 650 passed / 1 skipped
  - net10.0: 650 passed / 1 skipped
  - net472: 648 passed / 1 skipped
- `dotnet build .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -c Release --framework net8.0 --no-restore`
  - 0 warnings / 0 errors
- `git diff --check`
  - exit 0, only existing LF-to-CRLF notices from Git

## Read Profile Spot Checks

Latest 2500-row read-profile sanity run showed the new converter-aware paths staying on the fast side:

- `ReadRangeStream`: 7.36 ms
- `ReadRangeStream.CustomConverterFallback`: 7.29 ms
- `ReadRangeStream.CustomConverterCultureFallback`: 8.44 ms
- `ReadColumn.Dense`: 4.06 ms
- `ReadColumn.Dense.CustomConverterFallback`: 4.20 ms
- `ReadRows.Dense`: 5.33 ms
- `ReadRows.Dense.CustomConverterFallback`: 6.10 ms
- `ReadObjectsStreamAs`: 7.27 ms
- `ReadObjectsStreamAs.CustomConverterFallback`: 8.02 ms
