### PR TITLE
Optimize OfficeIMO Excel data paths

### DIFF
--- a/OfficeIMO.Excel.Benchmarks/ExcelLibraryComparisonRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelLibraryComparisonRunner.cs
@@ -83,6 +83,7 @@ internal static class ExcelLibraryComparisonRunner {
         var secondTableRows = rows.Skip(rowCount / 2).ToList();
         var salesDataTable = CreateSalesDataTable(rows, "SalesData");
         var objectColumnSalesDataTable = CreateObjectColumnSalesDataTable(rows, "SalesData");
+        var typedObjectRows = CreateTypedObjectRows(rows);
         var dictionaryRows = CreateDictionaryRows(rows);
         var salesDataSet = CreateSalesDataSet(firstTableRows, secondTableRows);
         var sparseDataSet = CreateSparseDataSet(rowCount);
@@ -168,6 +169,10 @@ internal static class ExcelLibraryComparisonRunner {
 
         AddScenarioGroup(scenarios, scenarioFilter, "build-object-datatable-dictionaries", warmupIterations, measuredIterations, [
             new LibraryComparisonCase("OfficeIMO.Excel", "Build a DataTable from dictionary rows matching the normalized PowerShell object shape.", () => ObjectDataTableBuilder.FromObjects(dictionaryRows, "SalesData").Rows.Count)
+        ]);
+
+        AddScenarioGroup(scenarios, scenarioFilter, "build-object-datatable-typed", warmupIterations, measuredIterations, [
+            new LibraryComparisonCase("OfficeIMO.Excel", "Build a DataTable from typed object rows through the normal object projection API.", () => ObjectDataTableBuilder.FromObjects(typedObjectRows, "SalesData").Rows.Count)
         ]);
 
         AddScenarioGroup(scenarios, scenarioFilter, "write-dictionary-objects-table-direct", warmupIterations, measuredIterations, [
@@ -280,6 +285,13 @@ internal static class ExcelLibraryComparisonRunner {
             new LibraryComparisonCase("ClosedXML", "Insert the same typed objects and save.", () => ClosedXmlWriteDataTable(salesDataTable)),
             new LibraryComparisonCase("EPPlus", "Import the same typed objects and save.", () => EpPlusWriteDataTable(salesDataTable)),
             new LibraryComparisonCase("MiniExcel", "Streaming typed object export and save.", () => MiniExcelWriteSalesRows(rows))
+        ]);
+
+        AddScenarioGroup(scenarios, scenarioFilter, "write-insertobjects-flat-dictionaries-direct", warmupIterations, measuredIterations, [
+            new LibraryComparisonCase("OfficeIMO.Excel", "Insert flat dictionary rows through the normal worksheet API and save.", () => OfficeImoWriteInsertDictionaryObjects(dictionaryRows)),
+            new LibraryComparisonCase("ClosedXML", "Import the same prepared data and save.", () => ClosedXmlWriteDataTable(salesDataTable)),
+            new LibraryComparisonCase("EPPlus", "Import the same prepared data and save.", () => EpPlusWriteDataTable(salesDataTable)),
+            new LibraryComparisonCase("MiniExcel", "Streaming typed row export with the same values and save.", () => MiniExcelWriteSalesRows(rows))
         ]);
 
         AddScenarioGroup(scenarios, scenarioFilter, "write-fluent-rowsfrom-direct", warmupIterations, measuredIterations, [
@@ -522,6 +534,7 @@ internal static class ExcelLibraryComparisonRunner {
         var firstTableRows = rows.Take(rowCount / 2).ToList();
         var secondTableRows = rows.Skip(rowCount / 2).ToList();
         var salesDataTable = CreateSalesDataTable(rows, "SalesData");
+        var dictionaryRows = CreateDictionaryRows(rows);
         var salesDataSet = CreateSalesDataSet(firstTableRows, secondTableRows);
         var sparseDataSet = CreateSparseDataSet(rowCount);
         var officeImoWorkbookBytes = new Lazy<byte[]>(() => ExcelBenchmarkScenarioFactory.CreateWorkbookBytes(rows));
@@ -678,6 +691,13 @@ internal static class ExcelLibraryComparisonRunner {
             new PackageProfileCase("ClosedXML", "Insert the same typed objects and save.", () => ClosedXmlWriteDataTableBytes(salesDataTable)),
             new PackageProfileCase("EPPlus", "Import the same typed objects and save.", () => EpPlusWriteDataTableBytes(salesDataTable)),
             new PackageProfileCase("MiniExcel", "Streaming typed object export and save.", () => MiniExcelWriteSalesRowsBytes(rows))
+        ]);
+
+        AddPackageProfileGroup(scenarios, scenarioFilter, "write-insertobjects-flat-dictionaries-direct", warmupIterations, measuredIterations, [
+            new PackageProfileCase("OfficeIMO.Excel", "Insert flat dictionary rows through the normal worksheet API and save.", () => OfficeImoWriteInsertDictionaryObjectsBytes(dictionaryRows)),
+            new PackageProfileCase("ClosedXML", "Import the same prepared data and save.", () => ClosedXmlWriteDataTableBytes(salesDataTable)),
+            new PackageProfileCase("EPPlus", "Import the same prepared data and save.", () => EpPlusWriteDataTableBytes(salesDataTable)),
+            new PackageProfileCase("MiniExcel", "Streaming typed row export with the same values and save.", () => MiniExcelWriteSalesRowsBytes(rows))
         ]);
 
         AddPackageProfileGroup(scenarios, scenarioFilter, "write-fluent-rowsfrom-direct", warmupIterations, measuredIterations, [
@@ -1373,6 +1393,21 @@ internal static class ExcelLibraryComparisonRunner {
             ExcelBenchmarkScenarioFactory.InsertOfficeImoObjects(sheet, rows);
             document.Save(stream);
             AssertOfficeImoDirectPackageWriter(document, "InsertObjects comparison");
+        }
+
+        return stream.ToArray();
+    }
+
+    private static int OfficeImoWriteInsertDictionaryObjects(IReadOnlyList<object?> rows)
+        => ByteCount(OfficeImoWriteInsertDictionaryObjectsBytes(rows));
+
+    private static byte[] OfficeImoWriteInsertDictionaryObjectsBytes(IReadOnlyList<object?> rows) {
+        using var stream = new MemoryStream();
+        using (var document = ExcelDocument.Create(stream, autoSave: false)) {
+            var sheet = document.AddWorkSheet("Data");
+            sheet.InsertObjects(rows);
+            document.Save(stream);
+            AssertOfficeImoDirectPackageWriter(document, "InsertObjects flat dictionary comparison");
         }
 
         return stream.ToArray();
@@ -4118,6 +4153,15 @@ internal static class ExcelLibraryComparisonRunner {
         }
 
         return table;
+    }
+
+    private static IReadOnlyList<object?> CreateTypedObjectRows(IEnumerable<ExcelBenchmarkScenarioFactory.SalesRecord> rows) {
+        var result = new List<object?>();
+        foreach (var row in rows) {
+            result.Add(row);
+        }
+
+        return result;
     }
 
     private static IReadOnlyList<object?> CreateDictionaryRows(IEnumerable<ExcelBenchmarkScenarioFactory.SalesRecord> rows) {

--- a/OfficeIMO.Excel.Benchmarks/Program.cs
+++ b/OfficeIMO.Excel.Benchmarks/Program.cs
@@ -354,6 +354,7 @@ static string[] FilterPackageProfileScenarios(IReadOnlyCollection<string> scenar
         "write-cellvalue-object-sparse-batch",
         "write-cellformula",
         "write-insertobjects-direct",
+        "write-insertobjects-flat-dictionaries-direct",
         "write-fluent-rowsfrom-direct",
         "append-plain-rows",
         "autofit-existing",

--- a/OfficeIMO.Excel/ExcelSheet.DataExchange.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataExchange.cs
@@ -1,3 +1,6 @@
+#if NET6_0_OR_GREATER
+using System.Buffers;
+#endif
 using System.Data;
 using System.Globalization;
 using System.Text;
@@ -6,6 +9,8 @@ using System.Threading;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
+        private static readonly char[] CsvSpecialCharacters = { ',', '"', '\r', '\n' };
+
         /// <summary>
         /// Reads the worksheet used range as a <see cref="DataTable"/>.
         /// </summary>
@@ -94,9 +99,10 @@ namespace OfficeIMO.Excel {
 
         private static string DataTableToCsv(DataTable table, bool includeHeaders) {
             if (table == null) throw new ArgumentNullException(nameof(table));
-            var builder = new StringBuilder();
+            var builder = new StringBuilder(EstimateCsvCapacity(table, includeHeaders));
+            int columnCount = table.Columns.Count;
             if (includeHeaders) {
-                for (int column = 0; column < table.Columns.Count; column++) {
+                for (int column = 0; column < columnCount; column++) {
                     if (column > 0) builder.Append(',');
                     AppendCsvField(builder, table.Columns[column].ColumnName);
                 }
@@ -104,9 +110,10 @@ namespace OfficeIMO.Excel {
             }
 
             foreach (DataRow row in table.Rows) {
-                for (int column = 0; column < table.Columns.Count; column++) {
+                for (int column = 0; column < columnCount; column++) {
                     if (column > 0) builder.Append(',');
-                    AppendCsvField(builder, row.IsNull(column) ? null : row[column]);
+                    object? value = row.IsNull(column) ? null : row[column];
+                    AppendCsvField(builder, value);
                 }
                 builder.AppendLine();
             }
@@ -116,29 +123,172 @@ namespace OfficeIMO.Excel {
 
         private static string DataTableToJson(DataTable table, JsonSerializerOptions? options) {
             if (table == null) throw new ArgumentNullException(nameof(table));
+            if (options == null) {
+                return DataTableToJsonStreaming(table);
+            }
+
+            int columnCount = table.Columns.Count;
+            string[] columnNames = new string[columnCount];
+            for (int column = 0; column < columnCount; column++) {
+                columnNames[column] = table.Columns[column].ColumnName;
+            }
+
             var rows = new List<Dictionary<string, object?>>(table.Rows.Count);
             foreach (DataRow row in table.Rows) {
-                var item = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-                foreach (DataColumn column in table.Columns) {
+                var item = new Dictionary<string, object?>(columnCount, StringComparer.OrdinalIgnoreCase);
+                for (int column = 0; column < columnCount; column++) {
                     object? value = row.IsNull(column) ? null : row[column];
-                    item[column.ColumnName] = value;
+                    item[columnNames[column]] = value;
                 }
+
                 rows.Add(item);
             }
 
             return JsonSerializer.Serialize(rows, options);
         }
 
+        private static string DataTableToJsonStreaming(DataTable table) {
+            JsonEncodedText[] propertyNames = CreateJsonPropertyNames(table.Columns);
+            int estimatedCapacity = EstimateJsonCapacity(table, propertyNames);
+#if NET6_0_OR_GREATER
+            var buffer = new ArrayBufferWriter<byte>(estimatedCapacity);
+            using (var writer = new Utf8JsonWriter(buffer)) {
+                WriteDataTableJson(table, propertyNames, writer);
+            }
+
+            return Encoding.UTF8.GetString(buffer.WrittenSpan);
+#else
+            using var stream = new MemoryStream(estimatedCapacity);
+            using (var writer = new Utf8JsonWriter(stream)) {
+                WriteDataTableJson(table, propertyNames, writer);
+            }
+
+            byte[] jsonBytes = stream.ToArray();
+            return Encoding.UTF8.GetString(jsonBytes, 0, jsonBytes.Length);
+#endif
+        }
+
+        private static void WriteDataTableJson(DataTable table, JsonEncodedText[] propertyNames, Utf8JsonWriter writer) {
+            writer.WriteStartArray();
+            foreach (DataRow row in table.Rows) {
+                writer.WriteStartObject();
+                for (int i = 0; i < propertyNames.Length; i++) {
+                    writer.WritePropertyName(propertyNames[i]);
+                    object? value = row.IsNull(i) ? null : row[i];
+                    if (value == null) {
+                        writer.WriteNullValue();
+                    } else {
+                        WriteJsonValue(writer, value);
+                    }
+                }
+
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+        }
+
+        private static void WriteJsonValue(Utf8JsonWriter writer, object value) {
+            switch (value) {
+                case string stringValue:
+                    writer.WriteStringValue(stringValue);
+                    return;
+                case bool boolValue:
+                    writer.WriteBooleanValue(boolValue);
+                    return;
+                case int intValue:
+                    writer.WriteNumberValue(intValue);
+                    return;
+                case long longValue:
+                    writer.WriteNumberValue(longValue);
+                    return;
+                case double doubleValue:
+                    writer.WriteNumberValue(doubleValue);
+                    return;
+                case decimal decimalValue:
+                    writer.WriteNumberValue(decimalValue);
+                    return;
+                case DateTime dateTime:
+                    writer.WriteStringValue(dateTime);
+                    return;
+                case DateTimeOffset dateTimeOffset:
+                    writer.WriteStringValue(dateTimeOffset);
+                    return;
+                case Guid guid:
+                    writer.WriteStringValue(guid);
+                    return;
+                case float floatValue:
+                    writer.WriteNumberValue(floatValue);
+                    return;
+                case short shortValue:
+                    writer.WriteNumberValue(shortValue);
+                    return;
+                case byte byteValue:
+                    writer.WriteNumberValue(byteValue);
+                    return;
+                case sbyte sbyteValue:
+                    writer.WriteNumberValue(sbyteValue);
+                    return;
+                case ushort ushortValue:
+                    writer.WriteNumberValue(ushortValue);
+                    return;
+                case uint uintValue:
+                    writer.WriteNumberValue(uintValue);
+                    return;
+                case ulong ulongValue:
+                    writer.WriteNumberValue(ulongValue);
+                    return;
+                default:
+                    JsonSerializer.Serialize(writer, value, value.GetType());
+                    return;
+            }
+        }
+
+        private static JsonEncodedText[] CreateJsonPropertyNames(DataColumnCollection columns) {
+            var propertyNames = new JsonEncodedText[columns.Count];
+            for (int i = 0; i < propertyNames.Length; i++) {
+                propertyNames[i] = JsonEncodedText.Encode(columns[i].ColumnName);
+            }
+
+            return propertyNames;
+        }
+
+        private static int EstimateJsonCapacity(DataTable table, JsonEncodedText[] propertyNames) {
+            const int MaxInitialJsonBufferBytes = 16 * 1024 * 1024;
+            int rowCount = table.Rows.Count;
+            int columnCount = propertyNames.Length;
+            if (rowCount <= 0 || columnCount <= 0) {
+                return 256;
+            }
+
+            long perRow = 2;
+            for (int i = 0; i < propertyNames.Length; i++) {
+                perRow += propertyNames[i].EncodedUtf8Bytes.Length + 8L;
+            }
+
+            perRow += (long)columnCount * 16L;
+            long estimated = 2L + (long)rowCount * perRow;
+            if (estimated < 256L) {
+                return 256;
+            }
+
+            return estimated > MaxInitialJsonBufferBytes
+                ? MaxInitialJsonBufferBytes
+                : (int)estimated;
+        }
+
         private static DataTable CsvToDataTable(string csv, bool firstRowIsHeader) {
             if (csv == null) throw new ArgumentNullException(nameof(csv));
+            if (csv.IndexOf('"') < 0) {
+                return UnquotedCsvToDataTable(csv, firstRowIsHeader);
+            }
 
-            var records = ParseCsv(csv).ToList();
+            List<List<string?>> records = ParseCsv(csv, out int columnCount);
             var table = new DataTable { Locale = CultureInfo.InvariantCulture };
             if (records.Count == 0) {
                 return table;
             }
 
-            int columnCount = records.Max(record => record.Count);
             int firstDataRow = 0;
             if (firstRowIsHeader) {
                 var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(columnCount, c => c < records[0].Count ? records[0][c] : null, true);
@@ -152,13 +302,57 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            for (int rowIndex = firstDataRow; rowIndex < records.Count; rowIndex++) {
-                var record = records[rowIndex];
-                DataRow row = table.NewRow();
-                for (int column = 0; column < table.Columns.Count; column++) {
-                    row[column] = column < record.Count && record[column] != null ? record[column] : DBNull.Value;
+            table.MinimumCapacity = Math.Max(0, records.Count - firstDataRow);
+            table.BeginLoadData();
+            try {
+                for (int rowIndex = firstDataRow; rowIndex < records.Count; rowIndex++) {
+                    var record = records[rowIndex];
+                    DataRow row = table.NewRow();
+                    int columnLimit = Math.Min(record.Count, table.Columns.Count);
+                    for (int column = 0; column < columnLimit; column++) {
+                        string? value = record[column];
+                        if (value != null) {
+                            row[column] = value;
+                        }
+                    }
+
+                    table.Rows.Add(row);
                 }
-                table.Rows.Add(row);
+            } finally {
+                table.EndLoadData();
+            }
+
+            return table;
+        }
+
+        private static DataTable UnquotedCsvToDataTable(string csv, bool firstRowIsHeader) {
+            CountUnquotedCsvShape(csv, out int recordCount, out int columnCount);
+            var table = new DataTable { Locale = CultureInfo.InvariantCulture };
+            if (recordCount == 0) {
+                return table;
+            }
+
+            int firstDataRow = 0;
+            if (firstRowIsHeader) {
+                List<string?> firstRecord = ParseFirstUnquotedCsvRecord(csv);
+                var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(columnCount, c => c < firstRecord.Count ? firstRecord[c] : null, true);
+                foreach (string header in headers) {
+                    table.Columns.Add(header, typeof(string));
+                }
+
+                firstDataRow = 1;
+            } else {
+                for (int column = 0; column < columnCount; column++) {
+                    table.Columns.Add($"Column{column + 1}", typeof(string));
+                }
+            }
+
+            table.MinimumCapacity = Math.Max(0, recordCount - firstDataRow);
+            table.BeginLoadData();
+            try {
+                AddUnquotedCsvRows(csv, firstDataRow, table);
+            } finally {
+                table.EndLoadData();
             }
 
             return table;
@@ -173,31 +367,132 @@ namespace OfficeIMO.Excel {
             }
 
             var table = new DataTable { Locale = CultureInfo.InvariantCulture };
-            var rows = new List<Dictionary<string, object?>>();
+            int expectedRowCount = document.RootElement.GetArrayLength();
+            table.MinimumCapacity = expectedRowCount;
+            var rows = new List<JsonTableRow>(expectedRowCount);
+            var columnIndexes = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             foreach (JsonElement element in document.RootElement.EnumerateArray()) {
                 if (element.ValueKind != JsonValueKind.Object) {
                     throw new ArgumentException("JSON input must be an array of objects.", nameof(json));
                 }
 
-                var row = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-                foreach (JsonProperty property in element.EnumerateObject()) {
-                    if (!table.Columns.Contains(property.Name)) {
-                        table.Columns.Add(property.Name, typeof(object));
-                    }
-                    row[property.Name] = JsonElementToValue(property.Value);
-                }
-                rows.Add(row);
+                rows.Add(CreateJsonTableRow(element, table, columnIndexes));
             }
 
-            foreach (var source in rows) {
-                DataRow row = table.NewRow();
-                foreach (DataColumn column in table.Columns) {
-                    row[column] = source.TryGetValue(column.ColumnName, out object? value) && value != null ? value : DBNull.Value;
+            table.BeginLoadData();
+            try {
+                foreach (JsonTableRow source in rows) {
+                    DataRow row = table.NewRow();
+                    if (source.Values != null) {
+                        object?[] values = source.Values;
+                        for (int column = 0; column < values.Length; column++) {
+                            object? value = values[column];
+                            if (value != null) {
+                                row[column] = value;
+                            }
+                        }
+                    } else if (source.SparseValues != null) {
+                        JsonCellValue[] values = source.SparseValues;
+                        for (int i = 0; i < values.Length; i++) {
+                            JsonCellValue cell = values[i];
+                            row[cell.ColumnIndex] = cell.Value ?? DBNull.Value;
+                        }
+                    }
+
+                    table.Rows.Add(row);
                 }
-                table.Rows.Add(row);
+            } finally {
+                table.EndLoadData();
             }
 
             return table;
+        }
+
+        private static JsonTableRow CreateJsonTableRow(JsonElement element, DataTable table, Dictionary<string, int> columnIndexes) {
+            int existingColumnCount = table.Columns.Count;
+            int propertyCount = CountJsonProperties(element);
+            if (UseSparseJsonRow(propertyCount, existingColumnCount)) {
+                var values = new JsonCellValue[propertyCount];
+                int valueIndex = 0;
+                foreach (JsonProperty property in element.EnumerateObject()) {
+                    int columnIndex = GetOrAddJsonColumn(table, columnIndexes, property.Name);
+                    values[valueIndex++] = new JsonCellValue(columnIndex, JsonElementToValue(property.Value));
+                }
+
+                return new JsonTableRow(values);
+            }
+
+            object?[] row = new object?[existingColumnCount];
+            foreach (JsonProperty property in element.EnumerateObject()) {
+                int columnIndex = GetOrAddJsonColumn(table, columnIndexes, property.Name);
+                EnsureJsonRowCapacity(ref row, columnIndex + 1);
+                row[columnIndex] = JsonElementToValue(property.Value);
+            }
+
+            return new JsonTableRow(row);
+        }
+
+        private static int GetOrAddJsonColumn(DataTable table, Dictionary<string, int> columnIndexes, string columnName) {
+            if (!columnIndexes.TryGetValue(columnName, out int columnIndex)) {
+                columnIndex = table.Columns.Count;
+                table.Columns.Add(columnName, typeof(object));
+                columnIndexes.Add(columnName, columnIndex);
+            }
+
+            return columnIndex;
+        }
+
+        private static bool UseSparseJsonRow(int propertyCount, int existingColumnCount) {
+            return propertyCount > 0 && existingColumnCount >= 32 && propertyCount * 4 <= existingColumnCount;
+        }
+
+        private static int CountJsonProperties(JsonElement element) {
+            int count = 0;
+            foreach (JsonProperty _ in element.EnumerateObject()) {
+                count++;
+            }
+
+            return count;
+        }
+
+        private readonly struct JsonTableRow {
+            internal JsonTableRow(object?[] values) {
+                Values = values;
+                SparseValues = null;
+            }
+
+            internal JsonTableRow(JsonCellValue[] sparseValues) {
+                Values = null;
+                SparseValues = sparseValues;
+            }
+
+            internal object?[]? Values { get; }
+
+            internal JsonCellValue[]? SparseValues { get; }
+        }
+
+        private readonly struct JsonCellValue {
+            internal JsonCellValue(int columnIndex, object? value) {
+                ColumnIndex = columnIndex;
+                Value = value;
+            }
+
+            internal int ColumnIndex { get; }
+
+            internal object? Value { get; }
+        }
+
+        private static void EnsureJsonRowCapacity(ref object?[] row, int requiredLength) {
+            if (row.Length >= requiredLength) {
+                return;
+            }
+
+            int newLength = row.Length == 0 ? 4 : row.Length * 2;
+            if (newLength < requiredLength) {
+                newLength = requiredLength;
+            }
+
+            Array.Resize(ref row, newLength);
         }
 
         private static object? JsonElementToValue(JsonElement element) {
@@ -221,11 +516,13 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static IEnumerable<List<string?>> ParseCsv(string csv) {
+        private static List<List<string?>> ParseCsv(string csv, out int maxColumnCount) {
+            var records = new List<List<string?>>();
             var record = new List<string?>();
             var field = new StringBuilder();
             bool inQuotes = false;
             bool quoted = false;
+            maxColumnCount = 0;
 
             for (int i = 0; i < csv.Length; i++) {
                 char ch = csv[i];
@@ -263,7 +560,7 @@ namespace OfficeIMO.Excel {
                     record.Add(FieldValue(field, quoted));
                     field.Clear();
                     quoted = false;
-                    yield return record;
+                    AddCsvRecord(records, record, ref maxColumnCount);
                     record = new List<string?>();
                     continue;
                 }
@@ -273,8 +570,141 @@ namespace OfficeIMO.Excel {
 
             if (field.Length > 0 || quoted || record.Count > 0) {
                 record.Add(FieldValue(field, quoted));
-                yield return record;
+                AddCsvRecord(records, record, ref maxColumnCount);
             }
+
+            return records;
+        }
+
+        private static void CountUnquotedCsvShape(string csv, out int recordCount, out int maxColumnCount) {
+            recordCount = 0;
+            maxColumnCount = 0;
+            int columnCount = 0;
+            int fieldStart = 0;
+
+            for (int i = 0; i < csv.Length; i++) {
+                char ch = csv[i];
+                if (ch == ',') {
+                    columnCount++;
+                    fieldStart = i + 1;
+                    continue;
+                }
+
+                if (ch == '\r' || ch == '\n') {
+                    columnCount++;
+                    if (columnCount > maxColumnCount) {
+                        maxColumnCount = columnCount;
+                    }
+
+                    recordCount++;
+                    columnCount = 0;
+                    if (ch == '\r' && i + 1 < csv.Length && csv[i + 1] == '\n') {
+                        i++;
+                    }
+
+                    fieldStart = i + 1;
+                }
+            }
+
+            if (fieldStart < csv.Length || columnCount > 0) {
+                columnCount++;
+                if (columnCount > maxColumnCount) {
+                    maxColumnCount = columnCount;
+                }
+
+                recordCount++;
+            }
+        }
+
+        private static List<string?> ParseFirstUnquotedCsvRecord(string csv) {
+            var record = new List<string?>();
+            int fieldStart = 0;
+
+            for (int i = 0; i < csv.Length; i++) {
+                char ch = csv[i];
+                if (ch == ',') {
+                    record.Add(UnquotedFieldValue(csv, fieldStart, i - fieldStart));
+                    fieldStart = i + 1;
+                    continue;
+                }
+
+                if (ch == '\r' || ch == '\n') {
+                    record.Add(UnquotedFieldValue(csv, fieldStart, i - fieldStart));
+                    return record;
+                }
+            }
+
+            if (fieldStart < csv.Length || record.Count > 0) {
+                record.Add(UnquotedFieldValue(csv, fieldStart, csv.Length - fieldStart));
+            }
+
+            return record;
+        }
+
+        private static void AddUnquotedCsvRows(string csv, int firstDataRow, DataTable table) {
+            int recordIndex = 0;
+            int columnIndex = 0;
+            int fieldStart = 0;
+            DataRow? row = null;
+
+            for (int i = 0; i < csv.Length; i++) {
+                char ch = csv[i];
+                if (ch == ',') {
+                    AddField(i - fieldStart);
+                    fieldStart = i + 1;
+                    continue;
+                }
+
+                if (ch == '\r' || ch == '\n') {
+                    AddField(i - fieldStart);
+                    AddRecord();
+                    if (ch == '\r' && i + 1 < csv.Length && csv[i + 1] == '\n') {
+                        i++;
+                    }
+
+                    fieldStart = i + 1;
+                }
+            }
+
+            if (fieldStart < csv.Length || columnIndex > 0) {
+                AddField(csv.Length - fieldStart);
+                AddRecord();
+            }
+
+            void AddField(int length) {
+                if (recordIndex >= firstDataRow && columnIndex < table.Columns.Count) {
+                    row ??= table.NewRow();
+                    string? value = UnquotedFieldValue(csv, fieldStart, length);
+                    if (value != null) {
+                        row[columnIndex] = value;
+                    }
+                }
+
+                columnIndex++;
+            }
+
+            void AddRecord() {
+                if (recordIndex >= firstDataRow) {
+                    row ??= table.NewRow();
+                    table.Rows.Add(row);
+                    row = null;
+                }
+
+                recordIndex++;
+                columnIndex = 0;
+            }
+        }
+
+        private static void AddCsvRecord(List<List<string?>> records, List<string?> record, ref int maxColumnCount) {
+            if (record.Count > maxColumnCount) {
+                maxColumnCount = record.Count;
+            }
+
+            records.Add(record);
+        }
+
+        private static string? UnquotedFieldValue(string csv, int start, int length) {
+            return length == 0 ? null : csv.Substring(start, length);
         }
 
         private static string? FieldValue(StringBuilder field, bool quoted) {
@@ -287,16 +717,44 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
-            string text = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
-            bool quote = text.IndexOfAny(new[] { ',', '"', '\r', '\n' }) >= 0;
-            if (!quote) {
+            string text = value as string ?? Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+            if (text.Length == 0) {
+                return;
+            }
+
+            if (text.IndexOfAny(CsvSpecialCharacters) < 0) {
                 builder.Append(text);
                 return;
             }
 
             builder.Append('"');
-            builder.Append(text.Replace("\"", "\"\""));
+            if (text.IndexOf('"') < 0) {
+                builder.Append(text);
+            } else {
+                foreach (char ch in text) {
+                    if (ch == '"') {
+                        builder.Append("\"\"");
+                    } else {
+                        builder.Append(ch);
+                    }
+                }
+            }
+
             builder.Append('"');
+        }
+
+        private static int EstimateCsvCapacity(DataTable table, bool includeHeaders) {
+            int rowCount = table.Rows.Count + (includeHeaders ? 1 : 0);
+            if (rowCount <= 0 || table.Columns.Count == 0) {
+                return 256;
+            }
+
+            long estimated = ((long)rowCount * table.Columns.Count * 12) + ((long)rowCount * Environment.NewLine.Length);
+            if (estimated < 256) {
+                return 256;
+            }
+
+            return estimated > int.MaxValue ? int.MaxValue : (int)estimated;
         }
 
         private static string BuildInsertedRange(DataTable table, int startRow, int startColumn, bool includeHeaders) {

--- a/OfficeIMO.Excel/ExcelSheet.DataReader.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataReader.cs
@@ -7,7 +7,7 @@ using DocumentFormat.OpenXml.Spreadsheet;
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
         private const int DirectDataReaderSaveCandidateRowLimit = 65536;
-        private const int DirectDataReaderInitialRowCapacity = 512;
+        private const int DirectDataReaderInitialRowCapacity = 4096;
 
         /// <summary>
         /// Streams rows from an <see cref="IDataReader"/> (including provider-owned DbDataReader implementations) into the worksheet and optionally creates an Excel table.
@@ -132,19 +132,19 @@ namespace OfficeIMO.Excel {
 
             int dataRows = 0;
             bool canCancel = ct.CanBeCanceled;
+            bool useBulkRead = CanUseBulkDataReaderValues(reader);
+            object?[]? reusableValues = directRows == null ? new object?[headers.Length] : null;
             while (reader.Read()) {
                 if (canCancel) {
                     ct.ThrowIfCancellationRequested();
                 }
 
-                object?[]? directRow = directRows != null ? new object?[headers.Length] : null;
+                object?[] values = directRows != null
+                    ? new object?[headers.Length]
+                    : reusableValues ??= new object?[headers.Length];
+                FillDataReaderValues(reader, values, headers.Length, ref useBulkRead);
                 for (int i = 0; i < headers.Length; i++) {
-                    object rawValue = reader.GetValue(i);
-                    object? value = rawValue == DBNull.Value ? null : rawValue;
-                    if (directRow != null) {
-                        directRow[i] = value;
-                    }
-
+                    object? value = values[i];
                     int column = startColumn + i;
                     CellValue(row, column, value);
 
@@ -158,7 +158,7 @@ namespace OfficeIMO.Excel {
                 dataRows++;
                 if (directRows != null) {
                     if (directRows.Count < DirectDataReaderSaveCandidateRowLimit) {
-                        directRows.Add(directRow!);
+                        directRows.Add(values);
                     } else {
                         directRows = null;
                     }
@@ -217,6 +217,7 @@ namespace OfficeIMO.Excel {
             int columnCount = headers.Count;
             var rows = CreateDirectDataReaderRowBuffer();
             bool canCancel = ct.CanBeCanceled;
+            bool useBulkRead = CanUseBulkDataReaderValues(reader);
             while (reader.Read()) {
                 if (canCancel) {
                     ct.ThrowIfCancellationRequested();
@@ -227,10 +228,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 var values = new object?[columnCount];
-                for (int offset = 0; offset < columnCount; offset++) {
-                    object value = reader.GetValue(offset);
-                    values[offset] = value == DBNull.Value ? null : value;
-                }
+                FillDataReaderValues(reader, values, columnCount, ref useBulkRead);
 
                 rows.Add(values);
             }
@@ -423,10 +421,7 @@ namespace OfficeIMO.Excel {
             }
 
             int columnCount = headers.Count;
-            var columnNames = new string[startColumn + columnCount];
-            for (int column = startColumn; column < startColumn + columnCount; column++) {
-                columnNames[column] = GetColumnName(column);
-            }
+            string[] columnReferencePrefixes = BuildColumnReferencePrefixes(startColumn, columnCount);
 
             string?[] numberFormats = BuildReaderNumberFormats(fieldTypes);
             var stylePlanner = new StylePlanner();
@@ -474,9 +469,11 @@ namespace OfficeIMO.Excel {
             bool canCancel = ct.CanBeCanceled;
 
             if (includeHeaders) {
-                appendedRows.Add(CreateDataReaderHeaderRow(rowIndex++, startColumn, columnNames, headers, useDirectStringCells, ref sharedStringIndexes, canCancel, ct));
+                appendedRows.Add(CreateDataReaderHeaderRow(rowIndex++, columnReferencePrefixes, headers, useDirectStringCells, ref sharedStringIndexes, canCancel, ct));
             }
 
+            bool useBulkRead = CanUseBulkDataReaderValues(reader);
+            object?[]? reusableValues = directRows == null ? new object?[columnCount] : null;
             while (reader.Read()) {
                 if (canCancel) {
                     ct.ThrowIfCancellationRequested();
@@ -486,19 +483,17 @@ namespace OfficeIMO.Excel {
                     throw new InvalidOperationException("Data reader import exceeds the maximum worksheet row count.");
                 }
 
-                object?[]? directRow = directRows != null ? new object?[columnCount] : null;
-                object?[] values = directRow ?? new object?[columnCount];
-                for (int offset = 0; offset < columnCount; offset++) {
-                    object value = reader.GetValue(offset);
-                    values[offset] = value == DBNull.Value ? null : value;
-                }
+                object?[] values = directRows != null
+                    ? new object?[columnCount]
+                    : reusableValues ??= new object?[columnCount];
+                FillDataReaderValues(reader, values, columnCount, ref useBulkRead);
 
-                appendedRows.Add(CreateDataReaderValueRow(rowIndex++, startColumn, columnNames, values, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes, canCancel, ct));
+                appendedRows.Add(CreateDataReaderValueRow(rowIndex++, columnReferencePrefixes, values, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes, canCancel, ct));
                 dataRows++;
 
                 if (directRows != null) {
                     if (directRows.Count < DirectDataReaderSaveCandidateRowLimit) {
-                        directRows.Add(directRow!);
+                        directRows.Add(values);
                     } else {
                         directRows = null;
                     }
@@ -523,8 +518,7 @@ namespace OfficeIMO.Excel {
 
         private Row CreateDataReaderHeaderRow(
             int rowIndex,
-            int startColumn,
-            IReadOnlyList<string> columnNames,
+            string[] columnReferencePrefixes,
             IReadOnlyList<string> headers,
             bool useDirectStringCells,
             ref Dictionary<string, int>? sharedStringIndexes,
@@ -537,10 +531,9 @@ namespace OfficeIMO.Excel {
                     ct.ThrowIfCancellationRequested();
                 }
 
-                int column = startColumn + offset;
                 var (cellValue, cellType) = CoerceDataTableAppendValue(headers[offset], useDirectStringCells, ref sharedStringIndexes);
                 row.Append(new Cell {
-                    CellReference = columnNames[column] + rowReference,
+                    CellReference = columnReferencePrefixes[offset] + rowReference,
                     CellValue = cellValue,
                     DataType = new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(cellType)
                 });
@@ -551,8 +544,7 @@ namespace OfficeIMO.Excel {
 
         private Row CreateDataReaderValueRow(
             int rowIndex,
-            int startColumn,
-            IReadOnlyList<string> columnNames,
+            string[] columnReferencePrefixes,
             IReadOnlyList<object?> values,
             IReadOnlyList<uint?> styleIndexes,
             uint? objectDateTimeStyleIndex,
@@ -569,10 +561,9 @@ namespace OfficeIMO.Excel {
                 }
 
                 object? value = values[offset];
-                int column = startColumn + offset;
                 var (cellValue, cellType) = CoerceDataTableAppendValue(value, useDirectStringCells, ref sharedStringIndexes);
                 var cell = new Cell {
-                    CellReference = columnNames[column] + rowReference,
+                    CellReference = columnReferencePrefixes[offset] + rowReference,
                     CellValue = cellValue,
                     DataType = new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(cellType)
                 };
@@ -645,6 +636,37 @@ namespace OfficeIMO.Excel {
         }
 
         private static List<object?[]> CreateDirectDataReaderRowBuffer() => new List<object?[]>(DirectDataReaderInitialRowCapacity);
+
+        private static bool CanUseBulkDataReaderValues(IDataReader reader) {
+            return reader is not DataTableReader;
+        }
+
+        private static void FillDataReaderValues(IDataReader reader, object?[] values, int columnCount, ref bool useBulkRead) {
+            int copied = 0;
+            if (useBulkRead) {
+                try {
+                    copied = reader.GetValues((object[])values!);
+                } catch (Exception) {
+                    useBulkRead = false;
+                    copied = 0;
+                }
+
+                if (copied > columnCount) {
+                    copied = columnCount;
+                }
+
+                for (int i = 0; i < copied; i++) {
+                    if (values[i] == DBNull.Value) {
+                        values[i] = null;
+                    }
+                }
+            }
+
+            for (int i = copied; i < columnCount; i++) {
+                object rawValue = reader.GetValue(i);
+                values[i] = rawValue == DBNull.Value ? null : rawValue;
+            }
+        }
 
         private static Type[] BuildReaderFieldTypes(IDataReader reader) {
             var types = new Type[reader.FieldCount];

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.cs
@@ -276,10 +276,7 @@ namespace OfficeIMO.Excel {
             }
 
             int columnCount = table.Columns.Count;
-            var columnNames = new string[startColumn + columnCount];
-            for (int column = startColumn; column < startColumn + columnCount; column++) {
-                columnNames[column] = GetColumnName(column);
-            }
+            string[] columnReferencePrefixes = BuildColumnReferencePrefixes(startColumn, columnCount);
 
             string?[] numberFormats = BuildDataTableNumberFormats(table);
             var stylePlanner = new StylePlanner();
@@ -325,14 +322,18 @@ namespace OfficeIMO.Excel {
             Dictionary<string, int>? sharedStringIndexes = null;
             var appendedRows = new List<OpenXmlElement>(Math.Max(1, table.Rows.Count + (includeHeaders ? 1 : 0)));
             int rowIndex = startRow;
+            bool canCancel = ct.CanBeCanceled;
 
             if (includeHeaders) {
-                appendedRows.Add(CreateDataTableHeaderRow(rowIndex++, startColumn, columnNames, table, useDirectStringCells, ref sharedStringIndexes, ct));
+                appendedRows.Add(CreateDataTableHeaderRow(rowIndex++, columnReferencePrefixes, table, useDirectStringCells, ref sharedStringIndexes, canCancel, ct));
             }
 
             foreach (DataRow dataRow in table.Rows) {
-                ct.ThrowIfCancellationRequested();
-                appendedRows.Add(CreateDataTableValueRow(rowIndex++, startColumn, columnNames, dataRow, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes, ct));
+                if (canCancel) {
+                    ct.ThrowIfCancellationRequested();
+                }
+
+                appendedRows.Add(CreateDataTableValueRow(rowIndex++, columnReferencePrefixes, dataRow, styleIndexes, objectDateTimeStyleIndex, objectTimeSpanStyleIndex, useDirectStringCells, ref sharedStringIndexes, canCancel, ct));
             }
 
             sheetData.Append(appendedRows);
@@ -350,20 +351,22 @@ namespace OfficeIMO.Excel {
 
         private Row CreateDataTableHeaderRow(
             int rowIndex,
-            int startColumn,
-            IReadOnlyList<string> columnNames,
+            string[] columnReferencePrefixes,
             DataTable table,
             bool useDirectStringCells,
             ref Dictionary<string, int>? sharedStringIndexes,
+            bool canCancel,
             CancellationToken ct) {
             string rowReference = InvariantNumberText.Get(rowIndex);
             var row = new Row { RowIndex = (uint)rowIndex };
             for (int offset = 0; offset < table.Columns.Count; offset++) {
-                ct.ThrowIfCancellationRequested();
-                int column = startColumn + offset;
+                if (canCancel) {
+                    ct.ThrowIfCancellationRequested();
+                }
+
                 var (cellValue, cellType) = CoerceDataTableAppendValue(table.Columns[offset].ColumnName, useDirectStringCells, ref sharedStringIndexes);
                 var cell = new Cell {
-                    CellReference = columnNames[column] + rowReference,
+                    CellReference = columnReferencePrefixes[offset] + rowReference,
                     CellValue = cellValue,
                     DataType = new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(cellType)
                 };
@@ -376,29 +379,31 @@ namespace OfficeIMO.Excel {
 
         private Row CreateDataTableValueRow(
             int rowIndex,
-            int startColumn,
-            IReadOnlyList<string> columnNames,
+            string[] columnReferencePrefixes,
             DataRow dataRow,
             IReadOnlyList<uint?> styleIndexes,
             uint? objectDateTimeStyleIndex,
             uint? objectTimeSpanStyleIndex,
             bool useDirectStringCells,
             ref Dictionary<string, int>? sharedStringIndexes,
+            bool canCancel,
             CancellationToken ct) {
             string rowReference = InvariantNumberText.Get(rowIndex);
             int columnCount = dataRow.Table.Columns.Count;
             var row = new Row { RowIndex = (uint)rowIndex };
             for (int offset = 0; offset < columnCount; offset++) {
-                ct.ThrowIfCancellationRequested();
+                if (canCancel) {
+                    ct.ThrowIfCancellationRequested();
+                }
+
                 object? value = dataRow[offset];
                 if (value == DBNull.Value) {
                     value = null;
                 }
 
-                int column = startColumn + offset;
                 var (cellValue, cellType) = CoerceDataTableAppendValue(value, useDirectStringCells, ref sharedStringIndexes);
                 var cell = new Cell {
-                    CellReference = columnNames[column] + rowReference,
+                    CellReference = columnReferencePrefixes[offset] + rowReference,
                     CellValue = cellValue,
                     DataType = new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(cellType)
                 };
@@ -413,6 +418,15 @@ namespace OfficeIMO.Excel {
             }
 
             return row;
+        }
+
+        private static string[] BuildColumnReferencePrefixes(int startColumn, int columnCount) {
+            var columnReferencePrefixes = new string[columnCount];
+            for (int offset = 0; offset < columnReferencePrefixes.Length; offset++) {
+                columnReferencePrefixes[offset] = GetColumnName(startColumn + offset);
+            }
+
+            return columnReferencePrefixes;
         }
 
         private (CellValue cellValue, DocumentFormat.OpenXml.Spreadsheet.CellValues cellType) CoerceDataTableAppendValue(
@@ -647,10 +661,8 @@ namespace OfficeIMO.Excel {
                 throw new InvalidOperationException($"Table '{tableName}' has a totals row. Appending before totals rows is not supported yet.");
             }
 
-            var tableColumnNames = table.TableColumns?.Elements<TableColumn>()
-                .Select(column => column.Name?.Value ?? string.Empty)
-                .ToList() ?? new List<string>();
             int tableColumnCount = endColumn - startColumn + 1;
+            var tableColumnNames = GetTableColumnNames(table.TableColumns, tableColumnCount);
             if (tableColumnNames.Count != tableColumnCount) {
                 throw new InvalidOperationException($"Table '{tableName}' column metadata does not match its range.");
             }
@@ -711,48 +723,62 @@ namespace OfficeIMO.Excel {
                 return source;
             }
 
-            var sourceColumns = new Dictionary<string, DataColumn>(StringComparer.OrdinalIgnoreCase);
+            var sourceColumns = new Dictionary<string, int>(source.Columns.Count, StringComparer.OrdinalIgnoreCase);
             foreach (DataColumn column in source.Columns) {
                 if (sourceColumns.ContainsKey(column.ColumnName)) {
                     throw new ArgumentException($"Source table contains duplicate column '{column.ColumnName}'.", nameof(source));
                 }
 
-                sourceColumns.Add(column.ColumnName, column);
+                sourceColumns.Add(column.ColumnName, column.Ordinal);
             }
 
-            var orderedColumns = new DataColumn[tableColumnNames.Count];
-            var matchedSourceNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var orderedColumnIndexes = new int[tableColumnNames.Count];
+            var matchedSourceColumns = new bool[source.Columns.Count];
             for (int i = 0; i < tableColumnNames.Count; i++) {
                 string tableColumnName = tableColumnNames[i];
-                if (!sourceColumns.TryGetValue(tableColumnName, out DataColumn? sourceColumn)) {
+                if (!sourceColumns.TryGetValue(tableColumnName, out int sourceColumnIndex)) {
                     throw new ArgumentException($"Source table is missing column '{tableColumnName}'.", nameof(source));
                 }
 
-                orderedColumns[i] = sourceColumn;
-                matchedSourceNames.Add(sourceColumn.ColumnName);
+                orderedColumnIndexes[i] = sourceColumnIndex;
+                matchedSourceColumns[sourceColumnIndex] = true;
             }
 
             foreach (DataColumn column in source.Columns) {
-                if (!matchedSourceNames.Contains(column.ColumnName)) {
+                if (!matchedSourceColumns[column.Ordinal]) {
                     throw new ArgumentException($"Source table column '{column.ColumnName}' does not exist in the Excel table.", nameof(source));
                 }
             }
 
             var ordered = new DataTable(source.TableName);
-            foreach (DataColumn sourceColumn in orderedColumns) {
+            for (int i = 0; i < orderedColumnIndexes.Length; i++) {
+                DataColumn sourceColumn = source.Columns[orderedColumnIndexes[i]];
                 ordered.Columns.Add(sourceColumn.ColumnName, sourceColumn.DataType);
             }
 
             foreach (DataRow sourceRow in source.Rows) {
                 DataRow row = ordered.NewRow();
-                for (int i = 0; i < orderedColumns.Length; i++) {
-                    row[i] = sourceRow[orderedColumns[i]];
+                for (int i = 0; i < orderedColumnIndexes.Length; i++) {
+                    row[i] = sourceRow[orderedColumnIndexes[i]];
                 }
 
                 ordered.Rows.Add(row);
             }
 
             return ordered;
+        }
+
+        private static List<string> GetTableColumnNames(TableColumns? tableColumns, int capacity) {
+            if (tableColumns == null) {
+                return new List<string>();
+            }
+
+            var names = new List<string>(Math.Max(0, capacity));
+            foreach (TableColumn column in tableColumns.Elements<TableColumn>()) {
+                names.Add(column.Name?.Value ?? string.Empty);
+            }
+
+            return names;
         }
 
         private static bool ShouldMapAppendColumnsByHeader(DataTable source, IReadOnlyList<string> tableColumnNames, bool hasHeaderRow) {

--- a/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.cs
@@ -35,6 +35,14 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
+            if (TryInsertSimpleObjectRowsAsCellValues(rows, includeHeaders, startRow)) {
+                return;
+            }
+
+            if (TryInsertFlatDictionaryRowsAsDeferredDirectSave(rows, includeHeaders, startRow)) {
+                return;
+            }
+
             var flattenedItems = new List<Dictionary<string, object?>>(rows.Count);
             List<string> headers = new List<string>();
             HashSet<string> headerSet = new HashSet<string>();
@@ -131,28 +139,17 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            var values = new object?[rows.Count][];
-            var inferredColumnTypes = new Type?[selectors.Length];
-            for (int r = 0; r < rows.Count; r++) {
-                var rowValues = new object?[selectors.Length];
-                for (int c = 0; c < selectors.Length; c++) {
-                    object? value = selectors[c](rows[r]);
-                    rowValues[c] = value;
-                    UpdateObjectExportColumnType(inferredColumnTypes, c, value);
-                }
-
-                values[r] = rowValues;
-            }
-
-            string? directSaveRange = null;
-            if (!hasBlankDisplayHeader && CanRegisterDirectTabularSaveCandidate(startRow, 1, headers.Length)) {
+            object?[][]? values = null;
+            if (!hasBlankDisplayHeader
+                && !HasDuplicateObjectExportHeaders(headers)
+                && CanRegisterDirectTabularSaveCandidate(startRow, 1, headers.Length)) {
+                Type?[] inferredColumnTypes;
+                values = CreateExplicitObjectExportRows(rows, selectors, out inferredColumnTypes);
                 try {
-                    if (!HasDuplicateObjectExportHeaders(headers)) {
-                        var columnTypes = CompleteObjectExportColumnTypes(inferredColumnTypes);
-                        directSaveRange = BuildObjectExportRange(startRow, headers.Length, rows.Count, includeHeaders);
-                        if (TryInsertRowsAsDeferredDirectSave(Name, headers, columnTypes, values, startRow, includeHeaders, directSaveRange)) {
-                            return;
-                        }
+                    var columnTypes = CompleteObjectExportColumnTypes(inferredColumnTypes);
+                    string directSaveRange = BuildObjectExportRange(startRow, headers.Length, rows.Count, includeHeaders);
+                    if (TryInsertRowsAsDeferredDirectSave(Name, headers, columnTypes, values, startRow, includeHeaders, directSaveRange)) {
+                        return;
                     }
                 } catch {
                     // Direct-save registration is opportunistic; fall back to the normal cell path.
@@ -171,18 +168,48 @@ namespace OfficeIMO.Excel {
                 row++;
             }
 
-            foreach (var item in rows) {
-                for (int c = 0; c < headers.Length; c++) {
-                    object value = values[row - startRow - headerRows][c] ?? string.Empty;
-                    cells[cellIndex++] = (row, c + 1, value);
+            if (values != null) {
+                foreach (object?[] rowValues in values) {
+                    for (int c = 0; c < headers.Length; c++) {
+                        cells[cellIndex++] = (row, c + 1, rowValues[c] ?? string.Empty);
+                    }
+
+                    row++;
                 }
-                row++;
+            } else {
+                foreach (var item in rows) {
+                    for (int c = 0; c < headers.Length; c++) {
+                        cells[cellIndex++] = (row, c + 1, selectors[c](item) ?? string.Empty);
+                    }
+
+                    row++;
+                }
             }
 
             CellValues(cells, hasBlankDisplayHeader ? ExecutionMode.Parallel : null);
         }
 
         private static object? NullObjectSelector<T>(T row) => null;
+
+        private static object?[][] CreateExplicitObjectExportRows<T>(
+            IReadOnlyList<T> rows,
+            IReadOnlyList<Func<T, object?>> selectors,
+            out Type?[] inferredColumnTypes) {
+            var values = new object?[rows.Count][];
+            inferredColumnTypes = new Type?[selectors.Count];
+            for (int r = 0; r < rows.Count; r++) {
+                var rowValues = new object?[selectors.Count];
+                for (int c = 0; c < selectors.Count; c++) {
+                    object? value = selectors[c](rows[r]);
+                    rowValues[c] = value;
+                    UpdateObjectExportColumnType(inferredColumnTypes, c, value);
+                }
+
+                values[r] = rowValues;
+            }
+
+            return values;
+        }
 
         internal bool TryInsertOwnedDataTableAsDeferredDirectSave(DataTable table, int startRow, bool includeHeaders, string range) {
             if (table == null) throw new ArgumentNullException(nameof(table));
@@ -337,6 +364,57 @@ namespace OfficeIMO.Excel {
             return TryInsertRowsAsDeferredDirectSave(Name, headers, plan.ColumnTypes, values, startRow, includeHeaders, range);
         }
 
+        private bool TryInsertSimpleObjectRowsAsCellValues<T>(
+            IReadOnlyList<T> rows,
+            bool includeHeaders,
+            int startRow) {
+            if (rows.Count == 0) {
+                return false;
+            }
+
+            bool requireRuntimeTypeCheck = !typeof(T).IsValueType && !typeof(T).IsSealed;
+            Type rowType = requireRuntimeTypeCheck ? rows[0]?.GetType() ?? typeof(object) : typeof(T);
+            if (rowType == typeof(object)) {
+                return false;
+            }
+
+            SimpleObjectExportPlan plan = GetSimpleObjectExportPlan(rowType);
+            if (!plan.CanUseDirectSave) {
+                return false;
+            }
+
+            string[] headers = plan.Headers;
+            SimpleObjectExportValueGetter[] getters = plan.Getters;
+            int headerRows = includeHeaders ? 1 : 0;
+            int totalCellCount = checked((rows.Count + headerRows) * headers.Length);
+            var cells = new (int Row, int Column, object Value)[totalCellCount];
+            int cellIndex = 0;
+            int row = startRow;
+            if (includeHeaders) {
+                for (int c = 0; c < headers.Length; c++) {
+                    cells[cellIndex++] = (row, c + 1, headers[c]);
+                }
+
+                row++;
+            }
+
+            for (int r = 0; r < rows.Count; r++) {
+                object? item = rows[r];
+                if (item == null || requireRuntimeTypeCheck && item.GetType() != rowType) {
+                    return false;
+                }
+
+                for (int c = 0; c < getters.Length; c++) {
+                    cells[cellIndex++] = (row, c + 1, getters[c](item) ?? string.Empty);
+                }
+
+                row++;
+            }
+
+            CellValues(cells);
+            return true;
+        }
+
         private static SimpleObjectExportPlan GetSimpleObjectExportPlan(Type type)
             => SimpleObjectExportPlans.GetOrAdd(type, CreateSimpleObjectExportPlan);
 
@@ -484,6 +562,218 @@ namespace OfficeIMO.Excel {
             }
 
             return columnTypes;
+        }
+
+        private bool TryInsertFlatDictionaryRowsAsDeferredDirectSave<T>(
+            IReadOnlyList<T> rows,
+            bool includeHeaders,
+            int startRow) {
+            if (rows.Count == 0) {
+                return false;
+            }
+
+            if (!CanRegisterDirectTabularSaveCandidate(startRow, 1, columnCount: 1)) {
+                return false;
+            }
+
+            var headers = new List<string>();
+            var headerIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
+            var directRows = new object?[rows.Count][];
+            var state = new FlatDictionaryProjectionState();
+
+            for (int r = 0; r < rows.Count; r++) {
+                if (!TryProjectFlatDictionaryRow(
+                    rows[r],
+                    r,
+                    headers,
+                    headerIndexes,
+                    directRows,
+                    state)) {
+                    return false;
+                }
+            }
+
+            NormalizeFlatDictionaryRowWidths(directRows, headers.Count);
+            state.NormalizeColumnTypeWidth(headers.Count);
+
+            if (headers.Count == 0
+                || includeHeaders && state.HasBlankDisplayHeader
+                || HasDuplicateObjectExportHeaders(headers)
+                || !CanRegisterDirectTabularSaveCandidate(startRow, 1, headers.Count)) {
+                return false;
+            }
+
+            string range = BuildObjectExportRange(startRow, headers.Count, directRows.Length, includeHeaders);
+            return TryInsertRowsAsDeferredDirectSave(
+                Name,
+                headers,
+                CompleteObjectExportColumnTypes(state.InferredColumnTypes),
+                directRows,
+                startRow,
+                includeHeaders,
+                range);
+        }
+
+        private static bool TryProjectFlatDictionaryRow(
+            object? item,
+            int rowIndex,
+            List<string> headers,
+            Dictionary<string, int> headerIndexes,
+            object?[][] directRows,
+            FlatDictionaryProjectionState state) {
+            if (item == null) {
+                return false;
+            }
+
+            object?[] rowValues = new object?[GetFlatDictionaryInitialRowCapacity(item, headers.Count)];
+            if (item is Dictionary<string, object?> exactDictionary) {
+                foreach (var entry in exactDictionary) {
+                    if (!TryAddFlatDictionaryValue(entry.Key, entry.Value)) {
+                        return false;
+                    }
+                }
+
+                directRows[rowIndex] = rowValues;
+                return true;
+            }
+
+            if (item is IReadOnlyDictionary<string, object?> readOnlyDictionary) {
+                foreach (var entry in readOnlyDictionary) {
+                    if (!TryAddFlatDictionaryValue(entry.Key, entry.Value)) {
+                        return false;
+                    }
+                }
+
+                directRows[rowIndex] = rowValues;
+                return true;
+            }
+
+            if (item is IDictionary<string, object?> dictionary) {
+                foreach (var entry in dictionary) {
+                    if (!TryAddFlatDictionaryValue(entry.Key, entry.Value)) {
+                        return false;
+                    }
+                }
+
+                directRows[rowIndex] = rowValues;
+                return true;
+            }
+
+            if (item is System.Collections.IDictionary legacyDictionary) {
+                foreach (System.Collections.DictionaryEntry entry in legacyDictionary) {
+                    string key = entry.Key?.ToString() ?? string.Empty;
+                    if (!TryAddFlatDictionaryValue(key, entry.Value)) {
+                        return false;
+                    }
+                }
+
+                directRows[rowIndex] = rowValues;
+                return true;
+            }
+
+            return false;
+
+            bool TryAddFlatDictionaryValue(string? key, object? value) {
+                if (!IsFlatDictionaryObjectExportValue(value)) {
+                    return false;
+                }
+
+                string columnName = key ?? string.Empty;
+                if (string.IsNullOrWhiteSpace(columnName)) {
+                    state.HasBlankDisplayHeader = true;
+                }
+
+                if (!headerIndexes.TryGetValue(columnName, out int columnIndex)) {
+                    columnIndex = headers.Count;
+                    headers.Add(columnName);
+                    headerIndexes.Add(columnName, columnIndex);
+                    state.EnsureColumnTypeCapacity(headers.Count);
+                    EnsureFlatDictionaryRowCapacity(ref rowValues, headers.Count);
+                }
+
+                rowValues[columnIndex] = value;
+                UpdateObjectExportColumnType(state.InferredColumnTypes, columnIndex, value);
+                return true;
+            }
+        }
+
+        private static int GetFlatDictionaryInitialRowCapacity(object item, int existingHeaderCount) {
+            int entryCount =
+                item is System.Collections.ICollection collection
+                    ? collection.Count
+                    : item is IReadOnlyCollection<KeyValuePair<string, object?>> readOnlyCollection
+                        ? readOnlyCollection.Count
+                        : 0;
+
+            if (existingHeaderCount == 0) {
+                return entryCount;
+            }
+
+            return entryCount > existingHeaderCount * 2
+                ? existingHeaderCount + entryCount
+                : existingHeaderCount;
+        }
+
+        private static void EnsureFlatDictionaryRowCapacity(ref object?[] row, int requiredLength) {
+            if (row.Length >= requiredLength) {
+                return;
+            }
+
+            int newLength = row.Length == 0 ? 4 : row.Length * 2;
+            if (newLength < requiredLength) {
+                newLength = requiredLength;
+            }
+
+            Array.Resize(ref row, newLength);
+        }
+
+        private static void NormalizeFlatDictionaryRowWidths(object?[][] rows, int columnCount) {
+            for (int i = 0; i < rows.Length; i++) {
+                if (rows[i].Length == columnCount) {
+                    continue;
+                }
+
+                object?[] row = rows[i];
+                Array.Resize(ref row, columnCount);
+                rows[i] = row;
+            }
+        }
+
+        private sealed class FlatDictionaryProjectionState {
+            internal Type?[] InferredColumnTypes = Array.Empty<Type?>();
+
+            internal bool HasBlankDisplayHeader;
+
+            internal void EnsureColumnTypeCapacity(int requiredLength) {
+                if (InferredColumnTypes.Length >= requiredLength) {
+                    return;
+                }
+
+                int newLength = InferredColumnTypes.Length == 0 ? 4 : InferredColumnTypes.Length * 2;
+                if (newLength < requiredLength) {
+                    newLength = requiredLength;
+                }
+
+                Array.Resize(ref InferredColumnTypes, newLength);
+            }
+
+            internal void NormalizeColumnTypeWidth(int columnCount) {
+                if (InferredColumnTypes.Length == columnCount) {
+                    return;
+                }
+
+                Array.Resize(ref InferredColumnTypes, columnCount);
+            }
+        }
+
+        private static bool IsFlatDictionaryObjectExportValue(object? value) {
+            return value == null
+                || value is string
+                || value is decimal
+                || value is DateTime
+                || value is DateTimeOffset
+                || value is Guid
+                || value.GetType().IsPrimitive;
         }
 
         private static void FlattenObject(object? value, string? prefix, IDictionary<string, object?> result) {

--- a/OfficeIMO.Excel/Fluent/RangeBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/RangeBuilder.cs
@@ -44,7 +44,7 @@ namespace OfficeIMO.Excel.Fluent {
                 throw new ArgumentException("Values array dimensions must match the range.", nameof(values));
             }
 
-            var cells = new List<(int Row, int Column, object Value)>();
+            var cells = new List<(int Row, int Column, object Value)>(Math.Max(1, rows * cols));
             for (int r = 0; r < rows; r++) {
                 for (int c = 0; c < cols; c++) {
                     cells.Add((_fromRow + r, _fromCol + c, values[r, c]));

--- a/OfficeIMO.Excel/Fluent/SheetBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/SheetBuilder.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Globalization;
 using System.Data;
 using System.Reflection;
+using System.Text;
 using OfficeColor = OfficeIMO.Drawing.OfficeColor;
 
 namespace OfficeIMO.Excel.Fluent {
@@ -64,16 +65,16 @@ namespace OfficeIMO.Excel.Fluent {
             if (rows.Count == 0) return this;
 
             int startRow = _currentRow;
-            if (configure == null && TryRowsFromSimpleDirectSave(rows, startRow)) {
+            if (configure == null && TryRowsFromSimpleFastPath(rows, startRow)) {
                 return this;
             }
 
             options ??= new ObjectFlattenerOptions();
             var flattener = new ObjectFlattener();
             var paths = options.Columns?.ToList() ?? flattener.GetPaths(typeof(T), options);
-            var headers = paths.Select(p => TransformHeader(p, options)).ToList();
+            var headers = BuildTransformedHeaders(paths, options);
 
-            var rowValues = new List<object?[]>();
+            var rowValues = new List<object?[]>(rows.Count);
             int dataRows = 0;
             foreach (var item in rows) {
                 var dict = flattener.Flatten(item, options);
@@ -154,8 +155,8 @@ namespace OfficeIMO.Excel.Fluent {
             return projected;
         }
 
-        private bool TryRowsFromSimpleDirectSave<T>(IReadOnlyList<T> rows, int startRow) {
-            if (Sheet == null || startRow != 1) {
+        private bool TryRowsFromSimpleFastPath<T>(IReadOnlyList<T> rows, int startRow) {
+            if (Sheet == null) {
                 return false;
             }
 
@@ -168,10 +169,13 @@ namespace OfficeIMO.Excel.Fluent {
             int tableEndRow = startRow + rows.Count;
             string[] headers = typePlan.Headers;
             string range = $"A{startRow}:{ColumnLetter(headers.Length)}{tableEndRow}";
-            if (!Sheet.TryInsertRowsAsDeferredDirectSave("RowsFrom", headers, columnTypes, directRows, startRow, includeHeaders: true, range: range)) {
-                return false;
+            if (startRow == 1 && Sheet.TryInsertRowsAsDeferredDirectSave("RowsFrom", headers, columnTypes, directRows, startRow, includeHeaders: true, range: range)) {
+                _currentRow = tableEndRow + 1;
+                _lastRange = range;
+                return true;
             }
 
+            AddSimpleRowsFromCellValues(startRow, headers, directRows);
             _currentRow = tableEndRow + 1;
             _lastRange = range;
             return true;
@@ -224,7 +228,7 @@ namespace OfficeIMO.Excel.Fluent {
                 throw new ArgumentException("Values array dimensions must match the specified range.", nameof(values));
             }
 
-            var cells = new List<(int Row, int Column, object Value)>();
+            var cells = new List<(int Row, int Column, object Value)>(Math.Max(1, rowCount * colCount));
             for (int r = 0; r < rowCount; r++) {
                 for (int c = 0; c < colCount; c++) {
                     object cellValue = values != null ? values[r, c] : string.Empty;
@@ -337,11 +341,52 @@ namespace OfficeIMO.Excel.Fluent {
                 }
             }
             return opts.HeaderCase switch {
-                HeaderCase.Pascal => string.Concat(path.Split('.').Select(s => char.ToUpperInvariant(s[0]) + s.Substring(1))),
+                HeaderCase.Pascal => TransformHeaderPascal(path),
                 HeaderCase.Title => string.Join(" ", path.Split('.').Select(s => CultureInfo.CurrentCulture.TextInfo.ToTitleCase(s.ToLowerInvariant()))),
                 _ => path
             };
         }
+
+        private static List<string> BuildTransformedHeaders(IReadOnlyList<string> paths, ObjectFlattenerOptions options) {
+            var headers = new List<string>(paths.Count);
+            for (int i = 0; i < paths.Count; i++) {
+                headers.Add(TransformHeader(paths[i], options));
+            }
+
+            return headers;
+        }
+
+        private static string TransformHeaderPascal(string path) {
+            if (path.Length == 0) {
+                ThrowEmptyHeaderSegment();
+            }
+
+            var builder = new StringBuilder(path.Length);
+            int segmentStart = 0;
+            for (int i = 0; i <= path.Length; i++) {
+                if (i < path.Length && path[i] != '.') {
+                    continue;
+                }
+
+                AppendPascalSegment(builder, path, segmentStart, i - segmentStart);
+                segmentStart = i + 1;
+            }
+
+            return builder.ToString();
+        }
+
+        private static void AppendPascalSegment(StringBuilder builder, string path, int start, int length) {
+            if (length == 0) {
+                ThrowEmptyHeaderSegment();
+            }
+
+            builder.Append(char.ToUpperInvariant(path[start]));
+            if (length > 1) {
+                builder.Append(path, start + 1, length - 1);
+            }
+        }
+
+        private static void ThrowEmptyHeaderSegment() => throw new IndexOutOfRangeException();
 
         private static bool CanUseRowsFromDataTable(IReadOnlyList<string> headers) {
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -654,6 +699,24 @@ namespace OfficeIMO.Excel.Fluent {
                     cells.Add((startRow + r + 1, c + 1, value ?? string.Empty));
                 }
             }
+        }
+
+        private void AddSimpleRowsFromCellValues(int startRow, IReadOnlyList<string> headers, IReadOnlyList<object?[]> rowValues) {
+            int totalCellCount = checked((rowValues.Count + 1) * headers.Count);
+            var cells = new (int Row, int Column, object Value)[totalCellCount];
+            int cellIndex = 0;
+            for (int i = 0; i < headers.Count; i++) {
+                cells[cellIndex++] = (startRow, i + 1, headers[i]);
+            }
+
+            for (int r = 0; r < rowValues.Count; r++) {
+                object?[] values = rowValues[r];
+                for (int c = 0; c < headers.Count; c++) {
+                    cells[cellIndex++] = (startRow + r + 1, c + 1, values[c] ?? string.Empty);
+                }
+            }
+
+            Sheet!.CellValues(cells);
         }
 
         private static string ColumnLetter(int column) {

--- a/OfficeIMO.Excel/Fluent/SheetComposer.ColumnsLayout.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.ColumnsLayout.cs
@@ -120,6 +120,8 @@ namespace OfficeIMO.Excel.Fluent {
                 // Enforce fixed-grid overflow behavior if configured
                 List<string> effPaths = paths;
                 bool summarize = false;
+                List<string>? summarizedPaths = null;
+                List<string>? summarizedLabels = null;
                 if (_maxTableColumns.HasValue && paths.Count > _maxTableColumns.Value) {
                     if (_overflowMode == OverflowMode.Throw)
                         throw new InvalidOperationException($"Table has {paths.Count} columns but only {_maxTableColumns.Value} fit in the fixed grid. Increase columnWidth or use ColumnsAdaptive(...).");
@@ -135,6 +137,8 @@ namespace OfficeIMO.Excel.Fluent {
                             effPaths.Add("__More__");
                         }
                         summarize = true;
+                        summarizedPaths = paths.Skip(keep).ToList();
+                        summarizedLabels = BuildTransformedHeaders(summarizedPaths, opts);
                         try { _sheet.EffectiveExecution.ReportInfo($"[Columns Summarize] Sheet='{_sheet.Name}', baseCol={_baseCol}, kept={(effPaths.Contains("__More__") ? effPaths.Count - 1 : effPaths.Count)}, summarized={paths.Count - (effPaths.Contains("__More__") ? effPaths.Count - 1 : effPaths.Count)}"); } catch { }
                     }
                 }
@@ -147,22 +151,21 @@ namespace OfficeIMO.Excel.Fluent {
                     while (!usedHeaders.Add(candidate)) candidate = $"{baseName} ({suffix++})";
                     headersT[i] = candidate;
                 }
+
+                var cells = new List<(int Row, int Column, object Value)>(System.Math.Max(1, (rows.Count + 1) * System.Math.Max(1, headersT.Count)));
                 for (int i = 0; i < headersT.Count; i++) {
-                    _sheet.Cell(headerRow, _baseCol + i, headersT[i]);
-                    _sheet.CellBold(headerRow, _baseCol + i, true);
-                    _sheet.CellBackground(headerRow, _baseCol + i, _theme.KeyFillHex);
+                    cells.Add((headerRow, _baseCol + i, headersT[i]));
                 }
                 _row++;
                 foreach (var dict in rows) {
                     if (summarize) {
                         string more = string.Empty;
-                        if (_maxTableColumns.HasValue && paths.Count > _maxTableColumns.Value) {
-                            int keep = Math.Max(1, _maxTableColumns.Value - 1);
-                            var omitted = paths.Skip(keep);
-                            var parts = new System.Collections.Generic.List<string>();
-                            foreach (var p in omitted) {
+                        if (summarizedPaths != null && summarizedLabels != null) {
+                            var parts = new System.Collections.Generic.List<string>(summarizedPaths.Count);
+                            for (int omittedIndex = 0; omittedIndex < summarizedPaths.Count; omittedIndex++) {
+                                var p = summarizedPaths[omittedIndex];
                                 dict.TryGetValue(p, out var v);
-                                var label = SheetComposer.TransformHeader(p, opts);
+                                var label = summarizedLabels[omittedIndex];
                                 parts.Add(string.Concat(label, "=", v?.ToString() ?? string.Empty));
                             }
                             more = string.Join("; ", parts);
@@ -170,15 +173,21 @@ namespace OfficeIMO.Excel.Fluent {
                         for (int i = 0; i < effPaths.Count; i++) {
                             object? val;
                             if (effPaths[i] == "__More__") val = more; else { dict.TryGetValue(effPaths[i], out val); }
-                            _sheet.Cell(_row, _baseCol + i, val ?? string.Empty);
+                            cells.Add((_row, _baseCol + i, val ?? string.Empty));
                         }
                     } else {
                         for (int i = 0; i < effPaths.Count; i++) {
                             dict.TryGetValue(effPaths[i], out var val);
-                            _sheet.Cell(_row, _baseCol + i, val ?? string.Empty);
+                            cells.Add((_row, _baseCol + i, val ?? string.Empty));
                         }
                     }
                     _row++;
+                }
+
+                _sheet.CellValues(cells);
+                for (int i = 0; i < headersT.Count; i++) {
+                    _sheet.CellBold(headerRow, _baseCol + i, true);
+                    _sheet.CellBackground(headerRow, _baseCol + i, _theme.KeyFillHex);
                 }
 
                 int lastRow = _row - 1;

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
@@ -60,14 +60,7 @@ namespace OfficeIMO.Excel.Fluent {
                 }
                 headersT[i] = candidate;
             }
-            var seen = new System.Collections.Generic.HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
             for (int i = 0; i < headersT.Count; i++) {
-                var h = headersT[i];
-                if (!seen.Add(h)) {
-                    int n = 2; string candidate;
-                    do { candidate = h + "_" + n++; } while (!seen.Add(candidate));
-                    headersT[i] = candidate;
-                }
                 cells.Add((_row, i + 1, headersT[i]));
             }
             _row++;

--- a/OfficeIMO.Excel/Fluent/SheetComposer.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.cs
@@ -7,6 +7,9 @@ namespace OfficeIMO.Excel.Fluent {
         private readonly SheetTheme _theme;
         private ExcelSheet _sheet;
         private int _row;
+        private static readonly HashSet<string> HeaderAcronyms = new HashSet<string>(new[] {
+            "ID", "URL", "URI", "DNS", "MX", "SPF", "DKIM", "DMARC", "BIMI", "IP", "TLS", "AAA", "AAAA", "SRV", "TXT", "CNAME", "NS", "CAA", "MTA", "STS", "TLS-RPT"
+        }, StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Creates a new sheet and prepares a composer for adding content top-to-bottom.
@@ -61,15 +64,21 @@ namespace OfficeIMO.Excel.Fluent {
                     foreach (var p in parts) yield return p;
                 }
             }
-            var acronym = new HashSet<string>(new[]{
-                "ID","URL","URI","DNS","MX","SPF","DKIM","DMARC","BIMI","IP","TLS","AAA","AAAA","SRV","TXT","CNAME","NS","CAA","MTA","STS","TLS-RPT"
-            }, StringComparer.OrdinalIgnoreCase);
             IEnumerable<string> segments = path.Split('.'); var words = new List<string>();
             foreach (var seg in segments) words.AddRange(Humanize(seg));
             var ti = System.Globalization.CultureInfo.CurrentCulture.TextInfo;
             for (int i = 0; i < words.Count; i++)
-                words[i] = acronym.Contains(words[i]) ? words[i].ToUpperInvariant() : ti.ToTitleCase(words[i].ToLowerInvariant());
+                words[i] = HeaderAcronyms.Contains(words[i]) ? words[i].ToUpperInvariant() : ti.ToTitleCase(words[i].ToLowerInvariant());
             return string.Join(" ", words);
+        }
+
+        private static List<string> BuildTransformedHeaders(IReadOnlyList<string> paths, ObjectFlattenerOptions opts) {
+            var headers = new List<string>(paths.Count);
+            for (int i = 0; i < paths.Count; i++) {
+                headers.Add(TransformHeader(paths[i], opts));
+            }
+
+            return headers;
         }
 
         private static string SanitizeName(string name) {

--- a/OfficeIMO.Excel/Utilities/ObjectDataTableBuilder.cs
+++ b/OfficeIMO.Excel/Utilities/ObjectDataTableBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -53,6 +54,7 @@ namespace OfficeIMO.Excel {
 
                     projector.FillValues(item, values);
                     table.Rows.Add(values);
+                    projector.ResetValues(values);
                 }
             } finally {
                 table.EndLoadData();
@@ -62,61 +64,130 @@ namespace OfficeIMO.Excel {
         }
 
         private sealed class ObjectRowProjector {
-            private readonly string[] _columns;
-            private readonly PropertyInfo[]? _properties;
-            private readonly Type? _sourceType;
+            private static readonly ConcurrentDictionary<Type, CachedObjectRowProjection> TypedProjectionCache = new();
 
-            private ObjectRowProjector(IReadOnlyList<string> columns, PropertyInfo[]? properties, Type? sourceType) {
-                _columns = columns.ToArray();
-                _properties = properties;
+            private readonly string[] _columns;
+            private readonly Dictionary<string, int>? _ordinalColumnIndexes;
+            private readonly Dictionary<string, int>? _ignoreCaseColumnIndexes;
+            private readonly ObjectValueGetter[]? _getters;
+            private readonly Type? _sourceType;
+            private int[]? _sparseTouchedColumns;
+            private byte[]? _sparseColumnStates;
+            private int _sparseTouchedCount;
+            private bool _valuesReadyForSparseProjection;
+
+            private ObjectRowProjector(string[] columns, ObjectValueGetter[]? getters, Type? sourceType, bool createOrdinalColumnIndexes) {
+                _columns = columns;
+                _ordinalColumnIndexes = createOrdinalColumnIndexes ? CreateOrdinalColumnIndexes(columns) : null;
+                _ignoreCaseColumnIndexes = createOrdinalColumnIndexes ? CreateIgnoreCaseColumnIndexes(columns) : null;
+                _getters = getters;
                 _sourceType = sourceType;
             }
 
             internal static ObjectRowProjector Create(object first, IReadOnlyList<string> columns) {
                 var firstType = first.GetType();
                 if (IsDictionaryLike(first)) {
-                    return new ObjectRowProjector(columns, properties: null, sourceType: null);
+                    return new ObjectRowProjector(columns.ToArray(), getters: null, sourceType: null, createOrdinalColumnIndexes: true);
                 }
 
-                var properties = new PropertyInfo[columns.Count];
+                var cachedProjection = TypedProjectionCache.GetOrAdd(firstType, type => CreateCachedProjection(type, columns));
+                if (ColumnsMatch(cachedProjection.Columns, columns)) {
+                    return new ObjectRowProjector(cachedProjection.Columns, cachedProjection.Getters, firstType, createOrdinalColumnIndexes: false);
+                }
+
+                var getters = CreateGetters(firstType, columns);
+                if (getters == null) {
+                    return new ObjectRowProjector(columns.ToArray(), getters: null, sourceType: null, createOrdinalColumnIndexes: false);
+                }
+
+                return new ObjectRowProjector(columns.ToArray(), getters, firstType, createOrdinalColumnIndexes: false);
+            }
+
+            private static CachedObjectRowProjection CreateCachedProjection(Type firstType, IReadOnlyList<string> columns) {
+                var getters = CreateGetters(firstType, columns);
+                return new CachedObjectRowProjection(columns.ToArray(), getters);
+            }
+
+            private static ObjectValueGetter[]? CreateGetters(Type firstType, IReadOnlyList<string> columns) {
+                var getters = new ObjectValueGetter[columns.Count];
                 for (int i = 0; i < columns.Count; i++) {
                     var property = firstType.GetProperty(columns[i], BindingFlags.Public | BindingFlags.Instance);
                     if (property == null || !property.CanRead || property.GetIndexParameters().Length != 0) {
-                        return new ObjectRowProjector(columns, properties: null, sourceType: null);
+                        return null;
                     }
 
-                    properties[i] = property;
+                    getters[i] = CreateObjectValueGetter(property);
                 }
 
-                return new ObjectRowProjector(columns, properties, firstType);
+                return getters;
+            }
+
+            private static bool ColumnsMatch(string[] cachedColumns, IReadOnlyList<string> columns) {
+                if (cachedColumns.Length != columns.Count) {
+                    return false;
+                }
+
+                for (int i = 0; i < cachedColumns.Length; i++) {
+                    if (!string.Equals(cachedColumns[i], columns[i], StringComparison.Ordinal)) {
+                        return false;
+                    }
+                }
+
+                return true;
             }
 
             internal object?[] CreateValuesBuffer() => new object?[_columns.Length];
 
             internal void FillValues(object item, object?[] values) {
+                _sparseTouchedCount = 0;
                 if (TryFillDictionaryValues(item, values)) {
                     return;
                 }
 
-                if (_properties != null && item.GetType() == _sourceType) {
-                    for (int i = 0; i < _properties.Length; i++) {
-                        values[i] = _properties[i].GetValue(item) ?? DBNull.Value;
+                if (_getters != null && item.GetType() == _sourceType) {
+                    for (int i = 0; i < _getters.Length; i++) {
+                        values[i] = _getters[i](item) ?? DBNull.Value;
                     }
 
+                    _valuesReadyForSparseProjection = false;
                     return;
                 }
 
                 for (int i = 0; i < _columns.Length; i++) {
                     values[i] = ObjectDataHelpers.GetValue(item, _columns[i]) ?? DBNull.Value;
                 }
+
+                _valuesReadyForSparseProjection = false;
+            }
+
+            internal void ResetValues(object?[] values) {
+                if (_sparseTouchedCount == 0) {
+                    return;
+                }
+
+                for (int i = 0; i < _sparseTouchedCount; i++) {
+                    int columnIndex = _sparseTouchedColumns![i];
+                    values[columnIndex] = DBNull.Value;
+                    if (_sparseColumnStates != null) {
+                        _sparseColumnStates[columnIndex] = 0;
+                    }
+                }
+
+                _sparseTouchedCount = 0;
             }
 
             private bool TryFillDictionaryValues(object item, object?[] values) {
                 if (item is Dictionary<string, object?> exactDictionary) {
+                    if (CanUseOrdinalEntryProjection(exactDictionary.Comparer)
+                        && TryFillSparseDictionaryValues(exactDictionary, values)) {
+                        return true;
+                    }
+
                     for (int i = 0; i < _columns.Length; i++) {
                         values[i] = exactDictionary.TryGetValue(_columns[i], out var value) ? value ?? DBNull.Value : DBNull.Value;
                     }
 
+                    _valuesReadyForSparseProjection = false;
                     return true;
                 }
 
@@ -125,6 +196,7 @@ namespace OfficeIMO.Excel {
                         values[i] = readOnlyDictionary.TryGetValue(_columns[i], out var value) ? value ?? DBNull.Value : DBNull.Value;
                     }
 
+                    _valuesReadyForSparseProjection = false;
                     return true;
                 }
 
@@ -133,18 +205,121 @@ namespace OfficeIMO.Excel {
                         values[i] = dictionary.TryGetValue(_columns[i], out var value) ? value ?? DBNull.Value : DBNull.Value;
                     }
 
+                    _valuesReadyForSparseProjection = false;
                     return true;
                 }
 
                 if (item is System.Collections.IDictionary legacyDictionary) {
+                    if (TryFillSparseLegacyDictionaryValues(legacyDictionary, values)) {
+                        return true;
+                    }
+
                     for (int i = 0; i < _columns.Length; i++) {
                         values[i] = GetLegacyDictionaryValue(legacyDictionary, _columns[i]) ?? DBNull.Value;
                     }
 
+                    _valuesReadyForSparseProjection = false;
                     return true;
                 }
 
                 return false;
+            }
+
+            private bool TryFillSparseDictionaryValues(IEnumerable<KeyValuePair<string, object?>> dictionary, object?[] values) {
+                if (_ordinalColumnIndexes == null || dictionary is ICollection<KeyValuePair<string, object?>> collection && collection.Count >= _columns.Length) {
+                    return false;
+                }
+
+                if (!_valuesReadyForSparseProjection) {
+                    FillDbNull(values);
+                    _valuesReadyForSparseProjection = true;
+                }
+
+                foreach (var entry in dictionary) {
+                    if (_ordinalColumnIndexes.TryGetValue(entry.Key, out int columnIndex)) {
+                        values[columnIndex] = entry.Value ?? DBNull.Value;
+                        TrackSparseTouchedColumn(columnIndex);
+                    }
+                }
+
+                return true;
+            }
+
+            private bool TryFillSparseLegacyDictionaryValues(System.Collections.IDictionary dictionary, object?[] values) {
+                if (_ordinalColumnIndexes == null
+                    || _ignoreCaseColumnIndexes == null
+                    || dictionary.Count >= _columns.Length) {
+                    return false;
+                }
+
+                if (!_valuesReadyForSparseProjection) {
+                    FillDbNull(values);
+                    _valuesReadyForSparseProjection = true;
+                }
+
+                _sparseColumnStates ??= new byte[_columns.Length];
+                foreach (System.Collections.DictionaryEntry entry in dictionary) {
+                    string key = entry.Key?.ToString() ?? string.Empty;
+                    if (_ordinalColumnIndexes.TryGetValue(key, out int exactColumnIndex)) {
+                        TrackSparseLegacyColumn(exactColumnIndex);
+                        values[exactColumnIndex] = entry.Value ?? DBNull.Value;
+                        _sparseColumnStates[exactColumnIndex] = 2;
+                        continue;
+                    }
+
+                    if (_ignoreCaseColumnIndexes.TryGetValue(key, out int ignoreCaseColumnIndex)
+                        && _sparseColumnStates[ignoreCaseColumnIndex] == 0) {
+                        TrackSparseLegacyColumn(ignoreCaseColumnIndex);
+                        values[ignoreCaseColumnIndex] = entry.Value ?? DBNull.Value;
+                        _sparseColumnStates[ignoreCaseColumnIndex] = 1;
+                    }
+                }
+
+                return true;
+            }
+
+            private void TrackSparseTouchedColumn(int columnIndex) {
+                _sparseTouchedColumns ??= new int[_columns.Length];
+                _sparseTouchedColumns[_sparseTouchedCount++] = columnIndex;
+            }
+
+            private void TrackSparseLegacyColumn(int columnIndex) {
+                if (_sparseColumnStates![columnIndex] != 0) {
+                    return;
+                }
+
+                TrackSparseTouchedColumn(columnIndex);
+            }
+
+            private static Dictionary<string, int> CreateOrdinalColumnIndexes(string[] columns) {
+                var indexes = new Dictionary<string, int>(columns.Length, StringComparer.Ordinal);
+                for (int i = 0; i < columns.Length; i++) {
+                    indexes[columns[i]] = i;
+                }
+
+                return indexes;
+            }
+
+            private static Dictionary<string, int> CreateIgnoreCaseColumnIndexes(string[] columns) {
+                var indexes = new Dictionary<string, int>(columns.Length, StringComparer.OrdinalIgnoreCase);
+                for (int i = 0; i < columns.Length; i++) {
+                    if (!indexes.ContainsKey(columns[i])) {
+                        indexes.Add(columns[i], i);
+                    }
+                }
+
+                return indexes;
+            }
+
+            private static void FillDbNull(object?[] values) {
+                for (int i = 0; i < values.Length; i++) {
+                    values[i] = DBNull.Value;
+                }
+            }
+
+            private static bool CanUseOrdinalEntryProjection(IEqualityComparer<string> comparer) {
+                return ReferenceEquals(comparer, EqualityComparer<string>.Default)
+                    || ReferenceEquals(comparer, StringComparer.Ordinal);
             }
 
             private static object? GetLegacyDictionaryValue(System.Collections.IDictionary dictionary, string column) {
@@ -168,7 +343,43 @@ namespace OfficeIMO.Excel {
                     || item is IDictionary<string, object?>
                     || item is System.Collections.IDictionary;
             }
+
+            private static ObjectValueGetter CreateObjectValueGetter(PropertyInfo property) {
+                MethodInfo? getMethod = property.GetMethod;
+                if (getMethod == null || property.DeclaringType == null) {
+                    return row => property.GetValue(row, null);
+                }
+
+                try {
+                    return (ObjectValueGetter)CreateObjectValueGetterMethod
+                        .MakeGenericMethod(property.DeclaringType, property.PropertyType)
+                        .Invoke(null, new object[] { getMethod })!;
+                } catch {
+                    return row => property.GetValue(row, null);
+                }
+            }
+
+            private static readonly MethodInfo CreateObjectValueGetterMethod =
+                typeof(ObjectRowProjector).GetMethod(nameof(CreateObjectValueGetterCore), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+            private static ObjectValueGetter CreateObjectValueGetterCore<TTarget, TValue>(MethodInfo getMethod) {
+                var getter = (Func<TTarget, TValue>)Delegate.CreateDelegate(typeof(Func<TTarget, TValue>), getMethod);
+                return row => getter((TTarget)row!);
+            }
+
+            private sealed class CachedObjectRowProjection {
+                internal CachedObjectRowProjection(string[] columns, ObjectValueGetter[]? getters) {
+                    Columns = columns;
+                    Getters = getters;
+                }
+
+                internal string[] Columns { get; }
+
+                internal ObjectValueGetter[]? Getters { get; }
+            }
         }
+
+        private delegate object? ObjectValueGetter(object row);
 
     }
 }

--- a/OfficeIMO.Excel/Utilities/ObjectFlattener.cs
+++ b/OfficeIMO.Excel/Utilities/ObjectFlattener.cs
@@ -132,15 +132,24 @@ namespace OfficeIMO.Excel {
     /// Flattens objects to a dictionary of dotted-path keys to values suitable for table generation.
     /// </summary>
     public class ObjectFlattener {
-        private static readonly ConcurrentDictionary<Type, PropertyInfo[]> _cache = new();
+        private static readonly ConcurrentDictionary<Type, ObjectFlattenerProperty[]> _propertyCache = new();
+        private static readonly ConcurrentDictionary<CollectionMapAccessorKey, CollectionMapAccessors> _collectionMapAccessorCache = new();
+        private static readonly ConcurrentDictionary<Type, FieldInfo[]> _valueTupleFieldCache = new();
+        private static readonly Type? _iTupleType = Type.GetType("System.Runtime.CompilerServices.ITuple");
+        private static readonly PropertyInfo? _iTupleLengthProperty = _iTupleType?.GetProperty("Length");
+        private static readonly PropertyInfo? _iTupleItemProperty = _iTupleType?.GetProperty("Item");
 
         /// <summary>
         /// Flattens <paramref name="item"/> into a dictionary according to <paramref name="opts"/>.
         /// </summary>
         public Dictionary<string, object?> Flatten<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(T item, ObjectFlattenerOptions opts) {
-            var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-            if (item == null) return result;
-            FlattenInternal(item!, result, string.Empty, 0, opts);
+            if (item == null) {
+                return new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            object source = item!;
+            var result = new Dictionary<string, object?>(GetInitialFlattenCapacity(source.GetType(), opts), StringComparer.OrdinalIgnoreCase);
+            FlattenInternal(source, result, string.Empty, 0, opts);
             return result;
         }
 
@@ -148,28 +157,29 @@ namespace OfficeIMO.Excel {
         /// Computes all reachable dotted paths for a given <paramref name="type"/> under <paramref name="opts"/>.
         /// </summary>
         public List<string> GetPaths([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] Type type, ObjectFlattenerOptions opts) {
-            var paths = new List<string>();
+            var paths = new List<string>(GetInitialFlattenCapacity(type, opts));
             BuildPaths(type, string.Empty, 0, opts, paths);
-            // Apply prefix-based ignore first
-            var filtered = paths
-                .Where(p => !opts.Ignore.Any(i => p.StartsWith(i, StringComparison.OrdinalIgnoreCase)))
-                .ToList();
+            var filtered = opts.IncludeProperties.Length == 0 && opts.ExcludeProperties.Length == 0
+                ? paths
+                : ApplySelection(paths, opts);
+            return (opts.PinnedFirst == null || opts.PinnedFirst.Length == 0)
+                   && (opts.PinnedLast == null || opts.PinnedLast.Length == 0)
+                   && opts.PropertyPriority.Count == 0
+                ? filtered
+                : ApplyOrdering(filtered, opts);
+        }
 
-            // Apply property-name based excludes
-            if (opts.ExcludeProperties.Length > 0) {
-                var ex = new HashSet<string>(opts.ExcludeProperties, StringComparer.OrdinalIgnoreCase);
-                filtered = filtered.Where(p => !ex.Contains(p) && !ex.Contains(LastSegment(p))).ToList();
+        private static int GetInitialFlattenCapacity(Type type, ObjectFlattenerOptions opts) {
+            if (opts.Columns != null && opts.Columns.Length > 0) {
+                return opts.Columns.Length;
             }
 
-            // Apply property-name based includes (acts as a filter if provided)
-            if (opts.IncludeProperties.Length > 0) {
-                var inc = new HashSet<string>(opts.IncludeProperties, StringComparer.OrdinalIgnoreCase);
-                filtered = filtered.Where(p => inc.Contains(p) || inc.Contains(LastSegment(p))).ToList();
+            if (IsValueTuple(type)) {
+                int fieldCount = GetValueTupleFields(type).Length;
+                return fieldCount > 0 ? fieldCount : type.IsGenericType ? type.GetGenericArguments().Length : 0;
             }
 
-            // Apply ordering preferences
-            filtered = ApplyOrdering(filtered, opts);
-            return filtered;
+            return GetObjectFlattenerProperties(type).Length;
         }
 
         private static void FlattenInternal(object obj, Dictionary<string, object?> dict, string prefix, int depth, ObjectFlattenerOptions opts) {
@@ -183,12 +193,16 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
-            var props = _cache.GetOrAdd(type, t => t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                                                                .OrderBy(p => p.MetadataToken).ToArray());
+            var props = GetObjectFlattenerProperties(type);
+            if (opts.ExpandProperties.Count == 0) {
+                FlattenInternalWithoutExpansion(obj, dict, prefix, opts, props);
+                return;
+            }
+
             foreach (var prop in props) {
                 var value = prop.GetValue(obj);
                 var path = string.IsNullOrEmpty(prefix) ? prop.Name : prefix + "." + prop.Name;
-                if (opts.Ignore.Any(i => path.StartsWith(i, StringComparison.OrdinalIgnoreCase))) continue;
+                if (ShouldIgnorePath(path, opts.Ignore)) continue;
 
                 bool expand = opts.ExpandProperties.Contains(prop.Name) || opts.ExpandProperties.Contains(path);
                 bool isCollection = value is IEnumerable && value is not string;
@@ -232,32 +246,26 @@ namespace OfficeIMO.Excel {
 
         private static void FlattenValueTuple(object obj, Dictionary<string, object?> dict, string prefix, int depth, ObjectFlattenerOptions opts) {
             // Try ITuple via reflection (available on newer frameworks). Avoids compile-time dependency for netstandard2.0
-            var iTupleType = Type.GetType("System.Runtime.CompilerServices.ITuple");
-            if (iTupleType != null && iTupleType.IsAssignableFrom(obj.GetType())) {
-                var lenProp = iTupleType.GetProperty("Length");
-                var itemProp = iTupleType.GetProperty("Item"); // indexer
-                if (lenProp != null && itemProp != null) {
-                    int length = Convert.ToInt32(lenProp.GetValue(obj, null));
-                    for (int i = 0; i < length; i++) {
-                        var path = string.IsNullOrEmpty(prefix) ? $"Item{i + 1}" : $"{prefix}.Item{i + 1}";
-                        var val = itemProp.GetValue(obj, new object[] { i });
-                        if (val == null) {
-                            dict[path] = ApplyNullPolicy(path, null, opts);
-                        } else if (IsSimple(val.GetType())) {
-                            dict[path] = ApplyFormatting(path, val, opts);
-                        } else {
-                            FlattenInternal(val, dict, path, depth + 1, opts);
-                        }
+            if (_iTupleType != null && _iTupleLengthProperty != null && _iTupleItemProperty != null && _iTupleType.IsAssignableFrom(obj.GetType())) {
+                int length = Convert.ToInt32(_iTupleLengthProperty.GetValue(obj, null));
+                var indexArguments = new object[1];
+                for (int i = 0; i < length; i++) {
+                    var path = string.IsNullOrEmpty(prefix) ? $"Item{i + 1}" : $"{prefix}.Item{i + 1}";
+                    indexArguments[0] = i;
+                    var val = _iTupleItemProperty.GetValue(obj, indexArguments);
+                    if (val == null) {
+                        dict[path] = ApplyNullPolicy(path, null, opts);
+                    } else if (IsSimple(val.GetType())) {
+                        dict[path] = ApplyFormatting(path, val, opts);
+                    } else {
+                        FlattenInternal(val, dict, path, depth + 1, opts);
                     }
-                    return;
                 }
+                return;
             }
 
             // Fallback: reflect public instance fields Item1..ItemN
-            var fields = obj.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance)
-                .Where(f => f.Name.StartsWith("Item", StringComparison.Ordinal))
-                .OrderBy(f => f.Name, StringComparer.Ordinal)
-                .ToArray();
+            var fields = GetValueTupleFields(obj.GetType());
             int idx = 1;
             foreach (var f in fields) {
                 var path = string.IsNullOrEmpty(prefix) ? $"Item{idx}" : $"{prefix}.Item{idx}";
@@ -274,22 +282,51 @@ namespace OfficeIMO.Excel {
         }
 
         private static void MapCollectionToColumns(string basePath, IEnumerable enumerable, CollectionColumnMapping map, Dictionary<string, object?> dict, ObjectFlattenerOptions opts) {
+            Type? lastType = null;
+            CollectionMapAccessors? lastAccessors = null;
             foreach (var item in enumerable) {
                 if (item == null) continue;
-                var t = item.GetType();
-                var keyProp = t.GetProperty(map.KeyProperty);
-                var valProp = t.GetProperty(map.ValueProperty);
-                if (keyProp == null || valProp == null) continue;
+                Type itemType = item.GetType();
+                var accessors = itemType == lastType
+                    ? lastAccessors!
+                    : GetCollectionMapAccessors(itemType, map);
+                lastType = itemType;
+                lastAccessors = accessors;
+                if (!accessors.IsValid) continue;
 
-                var keyObj = keyProp.GetValue(item);
+                var keyObj = accessors.GetKey(item);
                 if (keyObj == null) continue;
                 var key = keyObj.ToString() ?? string.Empty;
                 if (string.IsNullOrWhiteSpace(key)) continue;
 
                 var colPath = basePath + "." + key;
-                if (opts.Ignore.Any(i => colPath.StartsWith(i, StringComparison.OrdinalIgnoreCase))) continue;
-                var value = valProp.GetValue(item);
+                if (ShouldIgnorePath(colPath, opts.Ignore)) continue;
+                var value = accessors.GetValue(item);
                 dict[colPath] = ApplyFormatting(colPath, value, opts);
+            }
+        }
+
+        private static void FlattenInternalWithoutExpansion(object obj, Dictionary<string, object?> dict, string prefix, ObjectFlattenerOptions opts, ObjectFlattenerProperty[] props) {
+            foreach (var prop in props) {
+                var value = prop.GetValue(obj);
+                var path = string.IsNullOrEmpty(prefix) ? prop.Name : prefix + "." + prop.Name;
+                if (ShouldIgnorePath(path, opts.Ignore)) continue;
+
+                if (value == null) {
+                    dict[path] = ApplyNullPolicy(path, null, opts);
+                    continue;
+                }
+
+                if (value is IEnumerable enumerable && value is not string) {
+                    if (opts.CollectionMapColumns.TryGetValue(path, out var map)) {
+                        MapCollectionToColumns(path, enumerable, map, dict, opts);
+                    } else {
+                        dict[path] = HandleCollection(path, enumerable, opts);
+                    }
+                    continue;
+                }
+
+                dict[path] = ApplyFormatting(path, value, opts);
             }
         }
 
@@ -297,23 +334,28 @@ namespace OfficeIMO.Excel {
             if (depth >= opts.MaxDepth) return;
             if (IsValueTuple(type)) {
                 // Prefer counting actual Item* fields for precision (covers non-generic System.ValueTuple)
-                int itemCount = objFieldCount(type);
+                int itemCount = GetValueTupleFields(type).Length;
                 // If field count is 0 but the type is generic, fall back to generic arity (covers ITuple-backed cases)
                 if (itemCount == 0 && type.IsGenericType)
                     itemCount = type.GetGenericArguments().Length;
 
                 for (int i = 1; i <= itemCount; i++) {
                     var path = string.IsNullOrEmpty(prefix) ? $"Item{i}" : $"{prefix}.Item{i}";
-                    if (!opts.Ignore.Any(x => path.StartsWith(x, StringComparison.OrdinalIgnoreCase)))
+                    if (!ShouldIgnorePath(path, opts.Ignore))
                         paths.Add(path);
                 }
                 return;
             }
-            var props = _cache.GetOrAdd(type, t => t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                                                   .OrderBy(p => p.MetadataToken).ToArray());
+
+            var props = GetObjectFlattenerProperties(type);
+            if (opts.ExpandProperties.Count == 0) {
+                BuildPathsWithoutExpansion(prefix, opts, paths, props);
+                return;
+            }
+
             foreach (var prop in props) {
                 var path = string.IsNullOrEmpty(prefix) ? prop.Name : prefix + "." + prop.Name;
-                if (opts.Ignore.Any(i => path.StartsWith(i, StringComparison.OrdinalIgnoreCase))) continue;
+                if (ShouldIgnorePath(path, opts.Ignore)) continue;
                 bool expand = opts.ExpandProperties.Contains(prop.Name) || opts.ExpandProperties.Contains(path);
                 bool isCollection = typeof(IEnumerable).IsAssignableFrom(prop.PropertyType) && prop.PropertyType != typeof(string);
                 if (isCollection) {
@@ -329,12 +371,17 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static int objFieldCount(Type valueTupleType) {
+        private static FieldInfo[] GetValueTupleFields(Type valueTupleType)
+            => _valueTupleFieldCache.GetOrAdd(valueTupleType, CreateValueTupleFields);
+
+        private static FieldInfo[] CreateValueTupleFields(Type valueTupleType) {
             try {
                 return valueTupleType
                     .GetFields(BindingFlags.Public | BindingFlags.Instance)
-                    .Count(f => f.Name.StartsWith("Item", StringComparison.Ordinal));
-            } catch { return 0; }
+                    .Where(f => f.Name.StartsWith("Item", StringComparison.Ordinal))
+                    .OrderBy(f => f.Name, StringComparer.Ordinal)
+                    .ToArray();
+            } catch { return Array.Empty<FieldInfo>(); }
         }
 
         private static object? HandleCollection(string path, IEnumerable enumerable, ObjectFlattenerOptions opts) {
@@ -390,57 +437,274 @@ namespace OfficeIMO.Excel {
             return type.IsPrimitive || type.IsEnum || type == typeof(string) || type == typeof(decimal) || type == typeof(DateTime) || type == typeof(DateTimeOffset) || type == typeof(TimeSpan) || type == typeof(Guid);
         }
 
+        private static bool ShouldIgnorePath(string path, string[] ignorePaths) {
+            for (int i = 0; i < ignorePaths.Length; i++) {
+                if (path.StartsWith(ignorePaths[i], StringComparison.OrdinalIgnoreCase)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static ObjectFlattenerProperty[] GetObjectFlattenerProperties(Type type)
+            => _propertyCache.GetOrAdd(type, CreateObjectFlattenerProperties);
+
+        private static CollectionMapAccessors GetCollectionMapAccessors(Type type, CollectionColumnMapping map) {
+            var key = new CollectionMapAccessorKey(type, map.KeyProperty, map.ValueProperty);
+            return _collectionMapAccessorCache.GetOrAdd(key, CreateCollectionMapAccessors);
+        }
+
+        private static CollectionMapAccessors CreateCollectionMapAccessors(CollectionMapAccessorKey key) {
+            var keyProperty = key.ItemType.GetProperty(key.KeyProperty);
+            var valueProperty = key.ItemType.GetProperty(key.ValueProperty);
+            if (keyProperty == null || valueProperty == null) {
+                return CollectionMapAccessors.Missing;
+            }
+
+            return new CollectionMapAccessors(
+                CreateObjectFlattenerPropertyGetter(keyProperty),
+                CreateObjectFlattenerPropertyGetter(valueProperty));
+        }
+
+        private static ObjectFlattenerProperty[] CreateObjectFlattenerProperties(Type type) {
+            var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .OrderBy(p => p.MetadataToken)
+                .ToArray();
+            var result = new ObjectFlattenerProperty[properties.Length];
+            for (int i = 0; i < properties.Length; i++) {
+                result[i] = new ObjectFlattenerProperty(properties[i], CreateObjectFlattenerPropertyGetter(properties[i]));
+            }
+
+            return result;
+        }
+
+        private static ObjectFlattenerPropertyGetter CreateObjectFlattenerPropertyGetter(PropertyInfo property) {
+            MethodInfo? getMethod = property.GetMethod;
+            if (getMethod == null || property.DeclaringType == null) {
+                return row => property.GetValue(row, null);
+            }
+
+            try {
+                return (ObjectFlattenerPropertyGetter)CreateObjectFlattenerPropertyGetterMethod
+                    .MakeGenericMethod(property.DeclaringType, property.PropertyType)
+                    .Invoke(null, new object[] { getMethod })!;
+            } catch {
+                return row => property.GetValue(row, null);
+            }
+        }
+
+        private static void BuildPathsWithoutExpansion(string prefix, ObjectFlattenerOptions opts, List<string> paths, ObjectFlattenerProperty[] props) {
+            foreach (var prop in props) {
+                var path = string.IsNullOrEmpty(prefix) ? prop.Name : prefix + "." + prop.Name;
+                if (!ShouldIgnorePath(path, opts.Ignore)) {
+                    paths.Add(path);
+                }
+            }
+        }
+
+        private static readonly MethodInfo CreateObjectFlattenerPropertyGetterMethod =
+            typeof(ObjectFlattener).GetMethod(nameof(CreateObjectFlattenerPropertyGetterCore), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        private static ObjectFlattenerPropertyGetter CreateObjectFlattenerPropertyGetterCore<TTarget, TValue>(MethodInfo getMethod) {
+            var getter = (Func<TTarget, TValue>)Delegate.CreateDelegate(typeof(Func<TTarget, TValue>), getMethod);
+            return row => getter((TTarget)row!);
+        }
+
         private static string LastSegment(string path) {
             if (string.IsNullOrEmpty(path)) return path;
             int i = path.LastIndexOf('.');
             return i >= 0 ? path.Substring(i + 1) : path;
         }
 
+        private static bool LastSegmentEquals(string path, string value) {
+            if (string.Equals(path, value, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+
+            int start = path.LastIndexOf('.') + 1;
+            if (start == 0 || path.Length - start != value.Length) {
+                return false;
+            }
+
+            return string.Compare(path, start, value, 0, value.Length, StringComparison.OrdinalIgnoreCase) == 0;
+        }
+
+        private sealed class ObjectFlattenerProperty {
+            private readonly ObjectFlattenerPropertyGetter _getter;
+
+            internal ObjectFlattenerProperty(PropertyInfo property, ObjectFlattenerPropertyGetter getter) {
+                Name = property.Name;
+                PropertyType = property.PropertyType;
+                _getter = getter;
+            }
+
+            internal string Name { get; }
+
+            internal Type PropertyType { get; }
+
+            internal object? GetValue(object source) => _getter(source);
+        }
+
+        private delegate object? ObjectFlattenerPropertyGetter(object row);
+
+        private readonly struct CollectionMapAccessorKey : IEquatable<CollectionMapAccessorKey> {
+            internal CollectionMapAccessorKey(Type itemType, string keyProperty, string valueProperty) {
+                ItemType = itemType;
+                KeyProperty = keyProperty;
+                ValueProperty = valueProperty;
+            }
+
+            internal Type ItemType { get; }
+
+            internal string KeyProperty { get; }
+
+            internal string ValueProperty { get; }
+
+            public bool Equals(CollectionMapAccessorKey other)
+                => ItemType == other.ItemType
+                   && string.Equals(KeyProperty, other.KeyProperty, StringComparison.Ordinal)
+                   && string.Equals(ValueProperty, other.ValueProperty, StringComparison.Ordinal);
+
+            public override bool Equals(object? obj)
+                => obj is CollectionMapAccessorKey other && Equals(other);
+
+            public override int GetHashCode() {
+                unchecked {
+                    int hash = ItemType.GetHashCode();
+                    hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(KeyProperty);
+                    hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(ValueProperty);
+                    return hash;
+                }
+            }
+        }
+
+        private sealed class CollectionMapAccessors {
+            internal static readonly CollectionMapAccessors Missing = new CollectionMapAccessors();
+
+            private readonly ObjectFlattenerPropertyGetter? _keyGetter;
+            private readonly ObjectFlattenerPropertyGetter? _valueGetter;
+
+            private CollectionMapAccessors() {
+            }
+
+            internal CollectionMapAccessors(ObjectFlattenerPropertyGetter keyGetter, ObjectFlattenerPropertyGetter valueGetter) {
+                _keyGetter = keyGetter;
+                _valueGetter = valueGetter;
+                IsValid = true;
+            }
+
+            internal bool IsValid { get; }
+
+            internal object? GetKey(object source) => _keyGetter!(source);
+
+            internal object? GetValue(object source) => _valueGetter!(source);
+        }
+
+        private readonly struct OrderedPath {
+            internal OrderedPath(string path, int originalIndex, int priority) {
+                Path = path;
+                OriginalIndex = originalIndex;
+                Priority = priority;
+            }
+
+            internal string Path { get; }
+
+            internal int OriginalIndex { get; }
+
+            internal int Priority { get; }
+        }
+
         internal static List<string> ApplyOrdering(List<string> input, ObjectFlattenerOptions opts) {
             if (input == null || input.Count == 0) return new List<string>();
 
+            if ((opts.PinnedFirst == null || opts.PinnedFirst.Length == 0)
+                && (opts.PinnedLast == null || opts.PinnedLast.Length == 0)
+                && opts.PropertyPriority.Count == 0) {
+                return new List<string>(input);
+            }
+
+            string[] pinnedFirst = opts.PinnedFirst ?? Array.Empty<string>();
+            string[] pinnedLast = opts.PinnedLast ?? Array.Empty<string>();
             var result = new List<string>(input.Count);
             var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             // 1) PinnedFirst in the given order
-            foreach (var pin in opts.PinnedFirst) {
-                var match = input.FirstOrDefault(p => string.Equals(p, pin, StringComparison.OrdinalIgnoreCase) ||
-                                                       string.Equals(LastSegment(p), pin, StringComparison.OrdinalIgnoreCase));
+            foreach (var pin in pinnedFirst) {
+                var match = input.FirstOrDefault(p => LastSegmentEquals(p, pin));
                 if (!string.IsNullOrEmpty(match) && set.Add(match)) result.Add(match);
             }
 
             // 2) Remaining, grouped by priority ascending
             int GetPriority(string path) {
-                var key = opts.PropertyPriority
-                    .FirstOrDefault(kv => string.Equals(kv.Key, path, StringComparison.OrdinalIgnoreCase) ||
-                                          string.Equals(LastSegment(path), kv.Key, StringComparison.OrdinalIgnoreCase)).Key;
-                if (!string.IsNullOrEmpty(key) && opts.PropertyPriority.TryGetValue(key, out var pr)) return pr;
+                if (opts.PropertyPriority.Count == 0) {
+                    return 0;
+                }
+
+                string segment = LastSegment(path);
+                bool hasPath = opts.PropertyPriority.TryGetValue(path, out int pathPriority);
+                int segmentPriority = 0;
+                bool hasSegment = !string.Equals(path, segment, StringComparison.Ordinal)
+                    && opts.PropertyPriority.TryGetValue(segment, out segmentPriority);
+
+                if (hasPath && hasSegment && pathPriority != segmentPriority) {
+                    foreach (var priority in opts.PropertyPriority) {
+                        if (string.Equals(priority.Key, path, StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(priority.Key, segment, StringComparison.OrdinalIgnoreCase)) {
+                            return priority.Value;
+                        }
+                    }
+                }
+
+                if (hasPath) return pathPriority;
+                if (hasSegment) return segmentPriority;
                 return 0;
             }
 
-            var remaining = input.Where(p => !set.Contains(p)).ToList();
-            var originalOrder = new Dictionary<string, int>(input.Count, StringComparer.Ordinal);
+            var remaining = new List<OrderedPath>(input.Count);
             for (int i = 0; i < input.Count; i++) {
-                if (!originalOrder.ContainsKey(input[i])) {
-                    originalOrder.Add(input[i], i);
+                string path = input[i];
+                if (pinnedFirst.Length != 0 && set.Contains(path)) {
+                    continue;
+                }
+
+                remaining.Add(new OrderedPath(path, i, GetPriority(path)));
+            }
+
+            remaining.Sort((left, right) => {
+                int priorityComparison = left.Priority.CompareTo(right.Priority);
+                return priorityComparison != 0
+                    ? priorityComparison
+                    : left.OriginalIndex.CompareTo(right.OriginalIndex);
+            });
+
+            // 3) PinnedLast moved to the end in the given order
+            if (pinnedLast.Length == 0) {
+                foreach (var ordered in remaining) if (set.Add(ordered.Path)) result.Add(ordered.Path);
+                return result;
+            }
+
+            var pinnedLastMatches = new List<string>(pinnedLast.Length);
+            foreach (var pin in pinnedLast) {
+                foreach (var ordered in remaining) {
+                    string path = ordered.Path;
+                    if (LastSegmentEquals(path, pin)) {
+                        pinnedLastMatches.Add(path);
+                        break;
+                    }
                 }
             }
 
-            var prioritized = remaining.OrderBy(p => GetPriority(p)).ThenBy(p => originalOrder[p]).ToList();
-
-            // 3) PinnedLast moved to the end in the given order
-            var pinnedLastMatches = new List<string>();
-            foreach (var pin in opts.PinnedLast ?? Array.Empty<string>()) {
-                var match = prioritized.FirstOrDefault(p => string.Equals(p, pin, StringComparison.OrdinalIgnoreCase) ||
-                                                            string.Equals(LastSegment(p), pin, StringComparison.OrdinalIgnoreCase));
-                if (!string.IsNullOrEmpty(match)) pinnedLastMatches.Add(match);
+            if (pinnedLastMatches.Count == 0) {
+                foreach (var ordered in remaining) if (set.Add(ordered.Path)) result.Add(ordered.Path);
+                return result;
             }
+
             // Remove pinned-last matches from prioritized
             var pinnedLastSet = new HashSet<string>(pinnedLastMatches, StringComparer.OrdinalIgnoreCase);
-            var prioritizedNoPinnedLast = prioritized.Where(p => !pinnedLastSet.Contains(p)).ToList();
 
             // Merge
-            foreach (var p in prioritizedNoPinnedLast) if (set.Add(p)) result.Add(p);
+            foreach (var ordered in remaining) if (!pinnedLastSet.Contains(ordered.Path) && set.Add(ordered.Path)) result.Add(ordered.Path);
             foreach (var p in pinnedLastMatches) if (set.Add(p)) result.Add(p);
 
             return result;
@@ -449,18 +713,40 @@ namespace OfficeIMO.Excel {
         internal static List<string> ApplySelection(List<string> input, ObjectFlattenerOptions opts) {
             if (input == null || input.Count == 0) return new List<string>();
 
-            var filtered = input
-                .Where(p => !opts.Ignore.Any(i => p.StartsWith(i, StringComparison.OrdinalIgnoreCase)))
-                .ToList();
-
-            if (opts.ExcludeProperties.Length > 0) {
-                var ex = new HashSet<string>(opts.ExcludeProperties, StringComparer.OrdinalIgnoreCase);
-                filtered = filtered.Where(p => !ex.Contains(p) && !ex.Contains(LastSegment(p))).ToList();
+            if (opts.Ignore.Length == 0
+                && opts.ExcludeProperties.Length == 0
+                && opts.IncludeProperties.Length == 0) {
+                return new List<string>(input);
             }
 
-            if (opts.IncludeProperties.Length > 0) {
-                var inc = new HashSet<string>(opts.IncludeProperties, StringComparer.OrdinalIgnoreCase);
-                filtered = filtered.Where(p => inc.Contains(p) || inc.Contains(LastSegment(p))).ToList();
+            HashSet<string>? exclude = opts.ExcludeProperties.Length > 0
+                ? new HashSet<string>(opts.ExcludeProperties, StringComparer.OrdinalIgnoreCase)
+                : null;
+            HashSet<string>? include = opts.IncludeProperties.Length > 0
+                ? new HashSet<string>(opts.IncludeProperties, StringComparer.OrdinalIgnoreCase)
+                : null;
+            var filtered = new List<string>(input.Count);
+            foreach (string path in input) {
+                if (ShouldIgnorePath(path, opts.Ignore)) {
+                    continue;
+                }
+
+                string? segment = null;
+                if (exclude != null) {
+                    segment = LastSegment(path);
+                    if (exclude.Contains(path) || exclude.Contains(segment)) {
+                        continue;
+                    }
+                }
+
+                if (include != null) {
+                    segment ??= LastSegment(path);
+                    if (!include.Contains(path) && !include.Contains(segment)) {
+                        continue;
+                    }
+                }
+
+                filtered.Add(path);
             }
 
             return filtered;

--- a/OfficeIMO.Tests/Excel.DataExchange.cs
+++ b/OfficeIMO.Tests/Excel.DataExchange.cs
@@ -35,6 +35,80 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_DataExchange_CsvImportKeepsRowsWiderThanHeader() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataExchange.CsvWideRows.xlsx");
+            const string csv = "Name\r\nAlpha,Extra\r\n";
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                string range = sheet.FromCsv(csv);
+                Assert.Equal("A1:B2", range);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelSheet sheet = document.GetSheet("Data");
+                DataTable table = sheet.ToDataTable("A1:B2");
+
+                Assert.Equal(new[] { "Name", "Column2" }, table.Columns.Cast<DataColumn>().Select(column => column.ColumnName).ToArray());
+                Assert.Equal("Alpha", table.Rows[0]["Name"]);
+                Assert.Equal("Extra", table.Rows[0]["Column2"]);
+            }
+        }
+
+        [Fact]
+        public void Test_DataExchange_CsvImportKeepsSparseRowsBlank() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataExchange.CsvSparseRows.xlsx");
+            const string csv = "Name,Value,Note\r\nAlpha,1\r\nBeta,,Done\r\n";
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                string range = sheet.FromCsv(csv);
+                Assert.Equal("A1:C3", range);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelSheet sheet = document.GetSheet("Data");
+                DataTable table = sheet.ToDataTable("A1:C3");
+
+                Assert.Equal("Alpha", table.Rows[0]["Name"]);
+                Assert.Equal("1", table.Rows[0]["Value"]);
+                Assert.Equal(string.Empty, table.Rows[0]["Note"]);
+                Assert.Equal("Beta", table.Rows[1]["Name"]);
+                Assert.Equal(string.Empty, table.Rows[1]["Value"]);
+                Assert.Equal("Done", table.Rows[1]["Note"]);
+            }
+        }
+
+        [Fact]
+        public void Test_DataExchange_CsvImportPlainRowsKeepTrailingEmptyFields() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataExchange.CsvPlainTrailingEmpty.xlsx");
+            const string csv = "Name,Value,Note,\r\nAlpha,1,,\r\nBeta,2,Done,\r\n";
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                string range = sheet.FromCsv(csv);
+                Assert.Equal("A1:D3", range);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelSheet sheet = document.GetSheet("Data");
+                DataTable table = sheet.ToDataTable("A1:D3");
+
+                Assert.Equal(new[] { "Name", "Value", "Note", "Column4" }, table.Columns.Cast<DataColumn>().Select(column => column.ColumnName).ToArray());
+                Assert.Equal("Alpha", table.Rows[0]["Name"]);
+                Assert.Equal("1", table.Rows[0]["Value"]);
+                Assert.Equal(string.Empty, table.Rows[0]["Note"]);
+                Assert.Equal(string.Empty, table.Rows[0]["Column4"]);
+                Assert.Equal("Beta", table.Rows[1]["Name"]);
+                Assert.Equal("Done", table.Rows[1]["Note"]);
+                Assert.Equal(string.Empty, table.Rows[1]["Column4"]);
+            }
+        }
+
+        [Fact]
         public void Test_DataExchange_JsonRoundTripUsesHeaderObjects() {
             string filePath = Path.Combine(_directoryWithFiles, "DataExchange.Json.xlsx");
             const string json = "[{\"Name\":\"Alpha\",\"Amount\":10,\"Active\":true},{\"Name\":\"Beta\",\"Amount\":20.5,\"Active\":false}]";
@@ -58,6 +132,104 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(10, rows[0].GetProperty("Amount").GetInt32());
                 Assert.True(rows[0].GetProperty("Active").GetBoolean());
                 Assert.Equal("Beta", rows[1].GetProperty("Name").GetString());
+            }
+        }
+
+        [Fact]
+        public void Test_DataExchange_JsonCustomOptionsStillApply() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataExchange.JsonOptions.xlsx");
+            const string json = "[{\"FirstName\":\"Alpha\"}]";
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.FromJson(json);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelSheet sheet = document.GetSheet("Data");
+                string exported = sheet.ToJson("A1:A2", jsonOptions: new JsonSerializerOptions {
+                    DictionaryKeyPolicy = JsonNamingPolicy.CamelCase
+                });
+
+                using JsonDocument parsed = JsonDocument.Parse(exported);
+                Assert.True(parsed.RootElement[0].TryGetProperty("firstName", out JsonElement firstName));
+                Assert.Equal("Alpha", firstName.GetString());
+            }
+        }
+
+        [Fact]
+        public void Test_DataExchange_JsonImportHandlesLateColumnsAndHeaderCasing() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataExchange.JsonLateColumns.xlsx");
+            const string json = "[{\"Name\":\"Alpha\"},{\"name\":\"Beta\",\"Score\":20}]";
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                string range = sheet.FromJson(json);
+                Assert.Equal("A1:B3", range);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelSheet sheet = document.GetSheet("Data");
+                DataTable table = sheet.ToDataTable("A1:B3");
+
+                Assert.Equal(new[] { "Name", "Score" }, table.Columns.Cast<DataColumn>().Select(column => column.ColumnName).ToArray());
+                Assert.Equal("Alpha", table.Rows[0]["Name"]);
+                Assert.Equal(string.Empty, table.Rows[0]["Score"]);
+                Assert.Equal("Beta", table.Rows[1]["Name"]);
+                Assert.Equal(20D, Convert.ToDouble(table.Rows[1]["Score"]));
+            }
+        }
+
+        [Fact]
+        public void Test_DataExchange_JsonImportHandlesSparseLateWideColumns() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataExchange.JsonSparseLateWideColumns.xlsx");
+            const string json = "[{\"Name\":\"Alpha\"},{\"Name\":\"Beta\",\"Metric25\":25},{\"Metric50\":50}]";
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                string range = sheet.FromJson(json);
+                Assert.Equal("A1:C4", range);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelSheet sheet = document.GetSheet("Data");
+                DataTable table = sheet.ToDataTable("A1:C4");
+
+                Assert.Equal(new[] { "Name", "Metric25", "Metric50" }, table.Columns.Cast<DataColumn>().Select(column => column.ColumnName).ToArray());
+                Assert.Equal("Alpha", table.Rows[0]["Name"]);
+                Assert.Equal(string.Empty, table.Rows[0]["Metric25"]);
+                Assert.Equal(string.Empty, table.Rows[0]["Metric50"]);
+                Assert.Equal("Beta", table.Rows[1]["Name"]);
+                Assert.Equal(25D, Convert.ToDouble(table.Rows[1]["Metric25"]));
+                Assert.Equal(string.Empty, table.Rows[1]["Metric50"]);
+                Assert.Equal(string.Empty, table.Rows[2]["Name"]);
+                Assert.Equal(string.Empty, table.Rows[2]["Metric25"]);
+                Assert.Equal(50D, Convert.ToDouble(table.Rows[2]["Metric50"]));
+            }
+        }
+
+        [Fact]
+        public void Test_DataExchange_JsonImportSparseRowsKeepLastDuplicateValue() {
+            string filePath = Path.Combine(_directoryWithFiles, "DataExchange.JsonSparseDuplicateValues.xlsx");
+            string columns = string.Join(",", Enumerable.Range(0, 40).Select(index => "\"Metric" + index + "\":" + index));
+            string json = "[{" + columns + "},{\"Metric0\":\"Keep\",\"metric0\":null,\"Metric39\":39}]";
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                string range = sheet.FromJson(json);
+                Assert.Equal("A1:AN3", range);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelSheet sheet = document.GetSheet("Data");
+                DataTable table = sheet.ToDataTable("A1:AN3");
+
+                Assert.Equal(string.Empty, table.Rows[1]["Metric0"]);
+                Assert.Equal(39D, Convert.ToDouble(table.Rows[1]["Metric39"]));
             }
         }
     }

--- a/OfficeIMO.Tests/Excel.Enums.cs
+++ b/OfficeIMO.Tests/Excel.Enums.cs
@@ -55,6 +55,50 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ObjectFlattenerApplySelectionCombinesIgnoreExcludeAndInclude() {
+            var input = new List<string> {
+                "Id",
+                "Details.Score",
+                "Details.Status",
+                "Details.Secret",
+                "Ignored.Value",
+                "Notes"
+            };
+            var opts = new ObjectFlattenerOptions {
+                Ignore = new[] { "Ignored" },
+                IncludeProperties = new[] { "Id", "Score", "Status", "Secret", "Value" },
+                ExcludeProperties = new[] { "Secret" }
+            };
+
+            var selected = ObjectFlattener.ApplySelection(input, opts);
+
+            Assert.Equal(new[] {
+                "Id",
+                "Details.Score",
+                "Details.Status"
+            }, selected);
+        }
+
+        [Fact]
+        public void ObjectFlattenerGetPathsAppliesSelectionAndOrdering() {
+            var flattener = new ObjectFlattener();
+            var opts = new ObjectFlattenerOptions {
+                IncludeProperties = new[] { "Id", "Score", "Status", "Secret", "Value" },
+                ExcludeProperties = new[] { "Secret" },
+                Ignore = new[] { "Ignored" }
+            }.PinFirst("Status").PinLast("Id");
+            opts.ExpandProperties.Add(nameof(ObjectFlattenerSelectionPathRow.Details));
+
+            var paths = flattener.GetPaths(typeof(ObjectFlattenerSelectionPathRow), opts);
+
+            Assert.Equal(new[] {
+                "Details.Status",
+                "Details.Score",
+                "Id"
+            }, paths);
+        }
+
+        [Fact]
         public void ObjectFlattenerJoinCollectionsPreservesNullAndEmptyItems() {
             var flattener = new ObjectFlattener();
             var values = flattener.Flatten(new ObjectFlattenerCollectionRow(), new ObjectFlattenerOptions());
@@ -63,10 +107,79 @@ namespace OfficeIMO.Tests {
             Assert.Equal(string.Empty, values["Empty"]);
         }
 
+        [Fact]
+        public void ObjectFlattenerCollectionMapColumnsPreservesDynamicColumns() {
+            var flattener = new ObjectFlattener();
+            var options = new ObjectFlattenerOptions();
+            options.CollectionMapColumns["Metrics"] = new CollectionColumnMapping {
+                KeyProperty = nameof(ObjectFlattenerMetric.Name),
+                ValueProperty = nameof(ObjectFlattenerMetric.Value)
+            };
+
+            var values = flattener.Flatten(new ObjectFlattenerMetricsRow(), options);
+
+            Assert.Equal(2, values["Metrics.HasMX"]);
+            Assert.Equal(4, values["Metrics.EffectiveSPFSends"]);
+            Assert.False(values.ContainsKey("Metrics."));
+        }
+
+        [Fact]
+        public void ObjectFlattenerValueTuplePreservesItemPaths() {
+            var flattener = new ObjectFlattener();
+            var options = new ObjectFlattenerOptions();
+
+            var values = flattener.Flatten((Name: "Alice", Age: 30), options);
+            var paths = flattener.GetPaths(typeof((string Name, int Age)), options);
+
+            Assert.Equal("Alice", values["Item1"]);
+            Assert.Equal(30, values["Item2"]);
+            Assert.Equal(new[] { "Item1", "Item2" }, paths);
+        }
+
         private sealed class ObjectFlattenerCollectionRow {
             public List<string?> Tags { get; } = new() { "a", null, "b" };
 
             public string[] Empty { get; } = Array.Empty<string>();
+        }
+
+        private sealed class ObjectFlattenerSelectionPathRow {
+            public int Id { get; set; }
+
+            public ObjectFlattenerSelectionDetails Details { get; set; } = new();
+
+            public ObjectFlattenerIgnoredDetails Ignored { get; set; } = new();
+        }
+
+        private sealed class ObjectFlattenerSelectionDetails {
+            public int Score { get; set; }
+
+            public string Status { get; set; } = string.Empty;
+
+            public string Secret { get; set; } = string.Empty;
+        }
+
+        private sealed class ObjectFlattenerIgnoredDetails {
+            public string Value { get; set; } = string.Empty;
+        }
+
+        private sealed class ObjectFlattenerMetricsRow {
+            public List<ObjectFlattenerMetric?> Metrics { get; } = new() {
+                new ObjectFlattenerMetric("HasMX", 2),
+                null,
+                new ObjectFlattenerMetric(string.Empty, 3),
+                new ObjectFlattenerMetric("EffectiveSPFSends", 4)
+            };
+        }
+
+        private sealed class ObjectFlattenerMetric {
+            public ObjectFlattenerMetric(string name, int value) {
+                Name = name;
+                Value = value;
+            }
+
+            public string Name { get; }
+
+            public int Value { get; }
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.ObjectDataTableBuilder.cs
+++ b/OfficeIMO.Tests/Excel.ObjectDataTableBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using OfficeIMO.Excel;
@@ -66,6 +67,68 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ObjectDataTableBuilder_FromSparseOrdinalDictionaries_PreservesBlanks() {
+            var first = new Dictionary<string, object?>();
+            for (int i = 0; i < 32; i++) {
+                first["Column" + i] = i == 0 ? "First" : null;
+            }
+
+            var second = new Dictionary<string, object?> {
+                ["Column0"] = "Second",
+                ["Column31"] = 31
+            };
+
+            var table = ObjectDataTableBuilder.FromObjects(new object?[] { first, second }, "Data");
+
+            Assert.Equal(32, table.Columns.Count);
+            Assert.Equal("First", table.Rows[0]["Column0"]);
+            Assert.Equal(DBNull.Value, table.Rows[0]["Column31"]);
+            Assert.Equal("Second", table.Rows[1]["Column0"]);
+            Assert.Equal(DBNull.Value, table.Rows[1]["Column1"]);
+            Assert.Equal(31, table.Rows[1]["Column31"]);
+        }
+
+        [Fact]
+        public void Test_ObjectDataTableBuilder_FromCaseInsensitiveDictionaries_UsesDictionaryComparer() {
+            var items = new[] {
+                new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) {
+                    ["Name"] = "A",
+                    ["Value"] = 1
+                },
+                new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) {
+                    ["name"] = "B",
+                    ["value"] = 2
+                }
+            };
+
+            var table = ObjectDataTableBuilder.FromObjects(items, "Data");
+
+            Assert.Equal("B", table.Rows[1]["Name"]);
+            Assert.Equal(2, table.Rows[1]["Value"]);
+        }
+
+        [Fact]
+        public void Test_ObjectDataTableBuilder_FromSparseHashtables_PreservesCaseInsensitiveLookupAndExactPrecedence() {
+            var first = new Hashtable();
+            for (int i = 0; i < 40; i++) {
+                first["Column" + i] = i;
+            }
+
+            var second = new Hashtable {
+                ["column0"] = "Insensitive",
+                ["Column0"] = "Exact",
+                ["column39"] = 39
+            };
+
+            var table = ObjectDataTableBuilder.FromObjects(new object?[] { first, second }, "Data");
+
+            Assert.Equal(40, table.Columns.Count);
+            Assert.Equal("Exact", table.Rows[1]["Column0"]);
+            Assert.Equal(DBNull.Value, table.Rows[1]["Column1"]);
+            Assert.Equal(39, table.Rows[1]["Column39"]);
+        }
+
+        [Fact]
         public void Test_ObjectDataTableBuilder_FromObjects_InheritedProperties() {
             var items = new InheritedObjectRow[] {
                 new() { Name = "A", Value = 1, Notes = "First" },
@@ -87,6 +150,10 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         public void Test_ObjectDataTableBuilder_FromObjects_HiddenDerivedPropertiesUseRuntimeMember() {
+            ObjectDataTableBuilder.FromObjects(new ObjectDataBaseRow[] {
+                new() { Name = "Warm", Value = 0 }
+            }, "Warmup");
+
             var items = new ObjectDataBaseRow[] {
                 new() { Name = "Base", Value = 1 },
                 new HiddenObjectRow { Name = "Derived", Value = 2 }

--- a/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
+++ b/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
@@ -2659,6 +2660,122 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PerformanceReview_InsertObjects_FlatDictionaryRowsUseDirectPackageWhenWorkbookIsClean() {
+            using var memory = new MemoryStream();
+            var rows = new List<Dictionary<string, object?>> {
+                new Dictionary<string, object?> {
+                    ["Name"] = "Alpha",
+                    ["Score"] = 10,
+                    ["Created"] = new DateTime(2026, 5, 19)
+                },
+                new Dictionary<string, object?> {
+                    ["Name"] = "Beta",
+                    ["Score"] = 20,
+                    ["Created"] = new DateTime(2026, 5, 20),
+                    ["Active"] = true
+                }
+            };
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertObjects(rows);
+
+                document.Save(memory);
+
+                Assert.Equal(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+                Assert.True(document.LastSaveDiagnostics.UsedFastPackageWriter);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+            var cells = worksheetPart.Worksheet.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+            Assert.Equal("Name", GetSpreadsheetCellText(spreadsheet, cells["A1"]));
+            Assert.Equal("Score", GetSpreadsheetCellText(spreadsheet, cells["B1"]));
+            Assert.Equal("Created", GetSpreadsheetCellText(spreadsheet, cells["C1"]));
+            Assert.Equal("Active", GetSpreadsheetCellText(spreadsheet, cells["D1"]));
+            Assert.Equal("Alpha", GetSpreadsheetCellText(spreadsheet, cells["A2"]));
+            Assert.Equal("10", cells["B2"].CellValue!.Text);
+            Assert.Equal(1U, cells["C2"].StyleIndex!.Value);
+            Assert.Equal(string.Empty, GetSpreadsheetCellText(spreadsheet, cells["D2"]));
+            Assert.Equal("Beta", GetSpreadsheetCellText(spreadsheet, cells["A3"]));
+            Assert.Equal("20", cells["B3"].CellValue!.Text);
+            Assert.Equal("1", cells["D3"].CellValue!.Text);
+            Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
+        }
+
+        [Fact]
+        public void PerformanceReview_InsertObjects_FlatDictionaryWideLateColumnsUseDirectPackageWhenWorkbookIsClean() {
+            using var memory = new MemoryStream();
+            var rows = new List<Dictionary<string, object?>> {
+                new Dictionary<string, object?> {
+                    ["Name"] = "Alpha"
+                },
+                new Dictionary<string, object?> {
+                    ["Name"] = "Beta"
+                }
+            };
+
+            for (int i = 1; i <= 32; i++) {
+                rows[1]["Metric" + i.ToString(CultureInfo.InvariantCulture)] = i;
+            }
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertObjects(rows);
+
+                document.Save(memory);
+
+                Assert.Equal(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+                Assert.True(document.LastSaveDiagnostics.UsedFastPackageWriter);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+            var cells = worksheetPart.Worksheet.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+            Assert.Equal("Name", GetSpreadsheetCellText(spreadsheet, cells["A1"]));
+            Assert.Equal("Metric32", GetSpreadsheetCellText(spreadsheet, cells["AG1"]));
+            Assert.Equal("Alpha", GetSpreadsheetCellText(spreadsheet, cells["A2"]));
+            Assert.Equal(string.Empty, GetSpreadsheetCellText(spreadsheet, cells["AG2"]));
+            Assert.Equal("Beta", GetSpreadsheetCellText(spreadsheet, cells["A3"]));
+            Assert.Equal("32", cells["AG3"].CellValue!.Text);
+            Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
+        }
+
+        [Fact]
+        public void PerformanceReview_InsertObjects_FlatHashtableRowsUseDirectPackageWhenWorkbookIsClean() {
+            using var memory = new MemoryStream();
+            var rows = new List<Hashtable> {
+                new Hashtable {
+                    ["Name"] = "Alpha"
+                },
+                new Hashtable {
+                    ["Name"] = "Beta"
+                }
+            };
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertObjects(rows);
+
+                document.Save(memory);
+
+                Assert.Equal(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+                Assert.True(document.LastSaveDiagnostics.UsedFastPackageWriter);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+            var cells = worksheetPart.Worksheet.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+            Assert.Equal("Name", GetSpreadsheetCellText(spreadsheet, cells["A1"]));
+            Assert.Equal("Alpha", GetSpreadsheetCellText(spreadsheet, cells["A2"]));
+            Assert.Equal("Beta", GetSpreadsheetCellText(spreadsheet, cells["A3"]));
+            Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
+        }
+
+        [Fact]
         public void PerformanceReview_InsertObjects_ReflectionOverloadUsesDirectPackageWhenWorkbookIsClean() {
             using var memory = new MemoryStream();
             var rows = new[] {
@@ -2686,6 +2803,39 @@ namespace OfficeIMO.Tests {
             Assert.Equal("Alpha", cells["A2"].CellValue!.Text);
             Assert.Equal("10", cells["B2"].CellValue!.Text);
             Assert.Equal(1U, cells["C2"].StyleIndex!.Value);
+            Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
+        }
+
+        [Fact]
+        public void PerformanceReview_InsertObjects_ReflectionOverloadDirtyWorkbookPreservesSimpleRows() {
+            using var memory = new MemoryStream();
+            var rows = new[] {
+                new PerformanceObjectExportRow("Alpha", 10, new DateTime(2026, 5, 19)),
+                new PerformanceObjectExportRow("Beta", 20, new DateTime(2026, 5, 20))
+            };
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(5, 5, "Manual edit");
+                sheet.InsertObjects(rows);
+
+                document.Save(memory);
+
+                Assert.NotEqual(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var worksheet = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet!;
+            var cells = worksheet.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+            Assert.Equal("Name", GetSpreadsheetCellText(spreadsheet, cells["A1"]));
+            Assert.Equal("Score", GetSpreadsheetCellText(spreadsheet, cells["B1"]));
+            Assert.Equal("Created", GetSpreadsheetCellText(spreadsheet, cells["C1"]));
+            Assert.Equal("Alpha", GetSpreadsheetCellText(spreadsheet, cells["A2"]));
+            Assert.Equal("10", cells["B2"].CellValue!.Text);
+            Assert.Equal(1U, cells["C2"].StyleIndex!.Value);
+            Assert.Equal("Beta", GetSpreadsheetCellText(spreadsheet, cells["A3"]));
+            Assert.Equal("Manual edit", GetSpreadsheetCellText(spreadsheet, cells["E5"]));
             Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
         }
 
@@ -3002,6 +3152,40 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
                 Assert.True(document.LastSaveDiagnostics.UsedFastPackageWriter);
             }
+        }
+
+        [Fact]
+        public void PerformanceReview_FluentRowsFrom_DirtyWorkbookPreservesSimpleRows() {
+            using var memory = new MemoryStream();
+            var rows = new[] {
+                new PerformanceObjectExportRow("Alpha", 10, new DateTime(2026, 5, 19)),
+                new PerformanceObjectExportRow("Beta", 20, new DateTime(2026, 5, 20))
+            };
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                document.AsFluent()
+                    .Sheet("Data", sheet => sheet
+                        .Cell(5, 5, "Manual edit")
+                        .RowsFrom(rows))
+                    .End()
+                    .Save(memory);
+
+                Assert.NotEqual(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+            var cells = worksheetPart.Worksheet.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+            Assert.Equal("Name", GetSpreadsheetCellText(spreadsheet, cells["A1"]));
+            Assert.Equal("Score", GetSpreadsheetCellText(spreadsheet, cells["B1"]));
+            Assert.Equal("Created", GetSpreadsheetCellText(spreadsheet, cells["C1"]));
+            Assert.Equal("Alpha", GetSpreadsheetCellText(spreadsheet, cells["A2"]));
+            Assert.Equal("10", cells["B2"].CellValue!.Text);
+            Assert.Equal(1U, cells["C2"].StyleIndex!.Value);
+            Assert.Equal("Beta", GetSpreadsheetCellText(spreadsheet, cells["A3"]));
+            Assert.Equal("Manual edit", GetSpreadsheetCellText(spreadsheet, cells["E5"]));
+            Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
         }
 
         [Fact]
@@ -3557,6 +3741,59 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PerformanceReview_InsertDataReader_UsesBulkValueReadsWhenAvailable() {
+            using var memory = new MemoryStream();
+            var table = new DataTable("ReaderData");
+            table.Columns.Add("Name", typeof(string));
+            table.Columns.Add("Score", typeof(int));
+            table.Columns.Add("Note", typeof(string));
+            table.Rows.Add("Alpha", 10, "Ready");
+            table.Rows.Add("Beta", 20, DBNull.Value);
+
+            using var reader = new CountingDataReader(table.CreateDataReader());
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertDataReader(reader, tableName: "ReaderTable");
+                document.Save(memory);
+            }
+
+            Assert.Equal(2, reader.GetValuesCalls);
+            Assert.Equal(0, reader.GetValueCalls);
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet!.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+            Assert.Equal("Alpha", GetSpreadsheetCellText(spreadsheet, cells["A2"]));
+            Assert.Equal(string.Empty, cells["C3"].CellValue!.Text);
+        }
+
+        [Fact]
+        public void PerformanceReview_InsertDataReader_FallsBackWhenBulkValueReadsAreUnsupported() {
+            using var memory = new MemoryStream();
+            var table = new DataTable("ReaderData");
+            table.Columns.Add("Name", typeof(string));
+            table.Columns.Add("Score", typeof(int));
+            table.Rows.Add("Alpha", 10);
+            table.Rows.Add("Beta", 20);
+
+            using var reader = new CountingDataReader(table.CreateDataReader(), throwOnGetValues: true);
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertDataReader(reader, tableName: "ReaderTable");
+                document.Save(memory);
+            }
+
+            Assert.Equal(1, reader.GetValuesCalls);
+            Assert.Equal(4, reader.GetValueCalls);
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet!.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+            Assert.Equal("Beta", GetSpreadsheetCellText(spreadsheet, cells["A3"]));
+            Assert.Equal("20", cells["B3"].CellValue!.Text);
+        }
+
+        [Fact]
         public void PerformanceReview_WriteDataSet_ObjectColumnDateAndTimeValuesUseValueStyles() {
             using var memory = new MemoryStream();
             var dataSet = new DataSet();
@@ -3637,6 +3874,96 @@ namespace OfficeIMO.Tests {
             public IEnumerator<T> GetEnumerator() => throw new InvalidOperationException("RowsFrom direct-save path should use IReadOnlyList<T> indexing without snapshot enumeration.");
 
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        private sealed class CountingDataReader : IDataReader {
+            private readonly IDataReader _inner;
+            private readonly bool _throwOnGetValues;
+
+            internal CountingDataReader(IDataReader inner, bool throwOnGetValues = false) {
+                _inner = inner;
+                _throwOnGetValues = throwOnGetValues;
+            }
+
+            internal int GetValuesCalls { get; private set; }
+
+            internal int GetValueCalls { get; private set; }
+
+            public object this[int i] => _inner[i];
+
+            public object this[string name] => _inner[name];
+
+            public int Depth => _inner.Depth;
+
+            public bool IsClosed => _inner.IsClosed;
+
+            public int RecordsAffected => _inner.RecordsAffected;
+
+            public int FieldCount => _inner.FieldCount;
+
+            public void Close() => _inner.Close();
+
+            public void Dispose() => _inner.Dispose();
+
+            public bool GetBoolean(int i) => _inner.GetBoolean(i);
+
+            public byte GetByte(int i) => _inner.GetByte(i);
+
+            public long GetBytes(int i, long fieldOffset, byte[]? buffer, int bufferoffset, int length) => _inner.GetBytes(i, fieldOffset, buffer, bufferoffset, length);
+
+            public char GetChar(int i) => _inner.GetChar(i);
+
+            public long GetChars(int i, long fieldoffset, char[]? buffer, int bufferoffset, int length) => _inner.GetChars(i, fieldoffset, buffer, bufferoffset, length);
+
+            public IDataReader GetData(int i) => _inner.GetData(i);
+
+            public string GetDataTypeName(int i) => _inner.GetDataTypeName(i);
+
+            public DateTime GetDateTime(int i) => _inner.GetDateTime(i);
+
+            public decimal GetDecimal(int i) => _inner.GetDecimal(i);
+
+            public double GetDouble(int i) => _inner.GetDouble(i);
+
+            public Type GetFieldType(int i) => _inner.GetFieldType(i);
+
+            public float GetFloat(int i) => _inner.GetFloat(i);
+
+            public Guid GetGuid(int i) => _inner.GetGuid(i);
+
+            public short GetInt16(int i) => _inner.GetInt16(i);
+
+            public int GetInt32(int i) => _inner.GetInt32(i);
+
+            public long GetInt64(int i) => _inner.GetInt64(i);
+
+            public string GetName(int i) => _inner.GetName(i);
+
+            public int GetOrdinal(string name) => _inner.GetOrdinal(name);
+
+            public DataTable? GetSchemaTable() => _inner.GetSchemaTable();
+
+            public string GetString(int i) => _inner.GetString(i);
+
+            public object GetValue(int i) {
+                GetValueCalls++;
+                return _inner.GetValue(i);
+            }
+
+            public int GetValues(object[] values) {
+                GetValuesCalls++;
+                if (_throwOnGetValues) {
+                    throw new NotSupportedException();
+                }
+
+                return _inner.GetValues(values);
+            }
+
+            public bool IsDBNull(int i) => _inner.IsDBNull(i);
+
+            public bool NextResult() => _inner.NextResult();
+
+            public bool Read() => _inner.Read();
         }
 
         private static void RemoveFirstRowIndex(string filePath) {

--- a/OfficeIMO.Tests/Excel.RowsFromObjectsTests.cs
+++ b/OfficeIMO.Tests/Excel.RowsFromObjectsTests.cs
@@ -125,6 +125,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void RowsFrom_HeaderCaseTransformsNestedPaths() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            var data = new[] {
+                new Person { Name = "Alice", Address = new Address { City = "NY", Street = "1st" } }
+            };
+
+            using (var doc = ExcelDocument.Create(filePath)) {
+                doc.AsFluent()
+                    .Sheet("Pascal", s => s.RowsFrom(data, o => {
+                        o.ExpandProperties.Add(nameof(Person.Address));
+                        o.HeaderCase = HeaderCase.Pascal;
+                    }))
+                    .Sheet("Title", s => s.RowsFrom(data, o => {
+                        o.ExpandProperties.Add(nameof(Person.Address));
+                        o.HeaderCase = HeaderCase.Title;
+                    }))
+                    .End()
+                    .Save();
+            }
+
+            using (var document = SpreadsheetDocument.Open(filePath, false)) {
+                var workbookPart = document.WorkbookPart;
+                Assert.NotNull(workbookPart);
+                var sheets = workbookPart!.Workbook.Descendants<Sheet>().ToList();
+                var pascalPart = (WorksheetPart)workbookPart.GetPartById(sheets.First(s => s.Name == "Pascal").Id!.Value!);
+                var titlePart = (WorksheetPart)workbookPart.GetPartById(sheets.First(s => s.Name == "Title").Id!.Value!);
+
+                Assert.Equal("AddressCity", GetCellValue(document, pascalPart, "C1"));
+                Assert.Equal("Address City", GetCellValue(document, titlePart, "C1"));
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void RowsFrom_NullPolicyAndFormatter() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             var data = new[] {

--- a/OfficeIMO.Tests/Excel.SheetComposer.Report.cs
+++ b/OfficeIMO.Tests/Excel.SheetComposer.Report.cs
@@ -177,6 +177,38 @@ namespace OfficeIMO.Tests {
             File.Delete(filePath);
         }
 
+        [Fact]
+        public void Composer_ColumnTableFrom_SummarizeOverflowPreservesMoreColumn() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            var rows = new[] {
+                new WideComposerTableRow("Alpha", 10, 5, 7),
+                new WideComposerTableRow("Beta", 20, 6, 8)
+            };
+
+            using (var doc = ExcelDocument.Create(filePath)) {
+                doc.Compose("Report", c => {
+                    c.Columns(2, columns => {
+                        columns[0].TableFrom(rows, title: "Wide");
+                    }, columnWidth: 2, overflow: OverflowMode.Summarize);
+                    c.Finish(autoFitColumns: false);
+                });
+
+                doc.Save();
+            }
+
+            using (var ss = SpreadsheetDocument.Open(filePath, false)) {
+                var ws = ss.WorkbookPart!.WorksheetParts.First();
+                Assert.True(ws.TableDefinitionParts.Any());
+                Assert.Equal("Metric A", GetCellText(ss, ws, "A2"));
+                Assert.Equal("More", GetCellText(ss, ws, "B2"));
+                Assert.Equal("5", GetCellText(ss, ws, "A3"));
+                Assert.Contains("Name=Alpha", GetCellText(ss, ws, "B3"), StringComparison.Ordinal);
+                Assert.Contains("Score=10", GetCellText(ss, ws, "B3"), StringComparison.Ordinal);
+            }
+
+            File.Delete(filePath);
+        }
+
         private sealed class ComposerTableRow {
             public ComposerTableRow(string name, int score) {
                 Name = name;
@@ -186,6 +218,23 @@ namespace OfficeIMO.Tests {
             public string Name { get; }
 
             public int Score { get; }
+        }
+
+        private sealed class WideComposerTableRow {
+            public WideComposerTableRow(string name, int score, int metricA, int metricB) {
+                Name = name;
+                Score = score;
+                MetricA = metricA;
+                MetricB = metricB;
+            }
+
+            public string Name { get; }
+
+            public int Score { get; }
+
+            public int MetricA { get; }
+
+            public int MetricB { get; }
         }
 
         private sealed class ThrowOnEnumerateReadOnlyList<T> : System.Collections.Generic.IReadOnlyList<T> {


### PR DESCRIPTION
## Summary

Optimizes internal OfficeIMO.Excel data paths without changing the public API surface.

- speeds up typed object/DataTable projection through cached metadata, compiled getters, and lower-allocation flattening/order/filter paths
- improves dictionary, Hashtable, JSON, CSV, DataTable, DataReader, InsertObjects, RowsFrom, and SheetComposer hot paths
- adds benchmark/probe coverage and focused regression tests to lock behavior while keeping these changes invisible to callers

## Performance Evidence

Representative probes from the optimization pass:

- typed object DataTable build: cached projection path retained same output hash while reducing repeated reflection work
- flat dictionary InsertObjects direct path: direct package route added for flat dictionary and Hashtable rows
- ObjectFlattener ordering: priority-only path improved from 0.150 ms / 192.30 KB to 0.085 ms / 141.86 KB
- pinned ordering: improved from 4.341 ms / 12,585.51 KB to 3.167 ms / 894.88 KB
- GetPaths default route: reduced from 0.004 ms / 156.36 KB to 0.000 ms / 0 KB
- ValueTuple flattening: improved from 2359.434 us / 2,523,192 B to 659.414 us / 1,867,832 B
- SheetComposer summarize overflow: improved from 127258.887 us / 452,871,459 B to 13044.215 us / 34,906,983 B
- DataTable append-by-header mapping: improved from 10862.813 us / 8,922,457 B to 8107.233 us / 8,919,721 B

## Validation

- `dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --no-restore`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-build --filter "FullyQualifiedName~DataTableInsert|FullyQualifiedName~ObjectDataTableBuilder|FullyQualifiedName~DataExchange|FullyQualifiedName~ExcelRowsFromObjectsTests|FullyQualifiedName~ExcelSheetComposer|FullyQualifiedName~ExcelFluent|FullyQualifiedName~ObjectFlattener"`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-build --filter "FullyQualifiedName~Excel"`
- `git diff --cached --check`

The broad Excel-filter test run passed 829 tests with 1 existing skipped concurrency test.
