### PR TITLE
Add LZW PDF stream decoding

### DIFF
--- a/Docs/officeimo.pdf.roadmap.md
+++ b/Docs/officeimo.pdf.roadmap.md
@@ -319,7 +319,7 @@ Turn the reader/writer internals into a dependable PDF object engine.
 - Parse xref streams.
 - Parse trailers and incremental updates.
 - Preserve object identity.
-- Decode common stream filters.
+- Decode common stream filters. Initial stream decoding covers uncompressed, Flate, ASCIIHex, ASCII85, RunLength, and LZW content streams, including LZW `/EarlyChange` and predictor `DecodeParms` for parser-supported text extraction paths.
 - Support object streams.
 - Support encrypted-file detection with clear unsupported diagnostics. Initial trailer/xref-stream detection rejects encrypted files before parser-supported read/manipulation helpers process page content.
 - Add safe object copying between documents.

--- a/OfficeIMO.Pdf/README.md
+++ b/OfficeIMO.Pdf/README.md
@@ -90,7 +90,7 @@ Reading:
 - Extract text spans with positions.
 - Extract page image XObjects from bytes, paths, streams, or parsed documents with `PdfImageExtractor`; `ExtractImagesByPageRanges(..., PdfPageRange...)` selects reusable page-range lists for wrapper pipelines, JPEG images are returned as JPEG files and simple PNG-predictor Flate images as PNG files, compatible grayscale/RGB Flate images with grayscale `/SMask` alpha are returned as gray-alpha/RGBA PNGs, and helpers can write extracted images to deterministic page-numbered files.
 - Heuristic column-aware text extraction and simple structured extraction; `PdfTextExtractor` exposes layout-option overloads for bytes, paths, streams, page-range text/structured/table extraction with `PdfPageRange` lists, byte/path/stream whole-document text output to UTF-8 paths or caller-owned streams, and page-file output, plus structured-by-page and table-by-page extraction that preserves detected lines, lists, leader rows, simple table geometry, and selected source page numbers so wrappers can request readback without dropping to `PdfReadDocument`. Byte-, path-, and stream-based text/table extraction can also write deterministic `source-page-0001.txt` and `source-page-0001-table-0001.csv` files for all pages or selected page ranges, including option-aware selected text page output, with CSV escaping for table output.
-- Decode common simple streams used by many PDFs, including uncompressed, Flate, ASCIIHex, ASCII85, and RunLength paths.
+- Decode common simple streams used by many PDFs, including uncompressed, Flate, ASCIIHex, ASCII85, RunLength, and LZW paths.
 
 Manipulation:
 

--- a/OfficeIMO.Pdf/Reading/Filters/LzwDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/LzwDecoder.cs
@@ -1,0 +1,119 @@
+namespace OfficeIMO.Pdf.Filters;
+
+internal static class LzwDecoder {
+    private const int ClearCode = 256;
+    private const int EndOfDataCode = 257;
+    private const int FirstAvailableCode = 258;
+    private const int MaximumCodeValue = 4095;
+    private const int MaximumCodeSize = 12;
+
+    public static byte[] Decode(byte[] data, int earlyChange = 1) {
+        if (data == null || data.Length == 0) {
+            return Array.Empty<byte>();
+        }
+
+        earlyChange = earlyChange == 0 ? 0 : 1;
+        var reader = new BitReader(data);
+        using var output = new MemoryStream();
+        var dictionary = CreateInitialDictionary();
+        int nextCode = FirstAvailableCode;
+        int codeSize = 9;
+        byte[]? previous = null;
+
+        while (true) {
+            int code = reader.ReadBits(codeSize);
+            if (code < 0) {
+                break;
+            }
+
+            if (code == ClearCode) {
+                dictionary = CreateInitialDictionary();
+                nextCode = FirstAvailableCode;
+                codeSize = 9;
+                previous = null;
+                continue;
+            }
+
+            if (code == EndOfDataCode) {
+                break;
+            }
+
+            byte[] entry;
+            if (code < dictionary.Count && dictionary[code] is not null) {
+                entry = dictionary[code]!;
+            } else if (code == nextCode && previous is not null) {
+                entry = AppendByte(previous, previous[0]);
+            } else {
+                throw new FormatException("Invalid LZWDecode code.");
+            }
+
+            output.Write(entry, 0, entry.Length);
+
+            if (previous is not null && nextCode <= MaximumCodeValue) {
+                AddEntry(dictionary, nextCode, AppendByte(previous, entry[0]));
+                nextCode++;
+                if (codeSize < MaximumCodeSize && nextCode + earlyChange >= (1 << codeSize)) {
+                    codeSize++;
+                }
+            }
+
+            previous = entry;
+        }
+
+        return output.ToArray();
+    }
+
+    private static List<byte[]?> CreateInitialDictionary() {
+        var dictionary = new List<byte[]?>(MaximumCodeValue + 1);
+        for (int i = 0; i < 256; i++) {
+            dictionary.Add(new[] { (byte)i });
+        }
+
+        dictionary.Add(null);
+        dictionary.Add(null);
+        return dictionary;
+    }
+
+    private static void AddEntry(List<byte[]?> dictionary, int code, byte[] entry) {
+        if (code == dictionary.Count) {
+            dictionary.Add(entry);
+        } else if (code < dictionary.Count) {
+            dictionary[code] = entry;
+        } else {
+            throw new FormatException("Invalid LZWDecode dictionary state.");
+        }
+    }
+
+    private static byte[] AppendByte(byte[] bytes, byte value) {
+        var result = new byte[bytes.Length + 1];
+        Buffer.BlockCopy(bytes, 0, result, 0, bytes.Length);
+        result[result.Length - 1] = value;
+        return result;
+    }
+
+    private sealed class BitReader {
+        private readonly byte[] _data;
+        private int _bitOffset;
+
+        public BitReader(byte[] data) {
+            _data = data;
+        }
+
+        public int ReadBits(int bitCount) {
+            if (bitCount <= 0 || _bitOffset + bitCount > _data.Length * 8) {
+                return -1;
+            }
+
+            int value = 0;
+            for (int i = 0; i < bitCount; i++) {
+                int absoluteBit = _bitOffset + i;
+                int currentByte = _data[absoluteBit / 8];
+                int bit = (currentByte >> (7 - (absoluteBit % 8))) & 1;
+                value = (value << 1) | bit;
+            }
+
+            _bitOffset += bitCount;
+            return value;
+        }
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -31,6 +31,11 @@ internal static class StreamDecoder {
                     case "RL":
                         current = RunLengthDecoder.Decode(current);
                         break;
+                    case "LZWDecode":
+                    case "LZW":
+                        current = LzwDecoder.Decode(current, GetEarlyChange(dict, filterIndex, objects));
+                        current = ApplyDecodeParms(dict, filterIndex, current, objects);
+                        break;
                     default:
                         return original;
                 }
@@ -67,6 +72,15 @@ internal static class StreamDecoder {
         }
 
         return PngPredictorDecoder.Decode(data, columns, colors, bitsPerComponent);
+    }
+
+    private static int GetEarlyChange(PdfDictionary dict, int filterIndex, Dictionary<int, PdfIndirectObject>? objects) {
+        var decodeParms = GetDecodeParms(dict, filterIndex, objects);
+        if (decodeParms is null) {
+            return 1;
+        }
+
+        return (int)(decodeParms.Get<PdfNumber>("EarlyChange")?.Value ?? 1);
     }
 
     private static PdfDictionary? GetDecodeParms(PdfDictionary dict, int filterIndex, Dictionary<int, PdfIndirectObject>? objects) {

--- a/OfficeIMO.Pdf/Reading/PdfTextExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/PdfTextExtractor.cs
@@ -4,7 +4,7 @@ namespace OfficeIMO.Pdf;
 
 /// <summary>
 /// Minimal, zero-dependency text extractor for simple PDFs produced by OfficeIMO.Pdf
-/// and common external PDFs with basic text operators and FlateDecode content streams.
+/// and common external PDFs with basic text operators and common content-stream filters.
 /// Not a general-purpose PDF parser; designed as a pragmatic starting point.
 /// </summary>
 public static class PdfTextExtractor {

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -469,6 +469,46 @@ public class PdfReaderAndFooterRegressionTests {
     }
 
     [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsLzwEncodedContentStreams() {
+        byte[] bytes = BuildPdfWithLzwEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello LZW stream) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello LZW stream", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfReadPage_GetTextSpans_ReadsLzwEncodedContentStreams() {
+        byte[] bytes = BuildPdfWithLzwEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello LZW spans) Tj\nET\n");
+
+        var doc = PdfReadDocument.Load(bytes);
+
+        Assert.Single(doc.Pages);
+        var span = Assert.Single(doc.Pages[0].GetTextSpans());
+        Assert.Equal("Hello LZW spans", span.Text);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsChainedAscii85AndLzwContentStreamsWithEarlyChangeZero() {
+        byte[] bytes = BuildPdfWithAscii85AndLzwEncodedStream(
+            "BT\n/F1 12 Tf\n72 720 Td\n(Hello LZW chain with early change zero and enough repeated content for wider codes) Tj\nET\n",
+            earlyChange: 0);
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello LZW chain with early change zero", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsLzwStreamsWithPredictorDecodeParms() {
+        byte[] bytes = BuildPdfWithLzwPredictorEncodedStream("BT\n/F1 12 Tf\n72 720 Td\n(Hello LZW predictor) Tj\nET\n");
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("Hello LZW predictor", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PdfTextExtractor_ExtractAllText_ReadsInlineNestedFormResourceDictionaries() {
         byte[] bytes = BuildPdfWithInlineNestedFormResources();
 
@@ -1376,6 +1416,24 @@ public class PdfReaderAndFooterRegressionTests {
         return BuildSingleStreamPdf(encodedBytes, "/Filter [/A85 /RL]");
     }
 
+    private static byte[] BuildPdfWithLzwEncodedStream(string streamContent) {
+        byte[] encodedBytes = EncodeLzw(Encoding.ASCII.GetBytes(streamContent));
+        return BuildSingleStreamPdf(encodedBytes, "/Filter /LZWDecode");
+    }
+
+    private static byte[] BuildPdfWithAscii85AndLzwEncodedStream(string streamContent, int earlyChange) {
+        byte[] lzwBytes = EncodeLzw(Encoding.ASCII.GetBytes(streamContent), earlyChange);
+        byte[] encodedBytes = Encoding.ASCII.GetBytes(EncodeAscii85(lzwBytes));
+        return BuildSingleStreamPdf(encodedBytes, $"/Filter [/A85 /LZW] /DecodeParms [null << /EarlyChange {earlyChange} >>]");
+    }
+
+    private static byte[] BuildPdfWithLzwPredictorEncodedStream(string streamContent) {
+        byte[] streamBytes = Encoding.ASCII.GetBytes(streamContent);
+        byte[] predictedBytes = EncodeUpPredictedRows(streamBytes);
+        byte[] encodedBytes = EncodeLzw(predictedBytes);
+        return BuildSingleStreamPdf(encodedBytes, $"/Filter /LZWDecode /DecodeParms << /Predictor 12 /Columns {streamBytes.Length} >>");
+    }
+
     private static byte[] BuildPdfWithInlineNestedFormResources() {
         const string pageContent = "q\n/Fx Do\nQ\n";
         const string formContent = "BT\n/F1 12 Tf\n10 20 Td\n(Inline form) Tj\nET\n";
@@ -1511,6 +1569,48 @@ public class PdfReaderAndFooterRegressionTests {
         return output.ToArray();
     }
 
+    private static byte[] EncodeLzw(byte[] input, int earlyChange = 1) {
+        earlyChange = earlyChange == 0 ? 0 : 1;
+        var dictionary = new Dictionary<string, int>();
+        for (int i = 0; i < 256; i++) {
+            dictionary[Convert.ToBase64String(new[] { (byte)i })] = i;
+        }
+
+        using var output = new MemoryStream();
+        var writer = new LzwBitWriter(output);
+        int nextCode = 258;
+        int codeSize = 9;
+        writer.WriteBits(256, codeSize);
+        var current = new List<byte>();
+
+        foreach (byte value in input) {
+            var candidate = new List<byte>(current) { value };
+            string candidateKey = Convert.ToBase64String(candidate.ToArray());
+            if (dictionary.ContainsKey(candidateKey)) {
+                current = candidate;
+                continue;
+            }
+
+            writer.WriteBits(dictionary[Convert.ToBase64String(current.ToArray())], codeSize);
+            if (nextCode <= 4095) {
+                dictionary[candidateKey] = nextCode++;
+                if (codeSize < 12 && nextCode + earlyChange >= (1 << codeSize)) {
+                    codeSize++;
+                }
+            }
+
+            current = new List<byte> { value };
+        }
+
+        if (current.Count > 0) {
+            writer.WriteBits(dictionary[Convert.ToBase64String(current.ToArray())], codeSize);
+        }
+
+        writer.WriteBits(257, codeSize);
+        writer.Flush();
+        return output.ToArray();
+    }
+
     private static string EncodeAsciiHex(byte[] input) {
         var sb = new StringBuilder(input.Length * 2 + 1);
         for (int i = 0; i < input.Length; i++) {
@@ -1562,6 +1662,38 @@ public class PdfReaderAndFooterRegressionTests {
 
         for (int i = 0; i < count; i++) {
             sb.Append(encoded[i]);
+        }
+    }
+
+    private sealed class LzwBitWriter {
+        private readonly Stream _stream;
+        private int _currentByte;
+        private int _bitCount;
+
+        public LzwBitWriter(Stream stream) {
+            _stream = stream;
+        }
+
+        public void WriteBits(int value, int bitCount) {
+            for (int i = bitCount - 1; i >= 0; i--) {
+                _currentByte = (_currentByte << 1) | ((value >> i) & 1);
+                _bitCount++;
+                if (_bitCount == 8) {
+                    _stream.WriteByte((byte)_currentByte);
+                    _currentByte = 0;
+                    _bitCount = 0;
+                }
+            }
+        }
+
+        public void Flush() {
+            if (_bitCount == 0) {
+                return;
+            }
+
+            _stream.WriteByte((byte)(_currentByte << (8 - _bitCount)));
+            _currentByte = 0;
+            _bitCount = 0;
         }
     }
 


### PR DESCRIPTION
## Summary
- add a zero-dependency LZWDecode stream decoder for PDF reader paths
- route /LZWDecode and /LZW aliases through DecodeParms, including /EarlyChange and predictor handling
- add regression PDFs for text extraction, span extraction, filter chains, and predictor DecodeParms
- update OfficeIMO.Pdf docs and roadmap filter inventory

## Validation
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~PdfReaderAndFooterRegressionTests.PdfTextExtractor_ExtractAllText_ReadsLzwEncodedContentStreams|FullyQualifiedName~PdfReaderAndFooterRegressionTests.PdfReadPage_GetTextSpans_ReadsLzwEncodedContentStreams|FullyQualifiedName~PdfReaderAndFooterRegressionTests.PdfTextExtractor_ExtractAllText_ReadsChainedAscii85AndLzwContentStreamsWithEarlyChangeZero|FullyQualifiedName~PdfReaderAndFooterRegressionTests.PdfTextExtractor_ExtractAllText_ReadsLzwStreamsWithPredictorDecodeParms|FullyQualifiedName~PdfReaderAndFooterRegressionTests.PdfTextExtractor_ExtractAllText_ReadsRunLengthEncodedContentStreams|FullyQualifiedName~PdfReaderAndFooterRegressionTests.PdfTextExtractor_ExtractAllText_ReadsChainedAscii85AndRunLengthContentStreamsWithAliases|FullyQualifiedName~PdfReaderAndFooterRegressionTests.PdfTextExtractor_ExtractAllText_ReadsChainedAscii85AndFlateContentStreams|FullyQualifiedName~PdfReaderAndFooterRegressionTests.PdfTextExtractor_ExtractAllText_ReadsChainedAsciiHexAndFlateContentStreamsWithAliases" --logger "console;verbosity=minimal"
- dotnet build .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --no-restore -v:quiet -clp:ErrorsOnly