### PR TITLE
Improve native PDF font and layout fidelity

### DIFF
--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
@@ -28,6 +28,7 @@ namespace OfficeIMO.Excel.Pdf {
             }
 
             var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var registeredFontSlots = new HashSet<PdfCore.PdfStandardFont>();
             foreach (WorksheetPdfExportPlan plan in exportPlans) {
                 ExcelCellStyleSnapshot?[,]? styles = plan.ExportData.Styles;
                 if (styles == null) {
@@ -38,13 +39,13 @@ namespace OfficeIMO.Excel.Pdf {
                 int columns = styles.GetLength(1);
                 for (int row = 0; row < rows; row++) {
                     for (int column = 0; column < columns; column++) {
-                        RegisterWorksheetFontCandidate(styles[row, column]?.FontName, pdfOptions, registeredFamilies);
+                        RegisterWorksheetFontCandidate(styles[row, column]?.FontName, pdfOptions, registeredFamilies, registeredFontSlots);
                     }
                 }
             }
         }
 
-        private static void RegisterWorksheetFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+        private static void RegisterWorksheetFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
             if (string.IsNullOrWhiteSpace(familyName)) {
                 return;
             }
@@ -55,9 +56,10 @@ namespace OfficeIMO.Excel.Pdf {
             }
 
             if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(trimmedFamilyName, out PdfCore.PdfStandardFont standardFont)) {
-                pdfOptions.RegisterOfficeFontFamily(
-                    trimmedFamilyName,
-                    PdfCore.PdfStandardFontMapper.GetFontFamily(standardFont));
+                PdfCore.PdfStandardFont fontFamily = PdfCore.PdfStandardFontMapper.GetFontFamily(standardFont);
+                if (registeredFontSlots.Add(fontFamily)) {
+                    pdfOptions.RegisterOfficeFontFamily(trimmedFamilyName, fontFamily);
+                }
             }
         }
 

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
@@ -28,7 +28,7 @@ namespace OfficeIMO.Excel.Pdf {
             }
 
             var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var registeredFontSlots = new HashSet<PdfCore.PdfStandardFont>();
+            HashSet<PdfCore.PdfStandardFont> registeredFontSlots = CreateRegisteredFontSlots(pdfOptions);
             foreach (WorksheetPdfExportPlan plan in exportPlans) {
                 ExcelCellStyleSnapshot?[,]? styles = plan.ExportData.Styles;
                 if (styles == null) {
@@ -61,6 +61,22 @@ namespace OfficeIMO.Excel.Pdf {
                     pdfOptions.RegisterOfficeFontFamily(trimmedFamilyName, fontFamily);
                 }
             }
+        }
+
+        private static HashSet<PdfCore.PdfStandardFont> CreateRegisteredFontSlots(PdfCore.PdfOptions pdfOptions) {
+            var registeredFontSlots = new HashSet<PdfCore.PdfStandardFont>();
+            AddRegisteredFontSlot(registeredFontSlots, pdfOptions.DefaultFont);
+            AddRegisteredFontSlot(registeredFontSlots, pdfOptions.HeaderFont);
+            AddRegisteredFontSlot(registeredFontSlots, pdfOptions.FooterFont);
+            foreach (PdfCore.PdfStandardFont embeddedFont in pdfOptions.EmbeddedFonts.Keys) {
+                AddRegisteredFontSlot(registeredFontSlots, embeddedFont);
+            }
+
+            return registeredFontSlots;
+        }
+
+        private static void AddRegisteredFontSlot(HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PdfCore.PdfStandardFont font) {
+            registeredFontSlots.Add(PdfCore.PdfStandardFontMapper.GetFontFamily(font));
         }
 
         private static IReadOnlyList<WorksheetPdfExportPlan> BuildWorksheetExportPlans(ExcelDocument document, ExcelDocumentReader reader, IReadOnlyList<string> sheetNames, ExcelPdfSaveOptions options, bool hasExplicitSheetSelection, PdfCore.PdfStandardFont defaultFontFamily) {

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
@@ -4,9 +4,12 @@ using PdfCore = OfficeIMO.Pdf;
 namespace OfficeIMO.Excel.Pdf {
     public static partial class ExcelPdfConverterExtensions {
         private static PdfCore.PdfOptions CreatePdfOptions(ExcelPdfSaveOptions options) {
-            var pdfOptions = new PdfCore.PdfOptions {
-                CreateOutlineFromHeadings = true
-            };
+            PdfCore.PdfOptions pdfOptions = options.PdfOptions?.Clone() ?? new PdfCore.PdfOptions();
+            pdfOptions.CreateOutlineFromHeadings = true;
+
+            if (!string.IsNullOrWhiteSpace(options.FontFamily)) {
+                pdfOptions.UseOfficeFontFamily(options.FontFamily);
+            }
 
             if (options.PageSize.HasValue) {
                 pdfOptions.PageSize = options.PageSize.Value;
@@ -17,6 +20,45 @@ namespace OfficeIMO.Excel.Pdf {
             }
 
             return pdfOptions;
+        }
+
+        private static void RegisterWorksheetFonts(PdfCore.PdfOptions pdfOptions, IReadOnlyList<WorksheetPdfExportPlan> exportPlans, ExcelPdfSaveOptions options) {
+            if (!options.UseWorksheetCellStyles) {
+                return;
+            }
+
+            var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (WorksheetPdfExportPlan plan in exportPlans) {
+                ExcelCellStyleSnapshot?[,]? styles = plan.ExportData.Styles;
+                if (styles == null) {
+                    continue;
+                }
+
+                int rows = Math.Min(plan.ExportedRows, styles.GetLength(0));
+                int columns = styles.GetLength(1);
+                for (int row = 0; row < rows; row++) {
+                    for (int column = 0; column < columns; column++) {
+                        RegisterWorksheetFontCandidate(styles[row, column]?.FontName, pdfOptions, registeredFamilies);
+                    }
+                }
+            }
+        }
+
+        private static void RegisterWorksheetFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+            if (string.IsNullOrWhiteSpace(familyName)) {
+                return;
+            }
+
+            string trimmedFamilyName = familyName!.Trim();
+            if (!registeredFamilies.Add(trimmedFamilyName)) {
+                return;
+            }
+
+            if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(trimmedFamilyName, out PdfCore.PdfStandardFont standardFont)) {
+                pdfOptions.RegisterOfficeFontFamily(
+                    trimmedFamilyName,
+                    PdfCore.PdfStandardFontMapper.GetFontFamily(standardFont));
+            }
         }
 
         private static IReadOnlyList<WorksheetPdfExportPlan> BuildWorksheetExportPlans(ExcelDocument document, ExcelDocumentReader reader, IReadOnlyList<string> sheetNames, ExcelPdfSaveOptions options, bool hasExplicitSheetSelection) {

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
@@ -61,7 +61,7 @@ namespace OfficeIMO.Excel.Pdf {
             }
         }
 
-        private static IReadOnlyList<WorksheetPdfExportPlan> BuildWorksheetExportPlans(ExcelDocument document, ExcelDocumentReader reader, IReadOnlyList<string> sheetNames, ExcelPdfSaveOptions options, bool hasExplicitSheetSelection) {
+        private static IReadOnlyList<WorksheetPdfExportPlan> BuildWorksheetExportPlans(ExcelDocument document, ExcelDocumentReader reader, IReadOnlyList<string> sheetNames, ExcelPdfSaveOptions options, bool hasExplicitSheetSelection, PdfCore.PdfStandardFont defaultFontFamily) {
             var plans = new List<WorksheetPdfExportPlan>();
             for (int i = 0; i < sheetNames.Count; i++) {
                 string sheetName = sheetNames[i];
@@ -74,7 +74,7 @@ namespace OfficeIMO.Excel.Pdf {
                 ExcelSheetPageSetup? pageSetup = options.UseWorksheetPageSetup ? workbookSheet?.GetPageSetup() : null;
                 ExcelSheet.HeaderFooterSnapshot? headerFooter = (options.UseWorksheetHeadersAndFooters || options.UseWorksheetHeaderFooterImages) ? workbookSheet?.GetHeaderFooter() : null;
                 string exportRange = GetExportRange(sheet, workbookSheet, options);
-                SheetExportData exportData = ReadSheetExportData(sheet, workbookSheet, exportRange, options);
+                SheetExportData exportData = ReadSheetExportData(sheet, workbookSheet, exportRange, options, defaultFontFamily);
                 IReadOnlyList<int> manualRowBreaks = options.UseWorksheetPageBreaks && workbookSheet != null
                     ? workbookSheet.GetManualRowPageBreaks()
                     : Array.Empty<int>();

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.SheetData.Cells.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.SheetData.Cells.cs
@@ -110,7 +110,7 @@ namespace OfficeIMO.Excel.Pdf {
                     int sourceRow = visibility?.RowOffsets[row] ?? row;
                     int sourceColumn = visibility?.ColumnOffsets[column] ?? column;
                     ExcelCellStyleSnapshot style = workbookSheet.GetCellStyle(firstRow + sourceRow, firstColumn + sourceColumn);
-                    if (style.HasPdfVisualStyle) {
+                    if (HasPdfExportStyle(style)) {
                         styles[row, column] = style;
                         hasAnyStyle = true;
                     }
@@ -118,6 +118,15 @@ namespace OfficeIMO.Excel.Pdf {
             }
 
             return hasAnyStyle ? styles : null;
+        }
+
+        private static bool HasPdfExportStyle(ExcelCellStyleSnapshot style) {
+            if (style.HasPdfVisualStyle) {
+                return true;
+            }
+
+            return PdfCore.PdfStandardFontMapper.TryMapFontFamily(style.FontName, out PdfCore.PdfStandardFont font) &&
+                PdfCore.PdfStandardFontMapper.GetFontFamily(font) != PdfCore.PdfStandardFont.Helvetica;
         }
 
         private static ExcelHyperlinkSnapshot?[,]? ReadHyperlinkData(ExcelSheet? workbookSheet, string normalizedRange, int rowCount, int columnCount, bool enabled, VisibilityLayoutData? visibility = null) {

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.SheetData.Cells.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.SheetData.Cells.cs
@@ -94,7 +94,7 @@ namespace OfficeIMO.Excel.Pdf {
             return false;
         }
 
-        private static ExcelCellStyleSnapshot?[,]? ReadCellStyleData(ExcelSheet? workbookSheet, string normalizedRange, int rowCount, int columnCount, bool enabled, VisibilityLayoutData? visibility = null) {
+        private static ExcelCellStyleSnapshot?[,]? ReadCellStyleData(ExcelSheet? workbookSheet, string normalizedRange, int rowCount, int columnCount, bool enabled, PdfCore.PdfStandardFont defaultFontFamily, VisibilityLayoutData? visibility = null) {
             if (!enabled || workbookSheet == null || rowCount == 0 || columnCount == 0) {
                 return null;
             }
@@ -110,7 +110,7 @@ namespace OfficeIMO.Excel.Pdf {
                     int sourceRow = visibility?.RowOffsets[row] ?? row;
                     int sourceColumn = visibility?.ColumnOffsets[column] ?? column;
                     ExcelCellStyleSnapshot style = workbookSheet.GetCellStyle(firstRow + sourceRow, firstColumn + sourceColumn);
-                    if (HasPdfExportStyle(style)) {
+                    if (HasPdfExportStyle(style, defaultFontFamily)) {
                         styles[row, column] = style;
                         hasAnyStyle = true;
                     }
@@ -120,13 +120,13 @@ namespace OfficeIMO.Excel.Pdf {
             return hasAnyStyle ? styles : null;
         }
 
-        private static bool HasPdfExportStyle(ExcelCellStyleSnapshot style) {
+        private static bool HasPdfExportStyle(ExcelCellStyleSnapshot style, PdfCore.PdfStandardFont defaultFontFamily) {
             if (style.HasPdfVisualStyle) {
                 return true;
             }
 
             return PdfCore.PdfStandardFontMapper.TryMapFontFamily(style.FontName, out PdfCore.PdfStandardFont font) &&
-                PdfCore.PdfStandardFontMapper.GetFontFamily(font) != PdfCore.PdfStandardFont.Helvetica;
+                PdfCore.PdfStandardFontMapper.GetFontFamily(font) != defaultFontFamily;
         }
 
         private static ExcelHyperlinkSnapshot?[,]? ReadHyperlinkData(ExcelSheet? workbookSheet, string normalizedRange, int rowCount, int columnCount, bool enabled, VisibilityLayoutData? visibility = null) {

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.SheetData.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.SheetData.cs
@@ -64,10 +64,10 @@ namespace OfficeIMO.Excel.Pdf {
         private static string? GetWorksheetPrintArea(ExcelSheet? workbookSheet, ExcelPdfSaveOptions options) =>
             options.UseWorksheetPrintAreas && workbookSheet != null ? workbookSheet.GetPrintArea() : null;
 
-        private static SheetExportData ReadSheetExportData(ExcelSheetReader sheet, ExcelSheet? workbookSheet, string exportRange, ExcelPdfSaveOptions options) {
+        private static SheetExportData ReadSheetExportData(ExcelSheetReader sheet, ExcelSheet? workbookSheet, string exportRange, ExcelPdfSaveOptions options, PdfCore.PdfStandardFont defaultFontFamily) {
             string normalizedRange = NormalizeA1Range(exportRange);
             A1.TryParseRange(normalizedRange, out int rangeFirstRow, out int rangeFirstColumn, out _, out int rangeLastColumn);
-            RangeExportData bodyRange = ReadRangeExportData(sheet, workbookSheet, normalizedRange, options);
+            RangeExportData bodyRange = ReadRangeExportData(sheet, workbookSheet, normalizedRange, options, defaultFontFamily);
             object?[,] values = bodyRange.Values;
             ExcelCellStyleSnapshot?[,]? styles = bodyRange.Styles;
             ExcelHyperlinkSnapshot?[,]? hyperlinks = bodyRange.Hyperlinks;
@@ -90,7 +90,7 @@ namespace OfficeIMO.Excel.Pdf {
             if (firstTitleRow < rangeFirstRow) {
                 int prependedLastTitleRow = Math.Min(lastTitleRow, rangeFirstRow - 1);
                 string titleRange = ToA1Range(firstTitleRow, rangeFirstColumn, prependedLastTitleRow, rangeLastColumn);
-                RangeExportData titleRangeData = ReadRangeExportData(sheet, workbookSheet, titleRange, options);
+                RangeExportData titleRangeData = ReadRangeExportData(sheet, workbookSheet, titleRange, options, defaultFontFamily);
                 int prependedRowCount = titleRangeData.Values.GetLength(0);
                 int bodyRowCount = values.GetLength(0);
                 int columnCount = values.GetLength(1);
@@ -135,7 +135,7 @@ namespace OfficeIMO.Excel.Pdf {
             return new SheetExportData(values, styles, hyperlinks, cellReferences, mergedCells, columnWidths, rowHeights, headerRows, firstBodyRowNumber, conditionalFills);
         }
 
-        private static RangeExportData ReadRangeExportData(ExcelSheetReader sheet, ExcelSheet? workbookSheet, string normalizedRange, ExcelPdfSaveOptions options) {
+        private static RangeExportData ReadRangeExportData(ExcelSheetReader sheet, ExcelSheet? workbookSheet, string normalizedRange, ExcelPdfSaveOptions options, PdfCore.PdfStandardFont defaultFontFamily) {
             object?[,] rawValues = sheet.ReadRange(normalizedRange);
             VisibilityLayoutData? visibility = ReadVisibilityLayoutData(
                 workbookSheet,
@@ -157,6 +157,7 @@ namespace OfficeIMO.Excel.Pdf {
                 rowCount,
                 columnCount,
                 options.UseWorksheetCellStyles,
+                defaultFontFamily,
                 visibility);
             ExcelHyperlinkSnapshot?[,]? hyperlinks = ReadHyperlinkData(
                 workbookSheet,

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.TableChunks.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.TableChunks.cs
@@ -283,7 +283,7 @@ namespace OfficeIMO.Excel.Pdf {
             return false;
         }
 
-        private static IEnumerable<PdfCore.PdfTableCell[]> CreatePdfRows(object?[,] values, ExcelCellStyleSnapshot?[,]? styles, ExcelHyperlinkSnapshot?[,]? hyperlinks, string?[,]? cellReferences, MergeLayoutData? mergedCells, IReadOnlyDictionary<string, IReadOnlyList<WorksheetImageExportData>>? imagesByCellReference, IReadOnlyList<int> rowIndexes, int startColumn, int columnCount, string emptyCellText, IReadOnlyDictionary<string, string> sheetDestinations, IReadOnlyDictionary<string, string> cellDestinations, string sheetName) {
+        private static IEnumerable<PdfCore.PdfTableCell[]> CreatePdfRows(object?[,] values, ExcelCellStyleSnapshot?[,]? styles, ExcelHyperlinkSnapshot?[,]? hyperlinks, string?[,]? cellReferences, MergeLayoutData? mergedCells, IReadOnlyDictionary<string, IReadOnlyList<WorksheetImageExportData>>? imagesByCellReference, IReadOnlyList<int> rowIndexes, int startColumn, int columnCount, string emptyCellText, IReadOnlyDictionary<string, string> sheetDestinations, IReadOnlyDictionary<string, string> cellDestinations, string sheetName, PdfCore.PdfStandardFont defaultFontFamily) {
             int endColumn = Math.Min(values.GetLength(1), startColumn + columnCount);
             for (int localRow = 0; localRow < rowIndexes.Count; localRow++) {
                 int row = rowIndexes[localRow];
@@ -305,7 +305,7 @@ namespace OfficeIMO.Excel.Pdf {
                         ? destinationName
                         : null;
                     IReadOnlyList<WorksheetImageExportData>? cellImages = GetCellImages(imagesByCellReference, cellReferences, row, column);
-                    cells.Add(CreatePdfCell(text, style, hyperlink, span, sheetDestinations, cellDestinations, sheetName, cellDestinationName, cellImages));
+                    cells.Add(CreatePdfCell(text, style, hyperlink, span, sheetDestinations, cellDestinations, sheetName, cellDestinationName, cellImages, defaultFontFamily));
                 }
 
                 yield return cells.ToArray();
@@ -350,7 +350,7 @@ namespace OfficeIMO.Excel.Pdf {
                 : null;
         }
 
-        private static PdfCore.PdfTableCell CreatePdfCell(string text, ExcelCellStyleSnapshot? style, ExcelHyperlinkSnapshot? hyperlink, MergeSpan? span, IReadOnlyDictionary<string, string> sheetDestinations, IReadOnlyDictionary<string, string> cellDestinations, string sheetName, string? cellDestinationName, IReadOnlyList<WorksheetImageExportData>? cellImages) {
+        private static PdfCore.PdfTableCell CreatePdfCell(string text, ExcelCellStyleSnapshot? style, ExcelHyperlinkSnapshot? hyperlink, MergeSpan? span, IReadOnlyDictionary<string, string> sheetDestinations, IReadOnlyDictionary<string, string> cellDestinations, string sheetName, string? cellDestinationName, IReadOnlyList<WorksheetImageExportData>? cellImages, PdfCore.PdfStandardFont defaultFontFamily) {
             int rowSpan = span?.RowSpan ?? 1;
             int columnSpan = span?.ColumnSpan ?? 1;
             PdfCore.PdfColor? textColor = ToPdfColor(style?.FontColorHex);
@@ -360,7 +360,7 @@ namespace OfficeIMO.Excel.Pdf {
                 : null;
             string? linkContents = linkUri == null && linkDestinationName == null ? null : text;
             IReadOnlyList<PdfCore.PdfTableCellImage>? pdfImages = ToPdfTableCellImages(cellImages);
-            PdfCore.PdfStandardFont? font = MapFont(style?.FontName);
+            PdfCore.PdfStandardFont? font = MapFont(style?.FontName, defaultFontFamily);
             IReadOnlyList<PdfCore.TextRun> runs = style != null && (style.Bold || style.Italic || style.Underline || textColor.HasValue || font.HasValue)
                 ? new[] { new PdfCore.TextRun(text, bold: style.Bold, underline: style.Underline, color: textColor, italic: style.Italic, font: font) }
                 : new[] { PdfCore.TextRun.Normal(text) };
@@ -376,12 +376,12 @@ namespace OfficeIMO.Excel.Pdf {
                 namedDestinationName: cellDestinationName);
         }
 
-        private static PdfCore.PdfStandardFont? MapFont(string? fontName) {
+        private static PdfCore.PdfStandardFont? MapFont(string? fontName, PdfCore.PdfStandardFont defaultFontFamily) {
             if (!PdfCore.PdfStandardFontMapper.TryMapFontFamily(fontName, out PdfCore.PdfStandardFont font)) {
                 return null;
             }
 
-            return PdfCore.PdfStandardFontMapper.GetFontFamily(font) == PdfCore.PdfStandardFont.Helvetica
+            return PdfCore.PdfStandardFontMapper.GetFontFamily(font) == defaultFontFamily
                 ? null
                 : font;
         }

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.TableChunks.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.TableChunks.cs
@@ -360,8 +360,9 @@ namespace OfficeIMO.Excel.Pdf {
                 : null;
             string? linkContents = linkUri == null && linkDestinationName == null ? null : text;
             IReadOnlyList<PdfCore.PdfTableCellImage>? pdfImages = ToPdfTableCellImages(cellImages);
-            IReadOnlyList<PdfCore.TextRun> runs = style != null && (style.Bold || style.Italic || style.Underline || textColor.HasValue)
-                ? new[] { new PdfCore.TextRun(text, bold: style.Bold, underline: style.Underline, color: textColor, italic: style.Italic) }
+            PdfCore.PdfStandardFont? font = MapFont(style?.FontName);
+            IReadOnlyList<PdfCore.TextRun> runs = style != null && (style.Bold || style.Italic || style.Underline || textColor.HasValue || font.HasValue)
+                ? new[] { new PdfCore.TextRun(text, bold: style.Bold, underline: style.Underline, color: textColor, italic: style.Italic, font: font) }
                 : new[] { PdfCore.TextRun.Normal(text) };
 
             return new PdfCore.PdfTableCell(
@@ -373,6 +374,16 @@ namespace OfficeIMO.Excel.Pdf {
                 images: pdfImages,
                 linkDestinationName: linkDestinationName,
                 namedDestinationName: cellDestinationName);
+        }
+
+        private static PdfCore.PdfStandardFont? MapFont(string? fontName) {
+            if (!PdfCore.PdfStandardFontMapper.TryMapFontFamily(fontName, out PdfCore.PdfStandardFont font)) {
+                return null;
+            }
+
+            return PdfCore.PdfStandardFontMapper.GetFontFamily(font) == PdfCore.PdfStandardFont.Helvetica
+                ? null
+                : font;
         }
 
         private static IReadOnlyList<PdfCore.PdfTableCellImage>? ToPdfTableCellImages(IReadOnlyList<WorksheetImageExportData>? images) {

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.cs
@@ -16,11 +16,13 @@ namespace OfficeIMO.Excel.Pdf {
 
             options ??= new ExcelPdfSaveOptions();
             options.Warnings.Clear();
-            var pdf = PdfCore.PdfDocument.Create(CreatePdfOptions(options));
+            PdfCore.PdfOptions pdfOptions = CreatePdfOptions(options);
             using ExcelDocumentReader reader = document.CreateReader();
             IReadOnlyList<string> sheetNames = GetSheetNames(reader, options);
             bool hasExplicitSheetSelection = HasExplicitSheetSelection(options);
             IReadOnlyList<WorksheetPdfExportPlan> exportPlans = BuildWorksheetExportPlans(document, reader, sheetNames, options, hasExplicitSheetSelection);
+            RegisterWorksheetFonts(pdfOptions, exportPlans, options);
+            var pdf = PdfCore.PdfDocument.Create(pdfOptions);
             IReadOnlyDictionary<string, string> sheetDestinations = BuildSheetDestinationMap(exportPlans);
             IReadOnlyDictionary<string, string> cellDestinations = BuildCellDestinationMap(exportPlans);
             foreach (WorksheetPdfExportPlan plan in exportPlans) {

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.cs
@@ -17,10 +17,11 @@ namespace OfficeIMO.Excel.Pdf {
             options ??= new ExcelPdfSaveOptions();
             options.Warnings.Clear();
             PdfCore.PdfOptions pdfOptions = CreatePdfOptions(options);
+            PdfCore.PdfStandardFont defaultFontFamily = PdfCore.PdfStandardFontMapper.GetFontFamily(pdfOptions.DefaultFont);
             using ExcelDocumentReader reader = document.CreateReader();
             IReadOnlyList<string> sheetNames = GetSheetNames(reader, options);
             bool hasExplicitSheetSelection = HasExplicitSheetSelection(options);
-            IReadOnlyList<WorksheetPdfExportPlan> exportPlans = BuildWorksheetExportPlans(document, reader, sheetNames, options, hasExplicitSheetSelection);
+            IReadOnlyList<WorksheetPdfExportPlan> exportPlans = BuildWorksheetExportPlans(document, reader, sheetNames, options, hasExplicitSheetSelection, defaultFontFamily);
             RegisterWorksheetFonts(pdfOptions, exportPlans, options);
             var pdf = PdfCore.PdfDocument.Create(pdfOptions);
             IReadOnlyDictionary<string, string> sheetDestinations = BuildSheetDestinationMap(exportPlans);
@@ -58,7 +59,7 @@ namespace OfficeIMO.Excel.Pdf {
                                 }
 
                                 item.Table(
-                                    CreatePdfRows(values, plan.ExportData.Styles, plan.ExportData.Hyperlinks, plan.ExportData.CellReferences, plan.ExportData.MergedCells, imagesByCellReference, chunk.RowIndexes, chunk.StartColumn, chunk.ColumnCount, options.EmptyCellText, sheetDestinations, cellDestinations, plan.SheetName),
+                                    CreatePdfRows(values, plan.ExportData.Styles, plan.ExportData.Hyperlinks, plan.ExportData.CellReferences, plan.ExportData.MergedCells, imagesByCellReference, chunk.RowIndexes, chunk.StartColumn, chunk.ColumnCount, options.EmptyCellText, sheetDestinations, cellDestinations, plan.SheetName, defaultFontFamily),
                                     style: CreateTableStyle(options, plan.PageSetup, chunk.RowIndexes, chunk.HeaderRowCount, plan.ExportData.Styles, plan.ExportData.ConditionalFills, plan.ExportData.ColumnWidths, plan.ExportData.RowHeights, chunk.StartColumn, chunk.ColumnCount));
                             }
                         }

--- a/OfficeIMO.Excel.Pdf/ExcelPdfSaveOptions.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfSaveOptions.cs
@@ -16,6 +16,16 @@ namespace OfficeIMO.Excel.Pdf {
         public List<ExcelPdfExportWarning> Warnings { get; } = new List<ExcelPdfExportWarning>();
 
         /// <summary>
+        /// PDF creation options passed to the first-party PDF engine. The options are cloned before export.
+        /// </summary>
+        public PdfCore.PdfOptions? PdfOptions { get; set; }
+
+        /// <summary>
+        /// Optional workbook default font family used by the first-party PDF engine.
+        /// </summary>
+        public string? FontFamily { get; set; }
+
+        /// <summary>
         /// Optional first-party page size in PDF points.
         /// </summary>
         public PdfCore.PageSize? PageSize { get; set; }

--- a/OfficeIMO.Excel/ExcelCell.cs
+++ b/OfficeIMO.Excel/ExcelCell.cs
@@ -126,6 +126,14 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
+        /// Sets the font family name.
+        /// </summary>
+        public ExcelCell SetFontName(string fontName) {
+            Sheet.CellFontName(Row, Column, fontName);
+            return this;
+        }
+
+        /// <summary>
         /// Sets the font color using a hex color value.
         /// </summary>
         public ExcelCell SetFontColor(string hexColor) {
@@ -344,6 +352,14 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public ExcelRange SetFontColor(string hexColor) {
             ForEachCell((row, column) => Sheet.CellFontColor(row, column, hexColor));
+            return this;
+        }
+
+        /// <summary>
+        /// Applies a font family name to every cell in the range.
+        /// </summary>
+        public ExcelRange SetFontName(string fontName) {
+            ForEachCell((row, column) => Sheet.CellFontName(row, column, fontName));
             return this;
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.Inspection.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Inspection.cs
@@ -421,6 +421,7 @@ namespace OfficeIMO.Excel {
                 Bold = font?.Bold != null,
                 Italic = font?.Italic != null,
                 Underline = font?.Underline != null,
+                FontName = font?.FontName?.Val?.Value,
                 FontColorArgb = GetColorArgb(font?.Color),
                 FillColorArgb = GetFillColorArgb(fill),
                 Border = BuildBorderSnapshot(border),

--- a/OfficeIMO.Excel/ExcelInspectionSnapshot.cs
+++ b/OfficeIMO.Excel/ExcelInspectionSnapshot.cs
@@ -737,6 +737,11 @@ namespace OfficeIMO.Excel {
         public bool Underline { get; internal set; }
 
         /// <summary>
+        /// Resolved font family name, when available.
+        /// </summary>
+        public string? FontName { get; internal set; }
+
+        /// <summary>
         /// Font color in ARGB hexadecimal form, when directly resolvable.
         /// </summary>
         public string? FontColorArgb { get; internal set; }

--- a/OfficeIMO.Excel/ExcelSheet.CellStyle.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellStyle.cs
@@ -42,6 +42,7 @@ namespace OfficeIMO.Excel {
                 Bold = font?.Bold != null,
                 Italic = font?.Italic != null,
                 Underline = font?.Underline != null,
+                FontName = font?.FontName?.Val?.Value,
                 FontColorArgb = NormalizeReadArgb(font?.Color?.Rgb?.Value),
                 FillColorArgb = GetFillArgb(fill),
                 Border = BuildBorderSnapshot(border),

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.Styles.OpenXml.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.Styles.OpenXml.cs
@@ -155,6 +155,12 @@ namespace OfficeIMO.Excel {
             };
         }
 
+        private static void SetFontName(DocumentFormat.OpenXml.Spreadsheet.Font font, string fontName) {
+            font.FontName = new FontName {
+                Val = fontName.Trim()
+            };
+        }
+
         private static void SetUniformBorder(Border border, BorderStyleValues style, string? hexColor) {
             var argb = string.IsNullOrWhiteSpace(hexColor) ? null : NormalizeHexColor(hexColor!);
             border.LeftBorder = CreateBorderSide<LeftBorder>(style, argb);

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.Styles.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.Styles.cs
@@ -46,6 +46,20 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
+        /// Applies a font family name to a single cell.
+        /// </summary>
+        /// <param name="row">The 1-based row index of the cell to modify.</param>
+        /// <param name="column">The 1-based column index of the cell to modify.</param>
+        /// <param name="fontName">The font family name to assign.</param>
+        public void CellFontName(int row, int column, string fontName) {
+            if (string.IsNullOrWhiteSpace(fontName)) return;
+            WriteLockConditional(() => {
+                var cell = GetCell(row, column);
+                ApplyFontName(cell, fontName);
+            });
+        }
+
+        /// <summary>
         /// Applies solid background to a single cell. Accepts #RRGGBB or #AARRGGBB.
         /// </summary>
         /// <param name="row">The 1-based row index of the cell to fill.</param>
@@ -542,6 +556,25 @@ namespace OfficeIMO.Excel {
             var underlineFontId = GetOrCreateFontVariant(stylesheet, GetOptionalValue(baseFormat.FontId), font => SetUnderline(font, underline));
             ApplyCellFormatOverride(stylesheet, cell, format => {
                 format.FontId = underlineFontId;
+                format.ApplyFont = true;
+            });
+            stylesPart.Stylesheet.Save();
+        }
+
+        private void ApplyFontName(Cell cell, string fontName) {
+            var workbookPart = _excelDocument.WorkbookPartRoot ?? throw new InvalidOperationException("WorkbookPart is null");
+            var stylesPart = workbookPart.WorkbookStylesPart;
+            if (stylesPart == null)
+                stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+
+            var stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
+            EnsureDefaultStylePrimitives(stylesheet);
+
+            uint baseIndex = cell.StyleIndex?.Value ?? 0U;
+            var baseFormat = GetBaseCellFormat(stylesheet, baseIndex);
+            var namedFontId = GetOrCreateFontVariant(stylesheet, GetOptionalValue(baseFormat.FontId), font => SetFontName(font, fontName));
+            ApplyCellFormatOverride(stylesheet, cell, format => {
+                format.FontId = namedFontId;
                 format.ApplyFont = true;
             });
             stylesPart.Stylesheet.Save();

--- a/OfficeIMO.Excel/ExcelSheet.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Tables.cs
@@ -397,16 +397,16 @@ namespace OfficeIMO.Excel {
                 throw new ArgumentNullException(nameof(range));
             }
 
-            if (_excelDocument.HasPendingDirectCellValues) {
-                MaterializeDeferredDataSetImportIfNeeded();
-            }
-
-            if (_excelDocument.ShouldMaterializeDeferredDirectTabularSaveCandidateForTable(this, range, hasHeader)) {
-                _excelDocument.MaterializeDeferredDataSetImport();
-            }
-
             string resolvedName = string.Empty;
             WriteLock(() => {
+                if (_excelDocument.HasPendingDirectCellValues) {
+                    MaterializeDeferredDataSetImportIfNeeded();
+                }
+
+                if (_excelDocument.ShouldMaterializeDeferredDirectTabularSaveCandidateForTable(this, range, hasHeader)) {
+                    _excelDocument.MaterializeDeferredDataSetImport();
+                }
+
                 if (!A1.TryParseStrictRange(range, out int startRowIndex, out int startColumnIndex, out int endRowIndex, out int endColumnIndex)) {
                     throw new ArgumentException("Invalid range format", nameof(range));
                 }

--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.cs
@@ -46,7 +46,11 @@ public static partial class MarkdownPdfConverterExtensions {
         options ??= new MarkdownPdfSaveOptions();
         options.ResetExportState();
 
-        PdfCore.PdfOptions pdfOptions = options.PdfOptions ?? new PdfCore.PdfOptions();
+        PdfCore.PdfOptions pdfOptions = options.PdfOptions?.Clone() ?? new PdfCore.PdfOptions();
+        if (!string.IsNullOrWhiteSpace(options.FontFamily)) {
+            pdfOptions.UseOfficeFontFamily(options.FontFamily);
+        }
+
         if (options.CreateOutlineFromHeadings) {
             pdfOptions.CreateOutlineFromHeadings = true;
         }
@@ -57,6 +61,7 @@ public static partial class MarkdownPdfConverterExtensions {
         if (documentTheme != null) {
             pdf.Theme(documentTheme);
         }
+        ApplyMarkdownDefaultFont(pdf, options);
         visualTheme.ApplyPageDecorations(pdf, pdfOptions);
 
         IReadOnlyList<IMarkdownBlock> topLevelBlocks = GetPdfTopLevelBlocks(document);
@@ -68,6 +73,12 @@ public static partial class MarkdownPdfConverterExtensions {
         }
 
         return pdf;
+    }
+
+    private static void ApplyMarkdownDefaultFont(PdfCore.PdfDocument pdf, MarkdownPdfSaveOptions options) {
+        if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(options.FontFamily, out PdfCore.PdfStandardFont font)) {
+            pdf.DefaultTextStyle(style => style.Font(PdfCore.PdfStandardFontMapper.GetFontFamily(font)));
+        }
     }
 
     private static IReadOnlyList<IMarkdownBlock> GetPdfTopLevelBlocks(MarkdownDoc document) {

--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfSaveOptions.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfSaveOptions.cs
@@ -14,6 +14,9 @@ public sealed class MarkdownPdfSaveOptions {
     /// <summary>PDF creation options passed to the first-party PDF engine.</summary>
     public PdfCore.PdfOptions? PdfOptions { get; set; }
 
+    /// <summary>Optional Markdown default font family used by the first-party PDF engine.</summary>
+    public string? FontFamily { get; set; }
+
     /// <summary>Markdown reader options used by string and file overloads.</summary>
     public MarkdownReaderOptions? ReaderOptions { get; set; }
 

--- a/OfficeIMO.Pdf/Options/PdfOptions.Catalog.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.Catalog.cs
@@ -171,13 +171,7 @@ public sealed partial class PdfOptions {
     }
 
     internal PdfOptions UseDefaultTextFontFamily(PdfEmbeddedFontFamily fontFamily) {
-        Guard.NotNull(fontFamily, nameof(fontFamily));
-        PdfEmbeddedFontFamily snapshot = fontFamily.Clone();
-
-        EmbedStandardFont(PdfStandardFont.Helvetica, snapshot.RegularSnapshot, BuildFontFamilyFaceName(snapshot.FamilyName, "Regular"));
-        EmbedStandardFont(PdfStandardFont.HelveticaBold, snapshot.BoldSnapshot ?? snapshot.RegularSnapshot, BuildFontFamilyFaceName(snapshot.FamilyName, "Bold"));
-        EmbedStandardFont(PdfStandardFont.HelveticaOblique, snapshot.ItalicSnapshot ?? snapshot.RegularSnapshot, BuildFontFamilyFaceName(snapshot.FamilyName, "Italic"));
-        EmbedStandardFont(PdfStandardFont.HelveticaBoldOblique, snapshot.BoldItalicSnapshot ?? snapshot.BoldSnapshot ?? snapshot.ItalicSnapshot ?? snapshot.RegularSnapshot, BuildFontFamilyFaceName(snapshot.FamilyName, "BoldItalic"));
+        RegisterFontFamily(PdfStandardFont.Helvetica, fontFamily);
         DefaultFont = PdfStandardFont.Helvetica;
         return this;
     }

--- a/OfficeIMO.Pdf/Options/PdfOptions.Fonts.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.Fonts.cs
@@ -1,0 +1,95 @@
+namespace OfficeIMO.Pdf;
+
+public sealed partial class PdfOptions {
+    private static readonly char[] OfficeFontFamilySeparators = { ',', ';' };
+    private static readonly char[] OfficeFontFamilyTrimChars = { ' ', '\t', '"', '\'' };
+
+    /// <summary>
+    /// Uses an Office-style font family name for generated text, embedding the installed TrueType
+    /// family when it is available and otherwise falling back to the nearest PDF standard family.
+    /// </summary>
+    /// <param name="familyName">Office, CSS, or system font family name such as <c>Aptos</c>, <c>Calibri</c>, or <c>Consolas</c>.</param>
+    /// <param name="embedSystemFont">When true, installed TrueType faces are preferred over dependency-free standard PDF font aliases.</param>
+    public PdfOptions UseOfficeFontFamily(string? familyName, bool embedSystemFont = true) {
+        if (string.IsNullOrWhiteSpace(familyName)) {
+            return this;
+        }
+
+        if (PdfStandardFontMapper.TryMapFontFamily(familyName, out PdfStandardFont standardFont)) {
+            PdfStandardFont family = PdfStandardFontMapper.GetFontFamily(standardFont);
+            RegisterOfficeFontFamily(familyName, family, embedSystemFont);
+            DefaultFont = family;
+            HeaderFont = family;
+            FooterFont = family;
+            return this;
+        }
+
+        if (embedSystemFont && TryLoadOfficeFontFamily(familyName!, out PdfEmbeddedFontFamily? embeddedFamily) && embeddedFamily != null) {
+            RegisterFontFamily(PdfStandardFont.Helvetica, embeddedFamily);
+            DefaultFont = PdfStandardFont.Helvetica;
+            HeaderFont = PdfStandardFont.Helvetica;
+            FooterFont = PdfStandardFont.Helvetica;
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Registers an Office-style font family for one semantic PDF font family slot without changing
+    /// the document default font. This is used by converters for run-level and cell-level fonts.
+    /// </summary>
+    /// <param name="familyName">Office, CSS, or system font family name such as <c>Aptos</c>, <c>Georgia</c>, or <c>Consolas</c>.</param>
+    /// <param name="baseFontFamily">The semantic standard family slot to back: Helvetica, Times-Roman, or Courier.</param>
+    /// <param name="embedSystemFont">When true, installed TrueType faces are embedded into the selected semantic slot when available.</param>
+    public PdfOptions RegisterOfficeFontFamily(string? familyName, PdfStandardFont baseFontFamily, bool embedSystemFont = true) {
+        if (string.IsNullOrWhiteSpace(familyName)) {
+            return this;
+        }
+
+        PdfStandardFont normalizedFamily = PdfStandardFontMapper.GetFontFamily(baseFontFamily);
+        if (embedSystemFont && TryLoadOfficeFontFamily(familyName!, out PdfEmbeddedFontFamily? embeddedFamily) && embeddedFamily != null) {
+            RegisterFontFamily(normalizedFamily, embeddedFamily);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a caller-supplied TrueType font family for one semantic PDF font family slot without
+    /// changing the document default font. Use this for private, licensed, or packaged fonts that
+    /// should back a specific generated Helvetica, Times, or Courier family.
+    /// </summary>
+    /// <param name="baseFontFamily">The semantic standard family slot to back: Helvetica, Times-Roman, or Courier.</param>
+    /// <param name="fontFamily">Reusable TrueType font family to embed into that semantic slot.</param>
+    public PdfOptions RegisterFontFamily(PdfStandardFont baseFontFamily, PdfEmbeddedFontFamily fontFamily) {
+        Guard.NotNull(fontFamily, nameof(fontFamily));
+        PdfStandardFont normalizedFamily = PdfStandardFontMapper.GetFontFamily(baseFontFamily);
+        PdfEmbeddedFontFamily snapshot = fontFamily.Clone();
+
+        EmbedStandardFont(normalizedFamily, snapshot.RegularSnapshot, BuildFontFamilyFaceName(snapshot.FamilyName, "Regular"));
+        EmbedStandardFont(PdfStandardFontMapper.GetStyledFont(normalizedFamily, bold: true, italic: false), snapshot.BoldSnapshot ?? snapshot.RegularSnapshot, BuildFontFamilyFaceName(snapshot.FamilyName, "Bold"));
+        EmbedStandardFont(PdfStandardFontMapper.GetStyledFont(normalizedFamily, bold: false, italic: true), snapshot.ItalicSnapshot ?? snapshot.RegularSnapshot, BuildFontFamilyFaceName(snapshot.FamilyName, "Italic"));
+        EmbedStandardFont(PdfStandardFontMapper.GetStyledFont(normalizedFamily, bold: true, italic: true), snapshot.BoldItalicSnapshot ?? snapshot.BoldSnapshot ?? snapshot.ItalicSnapshot ?? snapshot.RegularSnapshot, BuildFontFamilyFaceName(snapshot.FamilyName, "BoldItalic"));
+        return this;
+    }
+
+    private static bool TryLoadOfficeFontFamily(string familyName, out PdfEmbeddedFontFamily? embeddedFamily) {
+        foreach (string candidate in EnumerateOfficeFontFamilyCandidates(familyName)) {
+            if (PdfEmbeddedFontFamily.TryFromSystem(candidate, out embeddedFamily) && embeddedFamily != null) {
+                return true;
+            }
+        }
+
+        embeddedFamily = null;
+        return false;
+    }
+
+    private static System.Collections.Generic.IEnumerable<string> EnumerateOfficeFontFamilyCandidates(string familyName) {
+        foreach (string value in familyName.Split(OfficeFontFamilySeparators)) {
+            string candidate = value.Trim(OfficeFontFamilyTrimChars);
+            if (!string.IsNullOrWhiteSpace(candidate)) {
+                yield return candidate;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Pdf/Utilities/PdfStandardFontMapper.cs
+++ b/OfficeIMO.Pdf/Utilities/PdfStandardFontMapper.cs
@@ -24,13 +24,14 @@ public static class PdfStandardFontMapper {
             return false;
         }
 
-        string normalized = NormalizeFontFamily(fontFamily!);
-        if (!TryMapNormalizedFamily(normalized, out PdfStandardFont family)) {
-            return false;
+        foreach (string candidate in EnumerateNormalizedFamilies(fontFamily!)) {
+            if (TryMapNormalizedFamily(candidate, out PdfStandardFont family)) {
+                font = GetStyledFont(family, bold, italic);
+                return true;
+            }
         }
 
-        font = GetStyledFont(family, bold, italic);
-        return true;
+        return false;
     }
 
     /// <summary>
@@ -73,8 +74,17 @@ public static class PdfStandardFontMapper {
         };
     }
 
-    private static string NormalizeFontFamily(string fontFamily) {
-        string firstFamily = fontFamily.Split(FamilySeparators, 2)[0].Trim(FamilyTrimChars);
+    private static IEnumerable<string> EnumerateNormalizedFamilies(string fontFamily) {
+        foreach (string family in fontFamily.Split(FamilySeparators)) {
+            string normalized = NormalizeSingleFontFamily(family);
+            if (normalized.Length > 0) {
+                yield return normalized;
+            }
+        }
+    }
+
+    private static string NormalizeSingleFontFamily(string fontFamily) {
+        string firstFamily = fontFamily.Trim(FamilyTrimChars);
         var builder = new StringBuilder(firstFamily.Length);
         foreach (char ch in firstFamily) {
             if (char.IsLetterOrDigit(ch)) {

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
@@ -97,7 +97,85 @@ public static partial class PowerPointPdfConverterExtensions {
         pdfOptions.PageWidth = presentation.SlideSize.WidthPoints;
         pdfOptions.PageHeight = presentation.SlideSize.HeightPoints;
         pdfOptions.Margins = PdfCore.PageMargins.Uniform(0);
+        RegisterPresentationFonts(pdfOptions, presentation, options);
         return pdfOptions;
+    }
+
+    private static void RegisterPresentationFonts(PdfCore.PdfOptions pdfOptions, PptCore.PowerPointPresentation presentation, PowerPointPdfSaveOptions options) {
+        var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        IReadOnlyList<PptCore.PowerPointSlide> slides = presentation.Slides;
+        for (int slideIndex = 0; slideIndex < slides.Count; slideIndex++) {
+            PptCore.PowerPointSlide slide = slides[slideIndex];
+            if (!options.IncludeHiddenSlides && slide.Hidden) {
+                continue;
+            }
+
+            RegisterPresentationShapesFonts(slide.GetInheritedShapesForExport(), pdfOptions, registeredFamilies);
+            RegisterPresentationShapesFonts(slide.Shapes, pdfOptions, registeredFamilies);
+        }
+    }
+
+    private static void RegisterPresentationShapesFonts(IReadOnlyList<PptCore.PowerPointShape> shapes, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+        foreach (PptCore.PowerPointShape shape in shapes) {
+            RegisterPresentationShapeFonts(shape, pdfOptions, registeredFamilies);
+        }
+    }
+
+    private static void RegisterPresentationShapeFonts(PptCore.PowerPointShape shape, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+        if (shape.Hidden) {
+            return;
+        }
+
+        if (shape is PptCore.PowerPointTextBox textBox) {
+            RegisterPresentationTextBoxFonts(textBox, pdfOptions, registeredFamilies);
+            return;
+        }
+
+        if (shape is PptCore.PowerPointTable table) {
+            RegisterPresentationTableFonts(table, pdfOptions, registeredFamilies);
+            return;
+        }
+
+        if (shape is PptCore.PowerPointGroupShape groupShape && groupShape.OwnerSlide != null) {
+            RegisterPresentationShapesFonts(groupShape.OwnerSlide.GetGroupChildren(groupShape), pdfOptions, registeredFamilies);
+        }
+    }
+
+    private static void RegisterPresentationTextBoxFonts(PptCore.PowerPointTextBox textBox, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+        RegisterPresentationFontCandidate(textBox.FontName, pdfOptions, registeredFamilies);
+        foreach (PptCore.PowerPointParagraph paragraph in textBox.Paragraphs) {
+            foreach (PptCore.PowerPointTextRun run in paragraph.Runs) {
+                RegisterPresentationFontCandidate(run.FontName, pdfOptions, registeredFamilies);
+            }
+        }
+    }
+
+    private static void RegisterPresentationTableFonts(PptCore.PowerPointTable table, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+        for (int row = 0; row < table.Rows; row++) {
+            for (int column = 0; column < table.Columns; column++) {
+                PptCore.PowerPointTableCell cell = table.GetCell(row, column);
+                if (!cell.IsMergedCell) {
+                    RegisterPresentationFontCandidate(cell.FontName, pdfOptions, registeredFamilies);
+                }
+            }
+        }
+    }
+
+    private static void RegisterPresentationFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+        if (string.IsNullOrWhiteSpace(familyName)) {
+            return;
+        }
+
+        string trimmedFamilyName = familyName!.Trim();
+        if (!registeredFamilies.Add(trimmedFamilyName)) {
+            return;
+        }
+
+        if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(trimmedFamilyName, out PdfCore.PdfStandardFont standardFont)) {
+            pdfOptions.RegisterOfficeFontFamily(
+                trimmedFamilyName,
+                PdfCore.PdfStandardFontMapper.GetFontFamily(standardFont));
+        }
     }
 
     private static void RenderSlide(PdfCore.PdfDocument pdf, PptCore.PowerPointSlide slide, int slideNumber, double pageWidth, double pageHeight, PowerPointPdfSaveOptions options) {
@@ -1012,20 +1090,9 @@ public static partial class PowerPointPdfConverterExtensions {
     }
 
     private static PdfCore.PdfStandardFont? MapFont(string? fontName) {
-        if (string.IsNullOrWhiteSpace(fontName)) {
-            return null;
-        }
-
-        string normalized = (fontName ?? string.Empty).ToUpperInvariant();
-        if (normalized.Contains("COURIER") || normalized.Contains("CONSOLAS")) {
-            return PdfCore.PdfStandardFont.Courier;
-        }
-
-        if (normalized.Contains("TIMES") || normalized.Contains("GEORGIA")) {
-            return PdfCore.PdfStandardFont.TimesRoman;
-        }
-
-        return PdfCore.PdfStandardFont.Helvetica;
+        return PdfCore.PdfStandardFontMapper.TryMapFontFamily(fontName, out PdfCore.PdfStandardFont font)
+            ? font
+            : null;
     }
 
     private static OfficeStrokeDashStyle MapDash(PresetLineDashValues? dash) {

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
@@ -110,34 +110,38 @@ public static partial class PowerPointPdfConverterExtensions {
                 continue;
             }
 
-            RegisterPresentationShapesFonts(slide.GetInheritedShapesForExport(), pdfOptions, registeredFamilies);
-            RegisterPresentationShapesFonts(slide.Shapes, pdfOptions, registeredFamilies);
+            RegisterPresentationShapesFonts(slide.GetInheritedShapesForExport(), pdfOptions, registeredFamilies, options);
+            RegisterPresentationShapesFonts(slide.Shapes, pdfOptions, registeredFamilies, options);
         }
     }
 
-    private static void RegisterPresentationShapesFonts(IReadOnlyList<PptCore.PowerPointShape> shapes, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+    private static void RegisterPresentationShapesFonts(IReadOnlyList<PptCore.PowerPointShape> shapes, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, PowerPointPdfSaveOptions options) {
         foreach (PptCore.PowerPointShape shape in shapes) {
-            RegisterPresentationShapeFonts(shape, pdfOptions, registeredFamilies);
+            RegisterPresentationShapeFonts(shape, pdfOptions, registeredFamilies, options);
         }
     }
 
-    private static void RegisterPresentationShapeFonts(PptCore.PowerPointShape shape, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+    private static void RegisterPresentationShapeFonts(PptCore.PowerPointShape shape, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, PowerPointPdfSaveOptions options) {
         if (shape.Hidden) {
             return;
         }
 
         if (shape is PptCore.PowerPointTextBox textBox) {
-            RegisterPresentationTextBoxFonts(textBox, pdfOptions, registeredFamilies);
+            if (options.IncludeTextBoxes) {
+                RegisterPresentationTextBoxFonts(textBox, pdfOptions, registeredFamilies);
+            }
             return;
         }
 
         if (shape is PptCore.PowerPointTable table) {
-            RegisterPresentationTableFonts(table, pdfOptions, registeredFamilies);
+            if (options.IncludeTables) {
+                RegisterPresentationTableFonts(table, pdfOptions, registeredFamilies);
+            }
             return;
         }
 
         if (shape is PptCore.PowerPointGroupShape groupShape && groupShape.OwnerSlide != null) {
-            RegisterPresentationShapesFonts(groupShape.OwnerSlide.GetGroupChildren(groupShape), pdfOptions, registeredFamilies);
+            RegisterPresentationShapesFonts(groupShape.OwnerSlide.GetGroupChildren(groupShape), pdfOptions, registeredFamilies, options);
         }
     }
 

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
@@ -103,6 +103,7 @@ public static partial class PowerPointPdfConverterExtensions {
 
     private static void RegisterPresentationFonts(PdfCore.PdfOptions pdfOptions, PptCore.PowerPointPresentation presentation, PowerPointPdfSaveOptions options) {
         var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var registeredFontSlots = new HashSet<PdfCore.PdfStandardFont>();
         IReadOnlyList<PptCore.PowerPointSlide> slides = presentation.Slides;
         for (int slideIndex = 0; slideIndex < slides.Count; slideIndex++) {
             PptCore.PowerPointSlide slide = slides[slideIndex];
@@ -110,62 +111,62 @@ public static partial class PowerPointPdfConverterExtensions {
                 continue;
             }
 
-            RegisterPresentationShapesFonts(slide.GetInheritedShapesForExport(), pdfOptions, registeredFamilies, options);
-            RegisterPresentationShapesFonts(slide.Shapes, pdfOptions, registeredFamilies, options);
+            RegisterPresentationShapesFonts(slide.GetInheritedShapesForExport(), pdfOptions, registeredFamilies, registeredFontSlots, options);
+            RegisterPresentationShapesFonts(slide.Shapes, pdfOptions, registeredFamilies, registeredFontSlots, options);
         }
     }
 
-    private static void RegisterPresentationShapesFonts(IReadOnlyList<PptCore.PowerPointShape> shapes, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, PowerPointPdfSaveOptions options) {
+    private static void RegisterPresentationShapesFonts(IReadOnlyList<PptCore.PowerPointShape> shapes, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PowerPointPdfSaveOptions options) {
         foreach (PptCore.PowerPointShape shape in shapes) {
-            RegisterPresentationShapeFonts(shape, pdfOptions, registeredFamilies, options);
+            RegisterPresentationShapeFonts(shape, pdfOptions, registeredFamilies, registeredFontSlots, options);
         }
     }
 
-    private static void RegisterPresentationShapeFonts(PptCore.PowerPointShape shape, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, PowerPointPdfSaveOptions options) {
+    private static void RegisterPresentationShapeFonts(PptCore.PowerPointShape shape, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PowerPointPdfSaveOptions options) {
         if (shape.Hidden) {
             return;
         }
 
         if (shape is PptCore.PowerPointTextBox textBox) {
             if (options.IncludeTextBoxes) {
-                RegisterPresentationTextBoxFonts(textBox, pdfOptions, registeredFamilies);
+                RegisterPresentationTextBoxFonts(textBox, pdfOptions, registeredFamilies, registeredFontSlots);
             }
             return;
         }
 
         if (shape is PptCore.PowerPointTable table) {
             if (options.IncludeTables) {
-                RegisterPresentationTableFonts(table, pdfOptions, registeredFamilies);
+                RegisterPresentationTableFonts(table, pdfOptions, registeredFamilies, registeredFontSlots);
             }
             return;
         }
 
         if (shape is PptCore.PowerPointGroupShape groupShape && groupShape.OwnerSlide != null) {
-            RegisterPresentationShapesFonts(groupShape.OwnerSlide.GetGroupChildren(groupShape), pdfOptions, registeredFamilies, options);
+            RegisterPresentationShapesFonts(groupShape.OwnerSlide.GetGroupChildren(groupShape), pdfOptions, registeredFamilies, registeredFontSlots, options);
         }
     }
 
-    private static void RegisterPresentationTextBoxFonts(PptCore.PowerPointTextBox textBox, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
-        RegisterPresentationFontCandidate(textBox.FontName, pdfOptions, registeredFamilies);
+    private static void RegisterPresentationTextBoxFonts(PptCore.PowerPointTextBox textBox, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
+        RegisterPresentationFontCandidate(textBox.FontName, pdfOptions, registeredFamilies, registeredFontSlots);
         foreach (PptCore.PowerPointParagraph paragraph in textBox.Paragraphs) {
             foreach (PptCore.PowerPointTextRun run in paragraph.Runs) {
-                RegisterPresentationFontCandidate(run.FontName, pdfOptions, registeredFamilies);
+                RegisterPresentationFontCandidate(run.FontName, pdfOptions, registeredFamilies, registeredFontSlots);
             }
         }
     }
 
-    private static void RegisterPresentationTableFonts(PptCore.PowerPointTable table, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+    private static void RegisterPresentationTableFonts(PptCore.PowerPointTable table, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
         for (int row = 0; row < table.Rows; row++) {
             for (int column = 0; column < table.Columns; column++) {
                 PptCore.PowerPointTableCell cell = table.GetCell(row, column);
                 if (!cell.IsMergedCell) {
-                    RegisterPresentationFontCandidate(cell.FontName, pdfOptions, registeredFamilies);
+                    RegisterPresentationFontCandidate(cell.FontName, pdfOptions, registeredFamilies, registeredFontSlots);
                 }
             }
         }
     }
 
-    private static void RegisterPresentationFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+    private static void RegisterPresentationFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
         if (string.IsNullOrWhiteSpace(familyName)) {
             return;
         }
@@ -176,9 +177,10 @@ public static partial class PowerPointPdfConverterExtensions {
         }
 
         if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(trimmedFamilyName, out PdfCore.PdfStandardFont standardFont)) {
-            pdfOptions.RegisterOfficeFontFamily(
-                trimmedFamilyName,
-                PdfCore.PdfStandardFontMapper.GetFontFamily(standardFont));
+            PdfCore.PdfStandardFont fontFamily = PdfCore.PdfStandardFontMapper.GetFontFamily(standardFont);
+            if (registeredFontSlots.Add(fontFamily)) {
+                pdfOptions.RegisterOfficeFontFamily(trimmedFamilyName, fontFamily);
+            }
         }
     }
 
@@ -1094,9 +1096,13 @@ public static partial class PowerPointPdfConverterExtensions {
     }
 
     private static PdfCore.PdfStandardFont? MapFont(string? fontName) {
-        return PdfCore.PdfStandardFontMapper.TryMapFontFamily(fontName, out PdfCore.PdfStandardFont font)
-            ? font
-            : null;
+        if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(fontName, out PdfCore.PdfStandardFont font)) {
+            return font;
+        }
+
+        return string.IsNullOrWhiteSpace(fontName)
+            ? null
+            : PdfCore.PdfStandardFont.Helvetica;
     }
 
     private static OfficeStrokeDashStyle MapDash(PresetLineDashValues? dash) {

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
@@ -103,7 +103,9 @@ public static partial class PowerPointPdfConverterExtensions {
 
     private static void RegisterPresentationFonts(PdfCore.PdfOptions pdfOptions, PptCore.PowerPointPresentation presentation, PowerPointPdfSaveOptions options) {
         var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var registeredFontSlots = new HashSet<PdfCore.PdfStandardFont>();
+        HashSet<PdfCore.PdfStandardFont> registeredFontSlots = CreateRegisteredFontSlots(pdfOptions);
+        double pageWidth = presentation.SlideSize.WidthPoints;
+        double pageHeight = presentation.SlideSize.HeightPoints;
         IReadOnlyList<PptCore.PowerPointSlide> slides = presentation.Slides;
         for (int slideIndex = 0; slideIndex < slides.Count; slideIndex++) {
             PptCore.PowerPointSlide slide = slides[slideIndex];
@@ -111,19 +113,24 @@ public static partial class PowerPointPdfConverterExtensions {
                 continue;
             }
 
-            RegisterPresentationShapesFonts(slide.GetInheritedShapesForExport(), pdfOptions, registeredFamilies, registeredFontSlots, options);
-            RegisterPresentationShapesFonts(slide.Shapes, pdfOptions, registeredFamilies, registeredFontSlots, options);
+            int slideNumber = slideIndex + 1;
+            RegisterPresentationShapesFonts(slide.GetInheritedShapesForExport(), slideNumber, pageWidth, pageHeight, pdfOptions, registeredFamilies, registeredFontSlots, options);
+            RegisterPresentationShapesFonts(slide.Shapes, slideNumber, pageWidth, pageHeight, pdfOptions, registeredFamilies, registeredFontSlots, options);
         }
     }
 
-    private static void RegisterPresentationShapesFonts(IReadOnlyList<PptCore.PowerPointShape> shapes, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PowerPointPdfSaveOptions options) {
+    private static void RegisterPresentationShapesFonts(IReadOnlyList<PptCore.PowerPointShape> shapes, int slideNumber, double pageWidth, double pageHeight, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PowerPointPdfSaveOptions options) {
         foreach (PptCore.PowerPointShape shape in shapes) {
-            RegisterPresentationShapeFonts(shape, pdfOptions, registeredFamilies, registeredFontSlots, options);
+            RegisterPresentationShapeFonts(shape, slideNumber, pageWidth, pageHeight, pdfOptions, registeredFamilies, registeredFontSlots, options);
         }
     }
 
-    private static void RegisterPresentationShapeFonts(PptCore.PowerPointShape shape, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PowerPointPdfSaveOptions options) {
+    private static void RegisterPresentationShapeFonts(PptCore.PowerPointShape shape, int slideNumber, double pageWidth, double pageHeight, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PowerPointPdfSaveOptions options) {
         if (shape.Hidden) {
+            return;
+        }
+
+        if (!TryGetShapeBox(shape, slideNumber, pageWidth, pageHeight, options, warnInvalidBounds: false, out _, out _, out _, out _)) {
             return;
         }
 
@@ -142,7 +149,7 @@ public static partial class PowerPointPdfConverterExtensions {
         }
 
         if (shape is PptCore.PowerPointGroupShape groupShape && groupShape.OwnerSlide != null) {
-            RegisterPresentationShapesFonts(groupShape.OwnerSlide.GetGroupChildren(groupShape), pdfOptions, registeredFamilies, registeredFontSlots, options);
+            RegisterPresentationShapesFonts(groupShape.OwnerSlide.GetGroupChildren(groupShape), slideNumber, pageWidth, pageHeight, pdfOptions, registeredFamilies, registeredFontSlots, options);
         }
     }
 
@@ -182,6 +189,22 @@ public static partial class PowerPointPdfConverterExtensions {
                 pdfOptions.RegisterOfficeFontFamily(trimmedFamilyName, fontFamily);
             }
         }
+    }
+
+    private static HashSet<PdfCore.PdfStandardFont> CreateRegisteredFontSlots(PdfCore.PdfOptions pdfOptions) {
+        var registeredFontSlots = new HashSet<PdfCore.PdfStandardFont>();
+        AddRegisteredFontSlot(registeredFontSlots, pdfOptions.DefaultFont);
+        AddRegisteredFontSlot(registeredFontSlots, pdfOptions.HeaderFont);
+        AddRegisteredFontSlot(registeredFontSlots, pdfOptions.FooterFont);
+        foreach (PdfCore.PdfStandardFont embeddedFont in pdfOptions.EmbeddedFonts.Keys) {
+            AddRegisteredFontSlot(registeredFontSlots, embeddedFont);
+        }
+
+        return registeredFontSlots;
+    }
+
+    private static void AddRegisteredFontSlot(HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PdfCore.PdfStandardFont font) {
+        registeredFontSlots.Add(PdfCore.PdfStandardFontMapper.GetFontFamily(font));
     }
 
     private static void RenderSlide(PdfCore.PdfDocument pdf, PptCore.PowerPointSlide slide, int slideNumber, double pageWidth, double pageHeight, PowerPointPdfSaveOptions options) {

--- a/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
@@ -55,9 +55,39 @@ public partial class Excel {
         Assert.Contains("PlainCell", text);
 
         string rawPdf = Encoding.ASCII.GetString(bytes);
-        Assert.Contains("/BaseFont /Courier", rawPdf, StringComparison.Ordinal);
+        AssertRawPdfContainsAnyBaseFont(rawPdf, "Courier", "Consolas");
         Assert.Contains("0.067 0.133 0.2 rg", rawPdf, StringComparison.Ordinal);
         Assert.Contains("0.867 0.933 1 rg", rawPdf, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SaveAsPdf_ExcelWorkbook_Preserves_Helvetica_Cell_Font_When_Default_Font_Changes() {
+        string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfHelveticaCellWithTimesDefault.xlsx");
+
+        byte[] bytes;
+        using (ExcelDocument document = ExcelDocument.Create(workbookPath, "Fonts")) {
+            ExcelSheet sheet = document.Sheets[0];
+            sheet.CellAt(1, 1).SetValue("ArialCell").SetFontName("Arial");
+            sheet.CellAt(1, 2).SetValue("PlainCell");
+            document.Save(false);
+
+            bytes = document.SaveAsPdf(new ExcelPdfSaveOptions {
+                FontFamily = "Times New Roman",
+                IncludeSheetHeadings = false,
+                HeaderRowCount = 0,
+                PageSize = new PdfCore.PageSize(360, 220),
+                Margins = PdfCore.PageMargins.Uniform(24)
+            });
+        }
+
+        using PdfPigDocument pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+        string text = pdf.GetPage(1).Text;
+        Assert.Contains("ArialCell", text);
+        Assert.Contains("PlainCell", text);
+
+        string rawPdf = Encoding.ASCII.GetString(bytes);
+        AssertRawPdfContainsAnyBaseFont(rawPdf, "Helvetica", "Arial", "Calibri", "LiberationSans", "Liberation Sans");
+        AssertRawPdfContainsAnyBaseFont(rawPdf, "Times");
     }
 
     [Fact]
@@ -96,6 +126,17 @@ public partial class Excel {
         Assert.Contains("1 0 0 rg", rawPdf, StringComparison.Ordinal);
         Assert.Contains("0.502 0.502 0 rg", rawPdf, StringComparison.Ordinal);
         Assert.Contains("0 1 0 rg", rawPdf, StringComparison.Ordinal);
+    }
+
+    private static void AssertRawPdfContainsAnyBaseFont(string rawPdf, params string[] fontNameParts) {
+        string[] baseFonts = Regex.Matches(rawPdf, @"/BaseFont /([^\s/<>\[\]()]+)")
+            .Cast<Match>()
+            .Select(match => match.Groups[1].Value)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        Assert.True(
+            fontNameParts.Any(fontNamePart => rawPdf.Contains("/BaseFont /" + fontNamePart, StringComparison.OrdinalIgnoreCase)),
+            "Expected raw PDF to contain one of these BaseFont names: " + string.Join(", ", fontNameParts) + ". Actual BaseFont names: " + string.Join(", ", baseFonts));
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
@@ -23,6 +23,7 @@ public partial class Excel {
             ExcelSheet sheet = document.Sheets[0];
             sheet.CellAt(1, 1)
                 .SetValue("StyledCell")
+                .SetFontName("Consolas")
                 .SetBold()
                 .SetItalic()
                 .SetUnderline()
@@ -34,6 +35,7 @@ public partial class Excel {
             Assert.True(style.Bold);
             Assert.True(style.Italic);
             Assert.True(style.Underline);
+            Assert.Equal("Consolas", style.FontName);
             Assert.Equal("112233", style.FontColorHex);
             Assert.Equal("DDEEFF", style.FillColorHex);
 
@@ -53,6 +55,7 @@ public partial class Excel {
         Assert.Contains("PlainCell", text);
 
         string rawPdf = Encoding.ASCII.GetString(bytes);
+        Assert.Contains("/BaseFont /Courier", rawPdf, StringComparison.Ordinal);
         Assert.Contains("0.067 0.133 0.2 rg", rawPdf, StringComparison.Ordinal);
         Assert.Contains("0.867 0.933 1 rg", rawPdf, StringComparison.Ordinal);
     }

--- a/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
@@ -91,6 +91,35 @@ public partial class Excel {
     }
 
     [Fact]
+    public void SaveAsPdf_ExcelWorkbook_DoesNotOverwriteSameFamilyCellFontSlot() {
+        string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfSameFamilyFontSlot.xlsx");
+
+        byte[] bytes;
+        using (ExcelDocument document = ExcelDocument.Create(workbookPath, "Fonts")) {
+            ExcelSheet sheet = document.Sheets[0];
+            sheet.CellAt(1, 1).SetValue("FirstSerif").SetFontName("Times New Roman");
+            sheet.CellAt(1, 2).SetValue("SecondSerif").SetFontName("Georgia");
+            document.Save(false);
+
+            bytes = document.SaveAsPdf(new ExcelPdfSaveOptions {
+                IncludeSheetHeadings = false,
+                HeaderRowCount = 0,
+                PageSize = new PdfCore.PageSize(360, 220),
+                Margins = PdfCore.PageMargins.Uniform(24)
+            });
+        }
+
+        using PdfPigDocument pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+        string text = pdf.GetPage(1).Text;
+        Assert.Contains("FirstSerif", text);
+        Assert.Contains("SecondSerif", text);
+
+        string rawPdf = Encoding.ASCII.GetString(bytes);
+        AssertRawPdfContainsAnyBaseFont(rawPdf, "Times");
+        AssertRawPdfBaseFontsDoNotContain(rawPdf, "Georgia");
+    }
+
+    [Fact]
     public void SaveAsPdf_ExcelWorkbook_Maps_Conditional_ColorScale_Fills() {
         string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfConditionalColorScale.xlsx");
 
@@ -137,6 +166,15 @@ public partial class Excel {
         Assert.True(
             fontNameParts.Any(fontNamePart => rawPdf.Contains("/BaseFont /" + fontNamePart, StringComparison.OrdinalIgnoreCase)),
             "Expected raw PDF to contain one of these BaseFont names: " + string.Join(", ", fontNameParts) + ". Actual BaseFont names: " + string.Join(", ", baseFonts));
+    }
+
+    private static void AssertRawPdfBaseFontsDoNotContain(string rawPdf, string fontNamePart) {
+        string[] baseFonts = Regex.Matches(rawPdf, @"/BaseFont /([^\s/<>\[\]()]+)")
+            .Cast<Match>()
+            .Select(match => match.Groups[1].Value)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        Assert.DoesNotContain(baseFonts, baseFont => baseFont.Contains(fontNamePart, StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
@@ -120,6 +120,36 @@ public partial class Excel {
     }
 
     [Fact]
+    public void SaveAsPdf_ExcelWorkbook_PreservesConfiguredDefaultFontSlot() {
+        string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfDefaultFontSlot.xlsx");
+
+        byte[] bytes;
+        using (ExcelDocument document = ExcelDocument.Create(workbookPath, "Fonts")) {
+            ExcelSheet sheet = document.Sheets[0];
+            sheet.CellAt(1, 1).SetValue("StyledSerif").SetFontName("Georgia");
+            sheet.CellAt(1, 2).SetValue("DefaultSerif");
+            document.Save(false);
+
+            bytes = document.SaveAsPdf(new ExcelPdfSaveOptions {
+                FontFamily = "Times New Roman",
+                IncludeSheetHeadings = false,
+                HeaderRowCount = 0,
+                PageSize = new PdfCore.PageSize(360, 220),
+                Margins = PdfCore.PageMargins.Uniform(24)
+            });
+        }
+
+        using PdfPigDocument pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+        string text = pdf.GetPage(1).Text;
+        Assert.Contains("StyledSerif", text);
+        Assert.Contains("DefaultSerif", text);
+
+        string rawPdf = Encoding.ASCII.GetString(bytes);
+        AssertRawPdfContainsAnyBaseFont(rawPdf, "Times");
+        AssertRawPdfBaseFontsDoNotContain(rawPdf, "Georgia");
+    }
+
+    [Fact]
     public void SaveAsPdf_ExcelWorkbook_Maps_Conditional_ColorScale_Fills() {
         string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfConditionalColorScale.xlsx");
 

--- a/OfficeIMO.Tests/Pdf/Markdown.SaveAsPdf.Options.cs
+++ b/OfficeIMO.Tests/Pdf/Markdown.SaveAsPdf.Options.cs
@@ -1,0 +1,40 @@
+using OfficeIMO.Markdown.Pdf;
+using PdfCore = OfficeIMO.Pdf;
+using System;
+using System.Text;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public class MarkdownSaveAsPdfOptionsTests {
+    [Fact]
+    public void ToPdfDocument_Markdown_ClonesCallerPdfOptionsBeforeApplyingAdapterDefaults() {
+        var pdfOptions = new PdfCore.PdfOptions();
+        var options = new MarkdownPdfSaveOptions {
+            PdfOptions = pdfOptions,
+            CreateOutlineFromHeadings = true
+        };
+
+        "# Heading".ToPdfDocument(options).ToBytes();
+
+        Assert.False(pdfOptions.CreateOutlineFromHeadings);
+    }
+
+    [Fact]
+    public void ToPdfDocument_Markdown_FontFamilyUsesSharedOfficeFontMapping() {
+        var options = new MarkdownPdfSaveOptions {
+            FontFamily = "Georgia",
+            PdfOptions = new PdfCore.PdfOptions {
+                CompressContentStreams = false
+            }
+        };
+
+        byte[] bytes = "# Heading\n\nBody".ToPdfDocument(options).ToBytes();
+        string raw = Encoding.ASCII.GetString(bytes);
+
+        Assert.True(
+            raw.Contains("/BaseFont /Georgia-Regular", StringComparison.Ordinal) ||
+            raw.Contains("/BaseFont /Times-Roman", StringComparison.Ordinal),
+            "Expected Markdown font-family export to use an installed Georgia TrueType font or the mapped Times standard family.");
+    }
+}

--- a/OfficeIMO.Tests/Pdf/PdfDocumentVisualQualityDocumentOptionsTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentVisualQualityDocumentOptionsTests.cs
@@ -224,6 +224,9 @@ public partial class PdfDocumentVisualQualityTests {
         Assert.True(PdfStandardFontMapper.TryMapFontFamily("Segoe UI, sans-serif", out PdfStandardFont sans));
         Assert.Equal(PdfStandardFont.Helvetica, sans);
 
+        Assert.True(PdfStandardFontMapper.TryMapFontFamily("Unmapped Display Face, Georgia, serif", out PdfStandardFont fallbackList));
+        Assert.Equal(PdfStandardFont.TimesRoman, fallbackList);
+
         Assert.True(PdfStandardFontMapper.TryMapFontFamily("\"Times New Roman\", serif", bold: true, italic: true, out PdfStandardFont serif));
         Assert.Equal(PdfStandardFont.TimesBoldItalic, serif);
 

--- a/OfficeIMO.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfFontFamilyTests.cs
@@ -71,6 +71,46 @@ public class PdfFontFamilyTests {
     }
 
     [Fact]
+    public void PdfOptions_UseOfficeFontFamilyFallsBackThroughFamilyListToStandardFont() {
+        PdfOptions options = new PdfOptions()
+            .UseOfficeFontFamily("OfficeIMO Missing Display, Consolas, monospace", embedSystemFont: false);
+
+        Assert.Equal(PdfStandardFont.Courier, options.DefaultFont);
+        Assert.Equal(PdfStandardFont.Courier, options.HeaderFont);
+        Assert.Equal(PdfStandardFont.Courier, options.FooterFont);
+    }
+
+    [Fact]
+    public void PdfOptions_RegisterFontFamilyEmbedsSemanticSlotWithoutChangingDefaults() {
+        string? fontPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
+        if (fontPath == null) {
+            return;
+        }
+
+        var options = new PdfOptions {
+            CompressContentStreams = false
+        }.RegisterFontFamily(
+            PdfStandardFont.TimesRoman,
+            PdfEmbeddedFontFamily.FromFiles("OfficeIMO Semantic Serif", fontPath));
+
+        byte[] bytes = PdfDocument.Create(options)
+            .Paragraph(paragraph => paragraph
+                .Font(PdfStandardFont.TimesRoman)
+                .Text("Semantic serif Łódź"))
+            .ToBytes();
+
+        string raw = Encoding.ASCII.GetString(bytes);
+        string text = PdfReadDocument.Load(bytes).ExtractText();
+
+        Assert.Equal(PdfStandardFont.Helvetica, options.DefaultFont);
+        Assert.Equal(PdfStandardFont.Helvetica, options.HeaderFont);
+        Assert.Equal(PdfStandardFont.Helvetica, options.FooterFont);
+        Assert.Contains("/BaseFont /OfficeIMOSemanticSerif-Regular", raw, StringComparison.Ordinal);
+        Assert.Contains("/Encoding /Identity-H", raw, StringComparison.Ordinal);
+        Assert.Contains("Semantic serif Łódź", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PdfEmbeddedFontFamily_TryFromSystemFontFilesMatchesRenamedTrueTypeMetadata() {
         if (!TryFindSingleInstalledRegularFontFace(out string familyName, out string fontPath)) {
             return;

--- a/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
@@ -54,7 +54,7 @@ public class PowerPointSaveAsPdfTests {
 
         string raw = Encoding.ASCII.GetString(bytes);
         Assert.Contains("20 108 120 48 re", raw, StringComparison.Ordinal);
-        Assert.Contains("/BaseFont /Times-Roman", raw, StringComparison.Ordinal);
+        AssertRawPdfContainsAnyBaseFont(raw, "Times-Roman", "Georgia");
         Assert.Contains("/Im1 Do", raw, StringComparison.Ordinal);
     }
 
@@ -847,6 +847,36 @@ public class PowerPointSaveAsPdfTests {
     }
 
     [Fact]
+    public void SaveAsPdf_PowerPointPresentation_SkipsExcludedShapeFontsBeforeRendering() {
+        using var stream = new MemoryStream();
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+        presentation.SlideSize.SetSizePoints(260, 180);
+        PowerPointSlide slide = presentation.Slides[0];
+
+        PowerPointTextBox excluded = slide.AddTextBoxPoints("Excluded", 30, 26, 100, 28);
+        excluded.FontName = "Georgia";
+
+        PowerPointTable table = slide.AddTablePoints(1, 1, 30, 74, 150, 42);
+        PowerPointTableCell cell = table.GetCell(0, 0);
+        cell.Text = "Visible";
+        cell.FontName = "Times New Roman";
+
+        byte[] bytes = presentation.SaveAsPdf(new PowerPointPdfSaveOptions {
+            IncludeTextBoxes = false,
+            IncludeTables = true
+        });
+
+        string raw = Encoding.ASCII.GetString(bytes);
+        AssertRawPdfContainsAnyBaseFont(raw, "Times");
+        Assert.DoesNotContain("Georgia", raw, StringComparison.OrdinalIgnoreCase);
+
+        using var pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+        string text = string.Join("", pdf.GetPage(1).Letters.Select(letter => letter.Value));
+        Assert.Contains("Visible", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Excluded", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SaveAsPdf_PowerPointPresentation_PreservesTableCellLineBreaks() {
         using var stream = new MemoryStream();
         using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
@@ -1425,5 +1455,11 @@ public class PowerPointSaveAsPdfTests {
         }
 
         throw new InvalidOperationException("Could not find word '" + word + "' in rendered PDF text.");
+    }
+
+    private static void AssertRawPdfContainsAnyBaseFont(string rawPdf, params string[] fontNameParts) {
+        Assert.True(
+            fontNameParts.Any(fontNamePart => rawPdf.Contains("/BaseFont /" + fontNamePart, StringComparison.OrdinalIgnoreCase)),
+            "Expected raw PDF to contain one of these BaseFont names: " + string.Join(", ", fontNameParts));
     }
 }

--- a/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
@@ -33,6 +33,7 @@ public class PowerPointSaveAsPdfTests {
         PowerPointTextBox textBox = slide.AddTextBoxPoints("Premium Slide", 32, 36, 150, 36);
         textBox.FillColor = "FFFFFF";
         textBox.OutlineColor = "94A3B8";
+        textBox.FontName = "Georgia";
         textBox.FontSize = 14;
         textBox.Color = "123456";
         textBox.Rotation = 0D;
@@ -53,6 +54,7 @@ public class PowerPointSaveAsPdfTests {
 
         string raw = Encoding.ASCII.GetString(bytes);
         Assert.Contains("20 108 120 48 re", raw, StringComparison.Ordinal);
+        Assert.Contains("/BaseFont /Times-Roman", raw, StringComparison.Ordinal);
         Assert.Contains("/Im1 Do", raw, StringComparison.Ordinal);
     }
 

--- a/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
@@ -877,6 +877,28 @@ public class PowerPointSaveAsPdfTests {
     }
 
     [Fact]
+    public void SaveAsPdf_PowerPointPresentation_UsesSansFallbackForUnmappedExplicitFonts() {
+        using var stream = new MemoryStream();
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+        presentation.SlideSize.SetSizePoints(260, 180);
+        PowerPointTextBox textBox = presentation.Slides[0].AddTextBoxPoints("VisibleSans", 30, 40, 150, 36);
+        textBox.FontName = "Aptos Display";
+
+        byte[] bytes = presentation.SaveAsPdf(new PowerPointPdfSaveOptions {
+            PdfOptions = new PdfCore.PdfOptions {
+                DefaultFont = PdfCore.PdfStandardFont.TimesRoman
+            }
+        });
+
+        string raw = Encoding.ASCII.GetString(bytes);
+        AssertRawPdfContainsAnyBaseFont(raw, "Helvetica");
+
+        using var pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+        string text = string.Join("", pdf.GetPage(1).Letters.Select(letter => letter.Value));
+        Assert.Contains("VisibleSans", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SaveAsPdf_PowerPointPresentation_PreservesTableCellLineBreaks() {
         using var stream = new MemoryStream();
         using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);

--- a/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
@@ -877,6 +877,63 @@ public class PowerPointSaveAsPdfTests {
     }
 
     [Fact]
+    public void SaveAsPdf_PowerPointPresentation_SkipsUnrenderableShapeFontsBeforeRendering() {
+        using var stream = new MemoryStream();
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+        presentation.SlideSize.SetSizePoints(260, 180);
+        PowerPointSlide slide = presentation.Slides[0];
+
+        PowerPointTextBox offSlide = slide.AddTextBoxPoints("OffSlide", -180, 24, 80, 28);
+        offSlide.FontName = "Georgia";
+
+        PowerPointTable table = slide.AddTablePoints(1, 1, 30, 74, 150, 42);
+        PowerPointTableCell cell = table.GetCell(0, 0);
+        cell.Text = "Visible";
+        cell.FontName = "Times New Roman";
+
+        byte[] bytes = presentation.SaveAsPdf(new PowerPointPdfSaveOptions {
+            IncludeTextBoxes = true,
+            IncludeTables = true
+        });
+
+        string raw = Encoding.ASCII.GetString(bytes);
+        AssertRawPdfContainsAnyBaseFont(raw, "Times");
+        Assert.DoesNotContain("Georgia", raw, StringComparison.OrdinalIgnoreCase);
+
+        using var pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+        string text = string.Join("", pdf.GetPage(1).Letters.Select(letter => letter.Value));
+        Assert.Contains("Visible", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("OffSlide", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SaveAsPdf_PowerPointPresentation_PreservesConfiguredDefaultFontSlot() {
+        using var stream = new MemoryStream();
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+        presentation.SlideSize.SetSizePoints(260, 180);
+        PowerPointSlide slide = presentation.Slides[0];
+
+        PowerPointTextBox styled = slide.AddTextBoxPoints("StyledSerif", 30, 34, 120, 28);
+        styled.FontName = "Georgia";
+        PowerPointTextBox plain = slide.AddTextBoxPoints("DefaultSerif", 30, 84, 120, 28);
+
+        byte[] bytes = presentation.SaveAsPdf(new PowerPointPdfSaveOptions {
+            PdfOptions = new PdfCore.PdfOptions {
+                DefaultFont = PdfCore.PdfStandardFont.TimesRoman
+            }
+        });
+
+        string raw = Encoding.ASCII.GetString(bytes);
+        AssertRawPdfContainsAnyBaseFont(raw, "Times");
+        Assert.DoesNotContain("Georgia", raw, StringComparison.OrdinalIgnoreCase);
+
+        using var pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+        string text = string.Join("", pdf.GetPage(1).Letters.Select(letter => letter.Value));
+        Assert.Contains("StyledSerif", text, StringComparison.Ordinal);
+        Assert.Contains("DefaultSerif", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SaveAsPdf_PowerPointPresentation_UsesSansFallbackForUnmappedExplicitFonts() {
         using var stream = new MemoryStream();
         using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Metadata.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.Metadata.cs
@@ -56,5 +56,22 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("native, keyword", info.Keywords);
             }
         }
+
+        [Fact]
+        public void Test_WordDocument_SaveAsPdf_OfficeIMOEngine_FontFamily_Does_Not_Pollute_MetadataKeywords() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfNativeFontMetadata.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeFontMetadata.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.BuiltinDocumentProperties.Keywords = "native, keyword";
+                document.AddParagraph("Native metadata font");
+                document.Save();
+                document.SaveAsPdf(pdfPath, new PdfSaveOptions { FontFamily = "Times New Roman" });
+            }
+
+            using (PdfPigDocument pdf = PdfPigDocument.Open(pdfPath)) {
+                Assert.Equal("native, keyword", pdf.Information.Keywords);
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.ParagraphFormatting.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.ParagraphFormatting.cs
@@ -395,6 +395,24 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SaveAsPdf_OfficeIMOEngine_Renders_Paragraph_Hanging_Indent_Without_Left_Indent() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfNativeHangingIndentNoLeft.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeHangingIndentNoLeft.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                WordParagraph paragraph = document.AddParagraph("HangingOnly alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu");
+                paragraph.IndentationHangingPoints = 36;
+
+                document.Save();
+                document.SaveAsPdf(pdfPath);
+            }
+
+            Assert.True(File.Exists(pdfPath));
+            using PdfPigDocument pdf = PdfPigDocument.Open(pdfPath);
+            Assert.Contains("HangingOnly", pdf.GetPage(1).Text);
+        }
+
+        [Fact]
         public void SaveAsPdf_OfficeIMOEngine_Renders_Paragraph_Hanging_Indent() {
             string docPath = Path.Combine(_directoryWithFiles, "PdfNativeHangingIndent.docx");
             string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeHangingIndent.pdf");

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.ParagraphFormatting.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.ParagraphFormatting.cs
@@ -2,6 +2,7 @@ using OfficeIMO.Word;
 using OfficeIMO.Word.Pdf;
 using OfficeIMO.Pdf;
 using DocumentFormat.OpenXml.Wordprocessing;
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -377,6 +378,52 @@ namespace OfficeIMO.Tests {
 
             Assert.Equal(2D, exactStyle.LineHeight);
             Assert.Equal(1.15D, autoStyle.LineHeight);
+        }
+
+        [Fact]
+        public void SaveAsPdf_OfficeIMOEngine_Maps_Paragraph_Hanging_Indent() {
+            using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeHangingIndentStyle.docx"));
+            WordParagraph paragraph = document.AddParagraph("Native hanging paragraph");
+            paragraph.IndentationBeforePoints = 72;
+            paragraph.IndentationHangingPoints = 36;
+
+            MethodInfo method = typeof(WordPdfConverterExtensions).GetMethod("CreateNativeParagraphStyle", BindingFlags.NonPublic | BindingFlags.Static)!;
+            PdfParagraphStyle style = Assert.IsType<PdfParagraphStyle>(method.Invoke(null, new object[] { paragraph }));
+
+            Assert.Equal(72D, style.LeftIndent);
+            Assert.Equal(-36D, style.FirstLineIndent);
+        }
+
+        [Fact]
+        public void SaveAsPdf_OfficeIMOEngine_Renders_Paragraph_Hanging_Indent() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfNativeHangingIndent.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeHangingIndent.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                WordParagraph paragraph = document.AddParagraph("HangingStart alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu");
+                paragraph.IndentationBeforePoints = 72;
+                paragraph.IndentationHangingPoints = 36;
+                paragraph.LineSpacingAfterPoints = 0;
+
+                document.Save();
+                document.SaveAsPdf(pdfPath, new PdfSaveOptions {
+                    IncludePageNumbers = false,
+                    PageSize = new OfficeIMO.Pdf.PageSize(260, 260),
+                    Margins = PageMargins.Uniform(36)
+                });
+            }
+
+            using PdfPigDocument pdf = PdfPigDocument.Open(pdfPath);
+            var lineLefts = pdf.GetPage(1)
+                .GetWords()
+                .GroupBy(word => Math.Round(word.BoundingBox.Bottom, 1))
+                .OrderByDescending(group => group.Key)
+                .Take(2)
+                .Select(group => group.Min(word => word.BoundingBox.Left))
+                .ToList();
+
+            Assert.Equal(2, lineLefts.Count);
+            Assert.True(lineLefts[1] > lineLefts[0] + 20D, $"Expected wrapped hanging-indent line to start farther right. First line x: {lineLefts[0]:0.##}; second line x: {lineLefts[1]:0.##}.");
         }
     }
 }

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
@@ -254,6 +254,23 @@ public partial class Word {
         AssertPdfUsesFont(pdfPath, "Times");
     }
 
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_RequestedUnavailableFont_FallsBack_To_DocumentDefaultFont() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfUnavailableRequestedFontFallsBack.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfUnavailableRequestedFontFallsBack.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            document.Settings.FontFamily = "OfficeIMO Missing Theme Font";
+            document.Settings.FontFamilyHighAnsi = "Times New Roman";
+            document.AddParagraph("Hello unavailable requested font fallback");
+            document.Save();
+            document.SaveAsPdf(pdfPath, new PdfSaveOptions { FontFamily = "OfficeIMO Missing Requested Font" });
+        }
+
+        Assert.True(File.Exists(pdfPath));
+        AssertPdfUsesFont(pdfPath, "Times");
+    }
+
     [Theory]
     [InlineData(PdfPageOrientation.Portrait)]
     [InlineData(PdfPageOrientation.Landscape)]

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
@@ -237,6 +237,23 @@ public partial class Word {
         AssertPdfUsesFont(pdfPath, "Courier");
     }
 
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_DocumentDefaultFont_FallsBack_To_HighAnsi_When_Primary_Font_Is_Unmapped() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfDocumentDefaultFontHighAnsiFallback.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfDocumentDefaultFontHighAnsiFallback.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            document.Settings.FontFamily = "OfficeIMO Missing Theme Font";
+            document.Settings.FontFamilyHighAnsi = "Times New Roman";
+            document.AddParagraph("Hello HighAnsi fallback font");
+            document.Save();
+            document.SaveAsPdf(pdfPath);
+        }
+
+        Assert.True(File.Exists(pdfPath));
+        AssertPdfUsesFont(pdfPath, "Times");
+    }
+
     [Theory]
     [InlineData(PdfPageOrientation.Portrait)]
     [InlineData(PdfPageOrientation.Landscape)]

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.cs
@@ -271,6 +271,23 @@ public partial class Word {
         AssertPdfUsesFont(pdfPath, "Times");
     }
 
+    [Fact]
+    public void Test_WordDocument_SaveAsPdf_Preserves_Default_Font_Slot_During_Font_Prepass() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfDefaultFontSlotPrepass.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfDefaultFontSlotPrepass.pdf");
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            document.AddParagraph("Styled serif").SetFontFamily("Georgia");
+            document.AddParagraph("Default serif");
+            document.Save();
+            document.SaveAsPdf(pdfPath, new PdfSaveOptions { FontFamily = "Times New Roman" });
+        }
+
+        Assert.True(File.Exists(pdfPath));
+        AssertPdfUsesFont(pdfPath, "Times");
+        AssertPdfDoesNotUseFont(pdfPath, "Georgia");
+    }
+
     [Theory]
     [InlineData(PdfPageOrientation.Portrait)]
     [InlineData(PdfPageOrientation.Landscape)]
@@ -556,5 +573,10 @@ public partial class Word {
 
         string pdfContent = Encoding.ASCII.GetString(File.ReadAllBytes(pdfPath));
         Assert.Contains("/BaseFont /" + expectedFontNamePart, pdfContent, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void AssertPdfDoesNotUseFont(string pdfPath, string fontNamePart) {
+        string pdfContent = Encoding.ASCII.GetString(File.ReadAllBytes(pdfPath));
+        Assert.DoesNotContain("/BaseFont /" + fontNamePart, pdfContent, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
+++ b/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
@@ -7,7 +7,12 @@ namespace OfficeIMO.Word.Pdf {
     /// </summary>
     public class PdfSaveOptions {
         /// <summary>
-        /// Optional Word-style font family used as the first-party PDF default font when it maps to Helvetica, Times, or Courier standard PDF families.
+        /// PDF creation options passed to the first-party PDF engine. The options are cloned before export.
+        /// </summary>
+        public PdfCore.PdfOptions? PdfOptions { get; set; }
+
+        /// <summary>
+        /// Optional Word-style font family used as the first-party PDF default font. Installed TrueType faces are embedded when available; otherwise the family maps to the nearest PDF standard font.
         /// </summary>
         public string? FontFamily { get; set; }
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -74,7 +74,7 @@ namespace OfficeIMO.Word.Pdf {
 
         private static void RegisterNativeDocumentFonts(WordDocument document, PdfCore.PdfOptions pdfOptions) {
             var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var registeredFontSlots = new HashSet<PdfCore.PdfStandardFont>();
+            HashSet<PdfCore.PdfStandardFont> registeredFontSlots = CreateNativeRegisteredFontSlots(pdfOptions);
             foreach (WordSection section in document.Sections) {
                 foreach (WordElement element in CollapseNativeParagraphElements(section.Elements)) {
                     if (element is WordParagraph paragraph) {
@@ -87,6 +87,22 @@ namespace OfficeIMO.Word.Pdf {
                     }
                 }
             }
+        }
+
+        private static HashSet<PdfCore.PdfStandardFont> CreateNativeRegisteredFontSlots(PdfCore.PdfOptions pdfOptions) {
+            var registeredFontSlots = new HashSet<PdfCore.PdfStandardFont>();
+            AddNativeRegisteredFontSlot(registeredFontSlots, pdfOptions.DefaultFont);
+            AddNativeRegisteredFontSlot(registeredFontSlots, pdfOptions.HeaderFont);
+            AddNativeRegisteredFontSlot(registeredFontSlots, pdfOptions.FooterFont);
+            foreach (PdfCore.PdfStandardFont embeddedFont in pdfOptions.EmbeddedFonts.Keys) {
+                AddNativeRegisteredFontSlot(registeredFontSlots, embeddedFont);
+            }
+
+            return registeredFontSlots;
+        }
+
+        private static void AddNativeRegisteredFontSlot(HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PdfCore.PdfStandardFont font) {
+            registeredFontSlots.Add(PdfCore.PdfStandardFontMapper.GetFontFamily(font));
         }
 
         private static void RegisterNativeTableFonts(WordTable table, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -13,31 +13,87 @@ namespace OfficeIMO.Word.Pdf {
     public static partial class WordPdfConverterExtensions {
         private static PdfCore.PdfOptions CreateNativeOptions(WordDocument document, PdfSaveOptions? options) {
             WordSection? firstSection = document.Sections.FirstOrDefault();
-            PdfCore.PdfStandardFont defaultFont = GetNativeDefaultFont(document, options);
-            return new PdfCore.PdfOptions {
-                PageSize = firstSection == null ? PdfCore.PageSizes.A4 : GetNativePageSize(firstSection, options),
-                Margins = firstSection == null ? PdfCore.PageMargins.Uniform(72) : GetNativeMargins(firstSection, options),
-                DefaultFont = defaultFont,
-                HeaderFont = defaultFont,
-                FooterFont = defaultFont,
-                BackgroundColor = ParseNativeColor(document.Background?.Color),
-                CreateOutlineFromHeadings = true
-            };
+            PdfCore.PdfOptions pdfOptions = options?.PdfOptions?.Clone() ?? new PdfCore.PdfOptions();
+            pdfOptions.PageSize = firstSection == null ? PdfCore.PageSizes.A4 : GetNativePageSize(firstSection, options);
+            pdfOptions.Margins = firstSection == null ? PdfCore.PageMargins.Uniform(72) : GetNativeMargins(firstSection, options);
+            ApplyNativeDefaultFont(document, options, pdfOptions);
+            RegisterNativeDocumentFonts(document, pdfOptions);
+            pdfOptions.BackgroundColor = ParseNativeColor(document.Background?.Color);
+            pdfOptions.CreateOutlineFromHeadings = true;
+            return pdfOptions;
         }
 
-        private static PdfCore.PdfStandardFont GetNativeDefaultFont(WordDocument document, PdfSaveOptions? options) {
-            if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(options?.FontFamily, out PdfCore.PdfStandardFont optionFont)) {
-                return optionFont;
+        private static void ApplyNativeDefaultFont(WordDocument document, PdfSaveOptions? options, PdfCore.PdfOptions pdfOptions) {
+            if (!string.IsNullOrWhiteSpace(options?.FontFamily)) {
+                pdfOptions.UseOfficeFontFamily(options!.FontFamily);
+                return;
             }
 
-            if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(document.Settings.FontFamily, out PdfCore.PdfStandardFont settingsFont) ||
-                PdfCore.PdfStandardFontMapper.TryMapFontFamily(document.Settings.FontFamilyHighAnsi, out settingsFont) ||
-                PdfCore.PdfStandardFontMapper.TryMapFontFamily(document.Settings.FontFamilyEastAsia, out settingsFont) ||
-                PdfCore.PdfStandardFontMapper.TryMapFontFamily(document.Settings.FontFamilyComplexScript, out settingsFont)) {
-                return settingsFont;
+            string? family = document.Settings.FontFamily ??
+                    document.Settings.FontFamilyHighAnsi ??
+                    document.Settings.FontFamilyEastAsia ??
+                    document.Settings.FontFamilyComplexScript;
+
+            if (!string.IsNullOrWhiteSpace(family)) {
+                pdfOptions.UseOfficeFontFamily(family, embedSystemFont: false);
+            }
+        }
+
+        private static void RegisterNativeDocumentFonts(WordDocument document, PdfCore.PdfOptions pdfOptions) {
+            var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (WordSection section in document.Sections) {
+                foreach (WordElement element in CollapseNativeParagraphElements(section.Elements)) {
+                    if (element is WordParagraph paragraph) {
+                        RegisterNativeParagraphFonts(paragraph, pdfOptions, registeredFamilies);
+                        foreach (WordParagraph run in GetNativeRuns(paragraph)) {
+                            RegisterNativeParagraphFonts(run, pdfOptions, registeredFamilies);
+                        }
+                    } else if (element is WordTable table) {
+                        RegisterNativeTableFonts(table, pdfOptions, registeredFamilies);
+                    }
+                }
+            }
+        }
+
+        private static void RegisterNativeTableFonts(WordTable table, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+            foreach (WordTableRow row in table.Rows) {
+                foreach (WordTableCell cell in row.Cells) {
+                    foreach (WordParagraph paragraph in cell.Paragraphs) {
+                        RegisterNativeParagraphFonts(paragraph, pdfOptions, registeredFamilies);
+                        foreach (WordParagraph run in GetNativeRuns(paragraph)) {
+                            RegisterNativeParagraphFonts(run, pdfOptions, registeredFamilies);
+                        }
+                    }
+
+                    foreach (WordTable nestedTable in cell.NestedTables) {
+                        RegisterNativeTableFonts(nestedTable, pdfOptions, registeredFamilies);
+                    }
+                }
+            }
+        }
+
+        private static void RegisterNativeParagraphFonts(WordParagraph paragraph, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+            RegisterNativeFontCandidate(paragraph.FontFamily, pdfOptions, registeredFamilies);
+            RegisterNativeFontCandidate(paragraph.FontFamilyHighAnsi, pdfOptions, registeredFamilies);
+            RegisterNativeFontCandidate(paragraph.FontFamilyEastAsia, pdfOptions, registeredFamilies);
+            RegisterNativeFontCandidate(paragraph.FontFamilyComplexScript, pdfOptions, registeredFamilies);
+        }
+
+        private static void RegisterNativeFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+            if (string.IsNullOrWhiteSpace(familyName)) {
+                return;
             }
 
-            return PdfCore.PdfStandardFont.Helvetica;
+            string trimmedFamilyName = familyName!.Trim();
+            if (!registeredFamilies.Add(trimmedFamilyName)) {
+                return;
+            }
+
+            if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(trimmedFamilyName, out PdfCore.PdfStandardFont standardFont)) {
+                pdfOptions.RegisterOfficeFontFamily(
+                    trimmedFamilyName,
+                    PdfCore.PdfStandardFontMapper.GetFontFamily(standardFont));
+            }
         }
 
         private sealed class NativeTableOfContentsEntry {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -29,13 +29,17 @@ namespace OfficeIMO.Word.Pdf {
                 return;
             }
 
-            string? family = document.Settings.FontFamily ??
-                    document.Settings.FontFamilyHighAnsi ??
-                    document.Settings.FontFamilyEastAsia ??
-                    document.Settings.FontFamilyComplexScript;
-
-            if (!string.IsNullOrWhiteSpace(family)) {
-                pdfOptions.UseOfficeFontFamily(family, embedSystemFont: false);
+            foreach (string? family in new[] {
+                document.Settings.FontFamily,
+                document.Settings.FontFamilyHighAnsi,
+                document.Settings.FontFamilyEastAsia,
+                document.Settings.FontFamilyComplexScript
+            }) {
+                if (!string.IsNullOrWhiteSpace(family) &&
+                    PdfCore.PdfStandardFontMapper.TryMapFontFamily(family, out _)) {
+                    pdfOptions.UseOfficeFontFamily(family, embedSystemFont: false);
+                    return;
+                }
             }
         }
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -24,8 +24,7 @@ namespace OfficeIMO.Word.Pdf {
         }
 
         private static void ApplyNativeDefaultFont(WordDocument document, PdfSaveOptions? options, PdfCore.PdfOptions pdfOptions) {
-            if (!string.IsNullOrWhiteSpace(options?.FontFamily)) {
-                pdfOptions.UseOfficeFontFamily(options!.FontFamily);
+            if (TryApplyNativeDefaultFontCandidate(options?.FontFamily, pdfOptions, embedSystemFont: true)) {
                 return;
             }
 
@@ -35,55 +34,86 @@ namespace OfficeIMO.Word.Pdf {
                 document.Settings.FontFamilyEastAsia,
                 document.Settings.FontFamilyComplexScript
             }) {
-                if (!string.IsNullOrWhiteSpace(family) &&
-                    PdfCore.PdfStandardFontMapper.TryMapFontFamily(family, out _)) {
-                    pdfOptions.UseOfficeFontFamily(family, embedSystemFont: false);
+                if (TryApplyNativeDefaultFontCandidate(family, pdfOptions, embedSystemFont: false)) {
                     return;
                 }
             }
         }
 
+        private static bool TryApplyNativeDefaultFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, bool embedSystemFont) {
+            if (string.IsNullOrWhiteSpace(familyName)) {
+                return false;
+            }
+
+            if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(familyName, out _)) {
+                pdfOptions.UseOfficeFontFamily(familyName, embedSystemFont);
+                return true;
+            }
+
+            if (!embedSystemFont) {
+                return false;
+            }
+
+            PdfCore.PdfStandardFont beforeDefault = pdfOptions.DefaultFont;
+            PdfCore.PdfStandardFont beforeHeader = pdfOptions.HeaderFont;
+            PdfCore.PdfStandardFont beforeFooter = pdfOptions.FooterFont;
+            string beforeEmbeddedFonts = CaptureNativeEmbeddedFontState(pdfOptions);
+            pdfOptions.UseOfficeFontFamily(familyName, embedSystemFont: true);
+
+            return beforeDefault != pdfOptions.DefaultFont ||
+                   beforeHeader != pdfOptions.HeaderFont ||
+                   beforeFooter != pdfOptions.FooterFont ||
+                   !string.Equals(beforeEmbeddedFonts, CaptureNativeEmbeddedFontState(pdfOptions), StringComparison.Ordinal);
+        }
+
+        private static string CaptureNativeEmbeddedFontState(PdfCore.PdfOptions pdfOptions) {
+            return string.Join("|", pdfOptions.EmbeddedFonts
+                .OrderBy(font => font.Key)
+                .Select(font => ((int)font.Key).ToString(CultureInfo.InvariantCulture) + ":" + (font.Value.FontName ?? string.Empty) + ":" + font.Value.Data.Length.ToString(CultureInfo.InvariantCulture)));
+        }
+
         private static void RegisterNativeDocumentFonts(WordDocument document, PdfCore.PdfOptions pdfOptions) {
             var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var registeredFontSlots = new HashSet<PdfCore.PdfStandardFont>();
             foreach (WordSection section in document.Sections) {
                 foreach (WordElement element in CollapseNativeParagraphElements(section.Elements)) {
                     if (element is WordParagraph paragraph) {
-                        RegisterNativeParagraphFonts(paragraph, pdfOptions, registeredFamilies);
+                        RegisterNativeParagraphFonts(paragraph, pdfOptions, registeredFamilies, registeredFontSlots);
                         foreach (WordParagraph run in GetNativeRuns(paragraph)) {
-                            RegisterNativeParagraphFonts(run, pdfOptions, registeredFamilies);
+                            RegisterNativeParagraphFonts(run, pdfOptions, registeredFamilies, registeredFontSlots);
                         }
                     } else if (element is WordTable table) {
-                        RegisterNativeTableFonts(table, pdfOptions, registeredFamilies);
+                        RegisterNativeTableFonts(table, pdfOptions, registeredFamilies, registeredFontSlots);
                     }
                 }
             }
         }
 
-        private static void RegisterNativeTableFonts(WordTable table, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+        private static void RegisterNativeTableFonts(WordTable table, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
             foreach (WordTableRow row in table.Rows) {
                 foreach (WordTableCell cell in row.Cells) {
                     foreach (WordParagraph paragraph in cell.Paragraphs) {
-                        RegisterNativeParagraphFonts(paragraph, pdfOptions, registeredFamilies);
+                        RegisterNativeParagraphFonts(paragraph, pdfOptions, registeredFamilies, registeredFontSlots);
                         foreach (WordParagraph run in GetNativeRuns(paragraph)) {
-                            RegisterNativeParagraphFonts(run, pdfOptions, registeredFamilies);
+                            RegisterNativeParagraphFonts(run, pdfOptions, registeredFamilies, registeredFontSlots);
                         }
                     }
 
                     foreach (WordTable nestedTable in cell.NestedTables) {
-                        RegisterNativeTableFonts(nestedTable, pdfOptions, registeredFamilies);
+                        RegisterNativeTableFonts(nestedTable, pdfOptions, registeredFamilies, registeredFontSlots);
                     }
                 }
             }
         }
 
-        private static void RegisterNativeParagraphFonts(WordParagraph paragraph, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
-            RegisterNativeFontCandidate(paragraph.FontFamily, pdfOptions, registeredFamilies);
-            RegisterNativeFontCandidate(paragraph.FontFamilyHighAnsi, pdfOptions, registeredFamilies);
-            RegisterNativeFontCandidate(paragraph.FontFamilyEastAsia, pdfOptions, registeredFamilies);
-            RegisterNativeFontCandidate(paragraph.FontFamilyComplexScript, pdfOptions, registeredFamilies);
+        private static void RegisterNativeParagraphFonts(WordParagraph paragraph, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
+            RegisterNativeFontCandidate(paragraph.FontFamily, pdfOptions, registeredFamilies, registeredFontSlots);
+            RegisterNativeFontCandidate(paragraph.FontFamilyHighAnsi, pdfOptions, registeredFamilies, registeredFontSlots);
+            RegisterNativeFontCandidate(paragraph.FontFamilyEastAsia, pdfOptions, registeredFamilies, registeredFontSlots);
+            RegisterNativeFontCandidate(paragraph.FontFamilyComplexScript, pdfOptions, registeredFamilies, registeredFontSlots);
         }
 
-        private static void RegisterNativeFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies) {
+        private static void RegisterNativeFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
             if (string.IsNullOrWhiteSpace(familyName)) {
                 return;
             }
@@ -94,9 +124,10 @@ namespace OfficeIMO.Word.Pdf {
             }
 
             if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(trimmedFamilyName, out PdfCore.PdfStandardFont standardFont)) {
-                pdfOptions.RegisterOfficeFontFamily(
-                    trimmedFamilyName,
-                    PdfCore.PdfStandardFontMapper.GetFontFamily(standardFont));
+                PdfCore.PdfStandardFont fontFamily = PdfCore.PdfStandardFontMapper.GetFontFamily(standardFont);
+                if (registeredFontSlots.Add(fontFamily)) {
+                    pdfOptions.RegisterOfficeFontFamily(trimmedFamilyName, fontFamily);
+                }
             }
         }
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.ParagraphStyles.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.ParagraphStyles.cs
@@ -33,6 +33,10 @@ namespace OfficeIMO.Word.Pdf {
                 style.FirstLineIndent = paragraph.IndentationFirstLinePoints.Value;
             }
 
+            if (paragraph.IndentationHangingPoints.HasValue) {
+                style.FirstLineIndent = -paragraph.IndentationHangingPoints.Value;
+            }
+
             double fontSize = paragraph.FontSize.HasValue && paragraph.FontSize.Value > 0 ? paragraph.FontSize.Value : 11D;
             style.LineHeight = ResolveNativeParagraphLineHeight(paragraph, fontSize);
 
@@ -403,13 +407,7 @@ namespace OfficeIMO.Word.Pdf {
         }
 
         private static string? BuildNativeKeywords(PdfSaveOptions? options, BuiltinDocumentProperties properties) {
-            string? keys = options?.Keywords ?? properties.Keywords;
-            string? family = options?.FontFamily;
-            if (!string.IsNullOrWhiteSpace(family)) {
-                keys = string.IsNullOrWhiteSpace(keys) ? family : keys + ";" + family;
-            }
-
-            return keys;
+            return options?.Keywords ?? properties.Keywords;
         }
 
         private static PdfCore.PdfColor? ParseNativeColor(string? hex) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.ParagraphStyles.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.ParagraphStyles.cs
@@ -34,7 +34,12 @@ namespace OfficeIMO.Word.Pdf {
             }
 
             if (paragraph.IndentationHangingPoints.HasValue) {
-                style.FirstLineIndent = -paragraph.IndentationHangingPoints.Value;
+                double hangingIndent = paragraph.IndentationHangingPoints.Value;
+                if (style.LeftIndent < hangingIndent) {
+                    style.LeftIndent = hangingIndent;
+                }
+
+                style.FirstLineIndent = -hangingIndent;
             }
 
             double fontSize = paragraph.FontSize.HasValue && paragraph.FontSize.Value > 0 ? paragraph.FontSize.Value : 11D;


### PR DESCRIPTION
## Summary
- add shared Office-style PDF font family registration and installed TrueType/TTC embedding hooks
- propagate font options through Word, Excel, PowerPoint, and Markdown PDF conversion paths
- preserve Excel font names in inspection/export and expose cell/range font setters
- improve Word native PDF layout fidelity by mapping hanging indents into the existing PDF paragraph layout engine
- add focused PDF font, adapter, metadata, Markdown, Excel style, PowerPoint, and hanging-indent tests

## Validation
- git diff --check
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-build --filter "FullyQualifiedName~Hanging_Indent|FullyQualifiedName~PdfFontFamilyTests|FullyQualifiedName~MarkdownSaveAsPdfOptionsTests|FullyQualifiedName~WordDocument_SaveAsPdf_OfficeIMOEngine_FontFamily|FullyQualifiedName~ExcelDocument_SaveAsPdf_CellStyles|FullyQualifiedName~PowerPointPresentation_SaveAsPdf" --logger "console;verbosity=minimal"
  - net472: 33 passed
  - net8.0: 33 passed
  - net10.0: 33 passed

## Notes
- keeps OfficeIMO on the first-party, zero-dependency PDF path
- does not claim full CFF/WOFF/variable-font shaping support; unsupported font formats remain future native engine work
