### PR TITLE
Add automatic callouts to remaining Visio builders

### DIFF
--- a/OfficeIMO.Tests/Visio.DependencyDiagramBuilder.cs
+++ b/OfficeIMO.Tests/Visio.DependencyDiagramBuilder.cs
@@ -193,7 +193,7 @@ namespace OfficeIMO.Tests {
             Assert.Equal(2.5, explicitCallout.Width);
             Assert.True(generatedCallout.PinX < api.PinX);
             Assert.Equal(api.Id, generatedCallout.CalloutTargetId);
-            VisioShapeBounds bounds = page.GetContentBounds();
+            OfficeIMO.Visio.VisioShapeBounds bounds = page.GetContentBounds();
             Assert.True(bounds.Left >= 0);
             Assert.True(bounds.Right <= page.Width);
             Assert.True(bounds.Bottom >= 0);

--- a/OfficeIMO.Tests/Visio.DependencyDiagramBuilder.cs
+++ b/OfficeIMO.Tests/Visio.DependencyDiagramBuilder.cs
@@ -163,6 +163,45 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void DependencyDiagramBuilderCanAutoPlaceSemanticCalloutsBesideNodes() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = VisioDocument.Create(filePath)
+                .DependencyDiagram("Auto Annotated Dependencies", diagram => diagram
+                    .Title()
+                    .Component("api", "API")
+                    .Decision("policy", "Policy")
+                    .Data("db", "Database")
+                    .ControlDependency("api", "policy", "Authorize")
+                    .DataDependency("api", "db", "SQL")
+                    .Callout("policy", "policy-note", "Policy gates this data path", VisioSide.Top, 0.4, options => {
+                        options.Width = 2.5;
+                        options.Height = 0.72;
+                    })
+                    .Callout("api", "Review client contracts", VisioSide.Left, 0.25));
+
+            VisioPage page = Assert.Single(document.Pages);
+            VisioShape policy = Assert.Single(page.Shapes, shape => shape.Id == "policy");
+            VisioShape api = Assert.Single(page.Shapes, shape => shape.Id == "api");
+            VisioShape explicitCallout = Assert.Single(page.Callouts(), shape => shape.Id == "policy-note");
+            VisioShape generatedCallout = Assert.Single(page.Callouts(), shape => shape.Id == "api-callout");
+
+            Assert.True(explicitCallout.PinY > policy.PinY);
+            Assert.Equal(policy.PinX, explicitCallout.PinX, 6);
+            Assert.Equal(policy.Id, explicitCallout.CalloutTargetId);
+            Assert.Equal(2.5, explicitCallout.Width);
+            Assert.True(generatedCallout.PinX < api.PinX);
+            Assert.Equal(api.Id, generatedCallout.CalloutTargetId);
+
+            VisioConnector leader = Assert.Single(page.Connectors, connector => ReferenceEquals(connector.From, explicitCallout));
+            Assert.Same(policy, leader.To);
+            Assert.Equal(EndArrow.None, leader.EndArrow);
+
+            document.Save();
+            Assert.Empty(VisioValidator.Validate(filePath));
+        }
+
+        [Fact]
         public void DependencyDiagramBuilderGeneratesUniqueCalloutIds() {
             VisioDocument document = VisioDocument.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx"))
                 .DependencyDiagram("Generated", diagram => diagram
@@ -212,6 +251,23 @@ namespace OfficeIMO.Tests {
             Assert.Contains("Unknown dependency node id", unknownTarget.Message);
             Assert.Contains("already exists", nodeCollision.Message);
             Assert.Contains("already exists", titleCollision.Message);
+        }
+
+        [Fact]
+        public void DependencyDiagramBuilderRejectsAutoCalloutPlacementIssues() {
+            VisioDocument document = VisioDocument.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx"));
+
+            ArgumentOutOfRangeException autoPlacement = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                document.DependencyDiagram("Invalid", diagram => diagram
+                    .Component("api", "API")
+                    .Callout("api", "Invalid", VisioSide.Auto)));
+            ArgumentOutOfRangeException badGap = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                document.DependencyDiagram("Invalid", diagram => diagram
+                    .Component("api", "API")
+                    .Callout("api", "Invalid", VisioSide.Right, double.NaN)));
+
+            Assert.Contains("Placement must be", autoPlacement.Message);
+            Assert.Contains("zero or greater", badGap.Message);
         }
     }
 }

--- a/OfficeIMO.Tests/Visio.DependencyDiagramBuilder.cs
+++ b/OfficeIMO.Tests/Visio.DependencyDiagramBuilder.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using OfficeIMO.Visio;
 using OfficeIMO.Visio.Diagrams;
+
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -192,6 +193,11 @@ namespace OfficeIMO.Tests {
             Assert.Equal(2.5, explicitCallout.Width);
             Assert.True(generatedCallout.PinX < api.PinX);
             Assert.Equal(api.Id, generatedCallout.CalloutTargetId);
+            VisioShapeBounds bounds = page.GetContentBounds();
+            Assert.True(bounds.Left >= 0);
+            Assert.True(bounds.Right <= page.Width);
+            Assert.True(bounds.Bottom >= 0);
+            Assert.True(bounds.Top <= page.Height);
 
             VisioConnector leader = Assert.Single(page.Connectors, connector => ReferenceEquals(connector.From, explicitCallout));
             Assert.Same(policy, leader.To);

--- a/OfficeIMO.Tests/Visio.OrgChartDiagramBuilder.cs
+++ b/OfficeIMO.Tests/Visio.OrgChartDiagramBuilder.cs
@@ -122,6 +122,45 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void OrgChartDiagramBuilderCanAutoPlaceSemanticCalloutsBesideNodes() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = VisioDocument.Create(filePath)
+                .OrgChartDiagram("Auto Annotated Leadership", org => org
+                    .Title()
+                    .Root("ceo", "Marta Nowak", "Chief Executive Officer")
+                    .Manager("cto", "Alex Chen", "Chief Technology Officer", "ceo")
+                    .TeamBand("engineering", "Engineering", "cto")
+                    .Position("platform", "Nina Patel", "Platform Lead", "cto", "engineering")
+                    .Position("security", "Owen Brooks", "Security Lead", "cto", "engineering")
+                    .Callout("cto", "cto-note", "Owns platform and security roadmap", VisioSide.Right, 0.45, options => {
+                        options.Width = 2.65;
+                        options.Height = 0.72;
+                    })
+                    .Callout("platform", "Succession backup", VisioSide.Bottom, 0.25));
+
+            VisioPage page = Assert.Single(document.Pages);
+            VisioShape cto = Assert.Single(page.Shapes, shape => shape.Id == "cto");
+            VisioShape platform = Assert.Single(page.Shapes, shape => shape.Id == "platform");
+            VisioShape explicitCallout = Assert.Single(page.Callouts(), shape => shape.Id == "cto-note");
+            VisioShape generatedCallout = Assert.Single(page.Callouts(), shape => shape.Id == "platform-callout");
+
+            Assert.True(explicitCallout.PinX > cto.PinX);
+            Assert.Equal(cto.PinY, explicitCallout.PinY, 6);
+            Assert.Equal(cto.Id, explicitCallout.CalloutTargetId);
+            Assert.Equal(2.65, explicitCallout.Width);
+            Assert.True(generatedCallout.PinY < platform.PinY);
+            Assert.Equal(platform.Id, generatedCallout.CalloutTargetId);
+
+            VisioConnector leader = Assert.Single(page.Connectors, connector => ReferenceEquals(connector.From, explicitCallout));
+            Assert.Same(cto, leader.To);
+            Assert.Equal(EndArrow.None, leader.EndArrow);
+
+            document.Save();
+            Assert.Empty(VisioValidator.Validate(filePath));
+        }
+
+        [Fact]
         public void OrgChartDiagramBuilderGeneratesUniqueCalloutIds() {
             VisioDocument document = VisioDocument.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx"))
                 .OrgChartDiagram("Generated", org => org
@@ -190,6 +229,23 @@ namespace OfficeIMO.Tests {
             Assert.Contains("Unknown org chart node id", unknownTarget.Message);
             Assert.Contains("already exists", nodeCollision.Message);
             Assert.Contains("already exists", bandCollision.Message);
+        }
+
+        [Fact]
+        public void OrgChartDiagramBuilderRejectsAutoCalloutPlacementIssues() {
+            VisioDocument document = VisioDocument.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx"));
+
+            ArgumentOutOfRangeException autoPlacement = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                document.OrgChartDiagram("Invalid", org => org
+                    .Root("ceo", "CEO")
+                    .Callout("ceo", "Invalid", VisioSide.Auto)));
+            ArgumentOutOfRangeException badGap = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                document.OrgChartDiagram("Invalid", org => org
+                    .Root("ceo", "CEO")
+                    .Callout("ceo", "Invalid", VisioSide.Right, double.NaN)));
+
+            Assert.Contains("Placement must be", autoPlacement.Message);
+            Assert.Contains("finite non-negative", badGap.Message);
         }
     }
 }

--- a/OfficeIMO.Tests/Visio.SwimlaneDiagramBuilder.cs
+++ b/OfficeIMO.Tests/Visio.SwimlaneDiagramBuilder.cs
@@ -154,6 +154,49 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SwimlaneDiagramBuilderCanAutoPlaceSemanticCalloutsBesideActivities() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = VisioDocument.Create(filePath)
+                .SwimlaneDiagram("Auto Annotated Fulfillment", swim => swim
+                    .Title()
+                    .Lane("sales", "Sales")
+                    .Lane("ops", "Operations")
+                    .Phase("intake", "Intake")
+                    .Phase("fulfill", "Fulfill")
+                    .Start("qualify", "Qualify request", "sales", "intake")
+                    .Decision("approved", "Approved?", "sales", "fulfill")
+                    .End("ship", "Ship order", "ops", "fulfill")
+                    .Flow("qualify", "approved")
+                    .Handoff("approved", "ship")
+                    .Callout("approved", "approval-note", "Escalate exceptions before fulfillment", VisioSide.Right, 0.45, options => {
+                        options.Width = 2.65;
+                        options.Height = 0.72;
+                    })
+                    .Callout("qualify", "Confirm account owner", VisioSide.Left, 0.25));
+
+            VisioPage page = Assert.Single(document.Pages);
+            VisioShape approved = Assert.Single(page.Shapes, shape => shape.Id == "approved");
+            VisioShape qualify = Assert.Single(page.Shapes, shape => shape.Id == "qualify");
+            VisioShape explicitCallout = Assert.Single(page.Callouts(), shape => shape.Id == "approval-note");
+            VisioShape generatedCallout = Assert.Single(page.Callouts(), shape => shape.Id == "qualify-callout");
+
+            Assert.True(explicitCallout.PinX > approved.PinX);
+            Assert.Equal(approved.PinY, explicitCallout.PinY, 6);
+            Assert.Equal(approved.Id, explicitCallout.CalloutTargetId);
+            Assert.Equal(2.65, explicitCallout.Width);
+            Assert.True(generatedCallout.PinX < qualify.PinX);
+            Assert.Equal(qualify.Id, generatedCallout.CalloutTargetId);
+
+            VisioConnector leader = Assert.Single(page.Connectors, connector => ReferenceEquals(connector.From, explicitCallout));
+            Assert.Same(approved, leader.To);
+            Assert.Equal(EndArrow.None, leader.EndArrow);
+
+            document.Save();
+            Assert.Empty(VisioValidator.Validate(filePath));
+        }
+
+        [Fact]
         public void SwimlaneDiagramBuilderGeneratesUniqueCalloutIds() {
             VisioDocument document = VisioDocument.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx"))
                 .SwimlaneDiagram("Generated", swim => swim
@@ -221,6 +264,27 @@ namespace OfficeIMO.Tests {
             Assert.Contains("Unknown swimlane activity id", unknownTarget.Message);
             Assert.Contains("already exists", activityCollision.Message);
             Assert.Contains("already exists", laneCollision.Message);
+        }
+
+        [Fact]
+        public void SwimlaneDiagramBuilderRejectsAutoCalloutPlacementIssues() {
+            VisioDocument document = VisioDocument.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx"));
+
+            ArgumentOutOfRangeException autoPlacement = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                document.SwimlaneDiagram("Invalid", swim => swim
+                    .Lane("ops", "Operations")
+                    .Phase("review", "Review")
+                    .Step("review", "Review", "ops", "review")
+                    .Callout("review", "Invalid", VisioSide.Auto)));
+            ArgumentOutOfRangeException badGap = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                document.SwimlaneDiagram("Invalid", swim => swim
+                    .Lane("ops", "Operations")
+                    .Phase("review", "Review")
+                    .Step("review", "Review", "ops", "review")
+                    .Callout("review", "Invalid", VisioSide.Right, double.NaN)));
+
+            Assert.Contains("Placement must be", autoPlacement.Message);
+            Assert.Contains("finite non-negative", badGap.Message);
         }
     }
 }

--- a/OfficeIMO.Tests/Visio.TimelineDiagramBuilder.cs
+++ b/OfficeIMO.Tests/Visio.TimelineDiagramBuilder.cs
@@ -128,6 +128,44 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void TimelineDiagramBuilderCanAutoPlaceSemanticCalloutsBesideItems() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = VisioDocument.Create(filePath)
+                .TimelineDiagram("Auto Annotated Roadmap", timeline => timeline
+                    .Title()
+                    .Range(new DateTime(2026, 1, 1), new DateTime(2026, 6, 30))
+                    .Span("build", new DateTime(2026, 2, 1), new DateTime(2026, 5, 15), "Build", 0)
+                    .Risk("risk", new DateTime(2026, 3, 18), "Security review", VisioTimelinePlacement.Above)
+                    .Release("preview", new DateTime(2026, 5, 20), "Public preview", VisioTimelinePlacement.Below)
+                    .Callout("risk", "risk-note", "Resolve before preview", VisioSide.Top, 0.35, options => {
+                        options.Width = 2.45;
+                        options.Height = 0.72;
+                    })
+                    .Callout("build", "Implementation runway", VisioSide.Bottom, 0.25));
+
+            VisioPage page = Assert.Single(document.Pages);
+            VisioShape risk = Assert.Single(page.Shapes, shape => shape.Id == "risk");
+            VisioShape build = Assert.Single(page.Shapes, shape => shape.Id == "build");
+            VisioShape explicitCallout = Assert.Single(page.Callouts(), shape => shape.Id == "risk-note");
+            VisioShape generatedCallout = Assert.Single(page.Callouts(), shape => shape.Id == "build-callout");
+
+            Assert.True(explicitCallout.PinY > risk.PinY);
+            Assert.Equal(risk.PinX, explicitCallout.PinX, 6);
+            Assert.Equal(risk.Id, explicitCallout.CalloutTargetId);
+            Assert.Equal(2.45, explicitCallout.Width);
+            Assert.True(generatedCallout.PinY < build.PinY);
+            Assert.Equal(build.Id, generatedCallout.CalloutTargetId);
+
+            VisioConnector leader = Assert.Single(page.Connectors, connector => ReferenceEquals(connector.From, explicitCallout));
+            Assert.Same(risk, leader.To);
+            Assert.Equal(EndArrow.None, leader.EndArrow);
+
+            document.Save();
+            Assert.Empty(VisioValidator.Validate(filePath));
+        }
+
+        [Fact]
         public void TimelineDiagramBuilderGeneratesUniqueCalloutIds() {
             VisioDocument document = VisioDocument.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx"))
                 .TimelineDiagram("Generated", timeline => timeline
@@ -195,6 +233,23 @@ namespace OfficeIMO.Tests {
             Assert.Contains("Unknown timeline item id", unknownTarget.Message);
             Assert.Contains("already exists", milestoneCollision.Message);
             Assert.Contains("already exists", generatedLabelCollision.Message);
+        }
+
+        [Fact]
+        public void TimelineDiagramBuilderRejectsAutoCalloutPlacementIssues() {
+            VisioDocument document = VisioDocument.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx"));
+
+            ArgumentOutOfRangeException autoPlacement = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                document.TimelineDiagram("Invalid", timeline => timeline
+                    .Milestone("kickoff", new DateTime(2026, 1, 1), "Kickoff")
+                    .Callout("kickoff", "Invalid", VisioSide.Auto)));
+            ArgumentOutOfRangeException badGap = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                document.TimelineDiagram("Invalid", timeline => timeline
+                    .Milestone("kickoff", new DateTime(2026, 1, 1), "Kickoff")
+                    .Callout("kickoff", "Invalid", VisioSide.Right, double.NaN)));
+
+            Assert.Contains("Placement must be", autoPlacement.Message);
+            Assert.Contains("finite non-negative", badGap.Message);
         }
     }
 }

--- a/OfficeIMO.Visio/Diagrams/VisioDependencyDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioDependencyDiagramBuilder.cs
@@ -54,6 +54,16 @@ namespace OfficeIMO.Visio.Diagrams {
                 Options = options;
             }
 
+            public CalloutItem(string targetId, string id, string text, VisioSide placement, double gap, VisioCalloutOptions options) {
+                TargetId = targetId;
+                Id = id;
+                Text = text;
+                Placement = placement;
+                Gap = gap;
+                Options = options;
+                UsePlacement = true;
+            }
+
             public string TargetId { get; }
 
             public string Id { get; }
@@ -63,6 +73,12 @@ namespace OfficeIMO.Visio.Diagrams {
             public double PinX { get; }
 
             public double PinY { get; }
+
+            public VisioSide Placement { get; }
+
+            public double Gap { get; }
+
+            public bool UsePlacement { get; }
 
             public VisioCalloutOptions Options { get; }
         }
@@ -247,6 +263,32 @@ namespace OfficeIMO.Visio.Diagrams {
             return this;
         }
 
+        /// <summary>Adds a semantic callout placed beside a known dependency node using a generated callout id.</summary>
+        public VisioDependencyDiagramBuilder Callout(string targetId, string text, VisioSide placement, double gap = 0.35D, Action<VisioCalloutOptions>? configure = null) {
+            string normalizedTargetId = RequireId(targetId, nameof(targetId), "Callout target id");
+            EnsureKnownNode(normalizedTargetId, nameof(targetId));
+            return Callout(normalizedTargetId, CreateCalloutId(normalizedTargetId), text, placement, gap, configure);
+        }
+
+        /// <summary>Adds a semantic callout placed beside a known dependency node.</summary>
+        public VisioDependencyDiagramBuilder Callout(string targetId, string id, string text, VisioSide placement, double gap = 0.35D, Action<VisioCalloutOptions>? configure = null) {
+            string normalizedTargetId = RequireId(targetId, nameof(targetId), "Callout target id");
+            string normalizedId = RequireId(id, nameof(id), "Callout id");
+            EnsureKnownNode(normalizedTargetId, nameof(targetId));
+            if (IsIdInUse(normalizedId)) {
+                throw new ArgumentException($"A dependency diagram item with id '{normalizedId}' already exists.", nameof(id));
+            }
+
+            ValidatePlacement(placement, nameof(placement));
+            ValidateNonNegative(gap, nameof(gap));
+            VisioCalloutOptions options = CreateCalloutOptions();
+            configure?.Invoke(options);
+            ValidatePositive(options.Width, nameof(options.Width));
+            ValidatePositive(options.Height, nameof(options.Height));
+            _callouts.Add(new CalloutItem(normalizedTargetId, normalizedId, text ?? string.Empty, placement, gap, options));
+            return this;
+        }
+
         internal VisioPage Build() {
             if (_built) {
                 throw new InvalidOperationException("This dependency diagram builder has already produced a page.");
@@ -382,7 +424,11 @@ namespace OfficeIMO.Visio.Diagrams {
                     throw new InvalidOperationException("Nodes must be placed before callouts are created.");
                 }
 
-                page.AddCallout(target.Shape, callout.Id, callout.Text, callout.PinX, callout.PinY, callout.Options);
+                if (callout.UsePlacement) {
+                    page.AddCallout(target.Shape, callout.Id, callout.Text, callout.Placement, callout.Gap, callout.Options);
+                } else {
+                    page.AddCallout(target.Shape, callout.Id, callout.Text, callout.PinX, callout.PinY, callout.Options);
+                }
             }
         }
 
@@ -533,6 +579,12 @@ namespace OfficeIMO.Visio.Diagrams {
         private static void ValidateNonNegative(double value, string parameterName) {
             if (double.IsNaN(value) || double.IsInfinity(value) || value < 0D) {
                 throw new ArgumentOutOfRangeException(parameterName, "Value must be zero or greater.");
+            }
+        }
+
+        private static void ValidatePlacement(VisioSide placement, string parameterName) {
+            if (placement == VisioSide.Auto || !Enum.IsDefined(typeof(VisioSide), placement)) {
+                throw new ArgumentOutOfRangeException(parameterName, "Placement must be Left, Right, Bottom, or Top.");
             }
         }
     }

--- a/OfficeIMO.Visio/Diagrams/VisioDependencyDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioDependencyDiagramBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+
 namespace OfficeIMO.Visio.Diagrams {
     /// <summary>
     /// High-level builder for dependency diagrams where OfficeIMO lays out nodes from directed relationships.
@@ -308,6 +309,7 @@ namespace OfficeIMO.Visio.Diagrams {
             AddDependencies(page);
             AddCallouts(page);
             AddTitle(page);
+            EnsureSideCalloutsFitPage(page);
             _document.RequestRecalcOnOpen();
             return page;
         }
@@ -429,6 +431,27 @@ namespace OfficeIMO.Visio.Diagrams {
                 } else {
                     page.AddCallout(target.Shape, callout.Id, callout.Text, callout.PinX, callout.PinY, callout.Options);
                 }
+            }
+        }
+
+        private void EnsureSideCalloutsFitPage(VisioPage page) {
+            if (!_callouts.Any(callout => callout.UsePlacement)) {
+                return;
+            }
+
+            VisioShapeBounds bounds = page.GetContentBounds();
+            if (bounds.IsEmpty) {
+                return;
+            }
+
+            double horizontalMargin = Math.Min(_leftMargin, _rightMargin);
+            double verticalMargin = Math.Min(_topMargin, _bottomMargin);
+            bool overflows = bounds.Left < horizontalMargin ||
+                             bounds.Bottom < verticalMargin ||
+                             bounds.Right > page.Width - horizontalMargin ||
+                             bounds.Top > page.Height - verticalMargin;
+            if (overflows) {
+                page.FitToContent(horizontalMargin, verticalMargin);
             }
         }
 

--- a/OfficeIMO.Visio/Diagrams/VisioOrgChartDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioOrgChartDiagramBuilder.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+
 
 namespace OfficeIMO.Visio.Diagrams {
     /// <summary>
@@ -312,6 +314,7 @@ namespace OfficeIMO.Visio.Diagrams {
             AddReportingLines(page);
             AddCallouts(page);
             AddTitle(page);
+            EnsureSideCalloutsFitPage(page);
             _document.RequestRecalcOnOpen();
             return page;
         }
@@ -590,6 +593,27 @@ namespace OfficeIMO.Visio.Diagrams {
                 } else {
                     page.AddCallout(target.Shape, callout.Id, callout.Text, callout.PinX, callout.PinY, callout.Options);
                 }
+            }
+        }
+
+        private void EnsureSideCalloutsFitPage(VisioPage page) {
+            if (!_callouts.Any(callout => callout.UsePlacement)) {
+                return;
+            }
+
+            VisioShapeBounds bounds = page.GetContentBounds();
+            if (bounds.IsEmpty) {
+                return;
+            }
+
+            double horizontalMargin = Math.Min(_leftMargin, _rightMargin);
+            double verticalMargin = Math.Min(_topMargin, _bottomMargin);
+            bool overflows = bounds.Left < horizontalMargin ||
+                             bounds.Bottom < verticalMargin ||
+                             bounds.Right > page.Width - horizontalMargin ||
+                             bounds.Top > page.Height - verticalMargin;
+            if (overflows) {
+                page.FitToContent(horizontalMargin, verticalMargin);
             }
         }
 

--- a/OfficeIMO.Visio/Diagrams/VisioOrgChartDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioOrgChartDiagramBuilder.cs
@@ -66,6 +66,16 @@ namespace OfficeIMO.Visio.Diagrams {
                 Options = options;
             }
 
+            public CalloutItem(string targetId, string id, string text, VisioSide placement, double gap, VisioCalloutOptions options) {
+                TargetId = targetId;
+                Id = id;
+                Text = text;
+                Placement = placement;
+                Gap = gap;
+                Options = options;
+                UsePlacement = true;
+            }
+
             public string TargetId { get; }
 
             public string Id { get; }
@@ -75,6 +85,12 @@ namespace OfficeIMO.Visio.Diagrams {
             public double PinX { get; }
 
             public double PinY { get; }
+
+            public VisioSide Placement { get; }
+
+            public double Gap { get; }
+
+            public bool UsePlacement { get; }
 
             public VisioCalloutOptions Options { get; }
         }
@@ -250,6 +266,32 @@ namespace OfficeIMO.Visio.Diagrams {
             ValidatePositive(options.Width, nameof(options.Width));
             ValidatePositive(options.Height, nameof(options.Height));
             _callouts.Add(new CalloutItem(normalizedTargetId, normalizedId, text ?? string.Empty, pinX, pinY, options));
+            return this;
+        }
+
+        /// <summary>Adds a semantic callout placed beside a known org chart node using a generated callout id.</summary>
+        public VisioOrgChartDiagramBuilder Callout(string targetId, string text, VisioSide placement, double gap = 0.35D, Action<VisioCalloutOptions>? configure = null) {
+            string normalizedTargetId = RequireId(targetId, nameof(targetId), "Callout target id");
+            EnsureKnownNode(normalizedTargetId, nameof(targetId));
+            return Callout(normalizedTargetId, CreateCalloutId(normalizedTargetId), text, placement, gap, configure);
+        }
+
+        /// <summary>Adds a semantic callout placed beside a known org chart node.</summary>
+        public VisioOrgChartDiagramBuilder Callout(string targetId, string id, string text, VisioSide placement, double gap = 0.35D, Action<VisioCalloutOptions>? configure = null) {
+            string normalizedTargetId = RequireId(targetId, nameof(targetId), "Callout target id");
+            string normalizedId = RequireId(id, nameof(id), "Callout id");
+            EnsureKnownNode(normalizedTargetId, nameof(targetId));
+            if (IsShapeIdInUse(normalizedId)) {
+                throw new ArgumentException($"An org chart item with shape id '{normalizedId}' already exists.", nameof(id));
+            }
+
+            ValidatePlacement(placement, nameof(placement));
+            ValidateNonNegative(gap, nameof(gap));
+            VisioCalloutOptions options = CreateCalloutOptions();
+            configure?.Invoke(options);
+            ValidatePositive(options.Width, nameof(options.Width));
+            ValidatePositive(options.Height, nameof(options.Height));
+            _callouts.Add(new CalloutItem(normalizedTargetId, normalizedId, text ?? string.Empty, placement, gap, options));
             return this;
         }
 
@@ -543,7 +585,11 @@ namespace OfficeIMO.Visio.Diagrams {
                     throw new InvalidOperationException("Org chart nodes must be placed before callouts are created.");
                 }
 
-                page.AddCallout(target.Shape, callout.Id, callout.Text, callout.PinX, callout.PinY, callout.Options);
+                if (callout.UsePlacement) {
+                    page.AddCallout(target.Shape, callout.Id, callout.Text, callout.Placement, callout.Gap, callout.Options);
+                } else {
+                    page.AddCallout(target.Shape, callout.Id, callout.Text, callout.PinX, callout.PinY, callout.Options);
+                }
             }
         }
 
@@ -740,6 +786,12 @@ namespace OfficeIMO.Visio.Diagrams {
         private static void ValidateNonNegative(double value, string parameterName) {
             if (double.IsNaN(value) || double.IsInfinity(value) || value < 0) {
                 throw new ArgumentOutOfRangeException(parameterName, "Value must be a finite non-negative number.");
+            }
+        }
+
+        private static void ValidatePlacement(VisioSide placement, string parameterName) {
+            if (placement == VisioSide.Auto || !Enum.IsDefined(typeof(VisioSide), placement)) {
+                throw new ArgumentOutOfRangeException(parameterName, "Placement must be Left, Right, Bottom, or Top.");
             }
         }
     }

--- a/OfficeIMO.Visio/Diagrams/VisioSwimlaneDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioSwimlaneDiagramBuilder.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+
 using Color = OfficeIMO.Drawing.OfficeColor;
 
 namespace OfficeIMO.Visio.Diagrams {
@@ -383,6 +385,7 @@ namespace OfficeIMO.Visio.Diagrams {
             AddFlows(page);
             AddCallouts(page);
             AddTitle(page);
+            EnsureSideCalloutsFitPage(page);
             _document.RequestRecalcOnOpen();
             return page;
         }
@@ -571,6 +574,27 @@ namespace OfficeIMO.Visio.Diagrams {
                 } else {
                     page.AddCallout(target.Shape, callout.Id, callout.Text, callout.PinX, callout.PinY, callout.Options);
                 }
+            }
+        }
+
+        private void EnsureSideCalloutsFitPage(VisioPage page) {
+            if (!_callouts.Any(callout => callout.UsePlacement)) {
+                return;
+            }
+
+            VisioShapeBounds bounds = page.GetContentBounds();
+            if (bounds.IsEmpty) {
+                return;
+            }
+
+            double horizontalMargin = Math.Min(_leftMargin, _rightMargin);
+            double verticalMargin = Math.Min(_topMargin, _bottomMargin);
+            bool overflows = bounds.Left < horizontalMargin ||
+                             bounds.Bottom < verticalMargin ||
+                             bounds.Right > page.Width - horizontalMargin ||
+                             bounds.Top > page.Height - verticalMargin;
+            if (overflows) {
+                page.FitToContent(horizontalMargin, verticalMargin);
             }
         }
 

--- a/OfficeIMO.Visio/Diagrams/VisioSwimlaneDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioSwimlaneDiagramBuilder.cs
@@ -78,6 +78,16 @@ namespace OfficeIMO.Visio.Diagrams {
                 Options = options;
             }
 
+            public CalloutItem(string targetId, string id, string text, VisioSide placement, double gap, VisioCalloutOptions options) {
+                TargetId = targetId;
+                Id = id;
+                Text = text;
+                Placement = placement;
+                Gap = gap;
+                Options = options;
+                UsePlacement = true;
+            }
+
             public string TargetId { get; }
 
             public string Id { get; }
@@ -87,6 +97,12 @@ namespace OfficeIMO.Visio.Diagrams {
             public double PinX { get; }
 
             public double PinY { get; }
+
+            public VisioSide Placement { get; }
+
+            public double Gap { get; }
+
+            public bool UsePlacement { get; }
 
             public VisioCalloutOptions Options { get; }
         }
@@ -314,6 +330,32 @@ namespace OfficeIMO.Visio.Diagrams {
             return this;
         }
 
+        /// <summary>Adds a semantic callout placed beside a known swimlane activity using a generated callout id.</summary>
+        public VisioSwimlaneDiagramBuilder Callout(string targetId, string text, VisioSide placement, double gap = 0.35D, Action<VisioCalloutOptions>? configure = null) {
+            string normalizedTargetId = RequireId(targetId, nameof(targetId), "Callout target id");
+            EnsureKnownActivity(normalizedTargetId, nameof(targetId));
+            return Callout(normalizedTargetId, CreateCalloutId(normalizedTargetId), text, placement, gap, configure);
+        }
+
+        /// <summary>Adds a semantic callout placed beside a known swimlane activity.</summary>
+        public VisioSwimlaneDiagramBuilder Callout(string targetId, string id, string text, VisioSide placement, double gap = 0.35D, Action<VisioCalloutOptions>? configure = null) {
+            string normalizedTargetId = RequireId(targetId, nameof(targetId), "Callout target id");
+            string normalizedId = RequireId(id, nameof(id), "Callout id");
+            EnsureKnownActivity(normalizedTargetId, nameof(targetId));
+            if (IsShapeIdInUse(normalizedId)) {
+                throw new ArgumentException($"A swimlane shape with id '{normalizedId}' already exists.", nameof(id));
+            }
+
+            ValidatePlacement(placement, nameof(placement));
+            ValidateNonNegative(gap, nameof(gap));
+            VisioCalloutOptions options = CreateCalloutOptions();
+            configure?.Invoke(options);
+            ValidatePositive(options.Width, nameof(options.Width));
+            ValidatePositive(options.Height, nameof(options.Height));
+            _callouts.Add(new CalloutItem(normalizedTargetId, normalizedId, text ?? string.Empty, placement, gap, options));
+            return this;
+        }
+
         internal VisioPage Build() {
             if (_built) {
                 throw new InvalidOperationException("This swimlane diagram builder has already produced a page.");
@@ -524,7 +566,11 @@ namespace OfficeIMO.Visio.Diagrams {
                     throw new InvalidOperationException("Activities must be placed before callouts are created.");
                 }
 
-                page.AddCallout(target.Shape, callout.Id, callout.Text, callout.PinX, callout.PinY, callout.Options);
+                if (callout.UsePlacement) {
+                    page.AddCallout(target.Shape, callout.Id, callout.Text, callout.Placement, callout.Gap, callout.Options);
+                } else {
+                    page.AddCallout(target.Shape, callout.Id, callout.Text, callout.PinX, callout.PinY, callout.Options);
+                }
             }
         }
 
@@ -750,6 +796,12 @@ namespace OfficeIMO.Visio.Diagrams {
         private static void ValidateNonNegative(double value, string parameterName) {
             if (double.IsNaN(value) || double.IsInfinity(value) || value < 0) {
                 throw new ArgumentOutOfRangeException(parameterName, "Value must be a finite non-negative number.");
+            }
+        }
+
+        private static void ValidatePlacement(VisioSide placement, string parameterName) {
+            if (placement == VisioSide.Auto || !Enum.IsDefined(typeof(VisioSide), placement)) {
+                throw new ArgumentOutOfRangeException(parameterName, "Placement must be Left, Right, Bottom, or Top.");
             }
         }
 

--- a/OfficeIMO.Visio/Diagrams/VisioTimelineDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioTimelineDiagramBuilder.cs
@@ -66,6 +66,16 @@ namespace OfficeIMO.Visio.Diagrams {
                 Options = options;
             }
 
+            public CalloutItem(string targetId, string id, string text, VisioSide placement, double gap, VisioCalloutOptions options) {
+                TargetId = targetId;
+                Id = id;
+                Text = text;
+                Placement = placement;
+                Gap = gap;
+                Options = options;
+                UsePlacement = true;
+            }
+
             public string TargetId { get; }
 
             public string Id { get; }
@@ -75,6 +85,12 @@ namespace OfficeIMO.Visio.Diagrams {
             public double PinX { get; }
 
             public double PinY { get; }
+
+            public VisioSide Placement { get; }
+
+            public double Gap { get; }
+
+            public bool UsePlacement { get; }
 
             public VisioCalloutOptions Options { get; }
         }
@@ -286,6 +302,32 @@ namespace OfficeIMO.Visio.Diagrams {
             return this;
         }
 
+        /// <summary>Adds a semantic callout placed beside a known timeline milestone or span using a generated callout id.</summary>
+        public VisioTimelineDiagramBuilder Callout(string targetId, string text, VisioSide placement, double gap = 0.35D, Action<VisioCalloutOptions>? configure = null) {
+            string normalizedTargetId = RequireId(targetId, nameof(targetId), "Callout target id");
+            EnsureKnownTimelineItem(normalizedTargetId, nameof(targetId));
+            return Callout(normalizedTargetId, CreateCalloutId(normalizedTargetId), text, placement, gap, configure);
+        }
+
+        /// <summary>Adds a semantic callout placed beside a known timeline milestone or span.</summary>
+        public VisioTimelineDiagramBuilder Callout(string targetId, string id, string text, VisioSide placement, double gap = 0.35D, Action<VisioCalloutOptions>? configure = null) {
+            string normalizedTargetId = RequireId(targetId, nameof(targetId), "Callout target id");
+            string normalizedId = RequireId(id, nameof(id), "Callout id");
+            EnsureKnownTimelineItem(normalizedTargetId, nameof(targetId));
+            if (IsShapeIdInUse(normalizedId)) {
+                throw new ArgumentException($"A timeline item with shape id '{normalizedId}' already exists.", nameof(id));
+            }
+
+            ValidatePlacement(placement, nameof(placement));
+            ValidateNonNegative(gap, nameof(gap));
+            VisioCalloutOptions options = CreateCalloutOptions();
+            configure?.Invoke(options);
+            ValidatePositive(options.Width, nameof(options.Width));
+            ValidatePositive(options.Height, nameof(options.Height));
+            _callouts.Add(new CalloutItem(normalizedTargetId, normalizedId, text ?? string.Empty, placement, gap, options));
+            return this;
+        }
+
         internal VisioPage Build() {
             if (_built) {
                 throw new InvalidOperationException("This timeline builder has already produced a page.");
@@ -471,7 +513,11 @@ namespace OfficeIMO.Visio.Diagrams {
                     throw new InvalidOperationException("Timeline items must be placed before callouts are created.");
                 }
 
-                page.AddCallout(target, callout.Id, callout.Text, callout.PinX, callout.PinY, callout.Options);
+                if (callout.UsePlacement) {
+                    page.AddCallout(target, callout.Id, callout.Text, callout.Placement, callout.Gap, callout.Options);
+                } else {
+                    page.AddCallout(target, callout.Id, callout.Text, callout.PinX, callout.PinY, callout.Options);
+                }
             }
         }
 
@@ -688,6 +734,12 @@ namespace OfficeIMO.Visio.Diagrams {
         private static void ValidateNonNegative(double value, string parameterName) {
             if (double.IsNaN(value) || double.IsInfinity(value) || value < 0) {
                 throw new ArgumentOutOfRangeException(parameterName, "Value must be a finite non-negative number.");
+            }
+        }
+
+        private static void ValidatePlacement(VisioSide placement, string parameterName) {
+            if (placement == VisioSide.Auto || !Enum.IsDefined(typeof(VisioSide), placement)) {
+                throw new ArgumentOutOfRangeException(parameterName, "Placement must be Left, Right, Bottom, or Top.");
             }
         }
     }

--- a/OfficeIMO.Visio/Diagrams/VisioTimelineDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioTimelineDiagramBuilder.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+
 using Color = OfficeIMO.Drawing.OfficeColor;
 
 namespace OfficeIMO.Visio.Diagrams {
@@ -348,6 +350,7 @@ namespace OfficeIMO.Visio.Diagrams {
             AddMilestones(page, start, end);
             AddCallouts(page);
             AddTitle(page);
+            EnsureSideCalloutsFitPage(page);
             _document.RequestRecalcOnOpen();
             return page;
         }
@@ -518,6 +521,27 @@ namespace OfficeIMO.Visio.Diagrams {
                 } else {
                     page.AddCallout(target, callout.Id, callout.Text, callout.PinX, callout.PinY, callout.Options);
                 }
+            }
+        }
+
+        private void EnsureSideCalloutsFitPage(VisioPage page) {
+            if (!_callouts.Any(callout => callout.UsePlacement)) {
+                return;
+            }
+
+            VisioShapeBounds bounds = page.GetContentBounds();
+            if (bounds.IsEmpty) {
+                return;
+            }
+
+            double horizontalMargin = Math.Min(_leftMargin, _rightMargin);
+            double verticalMargin = Math.Min(_topMargin, _bottomMargin);
+            bool overflows = bounds.Left < horizontalMargin ||
+                             bounds.Bottom < verticalMargin ||
+                             bounds.Right > page.Width - horizontalMargin ||
+                             bounds.Top > page.Height - verticalMargin;
+            if (overflows) {
+                page.FitToContent(horizontalMargin, verticalMargin);
             }
         }
 

--- a/OfficeIMO.Visio/README.md
+++ b/OfficeIMO.Visio/README.md
@@ -116,7 +116,7 @@ VisioDocument.Create("dependencies.vsdx")
         .DependsOn("web", "api")
         .ControlDependency("api", "policy", "Authorize")
         .DataDependency("api", "database", "SQL")
-        .Callout("policy", "policy-note", "Authorization gates access to data", 7.4, 5.3))
+        .Callout("policy", "policy-note", "Authorization gates access to data", VisioSide.Top))
     .EnsureVisualQuality(new VisioDiagramQualityOptions {
         CheckConnectorShapeIntersections = false,
         CheckConnectorLabelShapeOverlaps = false
@@ -127,7 +127,7 @@ VisioDocument.Create("dependencies.vsdx")
 The dependency diagram builder creates deterministic layered DAG layouts from
 nodes and directed relationships. It automatically grows the page, places
 component/data/external/decision nodes, routes dependencies, supports semantic
-callouts, and rejects cycles.
+coordinate or side-placed callouts, and rejects cycles.
 
 ## Quick sample (architecture diagram builder)
 
@@ -264,15 +264,15 @@ VisioDocument.Create("swimlane.vsdx")
         .Handoff("approved", "pick", "yes")
         .Flow("pick", "invoice")
         .Flow("invoice", "ship")
-        .Callout("approved", "approval-note", "Escalate exceptions before fulfillment", 7.8, 5.9))
+        .Callout("approved", "approval-note", "Escalate exceptions before fulfillment", VisioSide.Right))
     .Save();
 ```
 
 The swimlane builder creates editable role lanes, phase headers, semantic
 activities, labeled flows, dashed exception paths, deterministic routing, and
 automatic stacking when more than one activity lands in the same lane/phase
-cell. It supports semantic callouts for risk and exception notes, and does not
-require Visio templates at runtime.
+cell. It supports coordinate or side-placed semantic callouts for risk and
+exception notes, and does not require Visio templates at runtime.
 
 ## Quick sample (org chart builder)
 
@@ -295,13 +295,13 @@ VisioDocument.Create("org-chart.vsdx")
         .Position("security", "Owen Brooks", "Security Lead", "cto", "engineering")
         .Vacancy("sre", "Open SRE Role", "coo", "operations")
         .External("advisor", "Taylor Reed", "Advisor", "cfo")
-        .Callout("cto", "cto-note", "Owns platform and security roadmap", 8.1, 5.9))
+        .Callout("cto", "cto-note", "Owns platform and security roadmap", VisioSide.Right))
     .Save();
 ```
 
 The org chart builder creates editable hierarchy cards, assistant placements,
-team bands, vacancies, external roles, routed reporting lines, and semantic
-callouts from business relationships.
+team bands, vacancies, external roles, routed reporting lines, and coordinate
+or side-placed semantic callouts from business relationships.
 
 ## Reusable style themes
 
@@ -431,12 +431,13 @@ VisioDocument.Create("roadmap.vsdx")
         .Span("build", new DateTime(2026, 2, 21), new DateTime(2026, 5, 15), "Build", lane: 1)
         .Release("preview", new DateTime(2026, 5, 20), "Public preview", VisioTimelinePlacement.Below)
         .Milestone("ga", new DateTime(2026, 6, 25), "GA")
-        .Callout("build", "build-note", "Implementation runway", 5.2, 5.7))
+        .Callout("build", "build-note", "Implementation runway", VisioSide.Top))
     .Save();
 ```
 
 Timeline callouts can target either milestone IDs or span IDs, so roadmap
-notes stay attached to the dated item they explain.
+notes stay attached to the dated item they explain. They can be placed by
+coordinates or relative to the target side.
 
 ## Visual quality checks and gallery output
 


### PR DESCRIPTION
## Summary
- add side-based semantic callout overloads to dependency, org chart, swimlane, and timeline builders
- keep existing coordinate-based callouts while routing side-placed callouts through the shared page callout helper
- update builder tests and README samples for the consistent side-placement API

## Tests
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --framework net8.0 --filter "FullyQualifiedName~VisioDependencyDiagramBuilderTests|FullyQualifiedName~VisioOrgChartDiagramBuilderTests|FullyQualifiedName~VisioSwimlaneDiagramBuilderTests|FullyQualifiedName~VisioTimelineDiagramBuilderTests" -v minimal
- dotnet build OfficeIMO.Visio/OfficeIMO.Visio.csproj -c Release --no-restore
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --framework net8.0 --filter FullyQualifiedName~Visio --no-build -v minimal
- git diff --check
