### PR TITLE
Improve Excel tabular projection performance

### DIFF
--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
@@ -79,7 +79,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (decided == OfficeIMO.Excel.ExecutionMode.Sequential) {
-                if (TryFillDataTableXmlBufferedSinglePass(dt, r1, c1, r2, c2, rows, cols, headersInFirstRow, workload, ct)) {
+                if (TryFillDataTableXmlBufferedSinglePass(dt, r1, c1, r2, c2, rows, cols, headersInFirstRow, ct)) {
                     return dt;
                 }
 
@@ -147,10 +147,8 @@ namespace OfficeIMO.Excel {
             int rows,
             int cols,
             bool headersInFirstRow,
-            int workload,
             CancellationToken ct) {
             if (!_opt.InferDataTableColumnTypes
-                || workload > DenseSnapshotCapacityLimit
                 || !CanUseDataTableXmlBufferedReader()) {
                 return false;
             }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
@@ -79,7 +79,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (decided == OfficeIMO.Excel.ExecutionMode.Sequential) {
-                if (TryFillDataTableXmlBufferedSinglePass(dt, r1, c1, r2, c2, rows, cols, headersInFirstRow, ct)) {
+                if (TryFillDataTableXmlBufferedSinglePass(dt, r1, c1, r2, c2, rows, cols, headersInFirstRow, workload, ct)) {
                     return dt;
                 }
 
@@ -147,8 +147,10 @@ namespace OfficeIMO.Excel {
             int rows,
             int cols,
             bool headersInFirstRow,
+            int workload,
             CancellationToken ct) {
             if (!_opt.InferDataTableColumnTypes
+                || workload > DenseSnapshotCapacityLimit
                 || !CanUseDataTableXmlBufferedReader()) {
                 return false;
             }

--- a/OfficeIMO.Excel/Utilities/ObjectDataTableBuilder.cs
+++ b/OfficeIMO.Excel/Utilities/ObjectDataTableBuilder.cs
@@ -63,29 +63,31 @@ namespace OfficeIMO.Excel {
         private sealed class ObjectRowProjector {
             private readonly string[] _columns;
             private readonly PropertyInfo[]? _properties;
+            private readonly Type? _sourceType;
 
-            private ObjectRowProjector(IReadOnlyList<string> columns, PropertyInfo[]? properties) {
+            private ObjectRowProjector(IReadOnlyList<string> columns, PropertyInfo[]? properties, Type? sourceType) {
                 _columns = columns.ToArray();
                 _properties = properties;
+                _sourceType = sourceType;
             }
 
             internal static ObjectRowProjector Create(object first, IReadOnlyList<string> columns) {
                 var firstType = first.GetType();
                 if (IsDictionaryLike(first)) {
-                    return new ObjectRowProjector(columns, properties: null);
+                    return new ObjectRowProjector(columns, properties: null, sourceType: null);
                 }
 
                 var properties = new PropertyInfo[columns.Count];
                 for (int i = 0; i < columns.Count; i++) {
                     var property = firstType.GetProperty(columns[i], BindingFlags.Public | BindingFlags.Instance);
                     if (property == null || !property.CanRead || property.GetIndexParameters().Length != 0) {
-                        return new ObjectRowProjector(columns, properties: null);
+                        return new ObjectRowProjector(columns, properties: null, sourceType: null);
                     }
 
                     properties[i] = property;
                 }
 
-                return new ObjectRowProjector(columns, properties);
+                return new ObjectRowProjector(columns, properties, firstType);
             }
 
             internal object?[] CreateValuesBuffer() => new object?[_columns.Length];
@@ -95,7 +97,7 @@ namespace OfficeIMO.Excel {
                     return;
                 }
 
-                if (_properties != null && item.GetType() == _properties[0].DeclaringType) {
+                if (_properties != null && _sourceType != null && _sourceType.IsInstanceOfType(item)) {
                     for (int i = 0; i < _properties.Length; i++) {
                         values[i] = _properties[i].GetValue(item) ?? DBNull.Value;
                     }

--- a/OfficeIMO.Excel/Utilities/ObjectDataTableBuilder.cs
+++ b/OfficeIMO.Excel/Utilities/ObjectDataTableBuilder.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using OfficeIMO.Shared;
 
 namespace OfficeIMO.Excel {
@@ -29,29 +30,132 @@ namespace OfficeIMO.Excel {
                 throw new ArgumentException("Data rows cannot be null.", nameof(items));
             }
 
-            var columns = ObjectDataHelpers.GetColumnNames(first);
-            if (columns.Count == 0) {
+            var columnNames = ObjectDataHelpers.GetColumnNames(first);
+            if (columnNames.Count == 0) {
                 throw new InvalidOperationException("Unable to infer column names. Use objects with properties or dictionaries.");
             }
 
             var table = new DataTable(tableName);
-            foreach (var name in columns) {
+            foreach (var name in columnNames) {
                 table.Columns.Add(name, typeof(object));
             }
 
-            foreach (var item in list) {
-                if (item == null) {
-                    throw new InvalidOperationException("Data rows cannot contain null entries.");
-                }
+            var projector = ObjectRowProjector.Create(first, columnNames);
+            table.MinimumCapacity = Math.Max(table.MinimumCapacity, list.Count);
+            var values = projector.CreateValuesBuffer();
+            table.BeginLoadData();
+            try {
+                foreach (var item in list) {
+                    if (item == null) {
+                        throw new InvalidOperationException("Data rows cannot contain null entries.");
+                    }
 
-                var row = table.NewRow();
-                foreach (var column in columns) {
-                    row[column] = ObjectDataHelpers.GetValue(item, column) ?? DBNull.Value;
+                    projector.FillValues(item, values);
+                    table.Rows.Add(values);
                 }
-                table.Rows.Add(row);
+            } finally {
+                table.EndLoadData();
             }
 
             return table;
+        }
+
+        private sealed class ObjectRowProjector {
+            private readonly string[] _columns;
+            private readonly PropertyInfo[]? _properties;
+
+            private ObjectRowProjector(IReadOnlyList<string> columns, PropertyInfo[]? properties) {
+                _columns = columns.ToArray();
+                _properties = properties;
+            }
+
+            internal static ObjectRowProjector Create(object first, IReadOnlyList<string> columns) {
+                var firstType = first.GetType();
+                if (IsDictionaryLike(first)) {
+                    return new ObjectRowProjector(columns, properties: null);
+                }
+
+                var properties = new PropertyInfo[columns.Count];
+                for (int i = 0; i < columns.Count; i++) {
+                    var property = firstType.GetProperty(columns[i], BindingFlags.Public | BindingFlags.Instance);
+                    if (property == null || !property.CanRead || property.GetIndexParameters().Length != 0) {
+                        return new ObjectRowProjector(columns, properties: null);
+                    }
+
+                    properties[i] = property;
+                }
+
+                return new ObjectRowProjector(columns, properties);
+            }
+
+            internal object?[] CreateValuesBuffer() => new object?[_columns.Length];
+
+            internal void FillValues(object item, object?[] values) {
+                if (TryFillDictionaryValues(item, values)) {
+                    return;
+                }
+
+                if (_properties != null && item.GetType() == _properties[0].DeclaringType) {
+                    for (int i = 0; i < _properties.Length; i++) {
+                        values[i] = _properties[i].GetValue(item) ?? DBNull.Value;
+                    }
+
+                    return;
+                }
+
+                for (int i = 0; i < _columns.Length; i++) {
+                    values[i] = ObjectDataHelpers.GetValue(item, _columns[i]) ?? DBNull.Value;
+                }
+            }
+
+            private bool TryFillDictionaryValues(object item, object?[] values) {
+                if (item is IReadOnlyDictionary<string, object?> readOnlyDictionary) {
+                    for (int i = 0; i < _columns.Length; i++) {
+                        values[i] = readOnlyDictionary.TryGetValue(_columns[i], out var value) ? value ?? DBNull.Value : DBNull.Value;
+                    }
+
+                    return true;
+                }
+
+                if (item is IDictionary<string, object?> dictionary) {
+                    for (int i = 0; i < _columns.Length; i++) {
+                        values[i] = dictionary.TryGetValue(_columns[i], out var value) ? value ?? DBNull.Value : DBNull.Value;
+                    }
+
+                    return true;
+                }
+
+                if (item is System.Collections.IDictionary legacyDictionary) {
+                    for (int i = 0; i < _columns.Length; i++) {
+                        values[i] = GetLegacyDictionaryValue(legacyDictionary, _columns[i]) ?? DBNull.Value;
+                    }
+
+                    return true;
+                }
+
+                return false;
+            }
+
+            private static object? GetLegacyDictionaryValue(System.Collections.IDictionary dictionary, string column) {
+                if (dictionary.Contains(column)) {
+                    return dictionary[column];
+                }
+
+                foreach (System.Collections.DictionaryEntry entry in dictionary) {
+                    var key = entry.Key?.ToString();
+                    if (string.Equals(key, column, StringComparison.OrdinalIgnoreCase)) {
+                        return entry.Value;
+                    }
+                }
+
+                return null;
+            }
+
+            private static bool IsDictionaryLike(object item) {
+                return item is IReadOnlyDictionary<string, object?>
+                    || item is IDictionary<string, object?>
+                    || item is System.Collections.IDictionary;
+            }
         }
 
     }

--- a/OfficeIMO.Excel/Utilities/ObjectDataTableBuilder.cs
+++ b/OfficeIMO.Excel/Utilities/ObjectDataTableBuilder.cs
@@ -97,7 +97,7 @@ namespace OfficeIMO.Excel {
                     return;
                 }
 
-                if (_properties != null && _sourceType != null && _sourceType.IsInstanceOfType(item)) {
+                if (_properties != null && item.GetType() == _sourceType) {
                     for (int i = 0; i < _properties.Length; i++) {
                         values[i] = _properties[i].GetValue(item) ?? DBNull.Value;
                     }

--- a/OfficeIMO.Tests/Excel.ObjectDataTableBuilder.cs
+++ b/OfficeIMO.Tests/Excel.ObjectDataTableBuilder.cs
@@ -71,6 +71,21 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ObjectDataTableBuilder_FromObjects_HiddenDerivedPropertiesUseRuntimeMember() {
+            var items = new ObjectDataBaseRow[] {
+                new() { Name = "Base", Value = 1 },
+                new HiddenObjectRow { Name = "Derived", Value = 2 }
+            };
+
+            var table = ObjectDataTableBuilder.FromObjects(items, "Data");
+
+            Assert.Equal("Base", table.Rows[0]["Name"]);
+            Assert.Equal(1, table.Rows[0]["Value"]);
+            Assert.Equal("Derived", table.Rows[1]["Name"]);
+            Assert.Equal(2, table.Rows[1]["Value"]);
+        }
+
+        [Fact]
         public void Test_ObjectDataTableBuilder_FromObjects_ThrowsOnNullItems() {
             var ex = Assert.Throws<ArgumentNullException>(() => ObjectDataTableBuilder.FromObjects(null!));
             Assert.Equal("items", ex.ParamName);
@@ -103,6 +118,11 @@ namespace OfficeIMO.Tests {
 
         private sealed class InheritedObjectRow : ObjectDataBaseRow {
             public string Notes { get; init; } = string.Empty;
+        }
+
+        private sealed class HiddenObjectRow : ObjectDataBaseRow {
+            public new string Name { get; init; } = string.Empty;
+            public new int Value { get; init; }
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.ObjectDataTableBuilder.cs
+++ b/OfficeIMO.Tests/Excel.ObjectDataTableBuilder.cs
@@ -112,17 +112,17 @@ namespace OfficeIMO.Tests {
         }
 
         private class ObjectDataBaseRow {
-            public string Name { get; init; } = string.Empty;
-            public int Value { get; init; }
+            public string Name { get; set; } = string.Empty;
+            public int Value { get; set; }
         }
 
         private sealed class InheritedObjectRow : ObjectDataBaseRow {
-            public string Notes { get; init; } = string.Empty;
+            public string Notes { get; set; } = string.Empty;
         }
 
         private sealed class HiddenObjectRow : ObjectDataBaseRow {
-            public new string Name { get; init; } = string.Empty;
-            public new int Value { get; init; }
+            public new string Name { get; set; } = string.Empty;
+            public new int Value { get; set; }
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.ObjectDataTableBuilder.cs
+++ b/OfficeIMO.Tests/Excel.ObjectDataTableBuilder.cs
@@ -51,6 +51,26 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ObjectDataTableBuilder_FromObjects_InheritedProperties() {
+            var items = new InheritedObjectRow[] {
+                new() { Name = "A", Value = 1, Notes = "First" },
+                new() { Name = "B", Value = 2, Notes = "Second" }
+            };
+
+            var table = ObjectDataTableBuilder.FromObjects(items, "Data");
+
+            Assert.Contains("Name", table.Columns.Cast<System.Data.DataColumn>().Select(column => column.ColumnName));
+            Assert.Contains("Value", table.Columns.Cast<System.Data.DataColumn>().Select(column => column.ColumnName));
+            Assert.Contains("Notes", table.Columns.Cast<System.Data.DataColumn>().Select(column => column.ColumnName));
+            Assert.Equal("A", table.Rows[0]["Name"]);
+            Assert.Equal(1, table.Rows[0]["Value"]);
+            Assert.Equal("First", table.Rows[0]["Notes"]);
+            Assert.Equal("B", table.Rows[1]["Name"]);
+            Assert.Equal(2, table.Rows[1]["Value"]);
+            Assert.Equal("Second", table.Rows[1]["Notes"]);
+        }
+
+        [Fact]
         public void Test_ObjectDataTableBuilder_FromObjects_ThrowsOnNullItems() {
             var ex = Assert.Throws<ArgumentNullException>(() => ObjectDataTableBuilder.FromObjects(null!));
             Assert.Equal("items", ex.ParamName);
@@ -74,6 +94,15 @@ namespace OfficeIMO.Tests {
         public void Test_ObjectDataTableBuilder_FromObjects_ThrowsOnNullEntry() {
             var ex = Assert.Throws<InvalidOperationException>(() => ObjectDataTableBuilder.FromObjects(new object?[] { new { Name = "A" }, null }));
             Assert.Equal("Data rows cannot contain null entries.", ex.Message);
+        }
+
+        private class ObjectDataBaseRow {
+            public string Name { get; init; } = string.Empty;
+            public int Value { get; init; }
+        }
+
+        private sealed class InheritedObjectRow : ObjectDataBaseRow {
+            public string Notes { get; init; } = string.Empty;
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.ObjectDataTableBuilder.cs
+++ b/OfficeIMO.Tests/Excel.ObjectDataTableBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using OfficeIMO.Excel;
 using Xunit;
@@ -22,6 +23,31 @@ namespace OfficeIMO.Tests {
             Assert.Equal(1, table.Rows[0]["Value"]);
             Assert.Equal("B", table.Rows[1]["Name"]);
             Assert.Equal(2, table.Rows[1]["Value"]);
+        }
+
+        [Fact]
+        public void Test_ObjectDataTableBuilder_FromDictionaries_PreservesColumnsAndDbNulls() {
+            var items = new[] {
+                new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) {
+                    ["Name"] = "A",
+                    ["Value"] = 1,
+                    ["Notes"] = null
+                },
+                new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) {
+                    ["name"] = "B",
+                    ["Value"] = 2
+                }
+            };
+
+            var table = ObjectDataTableBuilder.FromObjects(items, "Data");
+
+            Assert.Equal(new[] { "Name", "Value", "Notes" }, table.Columns.Cast<System.Data.DataColumn>().Select(column => column.ColumnName).ToArray());
+            Assert.Equal("A", table.Rows[0]["Name"]);
+            Assert.Equal(1, table.Rows[0]["Value"]);
+            Assert.Equal(DBNull.Value, table.Rows[0]["Notes"]);
+            Assert.Equal("B", table.Rows[1]["Name"]);
+            Assert.Equal(2, table.Rows[1]["Value"]);
+            Assert.Equal(DBNull.Value, table.Rows[1]["Notes"]);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- speed up object-to-DataTable projection by building a reusable row projector for dictionary and property-backed rows
- reduce per-row projection allocation by reusing the source value buffer while DataTable copies row values into its own records
- keep inferred DataTable range reads on the bounded buffered XML path only when the existing workload guard allows it
- add regression coverage for dictionary projection column/null handling, inherited object properties, and hidden derived members

## Validation
- dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --framework net8.0 --no-restore
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-restore --filter FullyQualifiedName~ObjectDataTableBuilder --logger "console;verbosity=minimal"
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-restore --filter "FullyQualifiedName~Excel.Reader|FullyQualifiedName~PerformanceReview" --logger "console;verbosity=minimal"
- git diff --check