### PR TITLE
Advance Visio validation and diagram authoring

### DIFF
--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -194,6 +194,11 @@ namespace OfficeIMO.Examples {
                 return;
             }
 
+            if (HasArgument(args, "--visio-installed-stencils")) {
+                Visio.InstalledVisioStencils.Example_InstalledVisioStencils(folderPath, HasArgument(args, "--open-visio") || HasArgument(args, "--visio-open"));
+                return;
+            }
+
             // Visio - Core Examples
             // Visio.BasicVisioDocument.Example_BasicVisio(folderPath, false);
             // Visio.FlowchartBuilder.Example_FlowchartBuilder(folderPath, false);

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -38,6 +38,16 @@ namespace OfficeIMO.Examples {
             Pdf.ShowcaseManipulationPdf.Example_Pdf_ShowcaseManipulation(folderPath, false);
         }
 
+        private static void RunVisioShowcaseExamples(string folderPath, string[] args) {
+            bool exportPreviews = HasArgument(args, "--visio-export")
+                || HasArgument(args, "--visio-showcase-export")
+                || HasArgument(args, "--visio-preview");
+            bool openVisio = HasArgument(args, "--open-visio")
+                || HasArgument(args, "--visio-open");
+
+            Visio.VisioShowcase.Example_VisioShowcase(folderPath, openVisio, exportPreviews);
+        }
+
         private static void RunPowerPointExamples(string folderPath) {
             DateTime startedUtc = DateTime.UtcNow.AddSeconds(-2);
 
@@ -150,6 +160,11 @@ namespace OfficeIMO.Examples {
                 return;
             }
 
+            if (HasArgument(args, "--visio-showcase") || HasArgument(args, "--visio")) {
+                RunVisioShowcaseExamples(folderPath, args);
+                return;
+            }
+
             // Visio - Core Examples
             // Visio.BasicVisioDocument.Example_BasicVisio(folderPath, false);
             // Visio.FlowchartBuilder.Example_FlowchartBuilder(folderPath, false);
@@ -161,6 +176,7 @@ namespace OfficeIMO.Examples {
             // Visio.SwimlaneDiagramBuilder.Example_SwimlaneDiagramBuilder(folderPath, false);
             // Visio.OrgChartDiagramBuilder.Example_OrgChartDiagramBuilder(folderPath, false);
             // Visio.TimelineDiagramBuilder.Example_TimelineDiagramBuilder(folderPath, false);
+            // Visio.SequenceDiagramBuilder.Example_SequenceDiagramBuilder(folderPath, false);
             // Visio.StencilCatalog.Example_StencilCatalog(folderPath, false);
             // Visio.QueryAndSelection.Example_QueryAndSelection(folderPath, false);
             // Visio.LayoutEditing.Example_LayoutEditing(folderPath, false);

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -199,11 +199,17 @@ namespace OfficeIMO.Examples {
                 return;
             }
 
+            if (HasArgument(args, "--visio-graph")) {
+                Visio.GraphDiagramBuilder.Example_GraphDiagramBuilder(folderPath, HasArgument(args, "--open-visio") || HasArgument(args, "--visio-open"));
+                return;
+            }
+
             // Visio - Core Examples
             // Visio.BasicVisioDocument.Example_BasicVisio(folderPath, false);
             // Visio.FlowchartBuilder.Example_FlowchartBuilder(folderPath, false);
             // Visio.BlockDiagramBuilder.Example_BlockDiagramBuilder(folderPath, false);
             // Visio.DependencyDiagramBuilder.Example_DependencyDiagramBuilder(folderPath, false);
+            // Visio.GraphDiagramBuilder.Example_GraphDiagramBuilder(folderPath, false);
             // Visio.ArchitectureDiagramBuilder.Example_ArchitectureDiagramBuilder(folderPath, false);
             // Visio.NetworkDiagramBuilder.Example_NetworkDiagramBuilder(folderPath, false);
             // Visio.NetworkTopologyDiagramBuilder.Example_NetworkTopologyDiagramBuilder(folderPath, false);

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -15,6 +15,24 @@ namespace OfficeIMO.Examples {
             return Array.Exists(args, arg => string.Equals(arg, value, StringComparison.OrdinalIgnoreCase));
         }
 
+        private static string? GetArgumentValue(string[] args, string name) {
+            for (int i = 0; i < args.Length; i++) {
+                if (!string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+
+                if (i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal)) {
+                    return args[i + 1];
+                }
+
+                return null;
+            }
+
+            string prefix = name + "=";
+            string? combined = args.FirstOrDefault(arg => arg.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+            return combined == null ? null : combined.Substring(prefix.Length);
+        }
+
         private static void RunPdfExamples(string folderPath) {
             Pdf.BasicPdf.Example_Pdf_HelloWorld(folderPath, false);
             Pdf.WriterDefaults.Example_Pdf_DefaultStyles(folderPath, false);
@@ -162,6 +180,17 @@ namespace OfficeIMO.Examples {
 
             if (HasArgument(args, "--visio-showcase") || HasArgument(args, "--visio")) {
                 RunVisioShowcaseExamples(folderPath, args);
+                return;
+            }
+
+            if (HasArgument(args, "--visio-external-stencils")) {
+                string? stencilPack = GetArgumentValue(args, "--visio-stencil-pack")
+                    ?? Environment.GetEnvironmentVariable("OFFICEIMO_VISIO_STENCIL_PACK");
+                if (string.IsNullOrWhiteSpace(stencilPack)) {
+                    throw new InvalidOperationException("Provide a .vssx/.vsdx/.vstx path with --visio-stencil-pack <path> or OFFICEIMO_VISIO_STENCIL_PACK.");
+                }
+
+                Visio.ExternalStencilPack.Example_ExternalStencilPack(folderPath, HasArgument(args, "--open-visio") || HasArgument(args, "--visio-open"), stencilPack);
                 return;
             }
 

--- a/OfficeIMO.Examples/README.md
+++ b/OfficeIMO.Examples/README.md
@@ -6,4 +6,6 @@ This project contains small, focused samples that demonstrate usage across Word,
 - Output is designed to be human-readable and PowerShell-friendly where applicable.
 - Run `dotnet run --project OfficeIMO.Examples -- --pdf-professional` to generate a professional `OfficeIMO.Pdf` report sample, `--pdf-table-styles` for the Word-like table style gallery, `--pdf-showcase` for richer statement/dashboard/manipulation PDFs, or `--pdf` for the full first-party PDF example set.
 - PowerPoint examples include direct slide building plus designer decks, design-brief recommendations, and semantic deck-plan scoring.
+- Run `dotnet run --project OfficeIMO.Examples --framework net8.0 -- --visio-showcase` to generate a curated Visio set from basic fluent shapes through advanced flowchart, block, swimlane, sequence, network, architecture, editing, and quality-gallery diagrams.
+- Add `--visio-export` when Microsoft Visio desktop is installed to export first-page `.png` and `.svg` previews plus a browseable `index.html` into `Documents/Visio Showcase/Preview`.
 

--- a/OfficeIMO.Examples/Visio/ExternalStencilPack.cs
+++ b/OfficeIMO.Examples/Visio/ExternalStencilPack.cs
@@ -33,7 +33,6 @@ namespace OfficeIMO.Examples.Visio {
             }
 
             VisioDocument document = VisioDocument.Create(filePath);
-            document.ImportStencilMastersAndGet(stencilPackPath, selected.Select(shape => shape.MasterNameU));
             VisioPage page = document.AddPage("External Stencil Pack", 14, 8.5);
             page.Grid(visible: false, snap: true);
 

--- a/OfficeIMO.Examples/Visio/ExternalStencilPack.cs
+++ b/OfficeIMO.Examples/Visio/ExternalStencilPack.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OfficeIMO.Visio;
+using OfficeIMO.Visio.Stencils;
+using Color = OfficeIMO.Drawing.OfficeColor;
+
+namespace OfficeIMO.Examples.Visio {
+    public static class ExternalStencilPack {
+        public static void Example_ExternalStencilPack(string folderPath, bool openVisio, string stencilPackPath) {
+            if (string.IsNullOrWhiteSpace(stencilPackPath)) throw new ArgumentException("Stencil pack path cannot be null or whitespace.", nameof(stencilPackPath));
+            if (!File.Exists(stencilPackPath)) throw new FileNotFoundException("Stencil pack was not found.", stencilPackPath);
+
+            Console.WriteLine("[*] Visio - External VSSX stencil pack");
+            string filePath = Path.Combine(folderPath, "External VSSX Stencil Pack.vsdx");
+
+            VisioStencilCatalog catalog = VisioStencilPackageCatalog.Load(stencilPackPath, new VisioStencilPackageLoadOptions {
+                CatalogName = "External Stencils",
+                Category = "External",
+                IncludeUnsupportedMasters = true
+            });
+
+            IReadOnlyList<VisioStencilShape> selected = SelectStencils(catalog,
+                "API Management Services",
+                "Logic Apps",
+                "Service Bus",
+                "Event Grid",
+                "Function App",
+                "Storage accounts");
+            if (selected.Count < 4) {
+                selected = catalog.Shapes.Take(6).ToList();
+            }
+
+            VisioDocument document = VisioDocument.Create(filePath);
+            document.ImportStencilMastersAndGet(stencilPackPath, selected.Select(shape => shape.MasterNameU));
+            VisioPage page = document.AddPage("External Stencil Pack", 14, 8.5);
+            page.Grid(visible: false, snap: true);
+
+            VisioShape frame = page.AddRectangle(7, 4.25, 13.2, 6.7, string.Empty);
+            frame.FillColor = Color.FromRgb(247, 250, 252);
+            frame.LineColor = Color.FromRgb(218, 230, 242);
+            frame.LineWeight = 0.012;
+
+            VisioShape lane = page.AddRectangle(7, 5.75, 12.4, 2.35, string.Empty);
+            lane.FillColor = Color.FromRgb(255, 255, 255);
+            lane.LineColor = Color.FromRgb(205, 220, 236);
+            lane.LineWeight = 0.01;
+
+            VisioTextStyle titleStyle = new() {
+                FontFamily = "Aptos Display",
+                Size = 22,
+                Bold = true,
+                Color = Color.FromRgb(32, 55, 75),
+                HorizontalAlignment = VisioTextHorizontalAlignment.Center,
+                VerticalAlignment = VisioTextVerticalAlignment.Middle
+            };
+            page.AddTextBox("title", 7, 8.0, 12.5, 0.5, "External VSSX stencil pack: real imported masters").TextStyle = titleStyle;
+
+            page.AddTextBox("subtitle", 7, 7.45, 10.8, 0.34, "Microsoft Integration and Azure stencil artwork imported from a .vssx package").TextStyle = new VisioTextStyle {
+                FontFamily = "Aptos",
+                Size = 11,
+                Color = Color.FromRgb(85, 99, 113),
+                HorizontalAlignment = VisioTextHorizontalAlignment.Center,
+                VerticalAlignment = VisioTextVerticalAlignment.Middle
+            };
+
+            double[] x = { 2.1, 4.8, 7.5, 10.2, 12.2, 7.5 };
+            double[] y = { 5.8, 5.8, 5.8, 5.8, 5.8, 3.2 };
+            List<VisioShape> shapes = new();
+            for (int i = 0; i < selected.Count && i < x.Length; i++) {
+                VisioStencilShape stencil = selected[i];
+                string id = "ext-" + i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                VisioShape shape = page.AddStencilShape(stencil, id, x[i], y[i], string.Empty);
+                shapes.Add(shape);
+
+                VisioShape label = page.AddTextBox(
+                    id + "-label",
+                    x[i],
+                    y[i] - Math.Max(0.7, shape.Height / 2D + 0.28),
+                    1.7,
+                    0.42,
+                    stencil.Name);
+                label.TextStyle = new VisioTextStyle {
+                    FontFamily = "Aptos",
+                    Size = 11,
+                    Color = Color.FromRgb(33, 37, 41),
+                    HorizontalAlignment = VisioTextHorizontalAlignment.Center,
+                    VerticalAlignment = VisioTextVerticalAlignment.Middle
+                };
+            }
+
+            for (int i = 0; i < shapes.Count - 1 && i < 4; i++) {
+                VisioConnector connector = page.AddConnector(shapes[i], shapes[i + 1], ConnectorKind.Straight, VisioSide.Right, VisioSide.Left);
+                connector.LineColor = Color.FromRgb(0, 120, 212);
+                connector.LineWeight = 0.025;
+                connector.EndArrow = EndArrow.Triangle;
+            }
+
+            if (shapes.Count > 5) {
+                VisioConnector connector = page.AddConnector(shapes[2], shapes[5], ConnectorKind.Straight, VisioSide.Bottom, VisioSide.Top);
+                connector.LineColor = Color.FromRgb(111, 66, 193);
+                connector.LinePattern = 2;
+                connector.LineWeight = 0.025;
+                connector.EndArrow = EndArrow.Triangle;
+            }
+
+            document.Save();
+            IReadOnlyList<string> issues = VisioValidator.Validate(filePath);
+            if (issues.Count > 0) {
+                throw new InvalidOperationException("Generated external stencil example failed package validation:" + Environment.NewLine + string.Join(Environment.NewLine, issues));
+            }
+
+            Console.WriteLine("    Source pack: " + stencilPackPath);
+            Console.WriteLine("    Imported masters: " + string.Join(", ", selected.Select(shape => shape.MasterNameU)));
+            Console.WriteLine("    Output: " + filePath);
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+
+        private static IReadOnlyList<VisioStencilShape> SelectStencils(VisioStencilCatalog catalog, params string[] preferredNames) {
+            List<VisioStencilShape> selected = new();
+            foreach (string preferredName in preferredNames) {
+                if (catalog.TryGet(preferredName, out VisioStencilShape? stencil) && stencil != null &&
+                    !selected.Any(existing => string.Equals(existing.MasterNameU, stencil.MasterNameU, StringComparison.OrdinalIgnoreCase))) {
+                    selected.Add(stencil);
+                }
+            }
+
+            return selected;
+        }
+    }
+}

--- a/OfficeIMO.Examples/Visio/GraphDiagramBuilder.cs
+++ b/OfficeIMO.Examples/Visio/GraphDiagramBuilder.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OfficeIMO.Visio;
+using OfficeIMO.Visio.Diagrams;
+using OfficeIMO.Visio.Stencils;
+
+namespace OfficeIMO.Examples.Visio {
+    public static class GraphDiagramBuilder {
+        public static void Example_GraphDiagramBuilder(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Graph diagram builder");
+            string filePath = Path.Combine(folderPath, "Graph Diagram Builder.vsdx");
+            VisioStencilCatalog? installedCatalog = TryLoadInstalledAzureCatalog();
+
+            VisioDocument.Create(filePath)
+                .GraphDiagram("Event-driven operations graph", graph => {
+                    graph
+                        .Title()
+                        .Theme(VisioStyleTheme.Technical())
+                        .Layout(VisioGraphLayout.Layered)
+                        .Direction(VisioGraphDirection.LeftToRight)
+                        .PageSize(13.5, 5.7)
+                        .Margins(0.8, 0.85, 0.8, 0.7)
+                        .NodeSize(1.25, 0.72)
+                        .Spacing(0.68, 0.86);
+
+                    AddNode(graph, installedCatalog, "users", "Users", VisioGraphNodeKind.External, "Users", "Laptop computer", "PC");
+                    AddNode(graph, installedCatalog, "gateway", "API gateway", VisioGraphNodeKind.Emphasis, "API Management Services", "Application Gateway", "Front Doors");
+                    AddNode(graph, installedCatalog, "events", "Events", VisioGraphNodeKind.Process, "Event Grid", "Service Bus", "Queues");
+                    AddNode(graph, installedCatalog, "function", "Function", VisioGraphNodeKind.Process, "Function Apps", "Azure Functions");
+                    AddNode(graph, installedCatalog, "worker", "Worker", VisioGraphNodeKind.Process, "Virtual Machine", "App Services", "Web server");
+                    AddNode(graph, installedCatalog, "sql", "SQL", VisioGraphNodeKind.Data, "Azure SQL Database", "SQL databases", "Database server");
+                    AddNode(graph, installedCatalog, "monitor", "Monitor", VisioGraphNodeKind.External, "Azure Monitor", "Monitor", "Application Insights");
+                    AddNode(graph, installedCatalog, "batch", "Batch", VisioGraphNodeKind.Emphasis, "Automation Accounts", "Logic Apps", "Runbooks");
+
+                    graph
+                        .Root("users")
+                        .Zone("edge", "Edge", "users", "gateway")
+                        .Zone("runtime", "Runtime", "events", "function", "worker", "batch", "monitor")
+                        .Zone("data", "Data", "sql")
+                        .Edge("users", "gateway", "HTTPS")
+                        .ControlEdge("gateway", "events", "publish")
+                        .ControlEdge("events", "function", "trigger")
+                        .Edge("function", "worker", "dispatch")
+                        .ControlEdge("worker", "batch", "schedule")
+                        .DataEdge("worker", "sql", "write")
+                        .DataEdge("sql", "function", "read model")
+                        .Relationship("monitor", "function", "metrics")
+                        .Relationship("monitor", "worker", "logs")
+                        .EmphasisEdge("batch", "sql", "reconcile");
+                })
+                .EnsureVisualQuality(new VisioDiagramQualityOptions {
+                    CheckShapeOverlaps = false,
+                    CheckConnectorShapeIntersections = false,
+                    CheckConnectorLabelShapeOverlaps = false
+                })
+                .Save();
+
+            IReadOnlyList<string> issues = VisioValidator.Validate(filePath);
+            if (issues.Count > 0) {
+                throw new InvalidOperationException("Generated graph example failed package validation:" + Environment.NewLine + string.Join(Environment.NewLine, issues));
+            }
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+
+        private static VisioStencilCatalog? TryLoadInstalledAzureCatalog() {
+            string[] selectedPackages = VisioStencilPackageCatalog.DiscoverInstalledVisioPackages()
+                .Where(path => Path.GetFileName(path).StartsWith("AZURE", StringComparison.OrdinalIgnoreCase) ||
+                               string.Equals(Path.GetFileName(path), "COMPS_M.VSSX", StringComparison.OrdinalIgnoreCase) ||
+                               string.Equals(Path.GetFileName(path), "SERVER_M.VSSX", StringComparison.OrdinalIgnoreCase))
+                .Take(12)
+                .ToArray();
+
+            if (selectedPackages.Length == 0) {
+                return null;
+            }
+
+            return VisioStencilPackageCatalog.LoadMany(selectedPackages, new VisioStencilPackageLoadOptions {
+                CatalogName = "Installed Visio Graph Stencils",
+                IncludeUnsupportedMasters = true
+            });
+        }
+
+        private static void AddNode(VisioGraphDiagramBuilder graph, VisioStencilCatalog? catalog, string id, string text, VisioGraphNodeKind fallbackKind, params string[] queries) {
+            if (catalog != null && TryPick(catalog, queries, out VisioStencilShape? stencil) && stencil != null) {
+                graph.StencilNode(id, text, stencil);
+                return;
+            }
+
+            graph.Node(id, text, fallbackKind);
+        }
+
+        private static bool TryPick(VisioStencilCatalog catalog, IEnumerable<string> queries, out VisioStencilShape? stencil) {
+            foreach (string query in queries) {
+                if (catalog.TryGet(query, out stencil) && stencil != null) {
+                    return true;
+                }
+
+                stencil = catalog.Search(query).FirstOrDefault();
+                if (stencil != null) {
+                    return true;
+                }
+            }
+
+            stencil = null;
+            return false;
+        }
+    }
+}

--- a/OfficeIMO.Examples/Visio/InstalledVisioStencils.cs
+++ b/OfficeIMO.Examples/Visio/InstalledVisioStencils.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OfficeIMO.Visio;
+using OfficeIMO.Visio.Stencils;
+using Color = OfficeIMO.Drawing.OfficeColor;
+
+namespace OfficeIMO.Examples.Visio {
+    public static class InstalledVisioStencils {
+        public static bool Example_InstalledVisioStencils(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Installed Visio stencil packages");
+            IReadOnlyList<string> installedPackages = VisioStencilPackageCatalog.DiscoverInstalledVisioPackages();
+            string[] selectedPackages = SelectInstalledPackages(installedPackages);
+            if (selectedPackages.Length == 0) {
+                Console.WriteLine("    Skipped: no installed Visio .vssx/.vstx packages were found.");
+                return false;
+            }
+
+            VisioStencilCatalog catalog = VisioStencilPackageCatalog.LoadMany(selectedPackages, new VisioStencilPackageLoadOptions {
+                CatalogName = "Installed Visio Stencils",
+                IncludeUnsupportedMasters = true
+            });
+
+            string filePath = Path.Combine(folderPath, "Installed Visio Stencils - Hybrid Network.vsdx");
+            VisioDocument document = VisioDocument.Create(filePath);
+            VisioPage page = document.AddPage("Installed Visio Stencils", 14, 8.5);
+            page.Grid(visible: false, snap: true);
+
+            AddHeader(page);
+            AddZone(page, "Users", 1.75, 4.35, 2.4, 4.2, Color.FromRgb(245, 250, 255), Color.FromRgb(188, 214, 238));
+            AddZone(page, "Network", 5.0, 4.35, 3.0, 4.2, Color.FromRgb(246, 252, 248), Color.FromRgb(179, 222, 190));
+            AddZone(page, "Compute", 8.55, 4.35, 3.0, 4.2, Color.FromRgb(255, 250, 242), Color.FromRgb(237, 203, 153));
+            AddZone(page, "Data", 12.05, 4.35, 2.25, 4.2, Color.FromRgb(250, 247, 255), Color.FromRgb(209, 194, 236));
+
+            VisioStencilShape userDevice = Pick(catalog, "Laptop computer", "PC", "Tablet computer");
+            VisioStencilShape gateway = Pick(catalog, "Virtual Network Gateways", "Azure VPN Gateway", "Load Balancers", "Front Doors");
+            VisioStencilShape networkSecurity = Pick(catalog, "Network Security Groups", "Application Security Groups", "Firewall");
+            VisioStencilShape app = Pick(catalog, "Function Apps", "App Services", "Web server");
+            VisioStencilShape worker = Pick(catalog, "Virtual Machine", "Virtual Machines", "Server");
+            VisioStencilShape data = Pick(catalog, "Azure SQL Database", "SQL databases", "Database server");
+
+            VisioShape client = page.AddStencilShape(userDevice, "client", 1.75, 4.9, string.Empty);
+            Label(page, "client-label", 1.75, 4.05, "Client");
+            VisioShape vpn = page.AddStencilShape(gateway, "gateway", 4.25, 5.25, string.Empty);
+            Label(page, "gateway-label", 4.25, 4.42, gateway.Name);
+            VisioShape nsg = page.AddStencilShape(networkSecurity, "security", 5.8, 3.8, string.Empty);
+            Label(page, "security-label", 5.8, 2.95, networkSecurity.Name);
+            VisioShape function = page.AddStencilShape(app, "app", 8.0, 5.25, string.Empty);
+            Label(page, "app-label", 8.0, 4.42, app.Name);
+            VisioShape vm = page.AddStencilShape(worker, "worker", 9.55, 3.8, string.Empty);
+            Label(page, "worker-label", 9.55, 2.95, worker.Name);
+            VisioShape database = page.AddStencilShape(data, "database", 12.05, 4.6, string.Empty);
+            Label(page, "database-label", 12.05, 3.75, data.Name);
+
+            Connect(page, client, vpn, "HTTPS");
+            Connect(page, vpn, function, "Ingress");
+            Connect(page, vpn, nsg, "Policy");
+            Connect(page, nsg, vm, "Private");
+            Connect(page, function, database, "Reads/Writes");
+            Connect(page, vm, database, "Batch");
+
+            VisioShape note = page.AddTextBox("source-note", 7, 0.75, 11.5, 0.42,
+                "Catalog composed from installed Microsoft Visio stencil packages: " + string.Join(", ", selectedPackages.Select(Path.GetFileName)));
+            note.TextStyle = new VisioTextStyle {
+                FontFamily = "Aptos",
+                Size = 9.5,
+                Color = Color.FromRgb(87, 96, 106),
+                HorizontalAlignment = VisioTextHorizontalAlignment.Center,
+                VerticalAlignment = VisioTextVerticalAlignment.Middle
+            };
+
+            document.Save();
+            IReadOnlyList<string> issues = VisioValidator.Validate(filePath);
+            if (issues.Count > 0) {
+                throw new InvalidOperationException("Generated installed stencil example failed package validation:" + Environment.NewLine + string.Join(Environment.NewLine, issues));
+            }
+
+            Console.WriteLine("    Source packages: " + string.Join(", ", selectedPackages.Select(Path.GetFileName)));
+            Console.WriteLine("    Output: " + filePath);
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+
+            return true;
+        }
+
+        private static void AddHeader(VisioPage page) {
+            page.AddTextBox("title", 7, 8.0, 12.5, 0.48, "Installed Visio stencil packages: hybrid network graph").TextStyle = new VisioTextStyle {
+                FontFamily = "Aptos Display",
+                Size = 21,
+                Bold = true,
+                Color = Color.FromRgb(32, 55, 75),
+                HorizontalAlignment = VisioTextHorizontalAlignment.Center,
+                VerticalAlignment = VisioTextVerticalAlignment.Middle
+            };
+            page.AddTextBox("subtitle", 7, 7.48, 10.8, 0.34, "Dependency-free .vssx/.vstx catalog discovery, source-aware auto-import, and graph-style placement").TextStyle = new VisioTextStyle {
+                FontFamily = "Aptos",
+                Size = 10.5,
+                Color = Color.FromRgb(85, 99, 113),
+                HorizontalAlignment = VisioTextHorizontalAlignment.Center,
+                VerticalAlignment = VisioTextVerticalAlignment.Middle
+            };
+        }
+
+        private static void AddZone(VisioPage page, string title, double x, double y, double width, double height, Color fill, Color stroke) {
+            VisioShape zone = page.AddRectangle(x, y, width, height, string.Empty);
+            zone.FillColor = fill;
+            zone.LineColor = stroke;
+            zone.LineWeight = 0.012;
+            VisioShape label = page.AddTextBox("zone-" + title.Replace(" ", "-", StringComparison.OrdinalIgnoreCase), x, y + (height / 2) - 0.25, width - 0.25, 0.3, title);
+            label.TextStyle = new VisioTextStyle {
+                FontFamily = "Aptos",
+                Size = 10,
+                Bold = true,
+                Color = Color.FromRgb(71, 85, 99),
+                HorizontalAlignment = VisioTextHorizontalAlignment.Center,
+                VerticalAlignment = VisioTextVerticalAlignment.Middle
+            };
+        }
+
+        private static void Label(VisioPage page, string id, double x, double y, string text) {
+            page.AddTextBox(id, x, y, 1.7, 0.36, text).TextStyle = new VisioTextStyle {
+                FontFamily = "Aptos",
+                Size = 9.5,
+                Color = Color.FromRgb(33, 37, 41),
+                HorizontalAlignment = VisioTextHorizontalAlignment.Center,
+                VerticalAlignment = VisioTextVerticalAlignment.Middle
+            };
+        }
+
+        private static void Connect(VisioPage page, VisioShape from, VisioShape to, string label) {
+            VisioConnector connector = page.AddConnector(from, to, ConnectorKind.Straight, VisioSide.Right, VisioSide.Left);
+            connector.LineColor = Color.FromRgb(0, 120, 212);
+            connector.LineWeight = 0.02;
+            connector.EndArrow = EndArrow.Triangle;
+            connector.Label = label;
+            connector.LabelPlacement = VisioConnectorLabelPlacement.Along(0.5, 0, 0.16, 1.05, 0.28);
+            connector.TextStyle = new VisioTextStyle {
+                FontFamily = "Aptos",
+                Size = 8.5,
+                Color = Color.FromRgb(36, 79, 124),
+                BackgroundColor = Color.FromRgb(255, 255, 255),
+                BackgroundTransparency = 0
+            };
+        }
+
+        private static VisioStencilShape Pick(VisioStencilCatalog catalog, params string[] queries) {
+            foreach (string query in queries) {
+                if (catalog.TryGet(query, out VisioStencilShape? exact) && exact != null) {
+                    return exact;
+                }
+
+                VisioStencilShape? match = catalog.Search(query).FirstOrDefault();
+                if (match != null) {
+                    return match;
+                }
+            }
+
+            throw new InvalidOperationException("None of the requested stencil shapes were found: " + string.Join(", ", queries));
+        }
+
+        private static string[] SelectInstalledPackages(IReadOnlyList<string> packages) {
+            string[] preferredNames = {
+                "COMPS_M.VSSX",
+                "SERVER_M.VSSX",
+                "AZURENETWORKING_M.VSSX",
+                "AZURECOMPUTE_M.VSSX",
+                "AZURECLOUD_M.VSSX",
+                "AZUREDATABASES_M.VSSX"
+            };
+
+            List<string> selected = new();
+            foreach (string preferredName in preferredNames) {
+                string? match = packages.FirstOrDefault(path => string.Equals(Path.GetFileName(path), preferredName, StringComparison.OrdinalIgnoreCase));
+                if (match != null) {
+                    selected.Add(match);
+                }
+            }
+
+            return selected.ToArray();
+        }
+    }
+}

--- a/OfficeIMO.Examples/Visio/SequenceDiagramBuilder.cs
+++ b/OfficeIMO.Examples/Visio/SequenceDiagramBuilder.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using OfficeIMO.Visio;
+using OfficeIMO.Visio.Diagrams;
+
+namespace OfficeIMO.Examples.Visio {
+    public static class SequenceDiagramBuilder {
+        public static void Example_SequenceDiagramBuilder(string folderPath, bool openVisio) {
+            Console.WriteLine("[*] Visio - Sequence diagram builder");
+            string filePath = Path.Combine(folderPath, "Sequence Diagram Builder.vsdx");
+
+            VisioDocument.Create(filePath)
+                .SequenceDiagram("Checkout Sequence", sequence => sequence
+                    .Title()
+                    .Theme(VisioStyleTheme.Fluent())
+                    .PageSize(8, 5)
+                    .Actor("customer", "Customer")
+                    .Participant("web", "Web App")
+                    .Control("api", "Orders API")
+                    .Database("db", "Orders DB")
+                    .Call("customer", "web", "Checkout", "checkout")
+                    .Call("web", "api", "POST /orders", "post-order")
+                    .Async("api", "db", "Persist order", "persist")
+                    .Return("api", "web", "201 Created", "created")
+                    .SelfMessage("web", "Render receipt", id: "render"))
+                .Save();
+
+            if (openVisio) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(filePath) { UseShellExecute = true });
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Visio/VisioShowcase.cs
+++ b/OfficeIMO.Examples/Visio/VisioShowcase.cs
@@ -28,6 +28,9 @@ namespace OfficeIMO.Examples.Visio {
             if (!string.IsNullOrWhiteSpace(externalStencilPack) && File.Exists(externalStencilPack)) {
                 examples.Add(new VisioShowcaseExample("11 External VSSX stencil pack", () => ExternalStencilPack.Example_ExternalStencilPack(showcasePath, false, externalStencilPack)));
             }
+            if (global::OfficeIMO.Visio.Stencils.VisioStencilPackageCatalog.DiscoverInstalledVisioPackages().Count > 0) {
+                examples.Add(new VisioShowcaseExample("12 Installed Visio stencil packages", () => InstalledVisioStencils.Example_InstalledVisioStencils(showcasePath, false)));
+            }
 
             foreach (VisioShowcaseExample example in examples) {
                 Console.WriteLine($"  - {example.Name}");

--- a/OfficeIMO.Examples/Visio/VisioShowcase.cs
+++ b/OfficeIMO.Examples/Visio/VisioShowcase.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Examples.Visio {
             string showcasePath = Path.Combine(folderPath, "Visio Showcase");
             Directory.CreateDirectory(showcasePath);
 
-            IReadOnlyList<VisioShowcaseExample> examples = new[] {
+            List<VisioShowcaseExample> examples = new() {
                 new VisioShowcaseExample("01 Basic fluent shapes", () => FluentBasicVisio.Example_FluentBasicVisio(showcasePath, false)),
                 new VisioShowcaseExample("02 Flowchart builder", () => FlowchartBuilder.Example_FlowchartBuilder(showcasePath, false)),
                 new VisioShowcaseExample("03 Block diagram builder", () => BlockDiagramBuilder.Example_BlockDiagramBuilder(showcasePath, false)),
@@ -24,6 +24,10 @@ namespace OfficeIMO.Examples.Visio {
                 new VisioShowcaseExample("09 Containers and routing", () => ContainerEditing.Example_ContainerEditing(showcasePath, false)),
                 new VisioShowcaseExample("10 Visual quality gallery", () => VisualQualityGallery.Example_VisualQualityGallery(showcasePath, false))
             };
+            string? externalStencilPack = Environment.GetEnvironmentVariable("OFFICEIMO_VISIO_STENCIL_PACK");
+            if (!string.IsNullOrWhiteSpace(externalStencilPack) && File.Exists(externalStencilPack)) {
+                examples.Add(new VisioShowcaseExample("11 External VSSX stencil pack", () => ExternalStencilPack.Example_ExternalStencilPack(showcasePath, false, externalStencilPack)));
+            }
 
             foreach (VisioShowcaseExample example in examples) {
                 Console.WriteLine($"  - {example.Name}");

--- a/OfficeIMO.Examples/Visio/VisioShowcase.cs
+++ b/OfficeIMO.Examples/Visio/VisioShowcase.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using OfficeIMO.Visio;
+
+namespace OfficeIMO.Examples.Visio {
+    public static class VisioShowcase {
+        public static void Example_VisioShowcase(string folderPath, bool openVisio, bool exportPreviews) {
+            Console.WriteLine("[*] Visio - Showcase examples");
+            string showcasePath = Path.Combine(folderPath, "Visio Showcase");
+            Directory.CreateDirectory(showcasePath);
+
+            IReadOnlyList<VisioShowcaseExample> examples = new[] {
+                new VisioShowcaseExample("01 Basic fluent shapes", () => FluentBasicVisio.Example_FluentBasicVisio(showcasePath, false)),
+                new VisioShowcaseExample("02 Flowchart builder", () => FlowchartBuilder.Example_FlowchartBuilder(showcasePath, false)),
+                new VisioShowcaseExample("03 Block diagram builder", () => BlockDiagramBuilder.Example_BlockDiagramBuilder(showcasePath, false)),
+                new VisioShowcaseExample("04 Swimlane builder", () => SwimlaneDiagramBuilder.Example_SwimlaneDiagramBuilder(showcasePath, false)),
+                new VisioShowcaseExample("05 Sequence builder", () => SequenceDiagramBuilder.Example_SequenceDiagramBuilder(showcasePath, false)),
+                new VisioShowcaseExample("06 Network topology builder", () => NetworkTopologyDiagramBuilder.Example_NetworkTopologyDiagramBuilder(showcasePath, false)),
+                new VisioShowcaseExample("07 Azure architecture builder", () => ArchitectureDiagramBuilder.Example_ArchitectureDiagramBuilder(showcasePath, false)),
+                new VisioShowcaseExample("08 Editing and data", () => ShapeDataEditing.Example_ShapeDataEditing(showcasePath, false)),
+                new VisioShowcaseExample("09 Containers and routing", () => ContainerEditing.Example_ContainerEditing(showcasePath, false)),
+                new VisioShowcaseExample("10 Visual quality gallery", () => VisualQualityGallery.Example_VisualQualityGallery(showcasePath, false))
+            };
+
+            foreach (VisioShowcaseExample example in examples) {
+                Console.WriteLine($"  - {example.Name}");
+                example.Create();
+            }
+
+            List<string> generatedFiles = Directory
+                .EnumerateFiles(showcasePath, "*.vsdx", SearchOption.AllDirectories)
+                .Where(file => !file.EndsWith(".visio-roundtrip.vsdx", StringComparison.OrdinalIgnoreCase))
+                .OrderBy(file => file, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            ValidateGeneratedPackages(generatedFiles);
+
+            if (exportPreviews || string.Equals(Environment.GetEnvironmentVariable("OFFICEIMO_VISIO_DESKTOP_SHOWCASE"), "1", StringComparison.OrdinalIgnoreCase)) {
+                ExportPreviewFiles(showcasePath, generatedFiles);
+            }
+
+            if (openVisio && generatedFiles.Count > 0) {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(generatedFiles[0]) { UseShellExecute = true });
+            }
+        }
+
+        private static void ValidateGeneratedPackages(IEnumerable<string> generatedFiles) {
+            foreach (string filePath in generatedFiles) {
+                IReadOnlyList<string> issues = VisioValidator.Validate(filePath);
+                if (issues.Count == 0) {
+                    Console.WriteLine($"    package ok: {Path.GetFileName(filePath)}");
+                    continue;
+                }
+
+                string message = string.Join(Environment.NewLine, issues.Select(issue => "      " + issue));
+                throw new InvalidOperationException($"Visio example failed package validation: {filePath}{Environment.NewLine}{message}");
+            }
+        }
+
+        private static void ExportPreviewFiles(string showcasePath, IReadOnlyList<string> generatedFiles) {
+            if (!VisioDesktopValidator.IsAvailable()) {
+                Console.WriteLine("    Visio desktop preview export skipped: Microsoft Visio automation is not available.");
+                return;
+            }
+
+            string previewPath = Path.Combine(showcasePath, "Preview");
+            Directory.CreateDirectory(previewPath);
+            List<string> previewFiles = new();
+
+            foreach (string filePath in generatedFiles) {
+                VisioDesktopValidationOptions options = new() {
+                    ExportDirectory = previewPath,
+                    ExportFileNamePrefix = CreatePreviewPrefix(filePath, showcasePath)
+                };
+                options.ExportFormats.Add(VisioDesktopExportFormat.Png);
+                options.ExportFormats.Add(VisioDesktopExportFormat.Svg);
+
+                VisioDesktopValidationResult result = VisioDesktopValidator.Validate(filePath, options);
+                if (!result.IsValid) {
+                    string message = string.Join(Environment.NewLine, result.Issues.Select(issue => "      " + issue));
+                    throw new InvalidOperationException($"Visio desktop preview export failed: {filePath}{Environment.NewLine}{message}");
+                }
+
+                foreach (string outputFile in result.OutputFiles) {
+                    previewFiles.Add(outputFile);
+                    Console.WriteLine($"    preview: {outputFile}");
+                }
+            }
+
+            string galleryPath = WritePreviewGallery(previewPath, previewFiles);
+            Console.WriteLine($"    gallery: {galleryPath}");
+        }
+
+        private static string WritePreviewGallery(string previewPath, IEnumerable<string> previewFiles) {
+            string galleryPath = Path.Combine(previewPath, "index.html");
+            IEnumerable<string> images = previewFiles
+                .Where(file => string.Equals(Path.GetExtension(file), ".png", StringComparison.OrdinalIgnoreCase))
+                .OrderBy(file => file, StringComparer.OrdinalIgnoreCase);
+
+            using StreamWriter writer = new(galleryPath, false);
+            writer.WriteLine("<!doctype html>");
+            writer.WriteLine("<html lang=\"en\">");
+            writer.WriteLine("<head>");
+            writer.WriteLine("  <meta charset=\"utf-8\">");
+            writer.WriteLine("  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">");
+            writer.WriteLine("  <title>OfficeIMO Visio Showcase</title>");
+            writer.WriteLine("  <style>");
+            writer.WriteLine("    body{margin:0;font-family:Segoe UI,Arial,sans-serif;background:#f6f7f9;color:#20242a}");
+            writer.WriteLine("    header{padding:28px 36px;background:#ffffff;border-bottom:1px solid #dfe3e8}");
+            writer.WriteLine("    h1{margin:0;font-size:28px;font-weight:650}");
+            writer.WriteLine("    main{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));gap:24px;padding:24px}");
+            writer.WriteLine("    figure{margin:0;background:#ffffff;border:1px solid #dfe3e8;border-radius:8px;overflow:hidden}");
+            writer.WriteLine("    figcaption{padding:12px 14px;font-weight:600;border-bottom:1px solid #edf0f3}");
+            writer.WriteLine("    img{display:block;width:100%;height:auto;background:#ffffff}");
+            writer.WriteLine("  </style>");
+            writer.WriteLine("</head>");
+            writer.WriteLine("<body>");
+            writer.WriteLine("  <header><h1>OfficeIMO Visio Showcase</h1></header>");
+            writer.WriteLine("  <main>");
+
+            foreach (string image in images) {
+                string fileName = Path.GetFileName(image);
+                string label = WebUtility.HtmlEncode(Path.GetFileNameWithoutExtension(image).Replace("-page1", string.Empty));
+                string src = WebUtility.HtmlEncode(fileName);
+                writer.WriteLine("    <figure>");
+                writer.WriteLine($"      <figcaption>{label}</figcaption>");
+                writer.WriteLine($"      <img src=\"{src}\" alt=\"{label}\">");
+                writer.WriteLine("    </figure>");
+            }
+
+            writer.WriteLine("  </main>");
+            writer.WriteLine("</body>");
+            writer.WriteLine("</html>");
+            return galleryPath;
+        }
+
+        private static string CreatePreviewPrefix(string filePath, string showcasePath) {
+            string relative = Path.GetRelativePath(showcasePath, filePath);
+            string withoutExtension = Path.Combine(
+                Path.GetDirectoryName(relative) ?? string.Empty,
+                Path.GetFileNameWithoutExtension(relative));
+
+            char[] invalidChars = Path.GetInvalidFileNameChars();
+            return string.Concat(withoutExtension.Select(ch =>
+                invalidChars.Contains(ch) || ch == Path.DirectorySeparatorChar || ch == Path.AltDirectorySeparatorChar
+                    ? '-'
+                    : ch));
+        }
+
+        private sealed class VisioShowcaseExample {
+            public VisioShowcaseExample(string name, Action create) {
+                Name = name;
+                Create = create;
+            }
+
+            public string Name { get; }
+
+            public Action Create { get; }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Visio/VisioShowcase.cs
+++ b/OfficeIMO.Examples/Visio/VisioShowcase.cs
@@ -10,7 +10,7 @@ namespace OfficeIMO.Examples.Visio {
         public static void Example_VisioShowcase(string folderPath, bool openVisio, bool exportPreviews) {
             Console.WriteLine("[*] Visio - Showcase examples");
             string showcasePath = Path.Combine(folderPath, "Visio Showcase");
-            Directory.CreateDirectory(showcasePath);
+            PrepareShowcaseDirectory(showcasePath);
 
             List<VisioShowcaseExample> examples = new() {
                 new VisioShowcaseExample("01 Basic fluent shapes", () => FluentBasicVisio.Example_FluentBasicVisio(showcasePath, false)),
@@ -20,16 +20,17 @@ namespace OfficeIMO.Examples.Visio {
                 new VisioShowcaseExample("05 Sequence builder", () => SequenceDiagramBuilder.Example_SequenceDiagramBuilder(showcasePath, false)),
                 new VisioShowcaseExample("06 Network topology builder", () => NetworkTopologyDiagramBuilder.Example_NetworkTopologyDiagramBuilder(showcasePath, false)),
                 new VisioShowcaseExample("07 Azure architecture builder", () => ArchitectureDiagramBuilder.Example_ArchitectureDiagramBuilder(showcasePath, false)),
-                new VisioShowcaseExample("08 Editing and data", () => ShapeDataEditing.Example_ShapeDataEditing(showcasePath, false)),
-                new VisioShowcaseExample("09 Containers and routing", () => ContainerEditing.Example_ContainerEditing(showcasePath, false)),
-                new VisioShowcaseExample("10 Visual quality gallery", () => VisualQualityGallery.Example_VisualQualityGallery(showcasePath, false))
+                new VisioShowcaseExample("08 Generic graph builder", () => GraphDiagramBuilder.Example_GraphDiagramBuilder(showcasePath, false)),
+                new VisioShowcaseExample("09 Editing and data", () => ShapeDataEditing.Example_ShapeDataEditing(showcasePath, false)),
+                new VisioShowcaseExample("10 Containers and routing", () => ContainerEditing.Example_ContainerEditing(showcasePath, false)),
+                new VisioShowcaseExample("11 Visual quality gallery", () => VisualQualityGallery.Example_VisualQualityGallery(showcasePath, false))
             };
             string? externalStencilPack = Environment.GetEnvironmentVariable("OFFICEIMO_VISIO_STENCIL_PACK");
             if (!string.IsNullOrWhiteSpace(externalStencilPack) && File.Exists(externalStencilPack)) {
-                examples.Add(new VisioShowcaseExample("11 External VSSX stencil pack", () => ExternalStencilPack.Example_ExternalStencilPack(showcasePath, false, externalStencilPack)));
+                examples.Add(new VisioShowcaseExample("12 External VSSX stencil pack", () => ExternalStencilPack.Example_ExternalStencilPack(showcasePath, false, externalStencilPack)));
             }
             if (global::OfficeIMO.Visio.Stencils.VisioStencilPackageCatalog.DiscoverInstalledVisioPackages().Count > 0) {
-                examples.Add(new VisioShowcaseExample("12 Installed Visio stencil packages", () => InstalledVisioStencils.Example_InstalledVisioStencils(showcasePath, false)));
+                examples.Add(new VisioShowcaseExample("13 Installed Visio stencil packages", () => InstalledVisioStencils.Example_InstalledVisioStencils(showcasePath, false)));
             }
 
             foreach (VisioShowcaseExample example in examples) {
@@ -51,6 +52,18 @@ namespace OfficeIMO.Examples.Visio {
 
             if (openVisio && generatedFiles.Count > 0) {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(generatedFiles[0]) { UseShellExecute = true });
+            }
+        }
+
+        private static void PrepareShowcaseDirectory(string showcasePath) {
+            Directory.CreateDirectory(showcasePath);
+            foreach (string filePath in Directory.EnumerateFiles(showcasePath, "*.vsdx", SearchOption.AllDirectories)) {
+                File.Delete(filePath);
+            }
+
+            string previewPath = Path.Combine(showcasePath, "Preview");
+            if (Directory.Exists(previewPath)) {
+                Directory.Delete(previewPath, recursive: true);
             }
         }
 

--- a/OfficeIMO.Tests/Visio.CircleAndTriangleGeometry.cs
+++ b/OfficeIMO.Tests/Visio.CircleAndTriangleGeometry.cs
@@ -26,7 +26,7 @@ namespace OfficeIMO.Tests {
             Assert.Equal(2, shapes.Length);
             var circleGeom = shapes.First(s => (string?)s.Attribute("NameU") == "Circle").Elements(ns + "Section").FirstOrDefault(e => (string?)e.Attribute("N") == "Geometry");
             Assert.NotNull(circleGeom);
-            Assert.Contains(circleGeom!.Elements(ns + "Row"), r => (string?)r.Attribute("T") == "EllipticalArcTo");
+            Assert.True(circleGeom!.Elements(ns + "Row").Count(r => (string?)r.Attribute("T") == "LineTo") >= 20);
             var triGeom = shapes.First(s => (string?)s.Attribute("NameU") == "Triangle").Elements(ns + "Section").FirstOrDefault(e => (string?)e.Attribute("N") == "Geometry");
             Assert.NotNull(triGeom);
             Assert.True(triGeom!.Elements(ns + "Row").Count(r => (string?)r.Attribute("T") == "LineTo") >= 3);

--- a/OfficeIMO.Tests/Visio.EllipseAndDiamondGeometry.cs
+++ b/OfficeIMO.Tests/Visio.EllipseAndDiamondGeometry.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace OfficeIMO.Tests {
     public class VisioEllipseAndDiamondGeometryTests {
         [Fact]
-        public void EllipseShapeEmitsEllipticalArcGeometry() {
+        public void EllipseShapeEmitsClosedLineGeometry() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
             var doc = VisioDocument.Create(filePath);
             doc.AsFluent().Page("Page-1", p => p.Ellipse("E1", x: 2, y: 2, width: 2, height: 1));
@@ -25,7 +25,7 @@ namespace OfficeIMO.Tests {
             var geom = shape.Elements(ns + "Section").FirstOrDefault(s => s.Attribute("N")?.Value == "Geometry");
             Assert.NotNull(geom);
             var rows = geom!.Elements(ns + "Row").ToArray();
-            Assert.Contains(rows, r => r.Attribute("T")?.Value == "EllipticalArcTo");
+            Assert.True(rows.Count(r => r.Attribute("T")?.Value == "LineTo") >= 20);
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Visio.FlowchartBuilder.cs
+++ b/OfficeIMO.Tests/Visio.FlowchartBuilder.cs
@@ -23,7 +23,7 @@ namespace OfficeIMO.Tests {
             Assert.Equal("Buying", page.Name);
             Assert.Equal(new[] { "start", "consult", "agreement", "close" }, page.Shapes.Select(shape => shape.Id).ToArray());
             Assert.Equal(new[] { "Ellipse", "Process", "Decision", "Ellipse" }, page.Shapes.Select(shape => shape.NameU).ToArray());
-            Assert.Equal(new[] { "Ellipse", "Process", "Decision", "Ellipse" }, page.Shapes.Select(shape => shape.Master?.NameU).ToArray());
+            Assert.All(page.Shapes, shape => Assert.Null(shape.Master));
             Assert.Equal(4, page.Connectors.Count);
             Assert.Contains(page.Connectors, connector => connector.Label == "No");
             Assert.All(page.Connectors, connector => Assert.Equal(EndArrow.Triangle, connector.EndArrow));

--- a/OfficeIMO.Tests/Visio.GraphDiagramBuilder.cs
+++ b/OfficeIMO.Tests/Visio.GraphDiagramBuilder.cs
@@ -1,0 +1,97 @@
+using System;
+using System.IO;
+using System.Linq;
+using OfficeIMO.Visio;
+using OfficeIMO.Visio.Diagrams;
+using OfficeIMO.Visio.Stencils;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioGraphDiagramBuilderTests {
+        [Fact]
+        public void GraphDiagramBuilderHandlesCyclesDisconnectedComponentsAndStencilNodes() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+            VisioStencilShape serverStencil = VisioStencils.Network.Get("server");
+
+            VisioDocument document = VisioDocument.Create(filePath)
+                .GraphDiagram("Runtime Graph", graph => graph
+                    .Title()
+                    .Theme(VisioStyleTheme.Fluent())
+                    .Root("users", "Users", VisioGraphNodeKind.External)
+                    .StencilNode("web", "Web", serverStencil)
+                    .Node("api", "API", VisioGraphNodeKind.Process)
+                    .Node("policy", "Policy", VisioGraphNodeKind.Decision)
+                    .Node("db", "Database", VisioGraphNodeKind.Data)
+                    .Node("batch", "Batch", VisioGraphNodeKind.Emphasis)
+                    .Zone("online", "Online path", "users", "web", "api", "policy", "db")
+                    .Zone("offline", "Offline path", "batch", "db")
+                    .Edge("users", "web", "HTTPS")
+                    .Edge("web", "api")
+                    .ControlEdge("api", "policy", "authorize")
+                    .DataEdge("api", "db", "read/write")
+                    .DataEdge("db", "api", "cache")
+                    .Relationship("batch", "db", "nightly"));
+
+            VisioPage page = Assert.Single(document.Pages);
+            Assert.Equal("Runtime Graph", page.Name);
+            Assert.Contains(page.Shapes, shape => shape.Id == "online" && shape.IsBackgroundSurface);
+            Assert.Contains(page.Shapes, shape => shape.Id == "offline" && shape.IsBackgroundSurface);
+            Assert.Contains(page.Shapes, shape => shape.Id == "online-label" && shape.Text == "Online path");
+            Assert.Equal(serverStencil.MasterNameU, page.Shapes.Single(shape => shape.Id == "web").MasterNameU);
+            Assert.True(page.Shapes.Single(shape => shape.Id == "users").PinX < page.Shapes.Single(shape => shape.Id == "web").PinX);
+            Assert.True(page.Shapes.Single(shape => shape.Id == "web").PinX < page.Shapes.Single(shape => shape.Id == "api").PinX);
+            Assert.Equal(6, page.Connectors.Count);
+            Assert.Contains(page.Connectors, connector => connector.Label == "authorize" && connector.LinePattern == 2);
+            Assert.Contains(page.Connectors, connector => connector.Label == "nightly" && connector.EndArrow == EndArrow.None);
+            Assert.All(page.Connectors.Where(connector => !string.IsNullOrWhiteSpace(connector.Label)), connector => Assert.NotNull(connector.LabelPlacement));
+
+            document.Save();
+            Assert.Empty(VisioValidator.Validate(filePath));
+
+            VisioDocument loaded = VisioDocument.Load(filePath);
+            Assert.Equal(11, loaded.Pages[0].Shapes.Count);
+            Assert.Equal(6, loaded.Pages[0].Connectors.Count);
+        }
+
+        [Fact]
+        public void GraphDiagramBuilderSupportsRadialLayoutForCyclicGraphs() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = VisioDocument.Create(filePath)
+                .GraphDiagram("Cyclic Service Map", graph => graph
+                    .Layout(VisioGraphLayout.Radial)
+                    .Root("api", "API")
+                    .Node("auth", "Auth")
+                    .Node("queue", "Queue")
+                    .Node("worker", "Worker")
+                    .Node("store", "Store", VisioGraphNodeKind.Data)
+                    .Edge("api", "auth", "token")
+                    .Edge("api", "queue", "publish")
+                    .Edge("queue", "worker", "consume")
+                    .DataEdge("worker", "store", "write")
+                    .DataEdge("store", "api", "read"));
+
+            VisioPage page = Assert.Single(document.Pages);
+            VisioShape api = page.Shapes.Single(shape => shape.Id == "api");
+            Assert.Equal(5, page.Shapes.Count);
+            Assert.Equal(5, page.Connectors.Count);
+            Assert.All(page.Connectors, connector => Assert.Empty(connector.Waypoints));
+            Assert.Contains(page.Shapes.Where(shape => shape.Id != "api"), shape => Math.Abs(shape.PinX - api.PinX) > 0.1D || Math.Abs(shape.PinY - api.PinY) > 0.1D);
+
+            document.Save();
+            Assert.Empty(VisioValidator.Validate(filePath));
+        }
+
+        [Fact]
+        public void GraphDiagramBuilderRejectsUnknownEdgeEndpoints() {
+            VisioDocument document = VisioDocument.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx"));
+
+            ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+                document.GraphDiagram("Invalid", graph => graph
+                    .Node("known", "Known")
+                    .Edge("known", "missing")));
+
+            Assert.Contains("Unknown graph node id", exception.Message);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.MasterGeometry.cs
+++ b/OfficeIMO.Tests/Visio.MasterGeometry.cs
@@ -40,11 +40,11 @@ namespace OfficeIMO.Tests {
                 return "visio/masters/" + (string)rel.Attribute("Target")!;
             }
 
-            // Circle master -> must contain EllipticalArcTo rows
+            // Circle master -> must contain enough line rows for Visio's preview renderer to render it reliably.
             var circlePath = GetMasterTarget("Circle");
             var circle = LoadZipXml(zip, circlePath);
             var cGeom = circle.Root!.Element(v + "Shapes")!.Element(v + "Shape")!.Elements(v + "Section").First(e => (string?)e.Attribute("N") == "Geometry");
-            Assert.Contains(cGeom.Elements(v + "Row"), row => (string?)row.Attribute("T") == "EllipticalArcTo");
+            Assert.True(cGeom.Elements(v + "Row").Count(row => (string?)row.Attribute("T") == "LineTo") >= 20);
 
             // Triangle master -> exactly 3 LineTo rows
             var triPath = GetMasterTarget("Triangle");

--- a/OfficeIMO.Tests/Visio.SequenceDiagramBuilder.cs
+++ b/OfficeIMO.Tests/Visio.SequenceDiagramBuilder.cs
@@ -1,0 +1,111 @@
+using System;
+using System.IO;
+using System.Linq;
+using OfficeIMO.Visio;
+using OfficeIMO.Visio.Diagrams;
+using OfficeIMO.Visio.Stencils;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioSequenceDiagramBuilderTests {
+        [Fact]
+        public void SequenceDiagramBuilderCreatesParticipantsLifelinesAndMessages() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = VisioDocument.Create(filePath)
+                .SequenceDiagram("Checkout Sequence", sequence => sequence
+                    .Title()
+                    .Theme(VisioStyleTheme.Fluent())
+                    .PageSize(6, 4)
+                    .Actor("customer", "Customer")
+                    .Participant("web", "Web App")
+                    .Control("api", "Orders API")
+                    .Database("db", "Orders DB")
+                    .Call("customer", "web", "Checkout", "checkout")
+                    .Call("web", "api", "POST /orders", "post-order")
+                    .Async("api", "db", "Persist order", "persist")
+                    .Return("api", "web", "201 Created", "created")
+                    .SelfMessage("web", "Render receipt", id: "render"));
+
+            VisioPage page = Assert.Single(document.Pages);
+            Assert.Equal("Checkout Sequence", page.Name);
+            Assert.True(page.Width >= 6);
+            Assert.True(page.Height >= 4);
+
+            VisioShape customer = Assert.Single(page.Shapes, shape => shape.Id == "customer");
+            VisioShape web = Assert.Single(page.Shapes, shape => shape.Id == "web");
+            VisioShape api = Assert.Single(page.Shapes, shape => shape.Id == "api");
+            VisioShape db = Assert.Single(page.Shapes, shape => shape.Id == "db");
+
+            Assert.Equal("Circle", customer.MasterNameU);
+            Assert.Equal("Rectangle", web.MasterNameU);
+            Assert.Equal("Rectangle", api.MasterNameU);
+            Assert.Equal("Data", db.MasterNameU);
+            Assert.True(customer.PinX < web.PinX);
+            Assert.True(web.PinX < api.PinX);
+            Assert.True(api.PinX < db.PinX);
+            Assert.Equal("SequenceParticipant", customer.GetUserCellValue("OfficeIMO.Kind"));
+            Assert.Equal("Database", db.GetUserCellValue("OfficeIMO.SequenceParticipantKind"));
+
+            VisioConnector[] messageConnectors = page.Connectors
+                .Where(connector => !string.IsNullOrWhiteSpace(connector.Label))
+                .ToArray();
+            Assert.Equal(5, messageConnectors.Length);
+            Assert.Contains(messageConnectors, connector => connector.Id == "created" && connector.LinePattern == 2);
+            Assert.Contains(messageConnectors, connector => connector.Id == "persist" && connector.EndArrow == EndArrow.Arrow);
+            VisioConnector selfMessage = Assert.Single(messageConnectors, connector => connector.Id == "render");
+            Assert.Equal(2, selfMessage.Waypoints.Count);
+            Assert.NotNull(selfMessage.LabelPlacement);
+            Assert.Contains(page.Layers, layer => layer.Name == "Sequence Lifelines");
+            Assert.Contains(page.Layers, layer => layer.Name == "Sequence Messages");
+
+            document.Save();
+            Assert.Empty(VisioValidator.Validate(filePath));
+
+            VisioDocument loaded = VisioDocument.Load(filePath);
+            Assert.Contains(loaded.Pages[0].Connectors, connector => connector.Label == "POST /orders");
+            Assert.Contains(loaded.Pages[0].Connectors, connector => connector.Label == "Render receipt" && connector.Waypoints.Count == 2);
+        }
+
+        [Fact]
+        public void SequenceDiagramBuilderRejectsUnknownParticipants() {
+            VisioDocument document = VisioDocument.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx"));
+
+            ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+                document.SequenceDiagram("Invalid", sequence => sequence
+                    .Participant("web", "Web")
+                    .Call("web", "missing", "request")));
+
+            Assert.Contains("Unknown sequence participant id", exception.Message);
+        }
+
+        [Fact]
+        public void SequenceDiagramBuilderRejectsDuplicateIds() {
+            VisioDocument document = VisioDocument.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx"));
+
+            ArgumentException participantCollision = Assert.Throws<ArgumentException>(() =>
+                document.SequenceDiagram("Invalid", sequence => sequence
+                    .Participant("web", "Web")
+                    .Participant("web", "Duplicate")));
+            ArgumentException messageCollision = Assert.Throws<ArgumentException>(() =>
+                document.SequenceDiagram("Invalid", sequence => sequence
+                    .Participant("web", "Web")
+                    .Participant("api", "API")
+                    .Call("web", "api", "first", "same")
+                    .Return("api", "web", "second", "same")));
+
+            Assert.Contains("already exists", participantCollision.Message);
+            Assert.Contains("already exists", messageCollision.Message);
+        }
+
+        [Fact]
+        public void SequenceStencilsAreSearchableAndIncludedInAllCatalog() {
+            VisioStencilShape participant = VisioStencils.Sequence.Get("seq.participant");
+            VisioStencilShape actor = Assert.Single(VisioStencils.Sequence.Search("person"));
+
+            Assert.Equal("Rectangle", participant.MasterNameU);
+            Assert.Equal("Actor", actor.Name);
+            Assert.Contains(VisioStencils.All.Shapes, shape => shape.Id == "seq.database");
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.Stencils.cs
+++ b/OfficeIMO.Tests/Visio.Stencils.cs
@@ -392,6 +392,54 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ImportedStencilMastersPreserveExternalMasterArtwork() {
+            string packagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vssx");
+            CreatePackageWithRawGroupMaster(packagePath, "FancyCloud", "Fancy Cloud");
+            VisioStencilCatalog catalog = VisioStencilPackageCatalog.Load(packagePath, new VisioStencilPackageLoadOptions {
+                IncludeUnsupportedMasters = true,
+                Category = "External"
+            });
+
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+            VisioDocument document = VisioDocument.Create(filePath);
+            IReadOnlyList<VisioMaster> imported = document.ImportStencilMastersAndGet(packagePath, new[] { "fancy-cloud" });
+            VisioPage page = document.AddPage("External Stencils");
+            VisioShape cloud = page.AddStencilShape(catalog, "fancy-cloud", "cloud", 2, 4, "Cloud");
+            document.Save();
+
+            Assert.Single(imported);
+            Assert.Same(imported[0], cloud.Master);
+            Assert.Equal("FancyCloud", cloud.MasterNameU);
+            Assert.Empty(VisioValidator.Validate(filePath));
+
+            using ZipArchive zip = ZipFile.OpenRead(filePath);
+            XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
+            XDocument masterDocument = XDocument.Load(zip.GetEntry("visio/masters/master1.xml")!.Open());
+            XElement rootShape = masterDocument.Root!.Element(ns + "Shapes")!.Element(ns + "Shape")!;
+            Assert.Equal("5", (string?)rootShape.Attribute("ID"));
+            Assert.Equal("Group", (string?)rootShape.Attribute("Type"));
+            Assert.NotNull(rootShape.Element(ns + "Shapes")?.Element(ns + "Shape"));
+
+            XDocument pageDocument = XDocument.Load(zip.GetEntry("visio/pages/page1.xml")!.Open());
+            XElement pageShape = pageDocument.Root!.Element(ns + "Shapes")!.Element(ns + "Shape")!;
+            Assert.Null(pageShape.Attribute("MasterShape"));
+            XElement pageChildShape = pageShape.Element(ns + "Shapes")!.Element(ns + "Shape")!;
+            Assert.Equal("6", (string?)pageChildShape.Attribute("MasterShape"));
+            Assert.DoesNotContain(pageShape.Elements(ns + "Section"), section => (string?)section.Attribute("N") == "Geometry");
+
+            XDocument documentXml = XDocument.Load(zip.GetEntry("visio/document.xml")!.Open());
+            Assert.NotNull(documentXml.Root!.Element(ns + "Colors")!.Elements(ns + "ColorEntry").FirstOrDefault(element => (string?)element.Attribute("IX") == "24"));
+            Assert.NotNull(documentXml.Root!.Element(ns + "StyleSheets")!.Elements(ns + "StyleSheet").FirstOrDefault(element => (string?)element.Attribute("ID") == "8"));
+            Assert.NotNull(zip.GetEntry("visio/theme/theme1.xml"));
+            Assert.NotNull(zip.GetEntry("visio/media/officeimo-master1-rel1.emf"));
+            XNamespace packageRel = "http://schemas.openxmlformats.org/package/2006/relationships";
+            XDocument masterRelationships = XDocument.Load(zip.GetEntry("visio/masters/_rels/master1.xml.rels")!.Open());
+            Assert.NotNull(masterRelationships.Root!.Elements(packageRel + "Relationship").FirstOrDefault(element =>
+                (string?)element.Attribute("Id") == "rIdImage" &&
+                ((string?)element.Attribute("Target"))!.Contains("officeimo-master1-rel1.emf", StringComparison.OrdinalIgnoreCase)));
+        }
+
+        [Fact]
         public void CatalogThrowsForUnknownStencilShape() {
             KeyNotFoundException exception = Assert.Throws<KeyNotFoundException>(() => VisioStencils.BasicShapes.Get("not-here"));
 
@@ -423,6 +471,114 @@ namespace OfficeIMO.Tests {
 
             XDocument document = new(root);
             writer.Write(document.Declaration + Environment.NewLine + document.ToString(SaveOptions.DisableFormatting));
+        }
+
+        private static void CreatePackageWithRawGroupMaster(string path, string nameU, string name) {
+            const string visioNamespace = "http://schemas.microsoft.com/office/visio/2012/main";
+            const string officeRelationshipNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+            const string packageRelationshipNamespace = "http://schemas.openxmlformats.org/package/2006/relationships";
+
+            using ZipArchive zip = ZipFile.Open(path, ZipArchiveMode.Create);
+            XNamespace ns = visioNamespace;
+            XNamespace rel = officeRelationshipNamespace;
+            XElement mastersRoot = new(ns + "Masters",
+                new XElement(ns + "Master",
+                    new XAttribute("ID", "42"),
+                    new XAttribute("Name", name),
+                    new XAttribute("NameU", nameU),
+                    new XElement(ns + "Rel", new XAttribute(rel + "id", "rId1"))));
+            WriteZipXml(zip, "visio/masters/masters.xml", new XDocument(mastersRoot));
+
+            XNamespace packageRel = packageRelationshipNamespace;
+            XElement relationshipsRoot = new(packageRel + "Relationships",
+                new XElement(packageRel + "Relationship",
+                    new XAttribute("Id", "rId1"),
+                    new XAttribute("Type", officeRelationshipNamespace + "/master"),
+                    new XAttribute("Target", "master42.xml")));
+            WriteZipXml(zip, "visio/masters/_rels/masters.xml.rels", new XDocument(relationshipsRoot));
+
+            XElement documentRoot = new(ns + "VisioDocument",
+                new XElement(ns + "DocumentSettings"),
+                new XElement(ns + "Colors",
+                    new XElement(ns + "ColorEntry", new XAttribute("IX", "24"), new XAttribute("RGB", "#50E6FF"))),
+                new XElement(ns + "FaceNames",
+                    new XElement(ns + "FaceName", new XAttribute("NameU", "Sample UI"))),
+                new XElement(ns + "StyleSheets",
+                    new XElement(ns + "StyleSheet",
+                        new XAttribute("ID", "8"),
+                        new XAttribute("Name", "External Azure"),
+                        new XAttribute("NameU", "External Azure"),
+                        new XAttribute("LineStyle", "0"),
+                        new XAttribute("FillStyle", "0"),
+                        new XAttribute("TextStyle", "0"),
+                        new XElement(ns + "Cell", new XAttribute("N", "FillForegnd"), new XAttribute("V", "#50E6FF")),
+                        new XElement(ns + "Cell", new XAttribute("N", "LineColor"), new XAttribute("V", "#0078D4")))));
+            WriteZipXml(zip, "visio/document.xml", new XDocument(documentRoot));
+            WriteZipXml(zip, "visio/theme/theme1.xml", new XDocument(new XElement(XName.Get("theme", "http://schemas.openxmlformats.org/drawingml/2006/main"), new XAttribute("name", "External Theme"))));
+
+            XElement childShape = new(ns + "Shape",
+                new XAttribute("ID", "6"),
+                new XAttribute("NameU", "FancyCloud.Icon"),
+                new XAttribute("Type", "Shape"),
+                new XElement(ns + "Cell", new XAttribute("N", "PinX"), new XAttribute("V", "0.5")),
+                new XElement(ns + "Cell", new XAttribute("N", "PinY"), new XAttribute("V", "0.35")),
+                new XElement(ns + "Cell", new XAttribute("N", "Width"), new XAttribute("V", "0.6")),
+                new XElement(ns + "Cell", new XAttribute("N", "Height"), new XAttribute("V", "0.4")),
+                new XElement(ns + "Cell", new XAttribute("N", "LocPinX"), new XAttribute("V", "0.3")),
+                new XElement(ns + "Cell", new XAttribute("N", "LocPinY"), new XAttribute("V", "0.2")),
+                new XElement(ns + "Section",
+                    new XAttribute("N", "Geometry"),
+                    new XAttribute("IX", "0"),
+                    new XElement(ns + "Row", new XAttribute("T", "MoveTo"),
+                        new XElement(ns + "Cell", new XAttribute("N", "X"), new XAttribute("V", "0")),
+                        new XElement(ns + "Cell", new XAttribute("N", "Y"), new XAttribute("V", "0.2"))),
+                    new XElement(ns + "Row", new XAttribute("T", "LineTo"),
+                        new XElement(ns + "Cell", new XAttribute("N", "X"), new XAttribute("V", "0.2")),
+                        new XElement(ns + "Cell", new XAttribute("N", "Y"), new XAttribute("V", "0.4"))),
+                    new XElement(ns + "Row", new XAttribute("T", "LineTo"),
+                        new XElement(ns + "Cell", new XAttribute("N", "X"), new XAttribute("V", "0.6")),
+                        new XElement(ns + "Cell", new XAttribute("N", "Y"), new XAttribute("V", "0.3"))),
+                    new XElement(ns + "Row", new XAttribute("T", "LineTo"),
+                        new XElement(ns + "Cell", new XAttribute("N", "X"), new XAttribute("V", "0.6")),
+                        new XElement(ns + "Cell", new XAttribute("N", "Y"), new XAttribute("V", "0.1"))),
+                    new XElement(ns + "Row", new XAttribute("T", "LineTo"),
+                        new XElement(ns + "Cell", new XAttribute("N", "X"), new XAttribute("V", "0")),
+                        new XElement(ns + "Cell", new XAttribute("N", "Y"), new XAttribute("V", "0.2")))));
+            XElement groupShape = new(ns + "Shape",
+                new XAttribute("ID", "5"),
+                new XAttribute("Name", name),
+                new XAttribute("NameU", nameU),
+                new XAttribute("Type", "Group"),
+                new XAttribute("LineStyle", "8"),
+                new XAttribute("FillStyle", "8"),
+                new XAttribute("TextStyle", "8"),
+                new XElement(ns + "Cell", new XAttribute("N", "PinX"), new XAttribute("V", "0.5")),
+                new XElement(ns + "Cell", new XAttribute("N", "PinY"), new XAttribute("V", "0.5")),
+                new XElement(ns + "Cell", new XAttribute("N", "Width"), new XAttribute("V", "1")),
+                new XElement(ns + "Cell", new XAttribute("N", "Height"), new XAttribute("V", "1")),
+                new XElement(ns + "Cell", new XAttribute("N", "LocPinX"), new XAttribute("V", "0.5")),
+                new XElement(ns + "Cell", new XAttribute("N", "LocPinY"), new XAttribute("V", "0.5")),
+                new XElement(ns + "Shapes", childShape));
+            XDocument masterDocument = new(new XElement(ns + "MasterContents",
+                new XAttribute(XNamespace.Xml + "space", "preserve"),
+                new XAttribute(XNamespace.Xmlns + "r", officeRelationshipNamespace),
+                new XElement(ns + "Shapes", groupShape),
+                new XElement(ns + "ForeignData",
+                    new XAttribute("ForeignType", "Bitmap"),
+                    new XAttribute(rel + "id", "rIdImage"))));
+            WriteZipXml(zip, "visio/masters/master42.xml", masterDocument);
+
+            XElement masterRelRoot = new(packageRel + "Relationships",
+                new XElement(packageRel + "Relationship",
+                    new XAttribute("Id", "rIdImage"),
+                    new XAttribute("Type", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"),
+                    new XAttribute("Target", "../media/image1.emf")));
+            WriteZipXml(zip, "visio/masters/_rels/master42.xml.rels", new XDocument(masterRelRoot));
+
+            ZipArchiveEntry mediaEntry = zip.CreateEntry("visio/media/image1.emf");
+            using Stream mediaStream = mediaEntry.Open();
+            byte[] media = { 1, 0, 0, 0, 32, 69, 77, 70 };
+            mediaStream.Write(media, 0, media.Length);
         }
 
         private static void CreatePackageWithMasterDimensions(string path, params (string NameU, string? Name, double Width, double Height, string? Unit)[] masters) {

--- a/OfficeIMO.Tests/Visio.Stencils.cs
+++ b/OfficeIMO.Tests/Visio.Stencils.cs
@@ -440,6 +440,45 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PackageCatalogLoadManyAutoImportsSourceMasters() {
+            string firstPackage = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vssx");
+            string secondPackage = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vssx");
+            CreatePackageWithRawGroupMaster(firstPackage, "FancyCloud", "Fancy Cloud");
+            CreatePackageWithRawGroupMaster(secondPackage, "DataVault", "Data Vault");
+
+            VisioStencilCatalog catalog = VisioStencilPackageCatalog.LoadMany(new[] { firstPackage, secondPackage }, new VisioStencilPackageLoadOptions {
+                CatalogName = "Combined",
+                IncludeUnsupportedMasters = true
+            });
+
+            VisioStencilShape cloudStencil = catalog.Get("fancy-cloud");
+            VisioStencilShape vaultStencil = catalog.Get("data-vault");
+            string manifestPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xml");
+            catalog.Save(manifestPath);
+            VisioStencilCatalog reloadedCatalog = VisioStencilCatalog.Load(manifestPath);
+            Assert.Equal(Path.GetFullPath(firstPackage), reloadedCatalog.Get("fancy-cloud").SourcePackagePath);
+
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+            VisioDocument document = VisioDocument.Create(filePath);
+            VisioPage page = document.AddPage("External Stencils");
+            VisioShape cloud = page.AddStencilShape(cloudStencil, "cloud", 2, 4);
+            VisioShape vault = page.AddStencilShape(vaultStencil, "vault", 5, 4);
+            document.Save();
+
+            Assert.Equal(Path.GetFullPath(firstPackage), cloudStencil.SourcePackagePath);
+            Assert.Equal(Path.GetFullPath(secondPackage), vaultStencil.SourcePackagePath);
+            Assert.Equal(cloudStencil.MasterNameU, cloud.MasterNameU);
+            Assert.Equal(vaultStencil.MasterNameU, vault.MasterNameU);
+            Assert.NotNull(cloud.Master);
+            Assert.NotNull(vault.Master);
+            Assert.Empty(VisioValidator.Validate(filePath));
+
+            using ZipArchive zip = ZipFile.OpenRead(filePath);
+            Assert.NotNull(zip.GetEntry("visio/masters/master1.xml"));
+            Assert.NotNull(zip.GetEntry("visio/masters/master2.xml"));
+        }
+
+        [Fact]
         public void CatalogThrowsForUnknownStencilShape() {
             KeyNotFoundException exception = Assert.Throws<KeyNotFoundException>(() => VisioStencils.BasicShapes.Get("not-here"));
 

--- a/OfficeIMO.Tests/Visio.TextStyles.cs
+++ b/OfficeIMO.Tests/Visio.TextStyles.cs
@@ -10,7 +10,7 @@ using Color = OfficeIMO.Drawing.OfficeColor;
 namespace OfficeIMO.Tests {
     public class VisioTextStyleTests {
         [Fact]
-        public void VisioTextStyleWritesCharParaAndTextBlockCells() {
+        public void VisioTextStyleWritesCharacterParagraphAndTextBlockCells() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
             VisioDocument document = VisioDocument.Create(filePath);
             VisioPage page = document.AddPage("Text");
@@ -64,15 +64,15 @@ namespace OfficeIMO.Tests {
             Assert.Equal("0.225", Cell(shape, ns, "TxtLocPinY").Attribute("V")?.Value);
             Assert.Equal("0.25", Cell(shape, ns, "TxtAngle").Attribute("V")?.Value);
 
-            XElement charSection = SingleSection(shape, ns, "Char");
+            XElement charSection = SingleSection(shape, ns, "Character");
             XElement charRow = Assert.Single(charSection.Elements(ns + "Row"));
             Assert.Equal("0", Cell(charRow, ns, "Font").Attribute("V")?.Value);
             Assert.Equal("#336699", Cell(charRow, ns, "Color").Attribute("V")?.Value);
-            Assert.Equal("13.5", Cell(charRow, ns, "Size").Attribute("V")?.Value);
+            Assert.Equal("0.1875", Cell(charRow, ns, "Size").Attribute("V")?.Value);
             Assert.Equal("PT", Cell(charRow, ns, "Size").Attribute("U")?.Value);
             Assert.Equal("3", Cell(charRow, ns, "Style").Attribute("V")?.Value);
 
-            XElement paraSection = SingleSection(shape, ns, "Para");
+            XElement paraSection = SingleSection(shape, ns, "Paragraph");
             XElement paraRow = Assert.Single(paraSection.Elements(ns + "Row"));
             Assert.Equal("1", Cell(paraRow, ns, "HorzAlign").Attribute("V")?.Value);
         }
@@ -132,14 +132,14 @@ namespace OfficeIMO.Tests {
             Assert.Empty(VisioValidator.Validate(savedPath));
             XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
             XElement savedShape = FindShape(ReadXml(savedPath, "visio/pages/page1.xml"), ns, "Round tripped");
-            Assert.Single(savedShape.Elements(ns + "Section"), section => (string?)section.Attribute("N") == "Char");
-            Assert.Single(savedShape.Elements(ns + "Section"), section => (string?)section.Attribute("N") == "Para");
+            Assert.Single(savedShape.Elements(ns + "Section"), section => (string?)section.Attribute("N") == "Character");
+            Assert.Single(savedShape.Elements(ns + "Section"), section => (string?)section.Attribute("N") == "Paragraph");
             Assert.Single(ReadXml(savedPath, "visio/document.xml")
                 .Descendants(ns + "FaceName"), element => (string?)element.Attribute("Name") == "Consolas");
         }
 
         [Fact]
-        public void ConnectorLabelTextStyleWritesCharParaAndTextBlockCells() {
+        public void ConnectorLabelTextStyleWritesCharacterParagraphAndTextBlockCells() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
             VisioDocument document = VisioDocument.Create(filePath);
             VisioPage page = document.AddPage("ConnectorText");
@@ -183,15 +183,15 @@ namespace OfficeIMO.Tests {
             Assert.Equal("1.4", Cell(connector, ns, "TxtWidth").Attribute("V")?.Value);
             Assert.Equal("0.35", Cell(connector, ns, "TxtHeight").Attribute("V")?.Value);
 
-            XElement charSection = SingleSection(connector, ns, "Char");
+            XElement charSection = SingleSection(connector, ns, "Character");
             XElement charRow = Assert.Single(charSection.Elements(ns + "Row"));
             Assert.Equal("0", Cell(charRow, ns, "Font").Attribute("V")?.Value);
             Assert.Equal("#1E90FF", Cell(charRow, ns, "Color").Attribute("V")?.Value);
-            Assert.Equal("9.5", Cell(charRow, ns, "Size").Attribute("V")?.Value);
+            Assert.Equal("0.131944444444444", Cell(charRow, ns, "Size").Attribute("V")?.Value);
             Assert.Equal("PT", Cell(charRow, ns, "Size").Attribute("U")?.Value);
             Assert.Equal("5", Cell(charRow, ns, "Style").Attribute("V")?.Value);
 
-            XElement paraSection = SingleSection(connector, ns, "Para");
+            XElement paraSection = SingleSection(connector, ns, "Paragraph");
             XElement paraRow = Assert.Single(paraSection.Elements(ns + "Row"));
             Assert.Equal("1", Cell(paraRow, ns, "HorzAlign").Attribute("V")?.Value);
             Assert.Single(ReadXml(filePath, "visio/document.xml")
@@ -245,8 +245,8 @@ namespace OfficeIMO.Tests {
             Assert.Empty(VisioValidator.Validate(savedPath));
             XNamespace ns = "http://schemas.microsoft.com/office/visio/2012/main";
             XElement savedConnector = FindShape(ReadXml(savedPath, "visio/pages/page1.xml"), ns, "Denied");
-            Assert.Single(savedConnector.Elements(ns + "Section"), section => (string?)section.Attribute("N") == "Char");
-            Assert.Single(savedConnector.Elements(ns + "Section"), section => (string?)section.Attribute("N") == "Para");
+            Assert.Single(savedConnector.Elements(ns + "Section"), section => (string?)section.Attribute("N") == "Character");
+            Assert.Single(savedConnector.Elements(ns + "Section"), section => (string?)section.Attribute("N") == "Paragraph");
             Assert.Single(ReadXml(savedPath, "visio/document.xml")
                 .Descendants(ns + "FaceName"), element => (string?)element.Attribute("Name") == "Consolas");
         }

--- a/OfficeIMO.Tests/Visio.Validation.cs
+++ b/OfficeIMO.Tests/Visio.Validation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -105,6 +106,54 @@ namespace OfficeIMO.Tests {
                 issue.Contains("Page ID 1 (Page-2)") &&
                 issue.IndexOf("Missing Override", StringComparison.OrdinalIgnoreCase) >= 0);
             Assert.DoesNotContain(issues, issue => issue.Contains("Page ID 0 (Page-1)"));
+        }
+
+        [Fact]
+        public void ValidatorReportsMissingContentTypesWithoutThrowing() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = VisioDocument.Create(filePath);
+            VisioPage page = document.AddPage("Page-1");
+            page.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "Start"));
+            document.Save();
+
+            using (FileStream stream = new(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            using (ZipArchive archive = new(stream, ZipArchiveMode.Update)) {
+                ZipArchiveEntry? entry = archive.GetEntry("[Content_Types].xml");
+                Assert.NotNull(entry);
+                entry!.Delete();
+            }
+
+            IReadOnlyList<string> issues = Array.Empty<string>();
+            Exception? exception = Record.Exception(() => issues = VisioValidator.Validate(filePath));
+
+            Assert.Null(exception);
+            Assert.Contains(issues, issue => issue.Contains("[Content_Types].xml", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public void ValidatorReportsMissingPagesRelationshipsWithoutThrowing() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = VisioDocument.Create(filePath);
+            VisioPage page = document.AddPage("Page-1");
+            page.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "Start"));
+            document.Save();
+
+            using (FileStream stream = new(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            using (ZipArchive archive = new(stream, ZipArchiveMode.Update)) {
+                ZipArchiveEntry? entry = archive.GetEntry("visio/pages/_rels/pages.xml.rels");
+                Assert.NotNull(entry);
+                entry!.Delete();
+            }
+
+            IReadOnlyList<string> issues = Array.Empty<string>();
+            Exception? exception = Record.Exception(() => issues = VisioValidator.Validate(filePath));
+
+            Assert.Null(exception);
+            Assert.Contains(issues, issue =>
+                issue.Contains("/visio/pages/_rels/pages.xml.rels", StringComparison.OrdinalIgnoreCase) &&
+                issue.Contains("missing", StringComparison.OrdinalIgnoreCase));
         }
 
         [Fact]

--- a/OfficeIMO.Visio/Diagrams/VisioArchitectureDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioArchitectureDiagramBuilder.cs
@@ -426,7 +426,6 @@ namespace OfficeIMO.Visio.Diagrams {
                 double height = (region.RowSpan * _componentHeight) + ((region.RowSpan - 1) * _rowGap) + 0.6;
                 VisioShape shape = new(region.Id, GridX(region.Column, region.ColumnSpan), GridY(region.Row, region.RowSpan), width, height, region.Text) {
                     NameU = "Rectangle",
-                    Master = _document.EnsureBuiltinMaster("Rectangle")
                 };
                 _theme.Container.ApplyTo(shape);
                 shape.SetUserCell(VisioSemanticUserCells.Kind, VisioSemanticUserCells.BackgroundSurfaceKind, "STR", prompt: "OfficeIMO semantic kind");
@@ -439,7 +438,6 @@ namespace OfficeIMO.Visio.Diagrams {
                 GetComponentShape(component.Kind, out string masterNameU, out double width, out double height);
                 VisioShape shape = new(component.Id, GridX(component.Column, 1), GridY(component.Row, 1), width, height, component.Text) {
                     NameU = masterNameU,
-                    Master = _document.EnsureBuiltinMaster(masterNameU)
                 };
                 GetComponentStyle(component.Kind).ApplyTo(shape);
                 component.Shape = shape;

--- a/OfficeIMO.Visio/Diagrams/VisioBlockDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioBlockDiagramBuilder.cs
@@ -340,8 +340,6 @@ namespace OfficeIMO.Visio.Diagrams {
                 if (_theme.RegionTextStyle != null) {
                     shape.TextStyle = _theme.RegionTextStyle.Clone();
                 }
-
-                shape.Master = _document.EnsureBuiltinMaster("Rectangle");
                 shape.SetUserCell(VisioSemanticUserCells.Kind, VisioSemanticUserCells.BackgroundSurfaceKind, "STR", prompt: "OfficeIMO semantic kind");
                 page.Shapes.Add(shape);
             }
@@ -353,10 +351,6 @@ namespace OfficeIMO.Visio.Diagrams {
                 double x = GridX(block.Column, 1);
                 double y = GridY(block.Row, 1);
                 VisioShape shape = CreateBlockShape(page, block, x, y);
-                string? nameU = shape.NameU;
-                if (!string.IsNullOrWhiteSpace(nameU)) {
-                    shape.Master = _document.EnsureBuiltinMaster(nameU!);
-                }
 
                 block.Shape = shape;
             }
@@ -418,6 +412,11 @@ namespace OfficeIMO.Visio.Diagrams {
 
                 if (_theme.ConnectorTextStyle != null) {
                     connector.TextStyle = _theme.ConnectorTextStyle.Clone();
+                }
+
+                if (!string.IsNullOrWhiteSpace(link.Label)) {
+                    double labelWidth = Math.Max(1.25D, Math.Min(2.2D, link.Label!.Length * 0.14D));
+                    connector.PlaceLabel(0.5D, offsetY: 0.18D, width: labelWidth, height: 0.35D);
                 }
             }
         }

--- a/OfficeIMO.Visio/Diagrams/VisioBlockDiagramTheme.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioBlockDiagramTheme.cs
@@ -36,16 +36,30 @@ namespace OfficeIMO.Visio.Diagrams {
         public double BlockHeight { get; set; } = 1.0;
 
         /// <summary>Default block text style.</summary>
-        public VisioTextStyle? BlockTextStyle { get; set; }
+        public VisioTextStyle? BlockTextStyle { get; set; } = FilledNodeText();
 
         /// <summary>Default emphasis block text style.</summary>
-        public VisioTextStyle? EmphasisTextStyle { get; set; }
+        public VisioTextStyle? EmphasisTextStyle { get; set; } = FilledNodeText();
 
         /// <summary>Default region text style.</summary>
-        public VisioTextStyle? RegionTextStyle { get; set; }
+        public VisioTextStyle? RegionTextStyle { get; set; } = new VisioTextStyle {
+            FontFamily = "Aptos",
+            Color = Color.FromRgb(40, 55, 70),
+            Size = 10,
+            HorizontalAlignment = VisioTextHorizontalAlignment.Center,
+            VerticalAlignment = VisioTextVerticalAlignment.Middle
+        };
 
         /// <summary>Default connector label text style.</summary>
-        public VisioTextStyle? ConnectorTextStyle { get; set; }
+        public VisioTextStyle? ConnectorTextStyle { get; set; } = new VisioTextStyle {
+            FontFamily = "Aptos",
+            Color = Color.FromRgb(20, 75, 120),
+            Size = 9,
+            HorizontalAlignment = VisioTextHorizontalAlignment.Center,
+            VerticalAlignment = VisioTextVerticalAlignment.Middle,
+            BackgroundColor = Color.FromRgb(255, 255, 255),
+            BackgroundTransparency = 8
+        };
 
         /// <summary>Default title text style.</summary>
         public VisioTextStyle? TitleTextStyle { get; set; } = new VisioTextStyle {
@@ -100,5 +114,18 @@ namespace OfficeIMO.Visio.Diagrams {
 
         /// <summary>Default blue/gray OfficeIMO block diagram theme.</summary>
         public static VisioBlockDiagramTheme TechnicalBlue() => new VisioBlockDiagramTheme();
+
+        private static VisioTextStyle FilledNodeText() => new VisioTextStyle {
+            FontFamily = "Aptos",
+            Color = Color.FromRgb(255, 255, 255),
+            Size = 10,
+            Bold = true,
+            HorizontalAlignment = VisioTextHorizontalAlignment.Center,
+            VerticalAlignment = VisioTextVerticalAlignment.Middle,
+            LeftMargin = 0.12,
+            RightMargin = 0.12,
+            TopMargin = 0.08,
+            BottomMargin = 0.08
+        };
     }
 }

--- a/OfficeIMO.Visio/Diagrams/VisioDependencyDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioDependencyDiagramBuilder.cs
@@ -388,7 +388,6 @@ namespace OfficeIMO.Visio.Diagrams {
                 GetNodeShape(node.Kind, out string masterNameU, out double width, out double height);
                 VisioShape shape = new(node.Id, XForLayer(node.Layer), YForRow(node.Layer, node.Row), width, height, node.Text) {
                     NameU = masterNameU,
-                    Master = _document.EnsureBuiltinMaster(masterNameU)
                 };
                 GetNodeStyle(node.Kind).ApplyTo(shape);
                 node.Shape = shape;

--- a/OfficeIMO.Visio/Diagrams/VisioFlowchartBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioFlowchartBuilder.cs
@@ -274,7 +274,7 @@ namespace OfficeIMO.Visio.Diagrams {
             }
 
             bool previousMastersByDefault = _document.UseMastersByDefault;
-            _document.UseMastersByDefault = true;
+            _document.UseMastersByDefault = false;
             try {
                 VisioPage page = _document.AddPage(_pageName, _pageWidth, _pageHeight, _unit);
                 page.Grid(visible: false, snap: true);
@@ -407,8 +407,6 @@ namespace OfficeIMO.Visio.Diagrams {
             if (textStyle != null) {
                 shape.TextStyle = textStyle.Clone();
             }
-
-            shape.Master = _document.EnsureBuiltinMaster(nameU);
             page.Shapes.Add(shape);
 
             return shape;

--- a/OfficeIMO.Visio/Diagrams/VisioFlowchartTheme.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioFlowchartTheme.cs
@@ -42,7 +42,7 @@ namespace OfficeIMO.Visio.Diagrams {
         public double ProcessHeight { get; set; } = 1.05;
 
         /// <summary>Default process text style.</summary>
-        public VisioTextStyle? ProcessTextStyle { get; set; }
+        public VisioTextStyle? ProcessTextStyle { get; set; } = FilledNodeText();
 
         /// <summary>Default decision width in page units.</summary>
         public double DecisionWidth { get; set; } = 2.35;
@@ -51,7 +51,7 @@ namespace OfficeIMO.Visio.Diagrams {
         public double DecisionHeight { get; set; } = 1.45;
 
         /// <summary>Default decision text style.</summary>
-        public VisioTextStyle? DecisionTextStyle { get; set; }
+        public VisioTextStyle? DecisionTextStyle { get; set; } = FilledNodeText();
 
         /// <summary>Default terminator width in page units.</summary>
         public double TerminatorWidth { get; set; } = 2.35;
@@ -60,16 +60,24 @@ namespace OfficeIMO.Visio.Diagrams {
         public double TerminatorHeight { get; set; } = 0.9;
 
         /// <summary>Default terminator text style.</summary>
-        public VisioTextStyle? TerminatorTextStyle { get; set; }
+        public VisioTextStyle? TerminatorTextStyle { get; set; } = FilledNodeText();
 
         /// <summary>Default continuation marker diameter in page units.</summary>
         public double MarkerDiameter { get; set; } = 0.55;
 
         /// <summary>Default continuation marker text style.</summary>
-        public VisioTextStyle? MarkerTextStyle { get; set; }
+        public VisioTextStyle? MarkerTextStyle { get; set; } = FilledNodeText(10);
 
         /// <summary>Default connector label text style.</summary>
-        public VisioTextStyle? ConnectorTextStyle { get; set; }
+        public VisioTextStyle? ConnectorTextStyle { get; set; } = new VisioTextStyle {
+            FontFamily = "Aptos",
+            Color = Color.FromRgb(20, 75, 120),
+            Size = 9.5,
+            HorizontalAlignment = VisioTextHorizontalAlignment.Center,
+            VerticalAlignment = VisioTextVerticalAlignment.Middle,
+            BackgroundColor = Color.FromRgb(255, 255, 255),
+            BackgroundTransparency = 8
+        };
 
         /// <summary>Default title text style.</summary>
         public VisioTextStyle? TitleTextStyle { get; set; } = new VisioTextStyle {
@@ -110,5 +118,18 @@ namespace OfficeIMO.Visio.Diagrams {
 
         /// <summary>Default blue/green OfficeIMO flowchart theme.</summary>
         public static VisioFlowchartTheme ModernBlueGreen() => new VisioFlowchartTheme();
+
+        private static VisioTextStyle FilledNodeText(double size = 9.5D) => new VisioTextStyle {
+            FontFamily = "Aptos",
+            Color = Color.FromRgb(255, 255, 255),
+            Size = size,
+            Bold = true,
+            HorizontalAlignment = VisioTextHorizontalAlignment.Center,
+            VerticalAlignment = VisioTextVerticalAlignment.Middle,
+            LeftMargin = 0.12,
+            RightMargin = 0.12,
+            TopMargin = 0.08,
+            BottomMargin = 0.08
+        };
     }
 }

--- a/OfficeIMO.Visio/Diagrams/VisioGraphConnectorKind.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioGraphConnectorKind.cs
@@ -1,0 +1,18 @@
+namespace OfficeIMO.Visio.Diagrams {
+    /// <summary>
+    /// Built-in visual category for generic graph edges.
+    /// </summary>
+    public enum VisioGraphConnectorKind {
+        /// <summary>Standard relationship edge.</summary>
+        Standard,
+
+        /// <summary>Data-flow or data-dependency edge.</summary>
+        Data,
+
+        /// <summary>Control-flow, policy, or management edge.</summary>
+        Control,
+
+        /// <summary>Highlighted or critical-path edge.</summary>
+        Emphasis
+    }
+}

--- a/OfficeIMO.Visio/Diagrams/VisioGraphDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioGraphDiagramBuilder.cs
@@ -1,0 +1,744 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OfficeIMO.Visio.Stencils;
+using Color = OfficeIMO.Drawing.OfficeColor;
+
+namespace OfficeIMO.Visio.Diagrams {
+    /// <summary>
+    /// High-level builder for generic graph diagrams where OfficeIMO lays out arbitrary nodes and edges.
+    /// </summary>
+    public sealed class VisioGraphDiagramBuilder {
+        private sealed class NodeItem {
+            public NodeItem(string id, string text, VisioGraphNodeKind kind, VisioStencilShape? stencil) {
+                Id = id;
+                Text = text;
+                Kind = kind;
+                Stencil = stencil;
+            }
+
+            public string Id { get; }
+
+            public string Text { get; }
+
+            public VisioGraphNodeKind Kind { get; }
+
+            public VisioStencilShape? Stencil { get; }
+
+            public int Layer { get; set; }
+
+            public int Row { get; set; }
+
+            public double PinX { get; set; }
+
+            public double PinY { get; set; }
+
+            public VisioShape? Shape { get; set; }
+        }
+
+        private sealed class EdgeItem {
+            public EdgeItem(string fromId, string toId, VisioGraphConnectorKind kind, string? label, bool directed) {
+                FromId = fromId;
+                ToId = toId;
+                Kind = kind;
+                Label = label;
+                Directed = directed;
+            }
+
+            public string FromId { get; }
+
+            public string ToId { get; }
+
+            public VisioGraphConnectorKind Kind { get; }
+
+            public string? Label { get; }
+
+            public bool Directed { get; }
+        }
+
+        private sealed class ZoneItem {
+            public ZoneItem(string id, string text, IReadOnlyList<string> nodeIds) {
+                Id = id;
+                Text = text;
+                NodeIds = nodeIds;
+            }
+
+            public string Id { get; }
+
+            public string Text { get; }
+
+            public IReadOnlyList<string> NodeIds { get; }
+        }
+
+        private readonly VisioDocument _document;
+        private readonly string _pageName;
+        private readonly List<NodeItem> _nodes = new();
+        private readonly Dictionary<string, NodeItem> _nodesById = new(StringComparer.Ordinal);
+        private readonly List<EdgeItem> _edges = new();
+        private readonly List<string> _rootIds = new();
+        private readonly HashSet<string> _rootIdSet = new(StringComparer.Ordinal);
+        private readonly List<ZoneItem> _zones = new();
+        private readonly HashSet<string> _zoneIds = new(StringComparer.Ordinal);
+        private VisioStyleTheme _theme = VisioStyleTheme.Technical();
+        private VisioMeasurementUnit _unit = VisioMeasurementUnit.Inches;
+        private VisioGraphLayout _layout = VisioGraphLayout.Layered;
+        private VisioGraphDirection _direction = VisioGraphDirection.LeftToRight;
+        private double _pageWidth = 11;
+        private double _pageHeight = 8.5;
+        private double _leftMargin = 0.8;
+        private double _topMargin = 0.8;
+        private double _rightMargin = 0.8;
+        private double _bottomMargin = 0.8;
+        private double _nodeWidth = 1.65;
+        private double _nodeHeight = 0.82;
+        private double _columnGap = 1.1;
+        private double _rowGap = 0.65;
+        private string? _titleText;
+        private string _titleId = "title";
+        private double _titleHeight = 0.45;
+        private double _titleGap = 0.35;
+        private int _maximumRows = 1;
+        private bool _fitPageToGraph = true;
+        private bool _built;
+
+        internal VisioGraphDiagramBuilder(VisioDocument document, string pageName) {
+            _document = document ?? throw new ArgumentNullException(nameof(document));
+            _pageName = string.IsNullOrWhiteSpace(pageName) ? "Graph Diagram" : pageName;
+        }
+
+        /// <summary>Sets the page size used by the generated graph page.</summary>
+        public VisioGraphDiagramBuilder PageSize(double width, double height, VisioMeasurementUnit unit = VisioMeasurementUnit.Inches) {
+            ValidatePositive(width, nameof(width));
+            ValidatePositive(height, nameof(height));
+            _pageWidth = width;
+            _pageHeight = height;
+            _unit = unit;
+            return this;
+        }
+
+        /// <summary>Sets whether the builder can grow the page to fit the graph. Enabled by default.</summary>
+        public VisioGraphDiagramBuilder FitPageToGraph(bool enabled = true) {
+            _fitPageToGraph = enabled;
+            return this;
+        }
+
+        /// <summary>Sets the automatic graph layout strategy.</summary>
+        public VisioGraphDiagramBuilder Layout(VisioGraphLayout layout) {
+            if (!Enum.IsDefined(typeof(VisioGraphLayout), layout)) {
+                throw new ArgumentOutOfRangeException(nameof(layout));
+            }
+
+            _layout = layout;
+            return this;
+        }
+
+        /// <summary>Sets the primary flow direction for layered layouts.</summary>
+        public VisioGraphDiagramBuilder Direction(VisioGraphDirection direction) {
+            if (!Enum.IsDefined(typeof(VisioGraphDirection), direction)) {
+                throw new ArgumentOutOfRangeException(nameof(direction));
+            }
+
+            _direction = direction;
+            return this;
+        }
+
+        /// <summary>Sets the visual theme.</summary>
+        public VisioGraphDiagramBuilder Theme(VisioStyleTheme theme) {
+            _theme = (theme ?? throw new ArgumentNullException(nameof(theme))).Clone();
+            return this;
+        }
+
+        /// <summary>Sets outer page margins used by automatic layout.</summary>
+        public VisioGraphDiagramBuilder Margins(double left, double top, double right = 0.8D, double bottom = 0.8D) {
+            ValidateNonNegative(left, nameof(left));
+            ValidateNonNegative(top, nameof(top));
+            ValidateNonNegative(right, nameof(right));
+            ValidateNonNegative(bottom, nameof(bottom));
+            _leftMargin = left;
+            _topMargin = top;
+            _rightMargin = right;
+            _bottomMargin = bottom;
+            return this;
+        }
+
+        /// <summary>Sets the default node size used for native graph nodes.</summary>
+        public VisioGraphDiagramBuilder NodeSize(double width, double height) {
+            ValidatePositive(width, nameof(width));
+            ValidatePositive(height, nameof(height));
+            _nodeWidth = width;
+            _nodeHeight = height;
+            return this;
+        }
+
+        /// <summary>Sets spacing between layers/columns and rows/rings.</summary>
+        public VisioGraphDiagramBuilder Spacing(double columnGap, double rowGap) {
+            ValidateNonNegative(columnGap, nameof(columnGap));
+            ValidateNonNegative(rowGap, nameof(rowGap));
+            _columnGap = columnGap;
+            _rowGap = rowGap;
+            return this;
+        }
+
+        /// <summary>Adds a centered editable title above the graph.</summary>
+        public VisioGraphDiagramBuilder Title(string? text = null, string id = "title", double height = 0.45D, double gap = 0.35D) {
+            string normalizedId = RequireId(id, nameof(id), "Title id");
+            if (IsIdInUse(normalizedId)) {
+                throw new ArgumentException($"A graph diagram item with id '{normalizedId}' already exists.", nameof(id));
+            }
+
+            ValidatePositive(height, nameof(height));
+            ValidateNonNegative(gap, nameof(gap));
+            _titleText = string.IsNullOrWhiteSpace(text) ? _pageName : text;
+            _titleId = normalizedId;
+            _titleHeight = height;
+            _titleGap = gap;
+            return this;
+        }
+
+        /// <summary>Adds a background zone around graph nodes.</summary>
+        public VisioGraphDiagramBuilder Zone(string id, string text, params string[] nodeIds) {
+            string normalizedId = RequireId(id, nameof(id), "Zone id");
+            if (IsIdInUse(normalizedId)) {
+                throw new ArgumentException($"A graph diagram item with id '{normalizedId}' already exists.", nameof(id));
+            }
+
+            IReadOnlyList<string> normalizedNodeIds = NormalizeZoneNodeIds(nodeIds);
+            _zones.Add(new ZoneItem(normalizedId, text ?? string.Empty, normalizedNodeIds));
+            _zoneIds.Add(normalizedId);
+            return this;
+        }
+
+        /// <summary>Adds and marks a root node used by layered and radial layout.</summary>
+        public VisioGraphDiagramBuilder Root(string id, string text, VisioGraphNodeKind kind = VisioGraphNodeKind.External) {
+            Node(id, text, kind);
+            AddRoot(RequireId(id, nameof(id), "Root node id"));
+            return this;
+        }
+
+        /// <summary>Marks an existing node as a root used by layered and radial layout.</summary>
+        public VisioGraphDiagramBuilder Root(string id) {
+            string normalizedId = RequireId(id, nameof(id), "Root node id");
+            EnsureKnownNode(normalizedId, nameof(id));
+            AddRoot(normalizedId);
+            return this;
+        }
+
+        /// <summary>Adds a native graph node.</summary>
+        public VisioGraphDiagramBuilder Node(string id, string text, VisioGraphNodeKind kind = VisioGraphNodeKind.Process) {
+            string normalizedId = RequireId(id, nameof(id), "Node id");
+            if (IsIdInUse(normalizedId)) {
+                throw new ArgumentException($"A graph diagram item with id '{normalizedId}' already exists.", nameof(id));
+            }
+
+            if (!Enum.IsDefined(typeof(VisioGraphNodeKind), kind)) {
+                throw new ArgumentOutOfRangeException(nameof(kind));
+            }
+
+            NodeItem node = new(normalizedId, text ?? string.Empty, kind, null);
+            _nodes.Add(node);
+            _nodesById.Add(normalizedId, node);
+            return this;
+        }
+
+        /// <summary>Adds a graph node backed by an OfficeIMO, installed Visio, or external package stencil.</summary>
+        public VisioGraphDiagramBuilder StencilNode(string id, string text, VisioStencilShape stencil) {
+            if (stencil == null) throw new ArgumentNullException(nameof(stencil));
+            string normalizedId = RequireId(id, nameof(id), "Node id");
+            if (IsIdInUse(normalizedId)) {
+                throw new ArgumentException($"A graph diagram item with id '{normalizedId}' already exists.", nameof(id));
+            }
+
+            NodeItem node = new(normalizedId, text ?? string.Empty, VisioGraphNodeKind.Process, stencil);
+            _nodes.Add(node);
+            _nodesById.Add(normalizedId, node);
+            return this;
+        }
+
+        /// <summary>Adds a standard directed graph edge.</summary>
+        public VisioGraphDiagramBuilder Edge(string fromId, string toId, string? label = null) =>
+            Edge(fromId, toId, VisioGraphConnectorKind.Standard, label, directed: true);
+
+        /// <summary>Adds a data-flow graph edge.</summary>
+        public VisioGraphDiagramBuilder DataEdge(string fromId, string toId, string? label = null) =>
+            Edge(fromId, toId, VisioGraphConnectorKind.Data, label, directed: true);
+
+        /// <summary>Adds a control-flow graph edge.</summary>
+        public VisioGraphDiagramBuilder ControlEdge(string fromId, string toId, string? label = null) =>
+            Edge(fromId, toId, VisioGraphConnectorKind.Control, label, directed: true);
+
+        /// <summary>Adds an emphasized graph edge.</summary>
+        public VisioGraphDiagramBuilder EmphasisEdge(string fromId, string toId, string? label = null) =>
+            Edge(fromId, toId, VisioGraphConnectorKind.Emphasis, label, directed: true);
+
+        /// <summary>Adds an undirected graph edge.</summary>
+        public VisioGraphDiagramBuilder Relationship(string fromId, string toId, string? label = null) =>
+            Edge(fromId, toId, VisioGraphConnectorKind.Standard, label, directed: false);
+
+        /// <summary>Adds a graph edge between two known nodes.</summary>
+        public VisioGraphDiagramBuilder Edge(string fromId, string toId, VisioGraphConnectorKind kind, string? label = null, bool directed = true) {
+            string normalizedFromId = RequireId(fromId, nameof(fromId), "From node id");
+            string normalizedToId = RequireId(toId, nameof(toId), "To node id");
+            EnsureKnownNode(normalizedFromId, nameof(fromId));
+            EnsureKnownNode(normalizedToId, nameof(toId));
+            if (!Enum.IsDefined(typeof(VisioGraphConnectorKind), kind)) {
+                throw new ArgumentOutOfRangeException(nameof(kind));
+            }
+
+            _edges.Add(new EdgeItem(normalizedFromId, normalizedToId, kind, label, directed));
+            return this;
+        }
+
+        internal VisioPage Build() {
+            if (_built) {
+                throw new InvalidOperationException("This graph diagram builder has already produced a page.");
+            }
+
+            _built = true;
+            if (_nodes.Count == 0) {
+                throw new InvalidOperationException("A graph diagram requires at least one node.");
+            }
+
+            ValidateZones();
+            AssignLayoutMetadata();
+            SizePageForLayout();
+            AssignCoordinates();
+
+            VisioPage page = _document.AddPage(_pageName, _pageWidth, _pageHeight, _unit);
+            page.Grid(visible: false, snap: true);
+            AddZones(page);
+            AddNodes(page);
+            AddEdges(page);
+            AddTitle(page);
+            page.PolishDiagram(new VisioDiagramPolishOptions {
+                FitToContent = false,
+                ResizeShapesToText = false,
+                ResizeConnectorLabelsToText = true,
+                ResolveConnectorLabelOverlaps = true
+            });
+            _document.RequestRecalcOnOpen();
+            return page;
+        }
+
+        private void ValidateZones() {
+            foreach (ZoneItem zone in _zones) {
+                foreach (string nodeId in zone.NodeIds) {
+                    EnsureKnownNode(nodeId, nameof(zone.NodeIds));
+                }
+            }
+        }
+
+        private void AssignLayoutMetadata() {
+            if (_layout == VisioGraphLayout.Grid) {
+                AssignGridMetadata();
+                return;
+            }
+
+            AssignBreadthFirstMetadata();
+        }
+
+        private void AssignGridMetadata() {
+            int columns = Math.Max(1, (int)Math.Ceiling(Math.Sqrt(_nodes.Count)));
+            for (int i = 0; i < _nodes.Count; i++) {
+                _nodes[i].Layer = i % columns;
+                _nodes[i].Row = i / columns;
+            }
+
+            _maximumRows = _nodes.GroupBy(node => node.Layer).Max(group => group.Count());
+        }
+
+        private void AssignBreadthFirstMetadata() {
+            Dictionary<string, List<string>> outgoing = _nodes.ToDictionary(node => node.Id, _ => new List<string>(), StringComparer.Ordinal);
+            Dictionary<string, List<string>> undirected = _nodes.ToDictionary(node => node.Id, _ => new List<string>(), StringComparer.Ordinal);
+            Dictionary<string, int> indegree = _nodes.ToDictionary(node => node.Id, _ => 0, StringComparer.Ordinal);
+            foreach (EdgeItem edge in _edges) {
+                outgoing[edge.FromId].Add(edge.ToId);
+                undirected[edge.FromId].Add(edge.ToId);
+                undirected[edge.ToId].Add(edge.FromId);
+                if (edge.Directed) {
+                    indegree[edge.ToId]++;
+                } else {
+                    outgoing[edge.ToId].Add(edge.FromId);
+                }
+            }
+
+            HashSet<string> assigned = new(StringComparer.Ordinal);
+            Queue<NodeItem> ready = new();
+
+            void Enqueue(NodeItem node, int layer) {
+                if (assigned.Add(node.Id)) {
+                    node.Layer = layer;
+                    ready.Enqueue(node);
+                }
+            }
+
+            if (_rootIds.Count > 0) {
+                foreach (string rootId in _rootIds) {
+                    Enqueue(_nodesById[rootId], 0);
+                }
+            } else {
+                foreach (NodeItem root in _nodes.Where(node => indegree[node.Id] == 0)) {
+                    Enqueue(root, 0);
+                }
+            }
+
+            if (assigned.Count == 0 && _nodes.Count > 0) {
+                Enqueue(_nodes[0], 0);
+            }
+
+            while (assigned.Count < _nodes.Count || ready.Count > 0) {
+                while (ready.Count > 0) {
+                    NodeItem node = ready.Dequeue();
+                    IReadOnlyList<string> nextIds = outgoing[node.Id].Count > 0 ? outgoing[node.Id] : undirected[node.Id];
+                    foreach (string nextId in nextIds) {
+                        if (!assigned.Contains(nextId)) {
+                            Enqueue(_nodesById[nextId], node.Layer + 1);
+                        }
+                    }
+                }
+
+                if (assigned.Count < _nodes.Count) {
+                    NodeItem nextRoot = _nodes.First(node => !assigned.Contains(node.Id));
+                    Enqueue(nextRoot, 0);
+                }
+            }
+
+            foreach (IGrouping<int, NodeItem> layer in _nodes.GroupBy(node => node.Layer).OrderBy(group => group.Key)) {
+                int row = 0;
+                foreach (NodeItem node in layer.OrderBy(node => _nodes.IndexOf(node))) {
+                    node.Row = row;
+                    row++;
+                }
+            }
+
+            _maximumRows = Math.Max(1, _nodes.GroupBy(node => node.Layer).Max(group => group.Count()));
+        }
+
+        private void SizePageForLayout() {
+            if (!_fitPageToGraph) {
+                return;
+            }
+
+            int layerCount = Math.Max(1, _nodes.Max(node => node.Layer) + 1);
+            int rowCount = Math.Max(1, _nodes.GroupBy(node => node.Layer).Max(group => group.Count()));
+            double requiredWidth;
+            double requiredHeight;
+            if (_layout == VisioGraphLayout.Radial) {
+                double radius = Math.Max(1D, _nodes.Max(node => node.Layer)) * Math.Max(_nodeWidth + _columnGap, _nodeHeight + _rowGap);
+                requiredWidth = _leftMargin + _rightMargin + (radius * 2D) + _nodeWidth * 2D;
+                requiredHeight = _topMargin + _bottomMargin + HeaderHeight + (radius * 2D) + _nodeHeight * 2D;
+            } else if (_direction == VisioGraphDirection.TopToBottom) {
+                requiredWidth = _leftMargin + _rightMargin + (rowCount * _nodeWidth) + Math.Max(0, rowCount - 1) * _columnGap;
+                requiredHeight = _topMargin + _bottomMargin + HeaderHeight + (layerCount * _nodeHeight) + Math.Max(0, layerCount - 1) * _rowGap;
+            } else {
+                requiredWidth = _leftMargin + _rightMargin + (layerCount * _nodeWidth) + Math.Max(0, layerCount - 1) * _columnGap;
+                requiredHeight = _topMargin + _bottomMargin + HeaderHeight + (rowCount * _nodeHeight) + Math.Max(0, rowCount - 1) * _rowGap;
+            }
+
+            _pageWidth = Math.Max(_pageWidth, requiredWidth);
+            _pageHeight = Math.Max(_pageHeight, requiredHeight);
+        }
+
+        private void AssignCoordinates() {
+            if (_layout == VisioGraphLayout.Radial) {
+                AssignRadialCoordinates();
+                return;
+            }
+
+            foreach (NodeItem node in _nodes) {
+                if (_direction == VisioGraphDirection.TopToBottom) {
+                    node.PinX = XForRow(node.Row);
+                    node.PinY = YForLayer(node.Layer);
+                } else {
+                    node.PinX = XForLayer(node.Layer);
+                    node.PinY = YForRow(node.Row);
+                }
+            }
+        }
+
+        private void AssignRadialCoordinates() {
+            double contentHeight = _pageHeight - _topMargin - _bottomMargin - HeaderHeight;
+            double centerX = _leftMargin + ((_pageWidth - _leftMargin - _rightMargin) / 2D);
+            double centerY = _bottomMargin + (contentHeight / 2D);
+            double ringGap = Math.Max(_nodeWidth + _columnGap, _nodeHeight + _rowGap);
+            foreach (IGrouping<int, NodeItem> layer in _nodes.GroupBy(node => node.Layer).OrderBy(group => group.Key)) {
+                NodeItem[] layerNodes = layer.OrderBy(node => _nodes.IndexOf(node)).ToArray();
+                double radius = layer.Key == 0 && layerNodes.Length == 1 ? 0D : Math.Max(0.9D, layer.Key) * ringGap;
+                for (int i = 0; i < layerNodes.Length; i++) {
+                    double angle = layerNodes.Length == 1 ? -Math.PI / 2D : (-Math.PI / 2D) + (2D * Math.PI * i / layerNodes.Length);
+                    layerNodes[i].PinX = centerX + Math.Cos(angle) * radius;
+                    layerNodes[i].PinY = centerY + Math.Sin(angle) * radius;
+                }
+            }
+        }
+
+        private void AddZones(VisioPage page) {
+            foreach (ZoneItem zone in _zones) {
+                GetZoneBounds(zone, out double left, out double bottom, out double right, out double top);
+                double width = right - left;
+                double height = top - bottom;
+                VisioShape shape = VisioNetworkDiagramVisuals.CreateBackgroundZone(
+                    _document,
+                    zone.Id,
+                    left + width / 2D,
+                    bottom + height / 2D,
+                    width,
+                    height,
+                    string.Empty,
+                    _theme);
+                page.Shapes.Add(shape);
+                VisioShape label = page.AddTextBox(zone.Id + "-label", left + width / 2D, top - 0.18D, Math.Max(0.8D, width - 0.25D), 0.28D, zone.Text);
+                VisioTextStyle labelStyle = _theme.Container.TextStyle?.Clone() ?? new VisioTextStyle();
+                labelStyle.FontFamily = string.IsNullOrWhiteSpace(labelStyle.FontFamily) ? "Aptos" : labelStyle.FontFamily;
+                labelStyle.Size = Math.Max(labelStyle.Size ?? 0D, 9.5D);
+                labelStyle.Bold = true;
+                labelStyle.HorizontalAlignment = VisioTextHorizontalAlignment.Center;
+                labelStyle.VerticalAlignment = VisioTextVerticalAlignment.Middle;
+                label.TextStyle = labelStyle;
+            }
+        }
+
+        private void AddNodes(VisioPage page) {
+            foreach (NodeItem node in _nodes) {
+                GetNodeShape(node, out string masterNameU, out double width, out double height);
+                VisioShape shape;
+                if (node.Stencil != null) {
+                    shape = page.AddStencilShape(node.Stencil, node.Id, node.PinX, node.PinY, width, height, node.Text);
+                } else {
+                    shape = new VisioShape(node.Id, node.PinX, node.PinY, width, height, node.Text) {
+                        NameU = masterNameU,
+                    };
+                    GetNodeStyle(node.Kind).ApplyTo(shape);
+                    page.Shapes.Add(shape);
+                }
+
+                node.Shape = shape;
+            }
+        }
+
+        private void AddEdges(VisioPage page) {
+            int routeIndex = 0;
+            foreach (EdgeItem edge in _edges) {
+                NodeItem from = _nodesById[edge.FromId];
+                NodeItem to = _nodesById[edge.ToId];
+                if (from.Shape == null || to.Shape == null) {
+                    throw new InvalidOperationException("Nodes must be placed before graph edges are created.");
+                }
+
+                VisioNetworkDiagramVisuals.ResolveSides(from.Shape, to.Shape, out VisioSide fromSide, out VisioSide toSide);
+                ConnectorKind connectorKind = _layout == VisioGraphLayout.Radial ? ConnectorKind.Straight : ConnectorKind.RightAngle;
+                VisioConnector connector = page.AddConnector(from.Shape, to.Shape, connectorKind, fromSide, toSide);
+                GetConnectorStyle(edge.Kind, edge.Directed).ApplyTo(connector);
+                connector.Label = edge.Label;
+                if (_layout != VisioGraphLayout.Radial) {
+                    connector.RouteOrthogonal(offset: (routeIndex % 7) * 0.05D);
+                }
+
+                if (!string.IsNullOrWhiteSpace(edge.Label)) {
+                    VisioTextStyle labelStyle = connector.TextStyle?.Clone() ?? new VisioTextStyle();
+                    labelStyle.BackgroundColor = Color.White;
+                    labelStyle.BackgroundTransparency = 0;
+                    labelStyle.Size = Math.Max(labelStyle.Size ?? 0D, 8.5D);
+                    connector.TextStyle = labelStyle;
+                    connector.PlaceLabel(0.5D, offsetY: 0.26D, width: 1.35D, height: 0.32D);
+                    connector.ResizeLabelToText(maximumWidth: 1.5D);
+                }
+
+                routeIndex++;
+            }
+        }
+
+        private void AddTitle(VisioPage page) {
+            if (string.IsNullOrWhiteSpace(_titleText)) {
+                return;
+            }
+
+            double y = _pageHeight - _topMargin - (_titleHeight / 2D);
+            VisioShape title = page.AddTextBox(_titleId, _pageWidth / 2D, y, Math.Max(1D, _pageWidth - _leftMargin - _rightMargin), _titleHeight, _titleText, _unit);
+            VisioTextStyle style = _theme.Emphasis.TextStyle?.Clone() ?? new VisioTextStyle();
+            style.FontFamily = string.IsNullOrWhiteSpace(style.FontFamily) ? "Aptos Display" : style.FontFamily;
+            style.Size = Math.Max(style.Size ?? 0D, 20D);
+            style.Bold = true;
+            style.Color = Color.FromRgb(32, 55, 75);
+            style.HorizontalAlignment = VisioTextHorizontalAlignment.Center;
+            style.VerticalAlignment = VisioTextVerticalAlignment.Middle;
+            title.TextStyle = style;
+        }
+
+        private void GetZoneBounds(ZoneItem zone, out double left, out double bottom, out double right, out double top) {
+            const double horizontalPadding = 0.45D;
+            const double verticalPadding = 0.35D;
+            left = double.MaxValue;
+            bottom = double.MaxValue;
+            right = double.MinValue;
+            top = double.MinValue;
+            foreach (string nodeId in zone.NodeIds) {
+                NodeItem node = _nodesById[nodeId];
+                GetNodeShape(node, out _, out double width, out double height);
+                left = Math.Min(left, node.PinX - width / 2D);
+                bottom = Math.Min(bottom, node.PinY - height / 2D);
+                right = Math.Max(right, node.PinX + width / 2D);
+                top = Math.Max(top, node.PinY + height / 2D);
+            }
+
+            left -= horizontalPadding;
+            bottom -= verticalPadding;
+            right += horizontalPadding;
+            top += verticalPadding;
+        }
+
+        private double XForLayer(int layer) {
+            return _leftMargin + (_nodeWidth / 2D) + layer * (_nodeWidth + _columnGap);
+        }
+
+        private double XForRow(int row) {
+            double contentWidth = _maximumRows * _nodeWidth + Math.Max(0, _maximumRows - 1) * _columnGap;
+            double availableWidth = _pageWidth - _leftMargin - _rightMargin;
+            double start = _leftMargin + Math.Max(0D, (availableWidth - contentWidth) / 2D);
+            return start + (_nodeWidth / 2D) + row * (_nodeWidth + _columnGap);
+        }
+
+        private double YForLayer(int layer) {
+            double top = _pageHeight - _topMargin - HeaderHeight;
+            return top - (_nodeHeight / 2D) - layer * (_nodeHeight + _rowGap);
+        }
+
+        private double YForRow(int row) {
+            double contentHeight = _maximumRows * _nodeHeight + Math.Max(0, _maximumRows - 1) * _rowGap;
+            double top = _pageHeight - _topMargin - HeaderHeight;
+            double availableHeight = _pageHeight - _topMargin - _bottomMargin - HeaderHeight;
+            double layerTop = top - Math.Max(0D, (availableHeight - contentHeight) / 2D);
+            return layerTop - (_nodeHeight / 2D) - row * (_nodeHeight + _rowGap);
+        }
+
+        private double HeaderHeight => string.IsNullOrWhiteSpace(_titleText) ? 0D : _titleHeight + _titleGap;
+
+        private void GetNodeShape(NodeItem node, out string masterNameU, out double width, out double height) {
+            width = node.Stencil?.DefaultWidth ?? _nodeWidth;
+            height = node.Stencil?.DefaultHeight ?? _nodeHeight;
+            if (node.Stencil != null) {
+                masterNameU = node.Stencil.MasterNameU;
+                return;
+            }
+
+            switch (node.Kind) {
+                case VisioGraphNodeKind.Data:
+                    masterNameU = "Data";
+                    break;
+                case VisioGraphNodeKind.External:
+                    masterNameU = "Circle";
+                    width = Math.Min(_nodeWidth, _nodeHeight * 1.15D);
+                    height = width;
+                    break;
+                case VisioGraphNodeKind.Decision:
+                    masterNameU = "Decision";
+                    height = _nodeHeight * 1.2D;
+                    break;
+                default:
+                    masterNameU = "Process";
+                    break;
+            }
+        }
+
+        private VisioShapeStyle GetNodeStyle(VisioGraphNodeKind kind) {
+            switch (kind) {
+                case VisioGraphNodeKind.Data:
+                    return _theme.Marker;
+                case VisioGraphNodeKind.External:
+                    return _theme.Success;
+                case VisioGraphNodeKind.Decision:
+                    return _theme.Decision;
+                case VisioGraphNodeKind.Emphasis:
+                    return _theme.Emphasis;
+                default:
+                    return _theme.Primary;
+            }
+        }
+
+        private VisioConnectorStyle GetConnectorStyle(VisioGraphConnectorKind kind, bool directed) {
+            VisioConnectorStyle style;
+            switch (kind) {
+                case VisioGraphConnectorKind.Data:
+                    style = _theme.DataConnector.Clone();
+                    break;
+                case VisioGraphConnectorKind.Control:
+                    style = _theme.ControlConnector.Clone();
+                    break;
+                case VisioGraphConnectorKind.Emphasis:
+                    style = _theme.Connector.Clone();
+                    style.LineWeight = Math.Max(style.LineWeight, 0.026D);
+                    break;
+                default:
+                    style = _theme.Connector.Clone();
+                    break;
+            }
+
+            if (!directed) {
+                style.EndArrow = EndArrow.None;
+            }
+
+            return style;
+        }
+
+        private void AddRoot(string id) {
+            if (_rootIdSet.Add(id)) {
+                _rootIds.Add(id);
+            }
+        }
+
+        private bool IsIdInUse(string id) {
+            if (!string.IsNullOrWhiteSpace(_titleText) && string.Equals(_titleId, id, StringComparison.Ordinal)) {
+                return true;
+            }
+
+            if (_nodesById.ContainsKey(id) || _zoneIds.Contains(id)) {
+                return true;
+            }
+
+            return false;
+        }
+
+        private void EnsureKnownNode(string id, string parameterName) {
+            if (!_nodesById.ContainsKey(id)) {
+                throw new ArgumentException($"Unknown graph node id '{id}'.", parameterName);
+            }
+        }
+
+        private static IReadOnlyList<string> NormalizeZoneNodeIds(string[] nodeIds) {
+            if (nodeIds == null) throw new ArgumentNullException(nameof(nodeIds));
+            List<string> normalizedNodeIds = new();
+            HashSet<string> seen = new(StringComparer.Ordinal);
+            for (int i = 0; i < nodeIds.Length; i++) {
+                string normalizedId = RequireId(nodeIds[i], nameof(nodeIds), "Zone node id");
+                if (seen.Add(normalizedId)) {
+                    normalizedNodeIds.Add(normalizedId);
+                }
+            }
+
+            if (normalizedNodeIds.Count == 0) {
+                throw new ArgumentException("A graph zone requires at least one node id.", nameof(nodeIds));
+            }
+
+            return normalizedNodeIds.AsReadOnly();
+        }
+
+        private static string RequireId(string id, string parameterName, string label) {
+            if (string.IsNullOrWhiteSpace(id)) {
+                throw new ArgumentException(label + " cannot be null or whitespace.", parameterName);
+            }
+
+            return id.Trim();
+        }
+
+        private static void ValidatePositive(double value, string parameterName) {
+            if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0D) {
+                throw new ArgumentOutOfRangeException(parameterName, "Value must be positive.");
+            }
+        }
+
+        private static void ValidateNonNegative(double value, string parameterName) {
+            if (double.IsNaN(value) || double.IsInfinity(value) || value < 0D) {
+                throw new ArgumentOutOfRangeException(parameterName, "Value must be zero or greater.");
+            }
+        }
+    }
+}

--- a/OfficeIMO.Visio/Diagrams/VisioGraphDiagramDocumentExtensions.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioGraphDiagramDocumentExtensions.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace OfficeIMO.Visio.Diagrams {
+    /// <summary>
+    /// High-level generic graph diagram authoring extensions for <see cref="VisioDocument"/>.
+    /// </summary>
+    public static class VisioGraphDiagramDocumentExtensions {
+        /// <summary>
+        /// Adds an automatically laid out generic graph page and returns the document for chaining.
+        /// </summary>
+        public static VisioDocument GraphDiagram(this VisioDocument document, string pageName, Action<VisioGraphDiagramBuilder> configure) {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+            VisioGraphDiagramBuilder builder = new VisioGraphDiagramBuilder(document, pageName);
+            configure?.Invoke(builder);
+            builder.Build();
+            return document;
+        }
+    }
+}

--- a/OfficeIMO.Visio/Diagrams/VisioGraphDirection.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioGraphDirection.cs
@@ -1,0 +1,12 @@
+namespace OfficeIMO.Visio.Diagrams {
+    /// <summary>
+    /// Primary flow direction for layered graph diagrams.
+    /// </summary>
+    public enum VisioGraphDirection {
+        /// <summary>Arrange graph layers from left to right.</summary>
+        LeftToRight,
+
+        /// <summary>Arrange graph layers from top to bottom.</summary>
+        TopToBottom
+    }
+}

--- a/OfficeIMO.Visio/Diagrams/VisioGraphLayout.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioGraphLayout.cs
@@ -1,0 +1,15 @@
+namespace OfficeIMO.Visio.Diagrams {
+    /// <summary>
+    /// Automatic layout strategy for generic graph diagrams.
+    /// </summary>
+    public enum VisioGraphLayout {
+        /// <summary>Place nodes in breadth-first layers from roots or inferred roots. Cycles are tolerated.</summary>
+        Layered,
+
+        /// <summary>Place nodes in a compact grid by insertion order.</summary>
+        Grid,
+
+        /// <summary>Place nodes on rings around root nodes.</summary>
+        Radial
+    }
+}

--- a/OfficeIMO.Visio/Diagrams/VisioGraphNodeKind.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioGraphNodeKind.cs
@@ -1,0 +1,21 @@
+namespace OfficeIMO.Visio.Diagrams {
+    /// <summary>
+    /// Built-in visual category for generic graph nodes.
+    /// </summary>
+    public enum VisioGraphNodeKind {
+        /// <summary>Standard component or process node.</summary>
+        Process,
+
+        /// <summary>Decision, gateway, or policy node.</summary>
+        Decision,
+
+        /// <summary>Data store or persisted data node.</summary>
+        Data,
+
+        /// <summary>External actor or external system node.</summary>
+        External,
+
+        /// <summary>Emphasized infrastructure or boundary node.</summary>
+        Emphasis
+    }
+}

--- a/OfficeIMO.Visio/Diagrams/VisioNetworkDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioNetworkDiagramBuilder.cs
@@ -404,7 +404,6 @@ namespace OfficeIMO.Visio.Diagrams {
                 VisioNetworkDiagramVisuals.GetNodeShape(node.Kind, _nodeWidth, _nodeHeight, out string masterNameU, out double width, out double height);
                 VisioShape shape = new(node.Id, GridX(node.Column, 1), GridY(node.Row, 1), width, height, node.Text) {
                     NameU = masterNameU,
-                    Master = _document.EnsureBuiltinMaster(masterNameU)
                 };
                 VisioNetworkDiagramVisuals.GetNodeStyle(_theme, node.Kind).ApplyTo(shape);
                 node.Shape = shape;

--- a/OfficeIMO.Visio/Diagrams/VisioNetworkDiagramVisuals.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioNetworkDiagramVisuals.cs
@@ -83,7 +83,6 @@ namespace OfficeIMO.Visio.Diagrams {
             VisioStyleTheme theme) {
             VisioShape shape = new(id, pinX, pinY, width, height, text) {
                 NameU = "Rectangle",
-                Master = document.EnsureBuiltinMaster("Rectangle")
             };
             theme.Container.ApplyTo(shape);
             shape.SetUserCell(VisioSemanticUserCells.Kind, VisioSemanticUserCells.BackgroundSurfaceKind, "STR", prompt: "OfficeIMO semantic kind");

--- a/OfficeIMO.Visio/Diagrams/VisioNetworkTopologyDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioNetworkTopologyDiagramBuilder.cs
@@ -510,7 +510,6 @@ namespace OfficeIMO.Visio.Diagrams {
                 VisioNetworkDiagramVisuals.GetNodeShape(node.Kind, _nodeWidth, _nodeHeight, out string masterNameU, out double width, out double height);
                 VisioShape shape = new(node.Id, XForLayer(node.Layer), YForRow(node.Layer, node.Row), width, height, node.Text) {
                     NameU = masterNameU,
-                    Master = _document.EnsureBuiltinMaster(masterNameU)
                 };
                 VisioNetworkDiagramVisuals.GetNodeStyle(_theme, node.Kind).ApplyTo(shape);
                 node.Shape = shape;

--- a/OfficeIMO.Visio/Diagrams/VisioOrgChartDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioOrgChartDiagramBuilder.cs
@@ -513,7 +513,6 @@ namespace OfficeIMO.Visio.Diagrams {
                 double y = (bottom + top) / 2D;
                 VisioShape shape = new(GetBandShapeId(band.Id), x, y, width, height, band.Text) {
                     NameU = "Rectangle",
-                    Master = _document.EnsureBuiltinMaster("Rectangle")
                 };
                 _theme.Container.ApplyTo(shape);
                 shape.SetUserCell(VisioSemanticUserCells.Kind, VisioSemanticUserCells.BackgroundSurfaceKind, "STR", prompt: "OfficeIMO semantic kind");
@@ -546,7 +545,6 @@ namespace OfficeIMO.Visio.Diagrams {
                 GetNodeShape(node.Kind, out string masterNameU, out double width, out double height);
                 VisioShape shape = new(node.Id, node.X, node.Y, width, height, GetNodeText(node)) {
                     NameU = masterNameU,
-                    Master = _document.EnsureBuiltinMaster(masterNameU)
                 };
                 GetNodeStyle(node.Kind).ApplyTo(shape);
                 node.Shape = shape;

--- a/OfficeIMO.Visio/Diagrams/VisioSequenceDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioSequenceDiagramBuilder.cs
@@ -1,0 +1,474 @@
+using System;
+using System.Collections.Generic;
+using OfficeIMO.Drawing;
+
+namespace OfficeIMO.Visio.Diagrams {
+    /// <summary>
+    /// High-level builder for UML-style sequence diagrams with deterministic participant,
+    /// lifeline, and message placement.
+    /// </summary>
+    public sealed class VisioSequenceDiagramBuilder {
+        private const string LifelineLayer = "Sequence Lifelines";
+        private const string MessageLayer = "Sequence Messages";
+        private const string GuideLayer = "Sequence Guides";
+
+        private sealed class ParticipantItem {
+            public ParticipantItem(string id, string text, VisioSequenceParticipantKind kind) {
+                Id = id;
+                Text = text;
+                Kind = kind;
+            }
+
+            public string Id { get; }
+
+            public string Text { get; }
+
+            public VisioSequenceParticipantKind Kind { get; }
+
+            public double PinX { get; set; }
+
+            public VisioShape? Header { get; set; }
+
+            public VisioShape? BottomAnchor { get; set; }
+        }
+
+        private sealed class MessageItem {
+            public MessageItem(string id, string fromId, string toId, string label, VisioSequenceMessageKind kind, bool selfMessage) {
+                Id = id;
+                FromId = fromId;
+                ToId = toId;
+                Label = label;
+                Kind = kind;
+                SelfMessage = selfMessage;
+            }
+
+            public string Id { get; }
+
+            public string FromId { get; }
+
+            public string ToId { get; }
+
+            public string Label { get; }
+
+            public VisioSequenceMessageKind Kind { get; }
+
+            public bool SelfMessage { get; }
+        }
+
+        private readonly VisioDocument _document;
+        private readonly string _pageName;
+        private readonly List<ParticipantItem> _participants = new();
+        private readonly Dictionary<string, ParticipantItem> _participantsById = new(StringComparer.Ordinal);
+        private readonly List<MessageItem> _messages = new();
+        private VisioStyleTheme _theme = VisioStyleTheme.Technical();
+        private VisioMeasurementUnit _unit = VisioMeasurementUnit.Inches;
+        private double _pageWidth = 11;
+        private double _pageHeight = 8.5;
+        private double _leftMargin = 0.85;
+        private double _rightMargin = 0.85;
+        private double _topMargin = 0.7;
+        private double _bottomMargin = 0.7;
+        private double _participantWidth = 1.45;
+        private double _participantHeight = 0.62;
+        private double _participantGap = 1.15;
+        private double _messageGap = 0.55;
+        private double _messageSpacing = 0.62;
+        private double _selfMessageWidth = 0.75;
+        private double _selfMessageHeight = 0.36;
+        private string? _titleText;
+        private string _titleId = "title";
+        private double _titleHeight = 0.45;
+        private double _titleGap = 0.35;
+        private bool _built;
+
+        internal VisioSequenceDiagramBuilder(VisioDocument document, string pageName) {
+            _document = document ?? throw new ArgumentNullException(nameof(document));
+            _pageName = string.IsNullOrWhiteSpace(pageName) ? "Sequence Diagram" : pageName;
+        }
+
+        /// <summary>Sets the page size used by the generated sequence diagram page.</summary>
+        public VisioSequenceDiagramBuilder PageSize(double width, double height, VisioMeasurementUnit unit = VisioMeasurementUnit.Inches) {
+            ValidatePositive(width, nameof(width));
+            ValidatePositive(height, nameof(height));
+            _pageWidth = width;
+            _pageHeight = height;
+            _unit = unit;
+            return this;
+        }
+
+        /// <summary>Sets the visual theme.</summary>
+        public VisioSequenceDiagramBuilder Theme(VisioStyleTheme theme) {
+            _theme = (theme ?? throw new ArgumentNullException(nameof(theme))).Clone();
+            return this;
+        }
+
+        /// <summary>Sets outer page margins used by the automatic layout.</summary>
+        public VisioSequenceDiagramBuilder Margins(double left, double top, double right = 0.85, double bottom = 0.7) {
+            ValidateNonNegative(left, nameof(left));
+            ValidateNonNegative(top, nameof(top));
+            ValidateNonNegative(right, nameof(right));
+            ValidateNonNegative(bottom, nameof(bottom));
+            _leftMargin = left;
+            _topMargin = top;
+            _rightMargin = right;
+            _bottomMargin = bottom;
+            return this;
+        }
+
+        /// <summary>Sets participant header size.</summary>
+        public VisioSequenceDiagramBuilder ParticipantSize(double width, double height) {
+            ValidatePositive(width, nameof(width));
+            ValidatePositive(height, nameof(height));
+            _participantWidth = width;
+            _participantHeight = height;
+            return this;
+        }
+
+        /// <summary>Sets participant and message spacing.</summary>
+        public VisioSequenceDiagramBuilder Spacing(double participantGap = 1.15, double messageSpacing = 0.62, double messageGap = 0.55) {
+            ValidateNonNegative(participantGap, nameof(participantGap));
+            ValidatePositive(messageSpacing, nameof(messageSpacing));
+            ValidateNonNegative(messageGap, nameof(messageGap));
+            _participantGap = participantGap;
+            _messageSpacing = messageSpacing;
+            _messageGap = messageGap;
+            return this;
+        }
+
+        /// <summary>Adds a centered editable title above the generated sequence diagram.</summary>
+        public VisioSequenceDiagramBuilder Title(string? text = null, string id = "title", double height = 0.45, double gap = 0.35) {
+            string normalizedId = RequireId(id, nameof(id), "Title id");
+            if (IsIdInUse(normalizedId)) {
+                throw new ArgumentException($"A sequence diagram item with id '{normalizedId}' already exists.", nameof(id));
+            }
+
+            ValidatePositive(height, nameof(height));
+            ValidateNonNegative(gap, nameof(gap));
+            _titleText = string.IsNullOrWhiteSpace(text) ? _pageName : text;
+            _titleId = normalizedId;
+            _titleHeight = height;
+            _titleGap = gap;
+            return this;
+        }
+
+        /// <summary>Adds a generic participant.</summary>
+        public VisioSequenceDiagramBuilder Participant(string id, string text) => Participant(id, text, VisioSequenceParticipantKind.Participant);
+
+        /// <summary>Adds an actor participant.</summary>
+        public VisioSequenceDiagramBuilder Actor(string id, string text) => Participant(id, text, VisioSequenceParticipantKind.Actor);
+
+        /// <summary>Adds a system/service participant.</summary>
+        public VisioSequenceDiagramBuilder System(string id, string text) => Participant(id, text, VisioSequenceParticipantKind.Participant);
+
+        /// <summary>Adds a boundary/interface participant.</summary>
+        public VisioSequenceDiagramBuilder Boundary(string id, string text) => Participant(id, text, VisioSequenceParticipantKind.Boundary);
+
+        /// <summary>Adds a control/coordinator participant.</summary>
+        public VisioSequenceDiagramBuilder Control(string id, string text) => Participant(id, text, VisioSequenceParticipantKind.Control);
+
+        /// <summary>Adds an entity participant.</summary>
+        public VisioSequenceDiagramBuilder Entity(string id, string text) => Participant(id, text, VisioSequenceParticipantKind.Entity);
+
+        /// <summary>Adds a database participant.</summary>
+        public VisioSequenceDiagramBuilder Database(string id, string text) => Participant(id, text, VisioSequenceParticipantKind.Database);
+
+        /// <summary>Adds a participant with an explicit semantic kind.</summary>
+        public VisioSequenceDiagramBuilder Participant(string id, string text, VisioSequenceParticipantKind kind) {
+            string normalizedId = RequireId(id, nameof(id), "Participant id");
+            if (IsIdInUse(normalizedId)) {
+                throw new ArgumentException($"A sequence diagram item with id '{normalizedId}' already exists.", nameof(id));
+            }
+
+            if (!Enum.IsDefined(typeof(VisioSequenceParticipantKind), kind)) {
+                throw new ArgumentOutOfRangeException(nameof(kind));
+            }
+
+            ParticipantItem participant = new(normalizedId, text ?? string.Empty, kind);
+            _participants.Add(participant);
+            _participantsById.Add(normalizedId, participant);
+            return this;
+        }
+
+        /// <summary>Adds a synchronous call message.</summary>
+        public VisioSequenceDiagramBuilder Call(string fromId, string toId, string label, string? id = null) =>
+            Message(fromId, toId, label, VisioSequenceMessageKind.Call, id);
+
+        /// <summary>Adds an asynchronous message.</summary>
+        public VisioSequenceDiagramBuilder Async(string fromId, string toId, string label, string? id = null) =>
+            Message(fromId, toId, label, VisioSequenceMessageKind.Async, id);
+
+        /// <summary>Adds a return/response message.</summary>
+        public VisioSequenceDiagramBuilder Return(string fromId, string toId, string label, string? id = null) =>
+            Message(fromId, toId, label, VisioSequenceMessageKind.Return, id);
+
+        /// <summary>Adds a message between two known participants.</summary>
+        public VisioSequenceDiagramBuilder Message(string fromId, string toId, string label, VisioSequenceMessageKind kind = VisioSequenceMessageKind.Call, string? id = null) {
+            string normalizedFromId = RequireId(fromId, nameof(fromId), "Participant id");
+            string normalizedToId = RequireId(toId, nameof(toId), "Participant id");
+            EnsureKnownParticipant(normalizedFromId, nameof(fromId));
+            EnsureKnownParticipant(normalizedToId, nameof(toId));
+            if (!Enum.IsDefined(typeof(VisioSequenceMessageKind), kind)) {
+                throw new ArgumentOutOfRangeException(nameof(kind));
+            }
+
+            string messageId = NormalizeMessageId(id);
+            _messages.Add(new MessageItem(messageId, normalizedFromId, normalizedToId, label ?? string.Empty, kind, selfMessage: false));
+            return this;
+        }
+
+        /// <summary>Adds a self-message loop on a known participant.</summary>
+        public VisioSequenceDiagramBuilder SelfMessage(string participantId, string label, VisioSequenceMessageKind kind = VisioSequenceMessageKind.Call, string? id = null) {
+            string normalizedParticipantId = RequireId(participantId, nameof(participantId), "Participant id");
+            EnsureKnownParticipant(normalizedParticipantId, nameof(participantId));
+            if (!Enum.IsDefined(typeof(VisioSequenceMessageKind), kind)) {
+                throw new ArgumentOutOfRangeException(nameof(kind));
+            }
+
+            string messageId = NormalizeMessageId(id);
+            _messages.Add(new MessageItem(messageId, normalizedParticipantId, normalizedParticipantId, label ?? string.Empty, kind, selfMessage: true));
+            return this;
+        }
+
+        internal VisioPage Build() {
+            if (_built) {
+                throw new InvalidOperationException("This sequence diagram builder has already produced a page.");
+            }
+
+            _built = true;
+            if (_participants.Count == 0) {
+                throw new InvalidOperationException("A sequence diagram requires at least one participant.");
+            }
+
+            double titleBand = string.IsNullOrWhiteSpace(_titleText) ? 0D : _titleHeight + _titleGap;
+            double requiredWidth = _leftMargin + _rightMargin + (_participants.Count * _participantWidth) + ((_participants.Count - 1) * _participantGap);
+            double messageRows = Math.Max(1, _messages.Count);
+            double requiredHeight = _topMargin + titleBand + _participantHeight + _messageGap + (messageRows * _messageSpacing) + _bottomMargin;
+            double pageWidth = Math.Max(_pageWidth, requiredWidth);
+            double pageHeight = Math.Max(_pageHeight, requiredHeight);
+            double headerY = pageHeight - _topMargin - titleBand - (_participantHeight / 2D);
+            double firstMessageY = headerY - (_participantHeight / 2D) - _messageGap;
+            double lifelineBottomY = Math.Max(_bottomMargin, firstMessageY - (messageRows * _messageSpacing));
+
+            bool previousMastersByDefault = _document.UseMastersByDefault;
+            _document.UseMastersByDefault = true;
+            try {
+                VisioPage page = _document.AddPage(_pageName, pageWidth, pageHeight, _unit);
+                page.Grid(visible: false, snap: true);
+                page.AddLayer(LifelineLayer);
+                page.AddLayer(MessageLayer);
+                page.AddLayer(GuideLayer).Print = false;
+
+                AddTitle(page, pageWidth, pageHeight);
+                PlaceParticipants(page, pageWidth, headerY, lifelineBottomY);
+                AddMessages(page, firstMessageY);
+                _document.RequestRecalcOnOpen();
+                return page;
+            } finally {
+                _document.UseMastersByDefault = previousMastersByDefault;
+            }
+        }
+
+        private void AddTitle(VisioPage page, double pageWidth, double pageHeight) {
+            if (string.IsNullOrWhiteSpace(_titleText)) {
+                return;
+            }
+
+            double y = pageHeight - _topMargin - (_titleHeight / 2D);
+            VisioShape title = page.AddTextBox(_titleId, pageWidth / 2D, y, Math.Max(1D, pageWidth - _leftMargin - _rightMargin), _titleHeight, _titleText, _unit);
+            if (_theme.Emphasis.TextStyle != null) {
+                title.TextStyle = _theme.Emphasis.TextStyle.Clone();
+            }
+        }
+
+        private void PlaceParticipants(VisioPage page, double pageWidth, double headerY, double lifelineBottomY) {
+            double totalWidth = (_participants.Count * _participantWidth) + ((_participants.Count - 1) * _participantGap);
+            double startX = Math.Max(_leftMargin + (_participantWidth / 2D), (pageWidth - totalWidth) / 2D + (_participantWidth / 2D));
+
+            for (int i = 0; i < _participants.Count; i++) {
+                ParticipantItem participant = _participants[i];
+                double x = startX + i * (_participantWidth + _participantGap);
+                participant.PinX = x;
+                participant.Header = CreateParticipantHeader(page, participant, x, headerY);
+                participant.BottomAnchor = CreateAnchor(page, participant.Id + "-lifeline-end", x, lifelineBottomY);
+
+                VisioConnector lifeline = page.AddConnector(participant.Header, participant.BottomAnchor, ConnectorKind.Straight, VisioSide.Bottom, VisioSide.Top);
+                lifeline.LineColor = _theme.Connector.LineColor;
+                lifeline.LineWeight = Math.Max(0.006D, _theme.Connector.LineWeight * 0.75D);
+                lifeline.LinePattern = 2;
+                lifeline.EndArrow = EndArrow.None;
+                page.AddToLayer(LifelineLayer, lifeline);
+            }
+        }
+
+        private VisioShape CreateParticipantHeader(VisioPage page, ParticipantItem participant, double x, double y) {
+            string masterNameU = GetParticipantMaster(participant.Kind);
+            VisioShape shape = new(participant.Id, x, y, _participantWidth, _participantHeight, participant.Text) {
+                NameU = masterNameU,
+                Master = _document.EnsureBuiltinMaster(masterNameU)
+            };
+            GetParticipantStyle(participant.Kind).ApplyTo(shape);
+            shape.SetUserCell(VisioSemanticUserCells.Kind, "SequenceParticipant", "STR", prompt: "OfficeIMO semantic kind");
+            shape.SetUserCell("OfficeIMO.SequenceParticipantKind", participant.Kind.ToString(), "STR", prompt: "OfficeIMO sequence participant kind");
+            page.Shapes.Add(shape);
+            page.AddToLayer(LifelineLayer, shape);
+            return shape;
+        }
+
+        private void AddMessages(VisioPage page, double firstMessageY) {
+            for (int i = 0; i < _messages.Count; i++) {
+                MessageItem message = _messages[i];
+                double y = firstMessageY - (i * _messageSpacing);
+                if (message.SelfMessage) {
+                    AddSelfMessage(page, message, y);
+                } else {
+                    AddParticipantMessage(page, message, y);
+                }
+            }
+        }
+
+        private void AddParticipantMessage(VisioPage page, MessageItem message, double y) {
+            ParticipantItem from = _participantsById[message.FromId];
+            ParticipantItem to = _participantsById[message.ToId];
+            bool leftToRight = from.PinX <= to.PinX;
+            VisioShape fromAnchor = CreateAnchor(page, message.Id + "-from", from.PinX, y);
+            VisioShape toAnchor = CreateAnchor(page, message.Id + "-to", to.PinX, y);
+            VisioConnector connector = page.AddConnector(
+                fromAnchor,
+                toAnchor,
+                ConnectorKind.Straight,
+                leftToRight ? VisioSide.Right : VisioSide.Left,
+                leftToRight ? VisioSide.Left : VisioSide.Right);
+
+            connector.Id = message.Id;
+            ApplyMessageStyle(connector, message.Kind);
+            connector.Label = message.Label;
+            double labelX = (from.PinX + to.PinX) / 2D;
+            double labelWidth = Math.Max(1.2D, Math.Min(2.6D, Math.Abs(to.PinX - from.PinX) - 0.2D));
+            connector.PlaceLabelAt(labelX, y + 0.16D, labelWidth, 0.28D);
+            page.AddToLayer(MessageLayer, connector);
+        }
+
+        private void AddSelfMessage(VisioPage page, MessageItem message, double y) {
+            ParticipantItem participant = _participantsById[message.FromId];
+            double lowerY = y - Math.Min(_selfMessageHeight, _messageSpacing * 0.55D);
+            VisioShape fromAnchor = CreateAnchor(page, message.Id + "-from", participant.PinX, y);
+            VisioShape toAnchor = CreateAnchor(page, message.Id + "-to", participant.PinX, lowerY);
+            VisioConnector connector = page.AddConnector(fromAnchor, toAnchor, ConnectorKind.RightAngle, VisioSide.Right, VisioSide.Right);
+            connector.Id = message.Id;
+            ApplyMessageStyle(connector, message.Kind);
+            connector.Label = message.Label;
+            connector.RouteThrough(
+                VisioConnectorWaypoint.At(participant.PinX + _selfMessageWidth, y),
+                VisioConnectorWaypoint.At(participant.PinX + _selfMessageWidth, lowerY));
+            connector.PlaceLabelAt(participant.PinX + _selfMessageWidth + 0.55D, y - 0.12D, 1.4D, 0.28D);
+            page.AddToLayer(MessageLayer, connector);
+        }
+
+        private VisioShape CreateAnchor(VisioPage page, string id, double x, double y) {
+            VisioShape anchor = new(id, x, y, 0.04D, 0.04D, string.Empty) {
+                NameU = "Circle",
+                FillPattern = 0,
+                LinePattern = 0,
+                FillColor = OfficeColor.Transparent,
+                LineColor = OfficeColor.Transparent
+            };
+            anchor.SetUserCell(VisioSemanticUserCells.Kind, VisioSemanticUserCells.DiagramAdornmentKind, "STR", prompt: "OfficeIMO semantic kind");
+            page.Shapes.Add(anchor);
+            page.AddToLayer(GuideLayer, anchor);
+            return anchor;
+        }
+
+        private void ApplyMessageStyle(VisioConnector connector, VisioSequenceMessageKind kind) {
+            VisioConnectorStyle style = kind switch {
+                VisioSequenceMessageKind.Async => _theme.DataConnector,
+                VisioSequenceMessageKind.Return => _theme.ControlConnector,
+                VisioSequenceMessageKind.Event => _theme.Marker.TextStyle != null
+                    ? new VisioConnectorStyle(_theme.Marker.LineColor, _theme.Marker.LineWeight, 1, EndArrow.Arrow) { TextStyle = _theme.Marker.TextStyle.Clone() }
+                    : _theme.Connector,
+                _ => _theme.Connector
+            };
+
+            connector.LineColor = style.LineColor;
+            connector.LineWeight = style.LineWeight;
+            connector.LinePattern = kind == VisioSequenceMessageKind.Return ? 2 : style.LinePattern;
+            connector.EndArrow = kind == VisioSequenceMessageKind.Call ? EndArrow.Triangle : EndArrow.Arrow;
+            connector.BeginArrow = EndArrow.None;
+            if (style.TextStyle != null) {
+                connector.TextStyle = style.TextStyle.Clone();
+            }
+        }
+
+        private VisioShapeStyle GetParticipantStyle(VisioSequenceParticipantKind kind) {
+            return kind switch {
+                VisioSequenceParticipantKind.Actor => _theme.Success,
+                VisioSequenceParticipantKind.Boundary => _theme.Marker,
+                VisioSequenceParticipantKind.Control => _theme.Emphasis,
+                VisioSequenceParticipantKind.Entity => _theme.Decision,
+                VisioSequenceParticipantKind.Database => _theme.Container,
+                _ => _theme.Primary
+            };
+        }
+
+        private static string GetParticipantMaster(VisioSequenceParticipantKind kind) {
+            return kind switch {
+                VisioSequenceParticipantKind.Actor => "Circle",
+                VisioSequenceParticipantKind.Database => "Data",
+                _ => "Rectangle"
+            };
+        }
+
+        private string NormalizeMessageId(string? id) {
+            string normalizedId = string.IsNullOrWhiteSpace(id) ? "message-" + (_messages.Count + 1).ToString(global::System.Globalization.CultureInfo.InvariantCulture) : id!.Trim();
+            if (IsIdInUse(normalizedId)) {
+                throw new ArgumentException($"A sequence diagram item with id '{normalizedId}' already exists.", nameof(id));
+            }
+
+            return normalizedId;
+        }
+
+        private void EnsureKnownParticipant(string id, string parameterName) {
+            string normalizedId = RequireId(id, parameterName, "Participant id");
+            if (!_participantsById.ContainsKey(normalizedId)) {
+                throw new ArgumentException($"Unknown sequence participant id '{normalizedId}'.", parameterName);
+            }
+        }
+
+        private bool IsIdInUse(string id) {
+            if (!string.IsNullOrWhiteSpace(_titleText) && string.Equals(id, _titleId, StringComparison.Ordinal)) {
+                return true;
+            }
+
+            if (_participantsById.ContainsKey(id)) {
+                return true;
+            }
+
+            foreach (MessageItem message in _messages) {
+                if (string.Equals(message.Id, id, StringComparison.Ordinal)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string RequireId(string id, string parameterName, string label) {
+            if (string.IsNullOrWhiteSpace(id)) {
+                throw new ArgumentException(label + " cannot be null or whitespace.", parameterName);
+            }
+
+            return id.Trim();
+        }
+
+        private static void ValidatePositive(double value, string parameterName) {
+            if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0) {
+                throw new ArgumentOutOfRangeException(parameterName, "Value must be a finite positive number.");
+            }
+        }
+
+        private static void ValidateNonNegative(double value, string parameterName) {
+            if (double.IsNaN(value) || double.IsInfinity(value) || value < 0) {
+                throw new ArgumentOutOfRangeException(parameterName, "Value must be a finite non-negative number.");
+            }
+        }
+    }
+}

--- a/OfficeIMO.Visio/Diagrams/VisioSequenceDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioSequenceDiagramBuilder.cs
@@ -250,7 +250,7 @@ namespace OfficeIMO.Visio.Diagrams {
             double lifelineBottomY = Math.Max(_bottomMargin, firstMessageY - (messageRows * _messageSpacing));
 
             bool previousMastersByDefault = _document.UseMastersByDefault;
-            _document.UseMastersByDefault = true;
+            _document.UseMastersByDefault = false;
             try {
                 VisioPage page = _document.AddPage(_pageName, pageWidth, pageHeight, _unit);
                 page.Grid(visible: false, snap: true);
@@ -304,7 +304,6 @@ namespace OfficeIMO.Visio.Diagrams {
             string masterNameU = GetParticipantMaster(participant.Kind);
             VisioShape shape = new(participant.Id, x, y, _participantWidth, _participantHeight, participant.Text) {
                 NameU = masterNameU,
-                Master = _document.EnsureBuiltinMaster(masterNameU)
             };
             GetParticipantStyle(participant.Kind).ApplyTo(shape);
             shape.SetUserCell(VisioSemanticUserCells.Kind, "SequenceParticipant", "STR", prompt: "OfficeIMO semantic kind");

--- a/OfficeIMO.Visio/Diagrams/VisioSequenceDiagramDocumentExtensions.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioSequenceDiagramDocumentExtensions.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace OfficeIMO.Visio.Diagrams {
+    /// <summary>
+    /// High-level sequence diagram authoring extensions for <see cref="VisioDocument"/>.
+    /// </summary>
+    public static class VisioSequenceDiagramDocumentExtensions {
+        /// <summary>
+        /// Adds a semantic sequence diagram page and returns the document for chaining.
+        /// </summary>
+        public static VisioDocument SequenceDiagram(this VisioDocument document, string pageName, Action<VisioSequenceDiagramBuilder> configure) {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+            VisioSequenceDiagramBuilder builder = new VisioSequenceDiagramBuilder(document, pageName);
+            configure?.Invoke(builder);
+            builder.Build();
+            return document;
+        }
+    }
+}

--- a/OfficeIMO.Visio/Diagrams/VisioSequenceMessageKind.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioSequenceMessageKind.cs
@@ -1,0 +1,18 @@
+namespace OfficeIMO.Visio.Diagrams {
+    /// <summary>
+    /// Semantic message kinds used by <see cref="VisioSequenceDiagramBuilder"/>.
+    /// </summary>
+    public enum VisioSequenceMessageKind {
+        /// <summary>Synchronous request/call message.</summary>
+        Call,
+
+        /// <summary>Asynchronous message or event.</summary>
+        Async,
+
+        /// <summary>Return or response message.</summary>
+        Return,
+
+        /// <summary>Notification/event message.</summary>
+        Event
+    }
+}

--- a/OfficeIMO.Visio/Diagrams/VisioSequenceParticipantKind.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioSequenceParticipantKind.cs
@@ -1,0 +1,24 @@
+namespace OfficeIMO.Visio.Diagrams {
+    /// <summary>
+    /// Semantic participant kinds used by <see cref="VisioSequenceDiagramBuilder"/>.
+    /// </summary>
+    public enum VisioSequenceParticipantKind {
+        /// <summary>Generic system, service, or component participant.</summary>
+        Participant,
+
+        /// <summary>External person, user, or actor.</summary>
+        Actor,
+
+        /// <summary>Boundary or edge/interface component.</summary>
+        Boundary,
+
+        /// <summary>Control or coordinator component.</summary>
+        Control,
+
+        /// <summary>Domain entity or stateful object.</summary>
+        Entity,
+
+        /// <summary>Database or durable data store.</summary>
+        Database
+    }
+}

--- a/OfficeIMO.Visio/Diagrams/VisioSwimlaneDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioSwimlaneDiagramBuilder.cs
@@ -458,14 +458,12 @@ namespace OfficeIMO.Visio.Diagrams {
                 double y = LaneCenterY(i);
                 VisioShape laneHeader = new("lane-header-" + lane.Id, _leftMargin + (_laneHeaderWidth / 2D), y, _laneHeaderWidth, _laneHeight, lane.Text) {
                     NameU = "Rectangle",
-                    Master = _document.EnsureBuiltinMaster("Rectangle")
                 };
                 _theme.Emphasis.ApplyTo(laneHeader);
                 page.Shapes.Add(laneHeader);
 
                 VisioShape laneBody = new("lane-" + lane.Id, processCenterX, y, processWidth, _laneHeight, string.Empty) {
                     NameU = "Rectangle",
-                    Master = _document.EnsureBuiltinMaster("Rectangle")
                 };
                 ApplyLaneBodyStyle(laneBody, i);
                 laneBody.SetUserCell(VisioSemanticUserCells.Kind, VisioSemanticUserCells.BackgroundSurfaceKind, "STR", prompt: "OfficeIMO semantic kind");
@@ -476,7 +474,6 @@ namespace OfficeIMO.Visio.Diagrams {
                 PhaseItem phase = _phases[i];
                 VisioShape phaseHeader = new("phase-" + phase.Id, PhaseCenterX(i), PhaseHeaderCenterY(), _phaseWidth, _phaseHeaderHeight, phase.Text) {
                     NameU = "Rectangle",
-                    Master = _document.EnsureBuiltinMaster("Rectangle")
                 };
                 _theme.Container.ApplyTo(phaseHeader);
                 phaseHeader.SetUserCell(VisioSemanticUserCells.Kind, VisioSemanticUserCells.BackgroundSurfaceKind, "STR", prompt: "OfficeIMO semantic kind");
@@ -491,7 +488,6 @@ namespace OfficeIMO.Visio.Diagrams {
                 GetActivityShape(activity.Kind, out string masterNameU, out double width, out double height);
                 VisioShape shape = new(activity.Id, PhaseCenterX(phaseIndex), ActivityCenterY(activity, laneIndex, height), width, height, activity.Text) {
                     NameU = masterNameU,
-                    Master = _document.EnsureBuiltinMaster(masterNameU)
                 };
                 GetActivityStyle(activity.Kind).ApplyTo(shape);
                 activity.Shape = shape;

--- a/OfficeIMO.Visio/Diagrams/VisioTimelineDiagramBuilder.cs
+++ b/OfficeIMO.Visio/Diagrams/VisioTimelineDiagramBuilder.cs
@@ -434,7 +434,6 @@ namespace OfficeIMO.Visio.Diagrams {
             double width = TimelineWidth();
             VisioShape axis = new("timeline-axis", _leftMargin + (width / 2D), _axisY, width, _axisHeight, string.Empty) {
                 NameU = "Rectangle",
-                Master = _document.EnsureBuiltinMaster("Rectangle")
             };
             _theme.Emphasis.ApplyTo(axis);
             page.Shapes.Add(axis);
@@ -451,7 +450,6 @@ namespace OfficeIMO.Visio.Diagrams {
 
             VisioShape label = new(id + "-label", x, _axisY - 0.42D, 1.05, 0.28, FormatShortDate(date)) {
                 NameU = "Rectangle",
-                Master = _document.EnsureBuiltinMaster("Rectangle")
             };
             _theme.Container.ApplyTo(label);
             page.Shapes.Add(label);
@@ -465,7 +463,6 @@ namespace OfficeIMO.Visio.Diagrams {
                 double y = SpanY(span);
                 VisioShape shape = new(span.Id, startX + (width / 2D), y, width, _spanHeight, span.Text) {
                     NameU = "Rectangle",
-                    Master = _document.EnsureBuiltinMaster("Rectangle")
                 };
                 _theme.Primary.ApplyTo(shape);
                 page.Shapes.Add(shape);
@@ -494,7 +491,6 @@ namespace OfficeIMO.Visio.Diagrams {
 
                 VisioShape marker = new(milestone.Id, x, markerY, _milestoneSize, _milestoneSize, string.Empty) {
                     NameU = GetMarkerMaster(milestone.Kind),
-                    Master = _document.EnsureBuiltinMaster(GetMarkerMaster(milestone.Kind))
                 };
                 GetMilestoneStyle(milestone.Kind).ApplyTo(marker);
                 page.Shapes.Add(marker);
@@ -502,7 +498,6 @@ namespace OfficeIMO.Visio.Diagrams {
 
                 VisioShape label = new(GetMilestoneLabelId(milestone.Id), x, labelY, _labelWidth, _labelHeight, GetMilestoneText(milestone)) {
                     NameU = "Rectangle",
-                    Master = _document.EnsureBuiltinMaster("Rectangle")
                 };
                 GetMilestoneLabelStyle(milestone.Kind).ApplyTo(label);
                 page.Shapes.Add(label);

--- a/OfficeIMO.Visio/README.md
+++ b/OfficeIMO.Visio/README.md
@@ -556,14 +556,50 @@ doc.Save();
 ```
 
 `VisioStencilPackageCatalog.Load(...)` reads master metadata from `.vsdx`,
-`.vssx`, and `.vstx` packages. It does not use those files as runtime templates;
-by default it only exposes masters that OfficeIMO can generate natively and, when
-master parts are present, learns the native master width and height as reusable
-catalog metadata. The `MasterNames` filter can target the universal name, visible
-name, relationship id, numeric id, or normalized slug discovered in the package. Set
-`IncludeUnsupportedMasters` only when a generic generated placeholder is useful
-for discovery, migration tooling, or keeping a learned palette placeable without
-shipping the source stencil or template.
+`.vssx`, `.vstx`, and the macro-enabled package variants. It does not use those
+files as runtime templates. The `MasterNames` filter can target the universal
+name, visible name, relationship id, numeric id, or normalized slug discovered in
+the package.
+
+When you want real external artwork, load the package catalog with
+`IncludeUnsupportedMasters = true` and place shapes from that catalog. Package
+catalog shapes retain their `SourcePackagePath`, so `AddStencilShape(...)`
+auto-imports the required raw master XML, relationships, media, colors, styles,
+fonts, and theme into the generated `.vsdx`:
+
+```csharp
+using OfficeIMO.Visio;
+using OfficeIMO.Visio.Stencils;
+
+var catalog = VisioStencilPackageCatalog.Load("Azure.vssx",
+    new VisioStencilPackageLoadOptions {
+        IncludeUnsupportedMasters = true
+    });
+
+var doc = VisioDocument.Create("external-stencils.vsdx");
+var page = doc.AddPage("Architecture", 14, 8.5);
+
+var api = page.AddStencilShape(catalog.Get("API Management"), "api", 2, 5);
+var queue = page.AddStencilShape(catalog.Search("Service Bus").First(), "queue", 5, 5);
+
+page.AddConnector(api, queue, ConnectorKind.Straight, VisioSide.Right, VisioSide.Left);
+doc.Save();
+```
+
+Use `LoadMany(...)` or `LoadDirectory(...)` to compose a palette from many packs.
+`DiscoverInstalledVisioPackages()` finds the local Microsoft Visio `.vssx` and
+`.vstx` content folders without automating Visio, letting you build diagrams from
+installed Visio stencils while keeping OfficeIMO itself dependency-free:
+
+```csharp
+var installed = VisioStencilPackageCatalog.DiscoverInstalledVisioPackages()
+    .Where(path => Path.GetFileName(path).StartsWith("AZURE", StringComparison.OrdinalIgnoreCase));
+var azure = VisioStencilPackageCatalog.LoadMany(installed,
+    new VisioStencilPackageLoadOptions {
+        CatalogName = "Installed Azure Stencils",
+        IncludeUnsupportedMasters = true
+    });
+```
 
 `VisioStencilCatalog.Save(...)` and `VisioStencilCatalog.Load(...)` persist
 OfficeIMO-native catalog metadata as a small XML manifest. This is useful for

--- a/OfficeIMO.Visio/README.md
+++ b/OfficeIMO.Visio/README.md
@@ -234,6 +234,33 @@ needed, adds subnet/background zones around selected devices, routes links,
 supports coordinate or side-placed semantic callouts, and keeps mesh/cycle
 links valid.
 
+## Quick sample (sequence diagram builder)
+
+```csharp
+using OfficeIMO.Visio;
+using OfficeIMO.Visio.Diagrams;
+
+VisioDocument.Create("sequence.vsdx")
+    .SequenceDiagram("Checkout Sequence", sequence => sequence
+        .Title()
+        .Theme(VisioStyleTheme.Fluent())
+        .Actor("customer", "Customer")
+        .Participant("web", "Web App")
+        .Control("api", "Orders API")
+        .Database("db", "Orders DB")
+        .Call("customer", "web", "Checkout")
+        .Call("web", "api", "POST /orders")
+        .Async("api", "db", "Persist order")
+        .Return("api", "web", "201 Created")
+        .SelfMessage("web", "Render receipt"))
+    .Save();
+```
+
+The sequence builder creates editable participants, lifelines, synchronous,
+asynchronous, return, and self-message connectors from semantic calls. It grows
+the page as needed, uses reusable style themes, and adds a native searchable
+sequence stencil catalog without depending on Visio templates at runtime.
+
 ## Quick sample (swimlane diagram builder)
 
 ```csharp
@@ -998,8 +1025,8 @@ See `OfficeIMO.Examples/Visio/*` for more.
 - 📄 Pages: ✅ add/remove pages
 - 🧱 Shapes: ✅ basic shapes from masters (rectangle, etc.), ✅ set text
 - 🔗 Connectors: ✅ basic connectors between shapes
-- 🧭 Diagram builders: ✅ flowchart builder with vertical and two-column continuation layouts plus branch routing, ✅ block diagram builder with grid regions and data/control flows, ✅ architecture builder with infrastructure components, regions, and routed data/control/dependency flows, ✅ network builder with zones, devices, links, and legends, ✅ swimlane builder with lanes, phases, activities, handoffs, and exception paths, ✅ org chart builder with hierarchy, assistants, team bands, vacancies, and external roles, ✅ timeline builder with date-scaled milestones and span lanes
-- 🧰 Native stencils: ✅ built-in searchable catalogs for basic, flowchart, block-diagram, architecture, network, swimlane, org-chart, and timeline shapes
+- 🧭 Diagram builders: ✅ flowchart builder with vertical and two-column continuation layouts plus branch routing, ✅ block diagram builder with grid regions and data/control flows, ✅ architecture builder with infrastructure components, regions, and routed data/control/dependency flows, ✅ network builder with zones, devices, links, and legends, ✅ sequence builder with participants, lifelines, message types, and self-calls, ✅ swimlane builder with lanes, phases, activities, handoffs, and exception paths, ✅ org chart builder with hierarchy, assistants, team bands, vacancies, and external roles, ✅ timeline builder with date-scaled milestones and span lanes
+- 🧰 Native stencils: ✅ built-in searchable catalogs for basic, flowchart, block-diagram, architecture, network, sequence, swimlane, org-chart, and timeline shapes
 - 🎨 Style themes: ✅ reusable shape/connector/text styles and Modern/Office/Fluent/Technical/Minimal/Dark/Print authoring presets
 - 🔎 Rich editing: ✅ recursive shape queries, shape/data/text/master/layer/hyperlink selectors, connector neighbor queries, page layers, shape and connector hyperlinks, bulk style/data/layer/hyperlink edits, align/distribute, resize-to-text, center content, and fit-to-content
 - 🧩 VSDX learning fixtures: ✅ inspect supported masters without treating sample files as runtime templates

--- a/OfficeIMO.Visio/README.md
+++ b/OfficeIMO.Visio/README.md
@@ -129,6 +129,47 @@ nodes and directed relationships. It automatically grows the page, places
 component/data/external/decision nodes, routes dependencies, supports semantic
 coordinate or side-placed callouts, and rejects cycles.
 
+## Quick sample (graph diagram builder)
+
+```csharp
+using System;
+using System.IO;
+using System.Linq;
+using OfficeIMO.Visio;
+using OfficeIMO.Visio.Diagrams;
+using OfficeIMO.Visio.Stencils;
+
+var installed = VisioStencilPackageCatalog.DiscoverInstalledVisioPackages()
+    .Where(path => Path.GetFileName(path).StartsWith("AZURE", StringComparison.OrdinalIgnoreCase));
+var stencils = VisioStencilPackageCatalog.LoadMany(installed,
+    new VisioStencilPackageLoadOptions {
+        IncludeUnsupportedMasters = true
+    });
+
+VisioDocument.Create("graph.vsdx")
+    .GraphDiagram("Event-driven graph", graph => graph
+        .Title()
+        .Layout(VisioGraphLayout.Layered)
+        .Direction(VisioGraphDirection.LeftToRight)
+        .StencilNode("gateway", "API", stencils.Search("API Management").First())
+        .StencilNode("events", "Events", stencils.Search("Event Grid").First())
+        .Node("worker", "Worker")
+        .Node("database", "Database", VisioGraphNodeKind.Data)
+        .Zone("runtime", "Runtime", "gateway", "events", "worker")
+        .Root("gateway")
+        .ControlEdge("gateway", "events", "publish")
+        .Edge("events", "worker", "trigger")
+        .DataEdge("worker", "database", "write")
+        .DataEdge("database", "gateway", "read model"))
+    .Save();
+```
+
+The generic graph builder is for real node/edge maps that are not strict DAGs
+or one diagram domain. It supports layered, grid, and radial layouts; directed
+and undirected edges; cycles; disconnected components; background zones; native
+nodes; and source-aware `VisioStencilShape` nodes loaded from installed Visio
+or external `.vssx`/`.vstx` packages.
+
 ## Quick sample (architecture diagram builder)
 
 ```csharp
@@ -1061,7 +1102,7 @@ See `OfficeIMO.Examples/Visio/*` for more.
 - 📄 Pages: ✅ add/remove pages
 - 🧱 Shapes: ✅ basic shapes from masters (rectangle, etc.), ✅ set text
 - 🔗 Connectors: ✅ basic connectors between shapes
-- 🧭 Diagram builders: ✅ flowchart builder with vertical and two-column continuation layouts plus branch routing, ✅ block diagram builder with grid regions and data/control flows, ✅ architecture builder with infrastructure components, regions, and routed data/control/dependency flows, ✅ network builder with zones, devices, links, and legends, ✅ sequence builder with participants, lifelines, message types, and self-calls, ✅ swimlane builder with lanes, phases, activities, handoffs, and exception paths, ✅ org chart builder with hierarchy, assistants, team bands, vacancies, and external roles, ✅ timeline builder with date-scaled milestones and span lanes
+- 🧭 Diagram builders: ✅ flowchart builder with vertical and two-column continuation layouts plus branch routing, ✅ generic graph builder with cycles, disconnected components, layered/grid/radial layouts, zones, and package-backed stencil nodes, ✅ block diagram builder with grid regions and data/control flows, ✅ architecture builder with infrastructure components, regions, and routed data/control/dependency flows, ✅ network builder with zones, devices, links, and legends, ✅ sequence builder with participants, lifelines, message types, and self-calls, ✅ swimlane builder with lanes, phases, activities, handoffs, and exception paths, ✅ org chart builder with hierarchy, assistants, team bands, vacancies, and external roles, ✅ timeline builder with date-scaled milestones and span lanes
 - 🧰 Native stencils: ✅ built-in searchable catalogs for basic, flowchart, block-diagram, architecture, network, sequence, swimlane, org-chart, and timeline shapes
 - 🎨 Style themes: ✅ reusable shape/connector/text styles and Modern/Office/Fluent/Technical/Minimal/Dark/Print authoring presets
 - 🔎 Rich editing: ✅ recursive shape queries, shape/data/text/master/layer/hyperlink selectors, connector neighbor queries, page layers, shape and connector hyperlinks, bulk style/data/layer/hyperlink edits, align/distribute, resize-to-text, center content, and fit-to-content

--- a/OfficeIMO.Visio/Stencils/VisioStencilCatalogBuilder.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilCatalogBuilder.cs
@@ -75,7 +75,26 @@ namespace OfficeIMO.Visio.Stencils {
             IEnumerable<string>? tags,
             string? iconNameU,
             VisioMeasurementUnit? defaultUnit) {
-            return Add(CreateShape(id, name, masterNameU, category, defaultWidth, defaultHeight, keywords, aliases, tags, iconNameU, defaultUnit));
+            return AddWithMetadata(id, name, masterNameU, category, defaultWidth, defaultHeight, keywords, aliases, tags, iconNameU, defaultUnit, null);
+        }
+
+        /// <summary>
+        /// Adds a stencil shape with explicit search metadata, default-size unit, and source package path.
+        /// </summary>
+        public VisioStencilCatalogBuilder AddWithMetadata(
+            string id,
+            string name,
+            string masterNameU,
+            string category,
+            double defaultWidth,
+            double defaultHeight,
+            IEnumerable<string>? keywords,
+            IEnumerable<string>? aliases,
+            IEnumerable<string>? tags,
+            string? iconNameU,
+            VisioMeasurementUnit? defaultUnit,
+            string? sourcePackagePath) {
+            return Add(CreateShape(id, name, masterNameU, category, defaultWidth, defaultHeight, keywords, aliases, tags, iconNameU, defaultUnit, sourcePackagePath));
         }
 
         /// <summary>
@@ -109,7 +128,8 @@ namespace OfficeIMO.Visio.Stencils {
             IEnumerable<string>? aliases,
             IEnumerable<string>? tags,
             string? iconNameU,
-            VisioMeasurementUnit? defaultUnit) {
+            VisioMeasurementUnit? defaultUnit,
+            string? sourcePackagePath) {
             string prefix = id.Contains(".") ? id.Substring(0, id.IndexOf('.')) : id;
             string localId = id.Contains(".") ? id.Substring(id.IndexOf('.') + 1) : id;
             IEnumerable<string> effectiveKeywords = keywords ?? Enumerable.Empty<string>();
@@ -134,7 +154,8 @@ namespace OfficeIMO.Visio.Stencils {
                 effectiveAliases,
                 effectiveTags,
                 iconNameU ?? masterNameU,
-                defaultUnit);
+                defaultUnit,
+                sourcePackagePath);
         }
     }
 }

--- a/OfficeIMO.Visio/Stencils/VisioStencilCatalogManifest.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilCatalogManifest.cs
@@ -81,6 +81,7 @@ namespace OfficeIMO.Visio.Stencils {
                         new XAttribute("DefaultHeight", XmlConvert.ToString(shape.DefaultHeight)),
                         new XAttribute("IconNameU", shape.IconNameU),
                         shape.DefaultUnit.HasValue ? new XAttribute("DefaultUnit", shape.DefaultUnit.Value.ToString()) : null,
+                        string.IsNullOrWhiteSpace(shape.SourcePackagePath) ? null : new XAttribute("SourcePackagePath", shape.SourcePackagePath),
                         Values("Keywords", shape.Keywords),
                         Values("Aliases", shape.Aliases),
                         Values("Tags", shape.Tags))));
@@ -117,7 +118,8 @@ namespace OfficeIMO.Visio.Stencils {
                     ReadValues(shape, "Aliases"),
                     ReadValues(shape, "Tags"),
                     (string?)shape.Attribute("IconNameU"),
-                    ReadUnit(shape, "DefaultUnit"));
+                    ReadUnit(shape, "DefaultUnit"),
+                    (string?)shape.Attribute("SourcePackagePath"));
             }
 
             return builder.Build();

--- a/OfficeIMO.Visio/Stencils/VisioStencilPackageCatalog.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilPackageCatalog.cs
@@ -11,6 +11,15 @@ namespace OfficeIMO.Visio.Stencils {
     /// Creates OfficeIMO-native stencil catalogs from Visio package master metadata.
     /// </summary>
     public static class VisioStencilPackageCatalog {
+        private static readonly string[] SupportedPackageExtensions = {
+            ".vsdx",
+            ".vssx",
+            ".vstx",
+            ".vsdm",
+            ".vssm",
+            ".vstm"
+        };
+
         /// <summary>
         /// Loads supported master metadata from a `.vsdx`, `.vssx`, or `.vstx` package into a generated OfficeIMO stencil catalog.
         /// </summary>
@@ -86,10 +95,94 @@ namespace OfficeIMO.Visio.Stencils {
                     aliases,
                     tags,
                     master.NameU,
-                    defaultUnit);
+                    defaultUnit,
+                    Path.GetFullPath(packagePath));
             }
 
             return builder.Build();
+        }
+
+        /// <summary>
+        /// Loads multiple Visio packages into one catalog. Each shape retains its source package path so
+        /// <see cref="VisioStencilPageExtensions.AddStencilShape(VisioPage, VisioStencilShape, string, double, double, string?)"/>
+        /// can import the real master automatically.
+        /// </summary>
+        /// <param name="packagePaths">Package paths to load.</param>
+        /// <param name="options">Load options applied to every package.</param>
+        public static VisioStencilCatalog LoadMany(IEnumerable<string> packagePaths, VisioStencilPackageLoadOptions? options = null) {
+            if (packagePaths == null) throw new ArgumentNullException(nameof(packagePaths));
+
+            options ??= new VisioStencilPackageLoadOptions();
+            VisioStencilCatalogBuilder builder = new(string.IsNullOrWhiteSpace(options.CatalogName) ? "Visio Packages" : options.CatalogName!);
+            foreach (string packagePath in packagePaths.Where(path => !string.IsNullOrWhiteSpace(path)).Distinct(StringComparer.OrdinalIgnoreCase)) {
+                VisioStencilPackageLoadOptions packageOptions = CloneOptionsForPackage(options, packagePath);
+                VisioStencilCatalog catalog = Load(packagePath, packageOptions);
+                foreach (VisioStencilShape shape in catalog.Shapes) {
+                    builder.Add(shape);
+                }
+            }
+
+            return builder.Build();
+        }
+
+        /// <summary>
+        /// Loads all supported Visio package files from a directory into one catalog.
+        /// </summary>
+        /// <param name="directoryPath">Directory containing `.vssx`, `.vstx`, or `.vsdx` packages.</param>
+        /// <param name="options">Load options applied to every package.</param>
+        /// <param name="recursive">Whether to search subdirectories.</param>
+        public static VisioStencilCatalog LoadDirectory(string directoryPath, VisioStencilPackageLoadOptions? options = null, bool recursive = false) {
+            return LoadMany(EnumeratePackageFiles(directoryPath, recursive), options);
+        }
+
+        /// <summary>
+        /// Enumerates supported Visio package files from a directory.
+        /// </summary>
+        /// <param name="directoryPath">Directory containing Visio packages.</param>
+        /// <param name="recursive">Whether to search subdirectories.</param>
+        public static IReadOnlyList<string> EnumeratePackageFiles(string directoryPath, bool recursive = false) {
+            if (string.IsNullOrWhiteSpace(directoryPath)) throw new ArgumentException("Directory path cannot be null or whitespace.", nameof(directoryPath));
+            if (!Directory.Exists(directoryPath)) throw new DirectoryNotFoundException("Visio package directory was not found: " + directoryPath);
+
+            SearchOption searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+            return Directory
+                .EnumerateFiles(directoryPath, "*.*", searchOption)
+                .Where(IsSupportedPackagePath)
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToList()
+                .AsReadOnly();
+        }
+
+        /// <summary>
+        /// Discovers installed Microsoft Visio package stencils and templates without automating Visio.
+        /// </summary>
+        public static IReadOnlyList<string> DiscoverInstalledVisioPackages() {
+            return GetInstalledVisioContentDirectories()
+                .SelectMany(directory => Directory.Exists(directory) ? EnumeratePackageFiles(directory, recursive: true) : Enumerable.Empty<string>())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToList()
+                .AsReadOnly();
+        }
+
+        /// <summary>
+        /// Gets likely local Visio content directories.
+        /// </summary>
+        public static IReadOnlyList<string> GetInstalledVisioContentDirectories() {
+            List<string> directories = new();
+            AddOfficeVisioContentDirectory(directories, Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles));
+            AddOfficeVisioContentDirectory(directories, Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86));
+
+            string documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            if (!string.IsNullOrWhiteSpace(documents)) {
+                directories.Add(Path.Combine(documents, "My Shapes"));
+            }
+
+            return directories
+                .Where(directory => !string.IsNullOrWhiteSpace(directory))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList()
+                .AsReadOnly();
         }
 
         private static bool TryReadMasterDimensions(VisioAssets.MasterContent content, out double width, out double height) {
@@ -115,6 +208,35 @@ namespace OfficeIMO.Visio.Stencils {
             width = 0;
             height = 0;
             return false;
+        }
+
+        private static VisioStencilPackageLoadOptions CloneOptionsForPackage(VisioStencilPackageLoadOptions options, string packagePath) {
+            string fileName = Path.GetFileNameWithoutExtension(packagePath);
+            return new VisioStencilPackageLoadOptions {
+                CatalogName = fileName,
+                Category = string.IsNullOrWhiteSpace(options.Category) ? fileName : options.Category,
+                IdPrefix = string.IsNullOrWhiteSpace(options.IdPrefix) ? fileName : options.IdPrefix + "." + fileName,
+                MasterNames = options.MasterNames,
+                IncludeUnsupportedMasters = options.IncludeUnsupportedMasters,
+                LearnMasterDimensions = options.LearnMasterDimensions,
+                DefaultWidth = options.DefaultWidth,
+                DefaultHeight = options.DefaultHeight
+            };
+        }
+
+        private static bool IsSupportedPackagePath(string path) {
+            return SupportedPackageExtensions.Contains(Path.GetExtension(path), StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static void AddOfficeVisioContentDirectory(ICollection<string> directories, string root) {
+            if (string.IsNullOrWhiteSpace(root)) {
+                return;
+            }
+
+            string contentRoot = Path.Combine(root, "Microsoft Office", "root", "Office16", "Visio Content");
+            directories.Add(Path.Combine(contentRoot, CultureInfo.CurrentUICulture.LCID.ToString(CultureInfo.InvariantCulture)));
+            directories.Add(Path.Combine(contentRoot, "1033"));
+            directories.Add(contentRoot);
         }
 
         private static bool TryReadPositiveCell(XElement shape, string name, out double value) {

--- a/OfficeIMO.Visio/Stencils/VisioStencilPageExtensions.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilPageExtensions.cs
@@ -87,6 +87,12 @@ namespace OfficeIMO.Visio.Stencils {
             VisioDocument? document = page.OwnerDocument;
             string shapeText = text ?? stencil.Name;
 
+            if (document != null &&
+                !string.IsNullOrWhiteSpace(stencil.SourcePackagePath) &&
+                document.TryGetMaster(stencil.MasterNameU, out _) == false) {
+                document.ImportStencilMasters(stencil.SourcePackagePath!, new[] { stencil.MasterNameU });
+            }
+
             if (document?.TryGetMaster(stencil.MasterNameU, out VisioMaster? registeredMaster) == true && registeredMaster != null) {
                 x = x.ToInches(placementUnit);
                 y = y.ToInches(placementUnit);

--- a/OfficeIMO.Visio/Stencils/VisioStencilPageExtensions.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilPageExtensions.cs
@@ -87,6 +87,19 @@ namespace OfficeIMO.Visio.Stencils {
             VisioDocument? document = page.OwnerDocument;
             string shapeText = text ?? stencil.Name;
 
+            if (document?.TryGetMaster(stencil.MasterNameU, out VisioMaster? registeredMaster) == true && registeredMaster != null) {
+                x = x.ToInches(placementUnit);
+                y = y.ToInches(placementUnit);
+                width = width.ToInches(sizeUnit);
+                height = height.ToInches(sizeUnit);
+                VisioShape created = new(id, x, y, width, height, shapeText) {
+                    Master = registeredMaster,
+                    NameU = registeredMaster.NameU
+                };
+                page.Shapes.Add(created);
+                return created;
+            }
+
             if (document?.UseMastersByDefault == true) {
                 VisioMaster master = document.EnsureBuiltinMaster(stencil.MasterNameU);
                 x = x.ToInches(placementUnit);

--- a/OfficeIMO.Visio/Stencils/VisioStencilPageExtensions.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilPageExtensions.cs
@@ -87,7 +87,7 @@ namespace OfficeIMO.Visio.Stencils {
             VisioDocument? document = page.OwnerDocument;
             string shapeText = text ?? stencil.Name;
 
-            if (document != null) {
+            if (document?.UseMastersByDefault == true) {
                 VisioMaster master = document.EnsureBuiltinMaster(stencil.MasterNameU);
                 x = x.ToInches(placementUnit);
                 y = y.ToInches(placementUnit);

--- a/OfficeIMO.Visio/Stencils/VisioStencilShape.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilShape.cs
@@ -17,7 +17,14 @@ namespace OfficeIMO.Visio.Stencils {
         /// <summary>
         /// Initializes a new stencil shape definition with an explicit default-size unit.
         /// </summary>
-        public VisioStencilShape(string id, string name, string masterNameU, string category, double defaultWidth, double defaultHeight, IEnumerable<string>? keywords, IEnumerable<string>? aliases, IEnumerable<string>? tags, string? iconNameU, VisioMeasurementUnit? defaultUnit) {
+        public VisioStencilShape(string id, string name, string masterNameU, string category, double defaultWidth, double defaultHeight, IEnumerable<string>? keywords, IEnumerable<string>? aliases, IEnumerable<string>? tags, string? iconNameU, VisioMeasurementUnit? defaultUnit)
+            : this(id, name, masterNameU, category, defaultWidth, defaultHeight, keywords, aliases, tags, iconNameU, defaultUnit, null) {
+        }
+
+        /// <summary>
+        /// Initializes a new stencil shape definition with source package metadata.
+        /// </summary>
+        public VisioStencilShape(string id, string name, string masterNameU, string category, double defaultWidth, double defaultHeight, IEnumerable<string>? keywords, IEnumerable<string>? aliases, IEnumerable<string>? tags, string? iconNameU, VisioMeasurementUnit? defaultUnit, string? sourcePackagePath) {
             if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Stencil shape id cannot be null or whitespace.", nameof(id));
             if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Stencil shape name cannot be null or whitespace.", nameof(name));
             if (string.IsNullOrWhiteSpace(masterNameU)) throw new ArgumentException("Master NameU cannot be null or whitespace.", nameof(masterNameU));
@@ -48,6 +55,7 @@ namespace OfficeIMO.Visio.Stencils {
                 .AsReadOnly();
             IconNameU = string.IsNullOrWhiteSpace(iconNameU) ? masterNameU : iconNameU!;
             DefaultUnit = defaultUnit;
+            SourcePackagePath = string.IsNullOrWhiteSpace(sourcePackagePath) ? null : sourcePackagePath;
         }
 
         /// <summary>
@@ -85,6 +93,11 @@ namespace OfficeIMO.Visio.Stencils {
         /// When null, default sizes are interpreted in the caller's placement unit.
         /// </summary>
         public VisioMeasurementUnit? DefaultUnit { get; }
+
+        /// <summary>
+        /// Gets the source `.vssx`, `.vstx`, or `.vsdx` package path when this shape was cataloged from a package.
+        /// </summary>
+        public string? SourcePackagePath { get; }
 
         /// <summary>
         /// Gets searchable keywords.

--- a/OfficeIMO.Visio/Stencils/VisioStencils.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencils.cs
@@ -134,6 +134,21 @@ namespace OfficeIMO.Visio.Stencils {
             });
 
         /// <summary>
+        /// Gets UML-style sequence diagram shapes.
+        /// </summary>
+        public static VisioStencilCatalog Sequence { get; } = new(
+            "Sequence Diagram",
+            new[] {
+                Shape("seq.participant", "Participant", "Rectangle", "Sequence Diagram", 1.45, 0.62, "lifeline", "service", "component"),
+                Shape("seq.actor", "Actor", "Circle", "Sequence Diagram", 0.72, 0.72, "user", "person", "client"),
+                Shape("seq.boundary", "Boundary", "Rectangle", "Sequence Diagram", 1.45, 0.62, "edge", "interface"),
+                Shape("seq.control", "Control", "Rectangle", "Sequence Diagram", 1.45, 0.62, "coordinator", "controller"),
+                Shape("seq.entity", "Entity", "Rectangle", "Sequence Diagram", 1.45, 0.62, "domain", "object"),
+                Shape("seq.database", "Database", "Data", "Sequence Diagram", 1.45, 0.62, "store", "data-store"),
+                Shape("seq.note", "Note", "Rectangle", "Sequence Diagram", 1.8, 0.75, "annotation", "callout")
+            });
+
+        /// <summary>
         /// Gets a combined catalog containing all built-in OfficeIMO-native stencil shapes.
         /// </summary>
         public static VisioStencilCatalog All { get; } = new(
@@ -146,6 +161,7 @@ namespace OfficeIMO.Visio.Stencils {
                 .Concat(Swimlane.Shapes)
                 .Concat(OrgChart.Shapes)
                 .Concat(Timeline.Shapes)
+                .Concat(Sequence.Shapes)
                 .GroupBy(shape => shape.Id)
                 .Select(group => group.First())
                 .ToList());

--- a/OfficeIMO.Visio/VisioAssets.cs
+++ b/OfficeIMO.Visio/VisioAssets.cs
@@ -42,6 +42,38 @@ namespace OfficeIMO.Visio {
             public XDocument MasterXml { get; set; } = new XDocument();
             /// <summary>The corresponding <c>Master</c> element from masters.xml.</summary>
             public XElement MasterElement { get; set; } = new XElement(XName.Get("Master", V));
+            /// <summary>Relationships owned by the master part, including copied media payloads.</summary>
+            public IList<MasterRelationshipContent> Relationships { get; } = new List<MasterRelationshipContent>();
+        }
+
+        /// <summary>
+        /// A relationship from a master part to another package part or external target.
+        /// </summary>
+        public sealed class MasterRelationshipContent {
+            /// <summary>Relationship id from the source master part.</summary>
+            public string Id { get; set; } = string.Empty;
+            /// <summary>Relationship type URI.</summary>
+            public string Type { get; set; } = string.Empty;
+            /// <summary>Original relationship target.</summary>
+            public string Target { get; set; } = string.Empty;
+            /// <summary>Whether the relationship points outside the package.</summary>
+            public bool IsExternal { get; set; }
+            /// <summary>Content type of the internal target part, when known.</summary>
+            public string ContentType { get; set; } = string.Empty;
+            /// <summary>File extension for the copied internal target part.</summary>
+            public string Extension { get; set; } = string.Empty;
+            /// <summary>Raw internal target part bytes.</summary>
+            public byte[]? Data { get; set; }
+        }
+
+        /// <summary>
+        /// Visual context from a Visio package document part that imported masters may inherit.
+        /// </summary>
+        public sealed class PackageVisualContext {
+            /// <summary>Raw visio/document.xml from the source package.</summary>
+            public XDocument? DocumentXml { get; set; }
+            /// <summary>Raw theme XML from the source package, when present.</summary>
+            public XDocument? ThemeXml { get; set; }
         }
 
         /// <summary>
@@ -101,9 +133,35 @@ namespace OfficeIMO.Visio {
                 if (part == null) continue;
                 using var pStream = part.Open();
                 XDocument masterXml = XDocument.Load(pStream);
-                result.Add(new MasterContent { Id = id, NameU = nameU, MasterXml = masterXml, MasterElement = new XElement(m) });
+                MasterContent content = new() { Id = id, NameU = nameU, MasterXml = masterXml, MasterElement = new XElement(m) };
+                foreach (MasterRelationshipContent relationship in LoadMasterRelationships(zip, partPath)) {
+                    content.Relationships.Add(relationship);
+                }
+
+                result.Add(content);
             }
             return result;
+        }
+
+        /// <summary>
+        /// Loads package-level visual context that imported masters can depend on for inherited colors, styles, and theme values.
+        /// </summary>
+        public static PackageVisualContext LoadVisualContext(string vsdxPath) {
+            using ZipArchive zip = ZipFile.OpenRead(vsdxPath);
+            PackageVisualContext context = new();
+            ZipArchiveEntry? documentEntry = zip.GetEntry("visio/document.xml");
+            if (documentEntry != null) {
+                using Stream stream = documentEntry.Open();
+                context.DocumentXml = XDocument.Load(stream);
+            }
+
+            ZipArchiveEntry? themeEntry = zip.GetEntry("visio/theme/theme1.xml");
+            if (themeEntry != null) {
+                using Stream stream = themeEntry.Open();
+                context.ThemeXml = XDocument.Load(stream);
+            }
+
+            return context;
         }
 
         /// <summary>
@@ -117,6 +175,94 @@ namespace OfficeIMO.Visio {
                 using var fs = File.Create(filePath);
                 m.MasterXml.Save(fs, SaveOptions.DisableFormatting);
             }
+        }
+
+        private static IEnumerable<MasterRelationshipContent> LoadMasterRelationships(ZipArchive zip, string masterPartPath) {
+            string fileName = Path.GetFileName(masterPartPath.Replace('\\', '/'));
+            string relsPath = "visio/masters/_rels/" + fileName + ".rels";
+            ZipArchiveEntry? relsEntry = zip.GetEntry(relsPath);
+            if (relsEntry == null) {
+                return Array.Empty<MasterRelationshipContent>();
+            }
+
+            using Stream relsStream = relsEntry.Open();
+            XDocument relsDoc = XDocument.Load(relsStream);
+            XNamespace pr = REL_PKG;
+            List<MasterRelationshipContent> relationships = new();
+            foreach (XElement rel in relsDoc.Root?.Elements(pr + "Relationship") ?? Enumerable.Empty<XElement>()) {
+                string id = (string?)rel.Attribute("Id") ?? string.Empty;
+                string type = (string?)rel.Attribute("Type") ?? string.Empty;
+                string target = (string?)rel.Attribute("Target") ?? string.Empty;
+                bool external = string.Equals((string?)rel.Attribute("TargetMode"), "External", StringComparison.OrdinalIgnoreCase);
+                if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(type) || string.IsNullOrWhiteSpace(target)) {
+                    continue;
+                }
+
+                MasterRelationshipContent relationship = new() {
+                    Id = id,
+                    Type = type,
+                    Target = target,
+                    IsExternal = external
+                };
+
+                if (!external) {
+                    string masterDirectory = (Path.GetDirectoryName(masterPartPath.Replace('\\', '/')) ?? string.Empty).Replace('\\', '/');
+                    string targetPath = ResolveZipPath(masterDirectory, target);
+                    ZipArchiveEntry? targetEntry = zip.GetEntry(targetPath);
+                    if (targetEntry == null) {
+                        continue;
+                    }
+
+                    using Stream targetStream = targetEntry.Open();
+                    using MemoryStream buffer = new();
+                    targetStream.CopyTo(buffer);
+                    relationship.Data = buffer.ToArray();
+                    relationship.Extension = Path.GetExtension(targetPath);
+                    relationship.ContentType = GuessContentType(relationship.Extension);
+                }
+
+                relationships.Add(relationship);
+            }
+
+            return relationships;
+        }
+
+        private static string ResolveZipPath(string basePath, string target) {
+            string normalizedTarget = target.Replace('\\', '/');
+            if (normalizedTarget.StartsWith("/", StringComparison.Ordinal)) {
+                return normalizedTarget.TrimStart('/');
+            }
+
+            string combined = string.IsNullOrWhiteSpace(basePath) ? normalizedTarget : basePath.TrimEnd('/') + "/" + normalizedTarget;
+            Stack<string> parts = new();
+            foreach (string part in combined.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)) {
+                if (part == ".") {
+                    continue;
+                }
+
+                if (part == "..") {
+                    if (parts.Count > 0) {
+                        parts.Pop();
+                    }
+                    continue;
+                }
+
+                parts.Push(part);
+            }
+
+            return string.Join("/", parts.Reverse());
+        }
+
+        private static string GuessContentType(string extension) {
+            return extension.TrimStart('.').ToLowerInvariant() switch {
+                "emf" => "image/x-emf",
+                "png" => "image/png",
+                "jpg" or "jpeg" => "image/jpeg",
+                "gif" => "image/gif",
+                "svg" => "image/svg+xml",
+                "tif" or "tiff" => "image/tiff",
+                _ => "application/octet-stream"
+            };
         }
     }
 }

--- a/OfficeIMO.Visio/VisioDocument.LoadCore.cs
+++ b/OfficeIMO.Visio/VisioDocument.LoadCore.cs
@@ -800,13 +800,13 @@ namespace OfficeIMO.Visio {
                     connector.Kind = DetermineConnectorKind(connectorElement, vNs, masters);
                     ApplyLayerNamesFromIndexes(page, connector);
                     XElement? connectorCharSection = connectorElement.Elements(vNs + "Section")
-                        .FirstOrDefault(section => string.Equals(section.Attribute("N")?.Value, "Char", StringComparison.OrdinalIgnoreCase));
+                        .FirstOrDefault(section => IsCharacterSection(section.Attribute("N")?.Value));
                     if (connectorCharSection != null && TryParseSimpleConnectorCharSection(connector, connectorCharSection, vNs, faceNamesById)) {
                         connector.HasModeledCharSection = true;
                     }
 
                     XElement? connectorParaSection = connectorElement.Elements(vNs + "Section")
-                        .FirstOrDefault(section => string.Equals(section.Attribute("N")?.Value, "Para", StringComparison.OrdinalIgnoreCase));
+                        .FirstOrDefault(section => IsParagraphSection(section.Attribute("N")?.Value));
                     if (connectorParaSection != null && TryParseSimpleConnectorParaSection(connector, connectorParaSection, vNs)) {
                         connector.HasModeledParaSection = true;
                     }
@@ -1239,12 +1239,12 @@ namespace OfficeIMO.Visio {
         private static void ParseShapeProperties(VisioShape shape, XElement shapeElement, XNamespace ns, IReadOnlyDictionary<int, string>? faceNamesById) {
             List<XElement> sectionElements = shapeElement.Elements(ns + "Section").ToList();
 
-            XElement? charSection = sectionElements.FirstOrDefault(e => string.Equals(e.Attribute("N")?.Value, "Char", StringComparison.OrdinalIgnoreCase));
+            XElement? charSection = sectionElements.FirstOrDefault(e => IsCharacterSection(e.Attribute("N")?.Value));
             if (charSection != null && TryParseSimpleCharSection(shape, charSection, ns, faceNamesById)) {
                 shape.HasModeledCharSection = true;
             }
 
-            XElement? paraSection = sectionElements.FirstOrDefault(e => string.Equals(e.Attribute("N")?.Value, "Para", StringComparison.OrdinalIgnoreCase));
+            XElement? paraSection = sectionElements.FirstOrDefault(e => IsParagraphSection(e.Attribute("N")?.Value));
             if (paraSection != null && TryParseSimpleParaSection(shape, paraSection, ns)) {
                 shape.HasModeledParaSection = true;
             }
@@ -1809,7 +1809,7 @@ namespace OfficeIMO.Visio {
                         color = ParseColor(value, default);
                         break;
                     case "Size":
-                        size = ParseDouble(value);
+                        size = ParseTextSizeCell(cell);
                         break;
                     case "Style":
                         if (!TryParseCellIntValue(value, out int styleValue)) {
@@ -1898,7 +1898,7 @@ namespace OfficeIMO.Visio {
                         color = ParseColor(value, default);
                         break;
                     case "Size":
-                        size = ParseDouble(value);
+                        size = ParseTextSizeCell(cell);
                         break;
                     case "Style":
                         if (!TryParseCellIntValue(value, out int styleValue)) {
@@ -1923,6 +1923,16 @@ namespace OfficeIMO.Visio {
             textStyle.Italic = italic;
             textStyle.Underline = underline;
             return true;
+        }
+
+        private static double ParseTextSizeCell(XElement cell) {
+            double size = ParseDouble(cell.Attribute("V")?.Value);
+            string? unit = cell.Attribute("U")?.Value;
+            if (string.Equals(unit, "PT", StringComparison.OrdinalIgnoreCase) && size <= 3D) {
+                return Math.Round(size * 72D, 10);
+            }
+
+            return size;
         }
 
         private static bool TryParseSimpleConnectorParaSection(VisioConnector connector, XElement section, XNamespace ns) {
@@ -1983,9 +1993,9 @@ namespace OfficeIMO.Visio {
                         shape.PreservedShapeChildren.Add(new VisioShape.PreservedShapeChildEntry("Section:Connection"));
                     } else if (string.Equals(sectionName, "User", StringComparison.OrdinalIgnoreCase)) {
                         shape.PreservedShapeChildren.Add(new VisioShape.PreservedShapeChildEntry("Section:User"));
-                    } else if (shape.HasModeledCharSection && string.Equals(sectionName, "Char", StringComparison.OrdinalIgnoreCase)) {
+                    } else if (shape.HasModeledCharSection && IsCharacterSection(sectionName)) {
                         shape.PreservedShapeChildren.Add(new VisioShape.PreservedShapeChildEntry("Section:Char"));
-                    } else if (shape.HasModeledParaSection && string.Equals(sectionName, "Para", StringComparison.OrdinalIgnoreCase)) {
+                    } else if (shape.HasModeledParaSection && IsParagraphSection(sectionName)) {
                         shape.PreservedShapeChildren.Add(new VisioShape.PreservedShapeChildEntry("Section:Para"));
                     } else if (string.Equals(sectionName, "Hyperlink", StringComparison.OrdinalIgnoreCase)) {
                         shape.PreservedShapeChildren.Add(new VisioShape.PreservedShapeChildEntry("Section:Hyperlink"));
@@ -2506,10 +2516,10 @@ namespace OfficeIMO.Visio {
                     } else if (string.Equals(sectionName, "Hyperlink", StringComparison.OrdinalIgnoreCase)) {
                         connector.PreservedShapeChildren.Add(new VisioConnector.PreservedShapeChildEntry("Section:Hyperlink"));
                     } else if (connector.HasModeledCharSection &&
-                               string.Equals(sectionName, "Char", StringComparison.OrdinalIgnoreCase)) {
+                               IsCharacterSection(sectionName)) {
                         connector.PreservedShapeChildren.Add(new VisioConnector.PreservedShapeChildEntry("Section:Char"));
                     } else if (connector.HasModeledParaSection &&
-                               string.Equals(sectionName, "Para", StringComparison.OrdinalIgnoreCase)) {
+                               IsParagraphSection(sectionName)) {
                         connector.PreservedShapeChildren.Add(new VisioConnector.PreservedShapeChildEntry("Section:Para"));
                     } else if (string.Equals(sectionName, "Prop", StringComparison.OrdinalIgnoreCase)) {
                         connector.PreservedShapeChildren.Add(new VisioConnector.PreservedShapeChildEntry("Section:Prop"));
@@ -2607,12 +2617,12 @@ namespace OfficeIMO.Visio {
         private static bool ShouldPreserveConnectorSection(VisioConnector connector, XElement section) {
             string? sectionName = section.Attribute("N")?.Value;
             if (connector.HasModeledCharSection &&
-                string.Equals(sectionName, "Char", StringComparison.OrdinalIgnoreCase)) {
+                IsCharacterSection(sectionName)) {
                 return false;
             }
 
             if (connector.HasModeledParaSection &&
-                string.Equals(sectionName, "Para", StringComparison.OrdinalIgnoreCase)) {
+                IsParagraphSection(sectionName)) {
                 return false;
             }
 
@@ -2679,15 +2689,25 @@ namespace OfficeIMO.Visio {
 
         private static bool ShouldPreserveShapeSection(VisioShape shape, XElement section) {
             string? sectionName = section.Attribute("N")?.Value;
-            if (shape.HasModeledCharSection && string.Equals(sectionName, "Char", StringComparison.OrdinalIgnoreCase)) {
+            if (shape.HasModeledCharSection && IsCharacterSection(sectionName)) {
                 return false;
             }
 
-            if (shape.HasModeledParaSection && string.Equals(sectionName, "Para", StringComparison.OrdinalIgnoreCase)) {
+            if (shape.HasModeledParaSection && IsParagraphSection(sectionName)) {
                 return false;
             }
 
             return ShouldPreserveShapeSection(section);
+        }
+
+        private static bool IsCharacterSection(string? sectionName) {
+            return string.Equals(sectionName, "Character", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(sectionName, "Char", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsParagraphSection(string? sectionName) {
+            return string.Equals(sectionName, "Paragraph", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(sectionName, "Para", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool ShouldPreservePageCell(string? cellName) {

--- a/OfficeIMO.Visio/VisioDocument.SaveCore.cs
+++ b/OfficeIMO.Visio/VisioDocument.SaveCore.cs
@@ -1218,7 +1218,7 @@ namespace OfficeIMO.Visio {
                 WriteHyperlinkSection(writer, ns, shape.Hyperlinks);
                 double geometryWidth = shape.Width > 0 ? shape.Width : masterWidth;
                 double geometryHeight = shape.Height > 0 ? shape.Height : masterHeight;
-                WriteShapeGeometry(writer, ns, shape.PreservedGeometrySections, master.NameU, geometryWidth, geometryHeight);
+                WriteShapeGeometry(writer, ns, shape.PreservedGeometrySections, master.NameU, geometryWidth, geometryHeight, writeGeneratedGeometryWhenEmpty: false);
                 WriteConnectionSection(writer, ns, shape.ConnectionPoints);
                 WriteDataSection(writer, ns, shape.Data, shape.PreservedDataRows, originalIdEntry, shape.ShapeData);
                 WriteTextElement(writer, ns, shape.Text, shape.PreservedTextElement, shape.PreservedTextValue);

--- a/OfficeIMO.Visio/VisioDocument.SaveCore.cs
+++ b/OfficeIMO.Visio/VisioDocument.SaveCore.cs
@@ -709,6 +709,7 @@ namespace OfficeIMO.Visio {
 
             if (effectiveMaster != null) {
                 writer.WriteAttributeString("Master", GetPackageMasterId(packageMasters, effectiveMaster));
+                writer.WriteAttributeString("MasterShape", shape.MasterShapeId ?? "1");
             }
 
             KeyValuePair<string, string>? originalIdEntry = GetOriginalIdEntry(persistedIds, shape.Id);
@@ -1215,7 +1216,9 @@ namespace OfficeIMO.Visio {
                 WriteUserSection(writer, ns, shape.UserCells);
                 WriteTextStyleSections(writer, ns, shape.TextStyle);
                 WriteHyperlinkSection(writer, ns, shape.Hyperlinks);
-                WritePreservedGeometrySections(writer, shape.PreservedGeometrySections);
+                double geometryWidth = shape.Width > 0 ? shape.Width : masterWidth;
+                double geometryHeight = shape.Height > 0 ? shape.Height : masterHeight;
+                WriteShapeGeometry(writer, ns, shape.PreservedGeometrySections, master.NameU, geometryWidth, geometryHeight);
                 WriteConnectionSection(writer, ns, shape.ConnectionPoints);
                 WriteDataSection(writer, ns, shape.Data, shape.PreservedDataRows, originalIdEntry, shape.ShapeData);
                 WriteTextElement(writer, ns, shape.Text, shape.PreservedTextElement, shape.PreservedTextValue);
@@ -1257,6 +1260,7 @@ namespace OfficeIMO.Visio {
             WriteUserSection(writer, ns, shape.UserCells);
             WriteTextStyleSections(writer, ns, shape.TextStyle);
             WriteHyperlinkSection(writer, ns, shape.Hyperlinks);
+            WriteShapeGeometry(writer, ns, shape.PreservedGeometrySections, master.NameU, widthValue, heightValue);
             WriteConnectionSection(writer, ns, shape.ConnectionPoints);
             WriteDataSection(writer, ns, shape.Data, shape.PreservedDataRows, originalIdEntry, shape.ShapeData);
             WriteTextElement(writer, ns, shape.Text, shape.PreservedTextElement, shape.PreservedTextValue);
@@ -1599,7 +1603,7 @@ namespace OfficeIMO.Visio {
             }
 
             writer.WriteStartElement("Section", ns);
-            writer.WriteAttributeString("N", "Char");
+            writer.WriteAttributeString("N", "Character");
             writer.WriteStartElement("Row", ns);
             writer.WriteAttributeString("IX", "0");
 
@@ -1612,7 +1616,7 @@ namespace OfficeIMO.Visio {
             }
 
             if (textStyle.Size.HasValue) {
-                WriteCell(writer, ns, "Size", textStyle.Size.Value, "PT", null);
+                WriteCell(writer, ns, "Size", textStyle.Size.Value / 72D, "PT", null);
             }
 
             if (TryGetCharStyleValue(textStyle, out int styleValue)) {
@@ -1629,7 +1633,7 @@ namespace OfficeIMO.Visio {
             }
 
             writer.WriteStartElement("Section", ns);
-            writer.WriteAttributeString("N", "Para");
+            writer.WriteAttributeString("N", "Paragraph");
             writer.WriteStartElement("Row", ns);
             writer.WriteAttributeString("IX", "0");
             WriteCell(writer, ns, "HorzAlign", (int)textStyle.HorizontalAlignment.Value);

--- a/OfficeIMO.Visio/VisioDocument.SaveCore.cs
+++ b/OfficeIMO.Visio/VisioDocument.SaveCore.cs
@@ -237,6 +237,14 @@ namespace OfficeIMO.Visio {
                             part.CreateRelationship(new Uri($"../masters/master{entry.PartNumber}.xml", UriKind.Relative), TargetMode.Internal, MasterRelationshipType, $"rId{entry.PartNumber}");
                         }
 
+                        if (master.RawMasterContentXml != null) {
+                            using Stream stream = masterPart.GetStream(FileMode.Create, FileAccess.Write);
+                            using StreamWriter streamWriter = new(stream, new UTF8Encoding(false));
+                            streamWriter.Write(master.RawMasterContentXml.Declaration + Environment.NewLine + master.RawMasterContentXml.ToString(SaveOptions.DisableFormatting));
+                            WriteRawMasterRelationships(package, masterPart, master, entry.PartNumber);
+                            continue;
+                        }
+
                         using (XmlWriter writer = XmlWriter.Create(masterPart.GetStream(FileMode.Create, FileAccess.Write), settings)) {
                             writer.WriteStartDocument();
                             writer.WriteStartElement("MasterContents", ns);
@@ -483,8 +491,8 @@ namespace OfficeIMO.Visio {
 
                 foreach ((VisioPage page, PackagePart pagePart, _) in pageParts) {
                     using (XmlWriter writer = XmlWriter.Create(pagePart.GetStream(FileMode.Create, FileAccess.Write), settings)) {
-                        Dictionary<string, string> persistedIds = BuildPersistedIdMap(page);
                         Dictionary<string, VisioMaster> pageMasters = effectivePageMasters[page];
+                        Dictionary<string, string> persistedIds = BuildPersistedIdMap(page, pageMasters);
                         writer.WriteStartDocument();
                         writer.WriteStartElement("PageContents", ns);
                         writer.WriteAttributeString("xmlns", "r", null, "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
@@ -701,21 +709,31 @@ namespace OfficeIMO.Visio {
             VisioMaster? effectiveMaster = TryGetEffectiveMaster(effectiveMasters, shape);
             writer.WriteAttributeString("NameU", shape.NameU ?? effectiveMaster?.NameU ?? shapeName);
 
-            bool isGroup = string.Equals(shape.Type, "Group", StringComparison.OrdinalIgnoreCase) || shape.Children.Count > 0;
+            bool isRawMasterBackedShape = effectiveMaster?.RawMasterContentXml != null;
+            bool isRawMasterGroup = isRawMasterBackedShape &&
+                                    string.Equals(effectiveMaster!.Shape.Type, "Group", StringComparison.OrdinalIgnoreCase);
+            bool isGroup = string.Equals(shape.Type, "Group", StringComparison.OrdinalIgnoreCase) ||
+                           shape.Children.Count > 0 ||
+                           isRawMasterGroup;
             writer.WriteAttributeString("Type", isGroup ? "Group" : "Shape");
-            writer.WriteAttributeString("LineStyle", "0");
-            writer.WriteAttributeString("FillStyle", "0");
-            writer.WriteAttributeString("TextStyle", "0");
+            if (!isRawMasterBackedShape) {
+                writer.WriteAttributeString("LineStyle", "0");
+                writer.WriteAttributeString("FillStyle", "0");
+                writer.WriteAttributeString("TextStyle", "0");
+            }
 
             if (effectiveMaster != null) {
                 writer.WriteAttributeString("Master", GetPackageMasterId(packageMasters, effectiveMaster));
-                writer.WriteAttributeString("MasterShape", shape.MasterShapeId ?? "1");
+                if (shape.MasterShapeId != null || effectiveMaster.RawMasterContentXml == null) {
+                    writer.WriteAttributeString("MasterShape", shape.MasterShapeId ?? effectiveMaster.Shape.Id);
+                }
             }
 
             KeyValuePair<string, string>? originalIdEntry = GetOriginalIdEntry(persistedIds, shape.Id);
             bool wroteChildShapesInBody = false;
-            if (effectiveMaster != null && !isGroup) {
+            if (effectiveMaster != null && (isRawMasterBackedShape || !isGroup)) {
                 WriteMasterBackedShapeBody(writer, ns, shape, effectiveMaster, originalIdEntry, persistedIds, layerIndexes);
+                wroteChildShapesInBody = isRawMasterBackedShape;
             } else if (shape.PreservedShapeChildren.Count > 0) {
                 wroteChildShapesInBody = WriteStandaloneShapeBodyWithPreservedChildOrder(writer, ns, shape, isGroup, originalIdEntry, persistedIds, effectiveMasters, packageMasters, layerIndexes);
             } else {
@@ -1169,6 +1187,42 @@ namespace OfficeIMO.Visio {
         }
 
         private void WriteMasterBackedShapeBody(XmlWriter writer, string ns, VisioShape shape, VisioMaster master, KeyValuePair<string, string>? originalIdEntry, IReadOnlyDictionary<string, string> persistedIds, IReadOnlyDictionary<string, int> layerIndexes) {
+            if (WriteMasterDeltasOnly && master.RawMasterContentXml != null) {
+                double masterWidth = master.Shape.Width > 0 ? master.Shape.Width : 1;
+                double masterHeight = master.Shape.Height > 0 ? master.Shape.Height : 1;
+                double width = shape.Width > 0 ? shape.Width : masterWidth;
+                double height = shape.Height > 0 ? shape.Height : masterHeight;
+                double locPinX = Math.Abs(shape.LocPinX) < double.Epsilon ? width / 2 : shape.LocPinX;
+                double locPinY = Math.Abs(shape.LocPinY) < double.Epsilon ? height / 2 : shape.LocPinY;
+                double masterLocPinX = Math.Abs(master.Shape.LocPinX) < double.Epsilon ? masterWidth / 2 : master.Shape.LocPinX;
+                double masterLocPinY = Math.Abs(master.Shape.LocPinY) < double.Epsilon ? masterHeight / 2 : master.Shape.LocPinY;
+                bool sizeDiffers = Math.Abs(width - masterWidth) > 1e-12 ||
+                                   Math.Abs(height - masterHeight) > 1e-12;
+                bool locPinDiffers = Math.Abs(locPinX - masterLocPinX) > 1e-12 ||
+                                     Math.Abs(locPinY - masterLocPinY) > 1e-12;
+                if (sizeDiffers || locPinDiffers || Math.Abs(shape.Angle) > 1e-12) {
+                    WriteXForm(writer, ns, shape.PinX, shape.PinY, width, height, locPinX, locPinY, shape.Angle);
+                } else {
+                    WriteCell(writer, ns, "PinX", shape.PinX);
+                    WriteCell(writer, ns, "PinY", shape.PinY);
+                }
+
+                WriteCell(writer, ns, "ObjType", 1);
+                WriteLayerMemberCell(writer, ns, shape.LayerNames, layerIndexes);
+                WriteRelationshipCell(writer, ns, shape, persistedIds);
+                WriteShapeLayoutCells(writer, ns, shape);
+                WriteProtectionCells(writer, ns, shape.Protection);
+                WritePreservedElements(writer, shape.PreservedCellElements);
+                WritePreservedElements(writer, shape.PreservedNonGeometrySections);
+                WriteUserSection(writer, ns, shape.UserCells);
+                WriteHyperlinkSection(writer, ns, shape.Hyperlinks);
+                WriteConnectionSection(writer, ns, shape.ConnectionPoints);
+                WriteDataSection(writer, ns, shape.Data, shape.PreservedDataRows, originalIdEntry, shape.ShapeData);
+                WriteTextElement(writer, ns, shape.Text, shape.PreservedTextElement, shape.PreservedTextValue);
+                WriteRawMasterInstanceChildShapes(writer, ns, shape, master, persistedIds);
+                return;
+            }
+
             if (WriteMasterDeltasOnly) {
                 double masterWidth = master.Shape.Width > 0 ? master.Shape.Width : 1;
                 double masterHeight = master.Shape.Height > 0 ? master.Shape.Height : 1;
@@ -2309,7 +2363,7 @@ namespace OfficeIMO.Visio {
             "Angle"
         };
 
-        private static Dictionary<string, string> BuildPersistedIdMap(VisioPage page) {
+        private static Dictionary<string, string> BuildPersistedIdMap(VisioPage page, IReadOnlyDictionary<string, VisioMaster> effectiveMasters) {
             Dictionary<string, string> map = new(StringComparer.Ordinal);
             HashSet<int> usedIds = new();
 
@@ -2333,6 +2387,10 @@ namespace OfficeIMO.Visio {
 
             void VisitShape(VisioShape shape) {
                 Reserve(shape.Id);
+                if (effectiveMasters.TryGetValue(shape.Id, out VisioMaster? master) && master.RawMasterContentXml != null) {
+                    ReserveRawMasterInstanceChildIds(shape, master, Reserve);
+                }
+
                 foreach (VisioShape child in shape.Children) {
                     VisitShape(child);
                 }
@@ -2346,6 +2404,95 @@ namespace OfficeIMO.Visio {
             }
 
             return map;
+        }
+
+        private static void ReserveRawMasterInstanceChildIds(VisioShape shape, VisioMaster master, Action<string> reserve) {
+            XElement? rootShape = FindFirstMasterShape(master.RawMasterContentXml!);
+            if (rootShape == null) {
+                return;
+            }
+
+            foreach (XElement childShape in GetRawMasterChildShapes(rootShape)) {
+                ReserveRawMasterInstanceChildId(shape.Id, childShape, reserve);
+            }
+        }
+
+        private static void ReserveRawMasterInstanceChildId(string instanceShapeId, XElement masterShape, Action<string> reserve) {
+            string? masterShapeId = masterShape.Attribute("ID")?.Value;
+            if (string.IsNullOrWhiteSpace(masterShapeId)) {
+                return;
+            }
+
+            reserve(GetRawMasterInstanceChildKey(instanceShapeId, masterShapeId!));
+            foreach (XElement childShape in GetRawMasterChildShapes(masterShape)) {
+                ReserveRawMasterInstanceChildId(instanceShapeId, childShape, reserve);
+            }
+        }
+
+        private static void WriteRawMasterInstanceChildShapes(XmlWriter writer, string ns, VisioShape shape, VisioMaster master, IReadOnlyDictionary<string, string> persistedIds) {
+            XElement? rootShape = FindFirstMasterShape(master.RawMasterContentXml!);
+            if (rootShape == null) {
+                return;
+            }
+
+            List<XElement> childShapes = GetRawMasterChildShapes(rootShape).ToList();
+            if (childShapes.Count == 0) {
+                return;
+            }
+
+            writer.WriteStartElement("Shapes", ns);
+            foreach (XElement childShape in childShapes) {
+                WriteRawMasterInstanceChildShape(writer, ns, shape.Id, childShape, persistedIds);
+            }
+            writer.WriteEndElement();
+        }
+
+        private static void WriteRawMasterInstanceChildShape(XmlWriter writer, string ns, string instanceShapeId, XElement masterShape, IReadOnlyDictionary<string, string> persistedIds) {
+            string? masterShapeId = masterShape.Attribute("ID")?.Value;
+            if (string.IsNullOrWhiteSpace(masterShapeId)) {
+                return;
+            }
+
+            writer.WriteStartElement("Shape", ns);
+            writer.WriteAttributeString("ID", GetPersistedId(persistedIds, GetRawMasterInstanceChildKey(instanceShapeId, masterShapeId!)));
+            WriteRawMasterInstanceChildAttribute(writer, masterShape, "NameU");
+            WriteRawMasterInstanceChildAttribute(writer, masterShape, "IsCustomNameU");
+            WriteRawMasterInstanceChildAttribute(writer, masterShape, "Name");
+            WriteRawMasterInstanceChildAttribute(writer, masterShape, "IsCustomName");
+            string type = masterShape.Attribute("Type")?.Value ?? (GetRawMasterChildShapes(masterShape).Any() ? "Group" : "Shape");
+            writer.WriteAttributeString("Type", type);
+            writer.WriteAttributeString("MasterShape", masterShapeId);
+
+            List<XElement> childShapes = GetRawMasterChildShapes(masterShape).ToList();
+            if (childShapes.Count > 0) {
+                writer.WriteStartElement("Shapes", ns);
+                foreach (XElement childShape in childShapes) {
+                    WriteRawMasterInstanceChildShape(writer, ns, instanceShapeId, childShape, persistedIds);
+                }
+                writer.WriteEndElement();
+            }
+
+            writer.WriteEndElement();
+        }
+
+        private static void WriteRawMasterInstanceChildAttribute(XmlWriter writer, XElement masterShape, string attributeName) {
+            string? value = masterShape.Attribute(attributeName)?.Value;
+            if (!string.IsNullOrWhiteSpace(value)) {
+                writer.WriteAttributeString(attributeName, value);
+            }
+        }
+
+        private static IEnumerable<XElement> GetRawMasterChildShapes(XElement masterShape) {
+            XElement? shapes = masterShape
+                .Elements()
+                .FirstOrDefault(element => string.Equals(element.Name.LocalName, "Shapes", StringComparison.OrdinalIgnoreCase));
+            return shapes == null
+                ? Enumerable.Empty<XElement>()
+                : shapes.Elements().Where(element => string.Equals(element.Name.LocalName, "Shape", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static string GetRawMasterInstanceChildKey(string instanceShapeId, string masterShapeId) {
+            return instanceShapeId + "::raw-master-shape::" + masterShapeId;
         }
 
         private static string GetPersistedId(IReadOnlyDictionary<string, string> persistedIds, string originalId) {
@@ -2720,6 +2867,35 @@ namespace OfficeIMO.Visio {
 
         private static VisioMaster? TryGetEffectiveMaster(IReadOnlyDictionary<string, VisioMaster> effectiveMasters, VisioShape shape) {
             return effectiveMasters.TryGetValue(shape.Id, out VisioMaster? master) ? master : null;
+        }
+
+        private static void WriteRawMasterRelationships(Package package, PackagePart masterPart, VisioMaster master, int masterPartNumber) {
+            for (int i = 0; i < master.RawMasterRelationships.Count; i++) {
+                VisioAssets.MasterRelationshipContent relationship = master.RawMasterRelationships[i];
+                if (string.IsNullOrWhiteSpace(relationship.Id) || string.IsNullOrWhiteSpace(relationship.Type) || string.IsNullOrWhiteSpace(relationship.Target)) {
+                    continue;
+                }
+
+                if (relationship.IsExternal || relationship.Data == null || relationship.Data.Length == 0) {
+                    masterPart.CreateRelationship(new Uri(relationship.Target, UriKind.RelativeOrAbsolute), TargetMode.External, relationship.Type, relationship.Id);
+                    continue;
+                }
+
+                string extension = string.IsNullOrWhiteSpace(relationship.Extension) ? ".bin" : relationship.Extension;
+                if (!extension.StartsWith(".", StringComparison.Ordinal)) {
+                    extension = "." + extension;
+                }
+
+                string mediaName = $"officeimo-master{masterPartNumber}-rel{i + 1}{extension}";
+                Uri mediaUri = new($"/visio/media/{mediaName}", UriKind.Relative);
+                if (!package.PartExists(mediaUri)) {
+                    PackagePart mediaPart = package.CreatePart(mediaUri, string.IsNullOrWhiteSpace(relationship.ContentType) ? "application/octet-stream" : relationship.ContentType);
+                    using Stream mediaStream = mediaPart.GetStream(FileMode.Create, FileAccess.Write);
+                    mediaStream.Write(relationship.Data, 0, relationship.Data.Length);
+                }
+
+                masterPart.CreateRelationship(new Uri("../media/" + mediaName, UriKind.Relative), TargetMode.Internal, relationship.Type, relationship.Id);
+            }
         }
 
         private static void WriteMasterGeometry(XmlWriter writer, string ns, string? masterNameU, double width, double height) {

--- a/OfficeIMO.Visio/VisioDocument.SaveHelpers.cs
+++ b/OfficeIMO.Visio/VisioDocument.SaveHelpers.cs
@@ -1059,7 +1059,14 @@ namespace OfficeIMO.Visio {
             XElement root = new(ct + "Types",
                 new XElement(ct + "Default", new XAttribute("Extension", "rels"), new XAttribute("ContentType", "application/vnd.openxmlformats-package.relationships+xml")),
                 new XElement(ct + "Default", new XAttribute("Extension", "xml"), new XAttribute("ContentType", "application/xml")),
-                new XElement(ct + "Default", new XAttribute("Extension", "emf"), new XAttribute("ContentType", "image/x-emf")));
+                new XElement(ct + "Default", new XAttribute("Extension", "emf"), new XAttribute("ContentType", "image/x-emf")),
+                new XElement(ct + "Default", new XAttribute("Extension", "png"), new XAttribute("ContentType", "image/png")),
+                new XElement(ct + "Default", new XAttribute("Extension", "jpg"), new XAttribute("ContentType", "image/jpeg")),
+                new XElement(ct + "Default", new XAttribute("Extension", "jpeg"), new XAttribute("ContentType", "image/jpeg")),
+                new XElement(ct + "Default", new XAttribute("Extension", "gif"), new XAttribute("ContentType", "image/gif")),
+                new XElement(ct + "Default", new XAttribute("Extension", "svg"), new XAttribute("ContentType", "image/svg+xml")),
+                new XElement(ct + "Default", new XAttribute("Extension", "tif"), new XAttribute("ContentType", "image/tiff")),
+                new XElement(ct + "Default", new XAttribute("Extension", "tiff"), new XAttribute("ContentType", "image/tiff")));
 
             HashSet<string> overridePartNames = new(StringComparer.OrdinalIgnoreCase);
             void AddOverride(string partName, string contentType) {

--- a/OfficeIMO.Visio/VisioDocument.SaveHelpers.cs
+++ b/OfficeIMO.Visio/VisioDocument.SaveHelpers.cs
@@ -269,6 +269,9 @@ namespace OfficeIMO.Visio {
         private static void WriteEllipseGeometry(XmlWriter writer, string ns, double width, double height) {
             double rx = width / 2.0;
             double ry = height / 2.0;
+            double centerX = rx;
+            double centerY = ry;
+            const int segments = 24;
             writer.WriteStartElement("Section", ns);
             writer.WriteAttributeString("N", "Geometry");
             writer.WriteAttributeString("IX", "0");
@@ -276,26 +279,18 @@ namespace OfficeIMO.Visio {
 
             writer.WriteStartElement("Row", ns);
             writer.WriteAttributeString("T", "MoveTo");
-            WriteCell(writer, ns, "X", 0);
-            WriteCell(writer, ns, "Y", ry);
+            WriteCell(writer, ns, "X", centerX + rx);
+            WriteCell(writer, ns, "Y", centerY);
             writer.WriteEndElement();
 
-            writer.WriteStartElement("Row", ns);
-            writer.WriteAttributeString("T", "EllipticalArcTo");
-            WriteCell(writer, ns, "X", width);
-            WriteCell(writer, ns, "Y", ry);
-            WriteCell(writer, ns, "A", ry);
-            WriteCell(writer, ns, "B", width);
-            writer.WriteEndElement();
-
-            writer.WriteStartElement("Row", ns);
-            writer.WriteAttributeString("T", "EllipticalArcTo");
-            // Explicitly close back to the leftmost point to avoid viewer quirks
-            WriteCell(writer, ns, "X", 0);
-            WriteCell(writer, ns, "Y", ry);
-            WriteCell(writer, ns, "A", ry);
-            WriteCell(writer, ns, "B", width);
-            writer.WriteEndElement();
+            for (int i = 1; i <= segments; i++) {
+                double angle = (Math.PI * 2D * i) / segments;
+                writer.WriteStartElement("Row", ns);
+                writer.WriteAttributeString("T", "LineTo");
+                WriteCell(writer, ns, "X", centerX + (Math.Cos(angle) * rx));
+                WriteCell(writer, ns, "Y", centerY + (Math.Sin(angle) * ry));
+                writer.WriteEndElement();
+            }
 
             writer.WriteEndElement();
         }

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -396,11 +396,10 @@ namespace OfficeIMO.Visio {
                 AddMissingAttribute(PreservedColorsAttributes, attribute);
             }
 
-            HashSet<string> existingColorIndexes = PreservedColorsElements
+            HashSet<string> existingColorIndexes = new HashSet<string>(PreservedColorsElements
                 .Where(element => string.Equals(element.Name.LocalName, "ColorEntry", StringComparison.OrdinalIgnoreCase))
                 .Select(element => element.Attribute("IX")?.Value ?? string.Empty)
-                .Where(value => !string.IsNullOrWhiteSpace(value))
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                .Where(value => !string.IsNullOrWhiteSpace(value)), StringComparer.OrdinalIgnoreCase);
             foreach (XElement element in colors.Elements().Where(ShouldPreserveColorsElement)) {
                 string? colorIndex = element.Attribute("IX")?.Value;
                 if (!string.IsNullOrWhiteSpace(colorIndex) && !existingColorIndexes.Add(colorIndex!)) {
@@ -420,11 +419,10 @@ namespace OfficeIMO.Visio {
                 AddMissingAttribute(PreservedFaceNamesAttributes, attribute);
             }
 
-            HashSet<string> existingFaces = PreservedFaceNamesElements
+            HashSet<string> existingFaces = new HashSet<string>(PreservedFaceNamesElements
                 .Where(element => string.Equals(element.Name.LocalName, "FaceName", StringComparison.OrdinalIgnoreCase))
                 .Select(element => element.Attribute("NameU")?.Value ?? element.Attribute("Name")?.Value ?? element.Attribute("ID")?.Value ?? string.Empty)
-                .Where(value => !string.IsNullOrWhiteSpace(value))
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                .Where(value => !string.IsNullOrWhiteSpace(value)), StringComparer.OrdinalIgnoreCase);
             foreach (XElement element in faceNames.Elements().Where(ShouldPreserveFaceNamesElement)) {
                 string faceKey = element.Attribute("NameU")?.Value ?? element.Attribute("Name")?.Value ?? element.Attribute("ID")?.Value ?? Guid.NewGuid().ToString("N");
                 if (!existingFaces.Add(faceKey)) {
@@ -450,10 +448,9 @@ namespace OfficeIMO.Visio {
                 }
             }
 
-            HashSet<string> existingAdditionalStyleIds = PreservedAdditionalStyleSheets
+            HashSet<string> existingAdditionalStyleIds = new HashSet<string>(PreservedAdditionalStyleSheets
                 .Select(styleSheet => styleSheet.Attribute("ID")?.Value ?? string.Empty)
-                .Where(value => !string.IsNullOrWhiteSpace(value))
-                .ToHashSet(StringComparer.Ordinal);
+                .Where(value => !string.IsNullOrWhiteSpace(value)), StringComparer.Ordinal);
             foreach (XElement styleSheet in styleSheets.Elements(ns + "StyleSheet")) {
                 string id = styleSheet.Attribute("ID")?.Value ?? string.Empty;
                 if (string.IsNullOrWhiteSpace(id)) {

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using System.Xml.Linq;
+using OfficeIMO.Visio.Stencils;
 
 namespace OfficeIMO.Visio {
     /// <summary>
@@ -233,6 +234,32 @@ namespace OfficeIMO.Visio {
 
                 RegisterMaster(master);
                 imported.Add(master);
+            }
+
+            return imported.AsReadOnly();
+        }
+
+        /// <summary>
+        /// Imports the package-backed masters required by the provided stencil shapes.
+        /// Shapes loaded from multiple `.vssx`, `.vstx`, or `.vsdx` packages are grouped by source package.
+        /// </summary>
+        /// <param name="shapes">Stencil shapes with <see cref="VisioStencilShape.SourcePackagePath"/> metadata.</param>
+        public void ImportStencilMasters(IEnumerable<VisioStencilShape> shapes) {
+            ImportStencilMastersAndGet(shapes);
+        }
+
+        /// <summary>
+        /// Imports the package-backed masters required by the provided stencil shapes and returns the imported masters.
+        /// </summary>
+        /// <param name="shapes">Stencil shapes with <see cref="VisioStencilShape.SourcePackagePath"/> metadata.</param>
+        public IReadOnlyList<VisioMaster> ImportStencilMastersAndGet(IEnumerable<VisioStencilShape> shapes) {
+            if (shapes == null) throw new ArgumentNullException(nameof(shapes));
+
+            List<VisioMaster> imported = new();
+            foreach (IGrouping<string, VisioStencilShape> group in shapes
+                .Where(shape => shape != null && !string.IsNullOrWhiteSpace(shape.SourcePackagePath))
+                .GroupBy(shape => shape.SourcePackagePath!, StringComparer.OrdinalIgnoreCase)) {
+                imported.AddRange(ImportStencilMastersAndGet(group.Key, group.Select(shape => shape.MasterNameU)));
             }
 
             return imported.AsReadOnly();

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -390,10 +390,8 @@ namespace OfficeIMO.Visio {
         }
 
         private static VisioShape CreateMasterBlueprint(string nameU, BuiltinMasterDefinition? definition) {
-            VisioShape blueprint = new("1") {
-                NameU = nameU,
-                Width = 1,
-                Height = 1
+            VisioShape blueprint = new("1", 0.5, 0.5, 1, 1, string.Empty) {
+                NameU = nameU
             };
 
             if (definition?.GeometryKind != BuiltinGeometryKind.DynamicConnector) {

--- a/OfficeIMO.Visio/VisioDocument.cs
+++ b/OfficeIMO.Visio/VisioDocument.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
@@ -196,6 +197,48 @@ namespace OfficeIMO.Visio {
         }
 
         /// <summary>
+        /// Imports actual master definitions from a user-supplied Visio stencil, drawing, or template package.
+        /// Unlike <see cref="LearnMastersFromVsdx"/>, this preserves the package master XML so shapes can use
+        /// real external stencil artwork. Use this only for stencil packs the caller is allowed to embed.
+        /// </summary>
+        /// <param name="packagePath">Path to a `.vssx`, `.vsdx`, or `.vstx` package.</param>
+        /// <param name="names">Optional filters matching master NameU, display name, relationship id, numeric id, or normalized slug.</param>
+        public void ImportStencilMasters(string packagePath, IEnumerable<string>? names = null) {
+            ImportStencilMastersAndGet(packagePath, names);
+        }
+
+        /// <summary>
+        /// Imports actual master definitions from a user-supplied Visio stencil, drawing, or template package and returns the registered masters.
+        /// </summary>
+        /// <param name="packagePath">Path to a `.vssx`, `.vsdx`, or `.vstx` package.</param>
+        /// <param name="names">Optional filters matching master NameU, display name, relationship id, numeric id, or normalized slug.</param>
+        public IReadOnlyList<VisioMaster> ImportStencilMastersAndGet(string packagePath, IEnumerable<string>? names = null) {
+            if (string.IsNullOrWhiteSpace(packagePath)) throw new ArgumentException("Package path cannot be null or whitespace.", nameof(packagePath));
+            if (!File.Exists(packagePath)) throw new FileNotFoundException("Visio package was not found.", packagePath);
+
+            ImportStencilPackageVisualContext(packagePath);
+            IEnumerable<string>? resolvedNames = ResolvePackageMasterNameFilters(packagePath, names);
+            IReadOnlyList<VisioAssets.MasterContent> contents = VisioAssets.LoadMasterContents(packagePath, resolvedNames);
+            List<VisioMaster> imported = new();
+            foreach (VisioAssets.MasterContent content in contents) {
+                VisioShape shape = CreateImportedMasterShape(content);
+                XDocument rawMasterXml = new(content.MasterXml);
+                NormalizeImportedMasterRoot(rawMasterXml);
+                VisioMaster master = new(content.Id, content.NameU, shape) {
+                    RawMasterContentXml = rawMasterXml
+                };
+                foreach (VisioAssets.MasterRelationshipContent relationship in content.Relationships) {
+                    master.RawMasterRelationships.Add(relationship);
+                }
+
+                RegisterMaster(master);
+                imported.Add(master);
+            }
+
+            return imported.AsReadOnly();
+        }
+
+        /// <summary>
         /// Adds a new page to the document.
         /// </summary>
         /// <param name="name">Name of the page.</param>
@@ -280,6 +323,232 @@ namespace OfficeIMO.Visio {
         /// <param name="vsdxPath">Path to a VSDX file that contains canonical masters.</param>
         public void UseMastersFromTemplate(string vsdxPath) {
             LearnMastersFromVsdx(vsdxPath);
+        }
+
+        private static IEnumerable<string>? ResolvePackageMasterNameFilters(string packagePath, IEnumerable<string>? names) {
+            if (names == null) {
+                return null;
+            }
+
+            HashSet<string> filter = new(names, StringComparer.OrdinalIgnoreCase);
+            if (filter.Count == 0) {
+                return null;
+            }
+
+            return VisioAssets.ListMasters(packagePath)
+                .Where(master => VisioMasterIdentity.MatchesAny(master, filter))
+                .Select(master => master.NameU)
+                .ToArray();
+        }
+
+        private void ImportStencilPackageVisualContext(string packagePath) {
+            VisioAssets.PackageVisualContext context = VisioAssets.LoadVisualContext(packagePath);
+            XNamespace ns = VisioNamespace;
+
+            XElement? documentRoot = context.DocumentXml?.Root;
+            if (documentRoot != null) {
+                ImportColors(documentRoot.Element(ns + "Colors"), ns);
+                ImportFaceNames(documentRoot.Element(ns + "FaceNames"), ns);
+                ImportStyleSheets(documentRoot.Element(ns + "StyleSheets"), ns);
+            }
+
+            if (Theme == null && context.ThemeXml?.Root != null) {
+                Theme = new VisioTheme {
+                    Name = context.ThemeXml.Root.Attribute("name")?.Value,
+                    TemplateXml = new XDocument(context.ThemeXml)
+                };
+            }
+        }
+
+        private void ImportColors(XElement? colors, XNamespace ns) {
+            if (colors == null) {
+                return;
+            }
+
+            foreach (XAttribute attribute in colors.Attributes().Where(ShouldPreserveColorsAttribute)) {
+                AddMissingAttribute(PreservedColorsAttributes, attribute);
+            }
+
+            HashSet<string> existingColorIndexes = PreservedColorsElements
+                .Where(element => string.Equals(element.Name.LocalName, "ColorEntry", StringComparison.OrdinalIgnoreCase))
+                .Select(element => element.Attribute("IX")?.Value ?? string.Empty)
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (XElement element in colors.Elements().Where(ShouldPreserveColorsElement)) {
+                string? colorIndex = element.Attribute("IX")?.Value;
+                if (!string.IsNullOrWhiteSpace(colorIndex) && !existingColorIndexes.Add(colorIndex!)) {
+                    continue;
+                }
+
+                PreservedColorsElements.Add(new XElement(element));
+            }
+        }
+
+        private void ImportFaceNames(XElement? faceNames, XNamespace ns) {
+            if (faceNames == null) {
+                return;
+            }
+
+            foreach (XAttribute attribute in faceNames.Attributes().Where(ShouldPreserveFaceNamesAttribute)) {
+                AddMissingAttribute(PreservedFaceNamesAttributes, attribute);
+            }
+
+            HashSet<string> existingFaces = PreservedFaceNamesElements
+                .Where(element => string.Equals(element.Name.LocalName, "FaceName", StringComparison.OrdinalIgnoreCase))
+                .Select(element => element.Attribute("NameU")?.Value ?? element.Attribute("Name")?.Value ?? element.Attribute("ID")?.Value ?? string.Empty)
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (XElement element in faceNames.Elements().Where(ShouldPreserveFaceNamesElement)) {
+                string faceKey = element.Attribute("NameU")?.Value ?? element.Attribute("Name")?.Value ?? element.Attribute("ID")?.Value ?? Guid.NewGuid().ToString("N");
+                if (!existingFaces.Add(faceKey)) {
+                    continue;
+                }
+
+                PreservedFaceNamesElements.Add(new XElement(element));
+            }
+        }
+
+        private void ImportStyleSheets(XElement? styleSheets, XNamespace ns) {
+            if (styleSheets == null) {
+                return;
+            }
+
+            foreach (XAttribute attribute in styleSheets.Attributes().Where(ShouldPreserveStyleSheetsAttribute)) {
+                AddMissingAttribute(PreservedStyleSheetsAttributes, attribute);
+            }
+
+            foreach (XElement element in styleSheets.Elements().Where(ShouldPreserveStyleSheetsElement)) {
+                if (!PreservedStyleSheetsElements.Any(existing => XNode.DeepEquals(existing, element))) {
+                    PreservedStyleSheetsElements.Add(new XElement(element));
+                }
+            }
+
+            HashSet<string> existingAdditionalStyleIds = PreservedAdditionalStyleSheets
+                .Select(styleSheet => styleSheet.Attribute("ID")?.Value ?? string.Empty)
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .ToHashSet(StringComparer.Ordinal);
+            foreach (XElement styleSheet in styleSheets.Elements(ns + "StyleSheet")) {
+                string id = styleSheet.Attribute("ID")?.Value ?? string.Empty;
+                if (string.IsNullOrWhiteSpace(id)) {
+                    continue;
+                }
+
+                if (!IsGeneratedStyleSheet(id)) {
+                    if (existingAdditionalStyleIds.Add(id)) {
+                        PreservedAdditionalStyleSheets.Add(new XElement(styleSheet));
+                    }
+
+                    continue;
+                }
+
+                PreservedStyleSheetData preserved = GetOrCreatePreservedStyleSheet(this, id);
+                foreach (XAttribute attribute in styleSheet.Attributes().Where(attribute => ShouldPreserveStyleSheetAttribute(attribute, id))) {
+                    AddMissingAttribute(preserved.Attributes, attribute);
+                }
+
+                foreach (XElement element in styleSheet.Elements().Where(element => ShouldPreserveStyleSheetElement(element, id))) {
+                    if (!preserved.ChildElements.Any(existing => XNode.DeepEquals(existing, element))) {
+                        preserved.ChildElements.Add(new XElement(element));
+                    }
+                }
+            }
+        }
+
+        private static void AddMissingAttribute(IList<XAttribute> attributes, XAttribute attribute) {
+            if (!attributes.Any(existing => existing.Name == attribute.Name)) {
+                attributes.Add(new XAttribute(attribute));
+            }
+        }
+
+        private static void NormalizeImportedMasterRoot(XDocument masterXml) {
+            XElement? rootShape = FindFirstMasterShape(masterXml);
+            if (rootShape == null) {
+                return;
+            }
+
+            if (TryReadImportedMasterCell(rootShape, "LocPinX", out double locPinX)) {
+                SetImportedMasterCell(rootShape, "PinX", locPinX);
+            } else if (TryReadImportedMasterCell(rootShape, "Width", out double width) && width > 0) {
+                SetImportedMasterCell(rootShape, "PinX", width / 2D);
+            }
+
+            if (TryReadImportedMasterCell(rootShape, "LocPinY", out double locPinY)) {
+                SetImportedMasterCell(rootShape, "PinY", locPinY);
+            } else if (TryReadImportedMasterCell(rootShape, "Height", out double height) && height > 0) {
+                SetImportedMasterCell(rootShape, "PinY", height / 2D);
+            }
+        }
+
+        private static XElement? FindFirstMasterShape(XDocument masterXml) {
+            XNamespace ns = VisioNamespace;
+            XElement? shapeElement = masterXml.Root?
+                .Element(ns + "Shapes")?
+                .Elements(ns + "Shape")
+                .FirstOrDefault();
+            if (shapeElement != null) {
+                return shapeElement;
+            }
+
+            return masterXml.Root?
+                .Elements()
+                .FirstOrDefault(element => string.Equals(element.Name.LocalName, "Shapes", StringComparison.OrdinalIgnoreCase))?
+                .Elements()
+                .FirstOrDefault(element => string.Equals(element.Name.LocalName, "Shape", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static void SetImportedMasterCell(XElement shapeElement, string name, double value) {
+            XElement? cell = shapeElement
+                .Elements()
+                .FirstOrDefault(element =>
+                    string.Equals(element.Name.LocalName, "Cell", StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(element.Attribute("N")?.Value, name, StringComparison.OrdinalIgnoreCase));
+            XNamespace ns = shapeElement.Name.Namespace;
+            if (cell == null) {
+                shapeElement.AddFirst(new XElement(ns + "Cell", new XAttribute("N", name)));
+                cell = shapeElement
+                    .Elements()
+                    .FirstOrDefault(element =>
+                        string.Equals(element.Name.LocalName, "Cell", StringComparison.OrdinalIgnoreCase) &&
+                        string.Equals(element.Attribute("N")?.Value, name, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (cell != null) {
+                cell.SetAttributeValue("V", value.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+        private static VisioShape CreateImportedMasterShape(VisioAssets.MasterContent content) {
+            XElement? shapeElement = FindFirstMasterShape(content.MasterXml);
+
+            string shapeId = shapeElement?.Attribute("ID")?.Value ?? "1";
+            double width = TryReadImportedMasterCell(shapeElement, "Width", out double parsedWidth) && parsedWidth > 0 ? parsedWidth : 1D;
+            double height = TryReadImportedMasterCell(shapeElement, "Height", out double parsedHeight) && parsedHeight > 0 ? parsedHeight : 1D;
+            double pinX = TryReadImportedMasterCell(shapeElement, "PinX", out double parsedPinX) ? parsedPinX : width / 2D;
+            double pinY = TryReadImportedMasterCell(shapeElement, "PinY", out double parsedPinY) ? parsedPinY : height / 2D;
+            double locPinX = TryReadImportedMasterCell(shapeElement, "LocPinX", out double parsedLocPinX) ? parsedLocPinX : width / 2D;
+            double locPinY = TryReadImportedMasterCell(shapeElement, "LocPinY", out double parsedLocPinY) ? parsedLocPinY : height / 2D;
+
+            return new VisioShape(shapeId, pinX, pinY, width, height, string.Empty) {
+                Name = shapeElement?.Attribute("Name")?.Value ?? content.NameU,
+                NameU = shapeElement?.Attribute("NameU")?.Value ?? content.NameU,
+                Type = shapeElement?.Attribute("Type")?.Value,
+                LocPinX = locPinX,
+                LocPinY = locPinY
+            };
+        }
+
+        private static bool TryReadImportedMasterCell(XElement? shapeElement, string name, out double value) {
+            string? rawValue = shapeElement?
+                .Elements()
+                .FirstOrDefault(element =>
+                    string.Equals(element.Name.LocalName, "Cell", StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(element.Attribute("N")?.Value, name, StringComparison.OrdinalIgnoreCase))?
+                .Attribute("V")?
+                .Value;
+
+            return double.TryParse(rawValue, NumberStyles.Float, CultureInfo.InvariantCulture, out value) &&
+                   !double.IsNaN(value) &&
+                   !double.IsInfinity(value);
         }
 
         /// <summary>

--- a/OfficeIMO.Visio/VisioMaster.cs
+++ b/OfficeIMO.Visio/VisioMaster.cs
@@ -54,5 +54,9 @@ namespace OfficeIMO.Visio {
         internal IList<XAttribute> PreservedMastersRootAttributes { get; } = new List<XAttribute>();
 
         internal IList<XElement> PreservedMastersRootElements { get; } = new List<XElement>();
+
+        internal XDocument? RawMasterContentXml { get; set; }
+
+        internal IList<VisioAssets.MasterRelationshipContent> RawMasterRelationships { get; } = new List<VisioAssets.MasterRelationshipContent>();
     }
 }

--- a/OfficeIMO.Visio/VisioShape.cs
+++ b/OfficeIMO.Visio/VisioShape.cs
@@ -117,7 +117,7 @@ namespace OfficeIMO.Visio {
         /// <summary>
         /// Gets the universal name of the master.
         /// </summary>
-        public string? MasterNameU => Master?.NameU;
+        public string? MasterNameU => Master?.NameU ?? NameU;
 
         /// <summary>
         /// Gets or sets the X coordinate of the pin.

--- a/OfficeIMO.Visio/VisioValidator.cs
+++ b/OfficeIMO.Visio/VisioValidator.cs
@@ -31,14 +31,11 @@ namespace OfficeIMO.Visio {
         /// <returns>List of validation issues.</returns>
         public static IReadOnlyList<string> Validate(string vsdxPath) {
             List<string> issues = new();
-            using Package pkg = Package.Open(vsdxPath, FileMode.Open, FileAccess.Read, FileShare.Read);
 
-            XDocument ctDoc;
-            using (FileStream zipStream = File.OpenRead(vsdxPath))
-            using (ZipArchive archive = new(zipStream, ZipArchiveMode.Read))
-            using (Stream s = archive.GetEntry("[Content_Types].xml")!.Open()) {
-                ctDoc = XDocument.Load(s);
+            if (!TryLoadZipXml(vsdxPath, "[Content_Types].xml", "content types", issues, out XDocument? ctDoc)) {
+                return issues;
             }
+
             var defaults = ctDoc.Root!.Elements(ct + "Default").ToList();
             var overrides = ctDoc.Root!.Elements(ct + "Override").ToList();
 
@@ -62,33 +59,40 @@ namespace OfficeIMO.Visio {
                 issues.Add("Missing Override for /visio/pages/page1.xml -> application/vnd.ms-visio.page+xml.");
             }
 
-            XDocument rootRels = GetRels(pkg, "/_rels/.rels");
-            XElement? docRel = rootRels.Root!.Elements(pr + "Relationship").FirstOrDefault(r => RelationshipTargetMatches(r, "/visio/document.xml"));
-            if (docRel == null || (string?)docRel.Attribute("Type") != RT_Document) {
-                issues.Add("Root relationship must target /visio/document.xml with Visio document type.");
+            using Package pkg = Package.Open(vsdxPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+            if (TryLoadPackageXml(pkg, "/_rels/.rels", "relationship", issues, out XDocument? rootRels)) {
+                XElement? docRel = rootRels.Root!.Elements(pr + "Relationship").FirstOrDefault(r => RelationshipTargetMatches(r, "/visio/document.xml"));
+                if (docRel == null || (string?)docRel.Attribute("Type") != RT_Document) {
+                    issues.Add("Root relationship must target /visio/document.xml with Visio document type.");
+                }
             }
 
-            XDocument docRels = GetRels(pkg, "/visio/_rels/document.xml.rels");
-            XElement? pagesRel = docRels.Root!.Elements(pr + "Relationship").FirstOrDefault(r => (string?)r.Attribute("Target") == "pages/pages.xml");
-            if (pagesRel == null || (string?)pagesRel.Attribute("Type") != RT_Pages) {
-                issues.Add("document.xml must relate to pages/pages.xml with visio/2010/relationships/pages.");
+            if (TryLoadPackageXml(pkg, "/visio/_rels/document.xml.rels", "relationship", issues, out XDocument? docRels)) {
+                XElement? pagesRel = docRels.Root!.Elements(pr + "Relationship").FirstOrDefault(r => (string?)r.Attribute("Target") == "pages/pages.xml");
+                if (pagesRel == null || (string?)pagesRel.Attribute("Type") != RT_Pages) {
+                    issues.Add("document.xml must relate to pages/pages.xml with visio/2010/relationships/pages.");
+                }
             }
 
-            XDocument pagesXml = LoadXml(pkg, "/visio/pages/pages.xml");
-            IReadOnlyList<XElement> pageElements = pagesXml.Root!
-                .Elements(v + "Page")
-                .ToList();
+            IReadOnlyList<XElement> pageElements = Array.Empty<XElement>();
+            if (TryLoadPackageXml(pkg, "/visio/pages/pages.xml", "Visio", issues, out XDocument? pagesXml)) {
+                pageElements = pagesXml.Root!
+                    .Elements(v + "Page")
+                    .ToList();
 
-            if (pageElements.Count == 0) {
-                issues.Add("pages.xml must contain a Page element.");
+                if (pageElements.Count == 0) {
+                    issues.Add("pages.xml must contain a Page element.");
+                }
             }
 
-            XDocument pagesRels = GetRels(pkg, "/visio/pages/_rels/pages.xml.rels");
             Dictionary<string, XElement> relationshipsById = new(StringComparer.Ordinal);
-            foreach (XElement relElem in pagesRels.Root!.Elements(pr + "Relationship")) {
-                string? relIdAttr = (string?)relElem.Attribute("Id");
-                if (!string.IsNullOrEmpty(relIdAttr)) {
-                    relationshipsById[relIdAttr!] = relElem;
+            if (TryLoadPackageXml(pkg, "/visio/pages/_rels/pages.xml.rels", "relationship", issues, out XDocument? pagesRels)) {
+                foreach (XElement relElem in pagesRels.Root!.Elements(pr + "Relationship")) {
+                    string? relIdAttr = (string?)relElem.Attribute("Id");
+                    if (!string.IsNullOrEmpty(relIdAttr)) {
+                        relationshipsById[relIdAttr!] = relElem;
+                    }
                 }
             }
 
@@ -135,8 +139,7 @@ namespace OfficeIMO.Visio {
 
                     if (!pkg.PartExists(partUri)) {
                         issues.Add($"Page {pageLabel}: Target part '{partName}' referenced by relationship '{rid}' is missing.");
-                    } else if (processedPageParts.Add(partName)) {
-                        XDocument pageXml = LoadXml(pkg, partName);
+                    } else if (processedPageParts.Add(partName) && TryLoadPackageXml(pkg, partName, "Visio", issues, out XDocument? pageXml)) {
                         string? badId = pageXml
                             .Descendants(v + "Shape")
                             .Select(x => (string?)x.Attribute("ID"))
@@ -162,14 +165,45 @@ namespace OfficeIMO.Visio {
             }
         }
 
-        private static XDocument LoadXml(Package pkg, string partName) {
-            using Stream s = pkg.GetPart(new Uri(partName, UriKind.Relative)).GetStream();
-            return XDocument.Load(s);
+        private static bool TryLoadZipXml(string packagePath, string entryName, string partKind, List<string> issues, out XDocument document) {
+            document = null!;
+            try {
+                using FileStream zipStream = File.OpenRead(packagePath);
+                using ZipArchive archive = new(zipStream, ZipArchiveMode.Read);
+                ZipArchiveEntry? entry = archive.GetEntry(entryName);
+                if (entry == null) {
+                    issues.Add($"Missing required Visio {partKind} part '{entryName}'.");
+                    return false;
+                }
+
+                using Stream stream = entry.Open();
+                document = XDocument.Load(stream);
+                return true;
+            } catch (InvalidDataException ex) {
+                issues.Add($"Cannot read Visio package '{packagePath}' as a zip archive: {ex.Message}");
+                return false;
+            } catch (System.Xml.XmlException ex) {
+                issues.Add($"Visio {partKind} part '{entryName}' is not valid XML: {ex.Message}");
+                return false;
+            }
         }
 
-        private static XDocument GetRels(Package pkg, string relsPath) {
-            using Stream s = pkg.GetPart(new Uri(relsPath, UriKind.Relative)).GetStream();
-            return XDocument.Load(s);
+        private static bool TryLoadPackageXml(Package pkg, string partName, string partKind, List<string> issues, out XDocument document) {
+            document = null!;
+            Uri partUri = new(partName, UriKind.Relative);
+            if (!pkg.PartExists(partUri)) {
+                issues.Add($"Missing required Visio {partKind} part '{partName}'.");
+                return false;
+            }
+
+            try {
+                using Stream stream = pkg.GetPart(partUri).GetStream();
+                document = XDocument.Load(stream);
+                return true;
+            } catch (System.Xml.XmlException ex) {
+                issues.Add($"Visio {partKind} part '{partName}' is not valid XML: {ex.Message}");
+                return false;
+            }
         }
 
         private static bool RelationshipTargetMatches(XElement relationship, string expectedAbsolutePartName) {


### PR DESCRIPTION
## Summary
- Report missing or malformed Visio package parts as validation issues instead of throwing
- Harden content type, relationship, pages, and page XML loading in VisioValidator
- Add a high-level sequence diagram builder with participants, lifelines, sync/async/return/self messages, reusable styles, and sequence stencils
- Document the sequence builder in the Visio README

## Validation
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --framework net8.0 --filter FullyQualifiedName~VisioValidation -v minimal
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --framework net8.0 --filter FullyQualifiedName~VisioSequenceDiagramBuilder -v minimal
- dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -c Release --framework net8.0 --filter "FullyQualifiedName~VisioSequenceDiagramBuilder|FullyQualifiedName~VisioValidation" -v minimal
- dotnet build OfficeIMO.Visio/OfficeIMO.Visio.csproj -c Release --no-restore
- git diff --check HEAD~2..HEAD