### PR TITLE
Optimize Excel object export buffers

### DIFF
--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.cs
@@ -486,6 +486,8 @@ namespace OfficeIMO.Excel {
                 bool canCancel = ct.CanBeCanceled;
                 int rowIndex = startRowIndex;
                 if (styleAttributes == null) {
+                    object?[] values = cellValueRows.Values;
+                    int rowOffset = 0;
                     for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
                         if (canCancel) {
                             ct.ThrowIfCancellationRequested();
@@ -499,16 +501,19 @@ namespace OfficeIMO.Excel {
                             writer.Write(cellReferencePrefixes[c]);
                             writer.Write(rowReference);
                             writer.Write('"');
-                            WriteCellValue(writer, cellValueRows.GetValue(sourceRowIndex, c), cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                            WriteCellValue(writer, values[rowOffset + c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
                         }
 
                         writer.Write("</row>");
                         rowIndex++;
+                        rowOffset += columnCount;
                     }
 
                     return;
                 }
 
+                object?[] styledValues = cellValueRows.Values;
+                int styledRowOffset = 0;
                 for (int sourceRowIndex = 0; sourceRowIndex < rowCount; sourceRowIndex++) {
                     if (canCancel) {
                         ct.ThrowIfCancellationRequested();
@@ -527,11 +532,12 @@ namespace OfficeIMO.Excel {
                             writer.Write(styleAttribute);
                         }
 
-                        WriteCellValue(writer, cellValueRows.GetValue(sourceRowIndex, c), cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteCellValue(writer, styledValues[styledRowOffset + c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
                     }
 
                     writer.Write("</row>");
                     rowIndex++;
+                    styledRowOffset += columnCount;
                 }
             }
 
@@ -975,9 +981,11 @@ namespace OfficeIMO.Excel {
                     bool canCancel = ct.CanBeCanceled;
                     for (int sheetIndex = 0; sheetIndex < model.Sheets.Count; sheetIndex++) {
                         var sheet = model.Sheets[sheetIndex];
-                        // Dictionary-backed exports already pay keyed lookup cost while writing; for these
-                        // workloads the shared-string prepass tends to add CPU/allocation and larger packages.
-                        if (sheet.Table.TryGetExactDictionaryRows(out _)
+                        // Direct cell-value and dictionary-backed exports already use compact internal buffers
+                        // or pay keyed lookup cost while writing; for these workloads the shared-string prepass
+                        // tends to add CPU/allocation without enough package-size benefit.
+                        if (sheet.Table.TryGetCellValueRows(out _)
+                            || sheet.Table.TryGetExactDictionaryRows(out _)
                             || sheet.Table.TryGetDictionaryRows(out _)
                             || sheet.Table.TryGetLegacyDictionaryRows(out _)) {
                             return null;

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
@@ -1499,23 +1499,26 @@ namespace OfficeIMO.Excel {
         }
 
         private readonly struct DirectCellValueRows {
-            private readonly object?[] _values;
-            private readonly int _columnCount;
-
             internal DirectCellValueRows(
                 object?[] values,
                 int columnCount,
                 int rowCount) {
-                _values = values;
-                _columnCount = columnCount;
+                Values = values;
+                ColumnCount = columnCount;
                 Count = rowCount;
             }
 
+            internal object?[] Values { get; }
+
+            internal int ColumnCount { get; }
+
             internal int Count { get; }
 
+            internal int GetRowOffset(int rowIndex) => rowIndex * ColumnCount;
+
             internal object? GetValue(int rowIndex, int columnIndex) {
-                int index = (rowIndex * _columnCount) + columnIndex;
-                return _values[index];
+                int index = GetRowOffset(rowIndex) + columnIndex;
+                return Values[index];
             }
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.cs
@@ -140,16 +140,16 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            object?[][]? values = null;
+            object?[]? values = null;
             if (!hasBlankDisplayHeader
                 && !HasDuplicateObjectExportHeaders(headers)
                 && CanRegisterDirectTabularSaveCandidate(startRow, 1, headers.Length)) {
                 Type?[] inferredColumnTypes;
-                values = CreateExplicitObjectExportRows(rows, selectors, out inferredColumnTypes);
+                values = CreateExplicitObjectExportCellValues(rows, selectors, out inferredColumnTypes);
                 try {
                     var columnTypes = CompleteObjectExportColumnTypes(inferredColumnTypes);
                     string directSaveRange = BuildObjectExportRange(startRow, headers.Length, rows.Count, includeHeaders);
-                    if (TryInsertRowsAsDeferredDirectSave(Name, headers, columnTypes, values, startRow, includeHeaders, directSaveRange)) {
+                    if (TryInsertCellValuesAsDeferredDirectSave(Name, headers, columnTypes, values, headers.Length, rows.Count, startRow, includeHeaders, directSaveRange)) {
                         return;
                     }
                 } catch {
@@ -170,9 +170,10 @@ namespace OfficeIMO.Excel {
             }
 
             if (values != null) {
-                foreach (object?[] rowValues in values) {
+                for (int r = 0; r < rows.Count; r++) {
+                    int rowOffset = r * headers.Length;
                     for (int c = 0; c < headers.Length; c++) {
-                        cells[cellIndex++] = (row, c + 1, rowValues[c] ?? string.Empty);
+                        cells[cellIndex++] = (row, c + 1, values[rowOffset + c] ?? string.Empty);
                     }
 
                     row++;
@@ -192,21 +193,19 @@ namespace OfficeIMO.Excel {
 
         private static object? NullObjectSelector<T>(T row) => null;
 
-        private static object?[][] CreateExplicitObjectExportRows<T>(
+        private static object?[] CreateExplicitObjectExportCellValues<T>(
             IReadOnlyList<T> rows,
             IReadOnlyList<Func<T, object?>> selectors,
             out Type?[] inferredColumnTypes) {
-            var values = new object?[rows.Count][];
+            var values = new object?[checked(rows.Count * selectors.Count)];
             inferredColumnTypes = new Type?[selectors.Count];
             for (int r = 0; r < rows.Count; r++) {
-                var rowValues = new object?[selectors.Count];
+                int rowOffset = r * selectors.Count;
                 for (int c = 0; c < selectors.Count; c++) {
                     object? value = selectors[c](rows[r]);
-                    rowValues[c] = value;
+                    values[rowOffset + c] = value;
                     UpdateObjectExportColumnType(inferredColumnTypes, c, value);
                 }
-
-                values[r] = rowValues;
             }
 
             return values;
@@ -254,6 +253,43 @@ namespace OfficeIMO.Excel {
                 columnNames,
                 columnTypes,
                 rows,
+                includeHeaders,
+                range);
+        }
+
+        private bool TryInsertCellValuesAsDeferredDirectSave(
+            string tableNameForModel,
+            IReadOnlyList<string> columnNames,
+            IReadOnlyList<Type> columnTypes,
+            object?[] values,
+            int columnCount,
+            int rowCount,
+            int startRow,
+            bool includeHeaders,
+            string range) {
+            if (columnNames == null) throw new ArgumentNullException(nameof(columnNames));
+            if (columnTypes == null) throw new ArgumentNullException(nameof(columnTypes));
+            if (values == null) throw new ArgumentNullException(nameof(values));
+            if (string.IsNullOrEmpty(range)) {
+                return false;
+            }
+
+            if (!CanRegisterDirectTabularSaveCandidate(startRow, 1, columnNames.Count)) {
+                return false;
+            }
+
+            if (HasDuplicateObjectExportHeaders(columnNames)) {
+                return false;
+            }
+
+            return _excelDocument.RegisterDeferredDirectCellValuesSaveCandidate(
+                this,
+                tableNameForModel,
+                columnNames,
+                columnTypes,
+                values,
+                columnCount,
+                rowCount,
                 includeHeaders,
                 range);
         }
@@ -350,23 +386,21 @@ namespace OfficeIMO.Excel {
             }
 
             SimpleObjectExportValueGetter[] getters = plan.Getters;
-            var values = new object?[rows.Count][];
+            var values = new object?[checked(rows.Count * getters.Length)];
             for (int r = 0; r < rows.Count; r++) {
                 object? row = rows[r];
                 if (row == null || requireRuntimeTypeCheck && row.GetType() != rowType) {
                     return false;
                 }
 
-                var rowValues = new object?[getters.Length];
+                int rowOffset = r * getters.Length;
                 for (int c = 0; c < getters.Length; c++) {
-                    rowValues[c] = getters[c](row);
+                    values[rowOffset + c] = getters[c](row);
                 }
-
-                values[r] = rowValues;
             }
 
             string range = BuildObjectExportRange(startRow, headers.Length, rows.Count, includeHeaders);
-            return TryInsertRowsAsDeferredDirectSave(Name, headers, plan.ColumnTypes, values, startRow, includeHeaders, range);
+            return TryInsertCellValuesAsDeferredDirectSave(Name, headers, plan.ColumnTypes, values, headers.Length, rows.Count, startRow, includeHeaders, range);
         }
 
         private bool TryInsertSimpleObjectRowsAsCellValues<T>(

--- a/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
+++ b/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
@@ -3023,6 +3023,35 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PerformanceReview_InsertObjects_ExplicitSelectorsSnapshotValuesBeforeDeferredSave() {
+            using var memory = new MemoryStream();
+            var rows = new[] {
+                new MutablePerformanceObjectExportRow { Name = "Alpha", Score = 10 }
+            };
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertObjects(rows,
+                    ("Name", row => row.Name),
+                    ("Score", row => row.Score));
+
+                rows[0].Name = "Changed";
+                rows[0].Score = 99;
+                document.Save(memory);
+
+                Assert.Equal(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+                Assert.True(document.LastSaveDiagnostics.UsedFastPackageWriter);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet!.Descendants<Cell>()
+                .ToDictionary(cell => cell.CellReference!.Value!);
+            Assert.Equal("Alpha", GetSpreadsheetCellText(spreadsheet, cells["A2"]));
+            Assert.Equal("10", cells["B2"].CellValue!.Text);
+        }
+
+        [Fact]
         public void PerformanceReview_InsertObjects_ExplicitSelectorsPreserveBlankHeaders() {
             using var memory = new MemoryStream();
             var rows = new[] {
@@ -3305,6 +3334,33 @@ namespace OfficeIMO.Tests {
             Assert.Equal("10", cells["B2"].CellValue!.Text);
             Assert.Equal(1U, cells["C2"].StyleIndex!.Value);
             Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
+        }
+
+        [Fact]
+        public void PerformanceReview_InsertObjects_ReflectionOverloadSnapshotsValuesBeforeDeferredSave() {
+            using var memory = new MemoryStream();
+            var rows = new[] {
+                new MutablePerformanceObjectExportRow { Name = "Alpha", Score = 10 }
+            };
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertObjects(rows);
+
+                rows[0].Name = "Changed";
+                rows[0].Score = 99;
+                document.Save(memory);
+
+                Assert.Equal(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+                Assert.True(document.LastSaveDiagnostics.UsedFastPackageWriter);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet!.Descendants<Cell>()
+                .ToDictionary(cell => cell.CellReference!.Value!);
+            Assert.Equal("Alpha", GetSpreadsheetCellText(spreadsheet, cells["A2"]));
+            Assert.Equal("10", cells["B2"].CellValue!.Text);
         }
 
         [Fact]
@@ -4641,6 +4697,12 @@ namespace OfficeIMO.Tests {
             public DateTime? Created { get; }
 
             public string Note { get; }
+        }
+
+        private sealed class MutablePerformanceObjectExportRow {
+            public string Name { get; set; } = string.Empty;
+
+            public int Score { get; set; }
         }
 
 #if NET6_0_OR_GREATER


### PR DESCRIPTION
## Summary
- route simple and explicit `InsertObjects` direct-save exports through a flat cell-value buffer instead of per-row object arrays
- let the direct package writer consume flat cell-value rows without per-cell row-offset lookup and skip the shared-string prepass for that compact object-export path
- add regression coverage proving deferred direct saves snapshot object values before caller mutations

## Validation
- `dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --framework net8.0 --no-restore`
- `dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --framework netstandard2.0 --no-restore`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-restore --filter "FullyQualifiedName~PerformanceReview_InsertObjects"`
- `git diff --check`

## Benchmark evidence
- 100k `write-insertobjects-direct`, warmup 2 / iterations 5: OfficeIMO.Excel avg 151.37 ms, median 145.81 ms, alloc 45,614 KB
- same local 100k baseline before this branch: avg 150.85 ms, median 150.85 ms, alloc 50,156 KB
- allocation improvement is about 9%; wall-time samples are noisy but median improves on the steadier run
- 25k `write-insertobjects-direct`, warmup 1 / iterations 3: OfficeIMO.Excel avg 44.30 ms, alloc 11,319 KB; MiniExcel 127.92 ms; ClosedXML 385.27 ms; EPPlus 565.02 ms