### PR TITLE
Add system TrueType font family loading

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -153,7 +153,7 @@ jobs:
   test-ubuntu:
     name: 'Ubuntu'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.System.TrueTypeCollection.cs
+++ b/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.System.TrueTypeCollection.cs
@@ -1,0 +1,128 @@
+namespace OfficeIMO.Pdf;
+
+public sealed partial class PdfEmbeddedFontFamily {
+    private static System.Collections.Generic.List<byte[]> ExtractTrueTypeFontPrograms(byte[] data) {
+        if (!IsTrueTypeCollection(data)) {
+            return new System.Collections.Generic.List<byte[]> { data };
+        }
+
+        EnsureRange(data, 0, 12);
+        uint fontCount = ReadUInt32(data, 8);
+        if (fontCount == 0 || fontCount > 4096) {
+            throw new System.NotSupportedException("TrueType collection font count is invalid.");
+        }
+
+        EnsureRange(data, 12, checked((int)fontCount * 4));
+        var fonts = new System.Collections.Generic.List<byte[]>((int)fontCount);
+        for (int i = 0; i < fontCount; i++) {
+            uint offset = ReadUInt32(data, 12 + i * 4);
+            if (offset > int.MaxValue) {
+                throw new System.NotSupportedException("TrueType collection font offset is too large.");
+            }
+
+            fonts.Add(ExtractTrueTypeCollectionFont(data, (int)offset));
+        }
+
+        return fonts;
+    }
+
+    private static bool IsTrueTypeCollection(byte[] data) =>
+        data.Length >= 4 &&
+        data[0] == (byte)'t' &&
+        data[1] == (byte)'t' &&
+        data[2] == (byte)'c' &&
+        data[3] == (byte)'f';
+
+    private static byte[] ExtractTrueTypeCollectionFont(byte[] collectionData, int fontOffset) {
+        EnsureRange(collectionData, fontOffset, 12);
+        ushort tableCount = ReadUInt16(collectionData, fontOffset + 4);
+        if (tableCount == 0) {
+            throw new System.NotSupportedException("TrueType collection font has no tables.");
+        }
+
+        int directoryLength = checked(12 + tableCount * 16);
+        EnsureRange(collectionData, fontOffset, directoryLength);
+        var tables = new System.Collections.Generic.List<FontTableCopyRecord>(tableCount);
+        int outputOffset = Align4(directoryLength);
+        for (int i = 0; i < tableCount; i++) {
+            int recordOffset = fontOffset + 12 + i * 16;
+            string tag = System.Text.Encoding.ASCII.GetString(collectionData, recordOffset, 4);
+            uint checksum = ReadUInt32(collectionData, recordOffset + 4);
+            uint sourceOffset = ReadUInt32(collectionData, recordOffset + 8);
+            uint length = ReadUInt32(collectionData, recordOffset + 12);
+            if (sourceOffset > int.MaxValue || length > int.MaxValue) {
+                throw new System.NotSupportedException("TrueType collection table offsets are too large.");
+            }
+
+            EnsureRange(collectionData, (int)sourceOffset, (int)length);
+            tables.Add(new FontTableCopyRecord(tag, checksum, (int)sourceOffset, (int)length, outputOffset));
+            outputOffset = Align4(checked(outputOffset + (int)length));
+        }
+
+        byte[] fontData = new byte[outputOffset];
+        System.Array.Copy(collectionData, fontOffset, fontData, 0, 4);
+        WriteUInt16(fontData, 4, tableCount);
+        WriteSearchParameters(fontData, tableCount);
+        for (int i = 0; i < tables.Count; i++) {
+            FontTableCopyRecord table = tables[i];
+            int targetRecordOffset = 12 + i * 16;
+            byte[] tagBytes = System.Text.Encoding.ASCII.GetBytes(table.Tag);
+            System.Array.Copy(tagBytes, 0, fontData, targetRecordOffset, 4);
+            WriteUInt32(fontData, targetRecordOffset + 4, table.Checksum);
+            WriteUInt32(fontData, targetRecordOffset + 8, (uint)table.TargetOffset);
+            WriteUInt32(fontData, targetRecordOffset + 12, (uint)table.Length);
+            System.Array.Copy(collectionData, table.SourceOffset, fontData, table.TargetOffset, table.Length);
+        }
+
+        return fontData;
+    }
+
+    private static int Align4(int value) => checked((value + 3) & ~3);
+
+    private static void WriteSearchParameters(byte[] data, int tableCount) {
+        int maxPowerOfTwo = 1;
+        int entrySelector = 0;
+        while (maxPowerOfTwo * 2 <= tableCount) {
+            maxPowerOfTwo *= 2;
+            entrySelector++;
+        }
+
+        WriteUInt16(data, 6, (ushort)(maxPowerOfTwo * 16));
+        WriteUInt16(data, 8, (ushort)entrySelector);
+        WriteUInt16(data, 10, (ushort)((tableCount - maxPowerOfTwo) * 16));
+    }
+
+    private static void WriteUInt16(byte[] data, int offset, ushort value) {
+        EnsureRange(data, offset, 2);
+        data[offset] = (byte)(value >> 8);
+        data[offset + 1] = (byte)value;
+    }
+
+    private static void WriteUInt32(byte[] data, int offset, uint value) {
+        EnsureRange(data, offset, 4);
+        data[offset] = (byte)(value >> 24);
+        data[offset + 1] = (byte)(value >> 16);
+        data[offset + 2] = (byte)(value >> 8);
+        data[offset + 3] = (byte)value;
+    }
+
+    private readonly struct FontTableCopyRecord {
+        public FontTableCopyRecord(string tag, uint checksum, int sourceOffset, int length, int targetOffset) {
+            Tag = tag;
+            Checksum = checksum;
+            SourceOffset = sourceOffset;
+            Length = length;
+            TargetOffset = targetOffset;
+        }
+
+        public string Tag { get; }
+
+        public uint Checksum { get; }
+
+        public int SourceOffset { get; }
+
+        public int Length { get; }
+
+        public int TargetOffset { get; }
+    }
+}

--- a/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.System.cs
+++ b/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.System.cs
@@ -37,7 +37,7 @@ public sealed partial class PdfEmbeddedFontFamily {
         Guard.NotNullOrWhiteSpace(familyName, nameof(familyName));
         Guard.NotNull(fontFiles, nameof(fontFiles));
         string normalizedFamily = NormalizeFamilyKey(familyName);
-        string[] acceptedPrefixes = BuildAcceptedPrefixes(normalizedFamily);
+        string[] acceptedFileNamePrefixes = BuildAcceptedFileNamePrefixes(normalizedFamily);
 
         SystemFontFaceCandidate? regularFace = null;
         SystemFontFaceCandidate? boldFace = null;
@@ -45,24 +45,27 @@ public sealed partial class PdfEmbeddedFontFamily {
         SystemFontFaceCandidate? boldItalicFace = null;
 
         foreach (string fontFile in fontFiles) {
-            if (!TryReadSystemFontFace(fontFile, acceptedPrefixes, out SystemFontFaceCandidate? candidate) ||
-                candidate == null) {
+            if (!TryReadSystemFontFaces(fontFile, normalizedFamily, acceptedFileNamePrefixes, out System.Collections.Generic.List<SystemFontFaceCandidate>? candidates) ||
+                candidates == null) {
                 continue;
             }
 
-            switch (candidate.Kind) {
-                case FontFaceKind.Regular:
-                    SelectBetterFace(ref regularFace, candidate);
-                    break;
-                case FontFaceKind.Bold:
-                    SelectBetterFace(ref boldFace, candidate);
-                    break;
-                case FontFaceKind.Italic:
-                    SelectBetterFace(ref italicFace, candidate);
-                    break;
-                case FontFaceKind.BoldItalic:
-                    SelectBetterFace(ref boldItalicFace, candidate);
-                    break;
+            for (int i = 0; i < candidates.Count; i++) {
+                SystemFontFaceCandidate candidate = candidates[i];
+                switch (candidate.Kind) {
+                    case FontFaceKind.Regular:
+                        SelectBetterFace(ref regularFace, candidate);
+                        break;
+                    case FontFaceKind.Bold:
+                        SelectBetterFace(ref boldFace, candidate);
+                        break;
+                    case FontFaceKind.Italic:
+                        SelectBetterFace(ref italicFace, candidate);
+                        break;
+                    case FontFaceKind.BoldItalic:
+                        SelectBetterFace(ref boldItalicFace, candidate);
+                        break;
+                }
             }
         }
 
@@ -80,17 +83,44 @@ public sealed partial class PdfEmbeddedFontFamily {
         return true;
     }
 
-    private static bool TryReadSystemFontFace(string path, string[] acceptedPrefixes, out SystemFontFaceCandidate? candidate) {
-        candidate = null;
+    private static bool TryReadSystemFontFaces(string path, string normalizedMetadataFamily, string[] acceptedFileNamePrefixes, out System.Collections.Generic.List<SystemFontFaceCandidate>? candidates) {
+        candidates = null;
         if (string.IsNullOrWhiteSpace(path)) {
             return false;
         }
 
         try {
-            byte[] data = System.IO.File.ReadAllBytes(path);
+            byte[] fileData = System.IO.File.ReadAllBytes(path);
+            System.Collections.Generic.List<byte[]> fontPrograms = ExtractTrueTypeFontPrograms(fileData);
+            var found = new System.Collections.Generic.List<SystemFontFaceCandidate>();
+            for (int i = 0; i < fontPrograms.Count; i++) {
+                if (TryReadSystemFontFace(path, fontPrograms[i], normalizedMetadataFamily, acceptedFileNamePrefixes, out SystemFontFaceCandidate? candidate) &&
+                    candidate != null) {
+                    found.Add(candidate);
+                }
+            }
+
+            candidates = found;
+            return found.Count > 0;
+        } catch (System.Exception exception) when (
+            exception is System.IO.IOException ||
+            exception is System.UnauthorizedAccessException ||
+            exception is System.NotSupportedException ||
+            exception is System.ArgumentException ||
+            exception is System.ArithmeticException ||
+            exception is System.FormatException ||
+            exception is System.IndexOutOfRangeException ||
+            exception is System.InvalidOperationException) {
+            return false;
+        }
+    }
+
+    private static bool TryReadSystemFontFace(string path, byte[] data, string normalizedMetadataFamily, string[] acceptedFileNamePrefixes, out SystemFontFaceCandidate? candidate) {
+        candidate = null;
+        try {
             _ = PdfTrueTypeFontProgram.Parse(data);
             if (TryReadTrueTypeNameMetadata(data, out TrueTypeNameMetadata? metadata) && metadata != null) {
-                if (IsMetadataFamilyMatch(metadata, acceptedPrefixes)) {
+                if (IsMetadataFamilyMatch(metadata, normalizedMetadataFamily)) {
                     FontFaceKind kind = ClassifyMetadataFace(metadata, out int metadataScore);
                     candidate = new SystemFontFaceCandidate(path, kind, metadataScore, data);
                     return true;
@@ -100,7 +130,7 @@ public sealed partial class PdfEmbeddedFontFamily {
             }
 
             string fileName = System.IO.Path.GetFileNameWithoutExtension(path);
-            if (!TryClassifyFace(fileName, acceptedPrefixes, out FontFaceKind faceKind)) {
+            if (!TryClassifyFace(fileName, acceptedFileNamePrefixes, out FontFaceKind faceKind)) {
                 return false;
             }
 
@@ -164,22 +194,22 @@ public sealed partial class PdfEmbeddedFontFamily {
     private static int ScoreFileNameFace(FontFaceKind faceKind) =>
         faceKind == FontFaceKind.Regular ? 60 : 70;
 
-    private static bool IsMetadataFamilyMatch(TrueTypeNameMetadata metadata, string[] acceptedPrefixes) {
+    private static bool IsMetadataFamilyMatch(TrueTypeNameMetadata metadata, string normalizedMetadataFamily) {
         foreach (string? familyName in metadata.GetFamilyNames()) {
             if (string.IsNullOrWhiteSpace(familyName)) {
                 continue;
             }
 
-            string normalized = NormalizeFamilyKey(familyName!);
-            for (int i = 0; i < acceptedPrefixes.Length; i++) {
-                if (string.Equals(normalized, acceptedPrefixes[i], System.StringComparison.Ordinal)) {
-                    return true;
-                }
+            if (IsMetadataFamilyNameMatch(familyName!, normalizedMetadataFamily)) {
+                return true;
             }
         }
 
         return false;
     }
+
+    internal static bool IsMetadataFamilyNameMatch(string fontFamilyName, string requestedFamilyName) =>
+        string.Equals(NormalizeFamilyKey(fontFamilyName), NormalizeFamilyKey(requestedFamilyName), System.StringComparison.Ordinal);
 
     private static FontFaceKind ClassifyMetadataFace(TrueTypeNameMetadata metadata, out int score) {
         string primaryStyle = NormalizeFamilyKey(metadata.TypographicSubfamilyName ?? metadata.SubfamilyName ?? string.Empty);
@@ -188,10 +218,23 @@ public sealed partial class PdfEmbeddedFontFamily {
             (metadata.FullName ?? string.Empty));
 
         string style = primaryStyle.Length == 0 ? fallbackStyle : primaryStyle;
+        FontFaceKind kind = ClassifyMetadataStyle(style, primaryStyle, out score);
+        return kind;
+    }
+
+    private static FontFaceKind ClassifyMetadataStyle(string style, string primaryStyle, out int score) {
         bool bold = ContainsAny(style, "bold", "semibold", "demibold", "black", "heavy");
         bool italic = ContainsAny(style, "italic", "oblique");
         if (bold && italic) {
-            score = primaryStyle.Contains("bold") && (primaryStyle.Contains("italic") || primaryStyle.Contains("oblique")) ? 110 : 85;
+            if (string.Equals(primaryStyle, "bolditalic", System.StringComparison.Ordinal) ||
+                string.Equals(primaryStyle, "boldoblique", System.StringComparison.Ordinal)) {
+                score = 120;
+            } else if (primaryStyle.Contains("bold") && (primaryStyle.Contains("italic") || primaryStyle.Contains("oblique"))) {
+                score = primaryStyle.Contains("semibold") || primaryStyle.Contains("demibold") ? 100 : 105;
+            } else {
+                score = 85;
+            }
+
             return FontFaceKind.BoldItalic;
         }
 
@@ -218,6 +261,12 @@ public sealed partial class PdfEmbeddedFontFamily {
         return FontFaceKind.Regular;
     }
 
+    internal static int GetMetadataStyleScore(string styleName) {
+        string normalizedStyle = NormalizeFamilyKey(styleName);
+        _ = ClassifyMetadataStyle(normalizedStyle, normalizedStyle, out int score);
+        return score;
+    }
+
     private static bool ContainsAny(string value, params string[] needles) {
         for (int i = 0; i < needles.Length; i++) {
             if (value.Contains(needles[i])) {
@@ -228,7 +277,7 @@ public sealed partial class PdfEmbeddedFontFamily {
         return false;
     }
 
-    private static string[] BuildAcceptedPrefixes(string normalizedFamily) {
+    private static string[] BuildAcceptedFileNamePrefixes(string normalizedFamily) {
         if (normalizedFamily == "timesnewroman") {
             return new[] { "timesnewroman", "times" };
         }
@@ -301,7 +350,7 @@ public sealed partial class PdfEmbeddedFontFamily {
             string current = directories.Pop();
             string[] files;
             try {
-                files = System.IO.Directory.GetFiles(current, "*.ttf");
+                files = GetTrueTypeFontFiles(current);
             } catch (System.Exception exception) when (
                 exception is System.IO.IOException ||
                 exception is System.UnauthorizedAccessException) {
@@ -325,6 +374,19 @@ public sealed partial class PdfEmbeddedFontFamily {
                 directories.Push(children[i]);
             }
         }
+    }
+
+    private static string[] GetTrueTypeFontFiles(string root) {
+        string[] trueTypeFiles = System.IO.Directory.GetFiles(root, "*.ttf");
+        string[] collectionFiles = System.IO.Directory.GetFiles(root, "*.ttc");
+        if (collectionFiles.Length == 0) {
+            return trueTypeFiles;
+        }
+
+        string[] files = new string[trueTypeFiles.Length + collectionFiles.Length];
+        System.Array.Copy(trueTypeFiles, 0, files, 0, trueTypeFiles.Length);
+        System.Array.Copy(collectionFiles, 0, files, trueTypeFiles.Length, collectionFiles.Length);
+        return files;
     }
 
     private static bool TryReadTrueTypeNameMetadata(byte[] data, out TrueTypeNameMetadata? metadata) {
@@ -528,4 +590,5 @@ public sealed partial class PdfEmbeddedFontFamily {
 
         public int Length { get; }
     }
+
 }

--- a/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.System.cs
+++ b/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.System.cs
@@ -1,0 +1,519 @@
+namespace OfficeIMO.Pdf;
+
+public sealed partial class PdfEmbeddedFontFamily {
+    /// <summary>
+    /// Loads an installed TrueType font family from common operating-system font folders.
+    /// </summary>
+    /// <param name="familyName">Installed family name, for example <c>Arial</c>, <c>Segoe UI</c>, or <c>DejaVu Sans</c>.</param>
+    /// <param name="pdfFamilyName">Optional family name to expose in generated PDF font resource names.</param>
+    /// <returns>A reusable embedded font family backed by the discovered TrueType faces.</returns>
+    /// <exception cref="System.IO.FileNotFoundException">No embeddable TrueType regular face was found for <paramref name="familyName"/>.</exception>
+    public static PdfEmbeddedFontFamily FromSystem(string familyName, string? pdfFamilyName = null) {
+        if (TryFromSystem(familyName, out PdfEmbeddedFontFamily? fontFamily, pdfFamilyName)) {
+            return fontFamily!;
+        }
+
+        throw new System.IO.FileNotFoundException(
+            "Could not find an embeddable TrueType font family named '" + familyName + "' in common system font folders.",
+            familyName);
+    }
+
+    /// <summary>
+    /// Attempts to load an installed TrueType font family from common operating-system font folders.
+    /// </summary>
+    /// <param name="familyName">Installed family name, for example <c>Arial</c>, <c>Segoe UI</c>, or <c>DejaVu Sans</c>.</param>
+    /// <param name="fontFamily">When found, receives a reusable embedded font family backed by discovered TrueType faces.</param>
+    /// <param name="pdfFamilyName">Optional family name to expose in generated PDF font resource names.</param>
+    /// <returns><c>true</c> when an embeddable regular TrueType face was found; otherwise <c>false</c>.</returns>
+    public static bool TryFromSystem(string familyName, out PdfEmbeddedFontFamily? fontFamily, string? pdfFamilyName = null) {
+        return TryFromSystemFontFiles(familyName, EnumerateSystemTrueTypeFontFiles(), out fontFamily, pdfFamilyName);
+    }
+
+    internal static bool TryFromSystemFontFiles(
+        string familyName,
+        System.Collections.Generic.IEnumerable<string> fontFiles,
+        out PdfEmbeddedFontFamily? fontFamily,
+        string? pdfFamilyName = null) {
+        Guard.NotNullOrWhiteSpace(familyName, nameof(familyName));
+        Guard.NotNull(fontFiles, nameof(fontFiles));
+        string normalizedFamily = NormalizeFamilyKey(familyName);
+        string[] acceptedPrefixes = BuildAcceptedPrefixes(normalizedFamily);
+
+        SystemFontFaceCandidate? regularFace = null;
+        SystemFontFaceCandidate? boldFace = null;
+        SystemFontFaceCandidate? italicFace = null;
+        SystemFontFaceCandidate? boldItalicFace = null;
+
+        foreach (string fontFile in fontFiles) {
+            if (!TryReadSystemFontFace(fontFile, acceptedPrefixes, out SystemFontFaceCandidate? candidate) ||
+                candidate == null) {
+                continue;
+            }
+
+            switch (candidate.Kind) {
+                case FontFaceKind.Regular:
+                    SelectBetterFace(ref regularFace, candidate);
+                    break;
+                case FontFaceKind.Bold:
+                    SelectBetterFace(ref boldFace, candidate);
+                    break;
+                case FontFaceKind.Italic:
+                    SelectBetterFace(ref italicFace, candidate);
+                    break;
+                case FontFaceKind.BoldItalic:
+                    SelectBetterFace(ref boldItalicFace, candidate);
+                    break;
+            }
+        }
+
+        if (regularFace == null) {
+            fontFamily = null;
+            return false;
+        }
+
+        fontFamily = new PdfEmbeddedFontFamily(
+            string.IsNullOrWhiteSpace(pdfFamilyName) ? familyName : pdfFamilyName!,
+            regularFace.Data,
+            boldFace?.Data,
+            italicFace?.Data,
+            boldItalicFace?.Data);
+        return true;
+    }
+
+    private static bool TryReadSystemFontFace(string path, string[] acceptedPrefixes, out SystemFontFaceCandidate? candidate) {
+        candidate = null;
+        if (string.IsNullOrWhiteSpace(path)) {
+            return false;
+        }
+
+        try {
+            byte[] data = System.IO.File.ReadAllBytes(path);
+            _ = PdfTrueTypeFontProgram.Parse(data);
+            if (TryReadTrueTypeNameMetadata(data, out TrueTypeNameMetadata? metadata) &&
+                metadata != null &&
+                IsMetadataFamilyMatch(metadata, acceptedPrefixes)) {
+                FontFaceKind kind = ClassifyMetadataFace(metadata, out int metadataScore);
+                candidate = new SystemFontFaceCandidate(path, kind, metadataScore, data);
+                return true;
+            }
+
+            string fileName = System.IO.Path.GetFileNameWithoutExtension(path);
+            if (!TryClassifyFace(fileName, acceptedPrefixes, out FontFaceKind faceKind)) {
+                return false;
+            }
+
+            candidate = new SystemFontFaceCandidate(path, faceKind, ScoreFileNameFace(faceKind), data);
+            return true;
+        } catch (System.Exception exception) when (
+            exception is System.IO.IOException ||
+            exception is System.UnauthorizedAccessException ||
+            exception is System.NotSupportedException) {
+            return false;
+        }
+    }
+
+    private static void SelectBetterFace(ref SystemFontFaceCandidate? current, SystemFontFaceCandidate candidate) {
+        if (current == null || candidate.Score > current.Score) {
+            current = candidate;
+        }
+    }
+
+    private static bool TryClassifyFace(string fileName, string[] acceptedPrefixes, out FontFaceKind faceKind) {
+        string normalizedName = NormalizeFamilyKey(fileName);
+        foreach (string prefix in acceptedPrefixes) {
+            if (!normalizedName.StartsWith(prefix, System.StringComparison.Ordinal)) {
+                continue;
+            }
+
+            string suffix = normalizedName.Substring(prefix.Length);
+            faceKind = ClassifySuffix(suffix);
+            return true;
+        }
+
+        faceKind = FontFaceKind.Regular;
+        return false;
+    }
+
+    private static FontFaceKind ClassifySuffix(string suffix) {
+        if (suffix.Length == 0 || suffix == "regular" || suffix == "r" || suffix == "mt") {
+            return FontFaceKind.Regular;
+        }
+
+        if (suffix.Contains("bolditalic") || suffix.Contains("boldoblique") || suffix == "bi" || suffix == "z") {
+            return FontFaceKind.BoldItalic;
+        }
+
+        if (suffix.Contains("italic") || suffix.Contains("oblique") || suffix == "i") {
+            return FontFaceKind.Italic;
+        }
+
+        if (suffix.Contains("bold") || suffix == "bd" || suffix == "b") {
+            return FontFaceKind.Bold;
+        }
+
+        return FontFaceKind.Regular;
+    }
+
+    private static int ScoreFileNameFace(FontFaceKind faceKind) =>
+        faceKind == FontFaceKind.Regular ? 60 : 70;
+
+    private static bool IsMetadataFamilyMatch(TrueTypeNameMetadata metadata, string[] acceptedPrefixes) {
+        foreach (string? familyName in metadata.GetFamilyNames()) {
+            if (string.IsNullOrWhiteSpace(familyName)) {
+                continue;
+            }
+
+            string normalized = NormalizeFamilyKey(familyName!);
+            for (int i = 0; i < acceptedPrefixes.Length; i++) {
+                if (string.Equals(normalized, acceptedPrefixes[i], System.StringComparison.Ordinal)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static FontFaceKind ClassifyMetadataFace(TrueTypeNameMetadata metadata, out int score) {
+        string primaryStyle = NormalizeFamilyKey(metadata.TypographicSubfamilyName ?? metadata.SubfamilyName ?? string.Empty);
+        string fallbackStyle = NormalizeFamilyKey(
+            (metadata.PostScriptName ?? string.Empty) + " " +
+            (metadata.FullName ?? string.Empty));
+
+        string style = primaryStyle.Length == 0 ? fallbackStyle : primaryStyle;
+        bool bold = ContainsAny(style, "bold", "semibold", "demibold", "black", "heavy");
+        bool italic = ContainsAny(style, "italic", "oblique");
+        if (bold && italic) {
+            score = primaryStyle.Contains("bold") && (primaryStyle.Contains("italic") || primaryStyle.Contains("oblique")) ? 110 : 85;
+            return FontFaceKind.BoldItalic;
+        }
+
+        if (italic) {
+            score = primaryStyle.Contains("italic") || primaryStyle.Contains("oblique") ? 105 : 80;
+            return FontFaceKind.Italic;
+        }
+
+        if (bold) {
+            score = string.Equals(primaryStyle, "bold", System.StringComparison.Ordinal) ? 105 : 80;
+            return FontFaceKind.Bold;
+        }
+
+        if (primaryStyle.Length == 0 ||
+            string.Equals(primaryStyle, "regular", System.StringComparison.Ordinal) ||
+            string.Equals(primaryStyle, "normal", System.StringComparison.Ordinal) ||
+            string.Equals(primaryStyle, "book", System.StringComparison.Ordinal) ||
+            string.Equals(primaryStyle, "roman", System.StringComparison.Ordinal)) {
+            score = 105;
+            return FontFaceKind.Regular;
+        }
+
+        score = 55;
+        return FontFaceKind.Regular;
+    }
+
+    private static bool ContainsAny(string value, params string[] needles) {
+        for (int i = 0; i < needles.Length; i++) {
+            if (value.Contains(needles[i])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string[] BuildAcceptedPrefixes(string normalizedFamily) {
+        if (normalizedFamily == "timesnewroman") {
+            return new[] { "timesnewroman", "times" };
+        }
+
+        if (normalizedFamily == "couriernew") {
+            return new[] { "couriernew", "cour" };
+        }
+
+        if (normalizedFamily == "segoeui") {
+            return new[] { "segoeui", "segui" };
+        }
+
+        return new[] { normalizedFamily };
+    }
+
+    private static string NormalizeFamilyKey(string value) {
+        var builder = new System.Text.StringBuilder(value.Length);
+        foreach (char character in value) {
+            if (char.IsLetterOrDigit(character)) {
+                builder.Append(char.ToLowerInvariant(character));
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static System.Collections.Generic.IEnumerable<string> EnumerateSystemTrueTypeFontFiles() {
+        var seenRoots = new System.Collections.Generic.HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+        foreach (string root in GetSystemFontRoots()) {
+            if (root.Length == 0 || !seenRoots.Add(root) || !System.IO.Directory.Exists(root)) {
+                continue;
+            }
+
+            foreach (string file in EnumerateTrueTypeFontFiles(root)) {
+                yield return file;
+            }
+        }
+    }
+
+    private static System.Collections.Generic.IEnumerable<string> GetSystemFontRoots() {
+        string windows = System.Environment.GetFolderPath(System.Environment.SpecialFolder.Windows);
+        if (!string.IsNullOrWhiteSpace(windows)) {
+            yield return System.IO.Path.Combine(windows, "Fonts");
+        }
+
+        yield return "/usr/share/fonts";
+        yield return "/usr/local/share/fonts";
+
+        string userProfile = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(userProfile)) {
+            yield return System.IO.Path.Combine(userProfile, ".local", "share", "fonts");
+            yield return System.IO.Path.Combine(userProfile, ".fonts");
+            yield return System.IO.Path.Combine(userProfile, "Library", "Fonts");
+        }
+
+        yield return "/Library/Fonts";
+        yield return "/System/Library/Fonts";
+    }
+
+    private static System.Collections.Generic.IEnumerable<string> EnumerateTrueTypeFontFiles(string root) {
+        var directories = new System.Collections.Generic.Stack<string>();
+        directories.Push(root);
+
+        while (directories.Count > 0) {
+            string current = directories.Pop();
+            string[] files;
+            try {
+                files = System.IO.Directory.GetFiles(current, "*.ttf");
+            } catch (System.Exception exception) when (
+                exception is System.IO.IOException ||
+                exception is System.UnauthorizedAccessException) {
+                continue;
+            }
+
+            for (int i = 0; i < files.Length; i++) {
+                yield return files[i];
+            }
+
+            string[] children;
+            try {
+                children = System.IO.Directory.GetDirectories(current);
+            } catch (System.Exception exception) when (
+                exception is System.IO.IOException ||
+                exception is System.UnauthorizedAccessException) {
+                continue;
+            }
+
+            for (int i = 0; i < children.Length; i++) {
+                directories.Push(children[i]);
+            }
+        }
+    }
+
+    private static bool TryReadTrueTypeNameMetadata(byte[] data, out TrueTypeNameMetadata? metadata) {
+        metadata = null;
+        try {
+            if (data.Length < 12) {
+                return false;
+            }
+
+            var tables = ReadFontTableDirectory(data);
+            if (!tables.TryGetValue("name", out FontTableRecord nameTable)) {
+                return false;
+            }
+
+            var names = new System.Collections.Generic.Dictionary<int, TrueTypeNameValue>();
+            int offset = nameTable.Offset;
+            int count = ReadUInt16(data, offset + 2);
+            int stringOffset = offset + ReadUInt16(data, offset + 4);
+            for (int i = 0; i < count; i++) {
+                int record = offset + 6 + i * 12;
+                EnsureRange(data, record, 12);
+                int platformId = ReadUInt16(data, record);
+                int encodingId = ReadUInt16(data, record + 2);
+                int nameId = ReadUInt16(data, record + 6);
+                if (nameId != 1 && nameId != 2 && nameId != 4 && nameId != 6 && nameId != 16 && nameId != 17) {
+                    continue;
+                }
+
+                int length = ReadUInt16(data, record + 8);
+                int valueOffset = stringOffset + ReadUInt16(data, record + 10);
+                EnsureRange(data, valueOffset, length);
+                string? value = DecodeNameValue(data, valueOffset, length, platformId, encodingId);
+                if (string.IsNullOrWhiteSpace(value)) {
+                    continue;
+                }
+
+                int score = GetNameValueScore(platformId);
+                if (!names.TryGetValue(nameId, out TrueTypeNameValue? existing) || score > existing.Score) {
+                    names[nameId] = new TrueTypeNameValue(value!.Trim(), score);
+                }
+            }
+
+            metadata = new TrueTypeNameMetadata(
+                GetName(names, 1),
+                GetName(names, 2),
+                GetName(names, 4),
+                GetName(names, 6),
+                GetName(names, 16),
+                GetName(names, 17));
+            return true;
+        } catch (System.Exception exception) when (exception is System.NotSupportedException) {
+            return false;
+        }
+    }
+
+    private static System.Collections.Generic.Dictionary<string, FontTableRecord> ReadFontTableDirectory(byte[] data) {
+        int numTables = ReadUInt16(data, 4);
+        var tables = new System.Collections.Generic.Dictionary<string, FontTableRecord>(System.StringComparer.Ordinal);
+        int recordOffset = 12;
+        for (int index = 0; index < numTables; index++) {
+            int offset = recordOffset + index * 16;
+            EnsureRange(data, offset, 16);
+            string tag = System.Text.Encoding.ASCII.GetString(data, offset, 4);
+            uint tableOffset = ReadUInt32(data, offset + 8);
+            uint tableLength = ReadUInt32(data, offset + 12);
+            if (tableOffset > int.MaxValue || tableLength > int.MaxValue) {
+                throw new System.NotSupportedException("TrueType font table offsets are too large.");
+            }
+
+            EnsureRange(data, (int)tableOffset, (int)tableLength);
+            tables[tag] = new FontTableRecord((int)tableOffset, (int)tableLength);
+        }
+
+        return tables;
+    }
+
+    private static string? DecodeNameValue(byte[] data, int offset, int length, int platformId, int encodingId) {
+        if (platformId == 3 || platformId == 0) {
+            return length % 2 == 0
+                ? System.Text.Encoding.BigEndianUnicode.GetString(data, offset, length).TrimEnd('\0')
+                : null;
+        }
+
+        if (platformId == 1 && encodingId == 0) {
+            return System.Text.Encoding.ASCII.GetString(data, offset, length).TrimEnd('\0');
+        }
+
+        return null;
+    }
+
+    private static int GetNameValueScore(int platformId) {
+        if (platformId == 3) {
+            return 30;
+        }
+
+        if (platformId == 0) {
+            return 20;
+        }
+
+        return 10;
+    }
+
+    private static string? GetName(System.Collections.Generic.Dictionary<int, TrueTypeNameValue> names, int nameId) =>
+        names.TryGetValue(nameId, out TrueTypeNameValue? value) ? value.Value : null;
+
+    private static ushort ReadUInt16(byte[] data, int offset) {
+        EnsureRange(data, offset, 2);
+        return (ushort)((data[offset] << 8) | data[offset + 1]);
+    }
+
+    private static uint ReadUInt32(byte[] data, int offset) {
+        EnsureRange(data, offset, 4);
+        return ((uint)data[offset] << 24) |
+            ((uint)data[offset + 1] << 16) |
+            ((uint)data[offset + 2] << 8) |
+            data[offset + 3];
+    }
+
+    private static void EnsureRange(byte[] data, int offset, int length) {
+        if (offset < 0 || length < 0 || offset > data.Length - length) {
+            throw new System.NotSupportedException("TrueType font table data is truncated or invalid.");
+        }
+    }
+
+    private enum FontFaceKind {
+        Regular,
+        Bold,
+        Italic,
+        BoldItalic
+    }
+
+    private sealed class SystemFontFaceCandidate {
+        public SystemFontFaceCandidate(string path, FontFaceKind kind, int score, byte[] data) {
+            Path = path;
+            Kind = kind;
+            Score = score;
+            Data = data;
+        }
+
+        public string Path { get; }
+
+        public FontFaceKind Kind { get; }
+
+        public int Score { get; }
+
+        public byte[] Data { get; }
+    }
+
+    private sealed class TrueTypeNameMetadata {
+        public TrueTypeNameMetadata(
+            string? familyName,
+            string? subfamilyName,
+            string? fullName,
+            string? postScriptName,
+            string? typographicFamilyName,
+            string? typographicSubfamilyName) {
+            FamilyName = familyName;
+            SubfamilyName = subfamilyName;
+            FullName = fullName;
+            PostScriptName = postScriptName;
+            TypographicFamilyName = typographicFamilyName;
+            TypographicSubfamilyName = typographicSubfamilyName;
+        }
+
+        public string? FamilyName { get; }
+
+        public string? SubfamilyName { get; }
+
+        public string? FullName { get; }
+
+        public string? PostScriptName { get; }
+
+        public string? TypographicFamilyName { get; }
+
+        public string? TypographicSubfamilyName { get; }
+
+        public System.Collections.Generic.IEnumerable<string?> GetFamilyNames() {
+            yield return TypographicFamilyName;
+            yield return FamilyName;
+        }
+    }
+
+    private sealed class TrueTypeNameValue {
+        public TrueTypeNameValue(string value, int score) {
+            Value = value;
+            Score = score;
+        }
+
+        public string Value { get; }
+
+        public int Score { get; }
+    }
+
+    private readonly struct FontTableRecord {
+        public FontTableRecord(int offset, int length) {
+            Offset = offset;
+            Length = length;
+        }
+
+        public int Offset { get; }
+
+        public int Length { get; }
+    }
+}

--- a/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.System.cs
+++ b/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.System.cs
@@ -89,12 +89,14 @@ public sealed partial class PdfEmbeddedFontFamily {
         try {
             byte[] data = System.IO.File.ReadAllBytes(path);
             _ = PdfTrueTypeFontProgram.Parse(data);
-            if (TryReadTrueTypeNameMetadata(data, out TrueTypeNameMetadata? metadata) &&
-                metadata != null &&
-                IsMetadataFamilyMatch(metadata, acceptedPrefixes)) {
-                FontFaceKind kind = ClassifyMetadataFace(metadata, out int metadataScore);
-                candidate = new SystemFontFaceCandidate(path, kind, metadataScore, data);
-                return true;
+            if (TryReadTrueTypeNameMetadata(data, out TrueTypeNameMetadata? metadata) && metadata != null) {
+                if (IsMetadataFamilyMatch(metadata, acceptedPrefixes)) {
+                    FontFaceKind kind = ClassifyMetadataFace(metadata, out int metadataScore);
+                    candidate = new SystemFontFaceCandidate(path, kind, metadataScore, data);
+                    return true;
+                }
+
+                return false;
             }
 
             string fileName = System.IO.Path.GetFileNameWithoutExtension(path);
@@ -107,7 +109,12 @@ public sealed partial class PdfEmbeddedFontFamily {
         } catch (System.Exception exception) when (
             exception is System.IO.IOException ||
             exception is System.UnauthorizedAccessException ||
-            exception is System.NotSupportedException) {
+            exception is System.NotSupportedException ||
+            exception is System.ArgumentException ||
+            exception is System.ArithmeticException ||
+            exception is System.FormatException ||
+            exception is System.IndexOutOfRangeException ||
+            exception is System.InvalidOperationException) {
             return false;
         }
     }
@@ -261,10 +268,15 @@ public sealed partial class PdfEmbeddedFontFamily {
         }
     }
 
-    private static System.Collections.Generic.IEnumerable<string> GetSystemFontRoots() {
+    internal static System.Collections.Generic.IEnumerable<string> GetSystemFontRoots() {
         string windows = System.Environment.GetFolderPath(System.Environment.SpecialFolder.Windows);
         if (!string.IsNullOrWhiteSpace(windows)) {
             yield return System.IO.Path.Combine(windows, "Fonts");
+        }
+
+        string localAppData = System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData);
+        if (!string.IsNullOrWhiteSpace(localAppData)) {
+            yield return System.IO.Path.Combine(localAppData, "Microsoft", "Windows", "Fonts");
         }
 
         yield return "/usr/share/fonts";

--- a/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.cs
+++ b/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.cs
@@ -3,7 +3,7 @@ namespace OfficeIMO.Pdf;
 /// <summary>
 /// Represents a caller-supplied TrueType font family used by generated PDF text.
 /// </summary>
-public sealed class PdfEmbeddedFontFamily {
+public sealed partial class PdfEmbeddedFontFamily {
     private readonly byte[] _regular;
     private readonly byte[]? _bold;
     private readonly byte[]? _italic;

--- a/OfficeIMO.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfFontFamilyTests.cs
@@ -120,6 +120,48 @@ public class PdfFontFamilyTests {
     }
 
     [Fact]
+    public void PdfEmbeddedFontFamily_MetadataMatchingDoesNotUseFileNameAliases() {
+        Assert.False(PdfEmbeddedFontFamily.IsMetadataFamilyNameMatch("Times", "Times New Roman"));
+        Assert.False(PdfEmbeddedFontFamily.IsMetadataFamilyNameMatch("Courier", "Courier New"));
+        Assert.True(PdfEmbeddedFontFamily.IsMetadataFamilyNameMatch("Times New Roman", "Times New Roman"));
+    }
+
+    [Fact]
+    public void PdfEmbeddedFontFamily_MetadataStyleScoringPrefersExactBoldItalic() {
+        Assert.True(
+            PdfEmbeddedFontFamily.GetMetadataStyleScore("Bold Italic") >
+            PdfEmbeddedFontFamily.GetMetadataStyleScore("SemiBold Italic"));
+        Assert.True(
+            PdfEmbeddedFontFamily.GetMetadataStyleScore("Bold") >
+            PdfEmbeddedFontFamily.GetMetadataStyleScore("SemiBold"));
+    }
+
+    [Fact]
+    public void PdfEmbeddedFontFamily_TryFromSystemFontFilesMatchesTrueTypeCollectionFace() {
+        if (!TryFindSingleInstalledRegularFontFace(out string familyName, out string fontPath)) {
+            return;
+        }
+
+        string tempDir = Path.Combine(Path.GetTempPath(), "OfficeIMO.Pdf.Fonts." + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try {
+            string collectionPath = Path.Combine(tempDir, "officeimo-system-face.ttc");
+            File.WriteAllBytes(collectionPath, CreateSingleFaceTrueTypeCollection(File.ReadAllBytes(fontPath)));
+
+            bool found = PdfEmbeddedFontFamily.TryFromSystemFontFiles(
+                familyName,
+                new[] { collectionPath },
+                out PdfEmbeddedFontFamily? family);
+
+            Assert.True(found);
+            Assert.NotNull(family);
+            Assert.NotEmpty(family!.Regular);
+        } finally {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void PdfEmbeddedFontFamily_TryFromSystemFontFilesSkipsMalformedTrueTypeFiles() {
         string tempDir = Path.Combine(Path.GetTempPath(), "OfficeIMO.Pdf.Fonts." + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);
@@ -485,5 +527,47 @@ public class PdfFontFamilyTests {
         foreach (string file in files) {
             yield return file;
         }
+    }
+
+    private static byte[] CreateSingleFaceTrueTypeCollection(byte[] fontData) {
+        int fontOffset = 16;
+        int tableCount = ReadUInt16(fontData, 4);
+        int sourceDirectoryLength = 12 + tableCount * 16;
+        int collectionLength = fontOffset + fontData.Length;
+        byte[] collection = new byte[collectionLength];
+
+        collection[0] = (byte)'t';
+        collection[1] = (byte)'t';
+        collection[2] = (byte)'c';
+        collection[3] = (byte)'f';
+        WriteUInt32(collection, 4, 0x00010000);
+        WriteUInt32(collection, 8, 1);
+        WriteUInt32(collection, 12, (uint)fontOffset);
+        Array.Copy(fontData, 0, collection, fontOffset, fontData.Length);
+
+        for (int i = 0; i < tableCount; i++) {
+            int recordOffset = fontOffset + 12 + i * 16;
+            uint sourceOffset = ReadUInt32(fontData, 12 + i * 16 + 8);
+            WriteUInt32(collection, recordOffset + 8, (uint)(fontOffset + sourceOffset));
+        }
+
+        Assert.True(sourceDirectoryLength <= fontData.Length);
+        return collection;
+    }
+
+    private static ushort ReadUInt16(byte[] data, int offset) =>
+        (ushort)((data[offset] << 8) | data[offset + 1]);
+
+    private static uint ReadUInt32(byte[] data, int offset) =>
+        ((uint)data[offset] << 24) |
+        ((uint)data[offset + 1] << 16) |
+        ((uint)data[offset + 2] << 8) |
+        data[offset + 3];
+
+    private static void WriteUInt32(byte[] data, int offset, uint value) {
+        data[offset] = (byte)(value >> 24);
+        data[offset + 1] = (byte)(value >> 16);
+        data[offset + 2] = (byte)(value >> 8);
+        data[offset + 3] = (byte)value;
     }
 }

--- a/OfficeIMO.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfFontFamilyTests.cs
@@ -96,6 +96,63 @@ public class PdfFontFamilyTests {
     }
 
     [Fact]
+    public void PdfEmbeddedFontFamily_TryFromSystemFontFilesSkipsReadableMetadataMismatchBeforeFilenameFallback() {
+        if (!TryFindSingleInstalledRegularFontFace(out _, out string fontPath)) {
+            return;
+        }
+
+        string tempDir = Path.Combine(Path.GetTempPath(), "OfficeIMO.Pdf.Fonts." + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try {
+            string renamedPath = Path.Combine(tempDir, "OfficeIMOFilenameTrap-Regular.ttf");
+            File.Copy(fontPath, renamedPath);
+
+            bool found = PdfEmbeddedFontFamily.TryFromSystemFontFiles(
+                "OfficeIMO Filename Trap",
+                new[] { renamedPath },
+                out PdfEmbeddedFontFamily? family);
+
+            Assert.False(found);
+            Assert.Null(family);
+        } finally {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PdfEmbeddedFontFamily_TryFromSystemFontFilesSkipsMalformedTrueTypeFiles() {
+        string tempDir = Path.Combine(Path.GetTempPath(), "OfficeIMO.Pdf.Fonts." + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try {
+            string malformedPath = Path.Combine(tempDir, "OfficeIMOMalformed-Regular.ttf");
+            File.WriteAllBytes(malformedPath, new byte[] { 0, 1, 0, 0, 0, 255, 255, 255 });
+
+            bool found = PdfEmbeddedFontFamily.TryFromSystemFontFiles(
+                "OfficeIMO Malformed",
+                new[] { malformedPath },
+                out PdfEmbeddedFontFamily? family);
+
+            Assert.False(found);
+            Assert.Null(family);
+        } finally {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PdfEmbeddedFontFamily_GetSystemFontRootsIncludesWindowsPerUserFonts() {
+        string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(localAppData)) {
+            return;
+        }
+
+        string expected = Path.Combine(localAppData, "Microsoft", "Windows", "Fonts");
+        Assert.Contains(
+            PdfEmbeddedFontFamily.GetSystemFontRoots(),
+            root => string.Equals(root, expected, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void PdfDoc_UseFontFamilyObjectReusesTrueTypeFamilyForGeneratedText() {
         string? fontPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
         if (fontPath == null) {

--- a/OfficeIMO.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfFontFamilyTests.cs
@@ -33,6 +33,69 @@ public class PdfFontFamilyTests {
     }
 
     [Fact]
+    public void PdfEmbeddedFontFamily_TryFromSystemLoadsInstalledTrueTypeFamily() {
+        if (!TryFindInstalledSystemFontFamily(out PdfEmbeddedFontFamily? family)) {
+            return;
+        }
+
+        PdfOptions options = new PdfOptions().UseFontFamily(family);
+        byte[] bytes = PdfDoc.Create(new PdfOptions {
+                CompressContentStreams = false
+            })
+            .UseFontFamily(family)
+            .Paragraph(paragraph => paragraph
+                .Text("System regular ")
+                .Bold("system bold ")
+                .Italic("system italic ")
+                .Text("system done"))
+            .ToBytes();
+
+        string raw = Encoding.ASCII.GetString(bytes);
+        string text = PdfReadDocument.Load(bytes).ExtractText();
+
+        Assert.NotEmpty(family.Regular);
+        Assert.True(family.Bold != null || family.Italic != null || family.BoldItalic != null);
+        Assert.Contains(PdfStandardFont.Helvetica, options.EmbeddedFonts.Keys);
+        Assert.Contains(PdfStandardFont.HelveticaBold, options.EmbeddedFonts.Keys);
+        Assert.Contains(PdfStandardFont.HelveticaOblique, options.EmbeddedFonts.Keys);
+        Assert.Contains(PdfStandardFont.HelveticaBoldOblique, options.EmbeddedFonts.Keys);
+        Assert.Contains("/Subtype /Type0", raw, StringComparison.Ordinal);
+        Assert.Contains("/Encoding /Identity-H", raw, StringComparison.Ordinal);
+        Assert.Contains("System regular system bold system italic system done", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PdfEmbeddedFontFamily_FromSystemThrowsWhenFamilyIsMissing() {
+        Assert.Throws<FileNotFoundException>(() =>
+            PdfEmbeddedFontFamily.FromSystem("OfficeIMO Missing Font Family 404"));
+    }
+
+    [Fact]
+    public void PdfEmbeddedFontFamily_TryFromSystemFontFilesMatchesRenamedTrueTypeMetadata() {
+        if (!TryFindSingleInstalledRegularFontFace(out string familyName, out string fontPath)) {
+            return;
+        }
+
+        string tempDir = Path.Combine(Path.GetTempPath(), "OfficeIMO.Pdf.Fonts." + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try {
+            string renamedPath = Path.Combine(tempDir, "officeimo-renamed-system-face.ttf");
+            File.Copy(fontPath, renamedPath);
+
+            bool found = PdfEmbeddedFontFamily.TryFromSystemFontFiles(
+                familyName,
+                new[] { renamedPath },
+                out PdfEmbeddedFontFamily? family);
+
+            Assert.True(found);
+            Assert.NotNull(family);
+            Assert.NotEmpty(family!.Regular);
+        } finally {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void PdfDoc_UseFontFamilyObjectReusesTrueTypeFamilyForGeneratedText() {
         string? fontPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
         if (fontPath == null) {
@@ -258,5 +321,112 @@ public class PdfFontFamilyTests {
         string[] parts = objectHeader.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
         Assert.True(parts.Length >= 2, "Could not parse object header '" + objectHeader + "'.");
         return int.Parse(parts[0], CultureInfo.InvariantCulture);
+    }
+
+    private static bool TryFindInstalledSystemFontFamily(out PdfEmbeddedFontFamily? family) {
+        string[] candidates = {
+            "Arial",
+            "DejaVu Sans",
+            "Liberation Sans",
+            "Segoe UI"
+        };
+
+        foreach (string candidate in candidates) {
+            if (PdfEmbeddedFontFamily.TryFromSystem(candidate, out family) &&
+                family != null &&
+                (family.Bold != null || family.Italic != null || family.BoldItalic != null)) {
+                return true;
+            }
+        }
+
+        family = null;
+        return false;
+    }
+
+    private static bool TryFindSingleInstalledRegularFontFace(out string familyName, out string fontPath) {
+        string[] candidates = {
+            "Arial",
+            "DejaVu Sans",
+            "Liberation Sans",
+            "Segoe UI",
+            "Microsoft Sans Serif"
+        };
+
+        foreach (string path in EnumerateInstalledTrueTypeFonts()) {
+            foreach (string candidate in candidates) {
+                if (PdfEmbeddedFontFamily.TryFromSystemFontFiles(candidate, new[] { path }, out PdfEmbeddedFontFamily? family) &&
+                    family != null &&
+                    family.Bold == null &&
+                    family.Italic == null &&
+                    family.BoldItalic == null) {
+                    familyName = candidate;
+                    fontPath = path;
+                    return true;
+                }
+            }
+        }
+
+        familyName = string.Empty;
+        fontPath = string.Empty;
+        return false;
+    }
+
+    private static IEnumerable<string> EnumerateInstalledTrueTypeFonts() {
+        string windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        if (!string.IsNullOrWhiteSpace(windows)) {
+            foreach (string font in EnumerateTrueTypeFonts(Path.Combine(windows, "Fonts"))) {
+                yield return font;
+            }
+        }
+
+        foreach (string font in EnumerateTrueTypeFonts("/usr/share/fonts")) {
+            yield return font;
+        }
+
+        foreach (string font in EnumerateTrueTypeFonts("/usr/local/share/fonts")) {
+            yield return font;
+        }
+
+        string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(userProfile)) {
+            foreach (string font in EnumerateTrueTypeFonts(Path.Combine(userProfile, ".local", "share", "fonts"))) {
+                yield return font;
+            }
+
+            foreach (string font in EnumerateTrueTypeFonts(Path.Combine(userProfile, ".fonts"))) {
+                yield return font;
+            }
+
+            foreach (string font in EnumerateTrueTypeFonts(Path.Combine(userProfile, "Library", "Fonts"))) {
+                yield return font;
+            }
+        }
+
+        foreach (string font in EnumerateTrueTypeFonts("/Library/Fonts")) {
+            yield return font;
+        }
+
+        foreach (string font in EnumerateTrueTypeFonts("/System/Library/Fonts")) {
+            yield return font;
+        }
+    }
+
+    private static IEnumerable<string> EnumerateTrueTypeFonts(string root) {
+        if (string.IsNullOrWhiteSpace(root) || !Directory.Exists(root)) {
+            yield break;
+        }
+
+        string[] files;
+        try {
+            files = Directory.GetFiles(root, "*.ttf", SearchOption.AllDirectories);
+        } catch (IOException) {
+            yield break;
+        } catch (UnauthorizedAccessException) {
+            yield break;
+        }
+
+        foreach (string file in files) {
+            yield return file;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `PdfEmbeddedFontFamily.FromSystem` and `TryFromSystem` for loading installed TrueType font families
- discover system fonts across Windows, Linux, and macOS font locations
- prefer TrueType `name` table metadata for family/style matching, with filename matching as fallback
- cover renamed-font metadata matching and generated PDF font-family behavior

## Validation
- `dotnet build .\OfficeIMO.Pdf\OfficeIMO.Pdf.csproj --framework netstandard2.0 --no-restore --verbosity minimal`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~PdfFontFamilyTests" --no-restore --verbosity minimal`
- `dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter "FullyQualifiedName~PdfFontFamilyTests" --no-restore --verbosity minimal`