### PR TITLE
Resolve outline action destinations for PDF preflight

### DIFF
--- a/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.cs
@@ -1803,29 +1803,30 @@ public static class PdfPageExtractor {
     }
 
     private static bool IsDestinationForKnownPage(Dictionary<int, PdfIndirectObject> sourceObjects, PdfObject destination) {
-        return IsDestinationForKnownPage(sourceObjects, destination, new HashSet<int>());
-    }
+        var visitedReferences = new HashSet<int>();
+        while (true) {
+            if (destination is PdfReference reference) {
+                if (!visitedReferences.Add(reference.ObjectNumber) ||
+                    !sourceObjects.TryGetValue(reference.ObjectNumber, out var indirect)) {
+                    return false;
+                }
 
-    private static bool IsDestinationForKnownPage(Dictionary<int, PdfIndirectObject> sourceObjects, PdfObject destination, HashSet<int> visitedReferences) {
-        if (destination is PdfReference reference) {
-            return visitedReferences.Add(reference.ObjectNumber) &&
-                sourceObjects.TryGetValue(reference.ObjectNumber, out var indirect) &&
-                IsDestinationForKnownPage(sourceObjects, indirect.Value, visitedReferences);
-        }
+                destination = indirect.Value;
+                continue;
+            }
 
-        if (destination is PdfArray array) {
-            return array.Items.Count > 0 &&
+            if (destination is PdfDictionary dictionary &&
+                dictionary.Items.TryGetValue("D", out var explicitDestination)) {
+                destination = explicitDestination;
+                continue;
+            }
+
+            return destination is PdfArray array &&
+                array.Items.Count > 0 &&
                 array.Items[0] is PdfReference pageReference &&
                 sourceObjects.TryGetValue(pageReference.ObjectNumber, out var pageObject) &&
                 IsPageDictionary(pageObject.Value);
         }
-
-        if (destination is PdfDictionary dictionary &&
-            dictionary.Items.TryGetValue("D", out var explicitDestination)) {
-            return IsDestinationForKnownPage(sourceObjects, explicitDestination, visitedReferences);
-        }
-
-        return false;
     }
 
     private static bool ReferencesOnlyCopiedPages(PdfObject value, HashSet<int> copiedPageObjectIds) {

--- a/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.cs
@@ -1808,12 +1808,9 @@ public static class PdfPageExtractor {
 
     private static bool IsDestinationForKnownPage(Dictionary<int, PdfIndirectObject> sourceObjects, PdfObject destination, HashSet<int> visitedReferences) {
         if (destination is PdfReference reference) {
-            if (!visitedReferences.Add(reference.ObjectNumber) ||
-                !sourceObjects.TryGetValue(reference.ObjectNumber, out var indirect)) {
-                return false;
-            }
-
-            destination = indirect.Value;
+            return visitedReferences.Add(reference.ObjectNumber) &&
+                sourceObjects.TryGetValue(reference.ObjectNumber, out var indirect) &&
+                IsDestinationForKnownPage(sourceObjects, indirect.Value, visitedReferences);
         }
 
         if (destination is PdfArray array) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
@@ -691,26 +691,26 @@ internal static class PdfSyntax {
     }
 
     private static bool IsDestinationForKnownPage(Dictionary<int, PdfIndirectObject> map, PdfObject destination) {
-        return IsDestinationForKnownPage(map, destination, new HashSet<int>());
-    }
+        var visitedReferences = new HashSet<int>();
+        while (true) {
+            if (destination is PdfReference reference) {
+                if (!visitedReferences.Add(reference.ObjectNumber) ||
+                    !map.TryGetValue(reference.ObjectNumber, out var indirect)) {
+                    return false;
+                }
 
-    private static bool IsDestinationForKnownPage(Dictionary<int, PdfIndirectObject> map, PdfObject destination, HashSet<int> visitedReferences) {
-        if (destination is PdfReference reference) {
-            return visitedReferences.Add(reference.ObjectNumber) &&
-                map.TryGetValue(reference.ObjectNumber, out var indirect) &&
-                IsDestinationForKnownPage(map, indirect.Value, visitedReferences);
+                destination = indirect.Value;
+                continue;
+            }
+
+            if (destination is PdfDictionary dictionary &&
+                dictionary.Items.TryGetValue("D", out var explicitDestination)) {
+                destination = explicitDestination;
+                continue;
+            }
+
+            return destination is PdfArray array && IsDestinationForKnownPage(map, array);
         }
-
-        if (destination is PdfArray array) {
-            return IsDestinationForKnownPage(map, array);
-        }
-
-        if (destination is PdfDictionary dictionary &&
-            dictionary.Items.TryGetValue("D", out var explicitDestination)) {
-            return IsDestinationForKnownPage(map, explicitDestination, visitedReferences);
-        }
-
-        return false;
     }
 
     private static bool IsSupportedGoToActionDictionary(Dictionary<int, PdfIndirectObject> map, PdfDictionary dictionary) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
@@ -696,12 +696,9 @@ internal static class PdfSyntax {
 
     private static bool IsDestinationForKnownPage(Dictionary<int, PdfIndirectObject> map, PdfObject destination, HashSet<int> visitedReferences) {
         if (destination is PdfReference reference) {
-            if (!visitedReferences.Add(reference.ObjectNumber) ||
-                !map.TryGetValue(reference.ObjectNumber, out var indirect)) {
-                return false;
-            }
-
-            destination = indirect.Value;
+            return visitedReferences.Add(reference.ObjectNumber) &&
+                map.TryGetValue(reference.ObjectNumber, out var indirect) &&
+                IsDestinationForKnownPage(map, indirect.Value, visitedReferences);
         }
 
         if (destination is PdfArray array) {

--- a/OfficeIMO.Tests/Pdf/PdfReadStreamTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReadStreamTests.cs
@@ -222,16 +222,35 @@ public class PdfReadStreamTests {
     }
 
     [Fact]
-    public void RewriteApis_PreserveGoToActionOutlinePdfsWithIndirectAndDictionaryDestinations() {
-        AssertOutline(PdfPageExtractor.ExtractPages(BuildIndirectGoToActionOutlinePdf(), 1), "Indirect action", 144d);
-        AssertOutline(PdfPageExtractor.ExtractPages(BuildDictionaryGoToActionOutlinePdf(), 1), "Dictionary action", 132d);
+    public void RewriteApis_PreserveGoToActionOutlinePdfsWithIndirectDestinationsForCopiedPages() {
+        byte[] outline = BuildGoToActionIndirectDestinationPdf();
 
-        static void AssertOutline(byte[] output, string title, double top) {
-            PdfOutlineItem item = Assert.Single(PdfInspector.Inspect(output).Outlines);
-            Assert.Equal(title, item.Title);
-            Assert.Equal(1, item.PageNumber);
-            Assert.Equal(top, item.DestinationTop);
-        }
+        PdfDocumentPreflight preflight = PdfInspector.Preflight(outline);
+        Assert.True(preflight.CanRewrite);
+        Assert.False(preflight.HasRewriteBlocker(PdfRewriteBlockerKind.Outlines));
+
+        byte[] output = PdfPageExtractor.ExtractPages(outline, 1);
+
+        PdfOutlineItem item = Assert.Single(PdfInspector.Inspect(output).Outlines);
+        Assert.Equal("Indirect GoTo action", item.Title);
+        Assert.Equal(1, item.PageNumber);
+        Assert.Equal(188d, item.DestinationTop);
+    }
+
+    [Fact]
+    public void RewriteApis_PreserveGoToActionOutlinePdfsWithDictionaryDestinationsForCopiedPages() {
+        byte[] outline = BuildGoToActionDictionaryDestinationPdf();
+
+        PdfDocumentPreflight preflight = PdfInspector.Preflight(outline);
+        Assert.True(preflight.CanRewrite);
+        Assert.False(preflight.HasRewriteBlocker(PdfRewriteBlockerKind.Outlines));
+
+        byte[] output = PdfPageExtractor.ExtractPages(outline, 1);
+
+        PdfOutlineItem item = Assert.Single(PdfInspector.Inspect(output).Outlines);
+        Assert.Equal("Dictionary GoTo action", item.Title);
+        Assert.Equal(1, item.PageNumber);
+        Assert.Equal(188d, item.DestinationTop);
     }
 
     [Fact]
@@ -1116,7 +1135,7 @@ public class PdfReadStreamTests {
         return System.Text.Encoding.ASCII.GetBytes(pdf);
     }
 
-    private static byte[] BuildIndirectGoToActionOutlinePdf() {
+    private static byte[] BuildGoToActionIndirectDestinationPdf() {
         string pdf = string.Join("\n", new[] {
             "%PDF-1.4",
             "1 0 obj",
@@ -1138,10 +1157,10 @@ public class PdfReadStreamTests {
             "<< /Type /Outlines /First 6 0 R /Last 6 0 R /Count 1 >>",
             "endobj",
             "6 0 obj",
-            "<< /Title (Indirect action) /Parent 5 0 R /A << /S /GoTo /D 7 0 R >> >>",
+            "<< /Title (Indirect GoTo action) /Parent 5 0 R /A << /S /GoTo /D 7 0 R >> >>",
             "endobj",
             "7 0 obj",
-            "[3 0 R /XYZ 0 144 0]",
+            "[3 0 R /XYZ 0 188 0]",
             "endobj",
             "trailer",
             "<< /Root 1 0 R /Size 8 >>",
@@ -1151,7 +1170,7 @@ public class PdfReadStreamTests {
         return System.Text.Encoding.ASCII.GetBytes(pdf);
     }
 
-    private static byte[] BuildDictionaryGoToActionOutlinePdf() {
+    private static byte[] BuildGoToActionDictionaryDestinationPdf() {
         string pdf = string.Join("\n", new[] {
             "%PDF-1.4",
             "1 0 obj",
@@ -1173,7 +1192,7 @@ public class PdfReadStreamTests {
             "<< /Type /Outlines /First 6 0 R /Last 6 0 R /Count 1 >>",
             "endobj",
             "6 0 obj",
-            "<< /Title (Dictionary action) /Parent 5 0 R /A << /S /GoTo /D << /D [3 0 R /XYZ 0 132 0] >> >> >>",
+            "<< /Title (Dictionary GoTo action) /Parent 5 0 R /A << /S /GoTo /D << /D [3 0 R /XYZ 0 188 0] >> >> >>",
             "endobj",
             "trailer",
             "<< /Root 1 0 R /Size 7 >>",

--- a/OfficeIMO.Tests/Pdf/PdfReadStreamTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfReadStreamTests.cs
@@ -254,6 +254,15 @@ public class PdfReadStreamTests {
     }
 
     [Fact]
+    public void Preflight_BlocksCyclicGoToActionOutlineDestinations() {
+        PdfDocumentPreflight report = PdfInspector.Preflight(BuildCyclicGoToActionDestinationPdf());
+
+        Assert.True(report.CanRead);
+        Assert.False(report.CanRewrite);
+        Assert.Contains(report.RewriteBlockers, blocker => blocker.Kind == PdfRewriteBlockerKind.Outlines);
+    }
+
+    [Fact]
     public void RewriteApis_RejectComplexOutlinePdfsWithClearUnsupportedDiagnostic() {
         byte[] outline = BuildUriActionOutlinePdf();
 
@@ -1196,6 +1205,44 @@ public class PdfReadStreamTests {
             "endobj",
             "trailer",
             "<< /Root 1 0 R /Size 7 >>",
+            "%%EOF"
+        });
+
+        return System.Text.Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildCyclicGoToActionDestinationPdf() {
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R /Outlines 5 0 R /PageMode /UseOutlines >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Length 0 >>",
+            "stream",
+            "",
+            "endstream",
+            "endobj",
+            "5 0 obj",
+            "<< /Type /Outlines /First 6 0 R /Last 6 0 R /Count 1 >>",
+            "endobj",
+            "6 0 obj",
+            "<< /Title (Cyclic GoTo action) /Parent 5 0 R /A << /S /GoTo /D 7 0 R >> >>",
+            "endobj",
+            "7 0 obj",
+            "8 0 R",
+            "endobj",
+            "8 0 obj",
+            "7 0 R",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R /Size 9 >>",
             "%%EOF"
         });
 


### PR DESCRIPTION
## Summary
- resolve indirect GoTo outline action destinations during preflight and rewrite support checks
- accept dictionary-form explicit destinations in outline action validation
- add rewrite/preflight regression coverage for both shapes from late PR #1844 review feedback

## Tests
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release -f net8.0 --filter "FullyQualifiedName~PdfReadStreamTests"
- dotnet build .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release -f net472
- git diff --check
