### PR TITLE
Use xref stream root for PDF catalog resolution

### DIFF
--- a/Docs/officeimo.pdf.roadmap.md
+++ b/Docs/officeimo.pdf.roadmap.md
@@ -316,7 +316,7 @@ Exit criteria:
 Turn the reader/writer internals into a dependable PDF object engine.
 
 - Parse classic xref tables.
-- Parse xref streams.
+- Parse xref streams. Initial parser support now treats `/Type /XRef` stream dictionaries as trailer-like metadata for active `/Root` catalog resolution when no classic trailer is present; full xref-stream entry parsing remains roadmap work.
 - Parse trailers and incremental updates.
 - Preserve object identity.
 - Decode common stream filters.

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
@@ -648,6 +648,13 @@ internal static class PdfSyntax {
             return rootDictionary;
         }
 
+        if (TryGetXrefStreamRootObjectNumber(map, out rootObjectNumber) &&
+            map.TryGetValue(rootObjectNumber, out rootObject) &&
+            rootObject.Value is PdfDictionary xrefRootDictionary &&
+            xrefRootDictionary.Get<PdfName>("Type")?.Name == "Catalog") {
+            return xrefRootDictionary;
+        }
+
         return FindCatalogByScan(map);
     }
 
@@ -671,6 +678,27 @@ internal static class PdfSyntax {
         Match match = TrailerRootRegex.Match(trailerRaw);
         return match.Success &&
             int.TryParse(match.Groups[1].Value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out objectNumber);
+    }
+
+    private static bool TryGetXrefStreamRootObjectNumber(Dictionary<int, PdfIndirectObject> map, out int objectNumber) {
+        objectNumber = 0;
+        foreach (var entry in map.Values.OrderByDescending(static item => item.ObjectNumber)) {
+            PdfDictionary? dictionary = entry.Value switch {
+                PdfStream stream => stream.Dictionary,
+                PdfDictionary directDictionary => directDictionary,
+                _ => null
+            };
+
+            if (dictionary?.Get<PdfName>("Type")?.Name == "XRef" &&
+                ResolveObject(map, dictionary.Items.TryGetValue("Root", out var root) ? root : null) is PdfDictionary rootDictionary &&
+                rootDictionary.Get<PdfName>("Type")?.Name == "Catalog" &&
+                dictionary.Items["Root"] is PdfReference rootReference) {
+                objectNumber = rootReference.ObjectNumber;
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static PdfObject? ResolveObject(Dictionary<int, PdfIndirectObject> map, PdfObject? value) {

--- a/OfficeIMO.Tests/Pdf/PdfReadStreamTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReadStreamTests.cs
@@ -269,6 +269,30 @@ public class PdfReadStreamTests {
     }
 
     [Fact]
+    public void ReadApis_UseXrefStreamRootCatalogWhenClassicTrailerIsAbsent() {
+        PdfDocumentInfo info = PdfInspector.Inspect(BuildXrefStreamRootCatalogPdf());
+
+        PdfPageInfo page = Assert.Single(info.Pages);
+        Assert.Equal(200d, page.Width);
+        Assert.Equal(200d, page.Height);
+        PdfOutlineItem outline = Assert.Single(info.Outlines);
+        Assert.Equal("Current", outline.Title);
+        Assert.Equal(1, outline.PageNumber);
+        Assert.Equal("SinglePage", info.CatalogPageLayout);
+    }
+
+    [Fact]
+    public void RewriteApis_UseXrefStreamRootCatalogWhenClassicTrailerIsAbsent() {
+        byte[] output = PdfPageExtractor.ExtractPages(BuildXrefStreamRootCatalogPdf(), 1);
+
+        string text = System.Text.Encoding.ASCII.GetString(output);
+        Assert.Contains("/PageLayout /SinglePage", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("/PageLayout /TwoColumnLeft", text, StringComparison.Ordinal);
+        PdfOutlineItem outline = Assert.Single(PdfInspector.Inspect(output).Outlines);
+        Assert.Equal("Current", outline.Title);
+    }
+
+    [Fact]
     public void RewriteApis_PreserveCatalogViewSettings() {
         byte[] catalogViewSettingPdf = BuildCatalogViewSettingPdf();
         byte[] twoPageCatalogViewSettingPdf = BuildTwoPageCatalogViewSettingPdf();
@@ -1215,6 +1239,59 @@ public class PdfReadStreamTests {
             "endobj",
             "trailer",
             "<< /Root 5 0 R /Size 13 >>",
+            "%%EOF"
+        });
+
+        return System.Text.Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildXrefStreamRootCatalogPdf() {
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.5",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R /PageLayout /TwoColumnLeft >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 11 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Type /Outlines /First 12 0 R /Last 12 0 R /Count 1 >>",
+            "endobj",
+            "5 0 obj",
+            "<< /Type /Catalog /Pages 6 0 R /Outlines 8 0 R /PageLayout /SinglePage >>",
+            "endobj",
+            "6 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [7 0 R] >>",
+            "endobj",
+            "7 0 obj",
+            "<< /Type /Page /Parent 6 0 R /MediaBox [0 0 200 200] /Contents 11 0 R >>",
+            "endobj",
+            "8 0 obj",
+            "<< /Type /Outlines /First 9 0 R /Last 9 0 R /Count 1 >>",
+            "endobj",
+            "9 0 obj",
+            "<< /Title (Current) /Parent 8 0 R /Dest [7 0 R /XYZ 0 144 0] >>",
+            "endobj",
+            "10 0 obj",
+            "<< /Type /XRef /Root 5 0 R /Size 13 /Length 0 >>",
+            "stream",
+            "",
+            "endstream",
+            "endobj",
+            "11 0 obj",
+            "<< /Length 0 >>",
+            "stream",
+            "",
+            "endstream",
+            "endobj",
+            "12 0 obj",
+            "<< /Title (Old) /Parent 4 0 R /Dest [3 0 R /XYZ 0 72 0] >>",
+            "endobj",
+            "startxref",
+            "0",
             "%%EOF"
         });
 


### PR DESCRIPTION
## Summary
- use `/Type /XRef` stream dictionaries as trailer-like metadata for active `/Root` catalog resolution when no classic trailer is present
- keep classic trailer `/Root` precedence, then fall back to xref stream `/Root`, then object scan only as the last resort
- add read and rewrite regressions proving stale catalog objects are ignored when the active catalog is referenced only from an xref stream
- update the PDF roadmap with the exact supported xref-stream slice

## Validation
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~PdfReadStreamTests.ReadApis_UseXrefStreamRootCatalogWhenClassicTrailerIsAbsent|FullyQualifiedName~PdfReadStreamTests.RewriteApis_UseXrefStreamRootCatalogWhenClassicTrailerIsAbsent|FullyQualifiedName~PdfReadStreamTests.ReadApis_UseTrailerRootCatalogForPagesAndOutlinesWhenStaleCatalogsExist|FullyQualifiedName~PdfReadStreamTests.RewriteApis_UseTrailerRootCatalogWhenStaleCatalogRevisionsExist" --logger "console;verbosity=minimal"
- dotnet build .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --no-restore -v:quiet -clp:ErrorsOnly