### PR TITLE
Fix Excel direct save overlay preservation

### DIFF
--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.cs
@@ -819,6 +819,10 @@ namespace OfficeIMO.Excel {
                 int lastRow = sheet.Table.RowCount + (sheet.IncludeHeaders ? 1 : 0);
                 int lastColumn = sheet.Table.ColumnCount;
                 for (int i = 0; i < overlayCells.Count; i++) {
+                    if (overlayCells[i].IsDeleted) {
+                        continue;
+                    }
+
                     lastRow = Math.Max(lastRow, overlayCells[i].Row);
                     lastColumn = Math.Max(lastColumn, overlayCells[i].Column);
                 }
@@ -840,7 +844,7 @@ namespace OfficeIMO.Excel {
                 int row = -1;
                 for (int i = 0; i < overlayCells.Count; i++) {
                     var cell = overlayCells[i];
-                    if (cell.Row <= skipRowsAtOrBefore) {
+                    if (cell.IsDeleted || cell.Row <= skipRowsAtOrBefore) {
                         continue;
                     }
 
@@ -876,6 +880,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 return overlayCells
+                    .Where(static cell => !cell.IsDeleted)
                     .GroupBy(static cell => cell.Row)
                     .ToDictionary(
                         static group => group.Key,
@@ -888,7 +893,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 for (int i = 0; i < overlayCells.Count; i++) {
-                    if (overlayCells[i].Row <= row) {
+                    if (!overlayCells[i].IsDeleted && overlayCells[i].Row <= row) {
                         return true;
                     }
                 }
@@ -1200,6 +1205,10 @@ namespace OfficeIMO.Excel {
                         var overlayCells = model.Sheets[sheetIndex].Metadata?.OverlayCells;
                         if (overlayCells != null) {
                             for (int i = 0; i < overlayCells.Count; i++) {
+                                if (overlayCells[i].IsDeleted) {
+                                    continue;
+                                }
+
                                 AddCustomNumberFormat(overlayCells[i].NumberFormat, customNumberFormats, styleAttributeByFormat);
                             }
                         }

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
@@ -597,7 +597,7 @@ namespace OfficeIMO.Excel {
                     return false;
                 }
 
-                baseMetadata = MergeDirectWorksheetMetadata(baseMetadata, capturedMetadata);
+                baseMetadata = MergeDirectWorksheetMetadata(baseMetadata, capturedMetadata, replaceOverlayCells: true);
             }
 
             DirectWorksheetMetadata? updatedMetadata = updateMetadata(baseMetadata);
@@ -1044,13 +1044,12 @@ namespace OfficeIMO.Excel {
                         candidate.IsDeferred,
                         candidate.SubscribesToSourceChanges);
                     candidate.Dispose();
+                    if (_materializedDirectDataSetFastSaveModel != null) {
+                        _materializedDirectDataSetFastSaveModel = _materializedDirectDataSetFastSaveModel.WithColumnNumberFormat(sheet.Name, columnIndex, numberFormat);
+                        _preserveMaterializedDirectDataSetFastSaveModelForNextDirtyMark = true;
+                    }
                 } else {
                     _materializedDirectDataSetFastSaveModel = model;
-                    _preserveMaterializedDirectDataSetFastSaveModelForNextDirtyMark = true;
-                }
-
-                if (_materializedDirectDataSetFastSaveModel != null) {
-                    _materializedDirectDataSetFastSaveModel = _materializedDirectDataSetFastSaveModel.WithColumnNumberFormat(sheet.Name, columnIndex, numberFormat);
                     _preserveMaterializedDirectDataSetFastSaveModelForNextDirtyMark = true;
                 }
 
@@ -1341,8 +1340,8 @@ namespace OfficeIMO.Excel {
                 }
 
                 DirectWorksheetMetadata? preservedMetadata = null;
-                if (TryCaptureDirectWorksheetMetadata(sheetModel, out DirectWorksheetMetadata? sheetMetadata, out _, allowDrawings: true)) {
-                    preservedMetadata = MergeDirectWorksheetMetadata(sheetModel.Metadata, sheetMetadata);
+                if (TryCaptureDirectWorksheetMetadata(sheetModel, out DirectWorksheetMetadata? sheetMetadata, out _, allowDrawings: true, allowUnsupportedOverlayStyles: true)) {
+                    preservedMetadata = MergeDirectWorksheetMetadata(sheetModel.Metadata, sheetMetadata, replaceOverlayCells: true);
                 }
 
                 ResetWorksheetForDirectDataSetMaterialization(sheet.WorksheetPart);
@@ -1668,11 +1667,11 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
-            if (!CanCreateDirectPackageModel(candidate.Model, out _, allowDrawings: true)) {
+            if (!TryCreateDirectPackageModel(candidate.Model, out DirectDataSetWorkbookModel packageModel, out _, allowDrawings: true)) {
                 return;
             }
 
-            _materializedDirectDataSetFastSaveModel = candidate.Model;
+            _materializedDirectDataSetFastSaveModel = packageModel;
             _preserveMaterializedDirectDataSetFastSaveModelForNextDirtyMark = true;
             _directDataSetSaveCandidate = null;
             candidate.Dispose();
@@ -1957,7 +1956,7 @@ namespace OfficeIMO.Excel {
                     return false;
                 }
 
-                sheetMetadata = MergeDirectWorksheetMetadata(sheetModel.Metadata, sheetMetadata);
+                sheetMetadata = MergeDirectWorksheetMetadata(sheetModel.Metadata, sheetMetadata, replaceOverlayCells: true);
                 if (sheetMetadata?.IsEmpty == false) {
                     metadata ??= new DirectWorksheetMetadata?[sourceModel.Sheets.Count];
                     metadata[i] = sheetMetadata;
@@ -1965,17 +1964,6 @@ namespace OfficeIMO.Excel {
             }
 
             model = metadata != null ? sourceModel.WithWorksheetMetadata(metadata) : sourceModel;
-            skipReason = null;
-            return true;
-        }
-
-        private bool CanCreateDirectPackageModel(DirectDataSetWorkbookModel sourceModel, out string? skipReason, bool allowDrawings = false) {
-            for (int i = 0; i < sourceModel.Sheets.Count; i++) {
-                if (!CanCaptureDirectWorksheetMetadata(sourceModel.Sheets[i], out skipReason, allowDrawings)) {
-                    return false;
-                }
-            }
-
             skipReason = null;
             return true;
         }
@@ -1995,16 +1983,32 @@ namespace OfficeIMO.Excel {
             return true;
         }
 
-        private static DirectWorksheetMetadata? MergeDirectWorksheetMetadata(DirectWorksheetMetadata? existing, DirectWorksheetMetadata? captured) {
+        private static DirectWorksheetMetadata? MergeDirectWorksheetMetadata(DirectWorksheetMetadata? existing, DirectWorksheetMetadata? captured, bool replaceOverlayCells = false) {
             if (existing == null || existing.IsEmpty) {
-                return captured?.IsEmpty == true ? null : captured;
+                return NormalizeDirectWorksheetMetadata(captured);
             }
 
             if (captured == null || captured.IsEmpty) {
-                return existing;
+                if (replaceOverlayCells && existing.OverlayCells.Count > 0) {
+                    return NormalizeDirectWorksheetMetadata(new DirectWorksheetMetadata(
+                        existing.SheetPropertiesXml,
+                        existing.SheetViewsXml,
+                        existing.SheetFormatPropertiesXml,
+                        existing.AutoFilterXml,
+                        existing.ConditionalFormattingXml,
+                        existing.DataValidationsXml,
+                        existing.DrawingXml,
+                        existing.PostDataValidationXml,
+                        Array.Empty<DirectOverlayCell>()));
+                }
+
+                return NormalizeDirectWorksheetMetadata(existing);
             }
 
-            return new DirectWorksheetMetadata(
+            IReadOnlyList<DirectOverlayCell> overlayCells = replaceOverlayCells
+                ? captured.OverlayCells
+                : CombineOverlayCells(existing.OverlayCells, captured.OverlayCells);
+            return NormalizeDirectWorksheetMetadata(new DirectWorksheetMetadata(
                 existing.SheetPropertiesXml ?? captured.SheetPropertiesXml,
                 existing.SheetViewsXml ?? captured.SheetViewsXml,
                 existing.SheetFormatPropertiesXml ?? captured.SheetFormatPropertiesXml,
@@ -2013,7 +2017,45 @@ namespace OfficeIMO.Excel {
                 existing.DataValidationsXml ?? captured.DataValidationsXml,
                 existing.DrawingXml ?? captured.DrawingXml,
                 CombineMetadataXmlLists(existing.PostDataValidationXml, captured.PostDataValidationXml),
-                CombineOverlayCells(existing.OverlayCells, captured.OverlayCells));
+                overlayCells));
+        }
+
+        private static DirectWorksheetMetadata? NormalizeDirectWorksheetMetadata(DirectWorksheetMetadata? metadata) {
+            if (metadata == null) {
+                return null;
+            }
+
+            IReadOnlyList<DirectOverlayCell> overlayCells = metadata.OverlayCells;
+            if (overlayCells.Count > 0) {
+                List<DirectOverlayCell>? retainedOverlayCells = null;
+                for (int i = 0; i < overlayCells.Count; i++) {
+                    if (overlayCells[i].IsDeleted) {
+                        retainedOverlayCells ??= new List<DirectOverlayCell>(overlayCells.Count);
+                        for (int previous = 0; previous < i; previous++) {
+                            retainedOverlayCells.Add(overlayCells[previous]);
+                        }
+
+                        continue;
+                    }
+
+                    retainedOverlayCells?.Add(overlayCells[i]);
+                }
+
+                if (retainedOverlayCells != null) {
+                    metadata = new DirectWorksheetMetadata(
+                        metadata.SheetPropertiesXml,
+                        metadata.SheetViewsXml,
+                        metadata.SheetFormatPropertiesXml,
+                        metadata.AutoFilterXml,
+                        metadata.ConditionalFormattingXml,
+                        metadata.DataValidationsXml,
+                        metadata.DrawingXml,
+                        metadata.PostDataValidationXml,
+                        retainedOverlayCells.Count == 0 ? Array.Empty<DirectOverlayCell>() : retainedOverlayCells.ToArray());
+                }
+            }
+
+            return metadata.IsEmpty ? null : metadata;
         }
 
         private static IReadOnlyList<string> CombineMetadataXmlLists(IReadOnlyList<string> first, IReadOnlyList<string> second) {
@@ -2057,7 +2099,12 @@ namespace OfficeIMO.Excel {
                 .ToArray();
         }
 
-        private bool TryCaptureDirectWorksheetMetadata(DirectDataSetSheetModel sheetModel, out DirectWorksheetMetadata? metadata, out string? skipReason, bool allowDrawings = false) {
+        private bool TryCaptureDirectWorksheetMetadata(
+            DirectDataSetSheetModel sheetModel,
+            out DirectWorksheetMetadata? metadata,
+            out string? skipReason,
+            bool allowDrawings = false,
+            bool allowUnsupportedOverlayStyles = false) {
             metadata = null;
             skipReason = null;
 
@@ -2130,7 +2177,9 @@ namespace OfficeIMO.Excel {
                     case SheetDimension:
                         break;
                     case SheetData sheetData:
-                        overlayCells = CaptureDirectWorksheetOverlayCells(sheet, sheetModel, sheetData, _spreadSheetDocument.WorkbookPart?.WorkbookStylesPart?.Stylesheet);
+                        if (!TryCaptureDirectWorksheetOverlayCells(sheet, sheetModel, sheetData, _spreadSheetDocument.WorkbookPart?.WorkbookStylesPart?.Stylesheet, allowUnsupportedOverlayStyles, out overlayCells, out skipReason)) {
+                            return false;
+                        }
                         break;
                     case SheetViews sheetViews when sheetViewsXml == null:
                         sheetViewsXml = sheetViews.OuterXml;
@@ -2200,101 +2249,19 @@ namespace OfficeIMO.Excel {
             return true;
         }
 
-        private bool CanCaptureDirectWorksheetMetadata(DirectDataSetSheetModel sheetModel, out string? skipReason, bool allowDrawings = false) {
+        private static bool TryCaptureDirectWorksheetOverlayCells(
+            ExcelSheet sheet,
+            DirectDataSetSheetModel sheetModel,
+            SheetData sheetData,
+            Stylesheet? stylesheet,
+            bool allowUnsupportedOverlayStyles,
+            out IReadOnlyList<DirectOverlayCell> overlayCells,
+            out string? skipReason) {
+            overlayCells = Array.Empty<DirectOverlayCell>();
             skipReason = null;
-
-            ExcelSheet? sheet = null;
-            var metadataSourceSheet = _directDataSetMetadataSourceSheet;
-            if (metadataSourceSheet != null
-                && ReferenceEquals(metadataSourceSheet.Document, this)
-                && string.Equals(metadataSourceSheet.Name, sheetModel.SheetName, StringComparison.Ordinal)) {
-                sheet = metadataSourceSheet;
-            }
-
-            sheet ??= TryGetExistingSheet(sheetModel.SheetName);
-            if (sheet == null) {
-                return true;
-            }
-
-            var worksheetPart = sheet.DeferredMetadataWorksheetPart;
-            if (worksheetPart.DrawingsPart != null && !allowDrawings) {
-                skipReason = "Worksheet contains drawings.";
-                return false;
-            }
-
-            if (worksheetPart.WorksheetCommentsPart != null) {
-                skipReason = "Worksheet contains comments.";
-                return false;
-            }
-
-            if (worksheetPart.ExternalRelationships.Any()) {
-                skipReason = "Worksheet contains external relationships.";
-                return false;
-            }
-
-            if (worksheetPart.HyperlinkRelationships.Any()) {
-                skipReason = "Worksheet contains hyperlink relationships.";
-                return false;
-            }
-
-            foreach (var tableDefinitionPart in worksheetPart.TableDefinitionParts) {
-                if (!sheetModel.HasTable) {
-                    skipReason = "Worksheet contains table metadata outside the direct table model.";
-                    return false;
-                }
-
-                var tableAutoFilter = tableDefinitionPart.Table?.Elements<AutoFilter>().FirstOrDefault();
-                if (tableAutoFilter != null && tableAutoFilter.HasChildren) {
-                    skipReason = "Worksheet contains table AutoFilter criteria outside the direct table model.";
-                    return false;
-                }
-            }
-
-            var worksheet = worksheetPart.Worksheet;
-            if (worksheet == null) {
-                return true;
-            }
-
-            foreach (var child in worksheet.ChildElements) {
-                switch (child) {
-                    case SheetProperties:
-                    case SheetDimension:
-                    case SheetData:
-                    case SheetViews:
-                    case SheetFormatProperties:
-                    case AutoFilter:
-                    case DocumentFormat.OpenXml.Spreadsheet.ConditionalFormatting:
-                    case DataValidations:
-                    case PrintOptions:
-                    case PageMargins:
-                    case PageSetup:
-                    case HeaderFooter:
-                    case RowBreaks:
-                    case ColumnBreaks:
-                    case CellWatches:
-                    case DocumentFormat.OpenXml.Spreadsheet.IgnoredErrors:
-                        break;
-                    case Columns when sheetModel.ColumnWidths is { Length: > 0 }:
-                        break;
-                    case Columns:
-                        skipReason = "Worksheet contains column metadata outside the direct DataSet column width model.";
-                        return false;
-                    case DocumentFormat.OpenXml.Spreadsheet.Drawing when allowDrawings:
-                        break;
-                    case TableParts when sheetModel.HasTable:
-                        break;
-                    default:
-                        skipReason = "Worksheet contains unsupported element '" + child.LocalName + "' for the direct DataSet package writer.";
-                        return false;
-                }
-            }
-
-            return true;
-        }
-
-        private static IReadOnlyList<DirectOverlayCell> CaptureDirectWorksheetOverlayCells(ExcelSheet sheet, DirectDataSetSheetModel sheetModel, SheetData sheetData, Stylesheet? stylesheet) {
             int directLastRow = sheetModel.Table.RowCount + (sheetModel.IncludeHeaders ? 1 : 0);
             List<DirectOverlayCell>? cells = null;
+            Dictionary<uint, DirectOverlayStyleResolution>? styleResolutionCache = null;
             int nextRowIndex = 1;
             foreach (var row in sheetData.Elements<Row>()) {
                 int rowIndex = row.RowIndex?.Value is uint explicitRow ? checked((int)explicitRow) : nextRowIndex;
@@ -2317,29 +2284,90 @@ namespace OfficeIMO.Excel {
                         continue;
                     }
 
+                    if (!TryResolveDirectOverlayNumberFormat(stylesheet, cell, allowUnsupportedOverlayStyles, ref styleResolutionCache, out string? numberFormat)) {
+                        skipReason = "Worksheet contains overlay cell style metadata outside the direct DataSet style model.";
+                        return false;
+                    }
+
                     cells ??= new List<DirectOverlayCell>();
-                    cells.Add(new DirectOverlayCell(cellRow, cellColumn, value, cell.StyleIndex?.Value, ResolveDirectOverlayNumberFormat(stylesheet, cell)));
+                    cells.Add(new DirectOverlayCell(cellRow, cellColumn, value, cell.StyleIndex?.Value, numberFormat));
                 }
             }
 
-            return cells ?? (IReadOnlyList<DirectOverlayCell>)Array.Empty<DirectOverlayCell>();
+            overlayCells = cells ?? (IReadOnlyList<DirectOverlayCell>)Array.Empty<DirectOverlayCell>();
+            return true;
         }
 
-        private static string? ResolveDirectOverlayNumberFormat(Stylesheet? stylesheet, Cell cell) {
+        private static bool TryResolveDirectOverlayNumberFormat(
+            Stylesheet? stylesheet,
+            Cell cell,
+            bool allowUnsupportedOverlayStyles,
+            ref Dictionary<uint, DirectOverlayStyleResolution>? styleResolutionCache,
+            out string? numberFormat) {
+            numberFormat = null;
             if (cell.StyleIndex?.Value is not uint styleIndex) {
-                return null;
+                return true;
+            }
+
+            styleResolutionCache ??= new Dictionary<uint, DirectOverlayStyleResolution>();
+            if (!styleResolutionCache.TryGetValue(styleIndex, out var resolution)) {
+                bool supported = TryResolveDirectOverlayStyle(stylesheet, styleIndex, allowUnsupportedOverlayStyles, out string? resolvedNumberFormat);
+                resolution = new DirectOverlayStyleResolution(supported, resolvedNumberFormat);
+                styleResolutionCache.Add(styleIndex, resolution);
+            }
+
+            numberFormat = resolution.NumberFormat;
+            return resolution.Supported;
+        }
+
+        private static bool TryResolveDirectOverlayStyle(Stylesheet? stylesheet, uint styleIndex, bool allowUnsupportedOverlayStyles, out string? numberFormat) {
+            numberFormat = null;
+            if (styleIndex == 0U) {
+                return true;
+            }
+
+            if (stylesheet == null) {
+                return false;
             }
 
             var cellFormat = stylesheet?.CellFormats?.Elements<CellFormat>().ElementAtOrDefault((int)styleIndex);
-            if (cellFormat?.NumberFormatId?.Value is not uint numberFormatId || numberFormatId == 0U) {
-                return null;
+            if (cellFormat == null) {
+                return allowUnsupportedOverlayStyles;
+            }
+
+            if (HasUnsupportedDirectOverlayStyle(cellFormat)) {
+                return allowUnsupportedOverlayStyles;
+            }
+
+            if (cellFormat.NumberFormatId?.Value is not uint numberFormatId || numberFormatId == 0U) {
+                return true;
             }
 
             string? customFormat = stylesheet?.NumberingFormats?.Elements<NumberingFormat>()
                 .FirstOrDefault(format => format.NumberFormatId?.Value == numberFormatId)
                 ?.FormatCode
                 ?.Value;
-            return customFormat ?? ResolveBuiltInNumberFormatCode(numberFormatId);
+            numberFormat = customFormat ?? ResolveBuiltInNumberFormatCode(numberFormatId);
+            return numberFormat != null;
+        }
+
+        private static bool HasUnsupportedDirectOverlayStyle(CellFormat cellFormat) {
+            if ((cellFormat.FontId?.Value ?? 0U) != 0U
+                || (cellFormat.FillId?.Value ?? 0U) != 0U
+                || (cellFormat.BorderId?.Value ?? 0U) != 0U
+                || (cellFormat.ApplyFont?.Value ?? false)
+                || (cellFormat.ApplyFill?.Value ?? false)
+                || (cellFormat.ApplyBorder?.Value ?? false)
+                || (cellFormat.ApplyAlignment?.Value ?? false)
+                || (cellFormat.ApplyProtection?.Value ?? false)
+                || (cellFormat.QuotePrefix?.Value ?? false)
+                || (cellFormat.PivotButton?.Value ?? false)
+                || cellFormat.Alignment != null
+                || cellFormat.Protection != null) {
+                return true;
+            }
+
+            return false;
         }
 
         private static string? ResolveBuiltInNumberFormatCode(uint numberFormatId) {
@@ -3108,6 +3136,17 @@ namespace OfficeIMO.Excel {
             internal string? NumberFormat { get; }
 
             internal bool IsDeleted { get; }
+        }
+
+        private readonly struct DirectOverlayStyleResolution {
+            internal DirectOverlayStyleResolution(bool supported, string? numberFormat) {
+                Supported = supported;
+                NumberFormat = numberFormat;
+            }
+
+            internal bool Supported { get; }
+
+            internal string? NumberFormat { get; }
         }
 
         private readonly struct DirectBufferedRows {
@@ -4234,6 +4273,7 @@ namespace OfficeIMO.Excel {
             private readonly DataSet _dataSet;
             private readonly Action _invalidate;
             private readonly bool _subscribed;
+            private readonly HashSet<DataTable> _subscribedTables = new();
             private bool _disposed;
 
             internal DirectDataSetSaveCandidate(DataSet dataSet, DirectDataSetWorkbookModel model, Action invalidate, bool isDeferred, bool subscribeToSourceChanges) {
@@ -4267,6 +4307,10 @@ namespace OfficeIMO.Excel {
             }
 
             private void Subscribe(DataTable table) {
+                if (!_subscribedTables.Add(table)) {
+                    return;
+                }
+
                 table.Columns.CollectionChanged += OnCollectionChanged;
                 table.RowChanged += OnDataChanged;
                 table.RowChanging += OnDataChanging;
@@ -4280,12 +4324,16 @@ namespace OfficeIMO.Excel {
 
             private void Unsubscribe(DataSet dataSet) {
                 dataSet.Tables.CollectionChanged -= OnCollectionChanged;
-                foreach (DataTable table in dataSet.Tables) {
+                foreach (DataTable table in _subscribedTables.ToArray()) {
                     Unsubscribe(table);
                 }
             }
 
             private void Unsubscribe(DataTable table) {
+                if (!_subscribedTables.Remove(table)) {
+                    return;
+                }
+
                 table.Columns.CollectionChanged -= OnCollectionChanged;
                 table.RowChanged -= OnDataChanged;
                 table.RowChanging -= OnDataChanging;

--- a/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
+++ b/OfficeIMO.Tests/Excel.PerformanceReviewRegression.cs
@@ -1397,6 +1397,48 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PerformanceReview_InsertDataSet_DisposedCandidateUnsubscribesRemovedSourceTable() {
+            var dataSet = new DataSet("Export");
+            var table = new DataTable("Items");
+            table.Columns.Add("Name", typeof(string));
+            table.Rows.Add("Original");
+            dataSet.Tables.Add(table);
+
+            using var document = ExcelDocument.Create(new MemoryStream(), autoSave: false);
+            typeof(ExcelDocument).GetMethod("RegisterDirectDataSetSaveCandidate", BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(
+                document,
+                new object[] {
+                    dataSet,
+                    true,
+                    OfficeIMO.Excel.TableStyle.TableStyleMedium2,
+                    true,
+                    true,
+                    false,
+                    Array.Empty<ExcelDataSetImportResult>()
+                });
+
+            var candidateField = typeof(ExcelDocument).GetField("_directDataSetSaveCandidate", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            object? candidate = candidateField.GetValue(document);
+            Assert.NotNull(candidate);
+            var subscribeTableMethod = candidate.GetType()
+                .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+                .Single(method => method.Name == "Subscribe"
+                    && method.GetParameters() is { Length: 1 } parameters
+                    && parameters[0].ParameterType == typeof(DataTable));
+            subscribeTableMethod.Invoke(candidate, new object[] { table });
+            var subscribedTablesField = candidate.GetType().GetField("_subscribedTables", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var subscribedTables = Assert.IsAssignableFrom<ICollection<DataTable>>(subscribedTablesField.GetValue(candidate));
+            Assert.Contains(table, subscribedTables);
+
+            dataSet.Tables.Remove(table);
+
+            ((IDisposable)candidate).Dispose();
+
+            Assert.Empty(subscribedTables);
+            table.Rows.Add("Late");
+        }
+
+        [Fact]
         public void PerformanceReview_InsertDataSet_WorkbookMutationInvalidatesDirectDataSetPackageCandidate() {
             string filePath = Path.Combine(_directoryWithFiles, "PerformanceReview.InsertDataSetDirectSaveWorkbookMutation.xlsx");
             var dataSet = new DataSet("Export");
@@ -4339,6 +4381,95 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PerformanceReview_InsertObjects_DirectOverlayRichStyleFallsBackAndPersists() {
+            using var memory = new MemoryStream();
+            var rows = new[] {
+                new PerformanceObjectExportRow("North", 10, new DateTime(2026, 5, 19)),
+                new PerformanceObjectExportRow("South", 20, new DateTime(2026, 5, 20)),
+                new PerformanceObjectExportRow("East", 30, new DateTime(2026, 5, 21))
+            };
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertObjects(rows,
+                    ("Name", row => row.Name),
+                    ("Score", row => row.Score),
+                    ("Created", row => row.Created));
+                sheet.CellValue(2, 4, "Styled side note");
+
+                uint styleIndex = AddBoldCellStyle(document._spreadSheetDocument);
+                var sourceCells = sheet.WorksheetPart.Worksheet.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+                sourceCells["D2"].StyleIndex = styleIndex;
+
+                document.Save(memory);
+
+                Assert.NotEqual(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+            }
+
+            AssertRichOverlayStylePersisted(memory);
+        }
+
+        [Fact]
+        public void PerformanceReview_InsertObjects_MaterializationPreservesRichOverlayStyle() {
+            using var memory = new MemoryStream();
+            var rows = new[] {
+                new PerformanceObjectExportRow("North", 10, new DateTime(2026, 5, 19)),
+                new PerformanceObjectExportRow("South", 20, new DateTime(2026, 5, 20)),
+                new PerformanceObjectExportRow("East", 30, new DateTime(2026, 5, 21))
+            };
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertObjects(rows,
+                    ("Name", row => row.Name),
+                    ("Score", row => row.Score),
+                    ("Created", row => row.Created));
+                sheet.CellValue(2, 4, "Styled side note");
+
+                uint styleIndex = AddBoldCellStyle(document._spreadSheetDocument);
+                var sourceCells = sheet.WorksheetPart.Worksheet.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+                sourceCells["D2"].StyleIndex = styleIndex;
+
+                document.MaterializeDeferredDataSetImport();
+                document.Save(memory);
+            }
+
+            AssertRichOverlayStylePersisted(memory);
+        }
+
+        [Fact]
+        public void PerformanceReview_InsertObjects_ChartFallbackPreservesRichOverlayStyle() {
+            using var memory = new MemoryStream();
+            var rows = new[] {
+                new PerformanceObjectExportRow("North", 10, new DateTime(2026, 5, 19)),
+                new PerformanceObjectExportRow("South", 20, new DateTime(2026, 5, 20)),
+                new PerformanceObjectExportRow("East", 30, new DateTime(2026, 5, 21))
+            };
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertObjects(rows,
+                    ("Name", row => row.Name),
+                    ("Score", row => row.Score),
+                    ("Created", row => row.Created));
+                sheet.CellValue(2, 4, "Styled side note");
+
+                uint styleIndex = AddBoldCellStyle(document._spreadSheetDocument);
+                var sourceCells = sheet.WorksheetPart.Worksheet.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+                sourceCells["D2"].StyleIndex = styleIndex;
+
+                var chartData = new ExcelChartData(
+                    rows.Select(row => row.Name),
+                    new[] { new ExcelChartSeries("Score", rows.Select(row => (double)row.Score)) });
+                sheet.AddChart(chartData, row: 2, column: 6, widthPixels: 480, heightPixels: 280, type: ExcelChartType.ColumnClustered, title: "Scores");
+
+                document.Save(memory);
+            }
+
+            AssertRichOverlayStylePersisted(memory);
+        }
+
+        [Fact]
         public void PerformanceReview_InsertObjects_DirectOverlayClearRemovesPreservedCell() {
             using var firstMemory = new MemoryStream();
             using var secondMemory = new MemoryStream();
@@ -4372,6 +4503,48 @@ namespace OfficeIMO.Tests {
             var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
             var cells = worksheetPart.Worksheet.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
             Assert.True(!cells.ContainsKey("D2") || string.IsNullOrEmpty(GetSpreadsheetCellText(spreadsheet, cells["D2"])));
+            Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
+        }
+
+        [Fact]
+        public void PerformanceReview_InsertObjects_DirectOverlayClearBeyondTableDoesNotPreserveStaleValue() {
+            using var firstMemory = new MemoryStream();
+            using var secondMemory = new MemoryStream();
+            var rows = new[] {
+                new PerformanceObjectExportRow("North", 10, new DateTime(2026, 5, 19)),
+                new PerformanceObjectExportRow("South", 20, new DateTime(2026, 5, 20)),
+                new PerformanceObjectExportRow("East", 30, new DateTime(2026, 5, 21))
+            };
+
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.InsertObjects(rows,
+                    ("Name", row => row.Name),
+                    ("Score", row => row.Score),
+                    ("Created", row => row.Created));
+                sheet.AddTable("A1:C4", hasHeader: true, name: "ReportData", style: OfficeIMO.Excel.TableStyle.TableStyleMedium4, includeAutoFilter: true);
+                sheet.AddPivotTable(
+                    "A1:C4",
+                    "F20",
+                    rowFields: new[] { "Name" },
+                    dataFields: new[] { new ExcelPivotDataField("Score", DataConsolidateFunctionValues.Sum, "Total Score") });
+                sheet.CellValue(10, 4, "Manual");
+
+                document.Save(firstMemory);
+
+                sheet.CellValue(10, 4, (object?)null);
+
+                document.Save(secondMemory);
+
+                Assert.Equal(ExcelSavePackageWriter.ExtendedPackage, document.LastSaveDiagnostics.Writer);
+                Assert.True(document.LastSaveDiagnostics.UsedFastPackageWriter);
+            }
+
+            secondMemory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(secondMemory, false);
+            var worksheet = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet!;
+            var cells = worksheet.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+            Assert.True(!cells.ContainsKey("D10") || string.IsNullOrEmpty(GetSpreadsheetCellText(spreadsheet, cells["D10"])));
             Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
         }
 
@@ -6655,6 +6828,58 @@ namespace OfficeIMO.Tests {
                 document,
                 document._spreadSheetDocument,
                 new Sheet { Name = sheetName, Id = relationshipId, SheetId = 9999U });
+        }
+
+        private static uint AddBoldCellStyle(SpreadsheetDocument document) {
+            var stylesPart = document.WorkbookPart!.WorkbookStylesPart ?? document.WorkbookPart.AddNewPart<WorkbookStylesPart>();
+            stylesPart.Stylesheet ??= new Stylesheet(
+                new Fonts(new Font()),
+                new Fills(
+                    new Fill(new PatternFill { PatternType = PatternValues.None }),
+                    new Fill(new PatternFill { PatternType = PatternValues.Gray125 })),
+                new Borders(new Border()),
+                new CellFormats(new CellFormat()));
+
+            var stylesheet = stylesPart.Stylesheet;
+            stylesheet.Fonts ??= new Fonts(new Font());
+            stylesheet.Fills ??= new Fills(
+                new Fill(new PatternFill { PatternType = PatternValues.None }),
+                new Fill(new PatternFill { PatternType = PatternValues.Gray125 }));
+            stylesheet.Borders ??= new Borders(new Border());
+            stylesheet.CellFormats ??= new CellFormats(new CellFormat());
+
+            uint fontId = (uint)stylesheet.Fonts.Elements<Font>().Count();
+            stylesheet.Fonts.Append(new Font(new Bold()));
+            stylesheet.Fonts.Count = (uint)stylesheet.Fonts.Elements<Font>().Count();
+
+            uint styleIndex = (uint)stylesheet.CellFormats.Elements<CellFormat>().Count();
+            stylesheet.CellFormats.Append(new CellFormat {
+                FontId = fontId,
+                FillId = 0U,
+                BorderId = 0U,
+                ApplyFont = true
+            });
+            stylesheet.CellFormats.Count = (uint)stylesheet.CellFormats.Elements<CellFormat>().Count();
+            stylesheet.Save();
+            return styleIndex;
+        }
+
+        private static void AssertRichOverlayStylePersisted(MemoryStream memory) {
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts
+                .Single(part => part.Worksheet.Descendants<Cell>().Any(cell => string.Equals(cell.CellReference?.Value, "D2", StringComparison.Ordinal)));
+            var cells = worksheetPart.Worksheet.Descendants<Cell>().ToDictionary(cell => cell.CellReference!.Value!);
+            Assert.Equal("North", GetSpreadsheetCellText(spreadsheet, cells["A2"]));
+            Assert.Equal("Styled side note", GetSpreadsheetCellText(spreadsheet, cells["D2"]));
+            Assert.NotNull(cells["D2"].StyleIndex);
+            var stylesheet = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+            var cellFormat = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt((int)cells["D2"].StyleIndex!.Value);
+            Assert.NotNull(cellFormat.FontId);
+            Assert.NotEqual(0U, cellFormat.FontId!.Value);
+            var font = stylesheet.Fonts!.Elements<Font>().ElementAt((int)cellFormat.FontId.Value);
+            Assert.NotNull(font.Bold);
+            Assert.Empty(new OpenXmlValidator().Validate(spreadsheet).ToList());
         }
 
         private static string? GetCellNumberFormatCode(SpreadsheetDocument spreadsheet, Cell cell) {


### PR DESCRIPTION
## Summary
- fixes direct DataSet fast-save metadata refresh so freshly captured overlay cells replace stale overlay snapshots
- rejects unsupported rich overlay styles for direct package writes while preserving them in materialization/extended fallback paths
- prevents deleted overlay markers from affecting direct writer dimensions, row grouping, and style planning
- hardens source DataTable event unsubscription for removed tables

## Validation
- dotnet build .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-restore -v:quiet /clp:ErrorsOnly
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-build --filter "DirectOverlayClearBeyondTableDoesNotPreserveStaleValue|DirectOverlayClearRemovesPreservedCell|DirectOverlayRichStyleFallsBackAndPersists|MaterializationPreservesRichOverlayStyle|ChartFallbackPreservesRichOverlayStyle|DirectOverlayNumberFormatRemapsIntoDirectStyles|DisposedCandidateUnsubscribesRemovedSourceTable" --logger "console;verbosity=normal"
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-build --filter "PerformanceReview" --logger "console;verbosity=minimal"
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --no-build --filter "FullyQualifiedName~OfficeIMO.Tests.Excel" --logger "console;verbosity=minimal"
- git diff --check