### PR TITLE
Read TD text positioning in PDF extraction

### DIFF
--- a/Docs/officeimo.pdf.roadmap.md
+++ b/Docs/officeimo.pdf.roadmap.md
@@ -341,7 +341,7 @@ Text quality is the heart of PDF generation.
 - Add Unicode text support with ToUnicode maps.
 - Add glyph measurement and shaping boundaries.
 - Add fallback font selection.
-- Add text extraction support for simple encoded fonts and ToUnicode maps. Initial readback already includes layout-option overloads on the `PdfTextExtractor` facade, structured-by-page and table-by-page facade readback, a generated two-column regression gate for column-aware reading order, and a generated simple-table regression gate for structured table rows.
+- Add text extraction support for simple encoded fonts and ToUnicode maps. Initial readback already includes layout-option overloads on the `PdfTextExtractor` facade, structured-by-page and table-by-page facade readback, common text-showing operators, `TD` text-positioning line advances, a generated two-column regression gate for column-aware reading order, and a generated simple-table regression gate for structured table rows.
 - Add diagnostics when text cannot be represented in the selected font. Initial generated/stamped standard-font text now rejects unsupported WinAnsi characters with the exact Unicode code point and explains that embedded Unicode fonts are required; raw control characters are rejected with layout-oriented diagnostics instead of being written as invisible PDF text bytes.
 
 Exit criteria:

--- a/OfficeIMO.Pdf/Reading/PdfTextExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/PdfTextExtractor.cs
@@ -1043,10 +1043,13 @@ public static class PdfTextExtractor {
                     args.Clear();
                     break;
                 case "Td":
+                case "TD":
                     if (inText && args.Count >= 2) {
                         double advanceX = ToDouble(args[args.Count - 2]);
                         double advanceY = ToDouble(args[args.Count - 1]);
-                        if (advanceY == 0 && advanceX > 0.1) {
+                        if (Math.Abs(advanceY) > 0.1) {
+                            AppendLineBreak();
+                        } else if (advanceX > 0.1) {
                             pendingSpace = true;
                         }
                     }
@@ -1109,6 +1112,13 @@ public static class PdfTextExtractor {
 
         void RequestSpace() {
             pendingSpace = true;
+        }
+
+        void AppendLineBreak() {
+            if (sb.Length > 0 && sb[sb.Length - 1] != '\n' && sb[sb.Length - 1] != '\r') {
+                sb.AppendLine();
+            }
+            pendingSpace = false;
         }
 
         void AppendTextArray(object arrayObject) {

--- a/OfficeIMO.Pdf/Reading/PdfTextExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/PdfTextExtractor.cs
@@ -980,6 +980,7 @@ public static class PdfTextExtractor {
         var sb = new StringBuilder();
         bool inText = false;
         bool pendingSpace = false;
+        bool hasTextInCurrentTextObject = false;
         double currentFontSize = 12;
         double currentHorizontalScale = 1.0;
         var args = new List<object>(8);
@@ -1016,11 +1017,13 @@ public static class PdfTextExtractor {
                 case "BT":
                     inText = true;
                     pendingSpace = false;
+                    hasTextInCurrentTextObject = false;
                     args.Clear();
                     break;
                 case "ET":
                     inText = false;
                     pendingSpace = false;
+                    hasTextInCurrentTextObject = false;
                     args.Clear();
                     break;
                 case "T*":
@@ -1047,7 +1050,7 @@ public static class PdfTextExtractor {
                     if (inText && args.Count >= 2) {
                         double advanceX = ToDouble(args[args.Count - 2]);
                         double advanceY = ToDouble(args[args.Count - 1]);
-                        if (Math.Abs(advanceY) > 0.1) {
+                        if (Math.Abs(advanceY) > 0.1 && hasTextInCurrentTextObject) {
                             AppendLineBreak();
                         } else if (advanceX > 0.1) {
                             pendingSpace = true;
@@ -1107,6 +1110,9 @@ public static class PdfTextExtractor {
                 sb.Append(' ');
             }
             sb.Append(value);
+            if (inText) {
+                hasTextInCurrentTextObject = true;
+            }
             pendingSpace = false;
         }
 
@@ -1115,7 +1121,7 @@ public static class PdfTextExtractor {
         }
 
         void AppendLineBreak() {
-            if (sb.Length > 0 && sb[sb.Length - 1] != '\n' && sb[sb.Length - 1] != '\r') {
+            if (sb.Length > 0) {
                 sb.AppendLine();
             }
             pendingSpace = false;

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -338,6 +338,26 @@ public class PdfReaderAndFooterRegressionTests {
     }
 
     [Fact]
+    public void PdfTextExtractor_ExtractAllText_DoesNotTreatInitialTdAsLineAdvance() {
+        byte[] bytes = BuildPdfWithInitialTdTextPositioning();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Contains("First", text, StringComparison.Ordinal);
+        Assert.Contains("Second", text, StringComparison.Ordinal);
+        Assert.DoesNotMatch("First\\r?\\nSecond", text);
+    }
+
+    [Fact]
+    public void PdfTextExtractor_ExtractAllText_PreservesRepeatedTDLineAdvances() {
+        byte[] bytes = BuildPdfWithRepeatedTDTextPositioning();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Matches("First(?:\\r?\\n){2}Second", text);
+    }
+
+    [Fact]
     public void PdfTextExtractor_GetMetadata_ReadsHexUtf16InfoStrings() {
         byte[] bytes = BuildPdfWithHexMetadata("Hello metadata", "OfficeIMO");
 
@@ -1350,6 +1370,16 @@ public class PdfReaderAndFooterRegressionTests {
 
     private static byte[] BuildPdfWithTDTextPositioning() {
         const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(First) Tj\n0 -14 TD\n(Second) Tj\nET\n";
+        return BuildSingleStreamPdf(streamContent);
+    }
+
+    private static byte[] BuildPdfWithInitialTdTextPositioning() {
+        const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(First) Tj\nET\nBT\n/F1 12 Tf\n110 720 Td\n(Second) Tj\nET\n";
+        return BuildSingleStreamPdf(streamContent);
+    }
+
+    private static byte[] BuildPdfWithRepeatedTDTextPositioning() {
+        const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(First) Tj\n0 -14 TD\n0 -14 TD\n(Second) Tj\nET\n";
         return BuildSingleStreamPdf(streamContent);
     }
 

--- a/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReaderAndFooterRegressionTests.cs
@@ -328,6 +328,16 @@ public class PdfReaderAndFooterRegressionTests {
     }
 
     [Fact]
+    public void PdfTextExtractor_ExtractAllText_ReadsTDTextPositioningAsLineAdvance() {
+        byte[] bytes = BuildPdfWithTDTextPositioning();
+
+        string text = PdfTextExtractor.ExtractAllText(bytes);
+
+        Assert.Matches("First\\s+Second", text);
+        Assert.DoesNotContain("FirstSecond", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PdfTextExtractor_GetMetadata_ReadsHexUtf16InfoStrings() {
         byte[] bytes = BuildPdfWithHexMetadata("Hello metadata", "OfficeIMO");
 
@@ -1335,6 +1345,11 @@ public class PdfReaderAndFooterRegressionTests {
 
     private static byte[] BuildPdfWithDoubleQuoteOperator() {
         const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(Hello) Tj\n0 0 ( world) \"\nET\n";
+        return BuildSingleStreamPdf(streamContent);
+    }
+
+    private static byte[] BuildPdfWithTDTextPositioning() {
+        const string streamContent = "BT\n/F1 12 Tf\n72 720 Td\n(First) Tj\n0 -14 TD\n(Second) Tj\nET\n";
         return BuildSingleStreamPdf(streamContent);
     }
 


### PR DESCRIPTION
## Summary
- treat TD text-positioning as a readable line advance during text extraction
- keep horizontal text moves as spacing while separating vertical text moves
- add a regression fixture for TD-based two-line producer content
- update the PDF roadmap text extraction capability note

## Validation
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release -f net8.0 --filter "FullyQualifiedName~PdfReaderAndFooterRegressionTests"
- dotnet build .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release -f net472
- git diff --check