### PR TITLE
Add PDF row flow composition API

### DIFF
--- a/OfficeIMO.Pdf/Core/PdfDocument.Blocks.Tables.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Blocks.Tables.cs
@@ -5,6 +5,32 @@ namespace OfficeIMO.Pdf;
 public sealed partial class PdfDocument {
     internal void AddRow(RowBlock row) { AddBlock(row); }
 
+    /// <summary>Adds a row with percentage-based columns to the current document flow.</summary>
+    /// <remarks>
+    /// Rows are useful for report-style layouts where related content should sit side by side while still participating
+    /// in normal pagination, margins, themes, headers, footers, and subsequent document flow. The composed row is committed
+    /// once the supplied builder delegate finishes.
+    /// </remarks>
+    /// <param name="build">Row builder that defines column widths, layout rhythm, and column content.</param>
+    /// <returns>This <see cref="PdfDocument"/> for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// PdfDocument.Create()
+    ///     .Row(row => row
+    ///         .Gap(16)
+    ///         .Column(35, column => column.H2("Signals").Bullets(new[] { "Healthy", "Watch", "Needs action" }))
+    ///         .Column(65, column => column.Panel("Right-side report callout.")))
+    ///     .Save("report.pdf");
+    /// </code>
+    /// </example>
+    public PdfDocument Row(System.Action<PdfRowCompose> build) {
+        Guard.NotNull(build, nameof(build));
+        var row = new PdfRowCompose(this);
+        build(row);
+        row.Commit();
+        return this;
+    }
+
     /// <summary>Adds a simple table from rows of string arrays.</summary>
     public PdfDocument Table(System.Collections.Generic.IEnumerable<string[]> rows, PdfAlign align = PdfAlign.Left, PdfTableStyle? style = null) {
         AddBlock(new TableBlock(rows, align, style));


### PR DESCRIPTION
## Summary
- add `PdfDocument.Row(...)` as a public OfficeIMO.Pdf flow API for percentage-based row/column composition
- commit row content into normal document flow without forcing adapters through section workarounds
- expand XML documentation with a C# usage example

## Validation
- `dotnet build C:\Support\GitHub\OfficeIMO\OfficeIMO.Pdf\OfficeIMO.Pdf.csproj -c Debug -f net8.0 --no-restore -m:1 /v:minimal`
- PSWriteOffice downstream validation against this branch:
  - `dotnet build Sources\PSWriteOffice\PSWriteOffice.csproj -c Debug -f net8.0 --no-restore -m:1 /v:minimal`
  - `dotnet build Sources\PSWriteOffice\PSWriteOffice.csproj -c Debug -f net472 --no-restore -m:1 /v:minimal`
  - focused PDF Pester suite, 19 passed