### PR TITLE
Fix Excel line chart data label repair

### DIFF
--- a/OfficeIMO.Excel/ExcelChart.cs
+++ b/OfficeIMO.Excel/ExcelChart.cs
@@ -2269,7 +2269,7 @@ namespace OfficeIMO.Excel {
             ReplaceChild(labels, new C.ShowBubbleSize { Val = false });
 
             if (position != null) {
-                ReplaceChild(labels, new C.DataLabelPosition { Val = position.Value });
+                ReplaceChild(labels, new C.DataLabelPosition { Val = NormalizeDataLabelPosition(chartElement, position.Value) });
             }
 
             if (numberFormat != null) {
@@ -2646,7 +2646,7 @@ namespace OfficeIMO.Excel {
                 ReplaceChild(label, new C.ShowBubbleSize { Val = showBubbleSize.Value });
             }
             if (position != null) {
-                ReplaceChild(label, new C.DataLabelPosition { Val = position.Value });
+                ReplaceChild(label, new C.DataLabelPosition { Val = NormalizeDataLabelPosition(label, position.Value) });
             }
             if (numberFormat != null) {
                 ReplaceChild(label, new C.NumberingFormat {
@@ -2677,6 +2677,21 @@ namespace OfficeIMO.Excel {
             } else if (label is C.DataLabel dataLabel) {
                 NormalizeDataLabelOrder(dataLabel);
             }
+        }
+
+        private static C.DataLabelPositionValues NormalizeDataLabelPosition(OpenXmlElement context, C.DataLabelPositionValues position) {
+            if (position != C.DataLabelPositionValues.OutsideEnd) {
+                return position;
+            }
+
+            // Excel repairs line charts that contain an outEnd data label position.
+            for (OpenXmlElement? current = context; current != null; current = current.Parent) {
+                if (current is C.LineChart || current is C.Line3DChart || current is C.LineChartSeries) {
+                    return C.DataLabelPositionValues.Top;
+                }
+            }
+
+            return position;
         }
 
         private static void ApplyDataLabelTemplate(OpenXmlCompositeElement series, ExcelChartDataLabelTemplate template) {

--- a/OfficeIMO.Tests/Excel.Charts.cs
+++ b/OfficeIMO.Tests/Excel.Charts.cs
@@ -1666,6 +1666,23 @@ namespace OfficeIMO.Tests {
                 OpenXmlValidator validator = new OpenXmlValidator(FileFormatVersions.Microsoft365);
                 var errors = validator.Validate(spreadsheet).ToList();
                 Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+
+                WorksheetPart worksheetPart = GetWorksheetPartWithCharts(spreadsheet);
+                var lineChart = worksheetPart.DrawingsPart!.ChartParts
+                    .SelectMany(part => part.ChartSpace.Descendants<C.LineChart>())
+                    .First();
+                var lineSeries = lineChart.Elements<C.LineChartSeries>().First();
+                var pointLabel = lineSeries.GetFirstChild<C.DataLabels>()!
+                    .Elements<C.DataLabel>()
+                    .First(label => label.GetFirstChild<C.Index>()?.Val?.Value == 2U);
+                Assert.Equal(
+                    C.DataLabelPositionValues.Top,
+                    pointLabel.GetFirstChild<C.DataLabelPosition>()!.Val!.Value);
+            }
+
+            if (IsWindowsPlatform()) {
+                AssertWorkbookOpensViaExcelComWhenAvailable(filePath,
+                    "Excel repaired the combo/scatter chart workbook. Line chart point labels must not emit outEnd positions.");
             }
         }
 

--- a/OfficeIMO.Tests/Excel.ComValidation.cs
+++ b/OfficeIMO.Tests/Excel.ComValidation.cs
@@ -1,0 +1,202 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading;
+#if NET5_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using OfficeColor = OfficeIMO.Drawing.OfficeColor;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        private static readonly TimeSpan ExcelComOpenTimeout = TimeSpan.FromMinutes(2);
+
+#if NET5_0_OR_GREATER
+        [SupportedOSPlatformGuard("windows")]
+#endif
+        private static bool IsWindowsPlatform() =>
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+#if NET5_0_OR_GREATER
+        [SupportedOSPlatform("windows")]
+#endif
+        private static bool IsExcelComAvailable() =>
+            Type.GetTypeFromProgID("Excel.Application") != null;
+
+#if NET5_0_OR_GREATER
+        [SupportedOSPlatform("windows")]
+#endif
+        private static void AssertWorkbookOpensViaExcelComWhenAvailable(string path, string failureMessage) =>
+            AssertWorkbooksOpenViaExcelComWhenAvailable(new[] { path }, failureMessage);
+
+#if NET5_0_OR_GREATER
+        [SupportedOSPlatform("windows")]
+#endif
+        private static void AssertWorkbooksOpenViaExcelComWhenAvailable(IEnumerable<string> paths, string failureMessage) {
+            if (!IsExcelComAvailable()) {
+                return;
+            }
+
+            List<string> failures = new();
+            var thread = new Thread(() => OpenWorkbooksViaExcelCom(paths.ToList(), failures));
+            thread.IsBackground = true;
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            if (!thread.Join(ExcelComOpenTimeout)) {
+                failures.Add($"Excel COM smoke test timed out after {ExcelComOpenTimeout.TotalSeconds:0} seconds.");
+            }
+
+            Assert.True(failures.Count == 0, failureMessage + Environment.NewLine + string.Join(Environment.NewLine, failures));
+        }
+
+#if NET5_0_OR_GREATER
+        [SupportedOSPlatform("windows")]
+#endif
+        private static void OpenWorkbooksViaExcelCom(IReadOnlyList<string> paths, List<string> failures) {
+            object? excel = null;
+            object? workbooks = null;
+
+            try {
+                var excelType = Type.GetTypeFromProgID("Excel.Application")
+                    ?? throw new InvalidOperationException("Excel COM automation is not available.");
+                excel = Activator.CreateInstance(excelType)
+                    ?? throw new InvalidOperationException("Failed to create Excel COM automation instance.");
+
+                excelType.InvokeMember("DisplayAlerts", BindingFlags.SetProperty, null, excel, new object[] { false });
+                excelType.InvokeMember("Visible", BindingFlags.SetProperty, null, excel, new object[] { false });
+                workbooks = excelType.InvokeMember("Workbooks", BindingFlags.GetProperty, null, excel, null);
+
+                foreach (string path in paths) {
+                    object? workbook = null;
+                    try {
+                        workbook = workbooks!.GetType().InvokeMember("Open", BindingFlags.InvokeMethod, null, workbooks,
+                            new object[] { path, 0, true });
+                    } catch (Exception ex) when (ex is COMException or InvalidOperationException or MissingMethodException or TargetInvocationException) {
+                        failures.Add($"{Path.GetFileName(path)}: {DescribeExcelComFailure(ex)}");
+                    } finally {
+                        try {
+                            workbook?.GetType().InvokeMember("Close", BindingFlags.InvokeMethod, null, workbook, new object[] { false });
+                        } catch (Exception ex) when (ex is COMException or MissingMethodException or TargetInvocationException) {
+                            failures.Add($"{Path.GetFileName(path)} close: {DescribeExcelComFailure(ex)}");
+                        }
+
+                        if (workbook != null && Marshal.IsComObject(workbook)) {
+                            Marshal.FinalReleaseComObject(workbook);
+                        }
+                    }
+                }
+            } catch (Exception ex) when (ex is COMException or InvalidOperationException or MissingMethodException or TargetInvocationException) {
+                failures.Add(DescribeExcelComFailure(ex));
+            } finally {
+                try {
+                    excel?.GetType().InvokeMember("Quit", BindingFlags.InvokeMethod, null, excel, null);
+                } catch (Exception ex) when (ex is COMException or MissingMethodException or TargetInvocationException) {
+                    failures.Add("Excel quit: " + DescribeExcelComFailure(ex));
+                }
+
+                if (workbooks != null && Marshal.IsComObject(workbooks)) {
+                    Marshal.FinalReleaseComObject(workbooks);
+                }
+                if (excel != null && Marshal.IsComObject(excel)) {
+                    Marshal.FinalReleaseComObject(excel);
+                }
+            }
+        }
+
+        private static string DescribeExcelComFailure(Exception ex) {
+            Exception actual = ex is TargetInvocationException { InnerException: not null } target
+                ? target.InnerException!
+                : ex;
+            return actual.GetType().Name + ": " + actual.Message;
+        }
+
+        [Fact]
+        public void Test_ExcelWorkbooks_OpenInDesktopExcelWhenAvailable() {
+            if (!IsWindowsPlatform()) {
+                return;
+            }
+
+            string directory = Path.Combine(_directoryWithFiles, "DesktopExcelSmoke");
+            Directory.CreateDirectory(directory);
+
+            var files = new[] {
+                CreateDesktopExcelValuesWorkbook(Path.Combine(directory, "Values.Formulas.xlsx")),
+                CreateDesktopExcelTableWorkbook(Path.Combine(directory, "Table.Filter.Freeze.xlsx")),
+                CreateDesktopExcelFormattingWorkbook(Path.Combine(directory, "Formatting.Validation.xlsx")),
+                CreateDesktopExcelChartWorkbook(Path.Combine(directory, "Charts.ComboScatter.xlsx"))
+            };
+
+            AssertWorkbooksOpenViaExcelComWhenAvailable(files,
+                "One or more generated Excel workbooks required repair or failed to open in desktop Excel.");
+        }
+
+        private static string CreateDesktopExcelValuesWorkbook(string filePath) {
+            using var document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorkSheet("Values");
+            sheet.CellValue(1, 1, "Name");
+            sheet.CellValue(1, 2, "Amount");
+            sheet.CellValue(2, 1, "Alpha");
+            sheet.CellValue(2, 2, 10d);
+            sheet.CellValue(3, 1, "Beta");
+            sheet.CellValue(3, 2, 20.5d);
+            sheet.CellFormula(4, 2, "SUM(B2:B3)");
+            sheet.Range("A1:B1").HeaderStyle();
+            document.Save();
+            return filePath;
+        }
+
+        private static string CreateDesktopExcelTableWorkbook(string filePath) {
+            using var document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorkSheet("Data");
+            sheet.CellValue(1, 1, "Region");
+            sheet.CellValue(1, 2, "Score");
+            sheet.CellValue(2, 1, "North");
+            sheet.CellValue(2, 2, 80d);
+            sheet.CellValue(3, 1, "South");
+            sheet.CellValue(3, 2, 95d);
+            sheet.AddTable("A1:B3", true, "ScoresTable", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+            sheet.AddAutoFilter("A1:B3", new Dictionary<uint, IEnumerable<string>> {
+                { 0, new[] { "North", "South" } }
+            });
+            sheet.Freeze(topRows: 1, leftCols: 1);
+            document.Save();
+            return filePath;
+        }
+
+        private static string CreateDesktopExcelFormattingWorkbook(string filePath) {
+            using var document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorkSheet("Formatting");
+            sheet.CellValue(1, 1, "Score");
+            sheet.CellValue(2, 1, 42d);
+            sheet.CellValue(3, 1, 87d);
+            sheet.AddConditionalColorScale("A2:A3", OfficeColor.Red, OfficeColor.Lime);
+            sheet.AddConditionalDataBar("A2:A3", OfficeColor.Blue);
+            sheet.AddConditionalRule("A2:A3", ConditionalFormattingOperatorValues.GreaterThan, "50");
+            document.Save();
+            return filePath;
+        }
+
+        private static string CreateDesktopExcelChartWorkbook(string filePath) {
+            using var document = ExcelDocument.Create(filePath);
+            document.DefaultChartStylePreset = ExcelChartStylePreset.Default;
+            ExcelSheet sheet = document.AddWorkSheet("Summary");
+
+            var data = new ExcelChartData(
+                new[] { "Q1", "Q2", "Q3", "Q4" },
+                new[] {
+                    new ExcelChartSeries("Sales", new[] { 10d, 20d, 25d, 30d }, ExcelChartType.ColumnClustered, ExcelChartAxisGroup.Primary),
+                    new ExcelChartSeries("Trend", new[] { 12d, 18d, 28d, 35d }, ExcelChartType.Line, ExcelChartAxisGroup.Secondary)
+                });
+
+            ExcelChart chart = sheet.AddChart(data, row: 2, column: 6, widthPixels: 640, heightPixels: 360,
+                type: ExcelChartType.ColumnClustered, title: "Sales vs Trend");
+            chart.SetSeriesDataLabels(1, showValue: true, position: DocumentFormat.OpenXml.Drawing.Charts.DataLabelPositionValues.Top)
+                 .SetSeriesDataLabelForPoint(1, 2, showValue: true, position: DocumentFormat.OpenXml.Drawing.Charts.DataLabelPositionValues.OutsideEnd);
+
+            document.Save();
+            return filePath;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Normalize `OutsideEnd` data label positions to `Top` for line chart data labels so desktop Excel does not repair generated workbooks.
- Move Excel COM open validation into a reusable test helper and keep it gated to Windows machines with desktop Excel installed.
- Add a broader desktop Excel smoke test for values/formulas/styles, tables/filters/freeze panes, conditional formatting, and the combo chart repair scenario.

## Validation
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --configuration Debug --filter "FullyQualifiedName~Test_ExcelCharts_ComboScatter_ValidatesWithOpenXmlValidator"`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --configuration Debug --filter "FullyQualifiedName~Test_ExcelWorkbooks_OpenInDesktopExcelWhenAvailable|FullyQualifiedName~Test_ExcelCharts_ComboScatter_ValidatesWithOpenXmlValidator" --no-restore`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --configuration Debug --framework net8.0 --filter "FullyQualifiedName~ExcelCharts" --no-restore`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --configuration Debug --framework net8.0 --no-restore`
- temporary Excel example reflection sweep: 27 Excel example methods executed, 24 generated `.xlsx` workbooks passed OpenXML validation
- Excel COM smoke opened 24/24 generated Excel example workbooks, including `ExcelCharts.ComboScatter.xlsx`
- `dotnet run --project .\OfficeIMO.Examples\OfficeIMO.Examples.csproj --configuration Debug --framework net8.0 --no-build -- --powerpoint`
- `git diff --check`