### PR TITLE
Optimize Excel metadata cleanup paths

### DIFF
--- a/OfficeIMO.Excel.Benchmarks/ExcelReadProfileRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelReadProfileRunner.cs
@@ -107,6 +107,7 @@ internal static class ExcelReadProfileRunner {
         scenarios.Add(Measure("OfficeIMO.Excel", "GetHeaderMap.LoadedRebuild", "Rebuild the header lookup map on an already loaded worksheet after cache invalidation.", () => OfficeImoGetHeaderMapLoadedRebuild(loadedHeaderSheet), warmupIterations, measuredIterations));
         scenarios.Add(Measure("OfficeIMO.Excel", "GetHeaderMap.LoadedSharedStrings", "Rebuild headers when the worksheet has many unique shared strings below the header row.", () => OfficeImoGetHeaderMapLoadedRebuild(loadedSharedStringHeaderSheet), warmupIterations, measuredIterations));
         scenarios.Add(Measure("OfficeIMO.Excel", "TryGetColumnIndexByHeader.Cached", "Repeated cached header lookup without exposing the mutable header map.", () => OfficeImoTryGetHeaderLookupLoaded(loadedHeaderSheet), warmupIterations, measuredIterations));
+        scenarios.Add(Measure("OfficeIMO.Excel", "HeaderOps.SetByHeader.Cached", "Repeated header-based data-row updates through the normal SetByHeader API.", () => OfficeImoSetByHeaderLoaded(loadedHeaderOpsSheet, rowCount), warmupIterations, measuredIterations));
         scenarios.Add(Measure("OfficeIMO.Excel", "LoadedText.FindFirst.SharedStrings", "Repeated loaded-sheet text search over cells backed by many shared strings.", () => OfficeImoFindFirstSharedStringLoaded(loadedSharedStringHeaderSheet, rowCount), warmupIterations, measuredIterations));
         scenarios.Add(Measure("OfficeIMO.Excel", "LoadedText.ReplaceAll.SharedStrings", "Batch replacement over a loaded worksheet with many shared-string cells.", () => OfficeImoReplaceAllSharedStrings(sharedStringHeavyWorkbookBytes, rowCount), warmupIterations, measuredIterations));
         scenarios.Add(Measure("OfficeIMO.Excel", "HeaderOps.AutoFilterByHeaders.BatchMap", "Repeated multi-header AutoFilter updates using one internal cached header map per operation.", () => OfficeImoAutoFilterByHeadersLoaded(loadedHeaderOpsSheet), warmupIterations, measuredIterations));
@@ -413,6 +414,18 @@ internal static class ExcelReadProfileRunner {
             if (sheet.TryGetColumnIndexByHeader("Amount", out int columnIndex)) {
                 total += columnIndex;
             }
+        }
+
+        return total;
+    }
+
+    private static int OfficeImoSetByHeaderLoaded(ExcelSheet sheet, int rowCount) {
+        _ = sheet.GetHeaderMap();
+        int total = 0;
+        for (int i = 0; i < HeaderLookupIterations; i++) {
+            int row = (i % rowCount) + 2;
+            sheet.SetByHeader(row, "Amount", i);
+            total += row;
         }
 
         return total;

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.cs
@@ -213,23 +213,39 @@ namespace OfficeIMO.Excel {
                         bool rowStarted = false;
                         string rowReference = rowIndex.ToString(CultureInfo.InvariantCulture);
                         DataRow? sourceRow = sheet.Table.GetSourceRow(sourceRowIndex);
-                        object?[]? bufferedRow = sourceRow == null ? sheet.Table.GetBufferedRow(sourceRowIndex) : null;
-                        for (int c = 0; c < columnCount; c++) {
-                            object? value = sourceRow != null
-                                ? DirectDataSetTableModel.GetValue(sourceRow, c)
-                                : DirectDataSetTableModel.GetValue(bufferedRow!, c);
-                            if (sheet.OmitBlankCells && IsBlankCellValue(value)) {
-                                continue;
-                            }
+                        if (sourceRow != null) {
+                            for (int c = 0; c < columnCount; c++) {
+                                object? value = DirectDataSetTableModel.GetValue(sourceRow, c);
+                                if (sheet.OmitBlankCells && IsBlankCellValue(value)) {
+                                    continue;
+                                }
 
-                            if (!rowStarted) {
-                                writer.Write("<row r=\"");
-                                writer.Write(rowReference);
-                                writer.Write("\">");
-                                rowStarted = true;
-                            }
+                                if (!rowStarted) {
+                                    writer.Write("<row r=\"");
+                                    writer.Write(rowReference);
+                                    writer.Write("\">");
+                                    rowStarted = true;
+                                }
 
-                            WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                                WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                            }
+                        } else {
+                            object?[] bufferedRow = sheet.Table.GetBufferedRow(sourceRowIndex)!;
+                            for (int c = 0; c < columnCount; c++) {
+                                object? value = DirectDataSetTableModel.GetValue(bufferedRow, c);
+                                if (sheet.OmitBlankCells && IsBlankCellValue(value)) {
+                                    continue;
+                                }
+
+                                if (!rowStarted) {
+                                    writer.Write("<row r=\"");
+                                    writer.Write(rowReference);
+                                    writer.Write("\">");
+                                    rowStarted = true;
+                                }
+
+                                WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                            }
                         }
 
                         if (rowStarted) {
@@ -244,23 +260,39 @@ namespace OfficeIMO.Excel {
                         bool rowStarted = false;
                         string rowReference = rowIndex.ToString(CultureInfo.InvariantCulture);
                         DataRow? sourceRow = sheet.Table.GetSourceRow(sourceRowIndex);
-                        object?[]? bufferedRow = sourceRow == null ? sheet.Table.GetBufferedRow(sourceRowIndex) : null;
-                        for (int c = 0; c < columnCount; c++) {
-                            object? value = sourceRow != null
-                                ? DirectDataSetTableModel.GetValue(sourceRow, c)
-                                : DirectDataSetTableModel.GetValue(bufferedRow!, c);
-                            if (sheet.OmitBlankCells && IsBlankCellValue(value)) {
-                                continue;
-                            }
+                        if (sourceRow != null) {
+                            for (int c = 0; c < columnCount; c++) {
+                                object? value = DirectDataSetTableModel.GetValue(sourceRow, c);
+                                if (sheet.OmitBlankCells && IsBlankCellValue(value)) {
+                                    continue;
+                                }
 
-                            if (!rowStarted) {
-                                writer.Write("<row r=\"");
-                                writer.Write(rowReference);
-                                writer.Write("\">");
-                                rowStarted = true;
-                            }
+                                if (!rowStarted) {
+                                    writer.Write("<row r=\"");
+                                    writer.Write(rowReference);
+                                    writer.Write("\">");
+                                    rowStarted = true;
+                                }
 
-                            WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                                WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                            }
+                        } else {
+                            object?[] bufferedRow = sheet.Table.GetBufferedRow(sourceRowIndex)!;
+                            for (int c = 0; c < columnCount; c++) {
+                                object? value = DirectDataSetTableModel.GetValue(bufferedRow, c);
+                                if (sheet.OmitBlankCells && IsBlankCellValue(value)) {
+                                    continue;
+                                }
+
+                                if (!rowStarted) {
+                                    writer.Write("<row r=\"");
+                                    writer.Write(rowReference);
+                                    writer.Write("\">");
+                                    rowStarted = true;
+                                }
+
+                                WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                            }
                         }
 
                         if (rowStarted) {
@@ -444,14 +476,20 @@ namespace OfficeIMO.Excel {
                         for (int rowIndex = 0; rowIndex < sheet.Table.RowCount; rowIndex++) {
                             ct.ThrowIfCancellationRequested();
                             DataRow? sourceRow = sheet.Table.GetSourceRow(rowIndex);
-                            object?[]? bufferedRow = sourceRow == null ? sheet.Table.GetBufferedRow(rowIndex) : null;
-                            for (int stringColumnIndex = 0; stringColumnIndex < stringColumnIndexes.Length; stringColumnIndex++) {
-                                int columnIndex = stringColumnIndexes[stringColumnIndex];
-                                object? value = sourceRow != null
-                                    ? DirectDataSetTableModel.GetValue(sourceRow, columnIndex)
-                                    : DirectDataSetTableModel.GetValue(bufferedRow!, columnIndex);
-                                if (value is string text) {
-                                    NoteString(text);
+                            if (sourceRow != null) {
+                                for (int stringColumnIndex = 0; stringColumnIndex < stringColumnIndexes.Length; stringColumnIndex++) {
+                                    int columnIndex = stringColumnIndexes[stringColumnIndex];
+                                    if (DirectDataSetTableModel.GetValue(sourceRow, columnIndex) is string text) {
+                                        NoteString(text);
+                                    }
+                                }
+                            } else {
+                                object?[] bufferedRow = sheet.Table.GetBufferedRow(rowIndex)!;
+                                for (int stringColumnIndex = 0; stringColumnIndex < stringColumnIndexes.Length; stringColumnIndex++) {
+                                    int columnIndex = stringColumnIndexes[stringColumnIndex];
+                                    if (DirectDataSetTableModel.GetValue(bufferedRow, columnIndex) is string text) {
+                                        NoteString(text);
+                                    }
                                 }
                             }
                         }
@@ -491,7 +529,6 @@ namespace OfficeIMO.Excel {
                     return new DirectSharedStringTable(indexes, values, sharedStringReferences);
 
                     void NoteString(string text, bool forceShared = false) {
-                        CoerceValueHelper.ValidateSharedStringLength(text, "value");
                         totalStringReferences++;
                         if (sharedCounts.TryGetValue(text, out int count)) {
                             sharedCounts[text] = count + 1;
@@ -499,13 +536,21 @@ namespace OfficeIMO.Excel {
                         }
 
                         if (forceShared) {
-                            sharedCounts.Add(text, seenOnce.Remove(text) ? 2 : 1);
+                            if (seenOnce.Remove(text)) {
+                                sharedCounts.Add(text, 2);
+                            } else {
+                                CoerceValueHelper.ValidateSharedStringLength(text, "value");
+                                sharedCounts.Add(text, 1);
+                            }
+
                             return;
                         }
 
                         if (!seenOnce.Add(text)) {
                             seenOnce.Remove(text);
                             sharedCounts.Add(text, 2);
+                        } else {
+                            CoerceValueHelper.ValidateSharedStringLength(text, "value");
                         }
                     }
                 }

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
@@ -305,34 +305,21 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            DataTable promotedTable = sheetModel.Table.ToDataTable();
-            if (!includeHeaders) {
-                promotedTable = CreateHeaderlessDirectSaveTable(promotedTable);
-            }
-
-            if (candidate.IsDeferred) {
-                RegisterDeferredDirectTabularSaveCandidate(
-                    sheet,
-                    promotedTable,
-                    includeHeaders,
-                    range,
-                    tableName,
-                    createTable: true,
-                    tableStyle,
-                    includeAutoFilter,
-                    autoFit: false);
-            } else {
-                RegisterDirectTabularSaveCandidate(
-                    sheet,
-                    promotedTable,
-                    includeHeaders,
-                    range,
-                    tableName,
-                    createTable: true,
-                    tableStyle,
-                    includeAutoFilter,
-                    autoFit: false);
-            }
+            var promotedModel = candidate.Model.WithTable(
+                sheet.Name,
+                tableName,
+                includeHeaders,
+                tableStyle,
+                includeAutoFilter,
+                _dateTimeOffsetWriteStrategy,
+                CancellationToken.None);
+            _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(
+                candidate.Owner,
+                promotedModel,
+                candidate.InvalidateCallback,
+                candidate.IsDeferred,
+                subscribeToSourceChanges: false);
+            candidate.Dispose();
 
             return _directDataSetSaveCandidate != null && _directDataSetSaveCandidate.IsValid;
         }
@@ -428,32 +415,6 @@ namespace OfficeIMO.Excel {
                 ClearDirectDataSetSaveCandidate();
                 return false;
             }
-        }
-
-        private static DataTable CreateHeaderlessDirectSaveTable(DataTable source) {
-            var table = new DataTable(source.TableName) {
-                Locale = CultureInfo.InvariantCulture
-            };
-
-            for (int i = 0; i < source.Columns.Count; i++) {
-                table.Columns.Add("Column" + (i + 1).ToString(CultureInfo.InvariantCulture), source.Columns[i].DataType);
-            }
-
-            table.BeginLoadData();
-            try {
-                foreach (DataRow sourceRow in source.Rows) {
-                    var row = table.NewRow();
-                    for (int i = 0; i < source.Columns.Count; i++) {
-                        row[i] = sourceRow.IsNull(i) ? DBNull.Value : sourceRow[i];
-                    }
-
-                    table.Rows.Add(row);
-                }
-            } finally {
-                table.EndLoadData();
-            }
-
-            return table;
         }
 
         private bool TryRegisterDeferredDirectDataSetImport(
@@ -747,6 +708,50 @@ namespace OfficeIMO.Excel {
                 return new DirectDataSetWorkbookModel(sheets, Results, dateTimeOffsetWriteStrategy ?? DateTimeOffsetWriteStrategy);
             }
 
+            internal DirectDataSetWorkbookModel WithTable(
+                string sheetName,
+                string tableName,
+                bool includeHeaders,
+                TableStyle tableStyle,
+                bool includeAutoFilter,
+                Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                CancellationToken ct) {
+                var sheets = new DirectDataSetSheetModel[Sheets.Count];
+                var results = new ExcelDataSetImportResult[Sheets.Count];
+                for (int i = 0; i < Sheets.Count; i++) {
+                    ct.ThrowIfCancellationRequested();
+                    var sheet = Sheets[i];
+                    if (!string.Equals(sheet.SheetName, sheetName, StringComparison.Ordinal)) {
+                        sheets[i] = sheet;
+                        results[i] = new ExcelDataSetImportResult(sheet.SheetName, sheet.TableName, sheet.Range, sheet.Table.RowCount, sheet.Table.ColumnCount);
+                        continue;
+                    }
+
+                    var table = includeHeaders ? sheet.Table : sheet.Table.WithGeneratedColumnNames();
+                    double[]? columnWidths = sheet.ColumnWidths;
+                    if (sheet.AutoFitColumns && !ReferenceEquals(table, sheet.Table)) {
+                        columnWidths = table.CalculateColumnWidths(includeHeaders, dateTimeOffsetWriteStrategy, ct);
+                    }
+
+                    sheets[i] = new DirectDataSetSheetModel(
+                        sheet.Index,
+                        sheet.SheetName,
+                        tableName,
+                        sheet.Range,
+                        table,
+                        tableStyle,
+                        includeHeaders,
+                        includeAutoFilter,
+                        hasTable: true,
+                        sheet.AutoFitColumns,
+                        sheet.OmitBlankCells,
+                        columnWidths);
+                    results[i] = new ExcelDataSetImportResult(sheet.SheetName, tableName, sheet.Range, table.RowCount, table.ColumnCount);
+                }
+
+                return new DirectDataSetWorkbookModel(sheets, results, dateTimeOffsetWriteStrategy ?? DateTimeOffsetWriteStrategy);
+            }
+
             internal static DirectDataSetWorkbookModel Create(
                 DataSet dataSet,
                 bool createTables,
@@ -981,6 +986,8 @@ namespace OfficeIMO.Excel {
         }
 
         private sealed class DirectDataSetTableModel {
+            private const int MaxAutoFitStringWidthCacheEntriesPerColumn = 1024;
+
             private enum AutoFitWidthKind {
                 Object,
                 String,
@@ -1014,6 +1021,11 @@ namespace OfficeIMO.Excel {
                 _columns = CreateColumns(sourceTable);
             }
 
+            private DirectDataSetTableModel(DataTable sourceTable, DirectDataSetColumnModel[] columns) {
+                _sourceTable = sourceTable;
+                _columns = columns;
+            }
+
             private DirectDataSetTableModel(DirectDataSetColumnModel[] columns, object?[][] rows) {
                 _columns = columns;
                 _rows = rows;
@@ -1032,6 +1044,17 @@ namespace OfficeIMO.Excel {
                 }
 
                 return new DirectDataSetTableModel(columns, rows);
+            }
+
+            internal DirectDataSetTableModel WithGeneratedColumnNames() {
+                var columns = new DirectDataSetColumnModel[ColumnCount];
+                for (int i = 0; i < columns.Length; i++) {
+                    columns[i] = new DirectDataSetColumnModel("Column" + (i + 1).ToString(CultureInfo.InvariantCulture), GetColumnType(i));
+                }
+
+                return _sourceTable != null
+                    ? new DirectDataSetTableModel(_sourceTable, columns)
+                    : new DirectDataSetTableModel(columns, _rows!);
             }
 
             internal static DirectDataSetTableModel Snapshot(DataTable table, CancellationToken ct) {
@@ -1130,16 +1153,26 @@ namespace OfficeIMO.Excel {
                 }
 
                 AutoFitWidthKind[] widthKinds = CreateAutoFitWidthKinds();
+                Dictionary<string, double>?[]? stringWidthCaches = null;
                 int rowCount = RowCount;
                 for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
                     ct.ThrowIfCancellationRequested();
                     DataRow? sourceRow = GetSourceRow(rowIndex);
-                    object?[]? bufferedRow = sourceRow == null ? GetBufferedRow(rowIndex) : null;
-                    for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
-                        object? value = sourceRow != null
-                            ? GetValue(sourceRow, columnIndex)
-                            : GetValue(bufferedRow!, columnIndex);
-                        widths[columnIndex] = Math.Max(widths[columnIndex], EstimateAutoFitWidth(value, widthKinds[columnIndex], dateTimeOffsetWriteStrategy));
+                    if (sourceRow != null) {
+                        for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+                            object? value = GetValue(sourceRow, columnIndex);
+                            widths[columnIndex] = Math.Max(
+                                widths[columnIndex],
+                                EstimateAutoFitWidth(value, widthKinds[columnIndex], dateTimeOffsetWriteStrategy, ref stringWidthCaches, columnIndex, columnCount));
+                        }
+                    } else {
+                        object?[] bufferedRow = GetBufferedRow(rowIndex)!;
+                        for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+                            object? value = GetValue(bufferedRow, columnIndex);
+                            widths[columnIndex] = Math.Max(
+                                widths[columnIndex],
+                                EstimateAutoFitWidth(value, widthKinds[columnIndex], dateTimeOffsetWriteStrategy, ref stringWidthCaches, columnIndex, columnCount));
+                        }
                     }
                 }
 
@@ -1320,6 +1353,36 @@ namespace OfficeIMO.Excel {
                     default:
                         return EstimateAutoFitWidth(value, dateTimeOffsetWriteStrategy);
                 }
+            }
+
+            private static double EstimateAutoFitWidth(
+                object? value,
+                AutoFitWidthKind widthKind,
+                Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ref Dictionary<string, double>?[]? stringWidthCaches,
+                int columnIndex,
+                int columnCount) {
+                if (value is string stringValue && stringValue.Length > 0) {
+                    stringWidthCaches ??= new Dictionary<string, double>?[columnCount];
+                    Dictionary<string, double>? cache = stringWidthCaches[columnIndex];
+                    if (cache == null) {
+                        cache = new Dictionary<string, double>(StringComparer.Ordinal);
+                        stringWidthCaches[columnIndex] = cache;
+                    }
+
+                    if (cache.TryGetValue(stringValue, out double cachedWidth)) {
+                        return cachedWidth;
+                    }
+
+                    double width = EstimateAutoFitWidth(value, widthKind, dateTimeOffsetWriteStrategy);
+                    if (cache.Count < MaxAutoFitStringWidthCacheEntriesPerColumn) {
+                        cache[stringValue] = width;
+                    }
+
+                    return width;
+                }
+
+                return EstimateAutoFitWidth(value, widthKind, dateTimeOffsetWriteStrategy);
             }
 
             private static double EstimateDateTimeOffsetAutoFitWidth(DateTimeOffset value, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy) {

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -26,6 +26,7 @@ namespace OfficeIMO.Excel {
         internal ReaderWriterLockSlim? _lock;
         internal List<UInt32Value> id = new List<UInt32Value>() { 0 };
         private readonly Dictionary<string, int> _sharedStringCache = new Dictionary<string, int>();
+        private Dictionary<string, bool>? _sharedStringLineBreakCache;
         private readonly object _sharedStringLock = new object();
         private int _sharedStringTableCount = -1;
         // Workbook-level cache of table names for fast uniqueness checks
@@ -608,16 +609,30 @@ namespace OfficeIMO.Excel {
         }
 
         internal int GetSharedStringIndex(string text) {
+            return GetSharedStringIndex(text, validateNewString: false);
+        }
+
+        internal int GetSharedStringIndex(string text, bool validateNewString) {
             if (Locking.IsNoLock || (_lock != null && _lock.IsWriteLockHeld)) {
-                return GetSharedStringIndexCore(text);
+                return GetSharedStringIndexCore(text, validateNewString);
             }
 
             lock (_sharedStringLock) {
-                return GetSharedStringIndexCore(text);
+                return GetSharedStringIndexCore(text, validateNewString);
             }
         }
 
-        private int GetSharedStringIndexCore(string text) {
+        internal int GetSharedStringIndex(string text, bool validateNewString, out bool containsLineBreak) {
+            if (Locking.IsNoLock || (_lock != null && _lock.IsWriteLockHeld)) {
+                return GetSharedStringIndexCore(text, validateNewString, out containsLineBreak);
+            }
+
+            lock (_sharedStringLock) {
+                return GetSharedStringIndexCore(text, validateNewString, out containsLineBreak);
+            }
+        }
+
+        private int GetSharedStringIndexCore(string text, bool validateNewString) {
             // Check cache first
             if (_sharedStringCache.TryGetValue(text, out int cachedIndex)) {
                 return cachedIndex;
@@ -631,6 +646,10 @@ namespace OfficeIMO.Excel {
                 return foundIndex;
             }
 
+            if (validateNewString) {
+                CoerceValueHelper.ValidateSharedStringLength(text, nameof(text));
+            }
+
             // Add new string
             int newIndex = tableCount;
             sharedStringTable.AppendChild(new SharedStringItem(new Text(text)));
@@ -640,6 +659,54 @@ namespace OfficeIMO.Excel {
             _sharedStringCache[text] = newIndex;
 
             return newIndex;
+        }
+
+        private int GetSharedStringIndexCore(string text, bool validateNewString, out bool containsLineBreak) {
+            if (_sharedStringCache.TryGetValue(text, out int cachedIndex)) {
+                containsLineBreak = GetCachedOrComputeSharedStringLineBreak(text);
+                return cachedIndex;
+            }
+
+            var sharedStringTable = SharedStringTablePart.SharedStringTable ??= new SharedStringTable();
+            int tableCount = EnsureSharedStringCacheAndCount(sharedStringTable);
+
+            if (_sharedStringCache.TryGetValue(text, out int foundIndex)) {
+                containsLineBreak = GetCachedOrComputeSharedStringLineBreak(text);
+                return foundIndex;
+            }
+
+            if (validateNewString) {
+                CoerceValueHelper.ValidateSharedStringLength(text, nameof(text));
+            }
+
+            containsLineBreak = ContainsLineBreak(text);
+
+            int newIndex = tableCount;
+            sharedStringTable.AppendChild(new SharedStringItem(new Text(text)));
+            _sharedStringTableCount = newIndex + 1;
+            _sharedStringTableDirty = true;
+            MarkPackageDirty();
+            _sharedStringCache[text] = newIndex;
+
+            return newIndex;
+        }
+
+        private bool GetCachedOrComputeSharedStringLineBreak(string text) {
+            if (_sharedStringLineBreakCache != null
+                && _sharedStringLineBreakCache.TryGetValue(text, out bool containsLineBreak)) {
+                return containsLineBreak;
+            }
+
+            containsLineBreak = ContainsLineBreak(text);
+            if (text.Length >= 16) {
+                (_sharedStringLineBreakCache ??= new Dictionary<string, bool>(StringComparer.Ordinal))[text] = containsLineBreak;
+            }
+
+            return containsLineBreak;
+        }
+
+        private static bool ContainsLineBreak(string text) {
+            return text.IndexOf('\n') >= 0 || text.IndexOf('\r') >= 0;
         }
 
         internal Dictionary<string, int> GetSharedStringIndices(IEnumerable<string> texts, bool assumeDistinct = false) {
@@ -676,6 +743,53 @@ namespace OfficeIMO.Excel {
                     _sharedStringCache[text] = newIndex;
                     result[text] = newIndex;
                     changed = true;
+                }
+
+                _sharedStringTableCount = tableCount;
+
+                if (changed) {
+                    _sharedStringTableDirty = true;
+                    MarkPackageDirty();
+                }
+
+                return result;
+            }
+        }
+
+        internal int[] GetSharedStringIndexArray(IReadOnlyList<string> texts, bool assumeDistinct = false) {
+            if (texts == null) {
+                throw new ArgumentNullException(nameof(texts));
+            }
+
+            if (texts.Count == 0) {
+                return Array.Empty<int>();
+            }
+
+            lock (_sharedStringLock) {
+                var sharedStringTable = SharedStringTablePart.SharedStringTable ??= new SharedStringTable();
+                int tableCount = EnsureSharedStringCacheAndCount(sharedStringTable);
+                var result = new int[texts.Count];
+                Dictionary<string, int>? localIndexes = assumeDistinct
+                    ? null
+                    : new Dictionary<string, int>(texts.Count, StringComparer.Ordinal);
+                bool changed = false;
+
+                for (int i = 0; i < texts.Count; i++) {
+                    string text = texts[i];
+                    if (localIndexes != null && localIndexes.TryGetValue(text, out int duplicateIndex)) {
+                        result[i] = duplicateIndex;
+                        continue;
+                    }
+
+                    if (!_sharedStringCache.TryGetValue(text, out int sharedStringIndex)) {
+                        sharedStringIndex = tableCount++;
+                        sharedStringTable.AppendChild(new SharedStringItem(new Text(text)));
+                        _sharedStringCache[text] = sharedStringIndex;
+                        changed = true;
+                    }
+
+                    result[i] = sharedStringIndex;
+                    localIndexes?.Add(text, sharedStringIndex);
                 }
 
                 _sharedStringTableCount = tableCount;

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -70,7 +70,7 @@ namespace OfficeIMO.Excel {
             cell.CellValue = cellValue;
             cell.DataType = dataType;
             ApplyAutomaticCellFormatting(cell, value, dataType);
-            ClearHeaderCache();
+            ClearHeaderCacheForCellMutation(row);
         }
 
         private void CellStringValueCore(int row, int column, string? value) {
@@ -79,18 +79,22 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
-            CoerceValueHelper.ValidateSharedStringLength(value, nameof(value));
-            int sharedStringIndex = _excelDocument.GetSharedStringIndex(value);
+            int sharedStringIndex = _excelDocument.GetSharedStringIndex(value, validateNewString: true, out bool containsLineBreak);
 
             var cell = GetCell(row, column);
-            SetExistingCellSharedStringValue(cell, value, sharedStringIndex);
-            ClearHeaderCache();
+            SetExistingCellSharedStringValue(cell, sharedStringIndex, containsLineBreak);
+            ClearHeaderCacheForCellMutation(row);
         }
 
         private void SetExistingCellSharedStringValue(Cell cell, string value, int sharedStringIndex) {
+            SetExistingCellSharedStringValue(cell, sharedStringIndex, value.IndexOf('\n') >= 0 || value.IndexOf('\r') >= 0);
+        }
+
+        private void SetExistingCellSharedStringValue(Cell cell, int sharedStringIndex, bool containsLineBreak) {
             cell.CellValue = new CellValue(GetSharedStringIndexText(sharedStringIndex));
             cell.DataType = DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString;
-            if (value.IndexOf('\n') >= 0 || value.IndexOf('\r') >= 0) {
+            cell.InlineString = null;
+            if (containsLineBreak) {
                 ApplyWrapText(cell);
             }
         }
@@ -115,28 +119,28 @@ namespace OfficeIMO.Excel {
             var cell = GetCell(row, column);
             cell.CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture));
             cell.DataType = DocumentFormat.OpenXml.Spreadsheet.CellValues.Number;
-            ClearHeaderCache();
+            ClearHeaderCacheForCellMutation(row);
         }
 
         private void CellDecimalValueCore(int row, int column, decimal value) {
             var cell = GetCell(row, column);
             cell.CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture));
             cell.DataType = DocumentFormat.OpenXml.Spreadsheet.CellValues.Number;
-            ClearHeaderCache();
+            ClearHeaderCacheForCellMutation(row);
         }
 
         private void CellNumberTextValueCore(int row, int column, string text) {
             var cell = GetCell(row, column);
             cell.CellValue = new CellValue(text);
             cell.DataType = DocumentFormat.OpenXml.Spreadsheet.CellValues.Number;
-            ClearHeaderCache();
+            ClearHeaderCacheForCellMutation(row);
         }
 
         private void CellBooleanValueCore(int row, int column, bool value) {
             var cell = GetCell(row, column);
             cell.CellValue = new CellValue(value ? "1" : "0");
             cell.DataType = DocumentFormat.OpenXml.Spreadsheet.CellValues.Boolean;
-            ClearHeaderCache();
+            ClearHeaderCacheForCellMutation(row);
         }
 
         private void CellDateTimeValueCore(int row, int column, DateTime value) {
@@ -148,7 +152,7 @@ namespace OfficeIMO.Excel {
             cell.StyleIndex = baseStyleIndex == 0U
                 ? (_cellValueDefaultDateStyleIndex ??= GetOrCreateBuiltInNumberFormatStyleIndex(0U, 14))
                 : GetOrAddBuiltInNumberFormatStyleIndex(ref _cellValueDateStyleIndexes, baseStyleIndex, 14);
-            ClearHeaderCache();
+            ClearHeaderCacheForCellMutation(row);
         }
 
         private void CellDateTimeOffsetValueCore(int row, int column, DateTimeOffset value) {
@@ -172,7 +176,7 @@ namespace OfficeIMO.Excel {
                     : GetOrAddBuiltInNumberFormatStyleIndex(ref _cellValueDateStyleIndexes, baseStyleIndex, 14);
             }
 
-            ClearHeaderCache();
+            ClearHeaderCacheForCellMutation(row);
         }
 
         private void CellFormulaCore(int row, int column, string formula) {
@@ -180,7 +184,7 @@ namespace OfficeIMO.Excel {
             // Excel formulas in XML should not start with '=' and must not include illegal control characters
             var safe = Utilities.ExcelSanitizer.SanitizeFormula(formula);
             cell.CellFormula = new CellFormula(safe);
-            ClearHeaderCache();
+            ClearHeaderCacheForCellMutation(row);
         }
 
         private void CellTimeSpanValueCore(int row, int column, TimeSpan value) {
@@ -192,7 +196,7 @@ namespace OfficeIMO.Excel {
             cell.StyleIndex = baseStyleIndex == 0U
                 ? (_cellValueDefaultDurationStyleIndex ??= GetOrCreateBuiltInNumberFormatStyleIndex(0U, 46))
                 : GetOrAddBuiltInNumberFormatStyleIndex(ref _cellValueDurationStyleIndexes, baseStyleIndex, 46);
-            ClearHeaderCache();
+            ClearHeaderCacheForCellMutation(row);
         }
 
         // Core coercion logic shared between sequential and parallel operations
@@ -478,7 +482,7 @@ namespace OfficeIMO.Excel {
                     MaterializeDeferredDataSetImportIfNeeded();
                 }
 
-                var cell = GetCell(row, column);
+                var cell = TryGetCell(row, column);
                 if (cell == null) return false;
                 // Resolve shared string if needed
                 if (cell.DataType != null && cell.DataType.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString) {
@@ -904,6 +908,38 @@ namespace OfficeIMO.Excel {
             stylesPart.Stylesheet.Save();
         }
 
+        private void FillRangeCore(int firstRow, int firstColumn, int lastRow, int lastColumn, string hexColor) {
+            var workbookPart = _excelDocument.WorkbookPartRoot ?? throw new InvalidOperationException("WorkbookPart is null");
+            var stylesPart = workbookPart.WorkbookStylesPart;
+            if (stylesPart == null)
+                stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+
+            var stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
+            EnsureDefaultStylePrimitives(stylesheet);
+
+            string argb = NormalizeHexColor(hexColor);
+            var fill = new Fill(new PatternFill {
+                PatternType = PatternValues.Solid,
+                ForegroundColor = new ForegroundColor { Rgb = argb },
+                BackgroundColor = new BackgroundColor { Rgb = argb }
+            });
+            uint fillId = GetOrCreateFill(stylesheet, fill);
+            var styleIndexes = new Dictionary<uint, uint>();
+
+            for (int row = firstRow; row <= lastRow; row++) {
+                for (int column = firstColumn; column <= lastColumn; column++) {
+                    Cell cell = GetCell(row, column);
+                    uint baseStyleIndex = cell.StyleIndex?.Value ?? 0U;
+                    cell.StyleIndex = GetOrAddCellFormatOverride(styleIndexes, stylesheet, baseStyleIndex, format => {
+                        format.FillId = fillId;
+                        format.ApplyFill = true;
+                    });
+                }
+            }
+
+            stylesPart.Stylesheet.Save();
+        }
+
         private void ApplyBuiltInNumberFormat(int row, int column, uint builtInFormatId) {
             Cell cell = GetCell(row, column);
             ApplyBuiltInNumberFormat(cell, builtInFormatId);
@@ -938,29 +974,39 @@ namespace OfficeIMO.Excel {
             Stylesheet stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
             EnsureDefaultStylePrimitives(stylesheet);
 
-            stylesheet.NumberingFormats ??= new NumberingFormats();
-            NumberingFormat? existingFormat = stylesheet.NumberingFormats.Elements<NumberingFormat>()
-                .FirstOrDefault(n => n.FormatCode != null && n.FormatCode.Value == numberFormat);
-
-            uint numberFormatId;
-            if (existingFormat != null) {
-                numberFormatId = existingFormat.NumberFormatId!.Value;
-            } else {
-                numberFormatId = stylesheet.NumberingFormats.Elements<NumberingFormat>().Any()
-                    ? stylesheet.NumberingFormats.Elements<NumberingFormat>().Max(n => n.NumberFormatId!.Value) + 1
-                    : 164U;
-                NumberingFormat numberingFormat = new NumberingFormat {
-                    NumberFormatId = numberFormatId,
-                    FormatCode = StringValue.FromString(numberFormat)
-                };
-                stylesheet.NumberingFormats.Append(numberingFormat);
-                stylesheet.NumberingFormats.Count = (uint)stylesheet.NumberingFormats.Count();
-            }
+            uint numberFormatId = GetOrCreateNumberFormatId(stylesheet, numberFormat);
 
             ApplyCellFormatOverride(stylesheet, cell, format => {
                 format.NumberFormatId = numberFormatId;
                 format.ApplyNumberFormat = true;
             });
+            stylesPart.Stylesheet.Save();
+        }
+
+        private void FormatRangeCore(int firstRow, int firstColumn, int lastRow, int lastColumn, string numberFormat) {
+            var workbookPart = _excelDocument.WorkbookPartRoot ?? throw new InvalidOperationException("WorkbookPart is null");
+            WorkbookStylesPart? stylesPart = workbookPart.WorkbookStylesPart;
+            if (stylesPart == null) {
+                stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+            }
+
+            Stylesheet stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
+            EnsureDefaultStylePrimitives(stylesheet);
+
+            uint numberFormatId = GetOrCreateNumberFormatId(stylesheet, numberFormat);
+            var styleIndexes = new Dictionary<uint, uint>();
+
+            for (int row = firstRow; row <= lastRow; row++) {
+                for (int column = firstColumn; column <= lastColumn; column++) {
+                    Cell cell = GetCell(row, column);
+                    uint baseStyleIndex = cell.StyleIndex?.Value ?? 0U;
+                    cell.StyleIndex = GetOrAddCellFormatOverride(styleIndexes, stylesheet, baseStyleIndex, format => {
+                        format.NumberFormatId = numberFormatId;
+                        format.ApplyNumberFormat = true;
+                    });
+                }
+            }
+
             stylesPart.Stylesheet.Save();
         }
 
@@ -984,6 +1030,21 @@ namespace OfficeIMO.Excel {
             var baseFormat = GetBaseCellFormat(stylesheet, cell.StyleIndex?.Value ?? 0U);
             mutate(baseFormat);
             cell.StyleIndex = AppendOrReuseCellFormat(stylesheet, baseFormat);
+        }
+
+        private static uint GetOrAddCellFormatOverride(
+            Dictionary<uint, uint> styleIndexes,
+            Stylesheet stylesheet,
+            uint baseStyleIndex,
+            Action<CellFormat> mutate) {
+            if (!styleIndexes.TryGetValue(baseStyleIndex, out uint styleIndex)) {
+                var format = GetBaseCellFormat(stylesheet, baseStyleIndex);
+                mutate(format);
+                styleIndex = AppendOrReuseCellFormat(stylesheet, format);
+                styleIndexes.Add(baseStyleIndex, styleIndex);
+            }
+
+            return styleIndex;
         }
 
         private static uint AppendOrReuseCellFormat(Stylesheet stylesheet, CellFormat candidate) {
@@ -1012,6 +1073,27 @@ namespace OfficeIMO.Excel {
             fills.Append(candidate);
             fills.Count = (uint)fills.Count();
             return fills.Count!.Value - 1;
+        }
+
+        private static uint GetOrCreateNumberFormatId(Stylesheet stylesheet, string numberFormat) {
+            stylesheet.NumberingFormats ??= new NumberingFormats();
+            NumberingFormat? existingFormat = stylesheet.NumberingFormats.Elements<NumberingFormat>()
+                .FirstOrDefault(n => n.FormatCode != null && n.FormatCode.Value == numberFormat);
+
+            if (existingFormat != null) {
+                return existingFormat.NumberFormatId!.Value;
+            }
+
+            uint numberFormatId = stylesheet.NumberingFormats.Elements<NumberingFormat>().Any()
+                ? stylesheet.NumberingFormats.Elements<NumberingFormat>().Max(n => n.NumberFormatId!.Value) + 1
+                : 164U;
+            NumberingFormat numberingFormat = new NumberingFormat {
+                NumberFormatId = numberFormatId,
+                FormatCode = StringValue.FromString(numberFormat)
+            };
+            stylesheet.NumberingFormats.Append(numberingFormat);
+            stylesheet.NumberingFormats.Count = (uint)stylesheet.NumberingFormats.Count();
+            return numberFormatId;
         }
 
         private static uint GetOrCreateBorderVariant(Stylesheet stylesheet, uint? baseBorderId, Action<Border> mutate) {

--- a/OfficeIMO.Excel/ExcelSheet.Comments.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Comments.cs
@@ -75,11 +75,16 @@ namespace OfficeIMO.Excel {
                     return;
                 }
 
-                RemoveCommentInternal(commentsPart.Comments.CommentList, reference);
-                commentsPart.Comments.Save();
+                bool removedComment = RemoveCommentInternal(commentsPart.Comments.CommentList, reference);
+                if (removedComment) {
+                    commentsPart.Comments.Save();
+                }
+
                 RemoveCommentVmlShape(row, column);
-                CleanupCommentArtifacts();
-                WorksheetRoot.Save();
+                bool removedArtifacts = CleanupCommentArtifacts();
+                if (removedArtifacts) {
+                    WorksheetRoot.Save();
+                }
             });
         }
 
@@ -127,10 +132,15 @@ namespace OfficeIMO.Excel {
             return (uint)idx;
         }
 
-        private static void RemoveCommentInternal(CommentList list, string reference) {
+        private static bool RemoveCommentInternal(CommentList list, string reference) {
             var existing = list.Elements<Comment>()
                 .FirstOrDefault(c => string.Equals(c.Reference?.Value, reference, StringComparison.OrdinalIgnoreCase));
-            existing?.Remove();
+            if (existing == null) {
+                return false;
+            }
+
+            existing.Remove();
+            return true;
         }
 
         private static CommentText BuildCommentText(string text) {
@@ -192,18 +202,20 @@ namespace OfficeIMO.Excel {
             SaveVmlDocument(vmlPart, doc);
         }
 
-        private void RemoveCommentVmlShape(int row, int column) {
+        private bool RemoveCommentVmlShape(int row, int column) {
             var vmlPart = TryGetCommentVmlPart();
-            if (vmlPart == null) return;
+            if (vmlPart == null) return false;
 
             var doc = LoadOrCreateVmlDocument(vmlPart);
             var root = doc.Root;
-            if (root == null) return;
+            if (root == null) return false;
 
             bool removed = RemoveVmlShape(root, row, column);
             if (removed) {
                 SaveVmlDocument(vmlPart, doc);
             }
+
+            return removed;
         }
 
         private static bool RemoveVmlShape(XElement root, int row, int column) {
@@ -212,16 +224,14 @@ namespace OfficeIMO.Excel {
             string rowText = (row - 1).ToString(CultureInfo.InvariantCulture);
             string colText = (column - 1).ToString(CultureInfo.InvariantCulture);
 
+            if (!VmlShapesContainCell(root, v, x, rowText, colText)) {
+                return false;
+            }
+
             var shapes = root.Elements(v + "shape").ToList();
             bool removed = false;
             foreach (var shape in shapes) {
-                var clientData = shape.Element(x + "ClientData");
-                if (clientData == null) continue;
-                var rowEl = clientData.Element(x + "Row");
-                var colEl = clientData.Element(x + "Column");
-                if (rowEl != null && colEl != null
-                    && string.Equals(rowEl.Value?.Trim(), rowText, StringComparison.OrdinalIgnoreCase)
-                    && string.Equals(colEl.Value?.Trim(), colText, StringComparison.OrdinalIgnoreCase)) {
+                if (VmlShapeMatchesCell(shape, x, rowText, colText)) {
                     shape.Remove();
                     removed = true;
                 }
@@ -229,18 +239,120 @@ namespace OfficeIMO.Excel {
             return removed;
         }
 
-        internal void CleanupCommentArtifacts() {
+        private static bool VmlShapesContainCell(XElement root, XNamespace v, XNamespace x, string rowText, string colText) {
+            foreach (var shape in root.Elements(v + "shape")) {
+                if (VmlShapeMatchesCell(shape, x, rowText, colText)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool VmlShapeMatchesCell(XElement shape, XNamespace x, string rowText, string colText) {
+            var clientData = shape.Element(x + "ClientData");
+            if (clientData == null) return false;
+            var rowEl = clientData.Element(x + "Row");
+            var colEl = clientData.Element(x + "Column");
+            return rowEl != null
+                && colEl != null
+                && string.Equals(rowEl.Value?.Trim(), rowText, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(colEl.Value?.Trim(), colText, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private bool RemoveCommentVmlShapesInRange(int firstRow, int firstColumn, int lastRow, int lastColumn) {
+            var vmlPart = TryGetCommentVmlPart();
+            if (vmlPart == null) return false;
+
+            var doc = LoadOrCreateVmlDocument(vmlPart);
+            var root = doc.Root;
+            if (root == null) return false;
+
+            if (RemoveVmlShapesInRange(root, firstRow, firstColumn, lastRow, lastColumn)) {
+                SaveVmlDocument(vmlPart, doc);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool RemoveVmlShapesInRange(XElement root, int firstRow, int firstColumn, int lastRow, int lastColumn) {
+            var v = XNamespace.Get("urn:schemas-microsoft-com:vml");
+            var x = XNamespace.Get("urn:schemas-microsoft-com:office:excel");
+            int firstZeroBasedRow = firstRow - 1;
+            int lastZeroBasedRow = lastRow - 1;
+            int firstZeroBasedColumn = firstColumn - 1;
+            int lastZeroBasedColumn = lastColumn - 1;
+            bool removed = false;
+
+            if (!VmlShapesOverlapRange(root, firstZeroBasedRow, firstZeroBasedColumn, lastZeroBasedRow, lastZeroBasedColumn)) {
+                return false;
+            }
+
+            foreach (var shape in root.Elements(v + "shape").ToList()) {
+                var clientData = shape.Element(x + "ClientData");
+                if (clientData == null) continue;
+
+                if (!TryParseVmlCoordinate(clientData.Element(x + "Row")?.Value, out int row)
+                    || !TryParseVmlCoordinate(clientData.Element(x + "Column")?.Value, out int column)) {
+                    continue;
+                }
+
+                if (row >= firstZeroBasedRow
+                    && row <= lastZeroBasedRow
+                    && column >= firstZeroBasedColumn
+                    && column <= lastZeroBasedColumn) {
+                    shape.Remove();
+                    removed = true;
+                }
+            }
+
+            return removed;
+        }
+
+        private static bool VmlShapesOverlapRange(XElement root, int firstZeroBasedRow, int firstZeroBasedColumn, int lastZeroBasedRow, int lastZeroBasedColumn) {
+            var v = XNamespace.Get("urn:schemas-microsoft-com:vml");
+            var x = XNamespace.Get("urn:schemas-microsoft-com:office:excel");
+
+            foreach (var shape in root.Elements(v + "shape")) {
+                var clientData = shape.Element(x + "ClientData");
+                if (clientData == null) continue;
+
+                if (!TryParseVmlCoordinate(clientData.Element(x + "Row")?.Value, out int row)
+                    || !TryParseVmlCoordinate(clientData.Element(x + "Column")?.Value, out int column)) {
+                    continue;
+                }
+
+                if (row >= firstZeroBasedRow
+                    && row <= lastZeroBasedRow
+                    && column >= firstZeroBasedColumn
+                    && column <= lastZeroBasedColumn) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryParseVmlCoordinate(string? text, out int value) {
+            value = 0;
+            return int.TryParse(text?.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+        }
+
+        internal bool CleanupCommentArtifacts() {
             var ws = WorksheetRoot;
             var commentsPart = WorksheetCommentsPartRoot;
             bool hasComments = commentsPart?.Comments?.CommentList?.Elements<Comment>().Any() is true;
+            bool changed = false;
 
             if (!hasComments && commentsPart != null) {
                 _worksheetPart.DeletePart(commentsPart);
+                changed = true;
             }
 
             var legacy = ws.GetFirstChild<LegacyDrawing>();
             if (legacy?.Id?.Value is not string legacyRelId || string.IsNullOrWhiteSpace(legacyRelId)) {
-                return;
+                return changed;
             }
 
             OpenXmlPart? legacyPart = null;
@@ -248,13 +360,16 @@ namespace OfficeIMO.Excel {
                 legacyPart = _worksheetPart.GetPartById(legacyRelId);
             } catch {
                 ws.RemoveChild(legacy);
-                return;
+                return true;
             }
 
             if (!hasComments && legacyPart is VmlDrawingPart vmlPart) {
                 _worksheetPart.DeletePart(vmlPart);
                 ws.RemoveChild(legacy);
+                changed = true;
             }
+
+            return changed;
         }
 
         private VmlDrawingPart GetOrCreateCommentVmlPart() {

--- a/OfficeIMO.Excel/ExcelSheet.Core.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Core.cs
@@ -342,9 +342,6 @@ namespace OfficeIMO.Excel {
                             break;
                         }
 
-                        if (nextRowIndex > row) {
-                            break;
-                        }
                     }
                 }
             }
@@ -361,9 +358,6 @@ namespace OfficeIMO.Excel {
                         break;
                     }
 
-                    if (rowIndex > (uint)row) {
-                        return null;
-                    }
                 }
             }
 
@@ -393,12 +387,7 @@ namespace OfficeIMO.Excel {
                             return next;
                         }
 
-                        if (nextColumnIndex > targetColumnIndex) {
-                            return null;
-                        }
                     }
-
-                    return null;
                 }
             }
 
@@ -413,9 +402,6 @@ namespace OfficeIMO.Excel {
                     return cell;
                 }
 
-                if (existingColumnIndex > targetColumnIndex) {
-                    return null;
-                }
             }
 
             return null;

--- a/OfficeIMO.Excel/ExcelSheet.Core.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Core.cs
@@ -230,11 +230,7 @@ namespace OfficeIMO.Excel {
             if (createdRowElement) {
                 Cell createdCell = new Cell { CellReference = BuildCellReference(row, column) };
                 rowElement.Append(createdCell);
-                _lastAccessedRow = rowElement;
-                _lastAccessedRowIndex = row;
-                _lastAccessedCell = createdCell;
-                _lastAccessedCellRowIndex = row;
-                _lastAccessedCellColumnIndex = column;
+                CacheLastAccessedCell(rowElement, row, column, createdCell);
                 return createdCell;
             }
 
@@ -313,12 +309,128 @@ namespace OfficeIMO.Excel {
                 }
             }
 
+            CacheLastAccessedCell(rowElement, row, column, cell);
+            return cell;
+        }
+
+        private Cell? TryGetCell(int row, int column) {
+            if (row <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(row));
+            }
+            if (column <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(column));
+            }
+
+            SheetData? sheetData = WorksheetRoot.GetFirstChild<SheetData>();
+            if (sheetData == null) {
+                return null;
+            }
+
+            Row? rowElement = null;
+            if (_lastAccessedRow != null && ReferenceEquals(_lastAccessedRow.Parent, sheetData)) {
+                if (_lastAccessedRowIndex == row) {
+                    rowElement = _lastAccessedRow;
+                } else if (_lastAccessedRowIndex < row) {
+                    for (Row? next = _lastAccessedRow.NextSibling<Row>(); next != null; next = next.NextSibling<Row>()) {
+                        if (next.RowIndex == null) {
+                            continue;
+                        }
+
+                        int nextRowIndex = (int)next.RowIndex.Value;
+                        if (nextRowIndex == row) {
+                            rowElement = next;
+                            break;
+                        }
+
+                        if (nextRowIndex > row) {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (rowElement == null) {
+                foreach (Row r in sheetData.Elements<Row>()) {
+                    if (r.RowIndex == null) {
+                        continue;
+                    }
+
+                    uint rowIndex = r.RowIndex.Value;
+                    if (rowIndex == (uint)row) {
+                        rowElement = r;
+                        break;
+                    }
+
+                    if (rowIndex > (uint)row) {
+                        return null;
+                    }
+                }
+            }
+
+            if (rowElement == null) {
+                return null;
+            }
+
+            CacheLastAccessedRow(rowElement, row);
+
+            int targetColumnIndex = column;
+            if (_lastAccessedCell != null
+                && _lastAccessedCellRowIndex == row
+                && ReferenceEquals(_lastAccessedCell.Parent, rowElement)) {
+                if (_lastAccessedCellColumnIndex == targetColumnIndex) {
+                    return _lastAccessedCell;
+                }
+
+                if (_lastAccessedCellColumnIndex < targetColumnIndex) {
+                    for (Cell? next = _lastAccessedCell.NextSibling<Cell>(); next != null; next = next.NextSibling<Cell>()) {
+                        if (next.CellReference?.Value is not string nextRefValue || nextRefValue.Length == 0) {
+                            continue;
+                        }
+
+                        int nextColumnIndex = GetColumnIndex(nextRefValue);
+                        if (nextColumnIndex == targetColumnIndex) {
+                            CacheLastAccessedCell(rowElement, row, column, next);
+                            return next;
+                        }
+
+                        if (nextColumnIndex > targetColumnIndex) {
+                            return null;
+                        }
+                    }
+
+                    return null;
+                }
+            }
+
+            foreach (Cell cell in rowElement.Elements<Cell>()) {
+                if (cell.CellReference?.Value is not string existingRefValue || existingRefValue.Length == 0) {
+                    continue;
+                }
+
+                int existingColumnIndex = GetColumnIndex(existingRefValue);
+                if (existingColumnIndex == targetColumnIndex) {
+                    CacheLastAccessedCell(rowElement, row, column, cell);
+                    return cell;
+                }
+
+                if (existingColumnIndex > targetColumnIndex) {
+                    return null;
+                }
+            }
+
+            return null;
+        }
+
+        private void CacheLastAccessedRow(Row rowElement, int row) {
             _lastAccessedRow = rowElement;
             _lastAccessedRowIndex = row;
+        }
+
+        private void CacheLastAccessedCell(Row rowElement, int row, int column, Cell cell) {
+            CacheLastAccessedRow(rowElement, row);
             _lastAccessedCell = cell;
             _lastAccessedCellRowIndex = row;
             _lastAccessedCellColumnIndex = column;
-            return cell;
         }
 
         private SheetData GetOrCreateSheetData() {

--- a/OfficeIMO.Excel/ExcelSheet.DataOperations.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataOperations.cs
@@ -1,6 +1,7 @@
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System.Globalization;
+using System.Text;
 
 namespace OfficeIMO.Excel {
     /// <summary>
@@ -288,10 +289,16 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public string? FindFirst(string text) {
             if (string.IsNullOrEmpty(text)) return null;
+            if (TryGetFindFirstCache(text, out string? cachedAddress)) {
+                return cachedAddress;
+            }
 
             var ws = WorksheetRoot;
             var sd = ws.GetFirstChild<SheetData>();
-            if (sd == null) return null;
+            if (sd == null) {
+                SetFindFirstCache(text, null);
+                return null;
+            }
 
             var sharedStringCache = BuildCellTextSharedStringSnapshot();
             var sharedStringMatches = sharedStringCache.FindIndexesContaining(text, StringComparison.OrdinalIgnoreCase);
@@ -300,6 +307,7 @@ namespace OfficeIMO.Excel {
                     if (TryGetSharedStringCellIndex(cell, out int sharedStringIndex)) {
                         if (sharedStringMatches != null && sharedStringMatches.Contains(sharedStringIndex)) {
                             string? address = cell.CellReference?.Value;
+                            SetFindFirstCache(text, address);
                             return address;
                         }
 
@@ -309,11 +317,13 @@ namespace OfficeIMO.Excel {
                     var t = GetCellText(cell);
                     if (!string.IsNullOrEmpty(t) && t.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0) {
                         string? address = cell.CellReference?.Value;
+                        SetFindFirstCache(text, address);
                         return address;
                     }
                 }
             }
 
+            SetFindFirstCache(text, null);
             return null;
         }
 
@@ -333,25 +343,50 @@ namespace OfficeIMO.Excel {
                 var sharedStringMatches = sharedStringCache.FindIndexesContaining(oldText, StringComparison.OrdinalIgnoreCase);
                 int replacementCapacity = sharedStringMatches?.Count ?? 0;
                 var replacements = replacementCapacity > 0
-                    ? new List<(Cell Cell, string Text)>(replacementCapacity)
-                    : new List<(Cell Cell, string Text)>();
+                    ? new List<(Cell Cell, int TextIndex)>(replacementCapacity)
+                    : new List<(Cell Cell, int TextIndex)>();
                 var distinctReplacementTexts = replacementCapacity > 0
                     ? new List<string>(replacementCapacity)
                     : new List<string>();
-                var distinctReplacementLookup = new HashSet<string>(StringComparer.Ordinal);
+                var distinctReplacementLookup = replacementCapacity > 0
+                    ? new Dictionary<string, int>(replacementCapacity, StringComparer.Ordinal)
+                    : new Dictionary<string, int>(StringComparer.Ordinal);
+                Dictionary<int, int>? sharedStringReplacementIndexes = null;
+                if (sharedStringMatches != null) {
+                    sharedStringReplacementIndexes = new Dictionary<int, int>(sharedStringMatches.Count);
+                    foreach (int sharedStringIndex in sharedStringMatches) {
+                        string? current = sharedStringCache.Get(sharedStringIndex);
+                        if (string.IsNullOrEmpty(current)) {
+                            continue;
+                        }
+
+                        string replaced = ReplaceIgnoreCase(current!, oldText, newText);
+                        int replacementTextIndex = GetOrAddReplacementTextIndex(
+                            replaced,
+                            distinctReplacementTexts,
+                            distinctReplacementLookup,
+                            nameof(newText));
+                        sharedStringReplacementIndexes.Add(sharedStringIndex, replacementTextIndex);
+                    }
+                }
+
                 foreach (var row in sd.Elements<Row>()) {
                     foreach (var cell in row.Elements<Cell>()) {
                         string? current;
                         bool currentContainsOldText;
                         if (TryGetSharedStringCellIndex(cell, out int sharedStringIndex)) {
-                            if (sharedStringMatches == null || !sharedStringMatches.Contains(sharedStringIndex)) {
+                            if (sharedStringReplacementIndexes == null
+                                || !sharedStringReplacementIndexes.TryGetValue(sharedStringIndex, out int replacementTextIndex)) {
                                 continue;
                             }
 
-                            current = sharedStringCache.Get(sharedStringIndex);
-                            currentContainsOldText = true;
+                            replacements.Add((cell, replacementTextIndex));
+                            continue;
                         } else {
-                            current = GetCellText(cell);
+                            if (!TryGetReplaceableCellText(cell, out current)) {
+                                continue;
+                            }
+
                             currentContainsOldText = !string.IsNullOrEmpty(current)
                                 && current!.IndexOf(oldText, StringComparison.OrdinalIgnoreCase) >= 0;
                         }
@@ -360,19 +395,21 @@ namespace OfficeIMO.Excel {
                         string currentText = current!;
                         if (currentContainsOldText) {
                             var replaced = ReplaceIgnoreCase(currentText, oldText, newText);
-                            if (distinctReplacementLookup.Add(replaced)) {
-                                CoerceValueHelper.ValidateSharedStringLength(replaced, nameof(newText));
-                                distinctReplacementTexts.Add(replaced);
-                            }
+                            int replacementTextIndex = GetOrAddReplacementTextIndex(
+                                replaced,
+                                distinctReplacementTexts,
+                                distinctReplacementLookup,
+                                nameof(newText));
 
-                            replacements.Add((cell, replaced));
+                            replacements.Add((cell, replacementTextIndex));
                         }
                     }
                 }
                 if (replacements.Count > 0) {
-                    var replacementIndexes = _excelDocument.GetSharedStringIndices(distinctReplacementTexts, assumeDistinct: true);
+                    var replacementIndexes = _excelDocument.GetSharedStringIndexArray(distinctReplacementTexts, assumeDistinct: true);
                     foreach (var replacement in replacements) {
-                        SetExistingCellSharedStringValue(replacement.Cell, replacement.Text, replacementIndexes[replacement.Text]);
+                        string replacementText = distinctReplacementTexts[replacement.TextIndex];
+                        SetExistingCellSharedStringValue(replacement.Cell, replacementText, replacementIndexes[replacement.TextIndex]);
                     }
 
                     count = replacements.Count;
@@ -383,10 +420,72 @@ namespace OfficeIMO.Excel {
             return count;
         }
 
+        private static int GetOrAddReplacementTextIndex(
+            string replaced,
+            List<string> distinctReplacementTexts,
+            Dictionary<string, int> distinctReplacementLookup,
+            string paramName) {
+            if (!distinctReplacementLookup.TryGetValue(replaced, out int replacementTextIndex)) {
+                CoerceValueHelper.ValidateSharedStringLength(replaced, paramName);
+                replacementTextIndex = distinctReplacementTexts.Count;
+                distinctReplacementTexts.Add(replaced);
+                distinctReplacementLookup.Add(replaced, replacementTextIndex);
+            }
+
+            return replacementTextIndex;
+        }
+
         private static bool TryGetSharedStringCellIndex(Cell cell, out int index) {
             index = 0;
             return cell.DataType?.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString
                 && TryParseCellTextSharedStringIndex(cell.CellValue?.InnerText ?? cell.InnerText, out index);
+        }
+
+        private static bool TryGetReplaceableCellText(Cell cell, out string? text) {
+            var dataType = cell.DataType?.Value;
+            if (dataType == DocumentFormat.OpenXml.Spreadsheet.CellValues.InlineString
+                || dataType == DocumentFormat.OpenXml.Spreadsheet.CellValues.String) {
+                text = cell.DataType?.Value == DocumentFormat.OpenXml.Spreadsheet.CellValues.InlineString
+                    ? ExtractReplaceableInlineString(cell)
+                    : cell.CellValue?.InnerText ?? cell.InnerText;
+                return true;
+            }
+
+            if (cell.InlineString != null) {
+                text = ExtractReplaceableInlineString(cell);
+                return true;
+            }
+
+            text = null;
+            return false;
+        }
+
+        private static string ExtractReplaceableInlineString(Cell cell) {
+            var inline = cell.InlineString;
+            if (inline == null) {
+                return string.Empty;
+            }
+
+            if (inline.Text != null) {
+                return inline.Text.Text ?? string.Empty;
+            }
+
+            string? first = null;
+            StringBuilder? builder = null;
+            foreach (var run in inline.Elements<Run>()) {
+                string value = run.Text?.Text ?? string.Empty;
+                if (builder != null) {
+                    builder.Append(value);
+                } else if (first == null) {
+                    first = value;
+                } else {
+                    builder = new StringBuilder(first.Length + value.Length);
+                    builder.Append(first);
+                    builder.Append(value);
+                }
+            }
+
+            return builder?.ToString() ?? first ?? string.Empty;
         }
 
         private static string ReplaceIgnoreCase(string input, string oldValue, string newValue) {

--- a/OfficeIMO.Excel/ExcelSheet.DataOperations.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataOperations.cs
@@ -289,6 +289,7 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public string? FindFirst(string text) {
             if (string.IsNullOrEmpty(text)) return null;
+            // Text-mutating paths must clear this cache before rendered cell text changes.
             if (TryGetFindFirstCache(text, out string? cachedAddress)) {
                 return cachedAddress;
             }

--- a/OfficeIMO.Excel/ExcelSheet.DataOperations.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataOperations.cs
@@ -290,14 +290,15 @@ namespace OfficeIMO.Excel {
         public string? FindFirst(string text) {
             if (string.IsNullOrEmpty(text)) return null;
             // Text-mutating paths must clear this cache before rendered cell text changes.
-            if (TryGetFindFirstCache(text, out string? cachedAddress)) {
+            bool canUseCache = !_hasWorksheetMutations;
+            if (canUseCache && TryGetFindFirstCache(text, out string? cachedAddress)) {
                 return cachedAddress;
             }
 
             var ws = WorksheetRoot;
             var sd = ws.GetFirstChild<SheetData>();
             if (sd == null) {
-                SetFindFirstCache(text, null);
+                SetFindFirstCacheIfAllowed(null);
                 return null;
             }
 
@@ -308,7 +309,7 @@ namespace OfficeIMO.Excel {
                     if (TryGetSharedStringCellIndex(cell, out int sharedStringIndex)) {
                         if (sharedStringMatches != null && sharedStringMatches.Contains(sharedStringIndex)) {
                             string? address = cell.CellReference?.Value;
-                            SetFindFirstCache(text, address);
+                            SetFindFirstCacheIfAllowed(address);
                             return address;
                         }
 
@@ -318,14 +319,20 @@ namespace OfficeIMO.Excel {
                     var t = GetCellText(cell);
                     if (!string.IsNullOrEmpty(t) && t.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0) {
                         string? address = cell.CellReference?.Value;
-                        SetFindFirstCache(text, address);
+                        SetFindFirstCacheIfAllowed(address);
                         return address;
                     }
                 }
             }
 
-            SetFindFirstCache(text, null);
+            SetFindFirstCacheIfAllowed(null);
             return null;
+
+            void SetFindFirstCacheIfAllowed(string? address) {
+                if (canUseCache) {
+                    SetFindFirstCache(text, address);
+                }
+            }
         }
 
         /// <summary>

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.cs
@@ -43,7 +43,9 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (changed) {
-                    ClearFindFirstCache();
+                    _hasWorksheetMutations = true;
+                    MarkRequiresSavePreparation();
+                    ClearCellTextSharedStringCache();
                 }
 
                 WorksheetRoot.Save();
@@ -66,7 +68,9 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (count > 0) {
-                    ClearFindFirstCache();
+                    _hasWorksheetMutations = true;
+                    MarkRequiresSavePreparation();
+                    ClearCellTextSharedStringCache();
                 }
 
                 WorksheetRoot.Save();

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.cs
@@ -34,9 +34,18 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public void ClearCachedFormulaResults() {
             WriteLock(() => {
+                bool changed = false;
                 foreach (var cell in WorksheetRoot.Descendants<Cell>().Where(c => c.CellFormula != null)) {
-                    cell.CellValue = null;
+                    if (cell.CellValue != null) {
+                        cell.CellValue = null;
+                        changed = true;
+                    }
                 }
+
+                if (changed) {
+                    ClearFindFirstCache();
+                }
+
                 WorksheetRoot.Save();
             });
         }
@@ -54,6 +63,10 @@ namespace OfficeIMO.Excel {
                         cell.CellFormula.CalculateCell = false;
                         count++;
                     }
+                }
+
+                if (count > 0) {
+                    ClearFindFirstCache();
                 }
 
                 WorksheetRoot.Save();

--- a/OfficeIMO.Excel/ExcelSheet.Headers.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.cs
@@ -10,6 +10,8 @@ namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
         private Dictionary<string, int>? _headerMapCache;
         private string? _headerMapSourceA1;
+        private int _headerMapHeaderRowIndex;
+        private int _headerMapHeaderCellCount;
         private bool _headerMapNormalize;
         private bool _headerMapCachePopulated;
         private readonly object _headerMapLock = new object();
@@ -25,6 +27,18 @@ namespace OfficeIMO.Excel {
         }
 
         private Dictionary<string, int> GetHeaderMapCached(ExcelReadOptions opt) {
+            if (Volatile.Read(ref _headerMapCachePopulated)) {
+                lock (_headerMapLock) {
+                    if (_headerMapCache != null && _headerMapNormalize == opt.NormalizeHeaders) {
+                        if (HeaderMapCacheCanReturnWithoutRebuild()) {
+                            return _headerMapCache;
+                        }
+
+                        ClearHeaderMapCacheUnsafe();
+                    }
+                }
+            }
+
             if (!_excelDocument.IsMaterializingDeferredDataSetImport) {
                 _excelDocument.MaterializeDeferredDataSetImport();
             }
@@ -39,6 +53,8 @@ namespace OfficeIMO.Excel {
                 if (TryBuildHeaderMapFromWorksheetDom(r1, c1, c2, opt, out var directMap)) {
                     _headerMapCache = directMap;
                     _headerMapSourceA1 = a1Used;
+                    _headerMapHeaderRowIndex = r1;
+                    _headerMapHeaderCellCount = CountHeaderRowCells(r1);
                     _headerMapNormalize = opt.NormalizeHeaders;
                     Volatile.Write(ref _headerMapCachePopulated, true);
                     return _headerMapCache;
@@ -53,6 +69,8 @@ namespace OfficeIMO.Excel {
                     var empty = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
                     _headerMapCache = empty;
                     _headerMapSourceA1 = a1Used;
+                    _headerMapHeaderRowIndex = r1;
+                    _headerMapHeaderCellCount = CountHeaderRowCells(r1);
                     _headerMapNormalize = opt.NormalizeHeaders;
                     Volatile.Write(ref _headerMapCachePopulated, true);
                     return _headerMapCache;
@@ -71,6 +89,8 @@ namespace OfficeIMO.Excel {
                 if (!anyHeader) {
                     _headerMapCache = map;
                     _headerMapSourceA1 = a1Used;
+                    _headerMapHeaderRowIndex = r1;
+                    _headerMapHeaderCellCount = CountHeaderRowCells(r1);
                     _headerMapNormalize = opt.NormalizeHeaders;
                     Volatile.Write(ref _headerMapCachePopulated, true);
                     return _headerMapCache;
@@ -83,10 +103,51 @@ namespace OfficeIMO.Excel {
                 }
                 _headerMapCache = map;
                 _headerMapSourceA1 = a1Used;
+                _headerMapHeaderRowIndex = r1;
+                _headerMapHeaderCellCount = CountHeaderRowCells(r1);
                 _headerMapNormalize = opt.NormalizeHeaders;
                 Volatile.Write(ref _headerMapCachePopulated, true);
                 return _headerMapCache;
             }
+        }
+
+        private bool HeaderMapCacheCanReturnWithoutRebuild() {
+            if (_hasWorksheetMutations) {
+                return true;
+            }
+
+            int headerRowIndex = Volatile.Read(ref _headerMapHeaderRowIndex);
+            if (headerRowIndex <= 0) {
+                return false;
+            }
+
+            return CountHeaderRowCells(headerRowIndex) == Volatile.Read(ref _headerMapHeaderCellCount);
+        }
+
+        private int CountHeaderRowCells(int headerRowIndex) {
+            var sheetData = WorksheetRoot.GetFirstChild<SheetData>();
+            if (sheetData == null) {
+                return 0;
+            }
+
+            int inferredRow = 0;
+            foreach (var row in sheetData.Elements<Row>()) {
+                int rowIndex;
+                if (row.RowIndex != null) {
+                    rowIndex = checked((int)row.RowIndex.Value);
+                    inferredRow = rowIndex;
+                } else {
+                    rowIndex = ++inferredRow;
+                }
+
+                if (rowIndex < headerRowIndex) {
+                    continue;
+                }
+
+                return rowIndex == headerRowIndex ? row.Elements<Cell>().Count() : 0;
+            }
+
+            return 0;
         }
 
         private bool TryBuildHeaderMapFromWorksheetDom(int headerRowIndex, int firstColumn, int lastColumn, ExcelReadOptions options, out Dictionary<string, int> map) {
@@ -302,34 +363,65 @@ namespace OfficeIMO.Excel {
             if (rowIndex <= 0) throw new ArgumentOutOfRangeException(nameof(rowIndex));
             if (!TryGetColumnIndexByHeader(header, out var col, options))
                 return;
-            if (value is null)
-                CellValue(rowIndex, col, string.Empty);
-            else
-                CellValue(rowIndex, col, value);
+
+            WriteLockConditional(() => CellValueCore(rowIndex, col, value ?? string.Empty));
         }
 
         /// <summary>
         /// Clears the cached header map.
         /// </summary>
         public void ClearHeaderCache() {
-            _hasWorksheetMutations = true;
-            MarkRequiresSavePreparation();
-            ClearCellTextSharedStringCache();
+            ClearHeaderCacheCore(markWorksheetMutation: true, invalidateHeaderMap: true);
+        }
+
+        private void ClearHeaderCacheForCellMutation(int rowIndex) {
+            ClearHeaderCacheCore(
+                markWorksheetMutation: true,
+                invalidateHeaderMap: HeaderMapMayBeAffectedByCellMutation(rowIndex));
+        }
+
+        private bool HeaderMapMayBeAffectedByCellMutation(int rowIndex) {
+            if (!Volatile.Read(ref _headerMapCachePopulated)) {
+                return false;
+            }
+
+            int headerRowIndex = Volatile.Read(ref _headerMapHeaderRowIndex);
+            return headerRowIndex <= 0 || rowIndex <= headerRowIndex;
+        }
+
+        private void ClearHeaderCacheCore(bool markWorksheetMutation, bool invalidateHeaderMap) {
+            if (markWorksheetMutation) {
+                _hasWorksheetMutations = true;
+                MarkRequiresSavePreparation();
+                ClearCellTextSharedStringCache();
+            }
+
+            if (!invalidateHeaderMap) {
+                return;
+            }
+
             if (!Volatile.Read(ref _headerMapCachePopulated)) {
                 return;
             }
 
             lock (_headerMapLock) {
-                _headerMapCache = null;
-                _headerMapSourceA1 = null;
-                Volatile.Write(ref _headerMapCachePopulated, false);
+                ClearHeaderMapCacheUnsafe();
             }
+        }
+
+        private void ClearHeaderMapCacheUnsafe() {
+            _headerMapCache = null;
+            _headerMapSourceA1 = null;
+            _headerMapHeaderRowIndex = 0;
+            _headerMapHeaderCellCount = 0;
+            Volatile.Write(ref _headerMapCachePopulated, false);
         }
 
         /// <summary>
         /// Forces rebuilding the header map for the current UsedRange and options.
         /// </summary>
         public void RefreshHeaderCache(ExcelReadOptions? options = null) {
+            ClearHeaderCacheCore(markWorksheetMutation: false, invalidateHeaderMap: true);
             GetHeaderMap(options);
         }
     }

--- a/OfficeIMO.Excel/ExcelSheet.Headers.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.cs
@@ -112,16 +112,18 @@ namespace OfficeIMO.Excel {
         }
 
         private bool HeaderMapCacheCanReturnWithoutRebuild() {
-            if (_hasWorksheetMutations) {
-                return true;
-            }
-
             int headerRowIndex = Volatile.Read(ref _headerMapHeaderRowIndex);
             if (headerRowIndex <= 0) {
                 return false;
             }
 
-            return CountHeaderRowCells(headerRowIndex) == Volatile.Read(ref _headerMapHeaderCellCount);
+            if (CountHeaderRowCells(headerRowIndex) != Volatile.Read(ref _headerMapHeaderCellCount)) {
+                return false;
+            }
+
+            string reference = ExcelSheet.ComputeSheetDimensionReference(WorksheetRoot);
+            string a1Used = reference.IndexOf(":", StringComparison.Ordinal) >= 0 ? reference : reference + ":" + reference;
+            return string.Equals(_headerMapSourceA1, a1Used, StringComparison.Ordinal);
         }
 
         private int CountHeaderRowCells(int headerRowIndex) {

--- a/OfficeIMO.Excel/ExcelSheet.HyperlinkCleanup.cs
+++ b/OfficeIMO.Excel/ExcelSheet.HyperlinkCleanup.cs
@@ -7,35 +7,68 @@ namespace OfficeIMO.Excel {
             var worksheet = WorksheetRoot;
             var hyperlinks = worksheet.Elements<Hyperlinks>().FirstOrDefault();
             if (hyperlinks == null) {
-                CleanupUnreferencedHyperlinkRelationships(Array.Empty<string>());
+                CleanupUnreferencedHyperlinkRelationships(new HashSet<string>(StringComparer.OrdinalIgnoreCase));
                 return;
             }
 
-            var referenceGroups = hyperlinks.Elements<Hyperlink>()
-                .Where(hyperlink => !string.IsNullOrWhiteSpace(hyperlink.Reference?.Value))
-                .GroupBy(hyperlink => hyperlink.Reference!.Value!, StringComparer.OrdinalIgnoreCase)
-                .ToList();
+            RemoveDuplicateHyperlinkReferences(hyperlinks);
 
-            foreach (var group in referenceGroups) {
-                foreach (var duplicate in group.Take(Math.Max(0, group.Count() - 1)).ToList()) {
-                    RemoveHyperlinkAndUnusedRelationship(hyperlinks, duplicate);
-                }
-            }
+            var relationshipIds = BuildHyperlinkRelationshipIdSet();
 
             foreach (var hyperlink in hyperlinks.Elements<Hyperlink>().ToList()) {
-                if (!IsValidHyperlinkReference(hyperlink.Reference?.Value) || !IsValidHyperlinkTarget(hyperlink)) {
-                    RemoveHyperlinkAndUnusedRelationship(hyperlinks, hyperlink);
+                if (!IsValidHyperlinkReference(hyperlink.Reference?.Value) || !IsValidHyperlinkTarget(hyperlink, relationshipIds)) {
+                    hyperlink.Remove();
                 }
             }
 
-            var referencedRelationshipIds = hyperlinks.Elements<Hyperlink>()
-                .Select(hyperlink => hyperlink.Id?.Value)
-                .Where(id => !string.IsNullOrWhiteSpace(id))
-                .Select(id => id!)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
+            CleanupUnreferencedHyperlinkRelationships(BuildReferencedRelationshipIdSet(hyperlinks));
+        }
 
-            CleanupUnreferencedHyperlinkRelationships(referencedRelationshipIds);
+        private void RemoveDuplicateHyperlinkReferences(Hyperlinks hyperlinks) {
+            var byReference = new Dictionary<string, Hyperlink>(StringComparer.OrdinalIgnoreCase);
+            List<Hyperlink>? duplicates = null;
+
+            foreach (var hyperlink in hyperlinks.Elements<Hyperlink>()) {
+                string? reference = hyperlink.Reference?.Value;
+                if (string.IsNullOrWhiteSpace(reference)) {
+                    continue;
+                }
+
+                if (byReference.TryGetValue(reference, out var previous)) {
+                    (duplicates ??= new List<Hyperlink>()).Add(previous);
+                }
+
+                byReference[reference] = hyperlink;
+            }
+
+            if (duplicates == null) {
+                return;
+            }
+
+            foreach (var duplicate in duplicates) {
+                duplicate.Remove();
+            }
+        }
+
+        private HashSet<string> BuildHyperlinkRelationshipIdSet() {
+            var relationshipIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var relationship in _worksheetPart.HyperlinkRelationships) {
+                relationshipIds.Add(relationship.Id);
+            }
+
+            return relationshipIds;
+        }
+
+        private static HashSet<string> BuildReferencedRelationshipIdSet(Hyperlinks hyperlinks) {
+            var referencedRelationshipIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var hyperlink in hyperlinks.Elements<Hyperlink>()) {
+                string? id = hyperlink.Id?.Value;
+                if (!string.IsNullOrWhiteSpace(id)) {
+                    referencedRelationshipIds.Add(id);
+                }
+            }
+
+            return referencedRelationshipIds;
         }
 
         private static bool IsValidHyperlinkReference(string? reference) {
@@ -43,47 +76,27 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            string candidate = reference!.Trim();
-            if (A1.TryParseRange(candidate, out _, out _, out _, out _)) {
-                return true;
+            foreach (ReferenceListPart part in SplitReferenceList(reference!.Trim())) {
+                if (!TryParseReference(part, out _)) {
+                    return false;
+                }
             }
 
-            var cell = A1.ParseCellRef(candidate);
-            return cell.Row > 0 && cell.Col > 0;
+            return true;
         }
 
-        private bool IsValidHyperlinkTarget(Hyperlink hyperlink) {
+        private static bool IsValidHyperlinkTarget(Hyperlink hyperlink, HashSet<string> relationshipIds) {
             string? relationshipId = hyperlink.Id?.Value;
             if (!string.IsNullOrWhiteSpace(relationshipId)) {
-                return _worksheetPart.HyperlinkRelationships.Any(relationship => string.Equals(relationship.Id, relationshipId, StringComparison.OrdinalIgnoreCase));
+                return relationshipIds.Contains(relationshipId);
             }
 
             return !string.IsNullOrWhiteSpace(hyperlink.Location?.Value);
         }
 
-        private void RemoveHyperlinkAndUnusedRelationship(Hyperlinks hyperlinks, Hyperlink hyperlink) {
-            string? relationshipId = hyperlink.Id?.Value;
-            hyperlink.Remove();
-
-            if (string.IsNullOrWhiteSpace(relationshipId)) {
-                return;
-            }
-
-            if (hyperlinks.Elements<Hyperlink>().Any(existing => string.Equals(existing.Id?.Value, relationshipId, StringComparison.OrdinalIgnoreCase))) {
-                return;
-            }
-
-            var relationship = _worksheetPart.HyperlinkRelationships
-                .FirstOrDefault(existing => string.Equals(existing.Id, relationshipId, StringComparison.OrdinalIgnoreCase));
-            if (relationship != null) {
-                _worksheetPart.DeleteReferenceRelationship(relationship);
-            }
-        }
-
-        private void CleanupUnreferencedHyperlinkRelationships(IEnumerable<string> referencedRelationshipIds) {
-            var referenced = new HashSet<string>(referencedRelationshipIds, StringComparer.OrdinalIgnoreCase);
+        private void CleanupUnreferencedHyperlinkRelationships(HashSet<string> referencedRelationshipIds) {
             foreach (var relationship in _worksheetPart.HyperlinkRelationships.ToList()) {
-                if (!referenced.Contains(relationship.Id)) {
+                if (!referencedRelationshipIds.Contains(relationship.Id)) {
                     _worksheetPart.DeleteReferenceRelationship(relationship);
                 }
             }

--- a/OfficeIMO.Excel/ExcelSheet.HyperlinkCleanup.cs
+++ b/OfficeIMO.Excel/ExcelSheet.HyperlinkCleanup.cs
@@ -34,11 +34,11 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                if (byReference.TryGetValue(reference, out var previous)) {
+                if (byReference.TryGetValue(reference!, out var previous)) {
                     (duplicates ??= new List<Hyperlink>()).Add(previous);
                 }
 
-                byReference[reference] = hyperlink;
+                byReference[reference!] = hyperlink;
             }
 
             if (duplicates == null) {
@@ -64,7 +64,7 @@ namespace OfficeIMO.Excel {
             foreach (var hyperlink in hyperlinks.Elements<Hyperlink>()) {
                 string? id = hyperlink.Id?.Value;
                 if (!string.IsNullOrWhiteSpace(id)) {
-                    referencedRelationshipIds.Add(id);
+                    referencedRelationshipIds.Add(id!);
                 }
             }
 
@@ -88,7 +88,7 @@ namespace OfficeIMO.Excel {
         private static bool IsValidHyperlinkTarget(Hyperlink hyperlink, HashSet<string> relationshipIds) {
             string? relationshipId = hyperlink.Id?.Value;
             if (!string.IsNullOrWhiteSpace(relationshipId)) {
-                return relationshipIds.Contains(relationshipId);
+                return relationshipIds.Contains(relationshipId!);
             }
 
             return !string.IsNullOrWhiteSpace(hyperlink.Location?.Value);

--- a/OfficeIMO.Excel/ExcelSheet.ObjectModel.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectModel.cs
@@ -83,23 +83,26 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public void FormatRange(string a1Range, string numberFormat) {
             var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
-            for (int row = r1; row <= r2; row++) {
-                for (int column = c1; column <= c2; column++) {
-                    FormatCell(row, column, numberFormat);
-                }
+
+            if (!_excelDocument.IsMaterializingDeferredDataSetImport) {
+                MaterializeDeferredDataSetImportIfNeeded();
             }
+
+            WriteLock(() => FormatRangeCore(r1, c1, r2, c2, numberFormat));
         }
 
         /// <summary>
         /// Applies a solid fill to every cell in the range.
         /// </summary>
         public void FillRange(string a1Range, string hexColor) {
+            if (string.IsNullOrWhiteSpace(hexColor)) return;
             var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
-            for (int row = r1; row <= r2; row++) {
-                for (int column = c1; column <= c2; column++) {
-                    CellBackground(row, column, hexColor);
-                }
+
+            if (!_excelDocument.IsMaterializingDeferredDataSetImport) {
+                MaterializeDeferredDataSetImportIfNeeded();
             }
+
+            WriteLock(() => FillRangeCore(r1, c1, r2, c2, hexColor));
         }
 
         /// <summary>
@@ -107,39 +110,27 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public void ClearRange(string a1Range, ExcelClearOptions options = ExcelClearOptions.All) {
             var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
+            if (options == ExcelClearOptions.None) {
+                return;
+            }
+
             WriteLock(() => {
                 var ws = WorksheetRoot;
+                bool worksheetChanged = false;
                 bool clearCellFields = options.HasFlag(ExcelClearOptions.Values)
                     || options.HasFlag(ExcelClearOptions.Formulas)
                     || options.HasFlag(ExcelClearOptions.Styles);
 
                 if (clearCellFields) {
-                    for (int row = r1; row <= r2; row++) {
-                        for (int column = c1; column <= c2; column++) {
-                            var cell = GetCell(row, column);
-                            if (options.HasFlag(ExcelClearOptions.Values)) {
-                                cell.CellValue = null;
-                                cell.DataType = null;
-                                cell.InlineString = null;
-                            }
-
-                            if (options.HasFlag(ExcelClearOptions.Formulas)) {
-                                cell.CellFormula = null;
-                            }
-
-                            if (options.HasFlag(ExcelClearOptions.Styles)) {
-                                cell.StyleIndex = null;
-                            }
-                        }
-                    }
+                    worksheetChanged |= ClearExistingCellFieldsInRange((r1, c1, r2, c2), options);
                 }
 
                 if (options.HasFlag(ExcelClearOptions.Comments)) {
-                    ClearCommentsInRange(r1, c1, r2, c2);
+                    worksheetChanged |= ClearCommentsInRange(r1, c1, r2, c2);
                 }
 
                 if (options.HasFlag(ExcelClearOptions.Hyperlinks)) {
-                    ClearHyperlinksInRange(ws, a1Range);
+                    worksheetChanged |= ClearHyperlinksInRange(ws, (r1, c1, r2, c2));
                 }
 
                 if (options.HasFlag(ExcelClearOptions.DataValidations)) {
@@ -151,16 +142,67 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (options.HasFlag(ExcelClearOptions.Merges)) {
-                    UnmergeRangeCore(a1Range);
+                    UnmergeRangeCore((r1, c1, r2, c2));
                 }
 
                 if (options.HasFlag(ExcelClearOptions.Sparklines)) {
-                    ClearSparklinesInRange(a1Range);
+                    worksheetChanged |= ClearSparklinesInRange((r1, c1, r2, c2));
                 }
 
-                ws.Save();
-                ClearHeaderCache();
+                if (worksheetChanged) {
+                    ws.Save();
+                    ClearHeaderCache();
+                }
             });
+        }
+
+        private bool ClearExistingCellFieldsInRange((int r1, int c1, int r2, int c2) bounds, ExcelClearOptions options) {
+            var sheetData = WorksheetRoot.GetFirstChild<SheetData>();
+            if (sheetData == null) {
+                return false;
+            }
+
+            bool clearValues = options.HasFlag(ExcelClearOptions.Values);
+            bool clearFormulas = options.HasFlag(ExcelClearOptions.Formulas);
+            bool clearStyles = options.HasFlag(ExcelClearOptions.Styles);
+            bool changed = false;
+
+            foreach (var row in sheetData.Elements<Row>()) {
+                uint rowIndex = row.RowIndex?.Value ?? 0U;
+                if (rowIndex < (uint)bounds.r1 || rowIndex > (uint)bounds.r2) {
+                    continue;
+                }
+
+                foreach (var cell in row.Elements<Cell>()) {
+                    if (cell.CellReference?.Value is not string reference) {
+                        continue;
+                    }
+
+                    int columnIndex = GetColumnIndex(reference);
+                    if (columnIndex < bounds.c1 || columnIndex > bounds.c2) {
+                        continue;
+                    }
+
+                    if (clearValues && (cell.CellValue != null || cell.DataType != null || cell.InlineString != null)) {
+                        cell.CellValue = null;
+                        cell.DataType = null;
+                        cell.InlineString = null;
+                        changed = true;
+                    }
+
+                    if (clearFormulas && cell.CellFormula != null) {
+                        cell.CellFormula = null;
+                        changed = true;
+                    }
+
+                    if (clearStyles && cell.StyleIndex != null) {
+                        cell.StyleIndex = null;
+                        changed = true;
+                    }
+                }
+            }
+
+            return changed;
         }
 
         /// <summary>
@@ -210,6 +252,8 @@ namespace OfficeIMO.Excel {
             WriteLock(() => {
                 var ws = WorksheetRoot;
                 var merges = ws.GetFirstChild<MergeCells>();
+                uint mergeCount = 0;
+
                 if (merges == null) {
                     var customSheetViews = ws.GetFirstChild<CustomSheetViews>();
                     merges = new MergeCells();
@@ -218,37 +262,70 @@ namespace OfficeIMO.Excel {
                     } else {
                         ws.Append(merges);
                     }
+                } else if (MergeCellsContainReference(merges, a1Range, out mergeCount)) {
+                    return;
                 }
 
-                if (!merges.Elements<MergeCell>().Any(m => string.Equals(m.Reference?.Value, a1Range, StringComparison.OrdinalIgnoreCase))) {
-                    merges.Append(new MergeCell { Reference = a1Range });
-                    merges.Count = (uint)merges.Elements<MergeCell>().Count();
-                }
-
+                merges.Append(new MergeCell { Reference = a1Range });
+                merges.Count = mergeCount + 1U;
                 ws.Save();
             });
+        }
+
+        private static bool MergeCellsContainReference(MergeCells merges, string reference, out uint count) {
+            count = 0;
+            foreach (var merge in merges.Elements<MergeCell>()) {
+                count++;
+                if (string.Equals(merge.Reference?.Value, reference, StringComparison.OrdinalIgnoreCase)) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
         /// Removes merge definitions that overlap the supplied A1 range.
         /// </summary>
         public void UnmergeRange(string a1Range) {
-            WriteLock(() => UnmergeRangeCore(a1Range));
+            var bounds = A1.ParseRange(a1Range);
+            WriteLock(() => UnmergeRangeCore(bounds));
         }
 
-        private void UnmergeRangeCore(string a1Range) {
-            var bounds = A1.ParseRange(a1Range);
+        private void UnmergeRangeCore((int r1, int c1, int r2, int c2) bounds) {
             var merges = WorksheetRoot.GetFirstChild<MergeCells>();
             if (merges == null) return;
+            if (!MergeCellsOverlap(merges, bounds)) return;
 
+            bool changed = false;
+            uint remainingCount = 0;
             foreach (var merge in merges.Elements<MergeCell>().ToList()) {
-                if (merge.Reference?.Value is string reference && RangesOverlapInclusive(bounds, A1.ParseRange(reference))) {
+                if (merge.Reference?.Value is string reference
+                    && TryParseReference(reference, out var mergeBounds)
+                    && RangesOverlapInclusive(bounds, mergeBounds)) {
                     merge.Remove();
+                    changed = true;
+                } else {
+                    remainingCount++;
                 }
             }
 
-            merges.Count = (uint)merges.Elements<MergeCell>().Count();
-            WorksheetRoot.Save();
+            if (changed) {
+                merges.Count = remainingCount;
+                WorksheetRoot.Save();
+            }
+        }
+
+        private static bool MergeCellsOverlap(MergeCells merges, (int r1, int c1, int r2, int c2) bounds) {
+            foreach (var merge in merges.Elements<MergeCell>()) {
+                if (merge.Reference?.Value is string reference
+                    && TryParseReference(reference, out var mergeBounds)
+                    && RangesOverlapInclusive(bounds, mergeBounds)) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -311,30 +388,50 @@ namespace OfficeIMO.Excel {
             return runs;
         }
 
-        private void ClearCommentsInRange(int firstRow, int firstColumn, int lastRow, int lastColumn) {
+        private bool ClearCommentsInRange(int firstRow, int firstColumn, int lastRow, int lastColumn) {
+            bool changed = false;
             var commentsPart = WorksheetCommentsPartRoot;
             if (commentsPart?.Comments?.CommentList != null) {
-                foreach (var comment in commentsPart.Comments.CommentList.Elements<Comment>().ToList()) {
-                    if (comment.Reference?.Value is not string reference) {
-                        continue;
-                    }
+                bool removedComment = false;
+                var commentList = commentsPart.Comments.CommentList;
+                if (CommentListOverlapsRange(commentList, firstRow, firstColumn, lastRow, lastColumn)) {
+                    foreach (var comment in commentList.Elements<Comment>().ToList()) {
+                        if (comment.Reference?.Value is not string reference) {
+                            continue;
+                        }
 
-                    var (row, col) = A1.ParseCellRef(reference);
-                    if (row >= firstRow && row <= lastRow && col >= firstColumn && col <= lastColumn) {
-                        comment.Remove();
+                        var (row, col) = A1.ParseCellRef(reference);
+                        if (row >= firstRow && row <= lastRow && col >= firstColumn && col <= lastColumn) {
+                            comment.Remove();
+                            removedComment = true;
+                        }
                     }
                 }
 
-                commentsPart.Comments.Save();
-            }
-
-            for (int row = firstRow; row <= lastRow; row++) {
-                for (int column = firstColumn; column <= lastColumn; column++) {
-                    RemoveCommentVmlShape(row, column);
+                if (removedComment) {
+                    commentsPart.Comments.Save();
+                    changed = true;
                 }
             }
 
-            CleanupCommentArtifacts();
+            changed |= RemoveCommentVmlShapesInRange(firstRow, firstColumn, lastRow, lastColumn);
+            changed |= CleanupCommentArtifacts();
+            return changed;
+        }
+
+        private static bool CommentListOverlapsRange(CommentList commentList, int firstRow, int firstColumn, int lastRow, int lastColumn) {
+            foreach (var comment in commentList.Elements<Comment>()) {
+                if (comment.Reference?.Value is not string reference) {
+                    continue;
+                }
+
+                var (row, col) = A1.ParseCellRef(reference);
+                if (row >= firstRow && row <= lastRow && col >= firstColumn && col <= lastColumn) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static Dictionary<int, int> BuildSortedRowMap(IReadOnlyList<RowSnapshot> rows, int firstRow) {
@@ -409,16 +506,17 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                var references = SplitReferenceList(remapped);
-                if (references.Length == 0) {
-                    continue;
-                }
-
-                link.Reference = references[0];
+                bool firstReference = true;
                 var insertAfter = link;
-                for (int index = 1; index < references.Length; index++) {
+                foreach (ReferenceListPart remappedReference in SplitReferenceList(remapped)) {
+                    if (firstReference) {
+                        link.Reference = remappedReference.ToString();
+                        firstReference = false;
+                        continue;
+                    }
+
                     var clone = (Hyperlink)link.CloneNode(true);
-                    clone.Reference = references[index];
+                    clone.Reference = remappedReference.ToString();
                     hyperlinks.InsertAfter(clone, insertAfter);
                     insertAfter = clone;
                 }
@@ -513,29 +611,49 @@ namespace OfficeIMO.Excel {
         }
 
         private static bool TryRemapReferenceListForSortedRange(string referenceList, IReadOnlyDictionary<int, int> rowMap, int firstRow, int lastRow, int firstColumn, int lastColumn, out string remapped) {
-            bool changed = false;
-            var parts = new List<string>();
-            foreach (string part in SplitReferenceList(referenceList)) {
-                if (TryRemapReferenceForSortedRange(part, rowMap, firstRow, lastRow, firstColumn, lastColumn, out string remappedPart)) {
-                    parts.Add(remappedPart);
-                    changed = true;
-                } else {
-                    parts.Add(part);
+            foreach (ReferenceListPart part in SplitReferenceList(referenceList)) {
+                if (TryRemapReferenceForSortedRange(part, rowMap, firstRow, lastRow, firstColumn, lastColumn, out _)) {
+                    return BuildRemappedReferenceList(referenceList, rowMap, firstRow, lastRow, firstColumn, lastColumn, out remapped);
                 }
             }
 
-            remapped = string.Join(" ", parts);
-            return changed;
+            remapped = referenceList;
+            return false;
+        }
+
+        private static bool BuildRemappedReferenceList(string referenceList, IReadOnlyDictionary<int, int> rowMap, int firstRow, int lastRow, int firstColumn, int lastColumn, out string remapped) {
+            var builder = new StringBuilder(referenceList.Length);
+            bool first = true;
+            foreach (ReferenceListPart part in SplitReferenceList(referenceList)) {
+                if (!first) {
+                    builder.Append(' ');
+                }
+
+                if (TryRemapReferenceForSortedRange(part, rowMap, firstRow, lastRow, firstColumn, lastColumn, out string remappedPart)) {
+                    builder.Append(remappedPart);
+                } else {
+                    part.AppendTo(builder);
+                }
+
+                first = false;
+            }
+
+            remapped = builder.ToString();
+            return true;
         }
 
         private static bool TryRemapReferenceForSortedRange(string reference, IReadOnlyDictionary<int, int> rowMap, int firstRow, int lastRow, int firstColumn, int lastColumn, out string remapped) {
-            remapped = reference;
+            return TryRemapReferenceForSortedRange(new ReferenceListPart(reference, 0, reference.Length), rowMap, firstRow, lastRow, firstColumn, lastColumn, out remapped);
+        }
+
+        private static bool TryRemapReferenceForSortedRange(ReferenceListPart reference, IReadOnlyDictionary<int, int> rowMap, int firstRow, int lastRow, int firstColumn, int lastColumn, out string remapped) {
             var bounds = TryParseReference(reference, out var parsed) ? parsed : default;
             if (bounds == default
                 || bounds.r1 < firstRow
                 || bounds.r2 > lastRow
                 || bounds.c1 < firstColumn
                 || bounds.c2 > lastColumn) {
+                remapped = string.Empty;
                 return false;
             }
 
@@ -551,6 +669,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (!changed) {
+                remapped = string.Empty;
                 return false;
             }
 
@@ -573,16 +692,21 @@ namespace OfficeIMO.Excel {
             return true;
         }
 
-        private void ClearHyperlinksInRange(Worksheet ws, string a1Range) {
-            var bounds = A1.ParseRange(a1Range);
+        private bool ClearHyperlinksInRange(Worksheet ws, (int r1, int c1, int r2, int c2) bounds) {
             var hyperlinks = ws.GetFirstChild<Hyperlinks>();
-            if (hyperlinks == null) return;
+            if (hyperlinks == null) return false;
+            if (!HyperlinksOverlapRange(hyperlinks, bounds)) return false;
 
+            bool changed = false;
             foreach (var link in hyperlinks.Elements<Hyperlink>().ToList()) {
                 if (link.Reference?.Value is string reference) {
-                    var remaining = RemoveReferenceOverlap(reference, bounds);
+                    if (!TryRemoveReferenceOverlap(reference, bounds, out var remaining)) {
+                        continue;
+                    }
+
                     if (remaining.Count == 0) {
                         link.Remove();
+                        changed = true;
                         continue;
                     }
 
@@ -594,21 +718,52 @@ namespace OfficeIMO.Excel {
                         hyperlinks.InsertAfter(clone, insertAfter);
                         insertAfter = clone;
                     }
+
+                    changed = true;
                 }
             }
+
+            return changed;
         }
 
-        private void ClearSparklinesInRange(string a1Range) {
-            var bounds = A1.ParseRange(a1Range);
+        private static bool HyperlinksOverlapRange(Hyperlinks hyperlinks, (int r1, int c1, int r2, int c2) bounds) {
+            foreach (var link in hyperlinks.Elements<Hyperlink>()) {
+                if (link.Reference?.Value is string reference && ReferenceListOverlaps(reference, bounds)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool ClearSparklinesInRange((int r1, int c1, int r2, int c2) bounds) {
+            if (!SparklinesOverlap(bounds)) return false;
+
+            bool changed = false;
             foreach (var sparkline in WorksheetRoot.Descendants<DocumentFormat.OpenXml.Office2010.Excel.Sparkline>().ToList()) {
                 var reference = sparkline.ReferenceSequence?.Text;
-                if (!string.IsNullOrWhiteSpace(reference)) {
-                    var sparklineBounds = CellAsRange(reference!);
+                if (!string.IsNullOrWhiteSpace(reference) && TryParseReference(reference!, out var sparklineBounds)) {
                     if (RangesOverlapInclusive(bounds, sparklineBounds)) {
                         sparkline.Remove();
+                        changed = true;
                     }
                 }
             }
+
+            return changed;
+        }
+
+        private bool SparklinesOverlap((int r1, int c1, int r2, int c2) bounds) {
+            foreach (var sparkline in WorksheetRoot.Descendants<DocumentFormat.OpenXml.Office2010.Excel.Sparkline>()) {
+                var reference = sparkline.ReferenceSequence?.Text;
+                if (!string.IsNullOrWhiteSpace(reference)
+                    && TryParseReference(reference!, out var sparklineBounds)
+                    && RangesOverlapInclusive(bounds, sparklineBounds)) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static (int r1, int c1, int r2, int c2) CellAsRange(string cellRef) {
@@ -617,19 +772,136 @@ namespace OfficeIMO.Excel {
         }
 
         private static bool TryParseReference(string reference, out (int r1, int c1, int r2, int c2) bounds) {
-            string normalized = reference.Replace("$", string.Empty);
-            if (normalized.IndexOf(':') >= 0) {
-                return A1.TryParseRange(normalized, out bounds.r1, out bounds.c1, out bounds.r2, out bounds.c2);
-            }
+            return TryParseReference(new ReferenceListPart(reference, 0, reference.Length), out bounds);
+        }
 
-            var cell = A1.ParseCellRef(normalized);
-            if (cell.Row <= 0 || cell.Col <= 0) {
+        private static bool TryParseReference(ReferenceListPart reference, out (int r1, int c1, int r2, int c2) bounds) {
+            int start = reference.Start;
+            int length = reference.Length;
+            if (!TrimReferenceBounds(reference.Text, ref start, ref length)) {
                 bounds = default;
                 return false;
             }
 
-            bounds = (cell.Row, cell.Col, cell.Row, cell.Col);
+            int end = start + length;
+            int separator = -1;
+            for (int index = start; index < end; index++) {
+                if (reference.Text[index] == ':') {
+                    separator = index;
+                    break;
+                }
+            }
+
+            if (separator >= 0) {
+                if (!TryParseCellReferencePart(reference.Text, start, separator - start, out int r1, out int c1)
+                    || !TryParseCellReferencePart(reference.Text, separator + 1, end - separator - 1, out int r2, out int c2)) {
+                    bounds = default;
+                    return false;
+                }
+
+                if (c1 > c2) (c1, c2) = (c2, c1);
+                if (r1 > r2) (r1, r2) = (r2, r1);
+                bounds = (r1, c1, r2, c2);
+                return true;
+            }
+
+            if (!TryParseCellReferencePart(reference.Text, start, length, out int row, out int col)) {
+                bounds = default;
+                return false;
+            }
+
+            bounds = (row, col, row, col);
             return true;
+        }
+
+        private static bool TrimReferenceBounds(string text, ref int start, ref int length) {
+            if (string.IsNullOrEmpty(text) || length <= 0 || start < 0 || start > text.Length || length > text.Length - start) {
+                return false;
+            }
+
+            int end = start + length;
+            while (start < end && char.IsWhiteSpace(text[start])) {
+                start++;
+            }
+
+            while (end > start && char.IsWhiteSpace(text[end - 1])) {
+                end--;
+            }
+
+            length = end - start;
+            return length > 0;
+        }
+
+        private static bool TryParseCellReferencePart(string text, int start, int length, out int row, out int col) {
+            row = 0;
+            col = 0;
+            if (!TrimReferenceBounds(text, ref start, ref length)) {
+                return false;
+            }
+
+            int end = start + length;
+            int index = start;
+            if (index < end && text[index] == '$') {
+                index++;
+            }
+
+            int letterStart = index;
+            for (; index < end; index++) {
+                char ch = ToUpperAscii(text[index]);
+                if (ch < 'A' || ch > 'Z') {
+                    break;
+                }
+
+                int value = ch - 'A' + 1;
+                if (col > (int.MaxValue - value) / 26) {
+                    row = 0;
+                    col = 0;
+                    return false;
+                }
+
+                col = (col * 26) + value;
+            }
+
+            if (index == letterStart || index == end) {
+                row = 0;
+                col = 0;
+                return false;
+            }
+
+            if (text[index] == '$') {
+                index++;
+            }
+
+            int digitStart = index;
+            for (; index < end; index++) {
+                char ch = text[index];
+                if (ch < '0' || ch > '9') {
+                    row = 0;
+                    col = 0;
+                    return false;
+                }
+
+                int digit = ch - '0';
+                if (row > (int.MaxValue - digit) / 10) {
+                    row = 0;
+                    col = 0;
+                    return false;
+                }
+
+                row = (row * 10) + digit;
+            }
+
+            if (index == digitStart || row <= 0 || col <= 0) {
+                row = 0;
+                col = 0;
+                return false;
+            }
+
+            return true;
+        }
+
+        private static char ToUpperAscii(char character) {
+            return character >= 'a' && character <= 'z' ? (char)(character - 32) : character;
         }
 
         private static string ToReference(int r1, int c1, int r2, int c2) {
@@ -639,27 +911,7 @@ namespace OfficeIMO.Excel {
         }
 
         private Cell? TryGetExistingCell(int row, int column) {
-            if (row <= 0) throw new ArgumentOutOfRangeException(nameof(row));
-            if (column <= 0) throw new ArgumentOutOfRangeException(nameof(column));
-
-            var sheetData = WorksheetRoot.GetFirstChild<SheetData>();
-            if (sheetData == null) {
-                return null;
-            }
-
-            var rowElement = sheetData.Elements<Row>().FirstOrDefault(r => r.RowIndex?.Value == (uint)row);
-            if (rowElement == null) {
-                return null;
-            }
-
-            foreach (Cell cell in rowElement.Elements<Cell>()) {
-                if (cell.CellReference?.Value is string reference
-                    && GetColumnIndex(reference) == column) {
-                    return cell;
-                }
-            }
-
-            return null;
+            return TryGetCell(row, column);
         }
 
         private static string RewriteSortedFormulaReferences(string formula, IReadOnlyDictionary<int, int> rowMap, int firstColumn, int lastColumn) {

--- a/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
@@ -3,18 +3,18 @@ using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
+        private static readonly List<string> EmptyReferenceList = new List<string>(0);
+
         /// <summary>
         /// Lists conditional formatting rules on the worksheet.
         /// </summary>
         public IReadOnlyList<ExcelConditionalFormattingInfo> GetConditionalFormattingRules(string? a1Range = null) {
-            (int r1, int c1, int r2, int c2)? filter = string.IsNullOrWhiteSpace(a1Range) ? null : A1.ParseRange(a1Range!);
+            (int r1, int c1, int r2, int c2)? filter = string.IsNullOrWhiteSpace(a1Range) ? null : ParseReferenceArgument(a1Range!);
             var list = new List<ExcelConditionalFormattingInfo>();
             foreach (var conditional in WorksheetRoot.Elements<ConditionalFormatting>()) {
                 string range = conditional.SequenceOfReferences?.InnerText ?? string.Empty;
                 if (filter.HasValue && !string.IsNullOrWhiteSpace(range)) {
-                    bool overlaps = SplitReferenceList(range)
-                        .Any(part => RangesOverlapInclusive(filter.Value, part.IndexOf(':') >= 0 ? A1.ParseRange(part) : CellAsRange(part)));
-                    if (!overlaps) continue;
+                    if (!ReferenceListOverlaps(range, filter.Value)) continue;
                 }
 
                 foreach (var rule in conditional.Elements<ConditionalFormattingRule>()) {
@@ -69,7 +69,7 @@ namespace OfficeIMO.Excel {
         /// Lists data validation rules on the worksheet.
         /// </summary>
         public IReadOnlyList<ExcelDataValidationInfo> GetDataValidations(string? a1Range = null) {
-            (int r1, int c1, int r2, int c2)? filter = string.IsNullOrWhiteSpace(a1Range) ? null : A1.ParseRange(a1Range!);
+            (int r1, int c1, int r2, int c2)? filter = string.IsNullOrWhiteSpace(a1Range) ? null : ParseReferenceArgument(a1Range!);
             var result = new List<ExcelDataValidationInfo>();
             var validations = WorksheetRoot.GetFirstChild<DataValidations>();
             if (validations == null) return result;
@@ -77,9 +77,7 @@ namespace OfficeIMO.Excel {
             foreach (var validation in validations.Elements<DataValidation>()) {
                 string range = validation.SequenceOfReferences?.InnerText ?? string.Empty;
                 if (filter.HasValue) {
-                    bool overlaps = SplitReferenceList(range)
-                        .Any(part => RangesOverlapInclusive(filter.Value, part.IndexOf(':') >= 0 ? A1.ParseRange(part) : CellAsRange(part)));
-                    if (!overlaps) continue;
+                    if (!ReferenceListOverlaps(range, filter.Value)) continue;
                 }
 
                 result.Add(new ExcelDataValidationInfo {
@@ -111,25 +109,39 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public void SetDataValidationMessages(string a1Range, ExcelDataValidationMessageOptions options) {
             if (options == null) throw new ArgumentNullException(nameof(options));
-            var filter = A1.ParseRange(a1Range);
+            var filter = ParseReferenceArgument(a1Range);
             WriteLock(() => {
                 var validations = WorksheetRoot.GetFirstChild<DataValidations>();
                 if (validations == null) return;
+                bool changed = false;
+                bool showInputMessage = options.ShowInputMessage || !string.IsNullOrEmpty(options.Prompt) || !string.IsNullOrEmpty(options.PromptTitle);
+                bool showErrorMessage = options.ShowErrorMessage || !string.IsNullOrEmpty(options.Error) || !string.IsNullOrEmpty(options.ErrorTitle);
                 foreach (var validation in validations.Elements<DataValidation>()) {
                     string range = validation.SequenceOfReferences?.InnerText ?? string.Empty;
-                    bool overlaps = SplitReferenceList(range)
-                        .Any(part => RangesOverlapInclusive(filter, part.IndexOf(':') >= 0 ? A1.ParseRange(part) : CellAsRange(part)));
-                    if (!overlaps) continue;
+                    if (!ReferenceListOverlaps(range, filter)) continue;
+
+                    bool validationChanged =
+                        !string.Equals(validation.PromptTitle?.Value, options.PromptTitle, StringComparison.Ordinal)
+                        || !string.Equals(validation.Prompt?.Value, options.Prompt, StringComparison.Ordinal)
+                        || !string.Equals(validation.ErrorTitle?.Value, options.ErrorTitle, StringComparison.Ordinal)
+                        || !string.Equals(validation.Error?.Value, options.Error, StringComparison.Ordinal)
+                        || validation.ShowInputMessage?.Value != showInputMessage
+                        || validation.ShowErrorMessage?.Value != showErrorMessage;
+
+                    if (!validationChanged) continue;
 
                     validation.PromptTitle = options.PromptTitle;
                     validation.Prompt = options.Prompt;
                     validation.ErrorTitle = options.ErrorTitle;
                     validation.Error = options.Error;
-                    validation.ShowInputMessage = options.ShowInputMessage || !string.IsNullOrEmpty(options.Prompt) || !string.IsNullOrEmpty(options.PromptTitle);
-                    validation.ShowErrorMessage = options.ShowErrorMessage || !string.IsNullOrEmpty(options.Error) || !string.IsNullOrEmpty(options.ErrorTitle);
+                    validation.ShowInputMessage = showInputMessage;
+                    validation.ShowErrorMessage = showErrorMessage;
+                    changed = true;
                 }
 
-                WorksheetRoot.Save();
+                if (changed) {
+                    WorksheetRoot.Save();
+                }
             });
         }
 
@@ -156,47 +168,69 @@ namespace OfficeIMO.Excel {
         }
 
         private void ClearConditionalFormattingCore(string? a1Range) {
+            bool changed = false;
             if (string.IsNullOrWhiteSpace(a1Range)) {
                 foreach (var conditional in WorksheetRoot.Elements<ConditionalFormatting>().ToList()) {
                     conditional.Remove();
+                    changed = true;
                 }
             } else {
-                var filter = A1.ParseRange(a1Range!);
+                var filter = ParseReferenceArgument(a1Range!);
                 foreach (var conditional in WorksheetRoot.Elements<ConditionalFormatting>().ToList()) {
                     string range = conditional.SequenceOfReferences?.InnerText ?? string.Empty;
-                    var remaining = RemoveReferenceOverlap(range, filter);
+                    if (!TryRemoveReferenceOverlap(range, filter, out var remaining)) {
+                        continue;
+                    }
+
                     if (remaining.Count == 0) {
                         conditional.Remove();
-                    } else if (!string.Equals(range, string.Join(" ", remaining), StringComparison.OrdinalIgnoreCase)) {
-                        conditional.SequenceOfReferences = new ListValue<StringValue> { InnerText = string.Join(" ", remaining) };
+                        changed = true;
+                    } else {
+                        string replacement = string.Join(" ", remaining);
+                        conditional.SequenceOfReferences = new ListValue<StringValue> { InnerText = replacement };
+                        changed = true;
                     }
                 }
             }
 
-            WorksheetRoot.Save();
+            if (changed) {
+                WorksheetRoot.Save();
+            }
         }
 
         private void RemoveDataValidationsCore(string? a1Range) {
             var validations = WorksheetRoot.GetFirstChild<DataValidations>();
             if (validations == null) return;
 
+            bool changed = false;
             if (string.IsNullOrWhiteSpace(a1Range)) {
-                validations.RemoveAllChildren<DataValidation>();
+                foreach (var validation in validations.Elements<DataValidation>().ToList()) {
+                    validation.Remove();
+                    changed = true;
+                }
             } else {
-                var filter = A1.ParseRange(a1Range!);
+                var filter = ParseReferenceArgument(a1Range!);
                 foreach (var validation in validations.Elements<DataValidation>().ToList()) {
                     string range = validation.SequenceOfReferences?.InnerText ?? string.Empty;
-                    var remaining = RemoveReferenceOverlap(range, filter);
+                    if (!TryRemoveReferenceOverlap(range, filter, out var remaining)) {
+                        continue;
+                    }
+
                     if (remaining.Count == 0) {
                         validation.Remove();
-                    } else if (!string.Equals(range, string.Join(" ", remaining), StringComparison.OrdinalIgnoreCase)) {
-                        validation.SequenceOfReferences = new ListValue<StringValue> { InnerText = string.Join(" ", remaining) };
+                        changed = true;
+                    } else {
+                        string replacement = string.Join(" ", remaining);
+                        validation.SequenceOfReferences = new ListValue<StringValue> { InnerText = replacement };
+                        changed = true;
                     }
                 }
             }
 
-            validations.Count = (uint)validations.Elements<DataValidation>().Count();
-            WorksheetRoot.Save();
+            if (changed) {
+                validations.Count = (uint)validations.Elements<DataValidation>().Count();
+                WorksheetRoot.Save();
+            }
         }
 
         private void InsertConditionalFormatting(ConditionalFormatting conditionalFormatting) {
@@ -221,30 +255,63 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static string[] SplitReferenceList(string referenceList) {
-            return referenceList.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        private static ReferenceListEnumerable SplitReferenceList(string referenceList) {
+            return new ReferenceListEnumerable(referenceList);
         }
 
-        private static List<string> RemoveReferenceOverlap(string referenceList, (int r1, int c1, int r2, int c2) filter) {
+        private static (int r1, int c1, int r2, int c2) ParseReferenceArgument(string reference) {
+            if (TryParseReference(reference, out var bounds)) {
+                return bounds;
+            }
+
+            throw new ArgumentException($"Invalid A1 reference '{reference}'.");
+        }
+
+        private static bool ReferenceListOverlaps(string referenceList, (int r1, int c1, int r2, int c2) filter) {
+            foreach (ReferenceListPart part in SplitReferenceList(referenceList)) {
+                if (TryParseReference(part, out var bounds) && RangesOverlapInclusive(filter, bounds)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryRemoveReferenceOverlap(string referenceList, (int r1, int c1, int r2, int c2) filter, out List<string> remaining) {
+            foreach (ReferenceListPart part in SplitReferenceList(referenceList)) {
+                if (TryParseReference(part, out var bounds) && RangesOverlapInclusive(bounds, filter)) {
+                    remaining = RemoveReferenceOverlapAfterOverlap(referenceList, filter);
+                    return true;
+                }
+            }
+
+            remaining = EmptyReferenceList;
+            return false;
+        }
+
+        private static List<string> RemoveReferenceOverlapAfterOverlap(string referenceList, (int r1, int c1, int r2, int c2) filter) {
             var remaining = new List<string>();
-            foreach (string part in SplitReferenceList(referenceList)) {
+            foreach (ReferenceListPart part in SplitReferenceList(referenceList)) {
                 if (!TryParseReference(part, out var bounds)) {
-                    remaining.Add(part);
+                    remaining.Add(part.ToString());
                     continue;
                 }
 
-                foreach (var segment in SubtractRange(bounds, filter)) {
-                    remaining.Add(ToReference(segment.r1, segment.c1, segment.r2, segment.c2));
+                if (!RangesOverlapInclusive(bounds, filter)) {
+                    remaining.Add(part.ToString());
+                    continue;
                 }
+
+                AppendRangeDifference(remaining, bounds, filter);
             }
 
             return remaining;
         }
 
-        private static IEnumerable<(int r1, int c1, int r2, int c2)> SubtractRange((int r1, int c1, int r2, int c2) source, (int r1, int c1, int r2, int c2) remove) {
+        private static void AppendRangeDifference(List<string> references, (int r1, int c1, int r2, int c2) source, (int r1, int c1, int r2, int c2) remove) {
             if (!RangesOverlapInclusive(source, remove)) {
-                yield return source;
-                yield break;
+                references.Add(ToReference(source.r1, source.c1, source.r2, source.c2));
+                return;
             }
 
             int ir1 = Math.Max(source.r1, remove.r1);
@@ -253,19 +320,89 @@ namespace OfficeIMO.Excel {
             int ic2 = Math.Min(source.c2, remove.c2);
 
             if (source.r1 < ir1) {
-                yield return (source.r1, source.c1, ir1 - 1, source.c2);
+                references.Add(ToReference(source.r1, source.c1, ir1 - 1, source.c2));
             }
 
             if (ir2 < source.r2) {
-                yield return (ir2 + 1, source.c1, source.r2, source.c2);
+                references.Add(ToReference(ir2 + 1, source.c1, source.r2, source.c2));
             }
 
             if (source.c1 < ic1) {
-                yield return (ir1, source.c1, ir2, ic1 - 1);
+                references.Add(ToReference(ir1, source.c1, ir2, ic1 - 1));
             }
 
             if (ic2 < source.c2) {
-                yield return (ir1, ic2 + 1, ir2, source.c2);
+                references.Add(ToReference(ir1, ic2 + 1, ir2, source.c2));
+            }
+        }
+
+        private readonly struct ReferenceListEnumerable {
+            private readonly string _text;
+
+            public ReferenceListEnumerable(string text) {
+                _text = text;
+            }
+
+            public ReferenceListEnumerator GetEnumerator() {
+                return new ReferenceListEnumerator(_text);
+            }
+        }
+
+        private struct ReferenceListEnumerator {
+            private readonly string _text;
+            private int _index;
+
+            public ReferenceListEnumerator(string text) {
+                _text = text;
+                _index = 0;
+                Current = default;
+            }
+
+            public ReferenceListPart Current { get; private set; }
+
+            public bool MoveNext() {
+                int length = _text.Length;
+                int start = _index;
+                while (start < length && _text[start] == ' ') {
+                    start++;
+                }
+
+                if (start >= length) {
+                    _index = length;
+                    Current = default;
+                    return false;
+                }
+
+                int end = start + 1;
+                while (end < length && _text[end] != ' ') {
+                    end++;
+                }
+
+                _index = end + 1;
+                Current = new ReferenceListPart(_text, start, end - start);
+                return true;
+            }
+        }
+
+        private readonly struct ReferenceListPart {
+            public ReferenceListPart(string text, int start, int length) {
+                Text = text;
+                Start = start;
+                Length = length;
+            }
+
+            public string Text { get; }
+
+            public int Start { get; }
+
+            public int Length { get; }
+
+            public override string ToString() {
+                return Start == 0 && Length == Text.Length ? Text : Text.Substring(Start, Length);
+            }
+
+            public void AppendTo(StringBuilder builder) {
+                builder.Append(Text, Start, Length);
             }
         }
     }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
@@ -34,6 +34,21 @@ namespace OfficeIMO.Excel {
             var decided = requested;
             int workload = rows * cols;
             if (decided == OfficeIMO.Excel.ExecutionMode.Automatic) {
+                if (CanUseAutomaticXmlReadFastPath(policy)) {
+                    if (ShouldUseOrderedBufferedXmlStream(rows, c1, c2)
+                        && TryReadObjectsStreamOrderedXmlFast<T>(a1Range, r1, c1, r2, c2, rows, cols, ct, out var orderedRows)) {
+                        return orderedRows;
+                    }
+
+                    if (TryReadObjectsFromXmlMaterialized<T>(a1Range, r1, c1, r2, c2, rows, cols, ct, out var automaticStreamResult)) {
+                        return automaticStreamResult;
+                    }
+
+                    if (TryReadObjectsSequentialSinglePass<T>(a1Range, r1, c1, r2, c2, rows, cols, ct, out var automaticSinglePassResult)) {
+                        return automaticSinglePassResult;
+                    }
+                }
+
                 decided = policy.Decide("ReadObjectsAs", workload);
             }
 

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml.Spreadsheet;
+using System.Buffers;
 using System.Data;
 using System.Globalization;
 using System.IO;
@@ -37,6 +38,12 @@ namespace OfficeIMO.Excel {
             var decided = mode ?? policy.Mode;
             int workload = height * width;
             if (decided == OfficeIMO.Excel.ExecutionMode.Automatic) {
+                if (CanUseAutomaticXmlReadFastPath(policy)) {
+                    if (TryFillRangeXmlFast(result, r1, c1, r2, c2, ct)) {
+                        return result;
+                    }
+                }
+
                 decided = policy.Decide("ReadRange", workload);
             }
 
@@ -75,6 +82,20 @@ namespace OfficeIMO.Excel {
             var decided = mode ?? policy.Mode;
             int workload = rows * cols;
             if (decided == OfficeIMO.Excel.ExecutionMode.Automatic) {
+                if (CanUseAutomaticXmlReadFastPath(policy)) {
+                    if (TryFillDataTableXmlBufferedSinglePass(dt, r1, c1, r2, c2, rows, cols, headersInFirstRow, workload, ct)) {
+                        return dt;
+                    }
+
+                    if (TryFillDataTableXmlFast(dt, r1, c1, r2, c2, rows, cols, headersInFirstRow, ct)) {
+                        return dt;
+                    }
+
+                    if (TryFillDataTableSequentialSinglePass(dt, r1, c1, r2, c2, rows, cols, headersInFirstRow, ct)) {
+                        return dt;
+                    }
+                }
+
                 decided = policy.Decide("ReadRangeAsDataTable", workload);
             }
 
@@ -680,9 +701,14 @@ namespace OfficeIMO.Excel {
                 return Array.Empty<Dictionary<string, object?>>();
             }
 
-            if (CanUseReadObjectsXmlFastPath(mode)
-                && TryReadObjectsDictionaryXmlFast(r1, c1, r2, c2, rows, cols, ct, out var xmlResult)) {
-                return xmlResult;
+            if (CanUseReadObjectsXmlFastPath(mode)) {
+                if (TryReadObjectsDictionaryXmlStreamingFast(r1, c1, r2, c2, rows, cols, ct, out var streamingResult)) {
+                    return streamingResult;
+                }
+
+                if (TryReadObjectsDictionaryXmlFast(r1, c1, r2, c2, rows, cols, ct, out var xmlResult)) {
+                    return xmlResult;
+                }
             }
 
             if (CanUseSequentialRangeFastPath("ReadObjects", rows * cols, mode)) {
@@ -973,6 +999,199 @@ namespace OfficeIMO.Excel {
             return policy.OnDecision == null && CanUseXmlFastReader();
         }
 
+        private bool TryReadObjectsDictionaryXmlStreamingFast(
+            int r1,
+            int c1,
+            int r2,
+            int c2,
+            int rows,
+            int cols,
+            CancellationToken ct,
+            out List<Dictionary<string, object?>> result) {
+            int dataRowCount = rows - 1;
+            result = new List<Dictionary<string, object?>>(dataRowCount);
+            var headerValues = new object?[cols];
+            string[]? headers = null;
+            int nextDataRow = r1 + 1;
+            int lastDataRow = r1;
+
+            try {
+                using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
+                RewindWorksheetStream(stream);
+                using var reader = OpenWorksheetXmlReader(stream);
+                bool canCancel = ct.CanBeCanceled;
+                int nextRowIndex = 1;
+
+                while (reader.Read()) {
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
+                    if (reader.NodeType != XmlNodeType.Element || reader.LocalName != "row") {
+                        continue;
+                    }
+
+                    int rowIndex = ParsePositiveIntAttribute(reader.GetAttribute("r"));
+                    if (rowIndex <= 0) {
+                        rowIndex = nextRowIndex;
+                    }
+
+                    nextRowIndex = rowIndex + 1;
+                    if (rowIndex < r1) {
+                        SkipXmlElement(reader, "row");
+                        continue;
+                    }
+
+                    if (rowIndex > r2) {
+                        break;
+                    }
+
+                    if (rowIndex == r1) {
+                        if (nextDataRow != r1 + 1 || result.Count > 0 || lastDataRow != r1) {
+                            result = [];
+                            return false;
+                        }
+
+                        ReadXmlRowValuesInto(reader, rowIndex, c1, c2, headerValues, ct);
+                        headers = ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => headerValues[c]?.ToString(), _opt.NormalizeHeaders);
+                        continue;
+                    }
+
+                    if (rowIndex <= lastDataRow) {
+                        result = [];
+                        return false;
+                    }
+
+                    headers ??= ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => headerValues[c]?.ToString(), _opt.NormalizeHeaders);
+                    while (nextDataRow < rowIndex) {
+                        if (canCancel) {
+                            ct.ThrowIfCancellationRequested();
+                        }
+
+                        result.Add(CreateEmptyDictionaryRow(headers, cols));
+                        nextDataRow++;
+                    }
+
+                    result.Add(ReadXmlRowIntoDictionary(reader, c1, c2, headers, cols, ct));
+                    lastDataRow = rowIndex;
+                    nextDataRow = rowIndex + 1;
+                }
+
+                headers ??= ExcelHeaderNameHelper.BuildUniqueHeaders(cols, c => headerValues[c]?.ToString(), _opt.NormalizeHeaders);
+                while (nextDataRow <= r2) {
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
+                    result.Add(CreateEmptyDictionaryRow(headers, cols));
+                    nextDataRow++;
+                }
+
+                return result.Count == dataRowCount;
+            } catch (XmlException) {
+                result = [];
+                return false;
+            } catch (IOException) {
+                result = [];
+                return false;
+            } catch (UnauthorizedAccessException) {
+                result = [];
+                return false;
+            } catch (ObjectDisposedException) {
+                result = [];
+                return false;
+            }
+        }
+
+        private Dictionary<string, object?> ReadXmlRowIntoDictionary(
+            XmlReader rowReader,
+            int c1,
+            int c2,
+            string[] headers,
+            int cols,
+            CancellationToken ct) {
+            if (rowReader.IsEmptyElement) {
+                return CreateEmptyDictionaryRow(headers, cols);
+            }
+
+            object?[] values = ArrayPool<object?>.Shared.Rent(cols);
+            Array.Clear(values, 0, cols);
+            int depth = rowReader.Depth;
+            bool canCancel = ct.CanBeCanceled;
+            int nextColumnIndex = 1;
+            bool canTrackColumns = cols <= 64;
+            ulong seenColumns = 0;
+            try {
+                while (rowReader.Read()) {
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
+                    if (rowReader.NodeType == XmlNodeType.EndElement && rowReader.Depth == depth && rowReader.LocalName == "row") {
+                        return CreateDictionaryRow(headers, values, cols);
+                    }
+
+                    if (rowReader.NodeType != XmlNodeType.Element || rowReader.LocalName != "c") {
+                        continue;
+                    }
+
+                    int columnIndex = GetXmlCellColumnIndex(rowReader, ref nextColumnIndex);
+                    if (columnIndex <= 0) {
+                        SkipXmlElement(rowReader, "c");
+                        continue;
+                    }
+
+                    if (columnIndex < c1 || columnIndex > c2) {
+                        SkipXmlElement(rowReader, "c");
+                        continue;
+                    }
+
+                    int offset = columnIndex - c1;
+                    if ((uint)offset >= (uint)cols) {
+                        SkipXmlElement(rowReader, "c");
+                        continue;
+                    }
+
+                    values[offset] = ReadXmlCellValue(rowReader);
+                    if (canTrackColumns && MarkRequestedColumnSeen(offset, cols, ref seenColumns)) {
+                        SkipXmlElementContent(rowReader, depth, "row");
+                        return CreateDictionaryRow(headers, values, cols);
+                    }
+                }
+
+                return CreateDictionaryRow(headers, values, cols);
+            } finally {
+                Array.Clear(values, 0, cols);
+                ArrayPool<object?>.Shared.Return(values);
+            }
+        }
+
+        private static Dictionary<string, object?> CreateEmptyDictionaryRow(string[] headers, int columnCount) {
+            var dict = new Dictionary<string, object?>(columnCount, StringComparer.OrdinalIgnoreCase);
+            for (int c = 0; c < columnCount; c++) {
+                dict.Add(headers[c], null);
+            }
+
+            return dict;
+        }
+
+        private static Dictionary<string, object?> CreateDictionaryRow(string[] headers, object?[]? values, int columnCount) {
+            var dict = new Dictionary<string, object?>(columnCount, StringComparer.OrdinalIgnoreCase);
+            if (values == null) {
+                for (int c = 0; c < columnCount; c++) {
+                    dict.Add(headers[c], null);
+                }
+
+                return dict;
+            }
+
+            for (int c = 0; c < columnCount; c++) {
+                dict.Add(headers[c], values[c]);
+            }
+
+            return dict;
+        }
+
         private bool TryReadObjectsDictionaryXmlFast(
             int r1,
             int c1,
@@ -1074,22 +1293,6 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            static Dictionary<string, object?> CreateDictionaryRow(string[] headers, object?[]? values, int columnCount) {
-                var dict = new Dictionary<string, object?>(columnCount, StringComparer.OrdinalIgnoreCase);
-                if (values == null) {
-                    for (int c = 0; c < columnCount; c++) {
-                        dict.Add(headers[c], null);
-                    }
-
-                    return dict;
-                }
-
-                for (int c = 0; c < columnCount; c++) {
-                    dict.Add(headers[c], values[c]);
-                }
-
-                return dict;
-            }
         }
 
         private bool TryReadObjectsSequentialSinglePass(
@@ -1517,6 +1720,10 @@ namespace OfficeIMO.Excel {
             return _opt.CellValueConverter == null
                 && _opt.Culture == CultureInfo.InvariantCulture
                 && CanStreamWorksheetPart();
+        }
+
+        private bool CanUseAutomaticXmlReadFastPath(ExecutionPolicy policy) {
+            return policy.OnDecision == null;
         }
 
         private bool CanUseDataTableXmlBufferedReader() {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
@@ -1,5 +1,4 @@
 using DocumentFormat.OpenXml.Spreadsheet;
-using System.Buffers;
 using System.Data;
 using System.Globalization;
 using System.IO;
@@ -1114,56 +1113,50 @@ namespace OfficeIMO.Excel {
                 return CreateEmptyDictionaryRow(headers, cols);
             }
 
-            object?[] values = ArrayPool<object?>.Shared.Rent(cols);
-            Array.Clear(values, 0, cols);
+            object?[] values = new object?[cols];
             int depth = rowReader.Depth;
             bool canCancel = ct.CanBeCanceled;
             int nextColumnIndex = 1;
             bool canTrackColumns = cols <= 64;
             ulong seenColumns = 0;
-            try {
-                while (rowReader.Read()) {
-                    if (canCancel) {
-                        ct.ThrowIfCancellationRequested();
-                    }
-
-                    if (rowReader.NodeType == XmlNodeType.EndElement && rowReader.Depth == depth && rowReader.LocalName == "row") {
-                        return CreateDictionaryRow(headers, values, cols);
-                    }
-
-                    if (rowReader.NodeType != XmlNodeType.Element || rowReader.LocalName != "c") {
-                        continue;
-                    }
-
-                    int columnIndex = GetXmlCellColumnIndex(rowReader, ref nextColumnIndex);
-                    if (columnIndex <= 0) {
-                        SkipXmlElement(rowReader, "c");
-                        continue;
-                    }
-
-                    if (columnIndex < c1 || columnIndex > c2) {
-                        SkipXmlElement(rowReader, "c");
-                        continue;
-                    }
-
-                    int offset = columnIndex - c1;
-                    if ((uint)offset >= (uint)cols) {
-                        SkipXmlElement(rowReader, "c");
-                        continue;
-                    }
-
-                    values[offset] = ReadXmlCellValue(rowReader);
-                    if (canTrackColumns && MarkRequestedColumnSeen(offset, cols, ref seenColumns)) {
-                        SkipXmlElementContent(rowReader, depth, "row");
-                        return CreateDictionaryRow(headers, values, cols);
-                    }
+            while (rowReader.Read()) {
+                if (canCancel) {
+                    ct.ThrowIfCancellationRequested();
                 }
 
-                return CreateDictionaryRow(headers, values, cols);
-            } finally {
-                Array.Clear(values, 0, cols);
-                ArrayPool<object?>.Shared.Return(values);
+                if (rowReader.NodeType == XmlNodeType.EndElement && rowReader.Depth == depth && rowReader.LocalName == "row") {
+                    return CreateDictionaryRow(headers, values, cols);
+                }
+
+                if (rowReader.NodeType != XmlNodeType.Element || rowReader.LocalName != "c") {
+                    continue;
+                }
+
+                int columnIndex = GetXmlCellColumnIndex(rowReader, ref nextColumnIndex);
+                if (columnIndex <= 0) {
+                    SkipXmlElement(rowReader, "c");
+                    continue;
+                }
+
+                if (columnIndex < c1 || columnIndex > c2) {
+                    SkipXmlElement(rowReader, "c");
+                    continue;
+                }
+
+                int offset = columnIndex - c1;
+                if ((uint)offset >= (uint)cols) {
+                    SkipXmlElement(rowReader, "c");
+                    continue;
+                }
+
+                values[offset] = ReadXmlCellValue(rowReader);
+                if (canTrackColumns && MarkRequestedColumnSeen(offset, cols, ref seenColumns)) {
+                    SkipXmlElementContent(rowReader, depth, "row");
+                    return CreateDictionaryRow(headers, values, cols);
+                }
             }
+
+            return CreateDictionaryRow(headers, values, cols);
         }
 
         private static Dictionary<string, object?> CreateEmptyDictionaryRow(string[] headers, int columnCount) {

--- a/OfficeIMO.Tests/Excel.CellValues.cs
+++ b/OfficeIMO.Tests/Excel.CellValues.cs
@@ -97,6 +97,49 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_TryGetCellText_MissingCell_DoesNotCreateCell() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesMissingLookupNoMutation.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Header");
+
+                Assert.False(sheet.TryGetCellText(10, 5, out _));
+
+                WorksheetPart wsPart = document._spreadSheetDocument.WorkbookPart!.WorksheetParts.First();
+                Assert.DoesNotContain(wsPart.Worksheet.Descendants<Row>(), row => row.RowIndex?.Value == 10U);
+                Assert.DoesNotContain(wsPart.Worksheet.Descendants<Cell>(), cell => cell.CellReference?.Value == "E10");
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_CellAtGetValue_MissingCell_DoesNotCreateCell() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesObjectModelMissingLookupNoMutation.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(10, 1, "Existing row");
+
+                ExcelCellData value = sheet.CellAt(10, 5).GetValue();
+
+                Assert.Equal(ExcelCellDataKind.Blank, value.Kind);
+                Assert.Null(value.Value);
+                WorksheetPart wsPart = document._spreadSheetDocument.WorkbookPart!.WorksheetParts.First();
+                Assert.DoesNotContain(wsPart.Worksheet.Descendants<Cell>(), cell => cell.CellReference?.Value == "E10");
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
         public void Test_TryGetCellText_UsesFreshSharedStringsAfterMutation() {
             string filePath = Path.Combine(_directoryWithFiles, "CellValuesSharedStringCache.xlsx");
 
@@ -146,6 +189,21 @@ namespace OfficeIMO.Tests {
 
                 Assert.True(sheet.TryGetCellText(1, 1, out var refreshed));
                 Assert.Equal("Omega", refreshed);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
+        public void Test_CellValue_RejectsSharedStringsOverExcelLimit() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesSharedStringTooLong.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                string tooLong = new string('A', 32_768);
+
+                var exception = Assert.Throws<ArgumentException>(() => sheet.CellValue(1, 1, tooLong));
+                Assert.Contains("32,767", exception.Message, StringComparison.Ordinal);
             }
 
             File.Delete(filePath);
@@ -203,6 +261,40 @@ namespace OfficeIMO.Tests {
                 Assert.True(sheet.TryGetCellText(3, 1, out var third));
                 Assert.Equal("Status Processed", first);
                 Assert.Equal("Status Processed", third);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ReplaceAll_HandlesInlineStrings() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesInlineReplace.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                var worksheet = document._spreadSheetDocument.WorkbookPart!.WorksheetParts.First().Worksheet;
+                var sheetData = worksheet.GetFirstChild<SheetData>()!;
+                var row = new Row { RowIndex = 1 };
+                row.Append(new Cell {
+                    CellReference = "A1",
+                    DataType = CellValues.InlineString,
+                    InlineString = new InlineString(new Text("Status New"))
+                });
+                row.Append(new Cell {
+                    CellReference = "B1",
+                    DataType = CellValues.InlineString,
+                    InlineString = new InlineString(new Run(new Text("Status ")), new Run(new Text("New")))
+                });
+                sheetData.Append(row);
+
+                Assert.Equal(2, sheet.ReplaceAll("new", "Processed"));
+                Assert.True(sheet.TryGetCellText(1, 1, out var first));
+                Assert.True(sheet.TryGetCellText(1, 2, out var second));
+                Assert.Equal("Status Processed", first);
+                Assert.Equal("Status Processed", second);
                 document.Save();
             }
 

--- a/OfficeIMO.Tests/Excel.CellValues.cs
+++ b/OfficeIMO.Tests/Excel.CellValues.cs
@@ -118,6 +118,58 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_TryGetCellText_OutOfOrderRows_FindsExistingCell() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesOutOfOrderRows.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(5, 1, "Later");
+                sheet.CellValue(2, 1, "Target");
+
+                WorksheetPart wsPart = document._spreadSheetDocument.WorkbookPart!.WorksheetParts.First();
+                SheetData sheetData = wsPart.Worksheet.GetFirstChild<SheetData>()!;
+                Row row2 = sheetData.Elements<Row>().First(row => row.RowIndex?.Value == 2U);
+                row2.Remove();
+                sheetData.Append(row2);
+
+                Assert.True(sheet.TryGetCellText(5, 1, out _));
+                Assert.True(sheet.TryGetCellText(2, 1, out var text));
+                Assert.Equal("Target", text);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_TryGetCellText_OutOfOrderCells_FindsExistingCell() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesOutOfOrderCells.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 3, "Later");
+                sheet.CellValue(1, 1, "Target");
+
+                WorksheetPart wsPart = document._spreadSheetDocument.WorkbookPart!.WorksheetParts.First();
+                Row row1 = wsPart.Worksheet.GetFirstChild<SheetData>()!.Elements<Row>().First(row => row.RowIndex?.Value == 1U);
+                Cell cellA1 = row1.Elements<Cell>().First(cell => cell.CellReference?.Value == "A1");
+                cellA1.Remove();
+                row1.Append(cellA1);
+
+                Assert.True(sheet.TryGetCellText(1, 3, out _));
+                Assert.True(sheet.TryGetCellText(1, 1, out var text));
+                Assert.Equal("Target", text);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
         public void Test_CellAtGetValue_MissingCell_DoesNotCreateCell() {
             string filePath = Path.Combine(_directoryWithFiles, "CellValuesObjectModelMissingLookupNoMutation.xlsx");
 

--- a/OfficeIMO.Tests/Excel.CellValues.cs
+++ b/OfficeIMO.Tests/Excel.CellValues.cs
@@ -297,6 +297,32 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_FindFirst_UsesFreshFormulaCacheStateAfterCalculationChanges() {
+            string filePath = Path.Combine(_directoryWithFiles, "CellValuesFindFirstFormulaCacheMutation.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, 1d);
+                sheet.CellValue(2, 1, 2d);
+                sheet.CellFormula(3, 1, "SUM(A1:A2)");
+
+                Assert.Null(sheet.FindFirst("3"));
+
+                Assert.Equal(1, sheet.RecalculateSupportedFormulas());
+                Assert.Equal("A3", sheet.FindFirst("3"));
+
+                sheet.ClearCachedFormulaResults();
+                Assert.Null(sheet.FindFirst("3"));
+
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
         public void Test_FindFirstAndReplaceAll_HandleSharedStrings() {
             string filePath = Path.Combine(_directoryWithFiles, "CellValuesSharedStringFindReplace.xlsx");
 

--- a/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
+++ b/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
@@ -52,6 +53,81 @@ namespace OfficeIMO.Tests {
                 Assert.False(sheet.HasComment(2, 1));
 
                 document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_MergeRange_DuplicateCallKeepsSingleMerge() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.MergeDuplicate.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Merge");
+                sheet.MergeRange("A1:B1");
+                sheet.MergeRange("A1:B1");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                MergeCell merge = Assert.Single(worksheetPart.Worksheet.Descendants<MergeCell>());
+                Assert.Equal("A1:B1", merge.Reference?.Value);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_RangeFormatting_ReusesStylesAndValidates() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.RangeFormatting.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, 10d);
+                sheet.CellValue(1, 2, 20d);
+                sheet.CellValue(2, 1, 30d);
+                sheet.CellValue(2, 2, 40d);
+
+                sheet.Range("A1:B2").SetNumberFormat("0.00");
+                sheet.Range("C1:D2").SetFillColor("#FFF2CC");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorkbookStylesPart stylesPart = spreadsheet.WorkbookPart!.WorkbookStylesPart!;
+                Stylesheet stylesheet = stylesPart.Stylesheet!;
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                Dictionary<string, Cell> cells = worksheetPart.Worksheet.Descendants<Cell>()
+                    .Where(cell => cell.CellReference?.Value != null)
+                    .ToDictionary(cell => cell.CellReference!.Value!);
+
+                uint numberStyleIndex = cells["A1"].StyleIndex!.Value;
+                Assert.NotEqual(0U, numberStyleIndex);
+                Assert.Equal(numberStyleIndex, cells["A2"].StyleIndex!.Value);
+                Assert.Equal(numberStyleIndex, cells["B1"].StyleIndex!.Value);
+                Assert.Equal(numberStyleIndex, cells["B2"].StyleIndex!.Value);
+
+                uint fillStyleIndex = cells["C1"].StyleIndex!.Value;
+                Assert.NotEqual(0U, fillStyleIndex);
+                Assert.Equal(fillStyleIndex, cells["C2"].StyleIndex!.Value);
+                Assert.Equal(fillStyleIndex, cells["D1"].StyleIndex!.Value);
+                Assert.Equal(fillStyleIndex, cells["D2"].StyleIndex!.Value);
+
+                CellFormat numberFormat = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt((int)numberStyleIndex);
+                Assert.True(numberFormat.ApplyNumberFormat?.Value);
+                NumberingFormat customFormat = stylesheet.NumberingFormats!.Elements<NumberingFormat>()
+                    .First(format => format.NumberFormatId!.Value == numberFormat.NumberFormatId!.Value);
+                Assert.Equal("0.00", customFormat.FormatCode!.Value);
+
+                CellFormat fillFormat = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt((int)fillStyleIndex);
+                Assert.True(fillFormat.ApplyFill?.Value);
+                Fill fill = stylesheet.Fills!.Elements<Fill>().ElementAt((int)fillFormat.FillId!.Value);
+                Assert.Equal("FFFFF2CC", fill.PatternFill!.ForegroundColor!.Rgb!.Value);
             }
 
             using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
@@ -436,6 +512,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ClosedXmlGap_ClearHyperlinks_NoOverlapDoesNotSplitReferenceList() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.ClearHyperlinkNoOverlap.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Links");
+                sheet.CellValue(2, 1, "One");
+                sheet.CellValue(4, 1, "Two");
+                sheet.SetHyperlink(2, 1, "https://example.com", display: "Linked", style: false);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Hyperlink hyperlink = worksheetPart.Worksheet.Descendants<Hyperlink>().Single();
+                hyperlink.Reference = "A2 A4";
+                worksheetPart.Worksheet.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                document.Sheets[0].Range("C1:C3").Clear(ExcelClearOptions.Hyperlinks);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Hyperlink hyperlink = worksheetPart.Worksheet.Descendants<Hyperlink>().Single();
+                Assert.Equal("A2 A4", hyperlink.Reference?.Value);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
         public void Test_ClosedXmlGap_Sort_RewritesRelativeFormulaRows() {
             string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.SortFormulaRows.xlsx");
 
@@ -548,6 +659,187 @@ namespace OfficeIMO.Tests {
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
                 WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
                 Assert.Empty(worksheetPart.Worksheet.Descendants<Cell>());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_ClearRange_Values_DoesNotMaterializeSparseBlankCells() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.ClearSparseValues.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Clear");
+                sheet.CellValue(1, 1, "Keep");
+                sheet.CellValue(5, 5, "Clear");
+                sheet.ClearRange("A1:E5", ExcelClearOptions.Values);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                string[] references = worksheetPart.Worksheet.Descendants<Cell>()
+                    .Select(cell => cell.CellReference?.Value ?? string.Empty)
+                    .OrderBy(reference => reference)
+                    .ToArray();
+
+                Assert.Equal(new[] { "A1", "E5" }, references);
+                Assert.All(worksheetPart.Worksheet.Descendants<Cell>(), cell => Assert.Null(cell.CellValue));
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_ClearRange_CellFields_ScansExistingSparseCellsOnly() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.ClearSparseCellFields.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Clear");
+                sheet.CellValue(1, 1, "Keep");
+                sheet.CellAt(10, 5).SetValue("Clear").SetFillColor("FFF2CC");
+                sheet.CellAt(10, 6).SetFormula("E10");
+                sheet.CellAt(12, 5).SetValue("Outside").SetFillColor("D9EAD3");
+
+                sheet.ClearRange("E10:F10", ExcelClearOptions.Values | ExcelClearOptions.Formulas | ExcelClearOptions.Styles);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Dictionary<string, Cell> cells = worksheetPart.Worksheet.Descendants<Cell>()
+                    .Where(cell => cell.CellReference?.Value != null)
+                    .ToDictionary(cell => cell.CellReference!.Value!);
+
+                Assert.Equal(new[] { "A1", "E10", "E12", "F10" }, cells.Keys.OrderBy(reference => reference).ToArray());
+                Assert.Null(cells["E10"].CellValue);
+                Assert.Null(cells["E10"].StyleIndex);
+                Assert.Null(cells["F10"].CellFormula);
+                Assert.Null(cells["F10"].CellValue);
+                Assert.NotNull(cells["E12"].CellValue);
+                Assert.NotNull(cells["E12"].StyleIndex);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_ClearRange_Comments_RemovesOnlyShapesInsideSparseRange() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.ClearSparseComments.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Clear");
+                sheet.SetComment(1, 1, "Remove first", author: "Tester");
+                sheet.SetComment(5, 5, "Remove second", author: "Tester");
+                sheet.SetComment(7, 7, "Keep outside", author: "Tester");
+
+                sheet.ClearRange("A1:E5", ExcelClearOptions.Comments);
+
+                Assert.False(sheet.HasComment(1, 1));
+                Assert.False(sheet.HasComment(5, 5));
+                Assert.True(sheet.HasComment(7, 7));
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                string[] commentReferences = worksheetPart.WorksheetCommentsPart!.Comments!.CommentList!.Elements<Comment>()
+                    .Select(comment => comment.Reference?.Value ?? string.Empty)
+                    .ToArray();
+
+                Assert.Equal(new[] { "G7" }, commentReferences);
+
+                VmlDrawingPart vmlPart = Assert.Single(worksheetPart.VmlDrawingParts);
+                XDocument vml = XDocument.Load(vmlPart.GetStream());
+                XNamespace excelNamespace = "urn:schemas-microsoft-com:office:excel";
+                string[] vmlCoordinates = vml.Root!.Descendants(excelNamespace + "ClientData")
+                    .Select(clientData => string.Join(
+                        ",",
+                        clientData.Element(excelNamespace + "Row")?.Value.Trim(),
+                        clientData.Element(excelNamespace + "Column")?.Value.Trim()))
+                    .ToArray();
+
+                Assert.Equal(new[] { "6,6" }, vmlCoordinates);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_ClearRange_Comments_NoOverlapPreservesArtifacts() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.ClearCommentsNoOverlap.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Clear");
+                sheet.SetComment(1, 1, "Keep", author: "Tester");
+
+                sheet.ClearRange("C3:D4", ExcelClearOptions.Comments);
+                Assert.True(sheet.HasComment(1, 1));
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                string commentReference = Assert.Single(worksheetPart.WorksheetCommentsPart!.Comments!.CommentList!.Elements<Comment>())
+                    .Reference?.Value ?? string.Empty;
+
+                Assert.Equal("A1", commentReference);
+
+                VmlDrawingPart vmlPart = Assert.Single(worksheetPart.VmlDrawingParts);
+                XDocument vml = XDocument.Load(vmlPart.GetStream());
+                XNamespace excelNamespace = "urn:schemas-microsoft-com:office:excel";
+                string coordinate = Assert.Single(vml.Root!.Descendants(excelNamespace + "ClientData")
+                    .Select(clientData => string.Join(
+                        ",",
+                        clientData.Element(excelNamespace + "Row")?.Value.Trim(),
+                        clientData.Element(excelNamespace + "Column")?.Value.Trim())));
+
+                Assert.Equal("0,0", coordinate);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_ClearComment_MissingCellPreservesOtherCommentArtifacts() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.ClearMissingComment.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Clear");
+                sheet.SetComment(1, 1, "Keep", author: "Tester");
+
+                sheet.ClearComment("C3");
+                Assert.True(sheet.HasComment(1, 1));
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                string commentReference = Assert.Single(worksheetPart.WorksheetCommentsPart!.Comments!.CommentList!.Elements<Comment>())
+                    .Reference?.Value ?? string.Empty;
+
+                Assert.Equal("A1", commentReference);
+
+                VmlDrawingPart vmlPart = Assert.Single(worksheetPart.VmlDrawingParts);
+                XDocument vml = XDocument.Load(vmlPart.GetStream());
+                XNamespace excelNamespace = "urn:schemas-microsoft-com:office:excel";
+                string coordinate = Assert.Single(vml.Root!.Descendants(excelNamespace + "ClientData")
+                    .Select(clientData => string.Join(
+                        ",",
+                        clientData.Element(excelNamespace + "Row")?.Value.Trim(),
+                        clientData.Element(excelNamespace + "Column")?.Value.Trim())));
+
+                Assert.Equal("0,0", coordinate);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
             }
         }
 
@@ -666,6 +958,53 @@ namespace OfficeIMO.Tests {
                 Assert.Empty(sheet.GetConditionalFormattingRules("A2:A4"));
 
                 document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_RangeMetadata_NoOverlapClearPreservesReferenceLists() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.RulesNoOverlap.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Rules");
+                sheet.CellValue(1, 1, "Value");
+                sheet.CellValue(2, 1, 10d);
+                sheet.CellValue(3, 1, 20d);
+                sheet.CellValue(4, 1, 30d);
+                sheet.CellValue(6, 1, 40d);
+                sheet.CellValue(2, 2, 10d);
+                sheet.CellValue(3, 2, 20d);
+                sheet.CellValue(4, 2, 30d);
+                sheet.CellValue(6, 2, 40d);
+
+                sheet.AddConditionalFormulaRule("A2:A4 A6", "A2>15");
+                sheet.ValidationWholeNumber("B2:B4 B6", DataValidationOperatorValues.Between, 1, 50);
+
+                Assert.Single(sheet.GetConditionalFormattingRules("A6"));
+                Assert.Single(sheet.GetDataValidations("B6"));
+
+                sheet.SetDataValidationMessages("D1:D2", new ExcelDataValidationMessageOptions {
+                    PromptTitle = "Outside",
+                    Prompt = "Should not apply",
+                    ErrorTitle = "Outside",
+                    Error = "Should not apply"
+                });
+                ExcelDataValidationInfo untouchedValidation = Assert.Single(sheet.GetDataValidations("B2:B4"));
+                Assert.Null(untouchedValidation.PromptTitle);
+                Assert.Null(untouchedValidation.ErrorTitle);
+
+                sheet.ClearRange("D1:D3", ExcelClearOptions.ConditionalFormatting | ExcelClearOptions.DataValidations);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Assert.Equal("A2:A4 A6", worksheetPart.Worksheet.Elements<ConditionalFormatting>().Single().SequenceOfReferences?.InnerText);
+                Assert.Equal("B2:B4 B6", worksheetPart.Worksheet.Descendants<DataValidation>().Single().SequenceOfReferences?.InnerText);
             }
 
             using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {

--- a/OfficeIMO.Tests/Excel.HeadersHelpers.MissingHeader.cs
+++ b/OfficeIMO.Tests/Excel.HeadersHelpers.MissingHeader.cs
@@ -34,6 +34,32 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         [Trait("Category", "ExcelHeaders")]
+        public void Excel_SetByHeader_NullValue_WritesEmptyText() {
+            string filePath = Path.Combine(_directoryWithFiles, "Header_SetByHeader_Null.xlsx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+
+            using (var doc = ExcelDocument.Create(filePath)) {
+                var sheet = doc.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Name");
+                sheet.SetByHeader(2, "Name", null);
+
+                Assert.True(sheet.TryGetCellText(2, 1, out string text));
+                Assert.Equal(string.Empty, text);
+                doc.Save(false);
+            }
+
+            using (var pkg = SpreadsheetDocument.Open(filePath, false)) {
+                var wsPart = pkg.WorkbookPart!.WorksheetParts.First();
+                var sheetData = wsPart.Worksheet.GetFirstChild<SheetData>();
+                var row2 = sheetData?.Elements<Row>().FirstOrDefault(r => r.RowIndex?.Value == 2U);
+                var cellA2 = row2?.Elements<Cell>().FirstOrDefault(c => c.CellReference?.Value == "A2");
+                Assert.NotNull(cellA2);
+                Assert.Equal(CellValues.SharedString, cellA2!.DataType?.Value);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "ExcelHeaders")]
         public void Excel_AutoFilterByHeaderEquals_MissingHeader_DoesNothing() {
             string filePath = Path.Combine(_directoryWithFiles, "HeaderMissing_AutoFilter.xlsx");
             if (File.Exists(filePath)) File.Delete(filePath);

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.Serialization;
 using System.Threading;
 using DocumentFormat.OpenXml.Packaging;
@@ -1029,6 +1030,52 @@ namespace OfficeIMO.Tests {
                     File.Delete(filePath);
                 }
             }
+        }
+
+        [Fact]
+        public void Sheet_HeaderMapCache_RemainsWarmAfterDataRowWrites() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderHeaderCacheDataRowWrites.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Status");
+                    sheet.CellValue(1, 2, "Value");
+                    sheet.CellValue(2, 1, "Open");
+                    sheet.CellValue(2, 2, 10);
+                    document.Save();
+                }
+
+                using var loadedDocument = ExcelDocument.Load(filePath);
+                var loadedSheet = loadedDocument.GetSheet("Data");
+
+                Assert.Equal(1, loadedSheet.GetHeaderMap()["Status"]);
+                Assert.True(IsHeaderMapCachePopulated(loadedSheet));
+
+                loadedSheet.SetByHeader(2, "Status", "Closed");
+                loadedSheet.SetByHeader(2, "Value", 20);
+
+                Assert.True(IsHeaderMapCachePopulated(loadedSheet));
+                Assert.True(loadedSheet.TryGetColumnIndexByHeader("Status", out int statusColumn));
+                Assert.Equal(1, statusColumn);
+
+                loadedSheet.CellValue(1, 1, "State");
+
+                Assert.False(IsHeaderMapCachePopulated(loadedSheet));
+                var refreshedMap = loadedSheet.GetHeaderMap();
+                Assert.False(refreshedMap.ContainsKey("Status"));
+                Assert.Equal(1, refreshedMap["State"]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        private static bool IsHeaderMapCachePopulated(ExcelSheet sheet) {
+            var field = typeof(ExcelSheet).GetField("_headerMapCachePopulated", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            return (bool)field.GetValue(sheet)!;
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -1072,6 +1072,41 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Sheet_HeaderMapCache_RebuildsWhenDataRowExpandsUsedRangeColumns() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderHeaderCacheDataColumnExpansion.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "Status");
+                    sheet.CellValue(1, 2, "Value");
+                    sheet.CellValue(2, 1, "Open");
+                    sheet.CellValue(2, 2, 10);
+                    document.Save();
+                }
+
+                using var loadedDocument = ExcelDocument.Load(filePath);
+                var loadedSheet = loadedDocument.GetSheet("Data");
+
+                var initialMap = loadedSheet.GetHeaderMap();
+                Assert.Equal(1, initialMap["Status"]);
+                Assert.Equal(2, initialMap["Value"]);
+
+                loadedSheet.CellValue(2, 3, "Expanded");
+
+                Assert.True(loadedSheet.TryGetColumnIndexByHeader("Column3", out int generatedColumn));
+                Assert.Equal(3, generatedColumn);
+
+                var refreshedMap = loadedSheet.GetHeaderMap();
+                Assert.Equal(3, refreshedMap["Column3"]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
         private static bool IsHeaderMapCachePopulated(ExcelSheet sheet) {
             var field = typeof(ExcelSheet).GetField("_headerMapCachePopulated", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(field);


### PR DESCRIPTION
## Summary
- Optimizes Excel metadata cleanup paths for range clear, comments, hyperlinks, merges, sparklines, data validation, and conditional formatting.
- Adds the broader Excel performance work for normal APIs: shared-string batch indexing, cheaper string validation, cached line-break detection, non-mutating missing-cell reads, warmer header-map reuse for data-row writes, and faster `SetByHeader` value writes.
- Improves read/write paths that matter in real workloads: XML streaming read fast paths for ranges/objects, direct `DataSet` table promotion without copying through a `DataTable`, autofit string-width caching, and tighter source-row vs buffered-row loops.
- Adds regression and benchmark coverage for no-op preservation, sparse metadata cleanup, missing-cell reads, shared-string limits, inline-string replace, header cache retention, and cached `SetByHeader` workloads.

## Validation
- `dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --framework net8.0 --no-restore` - passed
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-build --filter "FullyQualifiedName~CellValues|FullyQualifiedName~ClosedXmlGap|FullyQualifiedName~WorksheetFeatures|FullyQualifiedName~PerformanceReview|FullyQualifiedName~HeaderMapCache|FullyQualifiedName~SetByHeader|FullyQualifiedName~Hyperlink|FullyQualifiedName~DataValidation|FullyQualifiedName~ConditionalFormatting|FullyQualifiedName~SheetNameValidationAndPreflight|FullyQualifiedName~ReaderHeaders"` - 293 passed, 1 skipped
- `dotnet build .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -c Release --framework net8.0 --no-restore` - passed
- `git diff --cached --check` - passed before each commit