### PR TITLE
Learn master dimensions for Visio stencil catalogs

### DIFF
--- a/OfficeIMO.Tests/Visio.Stencils.cs
+++ b/OfficeIMO.Tests/Visio.Stencils.cs
@@ -241,6 +241,59 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PackageStencilCatalogLearnsNativeMasterDimensionsWithoutRuntimeTemplateDependency() {
+            string packagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vssx");
+            CreatePackageWithMasterDimensions(
+                packagePath,
+                ("Rectangle", "Wide Box", 3.2, 1.1, null),
+                ("Decision", "Metric Decision", 50.8, 25.4, "MM"));
+
+            VisioStencilCatalog catalog = VisioStencilPackageCatalog.Load(packagePath, new VisioStencilPackageLoadOptions {
+                CatalogName = "Learned Sizes",
+                Category = "Learned",
+                IdPrefix = "learned",
+                DefaultWidth = 9,
+                DefaultHeight = 7
+            });
+
+            VisioStencilShape wideBox = catalog.Get("wide-box");
+            VisioStencilShape metricDecision = catalog.Get("metric-decision");
+
+            Assert.Equal(3.2, wideBox.DefaultWidth, 6);
+            Assert.Equal(1.1, wideBox.DefaultHeight, 6);
+            Assert.Equal(VisioMeasurementUnit.Inches, wideBox.DefaultUnit);
+            Assert.Equal(2.0, metricDecision.DefaultWidth, 6);
+            Assert.Equal(1.0, metricDecision.DefaultHeight, 6);
+            Assert.Equal(VisioMeasurementUnit.Inches, metricDecision.DefaultUnit);
+
+            using MemoryStream manifest = new();
+            catalog.Save(manifest);
+            manifest.Position = 0;
+            VisioStencilCatalog loadedCatalog = VisioStencilCatalog.Load(manifest);
+            Assert.Equal(VisioMeasurementUnit.Inches, loadedCatalog.Get("wide-box").DefaultUnit);
+
+            VisioStencilCatalog fallbackCatalog = VisioStencilPackageCatalog.Load(packagePath, new VisioStencilPackageLoadOptions {
+                LearnMasterDimensions = false,
+                DefaultWidth = 9,
+                DefaultHeight = 7
+            });
+            Assert.Equal(9, fallbackCatalog.Get("wide-box").DefaultWidth);
+            Assert.Null(fallbackCatalog.Get("wide-box").DefaultUnit);
+
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+            VisioDocument document = VisioDocument.Create(filePath);
+            VisioPage page = document.AddPage("Learned Stencils", 20, 15, VisioMeasurementUnit.Centimeters);
+            VisioShape shape = page.AddStencilShape(catalog, "wide-box", "wide", 5, 8);
+            document.Save();
+
+            Assert.Equal(5.0 / 2.54, shape.PinX, 6);
+            Assert.Equal(8.0 / 2.54, shape.PinY, 6);
+            Assert.Equal(3.2, shape.Width, 6);
+            Assert.Equal(1.1, shape.Height, 6);
+            Assert.Empty(VisioValidator.Validate(filePath));
+        }
+
+        [Fact]
         public void PackageStencilCatalogLoadsFromVstxAndCanIncludeUnsupportedMasters() {
             string packagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vstx");
             CreatePackageWithMasters(packagePath, "Rectangle", "FancyCloud");
@@ -336,6 +389,63 @@ namespace OfficeIMO.Tests {
                         new XElement(ns + "Rel", new XAttribute(rel + "id", $"rId{index + 1}")))));
 
             XDocument document = new(root);
+            writer.Write(document.Declaration + Environment.NewLine + document.ToString(SaveOptions.DisableFormatting));
+        }
+
+        private static void CreatePackageWithMasterDimensions(string path, params (string NameU, string? Name, double Width, double Height, string? Unit)[] masters) {
+            const string visioNamespace = "http://schemas.microsoft.com/office/visio/2012/main";
+            const string officeRelationshipNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+            const string packageRelationshipNamespace = "http://schemas.openxmlformats.org/package/2006/relationships";
+
+            using ZipArchive zip = ZipFile.Open(path, ZipArchiveMode.Create);
+            XNamespace ns = visioNamespace;
+            XNamespace rel = officeRelationshipNamespace;
+            XElement mastersRoot = new(ns + "Masters",
+                masters.Select((master, index) =>
+                    new XElement(ns + "Master",
+                        new XAttribute("ID", index + 1),
+                        new XAttribute("Name", master.Name ?? master.NameU),
+                        new XAttribute("NameU", master.NameU),
+                        new XElement(ns + "Rel", new XAttribute(rel + "id", $"rId{index + 1}")))));
+            WriteZipXml(zip, "visio/masters/masters.xml", new XDocument(mastersRoot));
+
+            XNamespace packageRel = packageRelationshipNamespace;
+            XElement relationshipsRoot = new(packageRel + "Relationships",
+                masters.Select((master, index) =>
+                    new XElement(packageRel + "Relationship",
+                        new XAttribute("Id", $"rId{index + 1}"),
+                        new XAttribute("Type", officeRelationshipNamespace + "/master"),
+                        new XAttribute("Target", $"master{index + 1}.xml"))));
+            WriteZipXml(zip, "visio/masters/_rels/masters.xml.rels", new XDocument(relationshipsRoot));
+
+            for (int index = 0; index < masters.Length; index++) {
+                (string nameU, string? name, double width, double height, string? unit) = masters[index];
+                XElement shape = new(ns + "Shape",
+                    new XAttribute("ID", "1"),
+                    new XAttribute("Name", name ?? nameU),
+                    new XAttribute("NameU", nameU),
+                    DimensionCell(ns, "Width", width, unit),
+                    DimensionCell(ns, "Height", height, unit));
+                XDocument masterDocument = new(new XElement(ns + "MasterContents", new XElement(ns + "Shapes", shape)));
+                WriteZipXml(zip, $"visio/masters/master{index + 1}.xml", masterDocument);
+            }
+        }
+
+        private static XElement DimensionCell(XNamespace ns, string name, double value, string? unit) {
+            XElement cell = new(ns + "Cell",
+                new XAttribute("N", name),
+                new XAttribute("V", value.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+            if (!string.IsNullOrWhiteSpace(unit)) {
+                cell.Add(new XAttribute("U", unit));
+            }
+
+            return cell;
+        }
+
+        private static void WriteZipXml(ZipArchive zip, string path, XDocument document) {
+            ZipArchiveEntry entry = zip.CreateEntry(path);
+            using Stream stream = entry.Open();
+            using StreamWriter writer = new(stream, new UTF8Encoding(false));
             writer.Write(document.Declaration + Environment.NewLine + document.ToString(SaveOptions.DisableFormatting));
         }
     }

--- a/OfficeIMO.Tests/Visio.Stencils.cs
+++ b/OfficeIMO.Tests/Visio.Stencils.cs
@@ -305,6 +305,7 @@ namespace OfficeIMO.Tests {
             VisioDocument document = VisioDocument.Create(filePath);
             VisioPage page = document.AddPage("Learned Stencils", 20, 15, VisioMeasurementUnit.Centimeters);
             VisioShape shape = page.AddStencilShape(catalog, "wide-box", "wide", 5, 8);
+            VisioShape coordinateUnitShape = page.AddStencilShape(wideBox, "wide-cm", 6, 9, "Wide in cm", VisioMeasurementUnit.Centimeters);
             VisioShape explicitShape = page.AddStencilShape(catalog, "wide-box", "explicit", 10, 8, 4, 2, "Explicit size");
             VisioShape resized = page.AddRectangle(14, 8, 1, 1, "Resize me", VisioMeasurementUnit.Centimeters);
             page.ReplaceMaster(resized, wideBox, resizeToMaster: true);
@@ -314,6 +315,10 @@ namespace OfficeIMO.Tests {
             Assert.Equal(8.0 / 2.54, shape.PinY, 6);
             Assert.Equal(3.2, shape.Width, 6);
             Assert.Equal(1.1, shape.Height, 6);
+            Assert.Equal(6.0 / 2.54, coordinateUnitShape.PinX, 6);
+            Assert.Equal(9.0 / 2.54, coordinateUnitShape.PinY, 6);
+            Assert.Equal(3.2, coordinateUnitShape.Width, 6);
+            Assert.Equal(1.1, coordinateUnitShape.Height, 6);
             Assert.Equal(4.0 / 2.54, explicitShape.Width, 6);
             Assert.Equal(2.0 / 2.54, explicitShape.Height, 6);
             Assert.Equal(3.2, resized.Width, 6);

--- a/OfficeIMO.Tests/Visio.Stencils.cs
+++ b/OfficeIMO.Tests/Visio.Stencils.cs
@@ -155,6 +155,27 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void StencilMetadataKeepsPreviousPublicOverloads() {
+            Type enumerableType = typeof(IEnumerable<string>);
+
+            Assert.NotNull(typeof(VisioStencilShape).GetConstructor(new[] {
+                typeof(string),
+                typeof(string),
+                typeof(string),
+                typeof(string),
+                typeof(double),
+                typeof(double),
+                enumerableType,
+                enumerableType,
+                enumerableType,
+                typeof(string)
+            }));
+            Assert.Contains(
+                typeof(VisioStencilCatalogBuilder).GetMethods().Where(method => method.Name == nameof(VisioStencilCatalogBuilder.AddWithMetadata)),
+                method => method.GetParameters().Length == 10);
+        }
+
+        [Fact]
         public void StencilCatalogManifestRoundTripsMetadataAndLoadedCatalogCanPlaceShapes() {
             string manifestPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".officeimo-visio-stencils.xml");
             VisioStencilCatalog source = VisioStencilCatalog.Create("Reusable Infrastructure", builder => builder
@@ -246,7 +267,7 @@ namespace OfficeIMO.Tests {
             CreatePackageWithMasterDimensions(
                 packagePath,
                 ("Rectangle", "Wide Box", 3.2, 1.1, null),
-                ("Decision", "Metric Decision", 50.8, 25.4, "MM"));
+                ("Decision", "Metric Decision", 2.0, 1.0, "MM"));
 
             VisioStencilCatalog catalog = VisioStencilPackageCatalog.Load(packagePath, new VisioStencilPackageLoadOptions {
                 CatalogName = "Learned Sizes",
@@ -284,12 +305,19 @@ namespace OfficeIMO.Tests {
             VisioDocument document = VisioDocument.Create(filePath);
             VisioPage page = document.AddPage("Learned Stencils", 20, 15, VisioMeasurementUnit.Centimeters);
             VisioShape shape = page.AddStencilShape(catalog, "wide-box", "wide", 5, 8);
+            VisioShape explicitShape = page.AddStencilShape(catalog, "wide-box", "explicit", 10, 8, 4, 2, "Explicit size");
+            VisioShape resized = page.AddRectangle(14, 8, 1, 1, "Resize me", VisioMeasurementUnit.Centimeters);
+            page.ReplaceMaster(resized, wideBox, resizeToMaster: true);
             document.Save();
 
             Assert.Equal(5.0 / 2.54, shape.PinX, 6);
             Assert.Equal(8.0 / 2.54, shape.PinY, 6);
             Assert.Equal(3.2, shape.Width, 6);
             Assert.Equal(1.1, shape.Height, 6);
+            Assert.Equal(4.0 / 2.54, explicitShape.Width, 6);
+            Assert.Equal(2.0 / 2.54, explicitShape.Height, 6);
+            Assert.Equal(3.2, resized.Width, 6);
+            Assert.Equal(1.1, resized.Height, 6);
             Assert.Empty(VisioValidator.Validate(filePath));
         }
 

--- a/OfficeIMO.Visio/Editing/VisioMasterEditingExtensions.cs
+++ b/OfficeIMO.Visio/Editing/VisioMasterEditingExtensions.cs
@@ -166,7 +166,8 @@ namespace OfficeIMO.Visio {
         }
 
         private static void ResizeToStencil(VisioShape shape, VisioStencilShape stencil, VisioMeasurementUnit unit) {
-            ResizeShape(shape, stencil.DefaultWidth.ToInches(unit), stencil.DefaultHeight.ToInches(unit));
+            VisioMeasurementUnit sizeUnit = stencil.DefaultUnit ?? unit;
+            ResizeShape(shape, stencil.DefaultWidth.ToInches(sizeUnit), stencil.DefaultHeight.ToInches(sizeUnit));
         }
 
         private static void ResizeShape(VisioShape shape, double width, double height) {

--- a/OfficeIMO.Visio/README.md
+++ b/OfficeIMO.Visio/README.md
@@ -516,6 +516,7 @@ var packageCatalog = VisioStencilPackageCatalog.Load("network.vssx",
     new VisioStencilPackageLoadOptions {
         Category = "Network",
         MasterNames = new[] { "Server", "rId4", "database-cylinder" },
+        LearnMasterDimensions = true,
         IncludeUnsupportedMasters = false
     });
 custom.Save("infrastructure.officeimo-visio-stencils.xml");
@@ -528,9 +529,10 @@ doc.Save();
 
 `VisioStencilPackageCatalog.Load(...)` reads master metadata from `.vsdx`,
 `.vssx`, and `.vstx` packages. It does not use those files as runtime templates;
-by default it only exposes masters that OfficeIMO can generate natively. The
-`MasterNames` filter can target the universal name, visible name, relationship id,
-numeric id, or normalized slug discovered in the package. Set
+by default it only exposes masters that OfficeIMO can generate natively and, when
+master parts are present, learns the native master width and height as reusable
+catalog metadata. The `MasterNames` filter can target the universal name, visible
+name, relationship id, numeric id, or normalized slug discovered in the package. Set
 `IncludeUnsupportedMasters` only when a generic generated placeholder is useful
 for discovery, migration tooling, or keeping a learned palette placeable without
 shipping the source stencil or template.

--- a/OfficeIMO.Visio/Stencils/VisioStencilCatalogBuilder.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilCatalogBuilder.cs
@@ -56,8 +56,25 @@ namespace OfficeIMO.Visio.Stencils {
             IEnumerable<string>? keywords = null,
             IEnumerable<string>? aliases = null,
             IEnumerable<string>? tags = null,
-            string? iconNameU = null,
-            VisioMeasurementUnit? defaultUnit = null) {
+            string? iconNameU = null) {
+            return AddWithMetadata(id, name, masterNameU, category, defaultWidth, defaultHeight, keywords, aliases, tags, iconNameU, null);
+        }
+
+        /// <summary>
+        /// Adds a stencil shape with explicit search metadata and default-size unit.
+        /// </summary>
+        public VisioStencilCatalogBuilder AddWithMetadata(
+            string id,
+            string name,
+            string masterNameU,
+            string category,
+            double defaultWidth,
+            double defaultHeight,
+            IEnumerable<string>? keywords,
+            IEnumerable<string>? aliases,
+            IEnumerable<string>? tags,
+            string? iconNameU,
+            VisioMeasurementUnit? defaultUnit) {
             return Add(CreateShape(id, name, masterNameU, category, defaultWidth, defaultHeight, keywords, aliases, tags, iconNameU, defaultUnit));
         }
 

--- a/OfficeIMO.Visio/Stencils/VisioStencilCatalogBuilder.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilCatalogBuilder.cs
@@ -56,8 +56,9 @@ namespace OfficeIMO.Visio.Stencils {
             IEnumerable<string>? keywords = null,
             IEnumerable<string>? aliases = null,
             IEnumerable<string>? tags = null,
-            string? iconNameU = null) {
-            return Add(CreateShape(id, name, masterNameU, category, defaultWidth, defaultHeight, keywords, aliases, tags, iconNameU));
+            string? iconNameU = null,
+            VisioMeasurementUnit? defaultUnit = null) {
+            return Add(CreateShape(id, name, masterNameU, category, defaultWidth, defaultHeight, keywords, aliases, tags, iconNameU, defaultUnit));
         }
 
         /// <summary>
@@ -90,7 +91,8 @@ namespace OfficeIMO.Visio.Stencils {
             IEnumerable<string>? keywords,
             IEnumerable<string>? aliases,
             IEnumerable<string>? tags,
-            string? iconNameU) {
+            string? iconNameU,
+            VisioMeasurementUnit? defaultUnit) {
             string prefix = id.Contains(".") ? id.Substring(0, id.IndexOf('.')) : id;
             string localId = id.Contains(".") ? id.Substring(id.IndexOf('.') + 1) : id;
             IEnumerable<string> effectiveKeywords = keywords ?? Enumerable.Empty<string>();
@@ -114,7 +116,8 @@ namespace OfficeIMO.Visio.Stencils {
                 effectiveKeywords,
                 effectiveAliases,
                 effectiveTags,
-                iconNameU ?? masterNameU);
+                iconNameU ?? masterNameU,
+                defaultUnit);
         }
     }
 }

--- a/OfficeIMO.Visio/Stencils/VisioStencilCatalogManifest.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilCatalogManifest.cs
@@ -80,6 +80,7 @@ namespace OfficeIMO.Visio.Stencils {
                         new XAttribute("DefaultWidth", XmlConvert.ToString(shape.DefaultWidth)),
                         new XAttribute("DefaultHeight", XmlConvert.ToString(shape.DefaultHeight)),
                         new XAttribute("IconNameU", shape.IconNameU),
+                        shape.DefaultUnit.HasValue ? new XAttribute("DefaultUnit", shape.DefaultUnit.Value.ToString()) : null,
                         Values("Keywords", shape.Keywords),
                         Values("Aliases", shape.Aliases),
                         Values("Tags", shape.Tags))));
@@ -115,7 +116,8 @@ namespace OfficeIMO.Visio.Stencils {
                     ReadValues(shape, "Keywords"),
                     ReadValues(shape, "Aliases"),
                     ReadValues(shape, "Tags"),
-                    (string?)shape.Attribute("IconNameU"));
+                    (string?)shape.Attribute("IconNameU"),
+                    ReadUnit(shape, "DefaultUnit"));
             }
 
             return builder.Build();
@@ -158,6 +160,19 @@ namespace OfficeIMO.Visio.Stencils {
             }
 
             return parsed;
+        }
+
+        private static VisioMeasurementUnit? ReadUnit(XElement element, string attributeName) {
+            string? value = (string?)element.Attribute(attributeName);
+            if (string.IsNullOrWhiteSpace(value)) {
+                return null;
+            }
+
+            if (Enum.TryParse(value, ignoreCase: true, out VisioMeasurementUnit unit)) {
+                return unit;
+            }
+
+            throw new InvalidDataException($"Stencil manifest attribute '{attributeName}' is not a supported measurement unit.");
         }
     }
 }

--- a/OfficeIMO.Visio/Stencils/VisioStencilPackageCatalog.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilPackageCatalog.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml.Linq;
 
 namespace OfficeIMO.Visio.Stencils {
     /// <summary>
@@ -30,6 +32,11 @@ namespace OfficeIMO.Visio.Stencils {
             HashSet<string>? filter = options.MasterNames != null
                 ? new HashSet<string>(options.MasterNames.Where(name => !string.IsNullOrWhiteSpace(name)), StringComparer.OrdinalIgnoreCase)
                 : null;
+            Dictionary<string, VisioAssets.MasterContent> masterContents = options.LearnMasterDimensions
+                ? VisioAssets.LoadMasterContents(packagePath)
+                    .GroupBy(master => master.Id, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, VisioAssets.MasterContent>(StringComparer.OrdinalIgnoreCase);
 
             VisioStencilCatalogBuilder builder = new(catalogName);
             HashSet<string> usedIds = new(StringComparer.OrdinalIgnoreCase);
@@ -58,21 +65,76 @@ namespace OfficeIMO.Visio.Stencils {
                     .Where(value => !string.IsNullOrWhiteSpace(value))
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToArray();
+                double defaultWidth = options.DefaultWidth;
+                double defaultHeight = options.DefaultHeight;
+                VisioMeasurementUnit? defaultUnit = null;
+                if (masterContents.TryGetValue(master.Id, out VisioAssets.MasterContent? content) &&
+                    TryReadMasterDimensions(content, out double masterWidth, out double masterHeight)) {
+                    defaultWidth = masterWidth;
+                    defaultHeight = masterHeight;
+                    defaultUnit = VisioMeasurementUnit.Inches;
+                }
 
                 builder.AddWithMetadata(
                     id,
                     displayName,
                     master.NameU,
                     category,
-                    options.DefaultWidth,
-                    options.DefaultHeight,
+                    defaultWidth,
+                    defaultHeight,
                     keywords,
                     aliases,
                     tags,
-                    master.NameU);
+                    master.NameU,
+                    defaultUnit);
             }
 
             return builder.Build();
+        }
+
+        private static bool TryReadMasterDimensions(VisioAssets.MasterContent content, out double width, out double height) {
+            XNamespace v = "http://schemas.microsoft.com/office/visio/2012/main";
+            XElement? shape = content.MasterXml.Root?
+                .Element(v + "Shapes")?
+                .Elements(v + "Shape")
+                .FirstOrDefault();
+            if (shape == null) {
+                shape = content.MasterXml.Root?
+                    .Elements()
+                    .FirstOrDefault(element => string.Equals(element.Name.LocalName, "Shapes", StringComparison.OrdinalIgnoreCase))?
+                    .Elements()
+                    .FirstOrDefault(element => string.Equals(element.Name.LocalName, "Shape", StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (shape != null &&
+                TryReadPositiveCell(shape, "Width", out width) &&
+                TryReadPositiveCell(shape, "Height", out height)) {
+                return true;
+            }
+
+            width = 0;
+            height = 0;
+            return false;
+        }
+
+        private static bool TryReadPositiveCell(XElement shape, string name, out double value) {
+            XElement? cell = shape.Elements()
+                .FirstOrDefault(element =>
+                    string.Equals(element.Name.LocalName, "Cell", StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals((string?)element.Attribute("N"), name, StringComparison.OrdinalIgnoreCase));
+            string? rawValue = (string?)cell?.Attribute("V");
+            if (string.IsNullOrWhiteSpace(rawValue) ||
+                !double.TryParse(rawValue, NumberStyles.Float, CultureInfo.InvariantCulture, out value) ||
+                value <= 0 ||
+                double.IsNaN(value) ||
+                double.IsInfinity(value)) {
+                value = 0;
+                return false;
+            }
+
+            VisioMeasurementUnit unit = VisioMeasurementUnitExtensions.FromVisioUnitCode((string?)cell!.Attribute("U"), VisioMeasurementUnit.Inches);
+            value = value.ToInches(unit);
+            return value > 0 && !double.IsNaN(value) && !double.IsInfinity(value);
         }
 
         private static string UniqueId(string baseId, string fallback, HashSet<string> usedIds) {

--- a/OfficeIMO.Visio/Stencils/VisioStencilPackageCatalog.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilPackageCatalog.cs
@@ -132,9 +132,7 @@ namespace OfficeIMO.Visio.Stencils {
                 return false;
             }
 
-            VisioMeasurementUnit unit = VisioMeasurementUnitExtensions.FromVisioUnitCode((string?)cell!.Attribute("U"), VisioMeasurementUnit.Inches);
-            value = value.ToInches(unit);
-            return value > 0 && !double.IsNaN(value) && !double.IsInfinity(value);
+            return true;
         }
 
         private static string UniqueId(string baseId, string fallback, HashSet<string> usedIds) {

--- a/OfficeIMO.Visio/Stencils/VisioStencilPackageLoadOptions.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilPackageLoadOptions.cs
@@ -33,6 +33,12 @@ namespace OfficeIMO.Visio.Stencils {
         public bool IncludeUnsupportedMasters { get; set; }
 
         /// <summary>
+        /// Gets or sets whether default stencil sizes should be learned from master shape dimensions when package master parts are available.
+        /// Defaults to true.
+        /// </summary>
+        public bool LearnMasterDimensions { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the default stencil width in the caller's placement unit.
         /// </summary>
         public double DefaultWidth { get; set; } = 1.8;

--- a/OfficeIMO.Visio/Stencils/VisioStencilPageExtensions.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilPageExtensions.cs
@@ -79,19 +79,29 @@ namespace OfficeIMO.Visio.Stencils {
             if (stencil == null) throw new ArgumentNullException(nameof(stencil));
             if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Shape id cannot be null or whitespace.", nameof(id));
 
-            VisioMeasurementUnit effectiveUnit = unit ?? page.DefaultUnit;
+            VisioMeasurementUnit placementUnit = unit ?? page.DefaultUnit;
+            VisioMeasurementUnit sizeUnit = unit ?? stencil.DefaultUnit ?? page.DefaultUnit;
             VisioDocument? document = page.OwnerDocument;
             string shapeText = text ?? stencil.Name;
 
             if (document != null) {
                 VisioMaster master = document.EnsureBuiltinMaster(stencil.MasterNameU);
-                return page.AddShape(id, master, x, y, width, height, shapeText, effectiveUnit);
+                x = x.ToInches(placementUnit);
+                y = y.ToInches(placementUnit);
+                width = width.ToInches(sizeUnit);
+                height = height.ToInches(sizeUnit);
+                VisioShape created = new(id, x, y, width, height, shapeText) {
+                    Master = master,
+                    NameU = master.NameU
+                };
+                page.Shapes.Add(created);
+                return created;
             }
 
-            x = x.ToInches(effectiveUnit);
-            y = y.ToInches(effectiveUnit);
-            width = width.ToInches(effectiveUnit);
-            height = height.ToInches(effectiveUnit);
+            x = x.ToInches(placementUnit);
+            y = y.ToInches(placementUnit);
+            width = width.ToInches(sizeUnit);
+            height = height.ToInches(sizeUnit);
 
             VisioShape shape = new(id, x, y, width, height, shapeText) {
                 NameU = stencil.MasterNameU

--- a/OfficeIMO.Visio/Stencils/VisioStencilPageExtensions.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilPageExtensions.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Visio.Stencils {
         /// </summary>
         public static VisioShape AddStencilShape(this VisioPage page, VisioStencilShape stencil, string id, double x, double y, string? text = null) {
             if (stencil == null) throw new ArgumentNullException(nameof(stencil));
-            return AddStencilShape(page, stencil, id, x, y, stencil.DefaultWidth, stencil.DefaultHeight, text, null);
+            return AddStencilShape(page, stencil, id, x, y, stencil.DefaultWidth, stencil.DefaultHeight, text, null, useStencilDefaultSize: true);
         }
 
         /// <summary>
@@ -18,21 +18,21 @@ namespace OfficeIMO.Visio.Stencils {
         /// </summary>
         public static VisioShape AddStencilShape(this VisioPage page, VisioStencilShape stencil, string id, double x, double y, string? text, VisioMeasurementUnit unit) {
             if (stencil == null) throw new ArgumentNullException(nameof(stencil));
-            return AddStencilShape(page, stencil, id, x, y, stencil.DefaultWidth, stencil.DefaultHeight, text, unit);
+            return AddStencilShape(page, stencil, id, x, y, stencil.DefaultWidth, stencil.DefaultHeight, text, unit, useStencilDefaultSize: true);
         }
 
         /// <summary>
         /// Adds a stencil shape using an explicit size and the page default measurement unit.
         /// </summary>
         public static VisioShape AddStencilShape(this VisioPage page, VisioStencilShape stencil, string id, double x, double y, double width, double height, string? text = null) {
-            return AddStencilShape(page, stencil, id, x, y, width, height, text, null);
+            return AddStencilShape(page, stencil, id, x, y, width, height, text, null, useStencilDefaultSize: false);
         }
 
         /// <summary>
         /// Adds a stencil shape using an explicit size and measurement unit.
         /// </summary>
         public static VisioShape AddStencilShape(this VisioPage page, VisioStencilShape stencil, string id, double x, double y, double width, double height, string? text, VisioMeasurementUnit unit) {
-            return AddStencilShape(page, stencil, id, x, y, width, height, text, (VisioMeasurementUnit?)unit);
+            return AddStencilShape(page, stencil, id, x, y, width, height, text, (VisioMeasurementUnit?)unit, useStencilDefaultSize: false);
         }
 
         /// <summary>
@@ -74,13 +74,14 @@ namespace OfficeIMO.Visio.Stencils {
             double width,
             double height,
             string? text,
-            VisioMeasurementUnit? unit) {
+            VisioMeasurementUnit? unit,
+            bool useStencilDefaultSize) {
             if (page == null) throw new ArgumentNullException(nameof(page));
             if (stencil == null) throw new ArgumentNullException(nameof(stencil));
             if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Shape id cannot be null or whitespace.", nameof(id));
 
             VisioMeasurementUnit placementUnit = unit ?? page.DefaultUnit;
-            VisioMeasurementUnit sizeUnit = unit ?? stencil.DefaultUnit ?? page.DefaultUnit;
+            VisioMeasurementUnit sizeUnit = unit ?? (useStencilDefaultSize ? stencil.DefaultUnit : null) ?? page.DefaultUnit;
             VisioDocument? document = page.OwnerDocument;
             string shapeText = text ?? stencil.Name;
 

--- a/OfficeIMO.Visio/Stencils/VisioStencilPageExtensions.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilPageExtensions.cs
@@ -81,7 +81,9 @@ namespace OfficeIMO.Visio.Stencils {
             if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Shape id cannot be null or whitespace.", nameof(id));
 
             VisioMeasurementUnit placementUnit = unit ?? page.DefaultUnit;
-            VisioMeasurementUnit sizeUnit = unit ?? (useStencilDefaultSize ? stencil.DefaultUnit : null) ?? page.DefaultUnit;
+            VisioMeasurementUnit sizeUnit = useStencilDefaultSize
+                ? stencil.DefaultUnit ?? page.DefaultUnit
+                : unit ?? page.DefaultUnit;
             VisioDocument? document = page.OwnerDocument;
             string shapeText = text ?? stencil.Name;
 

--- a/OfficeIMO.Visio/Stencils/VisioStencilShape.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilShape.cs
@@ -10,7 +10,14 @@ namespace OfficeIMO.Visio.Stencils {
         /// <summary>
         /// Initializes a new stencil shape definition.
         /// </summary>
-        public VisioStencilShape(string id, string name, string masterNameU, string category, double defaultWidth, double defaultHeight, IEnumerable<string>? keywords = null, IEnumerable<string>? aliases = null, IEnumerable<string>? tags = null, string? iconNameU = null, VisioMeasurementUnit? defaultUnit = null) {
+        public VisioStencilShape(string id, string name, string masterNameU, string category, double defaultWidth, double defaultHeight, IEnumerable<string>? keywords = null, IEnumerable<string>? aliases = null, IEnumerable<string>? tags = null, string? iconNameU = null)
+            : this(id, name, masterNameU, category, defaultWidth, defaultHeight, keywords, aliases, tags, iconNameU, null) {
+        }
+
+        /// <summary>
+        /// Initializes a new stencil shape definition with an explicit default-size unit.
+        /// </summary>
+        public VisioStencilShape(string id, string name, string masterNameU, string category, double defaultWidth, double defaultHeight, IEnumerable<string>? keywords, IEnumerable<string>? aliases, IEnumerable<string>? tags, string? iconNameU, VisioMeasurementUnit? defaultUnit) {
             if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Stencil shape id cannot be null or whitespace.", nameof(id));
             if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Stencil shape name cannot be null or whitespace.", nameof(name));
             if (string.IsNullOrWhiteSpace(masterNameU)) throw new ArgumentException("Master NameU cannot be null or whitespace.", nameof(masterNameU));

--- a/OfficeIMO.Visio/Stencils/VisioStencilShape.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilShape.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Visio.Stencils {
         /// <summary>
         /// Initializes a new stencil shape definition.
         /// </summary>
-        public VisioStencilShape(string id, string name, string masterNameU, string category, double defaultWidth, double defaultHeight, IEnumerable<string>? keywords = null, IEnumerable<string>? aliases = null, IEnumerable<string>? tags = null, string? iconNameU = null) {
+        public VisioStencilShape(string id, string name, string masterNameU, string category, double defaultWidth, double defaultHeight, IEnumerable<string>? keywords = null, IEnumerable<string>? aliases = null, IEnumerable<string>? tags = null, string? iconNameU = null, VisioMeasurementUnit? defaultUnit = null) {
             if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Stencil shape id cannot be null or whitespace.", nameof(id));
             if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Stencil shape name cannot be null or whitespace.", nameof(name));
             if (string.IsNullOrWhiteSpace(masterNameU)) throw new ArgumentException("Master NameU cannot be null or whitespace.", nameof(masterNameU));
@@ -40,6 +40,7 @@ namespace OfficeIMO.Visio.Stencils {
                 .ToList()
                 .AsReadOnly();
             IconNameU = string.IsNullOrWhiteSpace(iconNameU) ? masterNameU : iconNameU!;
+            DefaultUnit = defaultUnit;
         }
 
         /// <summary>
@@ -71,6 +72,12 @@ namespace OfficeIMO.Visio.Stencils {
         /// Gets the default shape height in the caller's placement unit.
         /// </summary>
         public double DefaultHeight { get; }
+
+        /// <summary>
+        /// Gets the unit used by the default size, when it is fixed by the source catalog.
+        /// When null, default sizes are interpreted in the caller's placement unit.
+        /// </summary>
+        public VisioMeasurementUnit? DefaultUnit { get; }
 
         /// <summary>
         /// Gets searchable keywords.


### PR DESCRIPTION
## Summary
- learn native master width and height from VSDX/VSSX/VSTX master parts when creating OfficeIMO stencil catalogs
- preserve learned size units through stencil manifests and use them when placing learned stencils on pages with different default units
- document package stencil learning and add focused validation for dimension learning, manifest round-trip, opt-out fallback, and VSDX validity

## Tests
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --framework net8.0 --filter FullyQualifiedName~VisioStencilsTests -v minimal
- dotnet build OfficeIMO.Visio/OfficeIMO.Visio.csproj -c Release --no-restore
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --framework net8.0 --filter FullyQualifiedName~Visio --no-build -v minimal
- git diff --check
