### PR TITLE
Optimize Excel direct export internals

### DIFF
--- a/OfficeIMO.Excel.Benchmarks/ExcelLibraryComparisonRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelLibraryComparisonRunner.cs
@@ -82,6 +82,8 @@ internal static class ExcelLibraryComparisonRunner {
         var firstTableRows = rows.Take(rowCount / 2).ToList();
         var secondTableRows = rows.Skip(rowCount / 2).ToList();
         var salesDataTable = CreateSalesDataTable(rows, "SalesData");
+        var objectColumnSalesDataTable = CreateObjectColumnSalesDataTable(rows, "SalesData");
+        var dictionaryRows = CreateDictionaryRows(rows);
         var salesDataSet = CreateSalesDataSet(firstTableRows, secondTableRows);
         var sparseDataSet = CreateSparseDataSet(rowCount);
         var officeImoWorkbookBytes = new Lazy<byte[]>(() => ExcelBenchmarkScenarioFactory.CreateWorkbookBytes(rows));
@@ -155,6 +157,21 @@ internal static class ExcelLibraryComparisonRunner {
             new LibraryComparisonCase("ClosedXML", "Import a prepared DataTable as a styled worksheet table and save.", () => ClosedXmlWriteDataTable(salesDataTable, includeTable: true)),
             new LibraryComparisonCase("EPPlus", "Import a prepared DataTable as a styled worksheet table and save.", () => EpPlusWriteDataTable(salesDataTable, includeTable: true)),
             new LibraryComparisonCase("MiniExcel", "Streaming DataTable export with table styling configuration.", () => MiniExcelWriteDataTable(salesDataTable, includeTable: true))
+        ]);
+
+        AddScenarioGroup(scenarios, scenarioFilter, "write-datatable-object-table-direct", warmupIterations, measuredIterations, [
+            new LibraryComparisonCase("OfficeIMO.Excel", "Insert an object-typed DataTable as a styled table through the normal worksheet API and save.", () => OfficeImoWriteDataTableAsTable(objectColumnSalesDataTable)),
+            new LibraryComparisonCase("ClosedXML", "Import an object-typed DataTable as a styled worksheet table and save.", () => ClosedXmlWriteDataTable(objectColumnSalesDataTable, includeTable: true)),
+            new LibraryComparisonCase("EPPlus", "Import an object-typed DataTable as a styled worksheet table and save.", () => EpPlusWriteDataTable(objectColumnSalesDataTable, includeTable: true)),
+            new LibraryComparisonCase("MiniExcel", "Streaming object-typed DataTable export with table styling configuration.", () => MiniExcelWriteDataTable(objectColumnSalesDataTable, includeTable: true))
+        ]);
+
+        AddScenarioGroup(scenarios, scenarioFilter, "build-object-datatable-dictionaries", warmupIterations, measuredIterations, [
+            new LibraryComparisonCase("OfficeIMO.Excel", "Build a DataTable from dictionary rows matching the normalized PowerShell object shape.", () => ObjectDataTableBuilder.FromObjects(dictionaryRows, "SalesData").Rows.Count)
+        ]);
+
+        AddScenarioGroup(scenarios, scenarioFilter, "write-dictionary-objects-table-direct", warmupIterations, measuredIterations, [
+            new LibraryComparisonCase("OfficeIMO.Excel", "Build a DataTable from normalized dictionary rows, insert it as a styled table, and save.", () => OfficeImoWriteDataTableAsTable(ObjectDataTableBuilder.FromObjects(dictionaryRows, "SalesData")))
         ]);
 
         AddScenarioGroup(scenarios, scenarioFilter, "write-datareader-table", warmupIterations, measuredIterations, [
@@ -4096,6 +4113,42 @@ internal static class ExcelLibraryComparisonRunner {
     private static DataTable CreateSalesDataTable(IEnumerable<ExcelBenchmarkScenarioFactory.SalesRecord> rows, string tableName) {
         var table = CreateSalesDataTable();
         table.TableName = tableName;
+        foreach (var row in rows) {
+            table.Rows.Add(row.Id, row.Region, row.Owner, row.CreatedOn, row.Amount, row.Units, row.Active, row.Notes);
+        }
+
+        return table;
+    }
+
+    private static IReadOnlyList<object?> CreateDictionaryRows(IEnumerable<ExcelBenchmarkScenarioFactory.SalesRecord> rows) {
+        var result = new List<object?>();
+        foreach (var row in rows) {
+            result.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) {
+                ["Id"] = row.Id,
+                ["Region"] = row.Region,
+                ["Owner"] = row.Owner,
+                ["CreatedOn"] = row.CreatedOn,
+                ["Amount"] = row.Amount,
+                ["Units"] = row.Units,
+                ["Active"] = row.Active,
+                ["Notes"] = row.Notes
+            });
+        }
+
+        return result;
+    }
+
+    private static DataTable CreateObjectColumnSalesDataTable(IEnumerable<ExcelBenchmarkScenarioFactory.SalesRecord> rows, string tableName) {
+        var table = new DataTable(tableName) { Locale = CultureInfo.InvariantCulture };
+        table.Columns.Add("Id", typeof(object));
+        table.Columns.Add("Region", typeof(object));
+        table.Columns.Add("Owner", typeof(object));
+        table.Columns.Add("CreatedOn", typeof(object));
+        table.Columns.Add("Amount", typeof(object));
+        table.Columns.Add("Units", typeof(object));
+        table.Columns.Add("Active", typeof(object));
+        table.Columns.Add("Notes", typeof(object));
+
         foreach (var row in rows) {
             table.Rows.Add(row.Id, row.Region, row.Owner, row.CreatedOn, row.Amount, row.Units, row.Active, row.Notes);
         }

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -33,9 +33,7 @@ namespace OfficeIMO.Excel {
 
             DirectCellValuesSaveCandidate? directSaveCandidate = null;
             DirectCellValuesSaveCandidate? appendSaveCandidate = null;
-            bool hasAutomaticFormattingText = ContainsDirectCellValuesAutomaticFormattingText(list);
-            if (!hasAutomaticFormattingText
-                && TryCreateDirectCellValuesSaveCandidate(list, mode, out DirectCellValuesSaveCandidate? candidate)
+            if (TryCreateDirectCellValuesSaveCandidate(list, mode, out DirectCellValuesSaveCandidate? candidate)
                 && candidate != null
                 && CanRegisterDirectTabularSaveCandidate(1, 1, candidate.ColumnNames.Length)) {
                 directSaveCandidate = candidate;
@@ -48,7 +46,6 @@ namespace OfficeIMO.Excel {
             }
 
             if (mode == ExecutionMode.Parallel
-                && !hasAutomaticFormattingText
                 && TryCreateDirectCellValuesAppendCandidate(list, out DirectCellValuesSaveCandidate? appendCandidate)) {
                 appendSaveCandidate = appendCandidate;
             }
@@ -447,7 +444,9 @@ namespace OfficeIMO.Excel {
 
             if (columnCount <= DirectCellValuesLinearHeaderDuplicateCheckLimit) {
                 for (int column = 0; column < columnCount; column++) {
-                    if (cells[column].Value is not string header || string.IsNullOrWhiteSpace(header)) {
+                    if (cells[column].Value is not string header
+                        || string.IsNullOrWhiteSpace(header)
+                        || IsDirectCellValuesAutomaticFormattingText(header)) {
                         return false;
                     }
 
@@ -463,7 +462,10 @@ namespace OfficeIMO.Excel {
 
             var headers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             for (int column = 0; column < columnCount; column++) {
-                if (cells[column].Value is not string header || string.IsNullOrWhiteSpace(header) || !headers.Add(header)) {
+                if (cells[column].Value is not string header
+                    || string.IsNullOrWhiteSpace(header)
+                    || IsDirectCellValuesAutomaticFormattingText(header)
+                    || !headers.Add(header)) {
                     return false;
                 }
             }
@@ -495,16 +497,17 @@ namespace OfficeIMO.Excel {
             int dataRowCount = (cells.Count - dataStartIndex) / columnCount;
             rows = new object?[dataRowCount][];
             var inferredTypes = new Type?[columnCount];
-            bool[]? blankColumns = null;
 
             int rowOffset = 0;
             for (int index = dataStartIndex; index < cells.Count; index += columnCount) {
                 var row = new object?[columnCount];
                 for (int column = 0; column < columnCount; column++) {
                     object? value = cells[index + column].Value;
+                    if (value is string text && IsDirectCellValuesAutomaticFormattingText(text)) {
+                        return false;
+                    }
+
                     if (IsDirectCellValuesBlankValue(value)) {
-                        blankColumns ??= new bool[columnCount];
-                        blankColumns[column] = true;
                         row[column] = value;
                         continue;
                     }
@@ -540,40 +543,13 @@ namespace OfficeIMO.Excel {
                 columnTypes[column] = inferredTypes[column] ?? typeof(string);
             }
 
-            if (blankColumns != null) {
-                for (int rowIndex = 0; rowIndex < rows.Length; rowIndex++) {
-                    object?[] row = rows[rowIndex];
-                    for (int column = 0; column < columnCount; column++) {
-                        if (!blankColumns[column] || !IsDirectCellValuesBlankValue(row[column])) {
-                            continue;
-                        }
-
-                        Type columnType = columnTypes[column];
-                        row[column] = columnType == typeof(string) || columnType == typeof(object)
-                            ? string.Empty
-                            : DBNull.Value;
-                    }
-                }
-            }
-
             return true;
-        }
-
-        private static bool ContainsDirectCellValuesAutomaticFormattingText(IReadOnlyList<(int Row, int Column, object Value)> cells) {
-            for (int i = 0; i < cells.Count; i++) {
-                if (cells[i].Value is string text && IsDirectCellValuesAutomaticFormattingText(text)) {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         private static bool IsDirectCellValuesAutomaticFormattingText(string text)
             => text.IndexOf('\r') >= 0 || text.IndexOf('\n') >= 0;
 
         private static Type NormalizeDirectCellValuesColumnType(Type type) {
-            type = Nullable.GetUnderlyingType(type) ?? type;
             if (type == typeof(DBNull) || type == typeof(void)) {
                 return typeof(object);
             }

--- a/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.cs
@@ -35,16 +35,11 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
-            var list = new List<object?>(rows.Count);
-            for (int i = 0; i < rows.Count; i++) {
-                list.Add(rows[i]);
-            }
-
-            var flattenedItems = new List<Dictionary<string, object?>>(list.Count);
+            var flattenedItems = new List<Dictionary<string, object?>>(rows.Count);
             List<string> headers = new List<string>();
             HashSet<string> headerSet = new HashSet<string>();
 
-            foreach (var item in list) {
+            foreach (var item in rows) {
                 var dict = new Dictionary<string, object?>();
                 FlattenObject(item, null, dict);
                 flattenedItems.Add(dict);
@@ -60,8 +55,7 @@ namespace OfficeIMO.Excel {
             if (!hasBlankDisplayHeader && CanRegisterDirectTabularSaveCandidate(startRow, 1, headers.Count)) {
                 try {
                     directSaveRange = BuildObjectExportRange(startRow, headers.Count, flattenedItems.Count, includeHeaders);
-                    var columnTypes = InferObjectExportColumnTypes(flattenedItems, headers);
-                    var directRows = CreateObjectExportRows(headers, flattenedItems);
+                    var directRows = CreateObjectExportRows(headers, flattenedItems, out var columnTypes);
                     if (TryInsertRowsAsDeferredDirectSave(Name, headers, columnTypes, directRows, startRow, includeHeaders, directSaveRange)) {
                         return;
                     }
@@ -71,7 +65,7 @@ namespace OfficeIMO.Excel {
             }
 
             int headerRows = includeHeaders ? 1 : 0;
-            int totalCellCount = checked((list.Count + headerRows) * Math.Max(1, headers.Count));
+            int totalCellCount = checked((rows.Count + headerRows) * Math.Max(1, headers.Count));
             var cells = new (int Row, int Column, object Value)[totalCellCount];
             int cellIndex = 0;
             int row = startRow;
@@ -138,10 +132,13 @@ namespace OfficeIMO.Excel {
             }
 
             var values = new object?[rows.Count][];
+            var inferredColumnTypes = new Type?[selectors.Length];
             for (int r = 0; r < rows.Count; r++) {
                 var rowValues = new object?[selectors.Length];
                 for (int c = 0; c < selectors.Length; c++) {
-                    rowValues[c] = selectors[c](rows[r]);
+                    object? value = selectors[c](rows[r]);
+                    rowValues[c] = value;
+                    UpdateObjectExportColumnType(inferredColumnTypes, c, value);
                 }
 
                 values[r] = rowValues;
@@ -151,7 +148,7 @@ namespace OfficeIMO.Excel {
             if (!hasBlankDisplayHeader && CanRegisterDirectTabularSaveCandidate(startRow, 1, headers.Length)) {
                 try {
                     if (!HasDuplicateObjectExportHeaders(headers)) {
-                        var columnTypes = InferObjectExportColumnTypes(values, headers.Length);
+                        var columnTypes = CompleteObjectExportColumnTypes(inferredColumnTypes);
                         directSaveRange = BuildObjectExportRange(startRow, headers.Length, rows.Count, includeHeaders);
                         if (TryInsertRowsAsDeferredDirectSave(Name, headers, columnTypes, values, startRow, includeHeaders, directSaveRange)) {
                             return;
@@ -249,8 +246,15 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            var sheets = WorkbookRoot.Sheets?.Elements<Sheet>().ToList();
-            if (sheets == null || sheets.Count != 1 || !ReferenceEquals(sheets[0], SheetElement)) {
+            var sheets = WorkbookRoot.Sheets;
+            if (sheets == null) {
+                return false;
+            }
+
+            using var sheetEnumerator = sheets.Elements<Sheet>().GetEnumerator();
+            if (!sheetEnumerator.MoveNext()
+                || !ReferenceEquals(sheetEnumerator.Current, SheetElement)
+                || sheetEnumerator.MoveNext()) {
                 return false;
             }
 
@@ -297,7 +301,8 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            Type rowType = rows[0]?.GetType() ?? typeof(object);
+            bool requireRuntimeTypeCheck = !typeof(T).IsValueType && !typeof(T).IsSealed;
+            Type rowType = requireRuntimeTypeCheck ? rows[0]?.GetType() ?? typeof(object) : typeof(T);
             if (rowType == typeof(object)) {
                 return false;
             }
@@ -316,7 +321,7 @@ namespace OfficeIMO.Excel {
             var values = new object?[rows.Count][];
             for (int r = 0; r < rows.Count; r++) {
                 object? row = rows[r];
-                if (row == null || row.GetType() != rowType) {
+                if (row == null || requireRuntimeTypeCheck && row.GetType() != rowType) {
                     return false;
                 }
 
@@ -442,80 +447,43 @@ namespace OfficeIMO.Excel {
 
         private delegate object? SimpleObjectExportValueGetter(object? row);
 
-        private static object?[][] CreateObjectExportRows(IReadOnlyList<string> headers, IReadOnlyList<Dictionary<string, object?>> rows) {
+        private static object?[][] CreateObjectExportRows(IReadOnlyList<string> headers, IReadOnlyList<Dictionary<string, object?>> rows, out Type[] columnTypes) {
             var values = new object?[rows.Count][];
+            var inferredColumnTypes = new Type?[headers.Count];
             for (int r = 0; r < rows.Count; r++) {
                 var rowValues = new object?[headers.Count];
                 for (int c = 0; c < headers.Count; c++) {
-                    rowValues[c] = rows[r].TryGetValue(headers[c], out var entry) ? entry : null;
+                    object? value = rows[r].TryGetValue(headers[c], out var entry) ? entry : null;
+                    rowValues[c] = value;
+                    UpdateObjectExportColumnType(inferredColumnTypes, c, value);
                 }
 
                 values[r] = rowValues;
             }
 
+            columnTypes = CompleteObjectExportColumnTypes(inferredColumnTypes);
             return values;
         }
 
-        private static Type[] InferObjectExportColumnTypes(IReadOnlyList<object?[]> values, int columnCount) {
-            var columnTypes = new Type[columnCount];
-            for (int c = 0; c < columnCount; c++) {
-                columnTypes[c] = InferObjectExportColumnType(values, c);
+        private static void UpdateObjectExportColumnType(Type?[] inferredColumnTypes, int columnIndex, object? value) {
+            if (value == null || value == DBNull.Value || inferredColumnTypes[columnIndex] == typeof(object)) {
+                return;
+            }
+
+            Type valueType = value.GetType();
+            Type? inferred = inferredColumnTypes[columnIndex];
+            inferredColumnTypes[columnIndex] = inferred == null || inferred == valueType
+                ? valueType
+                : typeof(object);
+        }
+
+        private static Type[] CompleteObjectExportColumnTypes(Type?[] inferredColumnTypes) {
+            var columnTypes = new Type[inferredColumnTypes.Length];
+            for (int i = 0; i < columnTypes.Length; i++) {
+                columnTypes[i] = inferredColumnTypes[i] ?? typeof(object);
             }
 
             return columnTypes;
-        }
-
-        private static Type[] InferObjectExportColumnTypes(IReadOnlyList<Dictionary<string, object?>> rows, IReadOnlyList<string> headers) {
-            var columnTypes = new Type[headers.Count];
-            for (int c = 0; c < headers.Count; c++) {
-                columnTypes[c] = InferObjectExportColumnType(rows, headers[c]);
-            }
-
-            return columnTypes;
-        }
-
-        private static Type InferObjectExportColumnType(IReadOnlyList<object?[]> values, int columnIndex) {
-            Type? inferred = null;
-            for (int r = 0; r < values.Count; r++) {
-                object? value = values[r][columnIndex];
-                if (value == null || value == DBNull.Value) {
-                    continue;
-                }
-
-                Type valueType = Nullable.GetUnderlyingType(value.GetType()) ?? value.GetType();
-                if (inferred == null) {
-                    inferred = valueType;
-                    continue;
-                }
-
-                if (inferred != valueType) {
-                    return typeof(object);
-                }
-            }
-
-            return inferred ?? typeof(object);
-        }
-
-        private static Type InferObjectExportColumnType(IReadOnlyList<Dictionary<string, object?>> rows, string header) {
-            Type? inferred = null;
-            for (int r = 0; r < rows.Count; r++) {
-                object? value = rows[r].TryGetValue(header, out var entry) ? entry : null;
-                if (value == null || value == DBNull.Value) {
-                    continue;
-                }
-
-                Type valueType = Nullable.GetUnderlyingType(value.GetType()) ?? value.GetType();
-                if (inferred == null) {
-                    inferred = valueType;
-                    continue;
-                }
-
-                if (inferred != valueType) {
-                    return typeof(object);
-                }
-            }
-
-            return inferred ?? typeof(object);
         }
 
         private static void FlattenObject(object? value, string? prefix, IDictionary<string, object?> result) {

--- a/OfficeIMO.Excel/Fluent/SheetBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/SheetBuilder.cs
@@ -404,6 +404,7 @@ namespace OfficeIMO.Excel.Fluent {
 
             var staticColumnTypes = new Type[properties.Length];
             var staticBlankAsEmptyString = new bool[properties.Length];
+            var staticRequiresBlankCoercion = new bool[properties.Length];
             var inferenceFallbackTypes = new Type[properties.Length];
             var inferColumns = new bool[properties.Length];
             var getters = new RowsFromSimpleValueGetter[properties.Length];
@@ -412,12 +413,19 @@ namespace OfficeIMO.Excel.Fluent {
             for (int i = 0; i < properties.Length; i++) {
                 getters[i] = CreateRowsFromSimpleValueGetter(properties[i]);
                 Type propertyType = properties[i].PropertyType;
-                Type declaredType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+                Type? nullableUnderlyingType = Nullable.GetUnderlyingType(propertyType);
+                Type declaredType = nullableUnderlyingType ?? propertyType;
                 if (declaredType == typeof(string)) {
                     staticColumnTypes[i] = typeof(string);
                     staticBlankAsEmptyString[i] = true;
+                    staticRequiresBlankCoercion[i] = true;
                     inferenceFallbackTypes[i] = typeof(string);
-                } else if (!declaredType.IsValueType || Nullable.GetUnderlyingType(propertyType) != null) {
+                } else if (nullableUnderlyingType != null && CanUseStaticNullableRowsFromColumnType(nullableUnderlyingType)) {
+                    staticColumnTypes[i] = nullableUnderlyingType;
+                    staticBlankAsEmptyString[i] = false;
+                    staticRequiresBlankCoercion[i] = true;
+                    inferenceFallbackTypes[i] = nullableUnderlyingType;
+                } else if (!declaredType.IsValueType || nullableUnderlyingType != null) {
                     inferColumns[i] = true;
                     inferenceColumnIndexes.Add(i);
                     hasInferenceColumns = true;
@@ -425,12 +433,13 @@ namespace OfficeIMO.Excel.Fluent {
                 } else {
                     staticColumnTypes[i] = declaredType;
                     staticBlankAsEmptyString[i] = false;
+                    staticRequiresBlankCoercion[i] = false;
                     inferenceFallbackTypes[i] = declaredType;
                 }
             }
 
             return CanUseRowsFromDataTable(headers)
-                ? new RowsFromSimpleTypePlan(getters, headers, staticColumnTypes, staticBlankAsEmptyString, inferenceFallbackTypes, inferColumns, inferenceColumnIndexes.ToArray(), hasInferenceColumns, canUseDirectSave: true)
+                ? new RowsFromSimpleTypePlan(getters, headers, staticColumnTypes, staticBlankAsEmptyString, staticRequiresBlankCoercion, inferenceFallbackTypes, inferColumns, inferenceColumnIndexes.ToArray(), hasInferenceColumns, canUseDirectSave: true)
                 : RowsFromSimpleTypePlan.NotSupported;
         }
 
@@ -476,6 +485,25 @@ namespace OfficeIMO.Excel.Fluent {
                 || type == typeof(Guid);
         }
 
+        private static bool CanUseStaticNullableRowsFromColumnType(Type type) {
+            if (type == typeof(DateTime)
+                || type == typeof(DateTimeOffset)
+                || type == typeof(TimeSpan)) {
+                return false;
+            }
+
+#if NET6_0_OR_GREATER
+            if (type == typeof(DateOnly) || type == typeof(TimeOnly)) {
+                return false;
+            }
+#endif
+
+            return type.IsPrimitive
+                || type.IsEnum
+                || type == typeof(decimal)
+                || type == typeof(Guid);
+        }
+
         private static object?[][] MaterializeSimpleRowsFromProperties<T>(RowsFromSimpleTypePlan typePlan, IReadOnlyList<T> rows, out Type[] columnTypes) {
             var directRows = new object?[rows.Count][];
             if (!typePlan.HasInferenceColumns) {
@@ -500,12 +528,16 @@ namespace OfficeIMO.Excel.Fluent {
         private static void MaterializeStaticSimpleRowsFromProperties<T>(RowsFromSimpleTypePlan typePlan, IReadOnlyList<T> rows, object?[][] directRows) {
             RowsFromSimpleValueGetter[] getters = typePlan.Getters;
             bool[] blankAsEmptyString = typePlan.StaticBlankAsEmptyString;
+            bool[] requiresBlankCoercion = typePlan.StaticRequiresBlankCoercion;
             int columnCount = getters.Length;
             for (int row = 0; row < rows.Count; row++) {
                 T sourceRow = rows[row];
                 var values = new object?[columnCount];
                 for (int column = 0; column < columnCount; column++) {
-                    values[column] = CoerceRowsFromDirectSaveValue(getters[column](sourceRow), blankAsEmptyString[column]);
+                    object? value = getters[column](sourceRow);
+                    values[column] = requiresBlankCoercion[column]
+                        ? CoerceRowsFromDirectSaveValue(value, blankAsEmptyString[column])
+                        : value;
                 }
 
                 directRows[row] = values;
@@ -516,6 +548,7 @@ namespace OfficeIMO.Excel.Fluent {
             RowsFromSimpleValueGetter[] getters = typePlan.Getters;
             bool[] inferColumns = typePlan.InferColumns;
             bool[] staticBlankAsEmptyString = typePlan.StaticBlankAsEmptyString;
+            bool[] staticRequiresBlankCoercion = typePlan.StaticRequiresBlankCoercion;
             int columnCount = getters.Length;
             var columnTypes = new Type[columnCount];
             Array.Copy(typePlan.StaticColumnTypes, columnTypes, columnTypes.Length);
@@ -527,7 +560,9 @@ namespace OfficeIMO.Excel.Fluent {
                 for (int column = 0; column < columnCount; column++) {
                     object? value = getters[column](sourceRow);
                     if (!inferColumns[column]) {
-                        values[column] = CoerceRowsFromDirectSaveValue(value, staticBlankAsEmptyString[column]);
+                        values[column] = staticRequiresBlankCoercion[column]
+                            ? CoerceRowsFromDirectSaveValue(value, staticBlankAsEmptyString[column])
+                            : value;
                         continue;
                     }
 
@@ -536,7 +571,7 @@ namespace OfficeIMO.Excel.Fluent {
                         continue;
                     }
 
-                    Type valueType = Nullable.GetUnderlyingType(value!.GetType()) ?? value.GetType();
+                    Type valueType = value!.GetType();
                     Type? inferred = inferredTypes![column];
                     if (inferred == null) {
                         inferredTypes[column] = valueType;
@@ -567,7 +602,7 @@ namespace OfficeIMO.Excel.Fluent {
                         continue;
                     }
 
-                    Type valueType = Nullable.GetUnderlyingType(value!.GetType()) ?? value.GetType();
+                    Type valueType = value!.GetType();
                     if (inferred == null) {
                         inferred = valueType;
                         continue;
@@ -653,6 +688,7 @@ namespace OfficeIMO.Excel.Fluent {
                 Array.Empty<string>(),
                 Array.Empty<Type>(),
                 Array.Empty<bool>(),
+                Array.Empty<bool>(),
                 Array.Empty<Type>(),
                 Array.Empty<bool>(),
                 Array.Empty<int>(),
@@ -664,6 +700,7 @@ namespace OfficeIMO.Excel.Fluent {
                 string[] headers,
                 Type[] staticColumnTypes,
                 bool[] staticBlankAsEmptyString,
+                bool[] staticRequiresBlankCoercion,
                 Type[] inferenceFallbackTypes,
                 bool[] inferColumns,
                 int[] inferenceColumnIndexes,
@@ -673,6 +710,7 @@ namespace OfficeIMO.Excel.Fluent {
                 Headers = headers;
                 StaticColumnTypes = staticColumnTypes;
                 StaticBlankAsEmptyString = staticBlankAsEmptyString;
+                StaticRequiresBlankCoercion = staticRequiresBlankCoercion;
                 InferenceFallbackTypes = inferenceFallbackTypes;
                 InferColumns = inferColumns;
                 InferenceColumnIndexes = inferenceColumnIndexes;
@@ -687,6 +725,8 @@ namespace OfficeIMO.Excel.Fluent {
             internal Type[] StaticColumnTypes { get; }
 
             internal bool[] StaticBlankAsEmptyString { get; }
+
+            internal bool[] StaticRequiresBlankCoercion { get; }
 
             internal Type[] InferenceFallbackTypes { get; }
 

--- a/OfficeIMO.Excel/Utilities/ObjectDataTableBuilder.cs
+++ b/OfficeIMO.Excel/Utilities/ObjectDataTableBuilder.cs
@@ -112,6 +112,14 @@ namespace OfficeIMO.Excel {
             }
 
             private bool TryFillDictionaryValues(object item, object?[] values) {
+                if (item is Dictionary<string, object?> exactDictionary) {
+                    for (int i = 0; i < _columns.Length; i++) {
+                        values[i] = exactDictionary.TryGetValue(_columns[i], out var value) ? value ?? DBNull.Value : DBNull.Value;
+                    }
+
+                    return true;
+                }
+
                 if (item is IReadOnlyDictionary<string, object?> readOnlyDictionary) {
                     for (int i = 0; i < _columns.Length; i++) {
                         values[i] = readOnlyDictionary.TryGetValue(_columns[i], out var value) ? value ?? DBNull.Value : DBNull.Value;
@@ -155,7 +163,8 @@ namespace OfficeIMO.Excel {
             }
 
             private static bool IsDictionaryLike(object item) {
-                return item is IReadOnlyDictionary<string, object?>
+                return item is Dictionary<string, object?>
+                    || item is IReadOnlyDictionary<string, object?>
                     || item is IDictionary<string, object?>
                     || item is System.Collections.IDictionary;
             }

--- a/OfficeIMO.Shared/ObjectDataHelpers.cs
+++ b/OfficeIMO.Shared/ObjectDataHelpers.cs
@@ -25,6 +25,11 @@ internal static class ObjectDataHelpers
         if (item == null) throw new ArgumentNullException(nameof(item));
 #endif
 
+        if (item is Dictionary<string, object?> dictionary)
+        {
+            return dictionary.Keys.Where(n => !string.IsNullOrWhiteSpace(n)).ToList();
+        }
+
         if (item is IReadOnlyDictionary<string, object?> roDict)
         {
             return roDict.Keys.Where(n => !string.IsNullOrWhiteSpace(n)).ToList();
@@ -75,6 +80,11 @@ internal static class ObjectDataHelpers
         if (item == null) throw new ArgumentNullException(nameof(item));
         if (column == null) throw new ArgumentNullException(nameof(column));
 #endif
+
+        if (item is Dictionary<string, object?> dictionary)
+        {
+            return dictionary.TryGetValue(column, out var value) ? value : null;
+        }
 
         if (item is IReadOnlyDictionary<string, object?> roDict)
         {

--- a/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
+++ b/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
@@ -1981,6 +1981,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PerformanceReview_CellValuesRectangle_WithMultilineTextDoesNotUseDirectPackage() {
+            AssertCellValuesMultilineFallback(new[] {
+                (1, 1, (object)"Name\nWrapped"),
+                (1, 2, (object)"Score"),
+                (2, 1, (object)"Alpha"),
+                (2, 2, (object)10)
+            }, "A1", "Name\nWrapped");
+
+            AssertCellValuesMultilineFallback(new[] {
+                (1, 1, (object)"Name"),
+                (1, 2, (object)"Notes"),
+                (2, 1, (object)"Alpha"),
+                (2, 2, (object)"Line one\nLine two")
+            }, "B2", "Line one\nLine two");
+
+            static void AssertCellValuesMultilineFallback((int Row, int Column, object Value)[] cells, string reference, string expectedText) {
+                using var memory = new MemoryStream();
+                using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValues(cells);
+                    document.Save(memory);
+
+                    Assert.NotEqual(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+                }
+
+                memory.Position = 0;
+                using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+                var savedCells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>()
+                    .ToDictionary(cell => cell.CellReference!.Value!);
+                Assert.Equal(expectedText, GetSpreadsheetCellText(spreadsheet, savedCells[reference]));
+                Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
+            }
+        }
+
+        [Fact]
         public void PerformanceReview_CellValuesRectangleParallel_UsesDirectPackageWithSharedStrings() {
             using var memory = new MemoryStream();
             var cells = new List<(int Row, int Column, object Value)> {


### PR DESCRIPTION
## Summary
- tighten OfficeIMO.Excel direct-save preparation for object, fluent rows, and CellValues paths
- add benchmark lanes for PowerShell-shaped object/DataTable export scenarios
- preserve multiline text fallback behavior with regression coverage
- add exact dictionary fast paths used by normalized PowerShell object rows

## Why
PSWriteOffice operator benchmarks showed OfficeIMO was already close to ExcelFast on export while preserving typed cells. This keeps the existing API unchanged and removes internal overhead in the normal OfficeIMO paths instead of adding user-facing switches.

## Validation
- `dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --framework net8.0 --no-restore`
- `dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --framework net472 --no-restore`
- `dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --framework net10.0 --no-restore`
- focused Excel regression tests: `81/81` passed
- combined PSWriteOffice + optimized OfficeIMO benchmark at 25k rows: default export `182.99 ms` median vs ExcelFast `198.31 ms`, with PSWriteOffice preserving numeric/bool/date cell types
