### PR TITLE
Improve Excel PSObject export performance

### DIFF
--- a/OfficeIMO.Excel.Benchmarks/ExcelLibraryComparisonRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelLibraryComparisonRunner.cs
@@ -33,6 +33,7 @@ internal static class ExcelLibraryComparisonRunner {
     private static readonly string[] HelloWorldColumnNames = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"];
     private static readonly string[] BlogStringColumnNames = Enumerable.Range(1, BlogStringColumnCount).Select(static index => "C" + index.ToString(CultureInfo.InvariantCulture)).ToArray();
     private static readonly string[] PowerShellMixedColumnNames = ["Id", "Name", "Department", "Region", "IsEnabled", "Created", "Score", "Owner", "TicketCount", "Notes"];
+    private static readonly string[] PowerShellWideColumnNames;
     private static readonly string[] PowerShellMixedRegions = ["EU", "US", "APAC", "LATAM"];
 #if DEBUG
     private const string BuildConfiguration = "Debug";
@@ -42,6 +43,9 @@ internal static class ExcelLibraryComparisonRunner {
 
     static ExcelLibraryComparisonRunner() {
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        PowerShellWideColumnNames = new[] { "Id", "Name", "Created", "Enabled" }
+            .Concat(Enumerable.Range(1, 36).Select(static index => "Metric" + index.ToString(CultureInfo.InvariantCulture)))
+            .ToArray();
     }
 
     internal static string WriteComparison(
@@ -92,7 +96,11 @@ internal static class ExcelLibraryComparisonRunner {
         var dictionaryRows = CreateDictionaryRows(rows);
         var blogStringRows = CreateBlogStringRows(rowCount);
         var powerShellMixedRows = CreatePowerShellMixedRows(rowCount);
+        var powerShellObjectMixedRows = CreatePowerShellObjectMixedRows(powerShellMixedRows);
         var powerShellMixedDataTable = CreatePowerShellMixedDataTable(powerShellMixedRows, "PowerShellMixed");
+        var powerShellWideRows = CreatePowerShellWideRows(rowCount);
+        var powerShellObjectWideRows = CreatePowerShellObjectMixedRows(powerShellWideRows);
+        var powerShellWideDataTable = CreatePowerShellWideDataTable(powerShellWideRows, "PowerShellWide");
         var salesDataSet = CreateSalesDataSet(firstTableRows, secondTableRows);
         var sparseDataSet = CreateSparseDataSet(rowCount);
         var officeImoWorkbookBytes = new Lazy<byte[]>(() => ExcelBenchmarkScenarioFactory.CreateWorkbookBytes(rows));
@@ -346,6 +354,22 @@ internal static class ExcelLibraryComparisonRunner {
             new LibraryComparisonCase("EPPlus", "Import the same mixed typed data and save.", () => EpPlusWriteDataTable(powerShellMixedDataTable)),
             new LibraryComparisonCase("MiniExcel", "Streaming mixed dictionary object export and save.", () => MiniExcelWriteDictionaryObjects(powerShellMixedRows)),
             new LibraryComparisonCase("LargeXlsx", "Streaming mixed dictionary rows and save.", () => LargeXlsxWritePowerShellMixedRows(powerShellMixedRows))
+        ]);
+
+        AddScenarioGroup(scenarios, scenarioFilter, "write-powershell-psobject-mixed-direct", warmupIterations, measuredIterations, [
+            new LibraryComparisonCase("OfficeIMO.Excel", "Insert PSObject-like mixed rows through the normal worksheet API and save.", () => OfficeImoWriteInsertPowerShellObjectMixedObjects(powerShellObjectMixedRows)),
+            new LibraryComparisonCase("ClosedXML", "Import the same mixed typed data and save.", () => ClosedXmlWriteDataTable(powerShellMixedDataTable)),
+            new LibraryComparisonCase("EPPlus", "Import the same mixed typed data and save.", () => EpPlusWriteDataTable(powerShellMixedDataTable)),
+            new LibraryComparisonCase("MiniExcel", "Streaming mixed dictionary object export and save.", () => MiniExcelWriteDictionaryObjects(powerShellMixedRows)),
+            new LibraryComparisonCase("LargeXlsx", "Streaming mixed dictionary rows and save.", () => LargeXlsxWritePowerShellMixedRows(powerShellMixedRows))
+        ]);
+
+        AddScenarioGroup(scenarios, scenarioFilter, "write-powershell-psobject-wide-direct", warmupIterations, measuredIterations, [
+            new LibraryComparisonCase("OfficeIMO.Excel", "Insert PSObject-like wide telemetry rows through the normal worksheet API and save.", () => OfficeImoWriteInsertPowerShellObjectWideObjects(powerShellObjectWideRows)),
+            new LibraryComparisonCase("ClosedXML", "Import the same wide typed data and save.", () => ClosedXmlWriteDataTable(powerShellWideDataTable)),
+            new LibraryComparisonCase("EPPlus", "Import the same wide typed data and save.", () => EpPlusWriteDataTable(powerShellWideDataTable)),
+            new LibraryComparisonCase("MiniExcel", "Streaming wide dictionary object export and save.", () => MiniExcelWriteDictionaryObjects(powerShellWideRows)),
+            new LibraryComparisonCase("LargeXlsx", "Streaming wide dictionary rows and save.", () => LargeXlsxWritePowerShellWideRows(powerShellWideRows))
         ]);
 
         AddScenarioGroup(scenarios, scenarioFilter, "write-fluent-rowsfrom-direct", warmupIterations, measuredIterations, [
@@ -603,7 +627,11 @@ internal static class ExcelLibraryComparisonRunner {
         var legacyDictionaryRows = CreateLegacyDictionaryRows(rows);
         var blogStringRows = CreateBlogStringRows(rowCount);
         var powerShellMixedRows = CreatePowerShellMixedRows(rowCount);
+        var powerShellObjectMixedRows = CreatePowerShellObjectMixedRows(powerShellMixedRows);
         var powerShellMixedDataTable = CreatePowerShellMixedDataTable(powerShellMixedRows, "PowerShellMixed");
+        var powerShellWideRows = CreatePowerShellWideRows(rowCount);
+        var powerShellObjectWideRows = CreatePowerShellObjectMixedRows(powerShellWideRows);
+        var powerShellWideDataTable = CreatePowerShellWideDataTable(powerShellWideRows, "PowerShellWide");
         var salesDataSet = CreateSalesDataSet(firstTableRows, secondTableRows);
         var sparseDataSet = CreateSparseDataSet(rowCount);
         var officeImoWorkbookBytes = new Lazy<byte[]>(() => ExcelBenchmarkScenarioFactory.CreateWorkbookBytes(rows));
@@ -821,6 +849,22 @@ internal static class ExcelLibraryComparisonRunner {
             new PackageProfileCase("EPPlus", "Import the same mixed typed data and save.", () => EpPlusWriteDataTableBytes(powerShellMixedDataTable)),
             new PackageProfileCase("MiniExcel", "Streaming mixed dictionary object export and save.", () => MiniExcelWriteDictionaryObjectsBytes(powerShellMixedRows)),
             new PackageProfileCase("LargeXlsx", "Streaming mixed dictionary rows and save.", () => LargeXlsxWritePowerShellMixedRowsBytes(powerShellMixedRows))
+        ]);
+
+        AddPackageProfileGroup(scenarios, scenarioFilter, "write-powershell-psobject-mixed-direct", warmupIterations, measuredIterations, [
+            new PackageProfileCase("OfficeIMO.Excel", "Insert PSObject-like mixed rows through the normal worksheet API and save.", () => OfficeImoWriteInsertPowerShellObjectMixedObjectsBytes(powerShellObjectMixedRows)),
+            new PackageProfileCase("ClosedXML", "Import the same mixed typed data and save.", () => ClosedXmlWriteDataTableBytes(powerShellMixedDataTable)),
+            new PackageProfileCase("EPPlus", "Import the same mixed typed data and save.", () => EpPlusWriteDataTableBytes(powerShellMixedDataTable)),
+            new PackageProfileCase("MiniExcel", "Streaming mixed dictionary object export and save.", () => MiniExcelWriteDictionaryObjectsBytes(powerShellMixedRows)),
+            new PackageProfileCase("LargeXlsx", "Streaming mixed dictionary rows and save.", () => LargeXlsxWritePowerShellMixedRowsBytes(powerShellMixedRows))
+        ]);
+
+        AddPackageProfileGroup(scenarios, scenarioFilter, "write-powershell-psobject-wide-direct", warmupIterations, measuredIterations, [
+            new PackageProfileCase("OfficeIMO.Excel", "Insert PSObject-like wide telemetry rows through the normal worksheet API and save.", () => OfficeImoWriteInsertPowerShellObjectWideObjectsBytes(powerShellObjectWideRows)),
+            new PackageProfileCase("ClosedXML", "Import the same wide typed data and save.", () => ClosedXmlWriteDataTableBytes(powerShellWideDataTable)),
+            new PackageProfileCase("EPPlus", "Import the same wide typed data and save.", () => EpPlusWriteDataTableBytes(powerShellWideDataTable)),
+            new PackageProfileCase("MiniExcel", "Streaming wide dictionary object export and save.", () => MiniExcelWriteDictionaryObjectsBytes(powerShellWideRows)),
+            new PackageProfileCase("LargeXlsx", "Streaming wide dictionary rows and save.", () => LargeXlsxWritePowerShellWideRowsBytes(powerShellWideRows))
         ]);
 
         AddPackageProfileGroup(scenarios, scenarioFilter, "write-fluent-rowsfrom-direct", warmupIterations, measuredIterations, [
@@ -1634,6 +1678,36 @@ internal static class ExcelLibraryComparisonRunner {
         return stream.ToArray();
     }
 
+    private static int OfficeImoWriteInsertPowerShellObjectMixedObjects(IReadOnlyList<System.Management.Automation.PSObject> rows)
+        => ByteCount(OfficeImoWriteInsertPowerShellObjectMixedObjectsBytes(rows));
+
+    private static byte[] OfficeImoWriteInsertPowerShellObjectMixedObjectsBytes(IReadOnlyList<System.Management.Automation.PSObject> rows) {
+        using var stream = new MemoryStream();
+        using (var document = ExcelDocument.Create(stream, autoSave: false)) {
+            var sheet = document.AddWorkSheet("Data");
+            sheet.InsertObjects(rows);
+            document.Save(stream);
+            AssertOfficeImoDirectPackageWriter(document, "InsertObjects PSObject mixed comparison");
+        }
+
+        return stream.ToArray();
+    }
+
+    private static int OfficeImoWriteInsertPowerShellObjectWideObjects(IReadOnlyList<System.Management.Automation.PSObject> rows)
+        => ByteCount(OfficeImoWriteInsertPowerShellObjectWideObjectsBytes(rows));
+
+    private static byte[] OfficeImoWriteInsertPowerShellObjectWideObjectsBytes(IReadOnlyList<System.Management.Automation.PSObject> rows) {
+        using var stream = new MemoryStream();
+        using (var document = ExcelDocument.Create(stream, autoSave: false)) {
+            var sheet = document.AddWorkSheet("Data");
+            sheet.InsertObjects(rows);
+            document.Save(stream);
+            AssertOfficeImoDirectPackageWriter(document, "InsertObjects PSObject wide comparison");
+        }
+
+        return stream.ToArray();
+    }
+
     private static int OfficeImoWriteFluentRowsFrom(IReadOnlyList<ExcelBenchmarkScenarioFactory.SalesRecord> rows)
         => ByteCount(OfficeImoWriteFluentRowsFromBytes(rows));
 
@@ -1973,6 +2047,18 @@ internal static class ExcelLibraryComparisonRunner {
         using var stream = new MemoryStream();
         using (var writer = new XlsxWriter(stream)) {
             WriteLargeXlsxPowerShellMixedRows(writer, rows);
+        }
+
+        return stream.ToArray();
+    }
+
+    private static int LargeXlsxWritePowerShellWideRows(IReadOnlyList<Dictionary<string, object?>> rows)
+        => ByteCount(LargeXlsxWritePowerShellWideRowsBytes(rows));
+
+    private static byte[] LargeXlsxWritePowerShellWideRowsBytes(IReadOnlyList<Dictionary<string, object?>> rows) {
+        using var stream = new MemoryStream();
+        using (var writer = new XlsxWriter(stream)) {
+            WriteLargeXlsxPowerShellWideRows(writer, rows);
         }
 
         return stream.ToArray();
@@ -4631,6 +4717,23 @@ internal static class ExcelLibraryComparisonRunner {
         }
     }
 
+    private static void WriteLargeXlsxPowerShellWideRows(XlsxWriter writer, IReadOnlyList<Dictionary<string, object?>> rows) {
+        writer.BeginWorksheet("Data");
+        writer.BeginRow();
+        for (int i = 0; i < PowerShellWideColumnNames.Length; i++) {
+            writer.Write(PowerShellWideColumnNames[i]);
+        }
+
+        for (int rowIndex = 0; rowIndex < rows.Count; rowIndex++) {
+            Dictionary<string, object?> row = rows[rowIndex];
+            writer.BeginRow();
+            for (int columnIndex = 0; columnIndex < PowerShellWideColumnNames.Length; columnIndex++) {
+                row.TryGetValue(PowerShellWideColumnNames[columnIndex], out object? value);
+                WriteLargeXlsxValue(writer, value);
+            }
+        }
+    }
+
     private static void WriteLargeXlsxBlogStringRows(XlsxWriter writer, IReadOnlyList<BlogStringRow> rows) {
         writer.BeginWorksheet("Data");
         writer.BeginRow();
@@ -4873,6 +4976,43 @@ internal static class ExcelLibraryComparisonRunner {
         return result;
     }
 
+    private static IReadOnlyList<Dictionary<string, object?>> CreatePowerShellWideRows(int count) {
+        var result = new List<Dictionary<string, object?>>(count);
+        var start = new DateTime(2024, 1, 1, 8, 0, 0, DateTimeKind.Unspecified);
+        for (int i = 0; i < count; i++) {
+            int id = i + 1;
+            var row = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) {
+                ["Id"] = id,
+                ["Name"] = "Server-" + id.ToString("D6", CultureInfo.InvariantCulture),
+                ["Created"] = start.AddDays(i % 365).AddMinutes(i % 240),
+                ["Enabled"] = id % 4 != 0
+            };
+
+            for (int metric = 1; metric <= 36; metric++) {
+                row["Metric" + metric.ToString(CultureInfo.InvariantCulture)] = Math.Round(((id * (metric + 7)) % 10000) / 10D, 3);
+            }
+
+            result.Add(row);
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyList<System.Management.Automation.PSObject> CreatePowerShellObjectMixedRows(IEnumerable<Dictionary<string, object?>> rows) {
+        var result = new List<System.Management.Automation.PSObject>();
+        foreach (var row in rows) {
+            var properties = new System.Management.Automation.PSPropertyInfo[row.Count];
+            int index = 0;
+            foreach (var entry in row) {
+                properties[index++] = new System.Management.Automation.PSPropertyInfo(entry.Key, entry.Value);
+            }
+
+            result.Add(new System.Management.Automation.PSObject(properties));
+        }
+
+        return result;
+    }
+
     private static IReadOnlyList<BlogStringRow> CreateBlogStringRows(int count) {
         var result = new List<BlogStringRow>(count);
         for (int i = 0; i < count; i++) {
@@ -4899,6 +5039,30 @@ internal static class ExcelLibraryComparisonRunner {
             object?[] values = new object?[PowerShellMixedColumnNames.Length];
             for (int i = 0; i < values.Length; i++) {
                 values[i] = sourceRow.TryGetValue(PowerShellMixedColumnNames[i], out object? value)
+                    ? value
+                    : DBNull.Value;
+            }
+
+            table.Rows.Add(values);
+        }
+
+        return table;
+    }
+
+    private static DataTable CreatePowerShellWideDataTable(IEnumerable<IReadOnlyDictionary<string, object?>> rows, string tableName) {
+        var table = new DataTable(tableName) { Locale = CultureInfo.InvariantCulture };
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Columns.Add("Created", typeof(DateTime));
+        table.Columns.Add("Enabled", typeof(bool));
+        for (int metric = 1; metric <= 36; metric++) {
+            table.Columns.Add("Metric" + metric.ToString(CultureInfo.InvariantCulture), typeof(double));
+        }
+
+        foreach (IReadOnlyDictionary<string, object?> sourceRow in rows) {
+            object?[] values = new object?[PowerShellWideColumnNames.Length];
+            for (int i = 0; i < values.Length; i++) {
+                values[i] = sourceRow.TryGetValue(PowerShellWideColumnNames[i], out object? value)
                     ? value
                     : DBNull.Value;
             }

--- a/OfficeIMO.Excel.Benchmarks/PowerShellObjectShims.cs
+++ b/OfficeIMO.Excel.Benchmarks/PowerShellObjectShims.cs
@@ -1,0 +1,23 @@
+namespace System.Management.Automation;
+
+internal sealed class PSObject {
+    public PSObject(params PSPropertyInfo[] properties) {
+        Properties = properties;
+    }
+
+    public IReadOnlyList<PSPropertyInfo> Properties { get; }
+}
+
+internal sealed class PSPropertyInfo {
+    public PSPropertyInfo(string name, object? value, bool isGettable = true) {
+        Name = name;
+        Value = value;
+        IsGettable = isGettable;
+    }
+
+    public string Name { get; }
+
+    public object? Value { get; }
+
+    public bool IsGettable { get; }
+}

--- a/OfficeIMO.Excel.Benchmarks/Program.cs
+++ b/OfficeIMO.Excel.Benchmarks/Program.cs
@@ -360,6 +360,8 @@ static string[] FilterPackageProfileScenarios(IReadOnlyCollection<string> scenar
         "write-insertobjects-flat-dictionaries-direct",
         "write-insertobjects-legacy-dictionaries-direct",
         "write-powershell-mixed-objects-direct",
+        "write-powershell-psobject-mixed-direct",
+        "write-powershell-psobject-wide-direct",
         "write-fluent-rowsfrom-direct",
         "append-plain-rows",
         "autofit-existing",

--- a/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.cs
@@ -11,6 +11,8 @@ using System.Threading.Tasks;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
+        private const int BufferedPowerShellObjectExportInitialColumnCapacity = 16;
+        private const int BufferedPowerShellObjectExportColumnLimit = 64;
         private static readonly ConcurrentDictionary<Type, SimpleObjectExportPlan> SimpleObjectExportPlans = new();
         private static readonly ConcurrentDictionary<Type, PowerShellObjectExportPlan> PowerShellObjectExportPlans = new();
 
@@ -595,6 +597,14 @@ namespace OfficeIMO.Excel {
             }
 
             Type valueType = value.GetType();
+            UpdateObjectExportColumnType(inferredColumnTypes, columnIndex, valueType);
+        }
+
+        private static void UpdateObjectExportColumnType(Type?[] inferredColumnTypes, int columnIndex, Type? valueType) {
+            if (valueType == null || inferredColumnTypes[columnIndex] == typeof(object)) {
+                return;
+            }
+
             Type? inferred = inferredColumnTypes[columnIndex];
             inferredColumnTypes[columnIndex] = inferred == null || inferred == valueType
                 ? valueType
@@ -634,6 +644,10 @@ namespace OfficeIMO.Excel {
                 return true;
             }
 
+            if (TryInsertPowerShellObjectRowsAsCellValues(rows, includeHeaders, startRow)) {
+                return true;
+            }
+
             var headers = new List<string>();
             var headerIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
             var directRows = new object?[rows.Count][];
@@ -670,6 +684,324 @@ namespace OfficeIMO.Excel {
                 startRow,
                 includeHeaders,
                 range);
+        }
+
+        private bool TryInsertPowerShellObjectRowsAsCellValues<T>(
+            IReadOnlyList<T> rows,
+            bool includeHeaders,
+            int startRow) {
+            if (rows.Count == 0 || rows[0] == null) {
+                return false;
+            }
+
+            object first = rows[0]!;
+            Type rowType = first.GetType();
+            if (!IsPowerShellObjectExportType(rowType)) {
+                return false;
+            }
+
+            PowerShellObjectExportPlan plan = PowerShellObjectExportPlans.GetOrAdd(rowType, CreatePowerShellObjectExportPlan);
+            if (!plan.CanProject) {
+                return false;
+            }
+
+            var propertyPlanCache = new PowerShellPropertyExportPlanCache();
+            var headers = new List<string>();
+            var state = new FlatDictionaryProjectionState {
+                InferredColumnTypes = new Type?[BufferedPowerShellObjectExportInitialColumnCapacity]
+            };
+            object?[] firstRow = new object?[BufferedPowerShellObjectExportInitialColumnCapacity];
+            if (!TryProjectPowerShellObjectFirstRow(first, plan, ref propertyPlanCache, headers, state, ref firstRow)) {
+                return false;
+            }
+
+            state.NormalizeColumnTypeWidth(headers.Count);
+            if (headers.Count == 0
+                || headers.Count > BufferedPowerShellObjectExportColumnLimit
+                || includeHeaders && state.HasBlankDisplayHeader
+                || HasDuplicateObjectExportHeaders(headers)
+                || !CanRegisterDirectTabularSaveCandidate(startRow, 1, headers.Count)) {
+                return false;
+            }
+
+            int columnCount = headers.Count;
+            string[] headerArray = headers.ToArray();
+            bool rowTypeIsSealed = rowType.IsSealed;
+            var values = new object?[checked(rows.Count * columnCount)];
+            for (int c = 0; c < columnCount; c++) {
+                values[c] = c < firstRow.Length ? firstRow[c] : null;
+            }
+
+            for (int r = 1; r < rows.Count; r++) {
+                object? row = rows[r];
+                if (row == null || (!rowTypeIsSealed && row.GetType() != rowType)) {
+                    return false;
+                }
+
+                int rowOffset = r * columnCount;
+                if (!TryProjectPowerShellObjectExistingRow(
+                    row,
+                    plan,
+                    ref propertyPlanCache,
+                    headerArray,
+                    state.InferredColumnTypes,
+                    values,
+                    rowOffset,
+                    columnCount)) {
+                    return false;
+                }
+            }
+
+            string range = BuildObjectExportRange(startRow, columnCount, rows.Count, includeHeaders);
+            return TryInsertCellValuesAsDeferredDirectSave(
+                Name,
+                headers,
+                CompleteObjectExportColumnTypes(state.InferredColumnTypes),
+                values,
+                columnCount,
+                rows.Count,
+                startRow,
+                includeHeaders,
+                range);
+
+        }
+
+        private static bool TryProjectPowerShellObjectFirstRow(
+            object item,
+            PowerShellObjectExportPlan plan,
+            ref PowerShellPropertyExportPlanCache propertyPlanCache,
+            List<string> headers,
+            FlatDictionaryProjectionState state,
+            ref object?[] firstRow) {
+            if (!TryGetPowerShellObjectProperties(item, plan, out object? propertiesValue)) {
+                return false;
+            }
+
+            bool added = false;
+            if (propertiesValue is object?[] propertyArray) {
+                for (int i = 0; i < propertyArray.Length; i++) {
+                    if (!TryProjectPowerShellObjectFirstProperty(propertyArray[i], plan, ref propertyPlanCache, headers, state, ref firstRow, ref added)) {
+                        return false;
+                    }
+                }
+
+                return added;
+            }
+
+            if (propertiesValue is System.Collections.IList propertyList) {
+                for (int i = 0; i < propertyList.Count; i++) {
+                    if (!TryProjectPowerShellObjectFirstProperty(propertyList[i], plan, ref propertyPlanCache, headers, state, ref firstRow, ref added)) {
+                        return false;
+                    }
+                }
+
+                return added;
+            }
+
+            if (propertiesValue is not IEnumerable properties) {
+                return false;
+            }
+
+            foreach (object? property in properties) {
+                if (!TryProjectPowerShellObjectFirstProperty(property, plan, ref propertyPlanCache, headers, state, ref firstRow, ref added)) {
+                    return false;
+                }
+            }
+
+            return added;
+        }
+
+        private static bool TryProjectPowerShellObjectExistingRow(
+            object item,
+            PowerShellObjectExportPlan plan,
+            ref PowerShellPropertyExportPlanCache propertyPlanCache,
+            string[] headers,
+            Type?[] inferredColumnTypes,
+            object?[] values,
+            int rowOffset,
+            int columnCount) {
+            if (!TryGetPowerShellObjectProperties(item, plan, out object? propertiesValue)) {
+                return false;
+            }
+
+            int propertyIndex = 0;
+            if (propertiesValue is object?[] propertyArray) {
+                for (int i = 0; i < propertyArray.Length; i++) {
+                    if (!TryProjectPowerShellObjectExistingProperty(propertyArray[i], plan, ref propertyPlanCache, headers, inferredColumnTypes, values, rowOffset, columnCount, ref propertyIndex)) {
+                        return false;
+                    }
+                }
+
+                return propertyIndex > 0;
+            }
+
+            if (propertiesValue is System.Collections.IList propertyList) {
+                for (int i = 0; i < propertyList.Count; i++) {
+                    if (!TryProjectPowerShellObjectExistingProperty(propertyList[i], plan, ref propertyPlanCache, headers, inferredColumnTypes, values, rowOffset, columnCount, ref propertyIndex)) {
+                        return false;
+                    }
+                }
+
+                return propertyIndex > 0;
+            }
+
+            if (propertiesValue is not IEnumerable properties) {
+                return false;
+            }
+
+            foreach (object? property in properties) {
+                if (!TryProjectPowerShellObjectExistingProperty(property, plan, ref propertyPlanCache, headers, inferredColumnTypes, values, rowOffset, columnCount, ref propertyIndex)) {
+                    return false;
+                }
+            }
+
+            return propertyIndex > 0;
+        }
+
+        private static bool TryGetPowerShellObjectProperties(
+            object item,
+            PowerShellObjectExportPlan plan,
+            out object? propertiesValue) {
+            if (!plan.CanProject) {
+                propertiesValue = null;
+                return false;
+            }
+
+            try {
+                propertiesValue = plan.PropertiesGetter(item);
+                return true;
+            } catch {
+                propertiesValue = null;
+                return false;
+            }
+        }
+
+        private static bool TryProjectPowerShellObjectFirstProperty(
+            object? property,
+            PowerShellObjectExportPlan plan,
+            ref PowerShellPropertyExportPlanCache propertyPlanCache,
+            List<string> headers,
+            FlatDictionaryProjectionState state,
+            ref object?[] firstRow,
+            ref bool added) {
+            if (property == null) {
+                return true;
+            }
+
+            Type propertyType = property.GetType();
+            PowerShellPropertyExportPlan propertyPlan = propertyPlanCache.Get(plan, propertyType);
+            if (!propertyPlan.CanProject) {
+                return true;
+            }
+
+            try {
+                if (propertyPlan.IsGettableGetter != null && !propertyPlan.IsGettableGetter(property)) {
+                    return true;
+                }
+
+                string? name = propertyPlan.NameGetter(property);
+                object? value = propertyPlan.ValueGetter(property);
+                if (!TryGetFlatObjectExportValueType(value, out Type? valueType)) {
+                    return false;
+                }
+
+                string columnName = name ?? string.Empty;
+                if (string.IsNullOrWhiteSpace(columnName)) {
+                    state.HasBlankDisplayHeader = true;
+                }
+
+                int columnIndex = headers.IndexOf(columnName);
+                if (columnIndex < 0) {
+                    if (headers.Count >= BufferedPowerShellObjectExportColumnLimit) {
+                        return false;
+                    }
+
+                    columnIndex = headers.Count;
+                    EnsurePowerShellObjectFirstRowCapacity(ref firstRow, state, columnIndex + 1);
+                    headers.Add(columnName);
+                }
+
+                firstRow[columnIndex] = value;
+                UpdateObjectExportColumnType(state.InferredColumnTypes, columnIndex, valueType);
+                added = true;
+                return true;
+            } catch {
+                return true;
+            }
+        }
+
+        private static void EnsurePowerShellObjectFirstRowCapacity(
+            ref object?[] firstRow,
+            FlatDictionaryProjectionState state,
+            int requiredLength) {
+            if (firstRow.Length >= requiredLength) {
+                return;
+            }
+
+            int newLength = firstRow.Length * 2;
+            if (newLength < requiredLength) {
+                newLength = requiredLength;
+            }
+
+            if (newLength > BufferedPowerShellObjectExportColumnLimit) {
+                newLength = BufferedPowerShellObjectExportColumnLimit;
+            }
+
+            Array.Resize(ref firstRow, newLength);
+            state.EnsureColumnTypeCapacity(newLength);
+        }
+
+        private static bool TryProjectPowerShellObjectExistingProperty(
+            object? property,
+            PowerShellObjectExportPlan plan,
+            ref PowerShellPropertyExportPlanCache propertyPlanCache,
+            string[] headers,
+            Type?[] inferredColumnTypes,
+            object?[] values,
+            int rowOffset,
+            int columnCount,
+            ref int propertyIndex) {
+            if (property == null) {
+                return true;
+            }
+
+            Type propertyType = property.GetType();
+            PowerShellPropertyExportPlan propertyPlan = propertyPlanCache.Get(plan, propertyType);
+            if (!propertyPlan.CanProject) {
+                return true;
+            }
+
+            try {
+                if (propertyPlan.IsGettableGetter != null && !propertyPlan.IsGettableGetter(property)) {
+                    return true;
+                }
+
+                string? name = propertyPlan.NameGetter(property);
+                object? value = propertyPlan.ValueGetter(property);
+                if (!TryGetFlatObjectExportValueType(value, out Type? valueType)) {
+                    return false;
+                }
+
+                string columnName = name ?? string.Empty;
+                int columnIndex;
+                if ((uint)propertyIndex < (uint)columnCount
+                    && string.Equals(columnName, headers[propertyIndex], StringComparison.Ordinal)) {
+                    columnIndex = propertyIndex;
+                } else {
+                    columnIndex = Array.IndexOf(headers, columnName);
+                }
+
+                if (columnIndex < 0) {
+                    return false;
+                }
+
+                values[rowOffset + columnIndex] = value;
+                UpdateObjectExportColumnType(inferredColumnTypes, columnIndex, valueType);
+                propertyIndex++;
+                return true;
+            } catch {
+                return true;
+            }
         }
 
         private bool TryInsertExactDictionaryRowsAsDeferredDirectSave<T>(
@@ -1015,7 +1347,67 @@ namespace OfficeIMO.Excel {
                 || IsObjectExportScalarType(value.GetType());
         }
 
+        private static bool TryGetFlatObjectExportValueType(object? value, out Type? valueType) {
+            switch (value) {
+                case null:
+                case DBNull _:
+                    valueType = null;
+                    return true;
+                case string _:
+                    valueType = typeof(string);
+                    return true;
+                case int _:
+                    valueType = typeof(int);
+                    return true;
+                case bool _:
+                    valueType = typeof(bool);
+                    return true;
+                case DateTime _:
+                    valueType = typeof(DateTime);
+                    return true;
+                case double _:
+                    valueType = typeof(double);
+                    return true;
+                case long _:
+                    valueType = typeof(long);
+                    return true;
+                case decimal _:
+                    valueType = typeof(decimal);
+                    return true;
+                case float _:
+                    valueType = typeof(float);
+                    return true;
+                case DateTimeOffset _:
+                    valueType = typeof(DateTimeOffset);
+                    return true;
+                case TimeSpan _:
+                    valueType = typeof(TimeSpan);
+                    return true;
+                case Guid _:
+                    valueType = typeof(Guid);
+                    return true;
+#if NET6_0_OR_GREATER
+                case DateOnly _:
+                    valueType = typeof(DateOnly);
+                    return true;
+                case TimeOnly _:
+                    valueType = typeof(TimeOnly);
+                    return true;
+#endif
+            }
+
+            Type type = value.GetType();
+            if (IsObjectExportScalarType(type)) {
+                valueType = type;
+                return true;
+            }
+
+            valueType = null;
+            return false;
+        }
+
         private delegate bool TryAddObjectExportValue(string? name, object? value);
+        private delegate bool TryAddIndexedObjectExportValue(int propertyIndex, string? name, object? value);
 
         private static bool TryProjectPowerShellObjectRow(object item, TryAddObjectExportValue tryAddValue) {
             Type itemType = item.GetType();
@@ -1024,6 +1416,27 @@ namespace OfficeIMO.Excel {
             }
 
             PowerShellObjectExportPlan plan = PowerShellObjectExportPlans.GetOrAdd(itemType, CreatePowerShellObjectExportPlan);
+            var propertyPlanCache = new PowerShellPropertyExportPlanCache();
+            return TryProjectPowerShellObjectRow(item, plan, ref propertyPlanCache, tryAddValue);
+        }
+
+        private static bool TryProjectPowerShellObjectRow(
+            object item,
+            PowerShellObjectExportPlan plan,
+            ref PowerShellPropertyExportPlanCache propertyPlanCache,
+            TryAddObjectExportValue tryAddValue) {
+            return TryProjectPowerShellObjectRow(
+                item,
+                plan,
+                ref propertyPlanCache,
+                (propertyIndex, name, value) => tryAddValue(name, value));
+        }
+
+        private static bool TryProjectPowerShellObjectRow(
+            object item,
+            PowerShellObjectExportPlan plan,
+            ref PowerShellPropertyExportPlanCache propertyPlanCache,
+            TryAddIndexedObjectExportValue tryAddValue) {
             if (!plan.CanProject) {
                 return false;
             }
@@ -1035,42 +1448,90 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            if (propertiesValue is not IEnumerable properties) {
-                return false;
-            }
+            var localPropertyPlanCache = propertyPlanCache;
+            try {
+                bool added = false;
+                int propertyIndex = 0;
 
-            bool added = false;
-            foreach (object? property in properties) {
-                if (property == null) {
-                    continue;
-                }
-
-                Type propertyType = property.GetType();
-                PowerShellPropertyExportPlan propertyPlan = plan.GetPropertyPlan(propertyType);
-                if (!propertyPlan.CanProject) {
-                    continue;
-                }
-
-                try {
-                    if (propertyPlan.IsGettableGetter != null
-                        && propertyPlan.IsGettableGetter(property) is bool isGettable
-                        && !isGettable) {
-                        continue;
+                if (propertiesValue is object?[] propertyArray) {
+                    for (int i = 0; i < propertyArray.Length; i++) {
+                        if (!TryProjectProperty(propertyArray[i])) {
+                            return false;
+                        }
                     }
 
-                    string? name = propertyPlan.NameGetter(property)?.ToString();
-                    object? value = propertyPlan.ValueGetter(property);
-                    if (!tryAddValue(name, value)) {
+                    return added;
+                }
+
+                if (propertiesValue is System.Collections.IList propertyList) {
+                    for (int i = 0; i < propertyList.Count; i++) {
+                        if (!TryProjectProperty(propertyList[i])) {
+                            return false;
+                        }
+                    }
+
+                    return added;
+                }
+
+                if (propertiesValue is not IEnumerable properties) {
+                    return false;
+                }
+
+                foreach (object? property in properties) {
+                    if (!TryProjectProperty(property)) {
                         return false;
                     }
-
-                    added = true;
-                } catch {
-                    continue;
                 }
-            }
 
-            return added;
+                return added;
+
+                bool TryProjectProperty(object? property) {
+                    if (property == null) {
+                        return true;
+                    }
+
+                    Type propertyType = property.GetType();
+                    PowerShellPropertyExportPlan propertyPlan = localPropertyPlanCache.Get(plan, propertyType);
+                    if (!propertyPlan.CanProject) {
+                        return true;
+                    }
+
+                    try {
+                        if (propertyPlan.IsGettableGetter != null && !propertyPlan.IsGettableGetter(property)) {
+                            return true;
+                        }
+
+                        string? name = propertyPlan.NameGetter(property);
+                        object? value = propertyPlan.ValueGetter(property);
+                        if (!tryAddValue(propertyIndex, name, value)) {
+                            return false;
+                        }
+
+                        added = true;
+                        propertyIndex++;
+                    } catch {
+                    }
+
+                    return true;
+                }
+            } finally {
+                propertyPlanCache = localPropertyPlanCache;
+            }
+        }
+
+        private struct PowerShellPropertyExportPlanCache {
+            private Type? _lastPropertyType;
+            private PowerShellPropertyExportPlan? _lastPropertyPlan;
+
+            internal PowerShellPropertyExportPlan Get(PowerShellObjectExportPlan plan, Type propertyType) {
+                if (_lastPropertyType == propertyType && _lastPropertyPlan != null) {
+                    return _lastPropertyPlan;
+                }
+
+                _lastPropertyType = propertyType;
+                _lastPropertyPlan = plan.GetPropertyPlan(propertyType);
+                return _lastPropertyPlan;
+            }
         }
 
         private static bool IsPowerShellObjectExportType(Type type)
@@ -1095,9 +1556,9 @@ namespace OfficeIMO.Excel {
             }
 
             return new PowerShellPropertyExportPlan(
-                CreatePowerShellValueGetter(name),
+                CreatePowerShellStringGetter(name),
                 CreatePowerShellValueGetter(value),
-                isGettable == null ? null : CreatePowerShellValueGetter(isGettable));
+                isGettable == null ? null : CreatePowerShellBooleanGetter(isGettable));
         }
 
         private static Func<object, object?> CreatePowerShellValueGetter(PropertyInfo property) {
@@ -1120,6 +1581,52 @@ namespace OfficeIMO.Excel {
 
         private static Func<object, object?> CreatePowerShellValueGetterCore<TTarget, TValue>(MethodInfo getMethod) {
             var getter = (Func<TTarget, TValue>)Delegate.CreateDelegate(typeof(Func<TTarget, TValue>), getMethod);
+            return row => getter((TTarget)row!);
+        }
+
+        private static Func<object, string?> CreatePowerShellStringGetter(PropertyInfo property) {
+            MethodInfo? getMethod = property.GetMethod;
+            if (getMethod == null || property.DeclaringType == null || property.PropertyType != typeof(string)) {
+                return row => property.GetValue(row, null)?.ToString();
+            }
+
+            try {
+                return (Func<object, string?>)CreatePowerShellStringGetterMethod
+                    .MakeGenericMethod(property.DeclaringType)
+                    .Invoke(null, new object[] { getMethod })!;
+            } catch {
+                return row => property.GetValue(row, null)?.ToString();
+            }
+        }
+
+        private static readonly MethodInfo CreatePowerShellStringGetterMethod =
+            typeof(ExcelSheet).GetMethod(nameof(CreatePowerShellStringGetterCore), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        private static Func<object, string?> CreatePowerShellStringGetterCore<TTarget>(MethodInfo getMethod) {
+            var getter = (Func<TTarget, string?>)Delegate.CreateDelegate(typeof(Func<TTarget, string?>), getMethod);
+            return row => getter((TTarget)row!);
+        }
+
+        private static Func<object, bool> CreatePowerShellBooleanGetter(PropertyInfo property) {
+            MethodInfo? getMethod = property.GetMethod;
+            if (getMethod == null || property.DeclaringType == null || property.PropertyType != typeof(bool)) {
+                return row => property.GetValue(row, null) is bool value && value;
+            }
+
+            try {
+                return (Func<object, bool>)CreatePowerShellBooleanGetterMethod
+                    .MakeGenericMethod(property.DeclaringType)
+                    .Invoke(null, new object[] { getMethod })!;
+            } catch {
+                return row => property.GetValue(row, null) is bool value && value;
+            }
+        }
+
+        private static readonly MethodInfo CreatePowerShellBooleanGetterMethod =
+            typeof(ExcelSheet).GetMethod(nameof(CreatePowerShellBooleanGetterCore), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        private static Func<object, bool> CreatePowerShellBooleanGetterCore<TTarget>(MethodInfo getMethod) {
+            var getter = (Func<TTarget, bool>)Delegate.CreateDelegate(typeof(Func<TTarget, bool>), getMethod);
             return row => getter((TTarget)row!);
         }
 
@@ -1156,9 +1663,9 @@ namespace OfficeIMO.Excel {
             }
 
             internal PowerShellPropertyExportPlan(
-                Func<object, object?> nameGetter,
+                Func<object, string?> nameGetter,
                 Func<object, object?> valueGetter,
-                Func<object, object?>? isGettableGetter) {
+                Func<object, bool>? isGettableGetter) {
                 NameGetter = nameGetter;
                 ValueGetter = valueGetter;
                 IsGettableGetter = isGettableGetter;
@@ -1167,11 +1674,11 @@ namespace OfficeIMO.Excel {
 
             internal bool CanProject { get; }
 
-            internal Func<object, object?> NameGetter { get; }
+            internal Func<object, string?> NameGetter { get; }
 
             internal Func<object, object?> ValueGetter { get; }
 
-            internal Func<object, object?>? IsGettableGetter { get; }
+            internal Func<object, bool>? IsGettableGetter { get; }
         }
 
         private static void FlattenObject(object? value, string? prefix, IDictionary<string, object?> result) {

--- a/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
+++ b/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
@@ -3762,6 +3762,79 @@ namespace OfficeIMO.Tests {
             Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
         }
 
+        [Fact]
+        public void PerformanceReview_InsertObjects_PowerShellObjectBagWideShapeUsesDirectPackage() {
+            using var memory = new MemoryStream();
+            var rows = new[] {
+                CreateWidePowerShellObject(1),
+                CreateWidePowerShellObject(2)
+            };
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertObjects(rows);
+
+                document.Save(memory);
+
+                Assert.Equal(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+                Assert.True(document.LastSaveDiagnostics.UsedFastPackageWriter);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+            Assert.Equal("Metric36", GetSpreadsheetCellText(spreadsheet, cells["AN1"]));
+            Assert.Equal("36", cells["AN2"].CellValue!.Text);
+            Assert.Equal("72", cells["AN3"].CellValue!.Text);
+            Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
+
+            static System.Management.Automation.PSObject CreateWidePowerShellObject(int id) {
+                var properties = new System.Management.Automation.PSPropertyInfo[40];
+                properties[0] = new System.Management.Automation.PSPropertyInfo("Id", id);
+                properties[1] = new System.Management.Automation.PSPropertyInfo("Name", "Server-" + id.ToString("D6", CultureInfo.InvariantCulture));
+                properties[2] = new System.Management.Automation.PSPropertyInfo("Created", new DateTime(2026, 5, 20).AddDays(id));
+                properties[3] = new System.Management.Automation.PSPropertyInfo("Enabled", id % 2 == 1);
+                for (int metric = 1; metric <= 36; metric++) {
+                    properties[metric + 3] = new System.Management.Automation.PSPropertyInfo("Metric" + metric.ToString(CultureInfo.InvariantCulture), id * metric);
+                }
+
+                return new System.Management.Automation.PSObject(properties);
+            }
+        }
+
+        [Fact]
+        public void PerformanceReview_InsertObjects_PowerShellObjectBagLateColumnsUseDirectPackage() {
+            using var memory = new MemoryStream();
+            var rows = new[] {
+                new System.Management.Automation.PSObject(
+                    new System.Management.Automation.PSPropertyInfo("Id", 1),
+                    new System.Management.Automation.PSPropertyInfo("Name", "Server-000001")),
+                new System.Management.Automation.PSObject(
+                    new System.Management.Automation.PSPropertyInfo("Id", 2),
+                    new System.Management.Automation.PSPropertyInfo("Name", "Server-000002"),
+                    new System.Management.Automation.PSPropertyInfo("TicketCount", 3))
+            };
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertObjects(rows);
+
+                document.Save(memory);
+
+                Assert.Equal(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+                Assert.True(document.LastSaveDiagnostics.UsedFastPackageWriter);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+            Assert.Equal("TicketCount", GetSpreadsheetCellText(spreadsheet, cells["C1"]));
+            Assert.True(!cells.TryGetValue("C2", out var blankTicketCount)
+                || string.IsNullOrEmpty(GetSpreadsheetCellText(spreadsheet, blankTicketCount)));
+            Assert.Equal("3", cells["C3"].CellValue!.Text);
+            Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
+        }
+
 #if NET6_0_OR_GREATER
         [Fact]
         public void PerformanceReview_InsertObjects_ExtendedSimpleScalarTypesUseDirectPackage() {


### PR DESCRIPTION
## Summary

- Add an internal PSObject/PSCustomObject-shaped export fast path for stable scalar object rows without adding a PowerShell dependency or changing public APIs.
- Add benchmark scenarios for mixed 10-column and wide 40-column PSObject-like exports against ClosedXML, EPPlus, MiniExcel, and LargeXlsx.
- Add regression coverage proving PSObject-like rows still use the direct package writer, including wide and late-column shapes.

## Performance evidence

Relevant local benchmark evidence from this branch:

- 25k mixed PSObject-like rows improved from prior baseline `121.68 ms avg / 20365 KB` to best retained `54.79 ms avg / 9767 KB`.
- 25k wide PSObject-like rows measured best retained `198.93 ms avg / 35974 KB`, narrowly ahead of LargeXlsx average in the same run.
- Later samples were slower across OfficeIMO, MiniExcel, and LargeXlsx, so they were treated as local machine noise rather than a code regression.

## Validation

- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-restore --filter "FullyQualifiedName~PerformanceReview_InsertObjects" -m:1 /nodeReuse:false`
- `dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --framework net8.0 --no-restore -m:1 /nodeReuse:false`
- `dotnet build .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -c Release --framework net8.0 --no-restore -m:1 /nodeReuse:false`
- `git diff --check` clean except CRLF normalization warnings