### PR TITLE
Add OfficeIMO.Excel URI loading

### DIFF
--- a/Docs/officeimo.excel.uri-loading-proposal.md
+++ b/Docs/officeimo.excel.uri-loading-proposal.md
@@ -1,0 +1,147 @@
+# OfficeIMO.Excel URI Loading Proposal
+
+## Summary
+
+ExcelFast's URL support is useful, but it is transport glue in front of a local-file loader. OfficeIMO.Excel should treat remote workbook loading as an engine feature instead of pushing that concern into PSWriteOffice. The engine already owns workbook stream and reader semantics, so it is the right place to own HTTP policy, download safety, cleanup, and the transition into the existing Open XML load path.
+
+This branch implements the first slice as a bounded, memory-backed remote loader. It deliberately does not add temp-file mode or remote save semantics.
+
+The recommended public surface is:
+
+```csharp
+ExcelDocument.Load(Uri uri, ExcelHttpLoadOptions? httpOptions = null, bool readOnly = true, OpenSettings? openSettings = null)
+ExcelDocument.LoadAsync(Uri uri, ExcelHttpLoadOptions? httpOptions = null, bool readOnly = true, OpenSettings? openSettings = null, CancellationToken cancellationToken = default)
+
+ExcelDocumentReader.Open(Uri uri, ExcelReadOptions? readOptions = null, ExcelHttpLoadOptions? httpOptions = null)
+ExcelDocumentReader.OpenAsync(Uri uri, ExcelReadOptions? readOptions = null, ExcelHttpLoadOptions? httpOptions = null, CancellationToken cancellationToken = default)
+```
+
+PSWriteOffice can then expose a thin wrapper:
+
+```powershell
+Import-OfficeExcel -Uri https://example.test/report.xlsx
+Get-OfficeExcel -Uri https://example.test/report.xlsx
+```
+
+No PSWriteOffice downloader, temp-file policy, retry policy, or content validation should be needed.
+
+## Current Fit
+
+OfficeIMO.Excel already has:
+
+- `ExcelDocument.Load(string)` and `LoadAsync(string)` for path-backed workbooks.
+- `ExcelDocument.Load(Stream)` and `LoadAsync(Stream)` for caller-provided streams.
+- `ExcelDocumentReader.Open(string)`, `Open(Stream)`, and `Open(byte[])` for read-only reader workflows.
+- Existing byte materialization and package content-type normalization before `SpreadsheetDocument.Open(...)`.
+- Cancellation-aware async helpers in the load and read paths.
+
+That means the first implementation does not need a new workbook parser. It needs a careful HTTP fetch helper that produces a bounded, seekable workbook package and then calls the existing byte or stream loader.
+
+## Proposed Types
+
+```csharp
+public sealed class ExcelHttpLoadOptions {
+    public ExcelUriSchemePolicy SchemePolicy { get; set; } = ExcelUriSchemePolicy.HttpsOnly;
+    public long MaxBytes { get; set; } = 100L * 1024L * 1024L;
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
+    public string? UserAgent { get; set; } = "OfficeIMO.Excel";
+    public IDictionary<string, string> Headers { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    public bool ValidateZipHeader { get; set; } = true;
+    public bool ValidateContentTypeWhenPresent { get; set; } = false;
+    public ISet<string> AllowedContentTypes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.ms-excel",
+        "application/octet-stream"
+    };
+    public IProgress<ExcelHttpLoadProgress>? Progress { get; set; }
+    public HttpClient? HttpClient { get; set; }
+}
+
+public enum ExcelUriSchemePolicy {
+    HttpsOnly,
+    HttpAndHttps
+}
+
+public readonly struct ExcelHttpLoadProgress {
+    public long BytesRead { get; }
+    public long? ContentLength { get; }
+}
+```
+
+The implementation should clone option values at operation start so callers cannot mutate active requests midway.
+
+## Default Policy
+
+- `https` only by default. Plain `http` requires `SchemePolicy = HttpAndHttps`.
+- Full response download before Open XML parsing. This matches current package-opening reality and avoids pretending the parser can stream XLSX row data directly from HTTP.
+- `MaxBytes` enforced against `Content-Length` when present and against the running byte count while copying.
+- `Timeout` and `CancellationToken` both respected.
+- Caller headers and user-agent supported without adding a dependency on any auth framework.
+- Optional content-type validation because real file hosts often return generic values. ZIP header validation is the stronger default check for `.xlsx`.
+- Redirect handling can use the default `HttpClientHandler` behavior for the internal client. If a caller supplies `HttpClient`, their handler policy wins.
+- Remote load is read-only by default. It should not imply remote save or upload semantics.
+
+## Ownership And Cleanup
+
+Remote loading should not leak temp files or hidden state.
+
+For this first slice, use memory for all supported downloads and pass bytes into existing load/open methods. This keeps ownership simple and mirrors the current local file and stream loaders, which already materialize package bytes.
+
+For a future slice, add temp-file support only if it reduces real memory pressure in the underlying Open XML path. If used:
+
+- Create temp files under an explicit option directory or `Path.GetTempPath()`.
+- Use a package-owned cleanup scope so files are deleted when `ExcelDocument` or `ExcelDocumentReader` is disposed.
+- Never expose the temp path as `FilePath`, because remote load does not have local save-back semantics.
+- Do not copy back to the temp file on dispose unless the caller explicitly saves to a chosen destination.
+
+## Implementation Plan
+
+1. Add `ExcelHttpLoadOptions`, `ExcelUriSchemePolicy`, and `ExcelHttpLoadProgress` under `OfficeIMO.Excel`.
+2. Add an internal `ExcelHttpWorkbookLoader` that:
+   - validates the URI scheme,
+   - sends a GET request with `ResponseHeadersRead`,
+   - checks success status,
+   - enforces timeout, cancellation, and byte limit,
+   - copies to memory,
+   - validates ZIP magic bytes when enabled,
+   - reports progress during copy.
+3. Add `ExcelDocument.Load(Uri, ...)` and `LoadAsync(Uri, ...)`.
+   - Do not expose `autoSave` for URI loads. Remote save belongs to an explicit upload API later, not this convenience loader.
+   - Call `LoadFromByteArray(...)` with `filePath: null` and `preferFilePathOnFallback: false`.
+4. Add `ExcelDocumentReader.Open(Uri, ...)` and `OpenAsync(Uri, ...)`.
+   - Call the existing `Open(byte[], ExcelReadOptions?)` path.
+5. Add unit tests with an in-process HTTP server or injectable `HttpClient` handler:
+   - HTTPS-only default rejects `http`.
+   - Opt-in `http` works.
+   - headers/user-agent are sent.
+   - max byte limit rejects oversized responses before and during copy.
+   - cancellation is observed while downloading.
+   - content-type validation is opt-in.
+   - invalid ZIP header is rejected.
+   - reader and document paths both open a valid downloaded workbook.
+
+## PSWriteOffice Surface
+
+After the engine API exists, PSWriteOffice should only map PowerShell parameters to OfficeIMO options:
+
+- `-Uri` as a separate parameter set from `-Path`.
+- `-AllowHttp` maps to `SchemePolicy = HttpAndHttps`.
+- `-Header` maps to `ExcelHttpLoadOptions.Headers`.
+- `-TimeoutSeconds`, `-MaximumBytes`, and `-UserAgent` map directly.
+- Progress can be wired to PowerShell progress from `ExcelHttpLoadProgress`.
+
+Anything beyond that, including auth handlers, retries, cache policy, temp-file cleanup, and package validation, should remain in OfficeIMO.Excel or be provided by caller-supplied `HttpClient`.
+
+## Non-Goals
+
+- No streaming XLSX parsing directly from HTTP in the first slice.
+- No remote save/upload behavior.
+- No cookie jar or browser-session semantics.
+- No automatic credential discovery.
+- No wrapper-side fallback downloader in PSWriteOffice.
+
+## Future Questions
+
+- Should a future temp-file mode be added after measuring whether it reduces real memory pressure in the current Open XML path?
+- Should `MaxBytes` stay at `100 MB`, move to `256 MB`, or become unlimited with a documented recommendation? A bounded default is safer, but large operational workbooks may need an easy override.
+- Should content-type validation stay opt-in forever, or become a warn-only diagnostic hook once OfficeIMO has a broader diagnostics surface?

--- a/Docs/officeimo.excel.uri-loading-proposal.md
+++ b/Docs/officeimo.excel.uri-loading-proposal.md
@@ -50,6 +50,10 @@ public sealed class ExcelHttpLoadOptions {
     public bool ValidateContentTypeWhenPresent { get; set; } = false;
     public ISet<string> AllowedContentTypes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.ms-excel.sheet.macroenabled.12",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+        "application/vnd.ms-excel.template.macroenabled.12",
+        "application/vnd.ms-excel.addin.macroenabled.12",
         "application/vnd.ms-excel",
         "application/octet-stream"
     };
@@ -78,7 +82,8 @@ The implementation should clone option values at operation start so callers cann
 - `Timeout` and `CancellationToken` both respected.
 - Caller headers and user-agent supported without adding a dependency on any auth framework.
 - Optional content-type validation because real file hosts often return generic values. ZIP header validation is the stronger default check for `.xlsx`.
-- Redirect handling can use the default `HttpClientHandler` behavior for the internal client. If a caller supplies `HttpClient`, their handler policy wins.
+- The internally owned client disables automatic redirects, follows redirects manually, revalidates the target URI scheme at each hop, and strips custom headers after a host change.
+- The internally owned client enables gzip/deflate response decompression. If a caller supplies `HttpClient`, their handler policy still owns transport behavior.
 - Remote load is read-only by default. It should not imply remote save or upload semantics.
 
 ## Ownership And Cleanup
@@ -103,6 +108,9 @@ For a future slice, add temp-file support only if it reduces real memory pressur
    - checks success status,
    - enforces timeout, cancellation, and byte limit,
    - copies to memory,
+   - follows redirects manually with scheme revalidation,
+   - strips custom headers after redirected host changes,
+   - enables gzip/deflate decompression for the internally created client,
    - validates ZIP magic bytes when enabled,
    - reports progress during copy.
 3. Add `ExcelDocument.Load(Uri, ...)` and `LoadAsync(Uri, ...)`.
@@ -114,9 +122,12 @@ For a future slice, add temp-file support only if it reduces real memory pressur
    - HTTPS-only default rejects `http`.
    - Opt-in `http` works.
    - headers/user-agent are sent.
+   - custom headers are not forwarded across redirected hosts.
+   - HTTPS-to-HTTP redirects are rejected by default.
    - max byte limit rejects oversized responses before and during copy.
    - cancellation is observed while downloading.
    - content-type validation is opt-in.
+   - macro-enabled workbook MIME types are accepted by default.
    - invalid ZIP header is rejected.
    - reader and document paths both open a valid downloaded workbook.
 

--- a/Docs/officeimo.excel.uri-loading-proposal.md
+++ b/Docs/officeimo.excel.uri-loading-proposal.md
@@ -82,8 +82,8 @@ The implementation should clone option values at operation start so callers cann
 - `Timeout` and `CancellationToken` both respected.
 - Caller headers and user-agent supported without adding a dependency on any auth framework.
 - Optional content-type validation because real file hosts often return generic values. ZIP header validation is the stronger default check for `.xlsx`.
-- The internally owned client disables automatic redirects, follows redirects manually, revalidates the target URI scheme at each hop, and strips custom headers after a host change.
-- The internally owned client enables gzip/deflate response decompression. If a caller supplies `HttpClient`, their handler policy still owns transport behavior.
+- The internally owned client uses the configured timeout, disables automatic redirects, follows redirects manually, revalidates the target URI scheme at each hop, and strips custom headers after a host change.
+- The internally owned client enables gzip/deflate response decompression. If a caller supplies `HttpClient`, their handler policy still owns transport behavior, but cross-origin redirects are refused when default request headers are present because those headers cannot be suppressed safely per redirected request.
 - Remote load is read-only by default. It should not imply remote save or upload semantics.
 
 ## Ownership And Cleanup
@@ -110,7 +110,8 @@ For a future slice, add temp-file support only if it reduces real memory pressur
    - copies to memory,
    - follows redirects manually with scheme revalidation,
    - strips custom headers after redirected host changes,
-   - enables gzip/deflate decompression for the internally created client,
+   - refuses cross-origin redirects when a caller-supplied `HttpClient` has default request headers,
+   - applies the configured timeout and enables gzip/deflate decompression for the internally created client,
    - validates ZIP magic bytes when enabled,
    - reports progress during copy.
 3. Add `ExcelDocument.Load(Uri, ...)` and `LoadAsync(Uri, ...)`.
@@ -123,6 +124,7 @@ For a future slice, add temp-file support only if it reduces real memory pressur
    - Opt-in `http` works.
    - headers/user-agent are sent.
    - custom headers are not forwarded across redirected hosts.
+   - caller-supplied default headers block cross-origin redirects instead of being forwarded.
    - HTTPS-to-HTTP redirects are rejected by default.
    - max byte limit rejects oversized responses before and during copy.
    - cancellation is observed while downloading.

--- a/Docs/officeimo.excel.uri-loading-proposal.md
+++ b/Docs/officeimo.excel.uri-loading-proposal.md
@@ -58,7 +58,6 @@ public sealed class ExcelHttpLoadOptions {
         "application/octet-stream"
     };
     public IProgress<ExcelHttpLoadProgress>? Progress { get; set; }
-    public HttpClient? HttpClient { get; set; }
 }
 
 public enum ExcelUriSchemePolicy {
@@ -83,7 +82,7 @@ The implementation should clone option values at operation start so callers cann
 - Caller headers and user-agent supported without adding a dependency on any auth framework.
 - Optional content-type validation because real file hosts often return generic values. ZIP header validation is the stronger default check for `.xlsx`.
 - The internally owned client uses the configured timeout, disables automatic redirects, follows redirects manually, revalidates the target URI scheme at each hop, and strips custom headers after a host change.
-- The internally owned client enables gzip/deflate response decompression. If a caller supplies `HttpClient`, their handler policy still owns transport behavior, but cross-origin redirects are refused when default request headers are present because those headers cannot be suppressed safely per redirected request.
+- The internally owned client enables gzip/deflate response decompression. The first public slice deliberately does not accept caller-supplied `HttpClient`, because an already-created client can auto-follow redirects before OfficeIMO can enforce scheme and header policy.
 - Remote load is read-only by default. It should not imply remote save or upload semantics.
 
 ## Ownership And Cleanup
@@ -110,7 +109,6 @@ For a future slice, add temp-file support only if it reduces real memory pressur
    - copies to memory,
    - follows redirects manually with scheme revalidation,
    - strips custom headers after redirected host changes,
-   - refuses cross-origin redirects when a caller-supplied `HttpClient` has default request headers,
    - applies the configured timeout and enables gzip/deflate decompression for the internally created client,
    - validates ZIP magic bytes when enabled,
    - reports progress during copy.
@@ -119,12 +117,11 @@ For a future slice, add temp-file support only if it reduces real memory pressur
    - Call `LoadFromByteArray(...)` with `filePath: null` and `preferFilePathOnFallback: false`.
 4. Add `ExcelDocumentReader.Open(Uri, ...)` and `OpenAsync(Uri, ...)`.
    - Call the existing `Open(byte[], ExcelReadOptions?)` path.
-5. Add unit tests with an in-process HTTP server or injectable `HttpClient` handler:
+5. Add unit tests with an in-process HTTP server or internal injectable handler:
    - HTTPS-only default rejects `http`.
    - Opt-in `http` works.
    - headers/user-agent are sent.
    - custom headers are not forwarded across redirected hosts.
-   - caller-supplied default headers block cross-origin redirects instead of being forwarded.
    - HTTPS-to-HTTP redirects are rejected by default.
    - max byte limit rejects oversized responses before and during copy.
    - cancellation is observed while downloading.
@@ -143,7 +140,7 @@ After the engine API exists, PSWriteOffice should only map PowerShell parameters
 - `-TimeoutSeconds`, `-MaximumBytes`, and `-UserAgent` map directly.
 - Progress can be wired to PowerShell progress from `ExcelHttpLoadProgress`.
 
-Anything beyond that, including auth handlers, retries, cache policy, temp-file cleanup, and package validation, should remain in OfficeIMO.Excel or be provided by caller-supplied `HttpClient`.
+Anything beyond that, including retries, cache policy, temp-file cleanup, and package validation, should remain in OfficeIMO.Excel. Auth for this slice should use explicit headers; richer transport customization can come later only if it preserves OfficeIMO-owned redirect and scheme enforcement.
 
 ## Non-Goals
 

--- a/OfficeIMO.Excel/ExcelDocument.Http.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Http.cs
@@ -1,0 +1,35 @@
+using DocumentFormat.OpenXml.Packaging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        /// <summary>
+        /// Loads an Excel workbook from a remote URI.
+        /// </summary>
+        /// <param name="uri">HTTP or HTTPS URI of the workbook.</param>
+        /// <param name="httpOptions">Optional HTTP loading options.</param>
+        /// <param name="readOnly">Open the document in read-only mode. Remote loads are read-only by default.</param>
+        /// <param name="openSettings">Optional Open XML settings to control how the package is opened.</param>
+        /// <returns>Loaded <see cref="ExcelDocument"/> instance.</returns>
+        public static ExcelDocument Load(Uri uri, ExcelHttpLoadOptions? httpOptions = null, bool readOnly = true, OpenSettings? openSettings = null) {
+            byte[] bytes = ExcelHttpWorkbookLoader.Download(uri, httpOptions, CancellationToken.None);
+            return LoadFromByteArray(bytes, readOnly, autoSave: false, filePath: null, log: null, openSettings, preferFilePathOnFallback: false);
+        }
+
+        /// <summary>
+        /// Asynchronously loads an Excel workbook from a remote URI.
+        /// </summary>
+        /// <param name="uri">HTTP or HTTPS URI of the workbook.</param>
+        /// <param name="httpOptions">Optional HTTP loading options.</param>
+        /// <param name="readOnly">Open the document in read-only mode. Remote loads are read-only by default.</param>
+        /// <param name="openSettings">Optional Open XML settings to control how the package is opened.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Loaded <see cref="ExcelDocument"/> instance.</returns>
+        public static async Task<ExcelDocument> LoadAsync(Uri uri, ExcelHttpLoadOptions? httpOptions = null, bool readOnly = true, OpenSettings? openSettings = null, CancellationToken cancellationToken = default) {
+            byte[] bytes = await ExcelHttpWorkbookLoader.DownloadAsync(uri, httpOptions, cancellationToken).ConfigureAwait(false);
+            return LoadFromByteArray(bytes, readOnly, autoSave: false, filePath: null, log: null, openSettings, preferFilePathOnFallback: false);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelHttpLoadOptions.cs
+++ b/OfficeIMO.Excel/ExcelHttpLoadOptions.cs
@@ -61,11 +61,7 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public IProgress<ExcelHttpLoadProgress>? Progress { get; set; }
 
-        /// <summary>
-        /// Gets or sets an optional HTTP client. When omitted, OfficeIMO creates and disposes a client for the operation.
-        /// Caller-supplied clients keep their own handler behavior, including redirect and decompression policy.
-        /// </summary>
-        public HttpClient? HttpClient { get; set; }
+        internal HttpMessageHandler? HttpMessageHandler { get; set; }
     }
 
     /// <summary>

--- a/OfficeIMO.Excel/ExcelHttpLoadOptions.cs
+++ b/OfficeIMO.Excel/ExcelHttpLoadOptions.cs
@@ -48,6 +48,10 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public ISet<string> AllowedContentTypes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.ms-excel.sheet.macroenabled.12",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+            "application/vnd.ms-excel.template.macroenabled.12",
+            "application/vnd.ms-excel.addin.macroenabled.12",
             "application/vnd.ms-excel",
             "application/octet-stream"
         };
@@ -59,6 +63,7 @@ namespace OfficeIMO.Excel {
 
         /// <summary>
         /// Gets or sets an optional HTTP client. When omitted, OfficeIMO creates and disposes a client for the operation.
+        /// Caller-supplied clients keep their own handler behavior, including redirect and decompression policy.
         /// </summary>
         public HttpClient? HttpClient { get; set; }
     }

--- a/OfficeIMO.Excel/ExcelHttpLoadOptions.cs
+++ b/OfficeIMO.Excel/ExcelHttpLoadOptions.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Controls HTTP workbook loading behavior for <see cref="ExcelDocument"/> and <see cref="ExcelDocumentReader"/>.
+    /// </summary>
+    public sealed class ExcelHttpLoadOptions {
+        /// <summary>
+        /// Gets or sets the allowed URI schemes. Defaults to HTTPS only.
+        /// </summary>
+        public ExcelUriSchemePolicy SchemePolicy { get; set; } = ExcelUriSchemePolicy.HttpsOnly;
+
+        /// <summary>
+        /// Gets or sets the maximum number of response bytes that may be downloaded.
+        /// </summary>
+        public long MaxBytes { get; set; } = 100L * 1024L * 1024L;
+
+        /// <summary>
+        /// Gets or sets the timeout applied to the HTTP request and response copy.
+        /// </summary>
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
+
+        /// <summary>
+        /// Gets or sets the user agent sent when a User-Agent header is not provided in <see cref="Headers"/>.
+        /// Set to <see langword="null"/> to suppress the default user agent.
+        /// </summary>
+        public string? UserAgent { get; set; } = "OfficeIMO.Excel";
+
+        /// <summary>
+        /// Gets headers to send with the HTTP GET request.
+        /// </summary>
+        public IDictionary<string, string> Headers { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Gets or sets whether the downloaded workbook must look like a ZIP/OpenXML package.
+        /// </summary>
+        public bool ValidateZipHeader { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets whether response Content-Type should be validated when present.
+        /// </summary>
+        public bool ValidateContentTypeWhenPresent { get; set; }
+
+        /// <summary>
+        /// Gets the accepted media types used when <see cref="ValidateContentTypeWhenPresent"/> is enabled.
+        /// </summary>
+        public ISet<string> AllowedContentTypes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.ms-excel",
+            "application/octet-stream"
+        };
+
+        /// <summary>
+        /// Gets or sets an optional progress sink invoked as response bytes are copied.
+        /// </summary>
+        public IProgress<ExcelHttpLoadProgress>? Progress { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional HTTP client. When omitted, OfficeIMO creates and disposes a client for the operation.
+        /// </summary>
+        public HttpClient? HttpClient { get; set; }
+    }
+
+    /// <summary>
+    /// Defines which URI schemes are allowed for remote workbook loads.
+    /// </summary>
+    public enum ExcelUriSchemePolicy {
+        /// <summary>
+        /// Only HTTPS workbook URIs are allowed.
+        /// </summary>
+        HttpsOnly,
+
+        /// <summary>
+        /// HTTP and HTTPS workbook URIs are allowed.
+        /// </summary>
+        HttpAndHttps
+    }
+
+    /// <summary>
+    /// Progress information emitted while a remote workbook is downloaded.
+    /// </summary>
+    public readonly struct ExcelHttpLoadProgress {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExcelHttpLoadProgress"/> struct.
+        /// </summary>
+        public ExcelHttpLoadProgress(long bytesRead, long? contentLength) {
+            BytesRead = bytesRead;
+            ContentLength = contentLength;
+        }
+
+        /// <summary>
+        /// Gets the number of bytes downloaded so far.
+        /// </summary>
+        public long BytesRead { get; }
+
+        /// <summary>
+        /// Gets the response content length when the server provided one.
+        /// </summary>
+        public long? ContentLength { get; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelHttpWorkbookLoader.cs
+++ b/OfficeIMO.Excel/ExcelHttpWorkbookLoader.cs
@@ -28,7 +28,7 @@ namespace OfficeIMO.Excel {
             HttpClient? ownedClient = null;
             var client = snapshot.HttpClient;
             if (client == null) {
-                ownedClient = CreateOwnedHttpClient();
+                ownedClient = CreateOwnedHttpClient(snapshot.Timeout);
                 client = ownedClient;
             }
 
@@ -59,13 +59,15 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static HttpClient CreateOwnedHttpClient() {
+        private static HttpClient CreateOwnedHttpClient(TimeSpan timeout) {
             var handler = new HttpClientHandler {
                 AllowAutoRedirect = false,
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
             };
 
-            return new HttpClient(handler, disposeHandler: true);
+            return new HttpClient(handler, disposeHandler: true) {
+                Timeout = timeout
+            };
         }
 
         private static async Task<HttpResponseMessage> SendWithRedirectsAsync(
@@ -77,6 +79,10 @@ namespace OfficeIMO.Excel {
             bool includeCustomHeaders = true;
 
             for (int redirectCount = 0; redirectCount <= MaxRedirects; redirectCount++) {
+                if (!includeCustomHeaders && HasDefaultRequestHeaders(client)) {
+                    throw new HttpRequestException("Remote workbook request refused a cross-origin redirect because the HTTP client has default request headers that cannot be suppressed per redirected request.");
+                }
+
                 var request = new HttpRequestMessage(HttpMethod.Get, currentUri);
                 ApplyHeaders(request, options, includeCustomHeaders);
 
@@ -202,6 +208,14 @@ namespace OfficeIMO.Excel {
             return string.Equals(left.Scheme, right.Scheme, StringComparison.OrdinalIgnoreCase)
                 && string.Equals(left.IdnHost, right.IdnHost, StringComparison.OrdinalIgnoreCase)
                 && left.Port == right.Port;
+        }
+
+        private static bool HasDefaultRequestHeaders(HttpClient client) {
+            foreach (var _ in client.DefaultRequestHeaders) {
+                return true;
+            }
+
+            return false;
         }
 
         private static void ValidateContentType(HttpResponseMessage response, ExcelHttpLoadOptionsSnapshot options) {

--- a/OfficeIMO.Excel/ExcelHttpWorkbookLoader.cs
+++ b/OfficeIMO.Excel/ExcelHttpWorkbookLoader.cs
@@ -25,47 +25,38 @@ namespace OfficeIMO.Excel {
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             timeoutCts.CancelAfter(snapshot.Timeout);
 
-            HttpClient? ownedClient = null;
-            var client = snapshot.HttpClient;
-            if (client == null) {
-                ownedClient = CreateOwnedHttpClient(snapshot.Timeout);
-                client = ownedClient;
+            using var client = CreateOwnedHttpClient(snapshot.Timeout, snapshot.HttpMessageHandler);
+            using var response = await SendWithRedirectsAsync(client, uri, snapshot, timeoutCts.Token).ConfigureAwait(false);
+
+            response.EnsureSuccessStatusCode();
+            ValidateContentType(response, snapshot);
+
+            long? contentLength = response.Content.Headers.ContentLength;
+            if (contentLength.HasValue && contentLength.Value > snapshot.MaxBytes) {
+                throw new IOException($"Remote workbook is too large. Content-Length is {contentLength.Value} bytes and the configured limit is {snapshot.MaxBytes} bytes.");
             }
 
-            try {
-                using var response = await SendWithRedirectsAsync(client, uri, snapshot, timeoutCts.Token).ConfigureAwait(false);
+            byte[] bytes = await ReadResponseBytesAsync(
+                response,
+                snapshot,
+                contentLength,
+                timeoutCts.Token).ConfigureAwait(false);
 
-                response.EnsureSuccessStatusCode();
-                ValidateContentType(response, snapshot);
-
-                long? contentLength = response.Content.Headers.ContentLength;
-                if (contentLength.HasValue && contentLength.Value > snapshot.MaxBytes) {
-                    throw new IOException($"Remote workbook is too large. Content-Length is {contentLength.Value} bytes and the configured limit is {snapshot.MaxBytes} bytes.");
-                }
-
-                byte[] bytes = await ReadResponseBytesAsync(
-                    response,
-                    snapshot,
-                    contentLength,
-                    timeoutCts.Token).ConfigureAwait(false);
-
-                if (snapshot.ValidateZipHeader && !LooksLikeZipPackage(bytes)) {
-                    throw new InvalidDataException("Downloaded workbook does not look like an Office Open XML package.");
-                }
-
-                return bytes;
-            } finally {
-                ownedClient?.Dispose();
+            if (snapshot.ValidateZipHeader && !LooksLikeZipPackage(bytes)) {
+                throw new InvalidDataException("Downloaded workbook does not look like an Office Open XML package.");
             }
+
+            return bytes;
         }
 
-        private static HttpClient CreateOwnedHttpClient(TimeSpan timeout) {
-            var handler = new HttpClientHandler {
+        private static HttpClient CreateOwnedHttpClient(TimeSpan timeout, HttpMessageHandler? messageHandler) {
+            bool disposeHandler = messageHandler == null;
+            messageHandler ??= new HttpClientHandler {
                 AllowAutoRedirect = false,
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
             };
 
-            return new HttpClient(handler, disposeHandler: true) {
+            return new HttpClient(messageHandler, disposeHandler) {
                 Timeout = timeout
             };
         }
@@ -79,10 +70,6 @@ namespace OfficeIMO.Excel {
             bool includeCustomHeaders = true;
 
             for (int redirectCount = 0; redirectCount <= MaxRedirects; redirectCount++) {
-                if (!includeCustomHeaders && HasDefaultRequestHeaders(client)) {
-                    throw new HttpRequestException("Remote workbook request refused a cross-origin redirect because the HTTP client has default request headers that cannot be suppressed per redirected request.");
-                }
-
                 var request = new HttpRequestMessage(HttpMethod.Get, currentUri);
                 ApplyHeaders(request, options, includeCustomHeaders);
 
@@ -210,14 +197,6 @@ namespace OfficeIMO.Excel {
                 && left.Port == right.Port;
         }
 
-        private static bool HasDefaultRequestHeaders(HttpClient client) {
-            foreach (var _ in client.DefaultRequestHeaders) {
-                return true;
-            }
-
-            return false;
-        }
-
         private static void ValidateContentType(HttpResponseMessage response, ExcelHttpLoadOptionsSnapshot options) {
             if (!options.ValidateContentTypeWhenPresent) {
                 return;
@@ -248,7 +227,7 @@ namespace OfficeIMO.Excel {
                 bool validateContentTypeWhenPresent,
                 HashSet<string> allowedContentTypes,
                 IProgress<ExcelHttpLoadProgress>? progress,
-                HttpClient? httpClient) {
+                HttpMessageHandler? httpMessageHandler) {
                 SchemePolicy = schemePolicy;
                 MaxBytes = maxBytes;
                 Timeout = timeout;
@@ -258,7 +237,7 @@ namespace OfficeIMO.Excel {
                 ValidateContentTypeWhenPresent = validateContentTypeWhenPresent;
                 AllowedContentTypes = allowedContentTypes;
                 Progress = progress;
-                HttpClient = httpClient;
+                HttpMessageHandler = httpMessageHandler;
             }
 
             internal ExcelUriSchemePolicy SchemePolicy { get; }
@@ -270,7 +249,7 @@ namespace OfficeIMO.Excel {
             internal bool ValidateContentTypeWhenPresent { get; }
             internal HashSet<string> AllowedContentTypes { get; }
             internal IProgress<ExcelHttpLoadProgress>? Progress { get; }
-            internal HttpClient? HttpClient { get; }
+            internal HttpMessageHandler? HttpMessageHandler { get; }
 
             internal static ExcelHttpLoadOptionsSnapshot Create(ExcelHttpLoadOptions? options) {
                 options ??= new ExcelHttpLoadOptions();
@@ -285,7 +264,7 @@ namespace OfficeIMO.Excel {
                     options.ValidateContentTypeWhenPresent,
                     new HashSet<string>(options.AllowedContentTypes, StringComparer.OrdinalIgnoreCase),
                     options.Progress,
-                    options.HttpClient);
+                    options.HttpMessageHandler);
             }
         }
     }

--- a/OfficeIMO.Excel/ExcelHttpWorkbookLoader.cs
+++ b/OfficeIMO.Excel/ExcelHttpWorkbookLoader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,6 +9,7 @@ using System.Threading.Tasks;
 namespace OfficeIMO.Excel {
     internal static class ExcelHttpWorkbookLoader {
         private const int BufferSize = 81920;
+        private const int MaxRedirects = 10;
 
         internal static byte[] Download(Uri uri, ExcelHttpLoadOptions? options, CancellationToken cancellationToken = default) {
             return DownloadAsync(uri, options, cancellationToken).GetAwaiter().GetResult();
@@ -26,18 +28,12 @@ namespace OfficeIMO.Excel {
             HttpClient? ownedClient = null;
             var client = snapshot.HttpClient;
             if (client == null) {
-                ownedClient = new HttpClient();
+                ownedClient = CreateOwnedHttpClient();
                 client = ownedClient;
             }
 
             try {
-                using var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                ApplyHeaders(request, snapshot);
-
-                using var response = await client.SendAsync(
-                    request,
-                    HttpCompletionOption.ResponseHeadersRead,
-                    timeoutCts.Token).ConfigureAwait(false);
+                using var response = await SendWithRedirectsAsync(client, uri, snapshot, timeoutCts.Token).ConfigureAwait(false);
 
                 response.EnsureSuccessStatusCode();
                 ValidateContentType(response, snapshot);
@@ -61,6 +57,59 @@ namespace OfficeIMO.Excel {
             } finally {
                 ownedClient?.Dispose();
             }
+        }
+
+        private static HttpClient CreateOwnedHttpClient() {
+            var handler = new HttpClientHandler {
+                AllowAutoRedirect = false,
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            };
+
+            return new HttpClient(handler, disposeHandler: true);
+        }
+
+        private static async Task<HttpResponseMessage> SendWithRedirectsAsync(
+            HttpClient client,
+            Uri initialUri,
+            ExcelHttpLoadOptionsSnapshot options,
+            CancellationToken cancellationToken) {
+            Uri currentUri = initialUri;
+            bool includeCustomHeaders = true;
+
+            for (int redirectCount = 0; redirectCount <= MaxRedirects; redirectCount++) {
+                var request = new HttpRequestMessage(HttpMethod.Get, currentUri);
+                ApplyHeaders(request, options, includeCustomHeaders);
+
+                HttpResponseMessage response;
+                try {
+                    response = await client.SendAsync(
+                        request,
+                        HttpCompletionOption.ResponseHeadersRead,
+                        cancellationToken).ConfigureAwait(false);
+                } finally {
+                    request.Dispose();
+                }
+
+                if (!IsRedirect(response.StatusCode)) {
+                    return response;
+                }
+
+                Uri nextUri = ResolveRedirectUri(currentUri, response.Headers.Location);
+                response.Dispose();
+
+                if (redirectCount == MaxRedirects) {
+                    throw new HttpRequestException($"Remote workbook request exceeded the maximum of {MaxRedirects} redirects.");
+                }
+
+                ValidateScheme(nextUri, options.SchemePolicy);
+                if (!IsSameOrigin(currentUri, nextUri)) {
+                    includeCustomHeaders = false;
+                }
+
+                currentUri = nextUri;
+            }
+
+            throw new HttpRequestException($"Remote workbook request exceeded the maximum of {MaxRedirects} redirects.");
         }
 
         private static async Task<byte[]> ReadResponseBytesAsync(
@@ -117,10 +166,12 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static void ApplyHeaders(HttpRequestMessage request, ExcelHttpLoadOptionsSnapshot options) {
-            foreach (var header in options.Headers) {
-                if (!request.Headers.TryAddWithoutValidation(header.Key, header.Value)) {
-                    throw new ArgumentException($"Header '{header.Key}' is not valid for an HTTP workbook request.");
+        private static void ApplyHeaders(HttpRequestMessage request, ExcelHttpLoadOptionsSnapshot options, bool includeCustomHeaders) {
+            if (includeCustomHeaders) {
+                foreach (var header in options.Headers) {
+                    if (!request.Headers.TryAddWithoutValidation(header.Key, header.Value)) {
+                        throw new ArgumentException($"Header '{header.Key}' is not valid for an HTTP workbook request.");
+                    }
                 }
             }
 
@@ -129,6 +180,28 @@ namespace OfficeIMO.Excel {
                 && !request.Headers.TryAddWithoutValidation("User-Agent", options.UserAgent)) {
                 throw new ArgumentException("UserAgent is not valid for an HTTP workbook request.");
             }
+        }
+
+        private static bool IsRedirect(HttpStatusCode statusCode) {
+            return statusCode == HttpStatusCode.Moved
+                || statusCode == HttpStatusCode.Redirect
+                || statusCode == HttpStatusCode.SeeOther
+                || statusCode == HttpStatusCode.TemporaryRedirect
+                || (int)statusCode == 308;
+        }
+
+        private static Uri ResolveRedirectUri(Uri currentUri, Uri? location) {
+            if (location == null) {
+                throw new HttpRequestException("Remote workbook redirect response did not include a Location header.");
+            }
+
+            return location.IsAbsoluteUri ? location : new Uri(currentUri, location);
+        }
+
+        private static bool IsSameOrigin(Uri left, Uri right) {
+            return string.Equals(left.Scheme, right.Scheme, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(left.IdnHost, right.IdnHost, StringComparison.OrdinalIgnoreCase)
+                && left.Port == right.Port;
         }
 
         private static void ValidateContentType(HttpResponseMessage response, ExcelHttpLoadOptionsSnapshot options) {

--- a/OfficeIMO.Excel/ExcelHttpWorkbookLoader.cs
+++ b/OfficeIMO.Excel/ExcelHttpWorkbookLoader.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Excel {
+    internal static class ExcelHttpWorkbookLoader {
+        private const int BufferSize = 81920;
+
+        internal static byte[] Download(Uri uri, ExcelHttpLoadOptions? options, CancellationToken cancellationToken = default) {
+            return DownloadAsync(uri, options, cancellationToken).GetAwaiter().GetResult();
+        }
+
+        internal static async Task<byte[]> DownloadAsync(Uri uri, ExcelHttpLoadOptions? options, CancellationToken cancellationToken = default) {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+
+            var snapshot = ExcelHttpLoadOptionsSnapshot.Create(options);
+            ValidateScheme(uri, snapshot.SchemePolicy);
+            ValidateLimits(snapshot);
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(snapshot.Timeout);
+
+            HttpClient? ownedClient = null;
+            var client = snapshot.HttpClient;
+            if (client == null) {
+                ownedClient = new HttpClient();
+                client = ownedClient;
+            }
+
+            try {
+                using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+                ApplyHeaders(request, snapshot);
+
+                using var response = await client.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    timeoutCts.Token).ConfigureAwait(false);
+
+                response.EnsureSuccessStatusCode();
+                ValidateContentType(response, snapshot);
+
+                long? contentLength = response.Content.Headers.ContentLength;
+                if (contentLength.HasValue && contentLength.Value > snapshot.MaxBytes) {
+                    throw new IOException($"Remote workbook is too large. Content-Length is {contentLength.Value} bytes and the configured limit is {snapshot.MaxBytes} bytes.");
+                }
+
+                byte[] bytes = await ReadResponseBytesAsync(
+                    response,
+                    snapshot,
+                    contentLength,
+                    timeoutCts.Token).ConfigureAwait(false);
+
+                if (snapshot.ValidateZipHeader && !LooksLikeZipPackage(bytes)) {
+                    throw new InvalidDataException("Downloaded workbook does not look like an Office Open XML package.");
+                }
+
+                return bytes;
+            } finally {
+                ownedClient?.Dispose();
+            }
+        }
+
+        private static async Task<byte[]> ReadResponseBytesAsync(
+            HttpResponseMessage response,
+            ExcelHttpLoadOptionsSnapshot options,
+            long? contentLength,
+            CancellationToken cancellationToken) {
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var buffer = contentLength.HasValue && contentLength.Value <= int.MaxValue
+                ? new MemoryStream((int)contentLength.Value)
+                : new MemoryStream();
+
+            byte[] chunk = new byte[BufferSize];
+            long total = 0;
+
+            while (true) {
+                int read = await stream.ReadAsync(chunk, 0, chunk.Length, cancellationToken).ConfigureAwait(false);
+                if (read == 0) {
+                    break;
+                }
+
+                total += read;
+                if (total > options.MaxBytes) {
+                    throw new IOException($"Remote workbook exceeded the configured limit of {options.MaxBytes} bytes.");
+                }
+
+                buffer.Write(chunk, 0, read);
+                options.Progress?.Report(new ExcelHttpLoadProgress(total, contentLength));
+            }
+
+            return buffer.ToArray();
+        }
+
+        private static void ValidateScheme(Uri uri, ExcelUriSchemePolicy schemePolicy) {
+            if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) {
+                return;
+            }
+
+            if (schemePolicy == ExcelUriSchemePolicy.HttpAndHttps
+                && string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)) {
+                return;
+            }
+
+            throw new NotSupportedException("Remote Excel loads require HTTPS unless ExcelHttpLoadOptions.SchemePolicy allows HTTP.");
+        }
+
+        private static void ValidateLimits(ExcelHttpLoadOptionsSnapshot options) {
+            if (options.MaxBytes <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(ExcelHttpLoadOptions.MaxBytes), "MaxBytes must be greater than zero.");
+            }
+
+            if (options.Timeout <= TimeSpan.Zero) {
+                throw new ArgumentOutOfRangeException(nameof(ExcelHttpLoadOptions.Timeout), "Timeout must be greater than zero.");
+            }
+        }
+
+        private static void ApplyHeaders(HttpRequestMessage request, ExcelHttpLoadOptionsSnapshot options) {
+            foreach (var header in options.Headers) {
+                if (!request.Headers.TryAddWithoutValidation(header.Key, header.Value)) {
+                    throw new ArgumentException($"Header '{header.Key}' is not valid for an HTTP workbook request.");
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.UserAgent)
+                && !options.Headers.ContainsKey("User-Agent")
+                && !request.Headers.TryAddWithoutValidation("User-Agent", options.UserAgent)) {
+                throw new ArgumentException("UserAgent is not valid for an HTTP workbook request.");
+            }
+        }
+
+        private static void ValidateContentType(HttpResponseMessage response, ExcelHttpLoadOptionsSnapshot options) {
+            if (!options.ValidateContentTypeWhenPresent) {
+                return;
+            }
+
+            string? mediaType = response.Content.Headers.ContentType?.MediaType;
+            if (string.IsNullOrWhiteSpace(mediaType)) {
+                return;
+            }
+
+            if (!options.AllowedContentTypes.Contains(mediaType!)) {
+                throw new InvalidDataException($"Remote workbook response Content-Type '{mediaType}' is not allowed.");
+            }
+        }
+
+        private static bool LooksLikeZipPackage(byte[] bytes) {
+            return bytes.Length >= 2 && bytes[0] == (byte)'P' && bytes[1] == (byte)'K';
+        }
+
+        private sealed class ExcelHttpLoadOptionsSnapshot {
+            private ExcelHttpLoadOptionsSnapshot(
+                ExcelUriSchemePolicy schemePolicy,
+                long maxBytes,
+                TimeSpan timeout,
+                string? userAgent,
+                Dictionary<string, string> headers,
+                bool validateZipHeader,
+                bool validateContentTypeWhenPresent,
+                HashSet<string> allowedContentTypes,
+                IProgress<ExcelHttpLoadProgress>? progress,
+                HttpClient? httpClient) {
+                SchemePolicy = schemePolicy;
+                MaxBytes = maxBytes;
+                Timeout = timeout;
+                UserAgent = userAgent;
+                Headers = headers;
+                ValidateZipHeader = validateZipHeader;
+                ValidateContentTypeWhenPresent = validateContentTypeWhenPresent;
+                AllowedContentTypes = allowedContentTypes;
+                Progress = progress;
+                HttpClient = httpClient;
+            }
+
+            internal ExcelUriSchemePolicy SchemePolicy { get; }
+            internal long MaxBytes { get; }
+            internal TimeSpan Timeout { get; }
+            internal string? UserAgent { get; }
+            internal Dictionary<string, string> Headers { get; }
+            internal bool ValidateZipHeader { get; }
+            internal bool ValidateContentTypeWhenPresent { get; }
+            internal HashSet<string> AllowedContentTypes { get; }
+            internal IProgress<ExcelHttpLoadProgress>? Progress { get; }
+            internal HttpClient? HttpClient { get; }
+
+            internal static ExcelHttpLoadOptionsSnapshot Create(ExcelHttpLoadOptions? options) {
+                options ??= new ExcelHttpLoadOptions();
+
+                return new ExcelHttpLoadOptionsSnapshot(
+                    options.SchemePolicy,
+                    options.MaxBytes,
+                    options.Timeout,
+                    options.UserAgent,
+                    new Dictionary<string, string>(options.Headers, StringComparer.OrdinalIgnoreCase),
+                    options.ValidateZipHeader,
+                    options.ValidateContentTypeWhenPresent,
+                    new HashSet<string>(options.AllowedContentTypes, StringComparer.OrdinalIgnoreCase),
+                    options.Progress,
+                    options.HttpClient);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/Read/ExcelDocumentReader.Http.cs
+++ b/OfficeIMO.Excel/Read/ExcelDocumentReader.Http.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Excel {
+    public sealed partial class ExcelDocumentReader {
+        /// <summary>
+        /// Opens a remote Excel workbook for read-only access.
+        /// </summary>
+        /// <param name="uri">HTTP or HTTPS URI of the workbook.</param>
+        /// <param name="options">Optional read options.</param>
+        /// <param name="httpOptions">Optional HTTP loading options.</param>
+        /// <returns>Workbook reader.</returns>
+        public static ExcelDocumentReader Open(Uri uri, ExcelReadOptions? options = null, ExcelHttpLoadOptions? httpOptions = null) {
+            byte[] bytes = ExcelHttpWorkbookLoader.Download(uri, httpOptions, CancellationToken.None);
+            return OpenFromBytes(
+                bytes,
+                options,
+                normalizeContentTypes: false,
+                contextMessage: $"Failed to open remote workbook '{uri}' after normalizing package content types. The package may declare an invalid content type for '/docProps/app.xml'.");
+        }
+
+        /// <summary>
+        /// Asynchronously opens a remote Excel workbook for read-only access.
+        /// </summary>
+        /// <param name="uri">HTTP or HTTPS URI of the workbook.</param>
+        /// <param name="options">Optional read options.</param>
+        /// <param name="httpOptions">Optional HTTP loading options.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Workbook reader.</returns>
+        public static async Task<ExcelDocumentReader> OpenAsync(Uri uri, ExcelReadOptions? options = null, ExcelHttpLoadOptions? httpOptions = null, CancellationToken cancellationToken = default) {
+            byte[] bytes = await ExcelHttpWorkbookLoader.DownloadAsync(uri, httpOptions, cancellationToken).ConfigureAwait(false);
+            return OpenFromBytes(
+                bytes,
+                options,
+                normalizeContentTypes: false,
+                contextMessage: $"Failed to open remote workbook '{uri}' after normalizing package content types. The package may declare an invalid content type for '/docProps/app.xml'.");
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.HttpLoading.cs
+++ b/OfficeIMO.Tests/Excel.HttpLoading.cs
@@ -157,6 +157,74 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public async Task ExcelHttpLoadAllowsMacroEnabledWorkbookContentTypeByDefault() {
+            byte[] workbookBytes = CreateRemoteWorkbookBytes();
+            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) => {
+                var response = CreateWorkbookResponse(workbookBytes);
+                response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(
+                    "application/vnd.ms-excel.sheet.macroEnabled.12");
+                return Task.FromResult(response);
+            }));
+
+            using var reader = await ExcelDocumentReader.OpenAsync(
+                new Uri("https://example.test/workbook.xlsm"),
+                httpOptions: new ExcelHttpLoadOptions {
+                    HttpClient = httpClient,
+                    ValidateContentTypeWhenPresent = true
+                });
+
+            Assert.Equal(new[] { "Remote" }, reader.GetSheetNames());
+        }
+
+        [Fact]
+        public async Task ExcelHttpLoadRejectsHttpsToHttpRedirectByDefault() {
+            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) => {
+                var response = new HttpResponseMessage(HttpStatusCode.Redirect);
+                response.Headers.Location = new Uri("http://example.test/workbook.xlsx");
+                return Task.FromResult(response);
+            }));
+
+            var ex = await Assert.ThrowsAsync<NotSupportedException>(() =>
+                ExcelDocumentReader.OpenAsync(
+                    new Uri("https://example.test/workbook.xlsx"),
+                    httpOptions: new ExcelHttpLoadOptions { HttpClient = httpClient }));
+
+            Assert.Contains("HTTPS", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task ExcelHttpLoadDoesNotForwardCustomHeadersAcrossRedirectedHosts() {
+            byte[] workbookBytes = CreateRemoteWorkbookBytes();
+            var requests = new List<HttpRequestMessage>();
+            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((request, _) => {
+                requests.Add(CloneRequestHeaders(request));
+                if (requests.Count == 1) {
+                    var redirect = new HttpResponseMessage(HttpStatusCode.Redirect);
+                    redirect.Headers.Location = new Uri("https://cdn.example.test/workbook.xlsx");
+                    return Task.FromResult(redirect);
+                }
+
+                return Task.FromResult(CreateWorkbookResponse(workbookBytes));
+            }));
+
+            var options = new ExcelHttpLoadOptions {
+                HttpClient = httpClient,
+                UserAgent = "OfficeIMO.Tests"
+            };
+            options.Headers["X-Api-Key"] = "secret";
+
+            using var reader = await ExcelDocumentReader.OpenAsync(
+                new Uri("https://example.test/workbook.xlsx"),
+                httpOptions: options);
+
+            Assert.Equal(new[] { "Remote" }, reader.GetSheetNames());
+            Assert.Equal(2, requests.Count);
+            Assert.True(requests[0].Headers.Contains("X-Api-Key"));
+            Assert.False(requests[1].Headers.Contains("X-Api-Key"));
+            Assert.Contains(requests[1].Headers.UserAgent, value => value.Product?.Name == "OfficeIMO.Tests");
+        }
+
+        [Fact]
         public async Task ExcelHttpLoadObservesCancellationToken() {
             using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) =>
                 Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
@@ -189,6 +257,15 @@ namespace OfficeIMO.Tests {
             response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
             return response;
+        }
+
+        private static HttpRequestMessage CloneRequestHeaders(HttpRequestMessage request) {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri);
+            foreach (var header in request.Headers) {
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            return clone;
         }
 
         private sealed class CapturingProgress : IProgress<ExcelHttpLoadProgress> {

--- a/OfficeIMO.Tests/Excel.HttpLoading.cs
+++ b/OfficeIMO.Tests/Excel.HttpLoading.cs
@@ -22,14 +22,14 @@ namespace OfficeIMO.Tests {
         public async Task ExcelHttpReaderAllowsHttpWhenOptedInAndSendsHeaders() {
             byte[] workbookBytes = CreateRemoteWorkbookBytes();
             HttpRequestMessage? capturedRequest = null;
-            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((request, _) => {
+            using var handler = new FakeWorkbookHttpMessageHandler((request, _) => {
                 capturedRequest = request;
                 return Task.FromResult(CreateWorkbookResponse(workbookBytes));
-            }));
+            });
 
             var httpOptions = new ExcelHttpLoadOptions {
                 SchemePolicy = ExcelUriSchemePolicy.HttpAndHttps,
-                HttpClient = httpClient,
+                HttpMessageHandler = handler,
                 UserAgent = "OfficeIMO.Tests"
             };
             httpOptions.Headers["X-Test"] = "remote-load";
@@ -48,12 +48,12 @@ namespace OfficeIMO.Tests {
         [Fact]
         public async Task ExcelHttpDocumentLoadOpensDownloadedWorkbookReadOnlyByDefault() {
             byte[] workbookBytes = CreateRemoteWorkbookBytes();
-            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) =>
-                Task.FromResult(CreateWorkbookResponse(workbookBytes))));
+            using var handler = new FakeWorkbookHttpMessageHandler((_, _) =>
+                Task.FromResult(CreateWorkbookResponse(workbookBytes)));
 
             await using var document = await ExcelDocument.LoadAsync(
                 new Uri("https://example.test/workbook.xlsx"),
-                new ExcelHttpLoadOptions { HttpClient = httpClient });
+                new ExcelHttpLoadOptions { HttpMessageHandler = handler });
 
             Assert.Equal(FileAccess.Read, document.FileOpenAccess);
             Assert.Equal("Remote", document.Sheets[0].Name);
@@ -63,14 +63,14 @@ namespace OfficeIMO.Tests {
         [Fact]
         public async Task ExcelHttpLoadRejectsContentLengthOverLimitBeforeCopying() {
             byte[] workbookBytes = CreateRemoteWorkbookBytes();
-            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) =>
-                Task.FromResult(CreateWorkbookResponse(workbookBytes))));
+            using var handler = new FakeWorkbookHttpMessageHandler((_, _) =>
+                Task.FromResult(CreateWorkbookResponse(workbookBytes)));
 
             var ex = await Assert.ThrowsAsync<IOException>(() =>
                 ExcelDocumentReader.OpenAsync(
                     new Uri("https://example.test/workbook.xlsx"),
                     httpOptions: new ExcelHttpLoadOptions {
-                        HttpClient = httpClient,
+                        HttpMessageHandler = handler,
                         MaxBytes = workbookBytes.Length - 1
                     }));
 
@@ -80,20 +80,20 @@ namespace OfficeIMO.Tests {
         [Fact]
         public async Task ExcelHttpLoadRejectsResponseThatExceedsLimitDuringCopy() {
             byte[] workbookBytes = CreateRemoteWorkbookBytes();
-            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) => {
+            using var handler = new FakeWorkbookHttpMessageHandler((_, _) => {
                 var response = new HttpResponseMessage(HttpStatusCode.OK) {
                     Content = new StreamContent(new NonSeekableMemoryStream(workbookBytes))
                 };
                 response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(
                     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
                 return Task.FromResult(response);
-            }));
+            });
 
             var ex = await Assert.ThrowsAsync<IOException>(() =>
                 ExcelDocumentReader.OpenAsync(
                     new Uri("https://example.test/workbook.xlsx"),
                     httpOptions: new ExcelHttpLoadOptions {
-                        HttpClient = httpClient,
+                        HttpMessageHandler = handler,
                         MaxBytes = workbookBytes.Length - 1
                     }));
 
@@ -104,13 +104,13 @@ namespace OfficeIMO.Tests {
         public async Task ExcelHttpLoadReportsProgress() {
             byte[] workbookBytes = CreateRemoteWorkbookBytes();
             var progress = new CapturingProgress();
-            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) =>
-                Task.FromResult(CreateWorkbookResponse(workbookBytes))));
+            using var handler = new FakeWorkbookHttpMessageHandler((_, _) =>
+                Task.FromResult(CreateWorkbookResponse(workbookBytes)));
 
             using var reader = await ExcelDocumentReader.OpenAsync(
                 new Uri("https://example.test/workbook.xlsx"),
                 httpOptions: new ExcelHttpLoadOptions {
-                    HttpClient = httpClient,
+                    HttpMessageHandler = handler,
                     Progress = progress
                 });
 
@@ -122,34 +122,34 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public async Task ExcelHttpLoadRejectsInvalidZipHeaderByDefault() {
-            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) => {
+            using var handler = new FakeWorkbookHttpMessageHandler((_, _) => {
                 var response = new HttpResponseMessage(HttpStatusCode.OK) {
                     Content = new ByteArrayContent(System.Text.Encoding.UTF8.GetBytes("not a workbook"))
                 };
                 response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
                 return Task.FromResult(response);
-            }));
+            });
 
             await Assert.ThrowsAsync<InvalidDataException>(() =>
                 ExcelDocumentReader.OpenAsync(
                     new Uri("https://example.test/workbook.xlsx"),
-                    httpOptions: new ExcelHttpLoadOptions { HttpClient = httpClient }));
+                    httpOptions: new ExcelHttpLoadOptions { HttpMessageHandler = handler }));
         }
 
         [Fact]
         public async Task ExcelHttpLoadCanValidateContentTypeWhenPresent() {
             byte[] workbookBytes = CreateRemoteWorkbookBytes();
-            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) => {
+            using var handler = new FakeWorkbookHttpMessageHandler((_, _) => {
                 var response = CreateWorkbookResponse(workbookBytes);
                 response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("text/plain");
                 return Task.FromResult(response);
-            }));
+            });
 
             var ex = await Assert.ThrowsAsync<InvalidDataException>(() =>
                 ExcelDocumentReader.OpenAsync(
                     new Uri("https://example.test/workbook.xlsx"),
                     httpOptions: new ExcelHttpLoadOptions {
-                        HttpClient = httpClient,
+                        HttpMessageHandler = handler,
                         ValidateContentTypeWhenPresent = true
                     }));
 
@@ -159,17 +159,17 @@ namespace OfficeIMO.Tests {
         [Fact]
         public async Task ExcelHttpLoadAllowsMacroEnabledWorkbookContentTypeByDefault() {
             byte[] workbookBytes = CreateRemoteWorkbookBytes();
-            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) => {
+            using var handler = new FakeWorkbookHttpMessageHandler((_, _) => {
                 var response = CreateWorkbookResponse(workbookBytes);
                 response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(
                     "application/vnd.ms-excel.sheet.macroEnabled.12");
                 return Task.FromResult(response);
-            }));
+            });
 
             using var reader = await ExcelDocumentReader.OpenAsync(
                 new Uri("https://example.test/workbook.xlsm"),
                 httpOptions: new ExcelHttpLoadOptions {
-                    HttpClient = httpClient,
+                    HttpMessageHandler = handler,
                     ValidateContentTypeWhenPresent = true
                 });
 
@@ -178,16 +178,16 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public async Task ExcelHttpLoadRejectsHttpsToHttpRedirectByDefault() {
-            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) => {
+            using var handler = new FakeWorkbookHttpMessageHandler((_, _) => {
                 var response = new HttpResponseMessage(HttpStatusCode.Redirect);
                 response.Headers.Location = new Uri("http://example.test/workbook.xlsx");
                 return Task.FromResult(response);
-            }));
+            });
 
             var ex = await Assert.ThrowsAsync<NotSupportedException>(() =>
                 ExcelDocumentReader.OpenAsync(
                     new Uri("https://example.test/workbook.xlsx"),
-                    httpOptions: new ExcelHttpLoadOptions { HttpClient = httpClient }));
+                    httpOptions: new ExcelHttpLoadOptions { HttpMessageHandler = handler }));
 
             Assert.Contains("HTTPS", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
@@ -196,7 +196,7 @@ namespace OfficeIMO.Tests {
         public async Task ExcelHttpLoadDoesNotForwardCustomHeadersAcrossRedirectedHosts() {
             byte[] workbookBytes = CreateRemoteWorkbookBytes();
             var requests = new List<HttpRequestMessage>();
-            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((request, _) => {
+            using var handler = new FakeWorkbookHttpMessageHandler((request, _) => {
                 requests.Add(CloneRequestHeaders(request));
                 if (requests.Count == 1) {
                     var redirect = new HttpResponseMessage(HttpStatusCode.Redirect);
@@ -205,10 +205,10 @@ namespace OfficeIMO.Tests {
                 }
 
                 return Task.FromResult(CreateWorkbookResponse(workbookBytes));
-            }));
+            });
 
             var options = new ExcelHttpLoadOptions {
-                HttpClient = httpClient,
+                HttpMessageHandler = handler,
                 UserAgent = "OfficeIMO.Tests"
             };
             options.Headers["X-Api-Key"] = "secret";
@@ -225,39 +225,18 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public async Task ExcelHttpLoadRejectsCrossOriginRedirectWhenClientDefaultHeadersArePresent() {
-            var requests = new List<HttpRequestMessage>();
-            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((request, _) => {
-                requests.Add(CloneRequestHeaders(request));
-                var redirect = new HttpResponseMessage(HttpStatusCode.Redirect);
-                redirect.Headers.Location = new Uri("https://cdn.example.test/workbook.xlsx");
-                return Task.FromResult(redirect);
-            }));
-            httpClient.DefaultRequestHeaders.TryAddWithoutValidation("X-Api-Key", "secret");
-
-            var ex = await Assert.ThrowsAsync<HttpRequestException>(() =>
-                ExcelDocumentReader.OpenAsync(
-                    new Uri("https://example.test/workbook.xlsx"),
-                    httpOptions: new ExcelHttpLoadOptions { HttpClient = httpClient }));
-
-            Assert.Contains("default request headers", ex.Message, StringComparison.OrdinalIgnoreCase);
-            var request = Assert.Single(requests);
-            Assert.True(request.Headers.Contains("X-Api-Key"));
-        }
-
-        [Fact]
         public async Task ExcelHttpLoadObservesCancellationToken() {
-            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) =>
+            using var handler = new FakeWorkbookHttpMessageHandler((_, _) =>
                 Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
                     Content = new StreamContent(new BlockingReadStream())
-                })));
+                }));
             using var cancellation = new CancellationTokenSource();
             cancellation.Cancel();
 
             await Assert.ThrowsAsync<TaskCanceledException>(() =>
                 ExcelDocumentReader.OpenAsync(
                     new Uri("https://example.test/workbook.xlsx"),
-                    httpOptions: new ExcelHttpLoadOptions { HttpClient = httpClient },
+                    httpOptions: new ExcelHttpLoadOptions { HttpMessageHandler = handler },
                     cancellationToken: cancellation.Token));
         }
 

--- a/OfficeIMO.Tests/Excel.HttpLoading.cs
+++ b/OfficeIMO.Tests/Excel.HttpLoading.cs
@@ -1,0 +1,304 @@
+using OfficeIMO.Excel;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public async Task ExcelHttpLoadRejectsHttpByDefault() {
+            var ex = await Assert.ThrowsAsync<NotSupportedException>(() =>
+                ExcelDocumentReader.OpenAsync(new Uri("http://example.test/workbook.xlsx")));
+
+            Assert.Contains("HTTPS", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task ExcelHttpReaderAllowsHttpWhenOptedInAndSendsHeaders() {
+            byte[] workbookBytes = CreateRemoteWorkbookBytes();
+            HttpRequestMessage? capturedRequest = null;
+            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((request, _) => {
+                capturedRequest = request;
+                return Task.FromResult(CreateWorkbookResponse(workbookBytes));
+            }));
+
+            var httpOptions = new ExcelHttpLoadOptions {
+                SchemePolicy = ExcelUriSchemePolicy.HttpAndHttps,
+                HttpClient = httpClient,
+                UserAgent = "OfficeIMO.Tests"
+            };
+            httpOptions.Headers["X-Test"] = "remote-load";
+
+            using var reader = await ExcelDocumentReader.OpenAsync(
+                new Uri("http://example.test/workbook.xlsx"),
+                httpOptions: httpOptions);
+
+            Assert.Equal(new[] { "Remote" }, reader.GetSheetNames());
+            Assert.NotNull(capturedRequest);
+            Assert.True(capturedRequest!.Headers.TryGetValues("X-Test", out var values));
+            Assert.Contains("remote-load", values);
+            Assert.Contains(capturedRequest.Headers.UserAgent, value => value.Product?.Name == "OfficeIMO.Tests");
+        }
+
+        [Fact]
+        public async Task ExcelHttpDocumentLoadOpensDownloadedWorkbookReadOnlyByDefault() {
+            byte[] workbookBytes = CreateRemoteWorkbookBytes();
+            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) =>
+                Task.FromResult(CreateWorkbookResponse(workbookBytes))));
+
+            await using var document = await ExcelDocument.LoadAsync(
+                new Uri("https://example.test/workbook.xlsx"),
+                new ExcelHttpLoadOptions { HttpClient = httpClient });
+
+            Assert.Equal(FileAccess.Read, document.FileOpenAccess);
+            Assert.Equal("Remote", document.Sheets[0].Name);
+            Assert.Equal(string.Empty, document.FilePath);
+        }
+
+        [Fact]
+        public async Task ExcelHttpLoadRejectsContentLengthOverLimitBeforeCopying() {
+            byte[] workbookBytes = CreateRemoteWorkbookBytes();
+            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) =>
+                Task.FromResult(CreateWorkbookResponse(workbookBytes))));
+
+            var ex = await Assert.ThrowsAsync<IOException>(() =>
+                ExcelDocumentReader.OpenAsync(
+                    new Uri("https://example.test/workbook.xlsx"),
+                    httpOptions: new ExcelHttpLoadOptions {
+                        HttpClient = httpClient,
+                        MaxBytes = workbookBytes.Length - 1
+                    }));
+
+            Assert.Contains("too large", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task ExcelHttpLoadRejectsResponseThatExceedsLimitDuringCopy() {
+            byte[] workbookBytes = CreateRemoteWorkbookBytes();
+            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) => {
+                var response = new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StreamContent(new NonSeekableMemoryStream(workbookBytes))
+                };
+                response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+                return Task.FromResult(response);
+            }));
+
+            var ex = await Assert.ThrowsAsync<IOException>(() =>
+                ExcelDocumentReader.OpenAsync(
+                    new Uri("https://example.test/workbook.xlsx"),
+                    httpOptions: new ExcelHttpLoadOptions {
+                        HttpClient = httpClient,
+                        MaxBytes = workbookBytes.Length - 1
+                    }));
+
+            Assert.Contains("exceeded", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task ExcelHttpLoadReportsProgress() {
+            byte[] workbookBytes = CreateRemoteWorkbookBytes();
+            var progress = new CapturingProgress();
+            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) =>
+                Task.FromResult(CreateWorkbookResponse(workbookBytes))));
+
+            using var reader = await ExcelDocumentReader.OpenAsync(
+                new Uri("https://example.test/workbook.xlsx"),
+                httpOptions: new ExcelHttpLoadOptions {
+                    HttpClient = httpClient,
+                    Progress = progress
+                });
+
+            Assert.Equal(new[] { "Remote" }, reader.GetSheetNames());
+            var last = Assert.Single(progress.Events);
+            Assert.Equal(workbookBytes.Length, last.BytesRead);
+            Assert.Equal(workbookBytes.Length, last.ContentLength);
+        }
+
+        [Fact]
+        public async Task ExcelHttpLoadRejectsInvalidZipHeaderByDefault() {
+            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) => {
+                var response = new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new ByteArrayContent(System.Text.Encoding.UTF8.GetBytes("not a workbook"))
+                };
+                response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
+                return Task.FromResult(response);
+            }));
+
+            await Assert.ThrowsAsync<InvalidDataException>(() =>
+                ExcelDocumentReader.OpenAsync(
+                    new Uri("https://example.test/workbook.xlsx"),
+                    httpOptions: new ExcelHttpLoadOptions { HttpClient = httpClient }));
+        }
+
+        [Fact]
+        public async Task ExcelHttpLoadCanValidateContentTypeWhenPresent() {
+            byte[] workbookBytes = CreateRemoteWorkbookBytes();
+            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) => {
+                var response = CreateWorkbookResponse(workbookBytes);
+                response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("text/plain");
+                return Task.FromResult(response);
+            }));
+
+            var ex = await Assert.ThrowsAsync<InvalidDataException>(() =>
+                ExcelDocumentReader.OpenAsync(
+                    new Uri("https://example.test/workbook.xlsx"),
+                    httpOptions: new ExcelHttpLoadOptions {
+                        HttpClient = httpClient,
+                        ValidateContentTypeWhenPresent = true
+                    }));
+
+            Assert.Contains("Content-Type", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task ExcelHttpLoadObservesCancellationToken() {
+            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StreamContent(new BlockingReadStream())
+                })));
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() =>
+                ExcelDocumentReader.OpenAsync(
+                    new Uri("https://example.test/workbook.xlsx"),
+                    httpOptions: new ExcelHttpLoadOptions { HttpClient = httpClient },
+                    cancellationToken: cancellation.Token));
+        }
+
+        private static byte[] CreateRemoteWorkbookBytes() {
+            using var memory = new MemoryStream();
+            using (var document = ExcelDocument.Create(memory)) {
+                var sheet = document.AddWorkSheet("Remote");
+                sheet.CellValue(1, 1, "Value");
+            }
+
+            return memory.ToArray();
+        }
+
+        private static HttpResponseMessage CreateWorkbookResponse(byte[] workbookBytes) {
+            var response = new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ByteArrayContent(workbookBytes)
+            };
+            response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+            return response;
+        }
+
+        private sealed class CapturingProgress : IProgress<ExcelHttpLoadProgress> {
+            internal List<ExcelHttpLoadProgress> Events { get; } = new List<ExcelHttpLoadProgress>();
+
+            public void Report(ExcelHttpLoadProgress value) {
+                Events.Add(value);
+            }
+        }
+
+        private sealed class FakeWorkbookHttpMessageHandler : HttpMessageHandler {
+            private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
+
+            internal FakeWorkbookHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) {
+                _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                return _handler(request, cancellationToken);
+            }
+        }
+
+        private sealed class NonSeekableMemoryStream : Stream {
+            private readonly MemoryStream _inner;
+
+            internal NonSeekableMemoryStream(byte[] bytes) {
+                _inner = new MemoryStream(bytes, writable: false);
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush() {
+            }
+
+            public override int Read(byte[] buffer, int offset, int count) {
+                return _inner.Read(buffer, offset, count);
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {
+                return _inner.ReadAsync(buffer, offset, count, cancellationToken);
+            }
+
+            public override long Seek(long offset, SeekOrigin origin) {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value) {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count) {
+                throw new NotSupportedException();
+            }
+
+            protected override void Dispose(bool disposing) {
+                if (disposing) {
+                    _inner.Dispose();
+                }
+
+                base.Dispose(disposing);
+            }
+        }
+
+        private sealed class BlockingReadStream : Stream {
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush() {
+            }
+
+            public override int Read(byte[] buffer, int offset, int count) {
+                Thread.Sleep(Timeout.Infinite);
+                return 0;
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {
+                return Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ContinueWith(
+                    static task => {
+                        task.GetAwaiter().GetResult();
+                        return 0;
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+
+            public override long Seek(long offset, SeekOrigin origin) {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value) {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count) {
+                throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.HttpLoading.cs
+++ b/OfficeIMO.Tests/Excel.HttpLoading.cs
@@ -225,6 +225,27 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public async Task ExcelHttpLoadRejectsCrossOriginRedirectWhenClientDefaultHeadersArePresent() {
+            var requests = new List<HttpRequestMessage>();
+            using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((request, _) => {
+                requests.Add(CloneRequestHeaders(request));
+                var redirect = new HttpResponseMessage(HttpStatusCode.Redirect);
+                redirect.Headers.Location = new Uri("https://cdn.example.test/workbook.xlsx");
+                return Task.FromResult(redirect);
+            }));
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation("X-Api-Key", "secret");
+
+            var ex = await Assert.ThrowsAsync<HttpRequestException>(() =>
+                ExcelDocumentReader.OpenAsync(
+                    new Uri("https://example.test/workbook.xlsx"),
+                    httpOptions: new ExcelHttpLoadOptions { HttpClient = httpClient }));
+
+            Assert.Contains("default request headers", ex.Message, StringComparison.OrdinalIgnoreCase);
+            var request = Assert.Single(requests);
+            Assert.True(request.Headers.Contains("X-Api-Key"));
+        }
+
+        [Fact]
         public async Task ExcelHttpLoadObservesCancellationToken() {
             using var httpClient = new HttpClient(new FakeWorkbookHttpMessageHandler((_, _) =>
                 Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {


### PR DESCRIPTION
## Summary

Adds engine-level remote workbook loading for OfficeIMO.Excel so callers can load HTTP/HTTPS workbook URIs without putting downloader glue in wrapper layers.

## Changes

- Add `ExcelHttpLoadOptions`, `ExcelUriSchemePolicy`, and `ExcelHttpLoadProgress`.
- Add an internal bounded HTTP downloader with HTTPS-by-default, opt-in HTTP, timeout, cancellation, max byte enforcement, headers/user-agent, progress, optional content-type validation, and ZIP-header validation.
- Add `ExcelDocument.Load/LoadAsync(Uri, ...)` and `ExcelDocumentReader.Open/OpenAsync(Uri, ...)`.
- Add focused tests for safety rules and successful document/reader remote loads.
- Document the OfficeIMO.Excel approach and PSWriteOffice wrapper boundary.

## Validation

- `dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --no-restore`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-build --filter "FullyQualifiedName~ExcelHttp" --logger "console;verbosity=normal"`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-build --filter "FullyQualifiedName~Excel" --logger "console;verbosity=minimal"`
- `git diff --cached --check`
