### PR TITLE
Optimize OfficeIMO Excel engine performance

### DIFF
--- a/OfficeIMO.Excel.Benchmarks/ExcelLibraryComparisonRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelLibraryComparisonRunner.cs
@@ -186,6 +186,12 @@ internal static class ExcelLibraryComparisonRunner {
             new LibraryComparisonCase("MiniExcel", "Streaming typed row export with the same columns and headers.", () => MiniExcelWriteSalesRows(rows))
         ]);
 
+        AddScenarioGroup(scenarios, scenarioFilter, "write-cellvalues-sparse-rectangle-direct", warmupIterations, measuredIterations, [
+            new LibraryComparisonCase("OfficeIMO.Excel", "Write a sparse A1 rectangle with CellValues and save.", () => OfficeImoWriteCellValuesSparseRectangle(rowCount)),
+            new LibraryComparisonCase("ClosedXML", "Assign sparse object-typed cells with null blanks one by one and save.", () => ClosedXmlWriteCellValueObjectSparse(rowCount)),
+            new LibraryComparisonCase("EPPlus", "Assign sparse object-typed cells with null blanks one by one and save.", () => EpPlusWriteCellValueObjectSparse(rowCount))
+        ]);
+
         AddScenarioGroup(scenarios, scenarioFilter, "write-cellvalue-strings", warmupIterations, measuredIterations, [
             new LibraryComparisonCase("OfficeIMO.Excel", "Assign repeated and distinct text-heavy cells one by one and save.", () => OfficeImoWriteCellValueStrings(rowCount)),
             new LibraryComparisonCase("ClosedXML", "Assign repeated and distinct text-heavy cells one by one and save.", () => ClosedXmlWriteSharedStrings(rowCount)),
@@ -297,10 +303,22 @@ internal static class ExcelLibraryComparisonRunner {
             new LibraryComparisonCase("EPPlus", "Enumerate cells from the requested A1 range.", () => EpPlusEnumerateRange(officeImoWorkbookBytes.Value, rowCount))
         ]);
 
+        AddScenarioGroup(scenarios, scenarioFilter, "enumerate-top-range", warmupIterations, measuredIterations, [
+            new LibraryComparisonCase("OfficeIMO.Excel", "Enumerate the first 100 data rows from a larger sheet.", () => OfficeImoEnumerateRange(officeImoWorkbookBytes.Value, topDataRange)),
+            new LibraryComparisonCase("ClosedXML", "Enumerate the first 100 data rows from the same larger sheet.", () => ClosedXmlEnumerateRange(officeImoWorkbookBytes.Value, topDataRows)),
+            new LibraryComparisonCase("EPPlus", "Enumerate the first 100 data rows from the same larger sheet.", () => EpPlusEnumerateRange(officeImoWorkbookBytes.Value, topDataRows))
+        ]);
+
         AddScenarioGroup(scenarios, scenarioFilter, "enumerate-cells", warmupIterations, measuredIterations, [
             new LibraryComparisonCase("OfficeIMO.Excel", "Enumerate all typed cells from the worksheet.", () => OfficeImoEnumerateCells(officeImoWorkbookBytes.Value)),
             new LibraryComparisonCase("ClosedXML", "Enumerate all used cells from the worksheet.", () => ClosedXmlEnumerateRange(officeImoWorkbookBytes.Value, rowCount)),
             new LibraryComparisonCase("EPPlus", "Enumerate all used cells from the worksheet.", () => EpPlusEnumerateRange(officeImoWorkbookBytes.Value, rowCount))
+        ]);
+
+        AddScenarioGroup(scenarios, scenarioFilter, "enumerate-first-column-from-wide-sheet", warmupIterations, measuredIterations, [
+            new LibraryComparisonCase("OfficeIMO.Excel", "Enumerate A1:A(row count + header) from the same 8-column workbook.", () => OfficeImoEnumerateFirstColumn(officeImoWorkbookBytes.Value, firstColumnRange, rowCount)),
+            new LibraryComparisonCase("ClosedXML", "Enumerate A1:A(row count + header) from the same 8-column workbook.", () => ClosedXmlEnumerateFirstColumn(officeImoWorkbookBytes.Value, rowCount)),
+            new LibraryComparisonCase("EPPlus", "Enumerate A1:A(row count + header) from the same 8-column workbook.", () => EpPlusEnumerateFirstColumn(officeImoWorkbookBytes.Value, rowCount))
         ]);
 
         AddScenarioGroup(scenarios, scenarioFilter, "read-first-column-from-wide-sheet", warmupIterations, measuredIterations, [
@@ -1313,6 +1331,21 @@ internal static class ExcelLibraryComparisonRunner {
         return stream.ToArray();
     }
 
+    private static int OfficeImoWriteCellValuesSparseRectangle(int rowCount)
+        => ByteCount(OfficeImoWriteCellValuesSparseRectangleBytes(rowCount));
+
+    private static byte[] OfficeImoWriteCellValuesSparseRectangleBytes(int rowCount) {
+        using var stream = new MemoryStream();
+        using (var document = ExcelDocument.Create(stream, autoSave: false)) {
+            var sheet = document.AddWorkSheet("SparseObjects");
+            sheet.CellValues(BuildSparseObjectCells(rowCount), ExecutionMode.Parallel);
+            document.Save(stream);
+            AssertOfficeImoDirectPackageWriter(document, "CellValues sparse rectangle comparison");
+        }
+
+        return stream.ToArray();
+    }
+
     private static int OfficeImoWriteInsertObjects(IReadOnlyList<ExcelBenchmarkScenarioFactory.SalesRecord> rows)
         => ByteCount(OfficeImoWriteInsertObjectsBytes(rows));
 
@@ -1811,6 +1844,23 @@ internal static class ExcelLibraryComparisonRunner {
         return metric;
     }
 
+    private static int OfficeImoEnumerateFirstColumn(byte[] workbookBytes, string dataRange, int rowCount) {
+        using var reader = ExcelDocumentReader.Open(workbookBytes);
+        int expectedRows = rowCount + 1;
+        int metric = 0;
+        int cellsRead = 0;
+        foreach (var cell in reader.GetSheet("Data").EnumerateRange(dataRange)) {
+            cellsRead++;
+            metric = AddSalesIdColumnMetric(metric, cell.Row, rowCount, cell.Value);
+        }
+
+        if (cellsRead != expectedRows) {
+            throw new InvalidOperationException($"Expected {expectedRows.ToString(CultureInfo.InvariantCulture)} first-column cells, got {cellsRead.ToString(CultureInfo.InvariantCulture)}.");
+        }
+
+        return metric;
+    }
+
     private static int ClosedXmlEnumerateRange(byte[] workbookBytes, int rowCount) {
         using var stream = new MemoryStream(workbookBytes, writable: false);
         using var workbook = new XLWorkbook(stream);
@@ -1835,6 +1885,22 @@ internal static class ExcelLibraryComparisonRunner {
         return metric;
     }
 
+    private static int ClosedXmlEnumerateFirstColumn(byte[] workbookBytes, int rowCount) {
+        using var stream = new MemoryStream(workbookBytes, writable: false);
+        using var workbook = new XLWorkbook(stream);
+        var worksheet = workbook.Worksheet("Data");
+        int metric = 0;
+        int expectedRows = rowCount + 1;
+        for (int row = 1; row <= expectedRows; row++) {
+            object value = row == 1
+                ? worksheet.Cell(row, 1).GetString()
+                : worksheet.Cell(row, 1).GetValue<int>();
+            metric = AddSalesIdColumnMetric(metric, row, rowCount, value);
+        }
+
+        return metric;
+    }
+
     private static int EpPlusEnumerateRange(byte[] workbookBytes, int rowCount) {
         using var stream = new MemoryStream(workbookBytes, writable: false);
         using var package = new ExcelPackage(stream);
@@ -1845,6 +1911,19 @@ internal static class ExcelLibraryComparisonRunner {
             for (int column = 1; column <= 8; column++) {
                 metric = AddSalesEnumeratedCellMetric(metric, row, column, worksheet.Cells[row, column].Value);
             }
+        }
+
+        return metric;
+    }
+
+    private static int EpPlusEnumerateFirstColumn(byte[] workbookBytes, int rowCount) {
+        using var stream = new MemoryStream(workbookBytes, writable: false);
+        using var package = new ExcelPackage(stream);
+        var worksheet = package.Workbook.Worksheets["Data"];
+        int metric = 0;
+        int expectedRows = rowCount + 1;
+        for (int row = 1; row <= expectedRows; row++) {
+            metric = AddSalesIdColumnMetric(metric, row, rowCount, worksheet.Cells[row, 1].Value);
         }
 
         return metric;
@@ -3803,6 +3882,30 @@ internal static class ExcelLibraryComparisonRunner {
             cells[offset++] = (rowNumber, 6, row.Units);
             cells[offset++] = (rowNumber, 7, row.Active);
             cells[offset++] = (rowNumber, 8, row.Notes);
+        }
+
+        return cells;
+    }
+
+    private static (int Row, int Column, object Value)[] BuildSparseObjectCells(int rowCount) {
+        var cells = new (int Row, int Column, object Value)[(rowCount + 1) * 4];
+        int offset = 0;
+        cells[offset++] = (1, 1, "Name");
+        cells[offset++] = (1, 2, "Amount");
+        cells[offset++] = (1, 3, "Active");
+        cells[offset++] = (1, 4, "Created");
+
+        var start = new DateTime(2026, 1, 1, 8, 30, 0, DateTimeKind.Unspecified);
+        for (int row = 1; row <= rowCount; row++) {
+            int rowNumber = row + 1;
+            object? name = row % 3 == 0 ? null : "Item " + (row % 12).ToString(CultureInfo.InvariantCulture);
+            object? amount = row % 4 == 0 ? null : (double)row * 1.25d;
+            object? active = row % 5 == 0 ? null : row % 2 == 0;
+            object? created = row % 7 == 0 ? null : start.AddDays(row);
+            cells[offset++] = (rowNumber, 1, name!);
+            cells[offset++] = (rowNumber, 2, amount!);
+            cells[offset++] = (rowNumber, 3, active!);
+            cells[offset++] = (rowNumber, 4, created!);
         }
 
         return cells;

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.cs
@@ -33,8 +33,12 @@ namespace OfficeIMO.Excel {
                     WriteSharedStrings(archive, sharedStrings);
                 }
 
+                bool canCancel = ct.CanBeCanceled;
                 foreach (var sheet in model.Sheets) {
-                    ct.ThrowIfCancellationRequested();
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
                     WriteWorksheet(archive, sheet, model.DateTimeOffsetWriteStrategy, sharedStrings, ct);
                     if (sheet.HasTable) {
                         string sheetIndexText = InvariantNumberText.Get(sheet.Index);
@@ -166,9 +170,11 @@ namespace OfficeIMO.Excel {
                 writer.Write("<sst xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"");
                 WriteInvariant(writer, sharedStrings.TotalStringReferences);
                 writer.Write("\" uniqueCount=\"");
-                WriteInvariant(writer, sharedStrings.Values.Count);
+                WriteInvariant(writer, sharedStrings.Values.Length);
                 writer.Write("\">");
-                foreach (string value in sharedStrings.Values) {
+                string[] values = sharedStrings.Values;
+                for (int i = 0; i < values.Length; i++) {
+                    string value = values[i];
                     writer.Write("<si><t");
                     if (NeedsPreserveSpace(value)) {
                         writer.Write(" xml:space=\"preserve\"");
@@ -197,9 +203,11 @@ namespace OfficeIMO.Excel {
                 int columnCount = sheet.Table.ColumnCount;
                 int rowCount = sheet.Table.RowCount;
                 string[] cellReferencePrefixes = CreateCellReferencePrefixes(columnCount);
-                string?[]? styleAttributes = CreateStyleAttributes(sheet.Table);
-                bool[]? valueStyleColumns = CreateValueStyleColumns(sheet.Table);
-                DirectCellValueKind[]? cellValueKinds = valueStyleColumns == null ? CreateCellValueKinds(sheet.Table) : null;
+                DirectColumnWritePlan columnWritePlan = CreateColumnWritePlan(sheet.Table);
+                string?[]? styleAttributes = columnWritePlan.StyleAttributes;
+                bool[]? valueStyleColumns = columnWritePlan.ValueStyleColumns;
+                DirectCellValueKind[] cellValueKinds = columnWritePlan.CellValueKinds;
+                bool canCancel = ct.CanBeCanceled;
                 int rowIndex = 1;
                 if (sheet.IncludeHeaders) {
                     const string headerRowReference = "1";
@@ -212,12 +220,27 @@ namespace OfficeIMO.Excel {
                     rowIndex++;
                 }
 
-                object?[][]? bufferedRows = sheet.Table.BufferedRows;
-                if (valueStyleColumns == null) {
-                    if (bufferedRows != null) {
+                bool hasBufferedRows = sheet.Table.TryGetBufferedRows(out DirectBufferedRows bufferedRows);
+                if (hasBufferedRows
+                    && !sheet.OmitBlankCells
+                    && styleAttributes == null
+                    && valueStyleColumns == null
+                    && AllColumnsUseCellValueKind(cellValueKinds, DirectCellValueKind.String)) {
+                    WritePlainStringBufferedRows(writer, bufferedRows, rowCount, columnCount, rowIndex, cellReferencePrefixes, sharedStrings, ct);
+                    rowIndex += rowCount;
+                } else if (hasBufferedRows
+                    && !sheet.OmitBlankCells
+                    && valueStyleColumns == null) {
+                    WriteFixedKindBufferedRows(writer, bufferedRows, rowCount, columnCount, rowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, dateTimeOffsetWriteStrategy, sharedStrings, ct);
+                    rowIndex += rowCount;
+                } else if (valueStyleColumns == null) {
+                    if (hasBufferedRows) {
                         if (sheet.OmitBlankCells) {
                             for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
-                                ct.ThrowIfCancellationRequested();
+                                if (canCancel) {
+                                    ct.ThrowIfCancellationRequested();
+                                }
+
                                 bool rowStarted = false;
                                 string rowReference = InvariantNumberText.Get(rowIndex);
                                 object?[] bufferedRow = bufferedRows[sourceRowIndex];
@@ -234,7 +257,7 @@ namespace OfficeIMO.Excel {
                                         rowStarted = true;
                                     }
 
-                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], cellValueKinds![c], dateTimeOffsetWriteStrategy, sharedStrings);
+                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
                                 }
 
                                 if (rowStarted) {
@@ -245,14 +268,17 @@ namespace OfficeIMO.Excel {
                             }
                         } else {
                             for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
-                                ct.ThrowIfCancellationRequested();
+                                if (canCancel) {
+                                    ct.ThrowIfCancellationRequested();
+                                }
+
                                 string rowReference = InvariantNumberText.Get(rowIndex);
                                 object?[] bufferedRow = bufferedRows[sourceRowIndex];
                                 writer.Write("<row r=\"");
                                 writer.Write(rowReference);
                                 writer.Write("\">");
                                 for (int c = 0; c < columnCount; c++) {
-                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], bufferedRow[c], styleAttributes?[c], cellValueKinds![c], dateTimeOffsetWriteStrategy, sharedStrings);
+                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], bufferedRow[c], styleAttributes?[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
                                 }
 
                                 writer.Write("</row>");
@@ -262,7 +288,10 @@ namespace OfficeIMO.Excel {
                     } else {
                         if (sheet.OmitBlankCells) {
                             for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
-                                ct.ThrowIfCancellationRequested();
+                                if (canCancel) {
+                                    ct.ThrowIfCancellationRequested();
+                                }
+
                                 bool rowStarted = false;
                                 string rowReference = InvariantNumberText.Get(rowIndex);
                                 DataRow sourceRow = sheet.Table.GetSourceRow(sourceRowIndex)!;
@@ -279,7 +308,7 @@ namespace OfficeIMO.Excel {
                                         rowStarted = true;
                                     }
 
-                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], cellValueKinds![c], dateTimeOffsetWriteStrategy, sharedStrings);
+                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
                                 }
 
                                 if (rowStarted) {
@@ -290,14 +319,17 @@ namespace OfficeIMO.Excel {
                             }
                         } else {
                             for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
-                                ct.ThrowIfCancellationRequested();
+                                if (canCancel) {
+                                    ct.ThrowIfCancellationRequested();
+                                }
+
                                 string rowReference = InvariantNumberText.Get(rowIndex);
                                 DataRow sourceRow = sheet.Table.GetSourceRow(sourceRowIndex)!;
                                 writer.Write("<row r=\"");
                                 writer.Write(rowReference);
                                 writer.Write("\">");
                                 for (int c = 0; c < columnCount; c++) {
-                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], sourceRow[c], styleAttributes?[c], cellValueKinds![c], dateTimeOffsetWriteStrategy, sharedStrings);
+                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], sourceRow[c], styleAttributes?[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
                                 }
 
                                 writer.Write("</row>");
@@ -305,10 +337,13 @@ namespace OfficeIMO.Excel {
                             }
                         }
                     }
-                } else if (bufferedRows != null) {
+                } else if (hasBufferedRows) {
                     if (sheet.OmitBlankCells) {
                         for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
-                            ct.ThrowIfCancellationRequested();
+                            if (canCancel) {
+                                ct.ThrowIfCancellationRequested();
+                            }
+
                             bool rowStarted = false;
                             string rowReference = InvariantNumberText.Get(rowIndex);
                             object?[] bufferedRow = bufferedRows[sourceRowIndex];
@@ -325,7 +360,7 @@ namespace OfficeIMO.Excel {
                                     rowStarted = true;
                                 }
 
-                                WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                                WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
                             }
 
                             if (rowStarted) {
@@ -336,14 +371,17 @@ namespace OfficeIMO.Excel {
                         }
                     } else {
                         for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
-                            ct.ThrowIfCancellationRequested();
+                            if (canCancel) {
+                                ct.ThrowIfCancellationRequested();
+                            }
+
                             string rowReference = InvariantNumberText.Get(rowIndex);
                             object?[] bufferedRow = bufferedRows[sourceRowIndex];
                             writer.Write("<row r=\"");
                             writer.Write(rowReference);
                             writer.Write("\">");
                             for (int c = 0; c < columnCount; c++) {
-                                WriteCell(writer, rowReference, cellReferencePrefixes[c], bufferedRow[c], styleAttributes?[c], valueStyleColumns[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                                WriteCell(writer, rowReference, cellReferencePrefixes[c], bufferedRow[c], styleAttributes?[c], valueStyleColumns[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
                             }
 
                             writer.Write("</row>");
@@ -353,7 +391,10 @@ namespace OfficeIMO.Excel {
                 } else {
                     if (sheet.OmitBlankCells) {
                         for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
-                            ct.ThrowIfCancellationRequested();
+                            if (canCancel) {
+                                ct.ThrowIfCancellationRequested();
+                            }
+
                             bool rowStarted = false;
                             string rowReference = InvariantNumberText.Get(rowIndex);
                             DataRow sourceRow = sheet.Table.GetSourceRow(sourceRowIndex)!;
@@ -370,7 +411,7 @@ namespace OfficeIMO.Excel {
                                     rowStarted = true;
                                 }
 
-                                WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                                WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
                             }
 
                             if (rowStarted) {
@@ -381,14 +422,17 @@ namespace OfficeIMO.Excel {
                         }
                     } else {
                         for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
-                            ct.ThrowIfCancellationRequested();
+                            if (canCancel) {
+                                ct.ThrowIfCancellationRequested();
+                            }
+
                             string rowReference = InvariantNumberText.Get(rowIndex);
                             DataRow sourceRow = sheet.Table.GetSourceRow(sourceRowIndex)!;
                             writer.Write("<row r=\"");
                             writer.Write(rowReference);
                             writer.Write("\">");
                             for (int c = 0; c < columnCount; c++) {
-                                WriteCell(writer, rowReference, cellReferencePrefixes[c], sourceRow[c], styleAttributes?[c], valueStyleColumns[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                                WriteCell(writer, rowReference, cellReferencePrefixes[c], sourceRow[c], styleAttributes?[c], valueStyleColumns[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
                             }
 
                             writer.Write("</row>");
@@ -405,6 +449,122 @@ namespace OfficeIMO.Excel {
                 writer.Write("</worksheet>");
             }
 
+            private static void WriteFixedKindBufferedRows(
+                TextWriter writer,
+                DirectBufferedRows bufferedRows,
+                int rowCount,
+                int columnCount,
+                int startRowIndex,
+                string[] cellReferencePrefixes,
+                string?[]? styleAttributes,
+                DirectCellValueKind[] cellValueKinds,
+                Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                DirectSharedStringTable? sharedStrings,
+                CancellationToken ct) {
+                bool canCancel = ct.CanBeCanceled;
+                int rowIndex = startRowIndex;
+                if (styleAttributes == null) {
+                    for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
+                        if (canCancel) {
+                            ct.ThrowIfCancellationRequested();
+                        }
+
+                        string rowReference = InvariantNumberText.Get(rowIndex);
+                        object?[] bufferedRow = bufferedRows[sourceRowIndex];
+                        writer.Write("<row r=\"");
+                        writer.Write(rowReference);
+                        writer.Write("\">");
+                        for (int c = 0; c < columnCount; c++) {
+                            writer.Write(cellReferencePrefixes[c]);
+                            writer.Write(rowReference);
+                            writer.Write('"');
+                            WriteCellValue(writer, bufferedRow[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                        }
+
+                        writer.Write("</row>");
+                        rowIndex++;
+                    }
+
+                    return;
+                }
+
+                for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
+                    string rowReference = InvariantNumberText.Get(rowIndex);
+                    object?[] bufferedRow = bufferedRows[sourceRowIndex];
+                    writer.Write("<row r=\"");
+                    writer.Write(rowReference);
+                    writer.Write("\">");
+                    for (int c = 0; c < columnCount; c++) {
+                        writer.Write(cellReferencePrefixes[c]);
+                        writer.Write(rowReference);
+                        writer.Write('"');
+                        string? styleAttribute = styleAttributes[c];
+                        if (styleAttribute != null) {
+                            writer.Write(styleAttribute);
+                        }
+
+                        WriteCellValue(writer, bufferedRow[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                    }
+
+                    writer.Write("</row>");
+                    rowIndex++;
+                }
+            }
+
+            private static void WritePlainStringBufferedRows(
+                TextWriter writer,
+                DirectBufferedRows bufferedRows,
+                int rowCount,
+                int columnCount,
+                int startRowIndex,
+                string[] cellReferencePrefixes,
+                DirectSharedStringTable? sharedStrings,
+                CancellationToken ct) {
+                bool canCancel = ct.CanBeCanceled;
+                int rowIndex = startRowIndex;
+                for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
+                    string rowReference = InvariantNumberText.Get(rowIndex);
+                    object?[] bufferedRow = bufferedRows[sourceRowIndex];
+                    writer.Write("<row r=\"");
+                    writer.Write(rowReference);
+                    writer.Write("\">");
+                    for (int c = 0; c < columnCount; c++) {
+                        writer.Write(cellReferencePrefixes[c]);
+                        writer.Write(rowReference);
+                        writer.Write('"');
+                        object? value = bufferedRow[c];
+                        if (value is string text) {
+                            WriteStringCellValue(writer, text, sharedStrings);
+                        } else if (value == null || value == DBNull.Value) {
+                            writer.Write(" t=\"str\"><v/></c>");
+                        } else {
+                            WriteStringCell(writer, value.ToString() ?? string.Empty, validateLength: true);
+                        }
+                    }
+
+                    writer.Write("</row>");
+                    rowIndex++;
+                }
+            }
+
+            private static bool AllColumnsUseCellValueKind(DirectCellValueKind[] cellValueKinds, DirectCellValueKind expected) {
+                for (int i = 0; i < cellValueKinds.Length; i++) {
+                    if (cellValueKinds[i] != expected) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
             private static bool IsBlankCellValue(object? value) {
                 return value == null || value == DBNull.Value;
             }
@@ -418,42 +578,30 @@ namespace OfficeIMO.Excel {
                 return columns;
             }
 
-            private static string?[]? CreateStyleAttributes(DirectDataSetTableModel table) {
+            private static DirectColumnWritePlan CreateColumnWritePlan(DirectDataSetTableModel table) {
+                int columnCount = table.ColumnCount;
+                var kinds = new DirectCellValueKind[columnCount];
                 string?[]? styleAttributes = null;
-                for (int i = 0; i < table.ColumnCount; i++) {
-                    string? styleAttribute = CreateStyleAttribute(table.GetColumnType(i));
-                    if (styleAttribute == null) {
-                        continue;
-                    }
-
-                    styleAttributes ??= new string?[table.ColumnCount];
-                    styleAttributes[i] = styleAttribute;
-                }
-
-                return styleAttributes;
-            }
-
-            private static bool[]? CreateValueStyleColumns(DirectDataSetTableModel table) {
                 bool[]? valueStyleColumns = null;
-                for (int i = 0; i < table.ColumnCount; i++) {
-                    if (table.GetColumnType(i) != typeof(object)) {
-                        continue;
+
+                for (int i = 0; i < columnCount; i++) {
+                    Type dataType = table.GetColumnType(i);
+                    DirectCellValueKind cellValueKind = GetCellValueKind(dataType);
+                    kinds[i] = cellValueKind;
+
+                    string? styleAttribute = GetStyleAttribute(cellValueKind);
+                    if (styleAttribute != null) {
+                        styleAttributes ??= new string?[columnCount];
+                        styleAttributes[i] = styleAttribute;
                     }
 
-                    valueStyleColumns ??= new bool[table.ColumnCount];
-                    valueStyleColumns[i] = true;
+                    if (dataType == typeof(object)) {
+                        valueStyleColumns ??= new bool[columnCount];
+                        valueStyleColumns[i] = true;
+                    }
                 }
 
-                return valueStyleColumns;
-            }
-
-            private static DirectCellValueKind[] CreateCellValueKinds(DirectDataSetTableModel table) {
-                var kinds = new DirectCellValueKind[table.ColumnCount];
-                for (int i = 0; i < kinds.Length; i++) {
-                    kinds[i] = GetCellValueKind(table.GetColumnType(i));
-                }
-
-                return kinds;
+                return new DirectColumnWritePlan(kinds, styleAttributes, valueStyleColumns);
             }
 
             private static DirectCellValueKind GetCellValueKind(Type dataType) {
@@ -590,6 +738,20 @@ namespace OfficeIMO.Excel {
 #endif
             }
 
+            private readonly struct DirectColumnWritePlan {
+                internal DirectColumnWritePlan(DirectCellValueKind[] cellValueKinds, string?[]? styleAttributes, bool[]? valueStyleColumns) {
+                    CellValueKinds = cellValueKinds;
+                    StyleAttributes = styleAttributes;
+                    ValueStyleColumns = valueStyleColumns;
+                }
+
+                internal DirectCellValueKind[] CellValueKinds { get; }
+
+                internal string?[]? StyleAttributes { get; }
+
+                internal bool[]? ValueStyleColumns { get; }
+            }
+
             private sealed class DirectSharedStringTable {
                 private const int MinimumStringReferences = 512;
                 private const int MinimumDuplicateReferences = 128;
@@ -602,7 +764,7 @@ namespace OfficeIMO.Excel {
                     TotalStringReferences = totalStringReferences;
                 }
 
-                internal IReadOnlyList<string> Values { get; }
+                internal string[] Values { get; }
 
                 internal int TotalStringReferences { get; }
 
@@ -616,6 +778,9 @@ namespace OfficeIMO.Excel {
                     var seenOnce = new HashSet<string>(StringComparer.Ordinal);
                     var sharedCounts = new Dictionary<string, int>(StringComparer.Ordinal);
                     int totalStringReferences = 0;
+                    int duplicateReferences = 0;
+                    long duplicateCharacters = 0L;
+                    bool canCancel = ct.CanBeCanceled;
                     foreach (var sheet in model.Sheets) {
                         int columnCount = sheet.Table.ColumnCount;
                         if (sheet.IncludeHeaders) {
@@ -631,10 +796,13 @@ namespace OfficeIMO.Excel {
 
                         int rowCount = sheet.Table.RowCount;
                         int stringColumnCount = stringColumnIndexes.Length;
-                        object?[][]? bufferedRows = sheet.Table.BufferedRows;
-                        if (bufferedRows != null) {
+                        bool hasBufferedRows = sheet.Table.TryGetBufferedRows(out DirectBufferedRows bufferedRows);
+                        if (hasBufferedRows) {
                             for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-                                ct.ThrowIfCancellationRequested();
+                                if (canCancel) {
+                                    ct.ThrowIfCancellationRequested();
+                                }
+
                                 object?[] bufferedRow = bufferedRows[rowIndex];
                                 for (int stringColumnIndex = 0; stringColumnIndex < stringColumnCount; stringColumnIndex++) {
                                     int columnIndex = stringColumnIndexes[stringColumnIndex];
@@ -645,7 +813,10 @@ namespace OfficeIMO.Excel {
                             }
                         } else {
                             for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-                                ct.ThrowIfCancellationRequested();
+                                if (canCancel) {
+                                    ct.ThrowIfCancellationRequested();
+                                }
+
                                 DataRow sourceRow = sheet.Table.GetSourceRow(rowIndex)!;
                                 for (int stringColumnIndex = 0; stringColumnIndex < stringColumnCount; stringColumnIndex++) {
                                     int columnIndex = stringColumnIndexes[stringColumnIndex];
@@ -659,18 +830,6 @@ namespace OfficeIMO.Excel {
 
                     if (totalStringReferences < MinimumStringReferences || sharedCounts.Count == 0) {
                         return null;
-                    }
-
-                    int duplicateReferences = 0;
-                    long duplicateCharacters = 0L;
-                    foreach (var entry in sharedCounts) {
-                        if (entry.Value <= 1) {
-                            continue;
-                        }
-
-                        int duplicates = entry.Value - 1;
-                        duplicateReferences += duplicates;
-                        duplicateCharacters += (long)duplicates * entry.Key.Length;
                     }
 
                     if (duplicateReferences < MinimumDuplicateReferences && duplicateCharacters < MinimumDuplicateCharacters) {
@@ -695,12 +854,16 @@ namespace OfficeIMO.Excel {
                         totalStringReferences++;
                         if (sharedCounts.TryGetValue(text, out int count)) {
                             sharedCounts[text] = count + 1;
+                            duplicateReferences++;
+                            duplicateCharacters += text.Length;
                             return;
                         }
 
                         if (forceShared) {
                             if (seenOnce.Remove(text)) {
                                 sharedCounts.Add(text, 2);
+                                duplicateReferences++;
+                                duplicateCharacters += text.Length;
                             } else {
                                 sharedCounts.Add(text, 1);
                             }
@@ -711,6 +874,8 @@ namespace OfficeIMO.Excel {
                         if (!seenOnce.Add(text)) {
                             seenOnce.Remove(text);
                             sharedCounts.Add(text, 2);
+                            duplicateReferences++;
+                            duplicateCharacters += text.Length;
                         }
                     }
                 }
@@ -738,31 +903,40 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            private static uint? GetStyleIndex(Type dataType) {
-                if (dataType == typeof(DateTime) || dataType == typeof(DateTimeOffset)) return 1U;
-                if (dataType == typeof(TimeSpan)) return 2U;
+            private static string? GetStyleAttribute(DirectCellValueKind cellValueKind) {
+                switch (cellValueKind) {
+                    case DirectCellValueKind.DateTime:
+                    case DirectCellValueKind.DateTimeOffset:
+                        return DateStyleAttribute;
+                    case DirectCellValueKind.TimeSpan:
+                        return TimeStyleAttribute;
 #if NET6_0_OR_GREATER
-                if (dataType == typeof(DateOnly)) return 1U;
-                if (dataType == typeof(TimeOnly)) return 2U;
+                    case DirectCellValueKind.DateOnly:
+                        return DateStyleAttribute;
+                    case DirectCellValueKind.TimeOnly:
+                        return TimeStyleAttribute;
 #endif
-                return null;
-            }
-
-            private static string? CreateStyleAttribute(Type dataType) {
-                uint? styleIndex = GetStyleIndex(dataType);
-                return styleIndex switch {
-                    1U => DateStyleAttribute,
-                    2U => TimeStyleAttribute,
-                    _ => null
-                };
+                    default:
+                        return null;
+                }
             }
 
             private static string? CreateStyleAttributeForValue(object? value) {
-                if (value == null || value == DBNull.Value) {
-                    return null;
+                switch (value) {
+                    case DateTime:
+                    case DateTimeOffset:
+                        return DateStyleAttribute;
+                    case TimeSpan:
+                        return TimeStyleAttribute;
+#if NET6_0_OR_GREATER
+                    case DateOnly:
+                        return DateStyleAttribute;
+                    case TimeOnly:
+                        return TimeStyleAttribute;
+#endif
+                    default:
+                        return null;
                 }
-
-                return CreateStyleAttribute(value.GetType());
             }
 
             private static void WriteCell(TextWriter writer, string rowReference, string cellReferencePrefix, object? value, string? styleAttribute, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, DirectSharedStringTable? sharedStrings) {
@@ -787,7 +961,7 @@ namespace OfficeIMO.Excel {
                 WriteCellValue(writer, value, cellValueKind, dateTimeOffsetWriteStrategy, sharedStrings);
             }
 
-            private static void WriteCell(TextWriter writer, string rowReference, string cellReferencePrefix, object? value, string? styleAttribute, bool useValueStyle, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, DirectSharedStringTable? sharedStrings) {
+            private static void WriteCell(TextWriter writer, string rowReference, string cellReferencePrefix, object? value, string? styleAttribute, bool useValueStyle, DirectCellValueKind cellValueKind, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, DirectSharedStringTable? sharedStrings) {
                 writer.Write(cellReferencePrefix);
                 writer.Write(rowReference);
                 writer.Write('"');
@@ -796,7 +970,11 @@ namespace OfficeIMO.Excel {
                     writer.Write(effectiveStyleAttribute);
                 }
 
-                WriteCellValue(writer, value, dateTimeOffsetWriteStrategy, sharedStrings);
+                if (useValueStyle) {
+                    WriteCellValue(writer, value, dateTimeOffsetWriteStrategy, sharedStrings);
+                } else {
+                    WriteCellValue(writer, value, cellValueKind, dateTimeOffsetWriteStrategy, sharedStrings);
+                }
             }
 
             private static void WriteCellValue(TextWriter writer, object? value, DirectCellValueKind cellValueKind, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, DirectSharedStringTable? sharedStrings) {

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
@@ -8,6 +8,8 @@ using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
+        private static readonly DataSet DirectTabularSnapshotOwner = new DataSet("DirectTabularExport") { Locale = CultureInfo.InvariantCulture };
+
         private static DateTime DefaultDateTimeOffsetWriteStrategy(DateTimeOffset value) => value.LocalDateTime;
 
         /// <summary>
@@ -103,8 +105,7 @@ namespace OfficeIMO.Excel {
                         autoFit,
                         _dateTimeOffsetWriteStrategy,
                         CancellationToken.None);
-                    var snapshotOwner = new DataSet("ObjectExport") { Locale = CultureInfo.InvariantCulture };
-                    _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(snapshotOwner, model, ClearDirectDataSetSaveCandidate, isDeferred: false, subscribeToSourceChanges: false);
+                    _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(DirectTabularSnapshotOwner, model, ClearDirectDataSetSaveCandidate, isDeferred: false, subscribeToSourceChanges: false);
                 } else {
                     var dataSet = new DataSet("ObjectExport") {
                         Locale = CultureInfo.InvariantCulture
@@ -171,8 +172,7 @@ namespace OfficeIMO.Excel {
                     autoFit,
                     _dateTimeOffsetWriteStrategy,
                     CancellationToken.None);
-                var owner = new DataSet("DeferredTabularExport") { Locale = CultureInfo.InvariantCulture };
-                _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(owner, model, MaterializeDeferredDataSetImport, isDeferred: true, subscribeToSourceChanges: false);
+                _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(DirectTabularSnapshotOwner, model, MaterializeDeferredDataSetImport, isDeferred: true, subscribeToSourceChanges: false);
                 _packageDirty = true;
                 _unchangedPackageBytes = null;
                 _requiresSavePreflight = false;
@@ -188,7 +188,7 @@ namespace OfficeIMO.Excel {
             string tableNameForModel,
             IReadOnlyList<string> columnNames,
             IReadOnlyList<Type> columnTypes,
-            object?[][] rows,
+            IReadOnlyList<object?[]> rows,
             bool includeHeaders,
             string range,
             string? tableName = null,
@@ -222,8 +222,7 @@ namespace OfficeIMO.Excel {
                     autoFit,
                     _dateTimeOffsetWriteStrategy,
                     CancellationToken.None);
-                var owner = new DataSet("DeferredTabularExport") { Locale = CultureInfo.InvariantCulture };
-                _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(owner, model, MaterializeDeferredDataSetImport, isDeferred: true, subscribeToSourceChanges: false);
+                _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(DirectTabularSnapshotOwner, model, MaterializeDeferredDataSetImport, isDeferred: true, subscribeToSourceChanges: false);
                 _packageDirty = true;
                 _unchangedPackageBytes = null;
                 _requiresSavePreflight = false;
@@ -239,7 +238,7 @@ namespace OfficeIMO.Excel {
             string tableNameForModel,
             IReadOnlyList<string> columnNames,
             IReadOnlyList<Type> columnTypes,
-            object?[][] rows,
+            IReadOnlyList<object?[]> rows,
             bool includeHeaders,
             string range,
             string? tableName = null,
@@ -273,8 +272,7 @@ namespace OfficeIMO.Excel {
                     autoFit,
                     _dateTimeOffsetWriteStrategy,
                     CancellationToken.None);
-                var owner = new DataSet("TabularExport") { Locale = CultureInfo.InvariantCulture };
-                _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(owner, model, ClearDirectDataSetSaveCandidate, isDeferred: false, subscribeToSourceChanges: false);
+                _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(DirectTabularSnapshotOwner, model, ClearDirectDataSetSaveCandidate, isDeferred: false, subscribeToSourceChanges: false);
             } catch {
                 ClearDirectDataSetSaveCandidate();
             }
@@ -599,7 +597,10 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            ct.ThrowIfCancellationRequested();
+            if (ct.CanBeCanceled) {
+                ct.ThrowIfCancellationRequested();
+            }
+
             PrepareDestinationStreamForWrite(destination);
             DirectDataSetWorkbookWriter.Write(destination, candidate.Model, ct);
             try { destination.Flush(); } catch (NotSupportedException) { }
@@ -681,8 +682,12 @@ namespace OfficeIMO.Excel {
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
                 CancellationToken ct) {
                 var sheets = new DirectDataSetSheetModel[Sheets.Count];
+                bool canCancel = ct.CanBeCanceled;
                 for (int i = 0; i < Sheets.Count; i++) {
-                    ct.ThrowIfCancellationRequested();
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
                     var sheet = Sheets[i];
                     if (!string.Equals(sheet.SheetName, sheetName, StringComparison.Ordinal)) {
                         sheets[i] = sheet;
@@ -718,8 +723,12 @@ namespace OfficeIMO.Excel {
                 CancellationToken ct) {
                 var sheets = new DirectDataSetSheetModel[Sheets.Count];
                 var results = new ExcelDataSetImportResult[Sheets.Count];
+                bool canCancel = ct.CanBeCanceled;
                 for (int i = 0; i < Sheets.Count; i++) {
-                    ct.ThrowIfCancellationRequested();
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
                     var sheet = Sheets[i];
                     if (!string.Equals(sheet.SheetName, sheetName, StringComparison.Ordinal)) {
                         sheets[i] = sheet;
@@ -769,8 +778,12 @@ namespace OfficeIMO.Excel {
                 var usedSheetNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 var usedTableNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 int index = 1;
+                bool canCancel = ct.CanBeCanceled;
                 foreach (DataTable table in dataSet.Tables) {
-                    ct.ThrowIfCancellationRequested();
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
                     var tableModel = snapshotTables
                         ? DirectDataSetTableModel.Snapshot(table, ct)
                         : DirectDataSetTableModel.Reference(table);
@@ -985,6 +998,27 @@ namespace OfficeIMO.Excel {
             internal double[]? ColumnWidths { get; }
         }
 
+        private readonly struct DirectBufferedRows {
+            private readonly object?[][]? _arrayRows;
+            private readonly List<object?[]>? _listRows;
+
+            internal DirectBufferedRows(object?[][] rows) {
+                _arrayRows = rows;
+                _listRows = null;
+            }
+
+            internal DirectBufferedRows(List<object?[]> rows) {
+                _arrayRows = null;
+                _listRows = rows;
+            }
+
+            internal int Count => _arrayRows?.Length ?? _listRows!.Count;
+
+            internal object?[] this[int index] => _arrayRows != null
+                ? _arrayRows[index]
+                : _listRows![index];
+        }
+
         private sealed class DirectDataSetTableModel {
             private const int MaxAutoFitStringWidthCacheEntriesPerColumn = 1024;
 
@@ -1015,7 +1049,8 @@ namespace OfficeIMO.Excel {
             private readonly DataTable? _sourceTable;
             private readonly DirectDataSetColumnModel[]? _columns;
             private readonly int[]? _stringCandidateColumnIndexes;
-            private readonly object?[][]? _rows;
+            private readonly object?[][]? _arrayRows;
+            private readonly List<object?[]>? _listRows;
 
             private DirectDataSetTableModel(DataTable sourceTable) {
                 _sourceTable = sourceTable;
@@ -1029,15 +1064,26 @@ namespace OfficeIMO.Excel {
                 _stringCandidateColumnIndexes = CreateStringCandidateColumnIndexes(columns);
             }
 
-            private DirectDataSetTableModel(DirectDataSetColumnModel[] columns, object?[][] rows) {
+            private DirectDataSetTableModel(DirectDataSetColumnModel[] columns, IReadOnlyList<object?[]> rows) {
                 _columns = columns;
                 _stringCandidateColumnIndexes = CreateStringCandidateColumnIndexes(columns);
-                _rows = rows;
+                if (rows is object?[][] arrayRows) {
+                    _arrayRows = arrayRows;
+                } else if (rows is List<object?[]> listRows) {
+                    _listRows = listRows;
+                } else {
+                    var copiedRows = new object?[rows.Count][];
+                    for (int i = 0; i < copiedRows.Length; i++) {
+                        copiedRows[i] = rows[i];
+                    }
+
+                    _arrayRows = copiedRows;
+                }
             }
 
             internal static DirectDataSetTableModel Reference(DataTable table) => new DirectDataSetTableModel(table);
 
-            internal static DirectDataSetTableModel FromRows(IReadOnlyList<string> columnNames, IReadOnlyList<Type> columnTypes, object?[][] rows) {
+            internal static DirectDataSetTableModel FromRows(IReadOnlyList<string> columnNames, IReadOnlyList<Type> columnTypes, IReadOnlyList<object?[]> rows) {
                 if (columnNames.Count != columnTypes.Count) {
                     throw new ArgumentException("Column name and type counts must match.", nameof(columnTypes));
                 }
@@ -1058,15 +1104,19 @@ namespace OfficeIMO.Excel {
 
                 return _sourceTable != null
                     ? new DirectDataSetTableModel(_sourceTable, columns)
-                    : new DirectDataSetTableModel(columns, _rows!);
+                    : new DirectDataSetTableModel(columns, GetBufferedRowsForReuse());
             }
 
             internal static DirectDataSetTableModel Snapshot(DataTable table, CancellationToken ct) {
                 var columns = CreateColumns(table);
 
                 var rows = new object?[table.Rows.Count][];
+                bool canCancel = ct.CanBeCanceled;
                 for (int rowIndex = 0; rowIndex < table.Rows.Count; rowIndex++) {
-                    ct.ThrowIfCancellationRequested();
+                    if (canCancel) {
+                        ct.ThrowIfCancellationRequested();
+                    }
+
                     DataRow row = table.Rows[rowIndex];
                     var values = new object?[columns.Length];
                     for (int columnIndex = 0; columnIndex < columns.Length; columnIndex++) {
@@ -1091,7 +1141,7 @@ namespace OfficeIMO.Excel {
 
             internal int ColumnCount => _columns!.Length;
 
-            internal int RowCount => _sourceTable?.Rows.Count ?? _rows!.Length;
+            internal int RowCount => _sourceTable?.Rows.Count ?? _arrayRows?.Length ?? _listRows!.Count;
 
             internal string GetColumnName(int index) => _columns![index].Name;
 
@@ -1126,14 +1176,33 @@ namespace OfficeIMO.Excel {
 
             internal DataRow? GetSourceRow(int rowIndex) => _sourceTable?.Rows[rowIndex];
 
-            internal object?[][]? BufferedRows => _rows;
+            internal bool TryGetBufferedRows(out DirectBufferedRows rows) {
+                if (_arrayRows != null) {
+                    rows = new DirectBufferedRows(_arrayRows);
+                    return true;
+                }
 
-            internal object?[]? GetBufferedRow(int rowIndex) => _rows?[rowIndex];
+                if (_listRows != null) {
+                    rows = new DirectBufferedRows(_listRows);
+                    return true;
+                }
+
+                rows = default;
+                return false;
+            }
+
+            internal object?[]? GetBufferedRow(int rowIndex) {
+                if (_arrayRows != null) {
+                    return _arrayRows[rowIndex];
+                }
+
+                return _listRows?[rowIndex];
+            }
 
             internal object? GetValue(int rowIndex, int columnIndex) {
                 object? value = _sourceTable != null
                     ? _sourceTable.Rows[rowIndex][columnIndex]
-                    : _rows![rowIndex][columnIndex];
+                    : GetBufferedRow(rowIndex)![columnIndex];
                 return value == DBNull.Value ? null : value;
             }
 
@@ -1154,9 +1223,13 @@ namespace OfficeIMO.Excel {
                 Dictionary<string, double>?[]? stringWidthCaches = null;
                 int rowCount = RowCount;
                 DataRowCollection? sourceRows = _sourceTable?.Rows;
+                bool canCancel = ct.CanBeCanceled;
                 if (sourceRows != null) {
                     for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-                        ct.ThrowIfCancellationRequested();
+                        if (canCancel) {
+                            ct.ThrowIfCancellationRequested();
+                        }
+
                         DataRow sourceRow = sourceRows[rowIndex];
                         for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
                             object? value = sourceRow[columnIndex];
@@ -1166,9 +1239,12 @@ namespace OfficeIMO.Excel {
                         }
                     }
                 } else {
-                    object?[][] bufferedRows = _rows!;
+                    TryGetBufferedRows(out DirectBufferedRows bufferedRows);
                     for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-                        ct.ThrowIfCancellationRequested();
+                        if (canCancel) {
+                            ct.ThrowIfCancellationRequested();
+                        }
+
                         object?[] bufferedRow = bufferedRows[rowIndex];
                         for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
                             object? value = bufferedRow[columnIndex];
@@ -1180,6 +1256,14 @@ namespace OfficeIMO.Excel {
                 }
 
                 return widths;
+            }
+
+            private IReadOnlyList<object?[]> GetBufferedRowsForReuse() {
+                if (_arrayRows != null) {
+                    return _arrayRows;
+                }
+
+                return _listRows!;
             }
 
             private AutoFitWidthKind[] CreateAutoFitWidthKinds() {
@@ -1218,6 +1302,10 @@ namespace OfficeIMO.Excel {
             private static double EstimateAutoFitWidth(string text) {
                 if (string.IsNullOrEmpty(text)) {
                     return 0D;
+                }
+
+                if (text.IndexOf('\r') < 0 && text.IndexOf('\n') < 0) {
+                    return EstimateAutoFitWidthFromLength(text.Length);
                 }
 
                 int maxLineLength = 0;
@@ -1478,7 +1566,9 @@ namespace OfficeIMO.Excel {
 
                 table.BeginLoadData();
                 try {
-                    foreach (var row in _rows!) {
+                    TryGetBufferedRows(out DirectBufferedRows rows);
+                    for (int rowIndex = 0; rowIndex < rows.Count; rowIndex++) {
+                        object?[] row = rows[rowIndex];
                         var values = new object?[row.Length];
                         for (int i = 0; i < row.Length; i++) {
                             values[i] = row[i] ?? DBNull.Value;
@@ -1508,6 +1598,7 @@ namespace OfficeIMO.Excel {
         private sealed class DirectDataSetSaveCandidate : IDisposable {
             private readonly DataSet _dataSet;
             private readonly Action _invalidate;
+            private readonly bool _subscribed;
             private bool _disposed;
 
             internal DirectDataSetSaveCandidate(DataSet dataSet, DirectDataSetWorkbookModel model, Action invalidate, bool isDeferred, bool subscribeToSourceChanges) {
@@ -1516,6 +1607,7 @@ namespace OfficeIMO.Excel {
                 _invalidate = invalidate;
                 IsDeferred = isDeferred;
                 if (subscribeToSourceChanges) {
+                    _subscribed = true;
                     Subscribe(dataSet);
                 }
             }
@@ -1597,9 +1689,11 @@ namespace OfficeIMO.Excel {
                 }
 
                 _disposed = true;
-                try {
-                    Unsubscribe(_dataSet);
-                } catch {
+                if (_subscribed) {
+                    try {
+                        Unsubscribe(_dataSet);
+                    } catch {
+                    }
                 }
             }
         }

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -337,11 +337,7 @@ namespace OfficeIMO.Excel {
         }
 
         internal void MarkPackageDirty() {
-            if (_packageDirty
-                && _unchangedPackageBytes == null
-                && _directDataSetSaveCandidate == null
-                && !_preserveDirectDataSetSaveCandidateForNextDirtyMark
-                && _directDataSetSaveCandidatePreservationDepth == 0) {
+            if (IsPackageDirtyWithoutPendingSaveCandidate) {
                 return;
             }
 
@@ -368,6 +364,13 @@ namespace OfficeIMO.Excel {
         }
 
         internal bool IsPackageDirty => _packageDirty;
+
+        internal bool IsPackageDirtyWithoutPendingSaveCandidate
+            => _packageDirty
+                && _unchangedPackageBytes == null
+                && _directDataSetSaveCandidate == null
+                && !_preserveDirectDataSetSaveCandidateForNextDirtyMark
+                && _directDataSetSaveCandidatePreservationDepth == 0;
 
         internal bool HasPackagePropertiesDirty => _packagePropertiesDirty;
 
@@ -642,6 +645,16 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        internal bool TryGetOrAddSharedStringIndexBelowLimit(string text, int addLimit, bool validateNewString, out int index, out bool containsLineBreak) {
+            if (Locking.IsNoLock || (_lock != null && _lock.IsWriteLockHeld)) {
+                return TryGetOrAddSharedStringIndexBelowLimitCore(text, addLimit, validateNewString, out index, out containsLineBreak);
+            }
+
+            lock (_sharedStringLock) {
+                return TryGetOrAddSharedStringIndexBelowLimitCore(text, addLimit, validateNewString, out index, out containsLineBreak);
+            }
+        }
+
         private int GetSharedStringIndexCore(string text, bool validateNewString) {
             // Check cache first
             if (_sharedStringCache.TryGetValue(text, out int cachedIndex)) {
@@ -708,6 +721,13 @@ namespace OfficeIMO.Excel {
                 return true;
             }
 
+            if (_sharedStringTablePart != null && _sharedStringTableCount >= 0 && _sharedStringCache.Count > 0) {
+                index = -1;
+                containsLineBreak = false;
+                sharedStringCount = _sharedStringTableCount;
+                return false;
+            }
+
             SharedStringTablePart? sharedStringTablePart = _sharedStringTablePart
                 ?? _workBookPart.GetPartsOfType<SharedStringTablePart>().FirstOrDefault();
             var sharedStringTable = sharedStringTablePart?.SharedStringTable;
@@ -728,6 +748,39 @@ namespace OfficeIMO.Excel {
             index = -1;
             containsLineBreak = false;
             return false;
+        }
+
+        private bool TryGetOrAddSharedStringIndexBelowLimitCore(string text, int addLimit, bool validateNewString, out int index, out bool containsLineBreak) {
+            if (_sharedStringCache.TryGetValue(text, out index)) {
+                containsLineBreak = GetCachedOrComputeSharedStringLineBreak(text);
+                return true;
+            }
+
+            var sharedStringTable = SharedStringTablePart.SharedStringTable ??= new SharedStringTable();
+            int tableCount = EnsureSharedStringCacheAndCount(sharedStringTable);
+            if (_sharedStringCache.TryGetValue(text, out index)) {
+                containsLineBreak = GetCachedOrComputeSharedStringLineBreak(text);
+                return true;
+            }
+
+            if (tableCount >= addLimit) {
+                index = -1;
+                containsLineBreak = ContainsLineBreak(text);
+                return false;
+            }
+
+            if (validateNewString) {
+                CoerceValueHelper.ValidateSharedStringLength(text, nameof(text));
+            }
+
+            containsLineBreak = ContainsLineBreak(text);
+            index = tableCount;
+            sharedStringTable.AppendChild(new SharedStringItem(new Text(text)));
+            _sharedStringTableCount = index + 1;
+            _sharedStringTableDirty = true;
+            MarkPackageDirty();
+            _sharedStringCache[text] = index;
+            return true;
         }
 
         private bool GetCachedOrComputeSharedStringLineBreak(string text) {

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.cs
@@ -6,14 +6,32 @@ using System.Globalization;
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
         internal const int CellValuePlainStringPromotionSharedStringCount = 4096;
+        private const int CellValueSharedStringIndexCacheLimit = 256;
         private static readonly DateTime CellValueExcelMinimumSupportedDate = DateTime.FromOADate(2d);
         private Dictionary<uint, uint>? _cellValueDateStyleIndexes;
         private Dictionary<uint, uint>? _cellValueDurationStyleIndexes;
+        private Dictionary<string, CellValueSharedStringIndexCacheEntry>? _cellValueSharedStringIndexCache;
         private uint? _cellValueDefaultDateStyleIndex;
         private uint? _cellValueDefaultDurationStyleIndex;
 
+        private readonly struct CellValueSharedStringIndexCacheEntry {
+            internal CellValueSharedStringIndexCacheEntry(int index, bool containsLineBreak) {
+                Index = index;
+                ContainsLineBreak = containsLineBreak;
+            }
+
+            internal int Index { get; }
+
+            internal bool ContainsLineBreak { get; }
+        }
+
         // Core implementation: single source of truth (no locks here)
         private void CellValueCore(int row, int column, object? value) {
+            MaterializeDeferredDataSetImportIfNeeded();
+            CellValueCoreNoMaterialize(row, column, value);
+        }
+
+        private void CellValueCoreNoMaterialize(int row, int column, object? value) {
             if (value == null || value == DBNull.Value) {
                 CellEmptyStringValueCore(row, column);
                 return;
@@ -95,20 +113,46 @@ namespace OfficeIMO.Excel {
 
             var cell = GetCell(row, column);
             string text = value!;
-            if (_excelDocument.TryGetExistingSharedStringIndex(
+            if (TryGetCellValueSharedStringIndex(text, out int cachedSharedStringIndex, out bool cachedContainsLineBreak)) {
+                SetExistingCellSharedStringValue(cell, cachedSharedStringIndex, cachedContainsLineBreak);
+            } else if (_excelDocument.TryGetOrAddSharedStringIndexBelowLimit(
                     text,
-                    out int existingSharedStringIndex,
-                    out bool existingContainsLineBreak,
-                    out int sharedStringCount)) {
-                SetExistingCellSharedStringValue(cell, existingSharedStringIndex, existingContainsLineBreak);
-            } else if (sharedStringCount >= CellValuePlainStringPromotionSharedStringCount) {
-                SetExistingCellPlainStringValue(cell, text);
-            } else {
-                int sharedStringIndex = _excelDocument.GetSharedStringIndex(text, validateNewString: true, out bool containsLineBreak);
+                    CellValuePlainStringPromotionSharedStringCount,
+                    validateNewString: true,
+                    out int sharedStringIndex,
+                    out bool containsLineBreak)) {
+                AddCellValueSharedStringIndex(text, sharedStringIndex, containsLineBreak);
                 SetExistingCellSharedStringValue(cell, sharedStringIndex, containsLineBreak);
+            } else {
+                SetExistingCellPlainStringValue(cell, text);
             }
 
             ClearHeaderCacheForCellMutation(row);
+        }
+
+        private bool TryGetCellValueSharedStringIndex(string text, out int index, out bool containsLineBreak) {
+            if (_cellValueSharedStringIndexCache != null
+                && _cellValueSharedStringIndexCache.TryGetValue(text, out CellValueSharedStringIndexCacheEntry entry)) {
+                index = entry.Index;
+                containsLineBreak = entry.ContainsLineBreak;
+                return true;
+            }
+
+            index = -1;
+            containsLineBreak = false;
+            return false;
+        }
+
+        private void AddCellValueSharedStringIndex(string text, int index, bool containsLineBreak) {
+            var cache = _cellValueSharedStringIndexCache;
+            if (cache == null) {
+                cache = new Dictionary<string, CellValueSharedStringIndexCacheEntry>(StringComparer.Ordinal);
+                _cellValueSharedStringIndexCache = cache;
+            } else if (cache.Count >= CellValueSharedStringIndexCacheLimit) {
+                return;
+            }
+
+            cache[text] = new CellValueSharedStringIndexCacheEntry(index, containsLineBreak);
         }
 
         private void CellEmptyStringValueCore(int row, int column) {
@@ -144,9 +188,20 @@ namespace OfficeIMO.Excel {
 
         private void CellDoubleValueCore(int row, int column, double value) {
             var cell = GetCell(row, column);
-            cell.CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture));
+            cell.CellValue = new CellValue(FormatDoubleCellValue(value));
             cell.DataType = DocumentFormat.OpenXml.Spreadsheet.CellValues.Number;
             ClearHeaderCacheForCellMutation(row);
+        }
+
+        private static string FormatDoubleCellValue(double value) {
+            if (value >= int.MinValue && value <= int.MaxValue) {
+                int integer = (int)value;
+                if (value == integer) {
+                    return InvariantNumberText.Get(integer);
+                }
+            }
+
+            return value.ToString(CultureInfo.InvariantCulture);
         }
 
         private void CellDecimalValueCore(int row, int column, decimal value) {
@@ -276,11 +331,10 @@ namespace OfficeIMO.Excel {
             return (cellValue, new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(cellType));
         }
 
-
-
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, string value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellStringValueCore(row, column, value);
                 return;
             }
@@ -298,6 +352,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, double value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellDoubleValueCore(row, column, value);
                 return;
             }
@@ -315,6 +370,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, float value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellDoubleValueCore(row, column, (double)value);
                 return;
             }
@@ -332,6 +388,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, decimal value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellDecimalValueCore(row, column, value);
                 return;
             }
@@ -349,6 +406,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, int value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellNumberTextValueCore(row, column, InvariantNumberText.Get(value));
                 return;
             }
@@ -366,6 +424,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, long value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellNumberTextValueCore(row, column, InvariantNumberText.Get(value));
                 return;
             }
@@ -383,6 +442,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, short value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellNumberTextValueCore(row, column, InvariantNumberText.Get(value));
                 return;
             }
@@ -400,6 +460,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, DateTime value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellDateTimeValueCore(row, column, value);
                 return;
             }
@@ -417,6 +478,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, DateTimeOffset value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellDateTimeOffsetValueCore(row, column, value);
                 return;
             }
@@ -435,6 +497,7 @@ namespace OfficeIMO.Excel {
 #if NET6_0_OR_GREATER
         public void CellValue(int row, int column, DateOnly value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellDateOnlyValueCore(row, column, value);
                 return;
             }
@@ -452,6 +515,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, TimeOnly value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellTimeOnlyValueCore(row, column, value);
                 return;
             }
@@ -470,6 +534,7 @@ namespace OfficeIMO.Excel {
 #endif
         public void CellValue(int row, int column, TimeSpan value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellTimeSpanValueCore(row, column, value);
                 return;
             }
@@ -487,6 +552,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, uint value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellNumberTextValueCore(row, column, InvariantNumberText.Get(value));
                 return;
             }
@@ -504,6 +570,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, ulong value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellNumberTextValueCore(row, column, InvariantNumberText.Get(value));
                 return;
             }
@@ -521,6 +588,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, ushort value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellNumberTextValueCore(row, column, InvariantNumberText.Get(value));
                 return;
             }
@@ -538,6 +606,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, byte value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellNumberTextValueCore(row, column, InvariantNumberText.Get(value));
                 return;
             }
@@ -555,6 +624,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, sbyte value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellNumberTextValueCore(row, column, InvariantNumberText.Get(value));
                 return;
             }
@@ -572,6 +642,7 @@ namespace OfficeIMO.Excel {
         /// <inheritdoc cref="CellValue(int,int,object)" />
         public void CellValue(int row, int column, bool value) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellBooleanValueCore(row, column, value);
                 return;
             }
@@ -594,6 +665,7 @@ namespace OfficeIMO.Excel {
         /// <param name="formula">The formula expression.</param>
         public void CellFormula(int row, int column, string formula) {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellFormulaCore(row, column, formula);
                 return;
             }
@@ -1525,7 +1597,7 @@ namespace OfficeIMO.Excel {
             var lck = _excelDocument.EnsureLock();
             lck.EnterWriteLock();
             try {
-                CellValueCore(row, column, value);
+                CellValueCoreNoMaterialize(row, column, value);
             } finally {
                 lck.ExitWriteLock();
             }
@@ -1540,6 +1612,7 @@ namespace OfficeIMO.Excel {
         /// <param name="value">The nullable value to assign.</param>
         public void CellValue<T>(int row, int column, T? value) where T : struct {
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 CellValueCore(row, column, value.HasValue ? value.Value : null);
                 return;
             }
@@ -1548,7 +1621,7 @@ namespace OfficeIMO.Excel {
             var lck = _excelDocument.EnsureLock();
             lck.EnterWriteLock();
             try {
-                CellValueCore(row, column, value.HasValue ? value.Value : null);
+                CellValueCoreNoMaterialize(row, column, value.HasValue ? value.Value : null);
             } finally {
                 lck.ExitWriteLock();
             }

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
         private const int DirectSequentialCellWriteLimit = 16;
+        private const int DirectCellValuesLinearHeaderDuplicateCheckLimit = 32;
 
         /// <summary>
         /// Writes multiple cell values efficiently, using parallelization when beneficial.
@@ -32,7 +33,8 @@ namespace OfficeIMO.Excel {
 
             DirectCellValuesSaveCandidate? directSaveCandidate = null;
             DirectCellValuesSaveCandidate? appendSaveCandidate = null;
-            if (!ContainsDirectCellValuesAutomaticFormattingText(list)
+            bool hasAutomaticFormattingText = ContainsDirectCellValuesAutomaticFormattingText(list);
+            if (!hasAutomaticFormattingText
                 && TryCreateDirectCellValuesSaveCandidate(list, mode, out DirectCellValuesSaveCandidate? candidate)
                 && candidate != null
                 && CanRegisterDirectTabularSaveCandidate(1, 1, candidate.ColumnNames.Length)) {
@@ -40,15 +42,13 @@ namespace OfficeIMO.Excel {
             }
 
             if (directSaveCandidate != null
-                && (directSaveCandidate.IncludeHeaders
-                    ? mode != ExecutionMode.Parallel
-                    : mode == ExecutionMode.Parallel)
+                && (directSaveCandidate.IncludeHeaders || mode == ExecutionMode.Parallel)
                 && RegisterDeferredDirectCellValuesSaveCandidateIfPossible(directSaveCandidate)) {
                 return;
             }
 
             if (mode == ExecutionMode.Parallel
-                && !ContainsDirectCellValuesAutomaticFormattingText(list)
+                && !hasAutomaticFormattingText
                 && TryCreateDirectCellValuesAppendCandidate(list, out DirectCellValuesSaveCandidate? appendCandidate)) {
                 appendSaveCandidate = appendCandidate;
             }
@@ -302,36 +302,12 @@ namespace OfficeIMO.Excel {
             out DirectCellValuesSaveCandidate? candidate) {
             candidate = null;
 
-            if (!TryInferDirectCellValuesColumnTypes(cells, 0, columnCount, out Type[] columnTypes)) {
+            if (!TryCreateDirectCellValuesRowsAndColumnTypes(cells, 0, columnCount, out Type[] columnTypes, out object?[][] rows)) {
                 return false;
-            }
-
-            int dataRowCount = cells.Count / columnCount;
-            var rows = new object?[dataRowCount][];
-            int rowOffset = 0;
-            for (int index = 0; index < cells.Count; index += columnCount) {
-                var row = new object?[columnCount];
-                for (int column = 0; column < columnCount; column++) {
-                    Type columnType = columnTypes[column];
-                    object? value = cells[index + column].Value;
-                    row[column] = CoerceDirectCellValuesTableValue(value, columnType);
-                }
-
-                rows[rowOffset++] = row;
             }
 
             candidate = new DirectCellValuesSaveCandidate(headers.ToArray(), columnTypes, rows, includeHeaders: true, range: string.Empty);
             return true;
-        }
-
-        private static bool ContainsDirectCellValuesAutomaticFormattingText(IReadOnlyList<(int Row, int Column, object Value)> cells) {
-            for (int i = 0; i < cells.Count; i++) {
-                if (cells[i].Value is string text && (text.IndexOf('\r') >= 0 || text.IndexOf('\n') >= 0)) {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         private static bool TryCreateDirectCellValuesSaveCandidate(
@@ -356,7 +332,7 @@ namespace OfficeIMO.Excel {
             }
 
             int dataStartIndex = includeHeaders ? columnCount : 0;
-            if (!TryInferDirectCellValuesColumnTypes(cells, dataStartIndex, columnCount, out Type[] columnTypes)) {
+            if (!TryCreateDirectCellValuesRowsAndColumnTypes(cells, dataStartIndex, columnCount, out Type[] columnTypes, out object?[][] rows)) {
                 return false;
             }
 
@@ -365,20 +341,6 @@ namespace OfficeIMO.Excel {
                 columnNames[column] = includeHeaders
                     ? Convert.ToString(cells[column].Value, CultureInfo.InvariantCulture) ?? string.Empty
                     : "Column" + (column + 1).ToString(CultureInfo.InvariantCulture);
-            }
-
-            int dataRowCount = (cells.Count - dataStartIndex) / columnCount;
-            var rows = new object?[dataRowCount][];
-            int rowOffset = 0;
-            for (int index = dataStartIndex; index < cells.Count; index += columnCount) {
-                var row = new object?[columnCount];
-                for (int column = 0; column < columnCount; column++) {
-                    Type columnType = columnTypes[column];
-                    object? value = cells[index + column].Value;
-                    row[column] = CoerceDirectCellValuesTableValue(value, columnType);
-                }
-
-                rows[rowOffset++] = row;
             }
 
             string range = A1.CellReference(1, 1) + ":" + A1.CellReference(rowCount, columnCount);
@@ -483,13 +445,25 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            var headers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            for (int column = 0; column < columnCount; column++) {
-                if (cells[column].Value is not string header || string.IsNullOrWhiteSpace(header)) {
-                    return false;
+            if (columnCount <= DirectCellValuesLinearHeaderDuplicateCheckLimit) {
+                for (int column = 0; column < columnCount; column++) {
+                    if (cells[column].Value is not string header || string.IsNullOrWhiteSpace(header)) {
+                        return false;
+                    }
+
+                    for (int previousColumn = 0; previousColumn < column; previousColumn++) {
+                        if (string.Equals((string)cells[previousColumn].Value, header, StringComparison.OrdinalIgnoreCase)) {
+                            return false;
+                        }
+                    }
                 }
 
-                if (!headers.Add(header)) {
+                return true;
+            }
+
+            var headers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (int column = 0; column < columnCount; column++) {
+                if (cells[column].Value is not string header || string.IsNullOrWhiteSpace(header) || !headers.Add(header)) {
                     return false;
                 }
             }
@@ -511,23 +485,40 @@ namespace OfficeIMO.Excel {
             return true;
         }
 
-        private static bool TryInferDirectCellValuesColumnTypes(
+        private static bool TryCreateDirectCellValuesRowsAndColumnTypes(
             IReadOnlyList<(int Row, int Column, object Value)> cells,
             int dataStartIndex,
             int columnCount,
-            out Type[] columnTypes) {
+            out Type[] columnTypes,
+            out object?[][] rows) {
             columnTypes = new Type[columnCount];
-            for (int column = 0; column < columnCount; column++) {
-                Type? inferred = null;
-                for (int index = dataStartIndex + column; index < cells.Count; index += columnCount) {
-                    object? value = cells[index].Value;
+            int dataRowCount = (cells.Count - dataStartIndex) / columnCount;
+            rows = new object?[dataRowCount][];
+            var inferredTypes = new Type?[columnCount];
+            bool[]? blankColumns = null;
+
+            int rowOffset = 0;
+            for (int index = dataStartIndex; index < cells.Count; index += columnCount) {
+                var row = new object?[columnCount];
+                for (int column = 0; column < columnCount; column++) {
+                    object? value = cells[index + column].Value;
                     if (IsDirectCellValuesBlankValue(value)) {
+                        blankColumns ??= new bool[columnCount];
+                        blankColumns[column] = true;
+                        row[column] = value;
                         continue;
                     }
 
-                    Type valueType = NormalizeDirectCellValuesColumnType(value!.GetType());
+                    Type valueType = GetDirectCellValuesColumnType(value!);
+                    Type? inferred = inferredTypes[column];
                     if (inferred == null) {
-                        inferred = valueType;
+                        inferredTypes[column] = valueType;
+                        row[column] = value;
+                        continue;
+                    }
+
+                    if (inferred == typeof(object)) {
+                        row[column] = value;
                         continue;
                     }
 
@@ -536,15 +527,50 @@ namespace OfficeIMO.Excel {
                             return false;
                         }
 
-                        inferred = typeof(object);
+                        inferredTypes[column] = typeof(object);
                     }
+
+                    row[column] = value;
                 }
 
-                columnTypes[column] = inferred ?? typeof(string);
+                rows[rowOffset++] = row;
+            }
+
+            for (int column = 0; column < columnCount; column++) {
+                columnTypes[column] = inferredTypes[column] ?? typeof(string);
+            }
+
+            if (blankColumns != null) {
+                for (int rowIndex = 0; rowIndex < rows.Length; rowIndex++) {
+                    object?[] row = rows[rowIndex];
+                    for (int column = 0; column < columnCount; column++) {
+                        if (!blankColumns[column] || !IsDirectCellValuesBlankValue(row[column])) {
+                            continue;
+                        }
+
+                        Type columnType = columnTypes[column];
+                        row[column] = columnType == typeof(string) || columnType == typeof(object)
+                            ? string.Empty
+                            : DBNull.Value;
+                    }
+                }
             }
 
             return true;
         }
+
+        private static bool ContainsDirectCellValuesAutomaticFormattingText(IReadOnlyList<(int Row, int Column, object Value)> cells) {
+            for (int i = 0; i < cells.Count; i++) {
+                if (cells[i].Value is string text && IsDirectCellValuesAutomaticFormattingText(text)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsDirectCellValuesAutomaticFormattingText(string text)
+            => text.IndexOf('\r') >= 0 || text.IndexOf('\n') >= 0;
 
         private static Type NormalizeDirectCellValuesColumnType(Type type) {
             type = Nullable.GetUnderlyingType(type) ?? type;
@@ -553,6 +579,51 @@ namespace OfficeIMO.Excel {
             }
 
             return type;
+        }
+
+        private static Type GetDirectCellValuesColumnType(object value) {
+            switch (value) {
+                case string:
+                    return typeof(string);
+                case bool:
+                    return typeof(bool);
+                case DateTime:
+                    return typeof(DateTime);
+                case DateTimeOffset:
+                    return typeof(DateTimeOffset);
+                case TimeSpan:
+                    return typeof(TimeSpan);
+                case double:
+                    return typeof(double);
+                case float:
+                    return typeof(float);
+                case decimal:
+                    return typeof(decimal);
+                case sbyte:
+                    return typeof(sbyte);
+                case byte:
+                    return typeof(byte);
+                case short:
+                    return typeof(short);
+                case ushort:
+                    return typeof(ushort);
+                case int:
+                    return typeof(int);
+                case uint:
+                    return typeof(uint);
+                case long:
+                    return typeof(long);
+                case ulong:
+                    return typeof(ulong);
+#if NET6_0_OR_GREATER
+                case DateOnly:
+                    return typeof(DateOnly);
+                case TimeOnly:
+                    return typeof(TimeOnly);
+#endif
+                default:
+                    return NormalizeDirectCellValuesColumnType(value.GetType());
+            }
         }
 
         private static bool IsDirectCellValuesStyleSensitiveType(Type type) {
@@ -568,16 +639,6 @@ namespace OfficeIMO.Excel {
 
         private static bool IsDirectCellValuesBlankValue(object? value) {
             return value == null || value == DBNull.Value;
-        }
-
-        private static object CoerceDirectCellValuesTableValue(object? value, Type columnType) {
-            if (IsDirectCellValuesBlankValue(value)) {
-                return columnType == typeof(string) || columnType == typeof(object)
-                    ? string.Empty
-                    : DBNull.Value;
-            }
-
-            return value!;
         }
 
         private bool TryApplyPlainCellsByAppendingRows(IReadOnlyList<(int Row, int Column, object Value)> source, CancellationToken ct) {

--- a/OfficeIMO.Excel/ExcelSheet.ColumnsRows.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ColumnsRows.cs
@@ -51,6 +51,22 @@ namespace OfficeIMO.Excel {
             AutoFitColumnsInternal(list, mode, ct);
         }
 
+        private void AutoFitContiguousColumns(int startColumn, int columnCount, ExecutionMode? mode = null, CancellationToken ct = default) {
+            if (startColumn <= 0 || columnCount <= 0) return;
+            _excelDocument.MaterializeDeferredDataSetImport();
+
+            var columns = new int[columnCount];
+            for (int i = 0; i < columns.Length; i++) {
+                columns[i] = startColumn + i;
+            }
+
+            if (CanSkipStableAutoFitColumns(columns)) {
+                return;
+            }
+
+            AutoFitColumnsInternal(columns, mode, ct);
+        }
+
         /// <summary>
         /// Automatically fits all columns except the supplied indexes.
         /// </summary>

--- a/OfficeIMO.Excel/ExcelSheet.Core.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Core.cs
@@ -27,7 +27,15 @@ namespace OfficeIMO.Excel {
         }
         private readonly UInt32Value _id;
         private readonly WorksheetPart _worksheetPart;
-        internal WorksheetPart WorksheetPart => _worksheetPart;
+        internal WorksheetPart WorksheetPart {
+            get {
+                if (!_excelDocument.IsMaterializingDeferredDataSetImport) {
+                    MaterializeDeferredDataSetImportIfNeeded();
+                }
+
+                return _worksheetPart;
+            }
+        }
         private readonly SpreadsheetDocument _spreadSheetDocument;
         private readonly ExcelDocument _excelDocument;
         private bool _isBatchOperation = false;
@@ -81,6 +89,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 action(this);
                 return;
             }
@@ -251,7 +260,11 @@ namespace OfficeIMO.Excel {
                 rowElement = new Row { RowIndex = (uint)row };
                 createdRowElement = true;
                 if (insertAfterRow != null) {
-                    sheetData.InsertAfter(rowElement, insertAfterRow);
+                    if (insertAfterRow.NextSibling<Row>() == null) {
+                        sheetData.Append(rowElement);
+                    } else {
+                        sheetData.InsertAfter(rowElement, insertAfterRow);
+                    }
                 } else {
                     // Insert at beginning
                     var firstRow = sheetData.Elements<Row>().FirstOrDefault();
@@ -325,7 +338,11 @@ namespace OfficeIMO.Excel {
             if (cell == null) {
                 cell = new Cell { CellReference = BuildCellReference(row, column) };
                 if (insertAfterCell != null) {
-                    rowElement.InsertAfter(cell, insertAfterCell);
+                    if (insertAfterCell.NextSibling<Cell>() == null) {
+                        rowElement.Append(cell);
+                    } else {
+                        rowElement.InsertAfter(cell, insertAfterCell);
+                    }
                 } else {
                     // Insert at beginning or append when row is empty or existing first cell has larger column index
                     var firstCell = rowElement.Elements<Cell>().FirstOrDefault();
@@ -678,6 +695,7 @@ namespace OfficeIMO.Excel {
             // If we're already in a batch operation or in a NoLock scope,
             // just execute the action directly
             if (_isBatchOperation || Locking.IsNoLock) {
+                MaterializeDeferredDataSetImportIfNeeded();
                 action();
                 MarkRequiresSavePreparation();
             } else {

--- a/OfficeIMO.Excel/ExcelSheet.DataReader.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataReader.cs
@@ -7,6 +7,7 @@ using DocumentFormat.OpenXml.Spreadsheet;
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
         private const int DirectDataReaderSaveCandidateRowLimit = 65536;
+        private const int DirectDataReaderInitialRowCapacity = 512;
 
         /// <summary>
         /// Streams rows from an <see cref="IDataReader"/> (including provider-owned DbDataReader implementations) into the worksheet and optionally creates an Excel table.
@@ -99,7 +100,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (autoFit) {
-                    AutoFitColumnsFor(Enumerable.Range(startColumn, headers.Length));
+                    AutoFitContiguousColumns(startColumn, headers.Length);
                 }
 
                 RegisterDirectDataReaderSaveCandidateIfPossible(
@@ -118,7 +119,7 @@ namespace OfficeIMO.Excel {
                 return appendedRange;
             }
 
-            List<object?[]>? directRows = canRegisterDirectSave ? new List<object?[]>() : null;
+            List<object?[]>? directRows = canRegisterDirectSave ? CreateDirectDataReaderRowBuffer() : null;
 
             int row = startRow;
             if (includeHeaders) {
@@ -130,12 +131,16 @@ namespace OfficeIMO.Excel {
             }
 
             int dataRows = 0;
+            bool canCancel = ct.CanBeCanceled;
             while (reader.Read()) {
-                ct.ThrowIfCancellationRequested();
+                if (canCancel) {
+                    ct.ThrowIfCancellationRequested();
+                }
+
                 object?[]? directRow = directRows != null ? new object?[headers.Length] : null;
                 for (int i = 0; i < headers.Length; i++) {
-                    bool isDbNull = reader.IsDBNull(i);
-                    object? value = isDbNull ? null : reader.GetValue(i);
+                    object rawValue = reader.GetValue(i);
+                    object? value = rawValue == DBNull.Value ? null : rawValue;
                     if (directRow != null) {
                         directRow[i] = value;
                     }
@@ -175,7 +180,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (autoFit) {
-                AutoFitColumnsFor(Enumerable.Range(startColumn, headers.Length));
+                AutoFitContiguousColumns(startColumn, headers.Length);
             }
 
             RegisterDirectDataReaderSaveCandidateIfPossible(
@@ -210,16 +215,21 @@ namespace OfficeIMO.Excel {
             out string range) {
             range = string.Empty;
             int columnCount = headers.Count;
-            var rows = new List<object?[]>();
+            var rows = CreateDirectDataReaderRowBuffer();
+            bool canCancel = ct.CanBeCanceled;
             while (reader.Read()) {
-                ct.ThrowIfCancellationRequested();
+                if (canCancel) {
+                    ct.ThrowIfCancellationRequested();
+                }
+
                 if (startRow + rows.Count + (includeHeaders ? 1 : 0) > A1.MaxRows) {
                     throw new InvalidOperationException("Data reader import exceeds the maximum worksheet row count.");
                 }
 
                 var values = new object?[columnCount];
                 for (int offset = 0; offset < columnCount; offset++) {
-                    values[offset] = reader.IsDBNull(offset) ? null : reader.GetValue(offset);
+                    object value = reader.GetValue(offset);
+                    values[offset] = value == DBNull.Value ? null : value;
                 }
 
                 rows.Add(values);
@@ -240,7 +250,7 @@ namespace OfficeIMO.Excel {
                 "ReaderData",
                 columnNames,
                 columnTypes,
-                rows.ToArray(),
+                rows,
                 includeHeaders,
                 range,
                 createTable ? tableName : null,
@@ -306,12 +316,14 @@ namespace OfficeIMO.Excel {
             }
 
             if (createTable && range.Length != 0) {
-                string[]? headerNames = includeHeaders ? headers.ToArray() : null;
+                string[]? headerNames = includeHeaders
+                    ? headers is string[] headerArray ? headerArray : headers.ToArray()
+                    : null;
                 AddTableAndGetName(range, includeHeaders, tableName ?? string.Empty, style, includeAutoFilter, headerNames: headerNames);
             }
 
             if (autoFit) {
-                AutoFitColumnsFor(Enumerable.Range(startColumn, headers.Count));
+                AutoFitContiguousColumns(startColumn, headers.Count);
             }
         }
 
@@ -327,7 +339,7 @@ namespace OfficeIMO.Excel {
             out int dataRows,
             out List<object?[]>? directRows) {
             dataRows = 0;
-            directRows = collectDirectRows ? new List<object?[]>() : null;
+            directRows = collectDirectRows ? CreateDirectDataReaderRowBuffer() : null;
 
             int columnCount = headers.Count;
             if (columnCount == 0 || startColumn + columnCount - 1 > A1.MaxColumns) {
@@ -371,7 +383,7 @@ namespace OfficeIMO.Excel {
             out int dataRows,
             out List<object?[]>? directRows) {
             dataRows = 0;
-            directRows = collectDirectRows ? new List<object?[]>() : null;
+            directRows = collectDirectRows ? CreateDirectDataReaderRowBuffer() : null;
 
             var sheetData = GetOrCreateSheetData();
             int minExistingRow = int.MaxValue;
@@ -459,13 +471,17 @@ namespace OfficeIMO.Excel {
             bool useDirectStringCells = collectDirectRows && columnCount > 1;
             var appendedRows = new List<OpenXmlElement>();
             int rowIndex = startRow;
+            bool canCancel = ct.CanBeCanceled;
 
             if (includeHeaders) {
-                appendedRows.Add(CreateDataReaderHeaderRow(rowIndex++, startColumn, columnNames, headers, useDirectStringCells, ref sharedStringIndexes, ct));
+                appendedRows.Add(CreateDataReaderHeaderRow(rowIndex++, startColumn, columnNames, headers, useDirectStringCells, ref sharedStringIndexes, canCancel, ct));
             }
 
             while (reader.Read()) {
-                ct.ThrowIfCancellationRequested();
+                if (canCancel) {
+                    ct.ThrowIfCancellationRequested();
+                }
+
                 if (rowIndex > A1.MaxRows) {
                     throw new InvalidOperationException("Data reader import exceeds the maximum worksheet row count.");
                 }
@@ -473,12 +489,11 @@ namespace OfficeIMO.Excel {
                 object?[]? directRow = directRows != null ? new object?[columnCount] : null;
                 object?[] values = directRow ?? new object?[columnCount];
                 for (int offset = 0; offset < columnCount; offset++) {
-                    bool isDbNull = reader.IsDBNull(offset);
-                    object? value = isDbNull ? null : reader.GetValue(offset);
-                    values[offset] = value;
+                    object value = reader.GetValue(offset);
+                    values[offset] = value == DBNull.Value ? null : value;
                 }
 
-                appendedRows.Add(CreateDataReaderValueRow(rowIndex++, startColumn, columnNames, values, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes, ct));
+                appendedRows.Add(CreateDataReaderValueRow(rowIndex++, startColumn, columnNames, values, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes, canCancel, ct));
                 dataRows++;
 
                 if (directRows != null) {
@@ -513,11 +528,15 @@ namespace OfficeIMO.Excel {
             IReadOnlyList<string> headers,
             bool useDirectStringCells,
             ref Dictionary<string, int>? sharedStringIndexes,
+            bool canCancel,
             CancellationToken ct) {
             string rowReference = InvariantNumberText.Get(rowIndex);
             var row = new Row { RowIndex = (uint)rowIndex };
             for (int offset = 0; offset < headers.Count; offset++) {
-                ct.ThrowIfCancellationRequested();
+                if (canCancel) {
+                    ct.ThrowIfCancellationRequested();
+                }
+
                 int column = startColumn + offset;
                 var (cellValue, cellType) = CoerceDataTableAppendValue(headers[offset], useDirectStringCells, ref sharedStringIndexes);
                 row.Append(new Cell {
@@ -540,11 +559,15 @@ namespace OfficeIMO.Excel {
             uint? objectTimeSpanStyleIndex,
             bool useDirectStringCells,
             ref Dictionary<string, int>? sharedStringIndexes,
+            bool canCancel,
             CancellationToken ct) {
             string rowReference = InvariantNumberText.Get(rowIndex);
             var row = new Row { RowIndex = (uint)rowIndex };
             for (int offset = 0; offset < values.Count; offset++) {
-                ct.ThrowIfCancellationRequested();
+                if (canCancel) {
+                    ct.ThrowIfCancellationRequested();
+                }
+
                 object? value = values[offset];
                 int column = startColumn + offset;
                 var (cellValue, cellType) = CoerceDataTableAppendValue(value, useDirectStringCells, ref sharedStringIndexes);
@@ -590,7 +613,7 @@ namespace OfficeIMO.Excel {
                 "ReaderData",
                 columnNames,
                 columnTypes,
-                directRows.ToArray(),
+                directRows,
                 includeHeaders,
                 range,
                 tableName,
@@ -601,7 +624,7 @@ namespace OfficeIMO.Excel {
         }
 
         private static string[] BuildReaderHeaders(IDataReader reader) {
-            var headers = new List<string>(reader.FieldCount);
+            var headers = new string[reader.FieldCount];
             for (int i = 0; i < reader.FieldCount; i++) {
                 string name;
                 try {
@@ -614,12 +637,14 @@ namespace OfficeIMO.Excel {
                     name = "Column" + (i + 1).ToString(CultureInfo.InvariantCulture);
                 }
 
-                headers.Add(name);
+                headers[i] = name;
             }
 
             EnsureUniqueReaderHeaders(headers);
-            return headers.ToArray();
+            return headers;
         }
+
+        private static List<object?[]> CreateDirectDataReaderRowBuffer() => new List<object?[]>(DirectDataReaderInitialRowCapacity);
 
         private static Type[] BuildReaderFieldTypes(IDataReader reader) {
             var types = new Type[reader.FieldCount];
@@ -636,26 +661,48 @@ namespace OfficeIMO.Excel {
 
         private static string[] BuildDirectReaderColumnNames(IReadOnlyList<string> headers, bool includeHeaders) {
             if (includeHeaders) {
+                if (headers is string[] headerArray) {
+                    return headerArray;
+                }
+
                 return headers.ToArray();
             }
 
-            return Enumerable.Range(1, headers.Count)
-                .Select(index => "Column" + index.ToString(CultureInfo.InvariantCulture))
-                .ToArray();
+            var columnNames = new string[headers.Count];
+            for (int i = 0; i < columnNames.Length; i++) {
+                columnNames[i] = "Column" + (i + 1).ToString(CultureInfo.InvariantCulture);
+            }
+
+            return columnNames;
         }
 
         private static Type[] BuildDirectReaderColumnTypes(IReadOnlyList<Type> fieldTypes) {
-            Type[] columnTypes = new Type[fieldTypes.Count];
             for (int i = 0; i < fieldTypes.Count; i++) {
                 Type fieldType = fieldTypes[i];
-                if (fieldType == typeof(DBNull) || fieldType == typeof(void)) {
-                    fieldType = typeof(object);
-                }
+                Type columnType = fieldType == typeof(DBNull) || fieldType == typeof(void)
+                    ? typeof(object)
+                    : Nullable.GetUnderlyingType(fieldType) ?? fieldType;
+                if (columnType != fieldType) {
+                    var columnTypes = new Type[fieldTypes.Count];
+                    for (int copyIndex = 0; copyIndex < i; copyIndex++) {
+                        columnTypes[copyIndex] = fieldTypes[copyIndex];
+                    }
 
-                columnTypes[i] = Nullable.GetUnderlyingType(fieldType) ?? fieldType;
+                    columnTypes[i] = columnType;
+                    for (int remainingIndex = i + 1; remainingIndex < fieldTypes.Count; remainingIndex++) {
+                        fieldType = fieldTypes[remainingIndex];
+                        columnTypes[remainingIndex] = fieldType == typeof(DBNull) || fieldType == typeof(void)
+                            ? typeof(object)
+                            : Nullable.GetUnderlyingType(fieldType) ?? fieldType;
+                    }
+
+                    return columnTypes;
+                }
             }
 
-            return columnTypes;
+            return fieldTypes is Type[] fieldTypeArray
+                ? fieldTypeArray
+                : fieldTypes.ToArray();
         }
 
         private static string?[] BuildReaderNumberFormats(IReadOnlyList<Type> fieldTypes) {

--- a/OfficeIMO.Excel/ExcelSheet.Headers.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.cs
@@ -387,7 +387,10 @@ namespace OfficeIMO.Excel {
                     return;
                 }
 
-                _excelDocument.MarkPackageDirty();
+                if (!_excelDocument.IsPackageDirtyWithoutPendingSaveCandidate) {
+                    _excelDocument.MarkPackageDirty();
+                }
+
                 return;
             }
 

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.EnumerateRange.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.EnumerateRange.cs
@@ -50,6 +50,7 @@ namespace OfficeIMO.Excel {
             bool fillBlanks = _opt.FillBlanksInRanges;
             bool hasCustomConverter = _opt.CellValueConverter != null;
             int nextRowIndex = 1;
+            var seenRows = CreateCompletedRowTracker(r2 - r1 + 1);
 
             while (reader.Read()) {
                 if (canCancel) {
@@ -67,6 +68,10 @@ namespace OfficeIMO.Excel {
 
                 nextRowIndex = rowIndex + 1;
                 if (rowIndex < r1 || rowIndex > r2) {
+                    if (rowIndex > r2 && seenRows.AllRowsSeen) {
+                        break;
+                    }
+
                     SkipXmlElement(reader, "row");
                     continue;
                 }
@@ -77,6 +82,10 @@ namespace OfficeIMO.Excel {
 
                 int depth = reader.Depth;
                 int nextColumnIndex = 1;
+                int width = c2 - c1 + 1;
+                bool canTrackColumns = width <= 64;
+                ulong allColumnsSeen = canTrackColumns ? CreateAllColumnsSeenMask(width) : 0UL;
+                ulong seenColumns = 0;
                 while (reader.Read()) {
                     if (canCancel) {
                         ct.ThrowIfCancellationRequested();
@@ -101,6 +110,7 @@ namespace OfficeIMO.Excel {
                         continue;
                     }
 
+                    int columnOffset = columnIndex - c1;
                     if (hasCustomConverter) {
                         if (TryReadXmlCellValueForEnumeration(reader, rowIndex, columnIndex, out object? customValue)) {
                             yield return new CellValueInfo(rowIndex, columnIndex, customValue);
@@ -113,7 +123,14 @@ namespace OfficeIMO.Excel {
                             yield return new CellValueInfo(rowIndex, columnIndex, cellValue);
                         }
                     }
+
+                    if (canTrackColumns && MarkRequestedColumnSeen(columnOffset, allColumnsSeen, ref seenColumns)) {
+                        SkipXmlElementContent(reader, depth, "row");
+                        break;
+                    }
                 }
+
+                seenRows.MarkSeen(rowIndex - r1);
             }
         }
 

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.EnumerateRange.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.EnumerateRange.cs
@@ -7,6 +7,8 @@ namespace OfficeIMO.Excel {
     /// Range enumeration for <see cref="ExcelSheetReader"/>.
     /// </summary>
     public sealed partial class ExcelSheetReader {
+        private const int CompletedEnumerateRangeOutsideRowProbeLimit = 16;
+
         /// <summary>
         /// Enumerates non-empty cells within the given A1 range as typed values.
         /// </summary>
@@ -50,6 +52,7 @@ namespace OfficeIMO.Excel {
             bool fillBlanks = _opt.FillBlanksInRanges;
             bool hasCustomConverter = _opt.CellValueConverter != null;
             int nextRowIndex = 1;
+            int outsideRowsAfterCompletedRange = 0;
             var seenRows = CreateCompletedRowTracker(r2 - r1 + 1);
 
             while (reader.Read()) {
@@ -69,13 +72,17 @@ namespace OfficeIMO.Excel {
                 nextRowIndex = rowIndex + 1;
                 if (rowIndex < r1 || rowIndex > r2) {
                     if (rowIndex > r2 && seenRows.AllRowsSeen) {
-                        break;
+                        outsideRowsAfterCompletedRange++;
+                        if (outsideRowsAfterCompletedRange >= CompletedEnumerateRangeOutsideRowProbeLimit) {
+                            break;
+                        }
                     }
 
                     SkipXmlElement(reader, "row");
                     continue;
                 }
 
+                outsideRowsAfterCompletedRange = 0;
                 if (reader.IsEmptyElement) {
                     continue;
                 }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.cs
@@ -559,6 +559,7 @@ namespace OfficeIMO.Excel {
             int nextColumnIndex = 1;
             int cols = values.Length;
             bool canTrackColumns = cols <= 64;
+            ulong allColumnsSeen = canTrackColumns ? CreateAllColumnsSeenMask(cols) : 0UL;
             ulong seenColumns = 0;
             while (rowReader.Read()) {
                 if (canCancel) {
@@ -581,7 +582,7 @@ namespace OfficeIMO.Excel {
 
                 CellRaw raw = ReadXmlCellRaw(rowReader, rowIndex, columnIndex);
                 values[columnIndex - c1] = ConvertRaw(raw).TypedValue;
-                if (canTrackColumns && MarkRequestedColumnSeen(columnIndex - c1, cols, ref seenColumns)) {
+                if (canTrackColumns && MarkRequestedColumnSeen(columnIndex - c1, allColumnsSeen, ref seenColumns)) {
                     SkipXmlElementContent(rowReader, depth, "row");
                     return;
                 }
@@ -1921,12 +1922,12 @@ namespace OfficeIMO.Excel {
                         return false;
                     }
 
-                    if (int.TryParse(rawText, NumberStyles.Integer, _opt.Culture, out int intValue)) {
+                    if (TryParseRawInt32(rawText, out int intValue)) {
                         binding.SetInt32(target, intValue);
                         return true;
                     }
 
-                    if (double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, _opt.Culture, out double doubleValue)
+                    if (TryParseRawDouble(rawText, out double doubleValue)
                         && doubleValue >= int.MinValue
                         && doubleValue <= int.MaxValue
                         && Math.Truncate(doubleValue) == doubleValue) {
@@ -1942,12 +1943,12 @@ namespace OfficeIMO.Excel {
                         return false;
                     }
 
-                    if (long.TryParse(rawText, NumberStyles.Integer, _opt.Culture, out long longValue)) {
+                    if (TryParseRawInt64(rawText, out long longValue)) {
                         binding.SetInt64(target, longValue);
                         return true;
                     }
 
-                    if (double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, _opt.Culture, out double doubleValue)
+                    if (TryParseRawDouble(rawText, out double doubleValue)
                         && doubleValue >= long.MinValue
                         && doubleValue <= long.MaxValue
                         && Math.Truncate(doubleValue) == doubleValue) {
@@ -1963,10 +1964,7 @@ namespace OfficeIMO.Excel {
                         return false;
                     }
 
-                    if ((_opt.Culture != CultureInfo.InvariantCulture
-                            && double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, _opt.Culture, out double doubleValue))
-                        || TryParseInvariantDoubleFast(rawText, out doubleValue)
-                        || double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out doubleValue)) {
+                    if (TryParseRawDouble(rawText, out double doubleValue)) {
                         binding.SetDouble(target, doubleValue);
                         return true;
                     }
@@ -1979,8 +1977,7 @@ namespace OfficeIMO.Excel {
                         return false;
                     }
 
-                    if (decimal.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, _opt.Culture, out decimal decimalValue)
-                        || decimal.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out decimalValue)) {
+                    if (TryParseRawDecimal(rawText, out decimal decimalValue)) {
                         binding.SetDecimal(target, decimalValue);
                         return true;
                     }
@@ -2062,12 +2059,12 @@ namespace OfficeIMO.Excel {
             Type destinationType = binding.DestinationType;
 
             if (destinationType == typeof(int)) {
-                if (int.TryParse(rawText, NumberStyles.Integer, _opt.Culture, out int intValue)) {
+                if (TryParseRawInt32(rawText, out int intValue)) {
                     converted = intValue;
                     return true;
                 }
 
-                if (double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, _opt.Culture, out double doubleValue)
+                if (TryParseRawDouble(rawText, out double doubleValue)
                     && doubleValue >= int.MinValue
                     && doubleValue <= int.MaxValue
                     && Math.Truncate(doubleValue) == doubleValue) {
@@ -2079,12 +2076,12 @@ namespace OfficeIMO.Excel {
             }
 
             if (destinationType == typeof(long)) {
-                if (long.TryParse(rawText, NumberStyles.Integer, _opt.Culture, out long longValue)) {
+                if (TryParseRawInt64(rawText, out long longValue)) {
                     converted = longValue;
                     return true;
                 }
 
-                if (double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, _opt.Culture, out double doubleValue)
+                if (TryParseRawDouble(rawText, out double doubleValue)
                     && doubleValue >= long.MinValue
                     && doubleValue <= long.MaxValue
                     && Math.Truncate(doubleValue) == doubleValue) {
@@ -2096,10 +2093,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (destinationType == typeof(double)) {
-                if ((_opt.Culture != CultureInfo.InvariantCulture
-                        && double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, _opt.Culture, out double doubleValue))
-                    || TryParseInvariantDoubleFast(rawText, out doubleValue)
-                    || double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out doubleValue)) {
+                if (TryParseRawDouble(rawText, out double doubleValue)) {
                     converted = doubleValue;
                     return true;
                 }
@@ -2108,8 +2102,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (destinationType == typeof(decimal)) {
-                if (decimal.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, _opt.Culture, out decimal decimalValue)
-                    || decimal.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out decimalValue)) {
+                if (TryParseRawDecimal(rawText, out decimal decimalValue)) {
                     converted = decimalValue;
                     return true;
                 }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.cs
@@ -179,6 +179,7 @@ namespace OfficeIMO.Excel {
             int dataRowCount = Math.Max(0, rows - startRow);
             var headerValues = headersInFirstRow ? new object?[cols] : null;
             var rowValues = new object?[dataRowCount][];
+            var completeRowsWithoutNulls = cols <= 64 ? new bool[dataRowCount] : null;
             var inferredTypes = new Type?[cols];
 
             try {
@@ -225,7 +226,10 @@ namespace OfficeIMO.Excel {
                     }
 
                     object?[] values = rowValues[rr] ??= new object?[cols];
-                    ReadXmlRowIntoDataTableBuffer(reader, c1, c2, cols, null, values, inferredTypes, ct);
+                    if (ReadXmlRowIntoDataTableBuffer(reader, c1, c2, cols, null, values, inferredTypes, ct)) {
+                        completeRowsWithoutNulls![rr] = true;
+                    }
+
                     seenRows.MarkSeen(rowIndex - r1);
                 }
 
@@ -248,7 +252,7 @@ namespace OfficeIMO.Excel {
                 dt.MinimumCapacity = Math.Max(dt.MinimumCapacity, dataRowCount);
                 dt.BeginLoadData();
                 try {
-                    AddBufferedRowsToDataTable(dt, rowValues, dataRowCount, cols, ct);
+                    AddBufferedRowsToDataTable(dt, rowValues, completeRowsWithoutNulls, dataRowCount, cols, ct);
                 } finally {
                     dt.EndLoadData();
                 }
@@ -273,7 +277,7 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static void AddBufferedRowsToDataTable(DataTable dt, object?[][] rowValues, int dataRowCount, int cols, CancellationToken ct) {
+        private static void AddBufferedRowsToDataTable(DataTable dt, object?[][] rowValues, bool[]? completeRowsWithoutNulls, int dataRowCount, int cols, CancellationToken ct) {
             bool canCancel = ct.CanBeCanceled;
             object[]? blankRow = null;
             for (int r = 0; r < dataRowCount; r++) {
@@ -288,8 +292,10 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                for (int c = 0; c < cols; c++) {
-                    source[c] ??= DBNull.Value;
+                if (completeRowsWithoutNulls == null || !completeRowsWithoutNulls[r]) {
+                    for (int c = 0; c < cols; c++) {
+                        source[c] ??= DBNull.Value;
+                    }
                 }
 
                 dt.Rows.Add(source);
@@ -305,7 +311,7 @@ namespace OfficeIMO.Excel {
             return values;
         }
 
-        private void ReadXmlRowIntoDataTableBuffer(
+        private bool ReadXmlRowIntoDataTableBuffer(
             XmlReader rowReader,
             int c1,
             int c2,
@@ -315,21 +321,23 @@ namespace OfficeIMO.Excel {
             Type?[]? inferredTypes,
             CancellationToken ct) {
             if (rowReader.IsEmptyElement) {
-                return;
+                return false;
             }
 
             int depth = rowReader.Depth;
             bool canCancel = ct.CanBeCanceled;
             int nextColumnIndex = 1;
             bool canTrackColumns = cols <= 64;
+            ulong allColumnsSeen = canTrackColumns ? CreateAllColumnsSeenMask(cols) : 0UL;
             ulong seenColumns = 0;
+            bool hasNullValue = false;
             while (rowReader.Read()) {
                 if (canCancel) {
                     ct.ThrowIfCancellationRequested();
                 }
 
                 if (rowReader.NodeType == XmlNodeType.EndElement && rowReader.Depth == depth && rowReader.LocalName == "row") {
-                    return;
+                    return canTrackColumns && seenColumns == allColumnsSeen && !hasNullValue;
                 }
 
                 if (rowReader.NodeType != XmlNodeType.Element || rowReader.LocalName != "c") {
@@ -354,6 +362,10 @@ namespace OfficeIMO.Excel {
                 }
 
                 object? value = ReadXmlCellValue(rowReader);
+                if (value == null) {
+                    hasNullValue = true;
+                }
+
                 if (headerValues != null) {
                     headerValues[cc] = value;
                 } else if (rowValues != null) {
@@ -363,11 +375,13 @@ namespace OfficeIMO.Excel {
                     }
                 }
 
-                if (canTrackColumns && MarkRequestedColumnSeen(cc, cols, ref seenColumns)) {
+                if (canTrackColumns && MarkRequestedColumnSeen(cc, allColumnsSeen, ref seenColumns)) {
                     SkipXmlElementContent(rowReader, depth, "row");
-                    return;
+                    return !hasNullValue;
                 }
             }
+
+            return canTrackColumns && seenColumns == allColumnsSeen && !hasNullValue;
         }
 
         private bool TryFillDataTableXmlFast(
@@ -515,6 +529,7 @@ namespace OfficeIMO.Excel {
             int nextColumnIndex = 1;
             int columnCount = c2 - c1 + 1;
             bool canTrackColumns = columnCount <= 64;
+            ulong allColumnsSeen = canTrackColumns ? CreateAllColumnsSeenMask(columnCount) : 0UL;
             ulong seenColumns = 0;
             while (rowReader.Read()) {
                 if (canCancel) {
@@ -555,7 +570,7 @@ namespace OfficeIMO.Excel {
                     }
                 }
 
-                if (canTrackColumns && MarkRequestedColumnSeen(cc, columnCount, ref seenColumns)) {
+                if (canTrackColumns && MarkRequestedColumnSeen(cc, allColumnsSeen, ref seenColumns)) {
                     SkipXmlElementContent(rowReader, depth, "row");
                     return;
                 }
@@ -579,6 +594,7 @@ namespace OfficeIMO.Excel {
             }
 
             var rowValues = new object?[dataRowCount][];
+            var completeRowsWithoutNulls = cols <= 64 ? new bool[dataRowCount] : null;
 
             try {
                 using var stream = _wsPart.GetStream(FileMode.Open, FileAccess.Read);
@@ -624,14 +640,16 @@ namespace OfficeIMO.Excel {
                     }
 
                     object?[] values = rowValues[rr] ??= new object?[cols];
-                    ReadXmlRowIntoDataTableBuffer(reader, c1, c2, cols, null, values, null, ct);
+                    if (ReadXmlRowIntoDataTableBuffer(reader, c1, c2, cols, null, values, null, ct)) {
+                        completeRowsWithoutNulls![rr] = true;
+                    }
                     seenRows.MarkSeen(rowIndex - r1);
                 }
 
                 dt.MinimumCapacity = Math.Max(dt.MinimumCapacity, dataRowCount);
                 dt.BeginLoadData();
                 try {
-                    AddBufferedRowsToDataTable(dt, rowValues, dataRowCount, cols, ct);
+                    AddBufferedRowsToDataTable(dt, rowValues, completeRowsWithoutNulls, dataRowCount, cols, ct);
                 } finally {
                     dt.EndLoadData();
                 }
@@ -816,7 +834,7 @@ namespace OfficeIMO.Excel {
             dt.MinimumCapacity = Math.Max(dt.MinimumCapacity, dataRowCount);
             dt.BeginLoadData();
             try {
-                AddBufferedRowsToDataTable(dt, rowValues, dataRowCount, cols, ct);
+                AddBufferedRowsToDataTable(dt, rowValues, null, dataRowCount, cols, ct);
             } finally {
                 dt.EndLoadData();
             }
@@ -1118,6 +1136,7 @@ namespace OfficeIMO.Excel {
             bool canCancel = ct.CanBeCanceled;
             int nextColumnIndex = 1;
             bool canTrackColumns = cols <= 64;
+            ulong allColumnsSeen = canTrackColumns ? CreateAllColumnsSeenMask(cols) : 0UL;
             ulong seenColumns = 0;
             while (rowReader.Read()) {
                 if (canCancel) {
@@ -1150,7 +1169,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 values[offset] = ReadXmlCellValue(rowReader);
-                if (canTrackColumns && MarkRequestedColumnSeen(offset, cols, ref seenColumns)) {
+                if (canTrackColumns && MarkRequestedColumnSeen(offset, allColumnsSeen, ref seenColumns)) {
                     SkipXmlElementContent(rowReader, depth, "row");
                     return CreateDictionaryRow(headers, values, cols);
                 }
@@ -1731,21 +1750,30 @@ namespace OfficeIMO.Excel {
         private struct CompletedRowTracker {
             private readonly int _rowCount;
             private bool[]? _seenRows;
-            private ulong _seenRowMask;
+            private ulong _seenRowMask0;
+            private ulong _seenRowMask1;
+            private ulong _seenRowMask2;
+            private ulong _seenRowMask3;
             private int _seenRowCount;
 
             internal CompletedRowTracker(int rowCount) {
                 if (rowCount <= 0 || rowCount > XmlFastCompletedRowTrackingLimit) {
                     _rowCount = 0;
                     _seenRows = null;
-                    _seenRowMask = 0;
+                    _seenRowMask0 = 0;
+                    _seenRowMask1 = 0;
+                    _seenRowMask2 = 0;
+                    _seenRowMask3 = 0;
                     _seenRowCount = 0;
                     return;
                 }
 
                 _rowCount = rowCount;
-                _seenRows = rowCount > 64 ? new bool[rowCount] : null;
-                _seenRowMask = 0;
+                _seenRows = rowCount > 256 ? new bool[rowCount] : null;
+                _seenRowMask0 = 0;
+                _seenRowMask1 = 0;
+                _seenRowMask2 = 0;
+                _seenRowMask3 = 0;
                 _seenRowCount = 0;
             }
 
@@ -1757,12 +1785,38 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (_seenRows == null) {
-                    ulong rowBit = 1UL << rowOffset;
-                    if ((_seenRowMask & rowBit) != 0) {
-                        return;
-                    }
+                    int maskIndex = rowOffset >> 6;
+                    ulong rowBit = 1UL << (rowOffset & 63);
+                    switch (maskIndex) {
+                        case 0:
+                            if ((_seenRowMask0 & rowBit) != 0) {
+                                return;
+                            }
 
-                    _seenRowMask |= rowBit;
+                            _seenRowMask0 |= rowBit;
+                            break;
+                        case 1:
+                            if ((_seenRowMask1 & rowBit) != 0) {
+                                return;
+                            }
+
+                            _seenRowMask1 |= rowBit;
+                            break;
+                        case 2:
+                            if ((_seenRowMask2 & rowBit) != 0) {
+                                return;
+                            }
+
+                            _seenRowMask2 |= rowBit;
+                            break;
+                        default:
+                            if ((_seenRowMask3 & rowBit) != 0) {
+                                return;
+                            }
+
+                            _seenRowMask3 |= rowBit;
+                            break;
+                    }
                 } else {
                     if (_seenRows[rowOffset]) {
                         return;
@@ -1775,13 +1829,12 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static bool MarkRequestedColumnSeen(int columnOffset, int columnCount, ref ulong seenColumns) {
-            if ((uint)columnOffset >= (uint)columnCount || (uint)columnCount > 64u) {
-                return false;
-            }
+        private static ulong CreateAllColumnsSeenMask(int columnCount) {
+            return columnCount == 64 ? ulong.MaxValue : (1UL << columnCount) - 1UL;
+        }
 
+        private static bool MarkRequestedColumnSeen(int columnOffset, ulong allColumnsSeen, ref ulong seenColumns) {
             seenColumns |= 1UL << columnOffset;
-            ulong allColumnsSeen = columnCount == 64 ? ulong.MaxValue : (1UL << columnCount) - 1UL;
             return seenColumns == allColumnsSeen;
         }
 
@@ -1800,6 +1853,7 @@ namespace OfficeIMO.Excel {
             bool canCancel = ct.CanBeCanceled;
             int nextColumnIndex = 1;
             bool canTrackColumns = width <= 64;
+            ulong allColumnsSeen = canTrackColumns ? CreateAllColumnsSeenMask(width) : 0UL;
             ulong seenColumns = 0;
             while (rowReader.Read()) {
                 if (canCancel) {
@@ -1832,7 +1886,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 result[rr, cc] = ReadXmlCellValue(rowReader);
-                if (canTrackColumns && MarkRequestedColumnSeen(cc, width, ref seenColumns)) {
+                if (canTrackColumns && MarkRequestedColumnSeen(cc, allColumnsSeen, ref seenColumns)) {
                     SkipXmlElementContent(rowReader, depth, "row");
                     return;
                 }
@@ -1946,7 +2000,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (numericAsDecimal
-                && decimal.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, culture, out decimal decimalNumber)) {
+                && TryParseRawDecimal(rawText, culture, out decimal decimalNumber)) {
                 return decimalNumber;
             }
 
@@ -2005,7 +2059,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (numericAsDecimal
-                && decimal.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, culture, out decimal decimalNumber)) {
+                && TryParseRawDecimal(rawText, culture, out decimal decimalNumber)) {
                 value = decimalNumber;
                 return true;
             }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Rows.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Rows.cs
@@ -476,6 +476,7 @@ namespace OfficeIMO.Excel {
             bool canCancel = ct.CanBeCanceled;
             int nextColumnIndex = 1;
             bool canTrackColumns = width <= 64;
+            ulong allColumnsSeen = canTrackColumns ? CreateAllColumnsSeenMask(width) : 0UL;
             ulong seenColumns = 0;
             while (rowReader.Read()) {
                 if (canCancel) {
@@ -509,7 +510,7 @@ namespace OfficeIMO.Excel {
 
                 values ??= new object?[width];
                 values[offset] = ReadXmlCellValue(rowReader);
-                if (canTrackColumns && MarkRequestedColumnSeen(offset, width, ref seenColumns)) {
+                if (canTrackColumns && MarkRequestedColumnSeen(offset, allColumnsSeen, ref seenColumns)) {
                     SkipXmlElementContent(rowReader, depth, "row");
                     return values;
                 }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Stream.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Stream.cs
@@ -679,6 +679,7 @@ namespace OfficeIMO.Excel {
             bool canCancel = ct.CanBeCanceled;
             int nextColumnIndex = 1;
             bool canTrackColumns = rowValues.Length <= 64;
+            ulong allColumnsSeen = canTrackColumns ? CreateAllColumnsSeenMask(rowValues.Length) : 0UL;
             ulong seenColumns = 0;
             while (rowReader.Read()) {
                 if (canCancel) {
@@ -711,7 +712,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 rowValues[columnOffset] = ReadXmlCellValue(rowReader);
-                if (canTrackColumns && MarkRequestedColumnSeen(columnOffset, rowValues.Length, ref seenColumns)) {
+                if (canTrackColumns && MarkRequestedColumnSeen(columnOffset, allColumnsSeen, ref seenColumns)) {
                     SkipXmlElementContent(rowReader, depth, "row");
                     return;
                 }

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.cs
@@ -584,13 +584,191 @@ namespace OfficeIMO.Excel {
                 || double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out value);
         }
 
-        private bool TryParseRawDecimal(string rawText, out decimal value) {
-            if (decimal.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, _opt.Culture, out value)) {
+        private bool TryParseRawInt32(string rawText, out int value) {
+            if (_opt.Culture == CultureInfo.InvariantCulture && TryParseInvariantInt32Fast(rawText, out value)) {
                 return true;
             }
 
-            return _opt.Culture != CultureInfo.InvariantCulture
-                && decimal.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out value);
+            return int.TryParse(rawText, NumberStyles.Integer, _opt.Culture, out value);
+        }
+
+        private static bool TryParseInvariantInt32Fast(string rawText, out int value) {
+            value = 0;
+            if (string.IsNullOrEmpty(rawText)) {
+                return false;
+            }
+
+            int index = 0;
+            bool negative = false;
+            if (rawText[0] == '-') {
+                negative = true;
+                index = 1;
+                if (index == rawText.Length) {
+                    return false;
+                }
+            } else if (rawText[0] == '+') {
+                index = 1;
+                if (index == rawText.Length) {
+                    return false;
+                }
+            }
+
+            uint limit = negative ? 2147483648U : int.MaxValue;
+            uint parsed = 0U;
+            for (; index < rawText.Length; index++) {
+                int digit = rawText[index] - '0';
+                if ((uint)digit > 9U) {
+                    return false;
+                }
+
+                if (parsed > (limit - (uint)digit) / 10U) {
+                    return false;
+                }
+
+                parsed = (parsed * 10U) + (uint)digit;
+            }
+
+            if (negative) {
+                value = parsed == 2147483648U ? int.MinValue : -(int)parsed;
+            } else {
+                value = (int)parsed;
+            }
+
+            return true;
+        }
+
+        private bool TryParseRawInt64(string rawText, out long value) {
+            if (_opt.Culture == CultureInfo.InvariantCulture && TryParseInvariantInt64Fast(rawText, out value)) {
+                return true;
+            }
+
+            return long.TryParse(rawText, NumberStyles.Integer, _opt.Culture, out value);
+        }
+
+        private static bool TryParseInvariantInt64Fast(string rawText, out long value) {
+            value = 0;
+            if (string.IsNullOrEmpty(rawText)) {
+                return false;
+            }
+
+            int index = 0;
+            bool negative = false;
+            if (rawText[0] == '-') {
+                negative = true;
+                index = 1;
+                if (index == rawText.Length) {
+                    return false;
+                }
+            } else if (rawText[0] == '+') {
+                index = 1;
+                if (index == rawText.Length) {
+                    return false;
+                }
+            }
+
+            ulong limit = negative ? 9223372036854775808UL : long.MaxValue;
+            ulong parsed = 0UL;
+            for (; index < rawText.Length; index++) {
+                int digit = rawText[index] - '0';
+                if ((uint)digit > 9U) {
+                    return false;
+                }
+
+                if (parsed > (limit - (uint)digit) / 10UL) {
+                    return false;
+                }
+
+                parsed = (parsed * 10UL) + (uint)digit;
+            }
+
+            if (negative) {
+                value = parsed == 9223372036854775808UL ? long.MinValue : -(long)parsed;
+            } else {
+                value = (long)parsed;
+            }
+
+            return true;
+        }
+
+        private bool TryParseRawDecimal(string rawText, out decimal value) {
+            return TryParseRawDecimal(rawText, _opt.Culture, out value);
+        }
+
+        private static bool TryParseRawDecimal(string rawText, CultureInfo culture, out decimal value) {
+            if (culture == CultureInfo.InvariantCulture) {
+                return TryParseInvariantDecimalFast(rawText, out value)
+                    || decimal.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out value);
+            }
+
+            if (decimal.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, culture, out value)) {
+                return true;
+            }
+
+            return TryParseInvariantDecimalFast(rawText, out value)
+                || decimal.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out value);
+        }
+
+        private static bool TryParseInvariantDecimalFast(string rawText, out decimal value) {
+            value = 0m;
+            if (string.IsNullOrEmpty(rawText)) {
+                return false;
+            }
+
+            int index = 0;
+            bool negative = false;
+            if (rawText[0] == '-') {
+                negative = true;
+                index = 1;
+                if (index == rawText.Length) {
+                    return false;
+                }
+            } else if (rawText[0] == '+') {
+                index = 1;
+                if (index == rawText.Length) {
+                    return false;
+                }
+            }
+
+            ulong parsed = 0UL;
+            int scale = 0;
+            bool hasDigit = false;
+            bool hasDecimalPoint = false;
+            for (; index < rawText.Length; index++) {
+                char ch = rawText[index];
+                int digit = ch - '0';
+                if ((uint)digit <= 9U) {
+                    if (parsed > (ulong.MaxValue - (uint)digit) / 10UL) {
+                        return false;
+                    }
+
+                    parsed = (parsed * 10UL) + (uint)digit;
+                    hasDigit = true;
+                    if (hasDecimalPoint && ++scale > 28) {
+                        return false;
+                    }
+
+                    continue;
+                }
+
+                if (ch == '.' && !hasDecimalPoint) {
+                    hasDecimalPoint = true;
+                    continue;
+                }
+
+                return false;
+            }
+
+            if (!hasDigit) {
+                return false;
+            }
+
+            value = new decimal(
+                (int)(parsed & 0xFFFFFFFF),
+                (int)((parsed >> 32) & 0xFFFFFFFF),
+                0,
+                negative,
+                (byte)scale);
+            return true;
         }
 
         private object? ConvertByHints(CellValues? type, uint? styleIndex, string? rawText, string? inlineText) {

--- a/OfficeIMO.Excel/Read/Helpers/SharedStringCache.cs
+++ b/OfficeIMO.Excel/Read/Helpers/SharedStringCache.cs
@@ -8,7 +8,6 @@ using System.Xml;
 
 namespace OfficeIMO.Excel {
     internal sealed class SharedStringCache {
-        private const int MinimumInitialCapacity = 1024;
         private static readonly XmlReaderSettings SharedStringXmlReaderSettings = CreateSharedStringXmlReaderSettings();
 
         private readonly SharedStringTablePart? _part;
@@ -45,7 +44,7 @@ namespace OfficeIMO.Excel {
             var part = _part;
             if (part == null || part.SharedStringTable == null) return new List<string>();
             var table = part.SharedStringTable;
-            var list = new List<string>(Math.Max(MinimumInitialCapacity, (int)(table.Count?.Value ?? 0)));
+            var list = new List<string>((int)(table.UniqueCount?.Value ?? table.Count?.Value ?? 0));
             foreach (var item in table.Elements<SharedStringItem>()) {
                 if (item.Text?.Text != null)
                     list.Add(item.Text.Text);
@@ -59,7 +58,7 @@ namespace OfficeIMO.Excel {
         }
 
         private bool TryLoadItemsXmlFast(out List<string> items) {
-            items = new List<string>(MinimumInitialCapacity);
+            items = new List<string>();
 
             try {
                 using var stream = _part!.GetStream(FileMode.Open, FileAccess.Read);
@@ -75,7 +74,7 @@ namespace OfficeIMO.Excel {
                             capacity = ParsePositiveIntAttribute(reader.GetAttribute("count"));
                         }
 
-                        if (capacity > MinimumInitialCapacity) {
+                        if (capacity > 0) {
                             items.Capacity = capacity;
                         }
 

--- a/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
+++ b/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
@@ -472,16 +472,41 @@ namespace OfficeIMO.Tests {
                 cells["A1"].CellValue = new CellValue("2024-01-02T03:04:05");
                 cells["B1"].DataType = CellValues.Number;
                 cells["B1"].CellValue = new CellValue("123.45");
+                var row = spreadsheet.WorkbookPart.WorksheetParts.First().Worksheet.GetFirstChild<SheetData>()!.Elements<Row>().First();
+                cells["C1"] = new Cell {
+                    CellReference = "C1",
+                    DataType = CellValues.Number,
+                    CellValue = new CellValue("1.2345E+2")
+                };
+                cells["D1"] = new Cell {
+                    CellReference = "D1",
+                    DataType = CellValues.Number,
+                    CellValue = new CellValue("0.000001")
+                };
+                cells["E1"] = new Cell {
+                    CellReference = "E1",
+                    DataType = CellValues.Number,
+                    CellValue = new CellValue("-9876543210.1234")
+                };
+                row.Append(cells["C1"]);
+                row.Append(cells["D1"]);
+                row.Append(cells["E1"]);
                 spreadsheet.WorkbookPart.WorksheetParts.First().Worksheet.Save();
             }
 
             using var reader = ExcelDocumentReader.Open(filePath, new ExcelReadOptions { NumericAsDecimal = true });
-            object?[,] values = reader.GetSheet("Data").ReadRange("A1:B1", ExecutionMode.Sequential);
+            object?[,] values = reader.GetSheet("Data").ReadRange("A1:E1", ExecutionMode.Sequential);
 
             var date = Assert.IsType<DateTime>(values[0, 0]);
             Assert.Equal(new DateTime(2024, 1, 2, 3, 4, 5), date);
             var number = Assert.IsType<decimal>(values[0, 1]);
             Assert.Equal(123.45m, number);
+            var exponentNumber = Assert.IsType<decimal>(values[0, 2]);
+            Assert.Equal(123.45m, exponentNumber);
+            var smallFraction = Assert.IsType<decimal>(values[0, 3]);
+            Assert.Equal(0.000001m, smallFraction);
+            var negativeNumber = Assert.IsType<decimal>(values[0, 4]);
+            Assert.Equal(-9876543210.1234m, negativeNumber);
         }
 
         [Fact]
@@ -2029,6 +2054,40 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PerformanceReview_CellValuesDeferredDirectCandidate_MaterializesForNoLockCellMutation() {
+            using var memory = new MemoryStream();
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValues(new[] {
+                    (1, 1, (object)"Name"),
+                    (1, 2, (object)"Score"),
+                    (2, 1, (object)"Alpha"),
+                    (2, 2, (object)10),
+                    (3, 1, (object)"Beta"),
+                    (3, 2, (object)20)
+                }, ExecutionMode.Parallel);
+
+                using (sheet.BeginNoLock()) {
+                    sheet.CellValue(2, 2, 999);
+                }
+
+                document.Save(memory);
+
+                Assert.NotEqual(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+            var savedCells = worksheetPart.Worksheet.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+
+            Assert.Equal("Alpha", GetSpreadsheetCellText(spreadsheet, savedCells["A2"]));
+            Assert.Equal("999", GetSpreadsheetCellText(spreadsheet, savedCells["B2"]));
+            Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
+        }
+
+        [Fact]
         public void PerformanceReview_CellValuesHeaderlessRectangleThenHeaderedTable_MaterializesBeforeHeaderRepair() {
             using var memory = new MemoryStream();
 
@@ -3346,11 +3405,12 @@ namespace OfficeIMO.Tests {
             table.Columns.Add("Created", typeof(DateTime));
             table.Rows.Add("Alpha", 10, new DateTime(2026, 5, 19));
             table.Rows.Add("Beta", 20, new DateTime(2026, 5, 20));
+            table.Rows.Add("Gamma", DBNull.Value, DBNull.Value);
 
             using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
                 var sheet = document.AddWorkSheet("Data");
                 using IDataReader reader = table.CreateDataReader();
-                Assert.Equal("A1:C3", sheet.InsertDataReader(reader, tableName: "Reader Table", style: OfficeIMO.Excel.TableStyle.TableStyleMedium4));
+                Assert.Equal("A1:C4", sheet.InsertDataReader(reader, tableName: "Reader Table", style: OfficeIMO.Excel.TableStyle.TableStyleMedium4));
 
                 document.Save(memory);
 
@@ -3365,8 +3425,11 @@ namespace OfficeIMO.Tests {
             Assert.Equal("Alpha", GetSpreadsheetCellText(spreadsheet, cells["A2"]));
             Assert.Equal("10", cells["B2"].CellValue!.Text);
             Assert.True(cells["C2"].StyleIndex?.Value > 0U);
+            Assert.Equal("Gamma", GetSpreadsheetCellText(spreadsheet, cells["A4"]));
+            Assert.Equal(string.Empty, cells["B4"].CellValue!.Text);
+            Assert.Equal(string.Empty, cells["C4"].CellValue!.Text);
             var tableDefinition = worksheetPart.TableDefinitionParts.Single().Table!;
-            Assert.Equal("A1:C3", tableDefinition.Reference!.Value);
+            Assert.Equal("A1:C4", tableDefinition.Reference!.Value);
             Assert.Equal("Reader_Table", tableDefinition.Name!.Value);
             Assert.Equal("TableStyleMedium4", tableDefinition.TableStyleInfo!.Name!.Value);
             Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -64,6 +64,11 @@ namespace OfficeIMO.Tests {
             public decimal? OptionalAmount { get; set; }
         }
 
+        private sealed class IntegerBoundaryTypedRow {
+            public int IntValue { get; set; }
+            public long LongValue { get; set; }
+        }
+
         private sealed class CultureDoubleTypedRow {
             public double Amount { get; set; }
         }
@@ -1655,6 +1660,37 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(678.90m, rows[0].OptionalAmount);
                 Assert.Equal(11.25m, rows[1].Amount);
                 Assert.Null(rows[1].OptionalAmount);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_TypedObjects_MapIntegerBoundaries() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderIntegerBoundaryTypedHeaders.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "IntValue");
+                    sheet.CellValue(1, 2, "LongValue");
+                    sheet.CellValue(2, 1, int.MinValue);
+                    sheet.CellValue(2, 2, long.MinValue);
+                    sheet.CellValue(3, 1, int.MaxValue);
+                    sheet.CellValue(3, 2, long.MaxValue);
+                    document.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                var rows = reader.GetSheet("Data").ReadObjects<IntegerBoundaryTypedRow>("A1:B3").ToList();
+
+                Assert.Equal(2, rows.Count);
+                Assert.Equal(int.MinValue, rows[0].IntValue);
+                Assert.Equal(long.MinValue, rows[0].LongValue);
+                Assert.Equal(int.MaxValue, rows[1].IntValue);
+                Assert.Equal(long.MaxValue, rows[1].LongValue);
             } finally {
                 if (File.Exists(filePath)) {
                     File.Delete(filePath);


### PR DESCRIPTION
## Summary
- Adds internal direct Excel write/read optimizations for tabular save candidates, CellValues, DataReader, shared strings, and range/reader enumeration hot paths.
- Keeps the public API unchanged while routing clean workbook/data scenarios through leaner internal paths.
- Expands benchmark coverage for CellValues sparse rectangle writes and adds regression coverage for performance-sensitive reader/header paths.

## Benchmark evidence
- `write-datareader-table-autofit` before: OfficeIMO 46.75 ms avg / 42.00 ms median / 15170.6 KB; after: 44.79 ms avg / 39.36 ms median / 15170.6 KB.
- `write-datareader-table` before: OfficeIMO 52.16 ms avg / 51.02 ms median / 15164.3 KB; after: 52.07 ms avg / 50.45 ms median / 15164.3 KB.
- `write-cellvalues-sparse-rectangle-direct` after: OfficeIMO 4.23 ms avg / 4.63 ms median / 3154.7 KB, ahead of ClosedXML 41.16 ms median and EPPlus 30.31 ms median.
- Earlier kept read-path improvements brought `enumerate-top-range` to 3.09 ms from a 14.15 ms baseline, ahead of ClosedXML 107.73 ms and EPPlus 37.69 ms in the same comparison suite.

## Validation
- `dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --no-restore`
- `dotnet build .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -c Release --framework net8.0 --no-restore`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-build --filter "DataReader|DataTable|PerformanceReview"`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-build --filter "CellValues|PerformanceReview"`
- `git diff --check`