### PR TITLE
Improve OfficeIMO HTML conversion robustness

### DIFF
--- a/Docs/officeimo.word-html-roadmap.md
+++ b/Docs/officeimo.word-html-roadmap.md
@@ -10,8 +10,8 @@ The library should preserve the content people expect from real documents, expos
 
 - Bidirectional conversion exists: HTML to `WordDocument` and `WordDocument` to HTML.
 - The HTML import path already handles headings, paragraphs, inline formatting, links, images, SVG, lists, tables, captions, notes, headers, footers, and sections.
-- CSS support covers inline declarations, stylesheet content, stylesheet files, remote stylesheets, class-to-style mapping, paragraph spacing, indentation, colors, line height, white space, list styles, table widths, borders, and alignment.
-- Resource handling already has caller-provided `HttpClient`, timeout support, data URI images, embedded images, external image links, SVG support, per-image and total image byte limits, declared image content-type validation, and URI scheme/host policy controls.
+- CSS support covers inline declarations, stylesheet content, stylesheet files, remote stylesheets, class-to-style mapping, paragraph spacing, indentation, colors, line height, white space, list styles, table widths, borders, cell spacing, and physical plus logical alignment.
+- Resource handling already has caller-provided `HttpClient`, timeout support, data URI images, embedded images, external image links, SVG support, per-image/image-total/CSS-total byte limits, declared image and stylesheet content-type validation, and URI scheme/host policy controls.
 - The export path already emits metadata, footnotes, endnotes, optional headers/footers, optional comments, images, SVG, lists, tables, paragraph/run classes, inline run colors/highlights, spacing, indentation, and optional default CSS.
 - Existing tests cover many real contracts across HTML import, Word export, style mapping, table behavior, image handling, links, notes, async/cancellation, and whitespace.
 - The current supported feature set is documented in `Docs/officeimo.word-html-support-matrix.md`.
@@ -24,12 +24,13 @@ The library should preserve the content people expect from real documents, expos
 - HTML import now accepts `data-bookmark` as an explicit bookmark source alongside `id` and `name`, so generated documents can preserve stable anchor names without overloading visible element IDs.
 - HTML table import now maps CSS auto margins and the table `align` attribute to Word table justification, including common `margin: 0 auto` centering and right alignment through `margin-left:auto`.
 - Image import now honors width-only sizing by preserving natural aspect ratio, and maps common percentage image widths against the Word section content width.
+- Image import/export now preserves HTML `title` metadata through `WordImage.Title`, including saved DOCX package reload, while continuing to map `alt` through `WordImage.Description`.
 - List import now accepts `!important` on `list-style-type`, quoted dash markers from Markdown/editor HTML, and OpenXML-backed international ordered list styles such as Russian, Hebrew, Arabic, Hiragana, and Katakana. List export now preserves those formats when `IncludeListStyles` is enabled.
 - Markdown and editor task-list HTML now imports `input[type=checkbox]` list markers as native Word checkbox content controls while preserving the surrounding list item text.
 - HTML import now maps text-like `input` elements to native Word structured document tags, preserving the input value plus alias/tag metadata from label-style attributes.
 - HTML import now maps single-select `select` elements to native Word dropdown list content controls and `textarea` elements to structured document tags, preserving selected/value text plus alias/tag metadata where available.
 - Word-to-HTML export now preserves native Word checkbox content controls as disabled HTML checkbox inputs, including checked state and available alias/tag metadata, instead of leaking checkbox glyphs or dropping the control.
-- Word-to-HTML export now preserves native Word structured text controls, dropdown lists, combo boxes, and date pickers as disabled HTML form controls with selected values, option lists, and available alias/tag metadata.
+- Word-to-HTML export now preserves native Word structured text controls, dropdown lists, combo boxes, and date pickers as disabled HTML form controls with selected values, option lists, and available alias/tag metadata. Multiline structured text controls now export as `textarea` elements so line breaks round-trip through HTML import.
 - HTML import now records conversion diagnostics for skipped or degraded image resources through `HtmlToWordOptions.Diagnostics` and `DiagnosticHandler`, replacing console-only failure reporting while preserving alt-text fallback behavior.
 - HTML import now supports `HtmlToWordOptions.MaxImageBytes` for remote, local, data URI, and SVG image resources, producing `ImageResourceTooLarge` diagnostics and preserving alt-text fallback when an image exceeds the configured limit.
 - HTML import now validates declared image content types for remote image resources and data URI images through `HtmlToWordOptions.ValidateImageContentTypes` and `AllowedImageContentTypes`, producing `ImageContentTypeRejected` diagnostics and preserving alt-text fallback when an image type is rejected.
@@ -44,28 +45,73 @@ The library should preserve the content people expect from real documents, expos
 - Word-to-HTML export can now preserve Word section/page metadata when `WordToHtmlOptions.IncludeSectionMetadata` is enabled, wrapping each section with page size, orientation, margin data attributes, and Word-like CSS dimensions.
 - Word-to-HTML export can now preserve custom document properties as typed HTML meta tags when `WordToHtmlOptions.IncludeCustomProperties` is enabled.
 - Word-to-HTML table export now preserves leading Word table header rows as `<thead>` / `<th>` markup while keeping ordinary tables in the legacy flat row shape.
+- Word-to-HTML table export now emits `scope="col"` on generated header-row `th` cells, giving browser and assistive-technology consumers explicit column-header semantics for Word repeated header rows.
+- Word-to-HTML table export now emits adjacent `Caption`-style table captions as semantic `<caption>` elements, and HTML import with `TableCaptionPosition.Below` now places body-level captions after the table instead of inside the last table cell.
+- HTML table import now inserts body-level tables directly into the section when no current paragraph exists, avoiding synthetic empty paragraphs before table-only HTML.
 - Word-to-HTML table export can now preserve Word table column widths as `<colgroup>` / `<col>` markup when `WordToHtmlOptions.IncludeTableColumnGroups` is enabled, including fractional percentage widths.
 - Word-to-HTML export now preserves native Word endnotes as an `endnotes` section with stable `en*` anchors, controlled independently by `WordToHtmlOptions.ExportEndnotes`, and HTML import recreates exported `section.endnotes` references as native Word endnotes.
+- Word-to-HTML export now restores imported HTML abbreviations from either footnote or endnote metadata as semantic `abbr title` markup, avoiding visible note-reference leaks in abbreviation round-trips.
+- HTML `blockquote cite` import now preserves the source citation URL through immediate Word-to-HTML export and saved DOCX package reload as a `blockquote cite` attribute instead of leaking the generated citation note as a visible footnote reference.
+- HTML `time datetime` import now preserves the source machine-readable value through immediate Word-to-HTML export even when the visible label differs from the `datetime` attribute.
+- HTML `del` and `ins` import now preserves source deleted/inserted inline semantics through immediate Word-to-HTML export while generic Word strike/underline formatting still exports as visual `s`/`u` tags.
+- HTML `mark` import now preserves source highlighted inline semantics through immediate Word-to-HTML export while generic Word highlight formatting remains available as opt-in highlight CSS.
 - Word-to-HTML export can now preserve Word comments when `WordToHtmlOptions.ExportComments` is enabled, emitting linked comment references plus a `comments` section with author, initials, date, and reply metadata; HTML import recreates that exported comment section as native Word comments with nested replies.
 - Word-to-HTML export can now preserve Word section headers and footers when `WordToHtmlOptions.ExportHeadersAndFooters` is enabled, emitting semantic `header` and `footer` regions with section index and header/footer type metadata; HTML import rehydrates those exported regions back into native section headers and footers.
 - Word-to-HTML export can now emit reusable list definition CSS when `WordToHtmlOptions.IncludeListDefinitions` is enabled, assigning stable `word-list-*` classes and Word list-level metadata to generated `ol` and `ul` elements.
 - HTML import now maps document-level `html` / `body` language attributes to `WordDocument.Settings.Language`, and Word-to-HTML export emits that setting as the root `html lang` attribute.
 - HTML import now maps element-level `lang` / `xml:lang` values to Word run language metadata, including inherited language values from parent containers.
+- Word-to-HTML export now emits run-level Word language metadata as `span lang` attributes when the run language differs from the document language, allowing element-level HTML language attributes to round-trip.
 - HTML import can now emit opt-in accessibility diagnostics through `HtmlToWordOptions.EnableAccessibilityDiagnostics` for missing image alternate text, weak or empty link text, skipped heading levels, and likely data tables without header cells.
 - Core Word table generation now writes table-look conditional formatting through the `w:tblLook` bitmask instead of validator-rejected expanded attributes, keeping generated table DOCX packages OpenXML-valid while preserving the `ConditionalFormatting*` API behavior.
 - Word-to-HTML export internals now keep note emission, section metadata, bookmark IDs, checkbox controls, and style-definition CSS in focused partials so the main converter stays below the structure-check threshold.
+- HTML import now uses one shared linked-stylesheet loading path for full document, body append, header append, footer append, and body-level `<link rel="stylesheet">` elements, so stylesheet diagnostics, base URL handling, and cancellation behavior stay consistent.
+- `OfficeIMO.Reader.Html` now preserves the full nested `HtmlToMarkdownOptions` clone contract when registered or used directly, so conversion controls such as input limits, markdown writer options, transforms, custom element converters, and visual round-trip hints are not silently dropped by the adapter.
+- HTML import now supports stylesheet URI policy controls through `HtmlToWordOptions.AllowedStylesheetUriSchemes` and `AllowedStylesheetHosts`, emits deterministic `StylesheetResourceRejectedByPolicy` diagnostics before blocked stylesheets are loaded, and applies `MaxCssBytes` to file and remote stylesheets before buffering the full CSS body when length metadata is available.
+- HTML import now supports `HtmlToWordOptions.MaxTotalCssBytes`, `ValidateStylesheetContentTypes`, and `AllowedStylesheetContentTypes`, so linked and configured CSS can be bounded across one conversion and remote stylesheets with disallowed declared media types are skipped with `StylesheetContentTypeRejected` diagnostics.
+- HTML import now emits specific linked-stylesheet diagnostics for non-success HTTP statuses, transport failures, and resource-timeout cancellations through `StylesheetHttpStatusRejected`, `StylesheetTransportFailed`, and `StylesheetLoadTimedOut` while preserving true caller cancellation.
+- HTML import now keys parsed stylesheet caching by CSS content hash instead of mutable source URL or path, so repeated identical CSS still reuses parsed rules without reusing stale rules when a local or remote stylesheet changes.
+- HTML import now emits source-aware linked-stylesheet diagnostics when document-provided links are disabled, when a stylesheet `<link>` has no `href`, and when unsupported stylesheet URI schemes are rejected by policy.
+- `HtmlToWordOptions` now provides named import profiles for default OfficeIMO behavior, bounded offline untrusted HTML ingestion, and trusted document stylesheet loading, plus `Clone()` support for reusable option templates without carrying runtime diagnostics between conversions.
+- `OfficeIMO.Reader.Html` now provides named adapter profiles for OfficeIMO-default, portable Markdown, and bounded untrusted HTML ingestion, plus public `ReaderHtmlOptions.Clone()` support so registered handler templates and direct-read templates stay independent.
+- HTML import now preserves `select multiple` values as structured document tag text, keeping all selected option values and avoiding the browser-inaccurate single-select fallback that picked only one value or defaulted to the first option.
+- HTML import now skips unsupported embedded media/widget elements (`iframe`, `object`, `embed`, `video`, `audio`, and `canvas`) with `HtmlEmbeddedContentSkipped` diagnostics instead of leaking fallback text into the generated Word document.
+- HTML import now maps named radio groups to a single Word dropdown list content control, preserving the checked value, using labels when radio values are omitted, and avoiding a false first-option selection for unselected groups.
+- HTML import now preserves visible value-bearing input types such as `number`, `time`, `datetime-local`, `month`, `week`, `color`, and `range` as structured document tags while continuing to ignore hidden, file, button, submit, reset, and image controls as non-document content.
+- HTML import now emits unsupported-value diagnostics for mapped `direction` and `border-collapse` CSS values that cannot be represented in Word output.
+- HTML import now maps logical `text-align:start` and `text-align:end` through inherited `dir` / CSS `direction` metadata for paragraphs and table-cell content instead of reporting them as unsupported values.
+- HTML import now preserves `meter` and `progress` values as structured document tags, using fallback element text when no explicit value is present.
+- HTML import now reports raw HTML comments through `HtmlCommentSkipped` diagnostics by default and can opt in to import non-empty raw comments as native Word comments through `HtmlToWordOptions.ImportHtmlComments`, `HtmlCommentAuthor`, and `HtmlCommentInitials`; native Word comment-section import remains the richer comment round-trip path.
+- HTML table import now maps the legacy `cellspacing` attribute and CSS `border-spacing` to Word table cell spacing, with unsupported `border-spacing` values reported through CSS value diagnostics.
+- Word-to-HTML table export now emits Word table cell spacing as CSS `border-spacing`, using `border-collapse:separate` when exported table borders are present so spacing survives HTML rendering and HTML import round-trips.
+- HTML table import now maps `td`/`th` CSS `vertical-align:top|middle|bottom` and the legacy `valign` attribute to Word table-cell vertical alignment, matching the existing Word-to-HTML export path.
+- Word-to-HTML table export now emits a final table row as `<tfoot>` when the Word table has last-row conditional formatting enabled, and HTML import preserves `tfoot` intent through the same Word table-look flag.
+- Word-to-HTML structural bookmark export now keeps the original block shape inside semantic wrappers such as `article`, so bookmarked headings export as `<article id="..."><h1>...</h1></article>` instead of flattening heading text into the wrapper.
+- The HTML artifact gallery now writes representative source HTML, generated DOCX, and round-trip HTML artifacts while validating the generated DOCX package with OpenXML validation.
+- HTML definition lists now round-trip through semantic `dt`/`dd` marker paragraphs, including table-cell cases, so imported descriptions no longer export as blockquotes.
+- HTML table-cell block imports now preserve earlier block paragraphs instead of clearing the cell every time another block child is added, and Word-to-HTML table-cell export now avoids duplicate definition-list items when OfficeIMO exposes empty and non-empty wrappers for the same underlying cell paragraph.
+- HTML list-item import now preserves source order when block children such as paragraphs and tables appear inside one `li`, so a table following list-item detail text no longer jumps ahead of that detail paragraph or behind later body content.
+- HTML list import/export now preserves common editor marker glyphs, including quoted asterisk and plus bullets, as Word list marker text and CSS `list-style-type` values.
+- HTML list import/export now preserves arbitrary quoted CSS marker strings as custom Word bullet marker text and quoted `list-style-type` values.
+- HTML figure import now normalizes `figcaption` elements after figure media/content, so both leading and trailing captions round-trip through Word's image-plus-caption export pattern as semantic `figure` / `figcaption` HTML.
+- HTML blockquote import now styles generated paragraphs from the active conversion scope, so blockquotes inside table cells no longer lose quoted text or export as ordinary paragraphs.
+- HTML blockquote citation import now keeps the Word note metadata while also restoring the original `cite` attribute during immediate Word-to-HTML export and after saved DOCX package reload.
+- HTML deleted and inserted inline text now round-trips as semantic `del` and `ins` tags instead of degrading to generic strike and underline tags.
+- HTML marked inline text now round-trips as semantic `mark` tags instead of degrading to generic highlight styling.
+- CSS text-decoration import now maps underline style variants from shorthand and longhand values, clears inherited decoration on `text-decoration:none`, and keeps unsupported decoration color tokens visible through value diagnostics.
 
 ## Capability Gaps To Close
 
 - CSS cascade quality: continue improving selector specificity, inherited computed styles, shorthand expansion, `!important`, style precedence, and broader value-level diagnostics for unsupported or degraded declarations.
+- CSS resource robustness: continue aligning linked stylesheets with the broader resource pipeline through optional prefetching and broader non-image resource budget coverage beyond CSS.
 - Layout and page controls: cover remaining margin and flow placement cases around constrained containers.
-- Lists: cover custom bullet symbols, CSS formats that Word does not expose as native numbering, richer nested restart/continuation rules, and robust non-standard list markup produced by editors.
-- Tables: continue hardening irregular row/column spans, nested tables in list items, captions, vertical alignment, cell spacing, collapsed/separate borders, and table width inside constrained containers.
-- Images and resources: add safer prefetching, broader raster/vector formats, and artifact-level proof for image dimensions.
-- Semantics and forms: deepen support for `abbr`, `cite`, `dfn`, `q`, `blockquote`, `time`, `figure`, `figcaption`, definition lists, structural elements, bidirectional text, richer input types, multi-select form controls, and richer reciprocal form behavior.
-- Word-to-HTML fidelity: import arbitrary HTML comments, preserve richer comment range fidelity, round-trip richer header/footer content, style definitions, richer list definitions, table styles, images, richer note formatting, and accessibility metadata more completely.
-- Security and reliability: keep parser/resource limits current, prevent regex and CSS parsing DoS paths, and expand warning coverage for skipped or degraded content beyond image resources.
+- Lists: cover CSS formats that Word does not expose as native numbering, richer nested restart/continuation rules, and robust non-standard list markup produced by editors.
+- Tables: continue hardening irregular row/column spans, malformed nested tables in list items, richer collapsed/separate border conflict behavior, multiple-row footer semantics, and table width inside constrained containers.
+- Images and resources: add safer prefetching and broader raster/vector formats.
+- Semantics and forms: deepen support for `abbr`, `cite`, `dfn`, `q`, `time`, structural elements, bidirectional text, richer specialized form export where practical, native-style multi-select export where practical, and richer reciprocal form behavior; continue expanding richer nested `blockquote` content and richer non-image `figure` content where Word has a durable representation.
+- Word-to-HTML fidelity: preserve richer comment range fidelity, round-trip richer header/footer content, style definitions, richer list definitions, table styles, images, richer note formatting, and accessibility metadata more completely.
+- Security and reliability: keep parser/resource limits current, prevent regex and CSS parsing DoS paths, and continue expanding warning coverage for skipped or degraded content as new unsupported HTML/resource cases are identified.
 - Developer experience: keep the support matrix current, broaden conversion diagnostics, sample gallery, benchmark suite, and round-trip fixture corpus.
+- HTML adapter options: keep `OfficeIMO.Reader.Html` pass-through documented as a public adapter contract and continue adding examples for custom transforms, element converters, visual round-trip hints, and Reader chunking profiles.
 
 ## Plan
 
@@ -89,7 +135,7 @@ The library should preserve the content people expect from real documents, expos
 - Export section and page metadata as structured HTML plus CSS where possible.
 - Export and round-trip richer header/footer content, richer comment content, bookmarks, richer footnote/endnote content, fields, table styles, richer list definitions, and document properties.
 - Generate cleaner, stable HTML with readable class names and optional embedded CSS.
-- Continue the HTML accessibility pass with bidirectional text, richer table semantics, and export-side run-level language/accessibility metadata.
+- Continue the HTML accessibility pass with bidirectional text, richer table semantics, and broader export-side accessibility metadata.
 
 ### Phase 4: Resource, Security, And Performance
 

--- a/Docs/officeimo.word-html-support-matrix.md
+++ b/Docs/officeimo.word-html-support-matrix.md
@@ -17,25 +17,25 @@ This matrix documents the current `OfficeIMO.Word.Html` conversion surface. It i
 | Basic blocks | Supported | `p`, `div`, `br`, and `hr` map to Word paragraphs, runs, line breaks, and horizontal-rule style paragraphs. |
 | Headings | Supported | `h1` through `h6` map to Word heading styles, with optional heading numbering. |
 | Structural sections | Supported | `section`, `article`, `aside`, `nav`, `header`, `footer`, and `main` preserve content; structural IDs can round-trip through bookmarks. |
-| Definition lists | Supported | `dl`, `dt`, and `dd` import as paragraphs, with `dd` indented. |
-| Block quotes | Supported | `blockquote` imports with quote styling/indentation and can preserve `cite` through note references. |
-| Inline formatting | Supported | `strong`, `b`, `em`, `i`, `u`, `s`, `del`, `ins`, `sup`, `sub`, `small`, `big`, `font`, and `span` map to run formatting where Word has an equivalent. |
-| Semantic inline text | Supported | `q`, `cite`, `dfn`, `time`, `abbr`, `acronym`, and `mark` preserve recognizable Word character styles or notes where available. |
+| Definition lists | Supported | `dl`, `dt`, and `dd` import as semantic term/description paragraphs, with `dd` indented and marker styles preserved for Word-to-HTML round-trip export. |
+| Block quotes | Supported | `blockquote` imports with quote styling/indentation in body and table-cell scopes, preserves `cite` through note references, restores imported citation URLs as `blockquote cite` attributes during immediate Word-to-HTML export and saved DOCX package reload, and exports scoped quoted paragraphs back as semantic blockquotes. |
+| Inline formatting | Supported | `strong`, `b`, `em`, `i`, `u`, `s`, `del`, `ins`, `sup`, `sub`, `small`, `big`, `font`, and `span` map to run formatting where Word has an equivalent. Imported `del` and `ins` runs preserve their source semantic tags during immediate Word-to-HTML export, while generic Word strike/underline formatting exports as visual `s`/`u` tags. |
+| Semantic inline text | Supported | `q`, `cite`, `dfn`, `time`, `abbr`, `acronym`, and `mark` preserve recognizable Word character styles or notes where available. Imported `mark` tags round-trip through immediate Word-to-HTML export, imported `time datetime` values round-trip through immediate Word-to-HTML export, and abbreviation title metadata can round-trip through footnote or endnote-backed import. |
 | Code and keyboard text | Supported | `pre` imports as block code; inline `code`, `kbd`, `samp`, and `tt` import as monospace runs. |
-| Ruby text | Partial | `ruby`, `rb`, `rt`, and `rp` keep child text and inline styles, but do not create Word ruby annotation structures yet. |
+| Ruby text | Partial | Simple `ruby` elements with base text and `rt` annotations import as native Word ruby annotation structures. `rb` contributes base text, `rt` contributes annotation text, and `rp` fallback punctuation is suppressed. Ruby without an annotation still falls through as visible child text. Rich multi-segment ruby pairing and Word-to-HTML ruby export remain planned. |
 | Links and anchors | Supported | `a href`, `id`, `name`, and `data-bookmark` map to hyperlinks and bookmarks. |
-| Images | Supported | `img` imports from data URIs, local paths, file URLs, remote URLs, and external image links depending on options. |
+| Images | Supported | `img` imports from data URIs, local paths, file URLs, remote URLs, and external image links depending on options. `alt` maps to `WordImage.Description`, and `title` maps to durable `WordImage.Title` metadata, including duplicate-source images that share the same binary part. |
 | SVG | Supported | Inline SVG and SVG image sources can be embedded, with alt-text fallback and diagnostics when skipped. |
-| Lists | Supported | `ul`, `ol`, and `li` map to Word lists, including nested lists, `start`, `value`, reversed lists, common `type` values, and CSS `list-style-type`. |
+| Lists | Supported | `ul`, `ol`, and `li` map to Word lists, including nested lists, `start`, `value`, reversed lists, common `type` values, CSS `list-style-type`, and source-ordered block children such as paragraphs and tables inside list items. |
 | Task lists | Supported | Markdown/editor `input[type=checkbox]` list markers import as native Word checkbox content controls. |
-| Tables | Supported | `table`, `tr`, `th`, `td`, `thead`, `tbody`, `tfoot`, `caption`, `colgroup`, and `col` import with spans, section rows, captions, widths, borders, and cell styling. |
-| Figures | Supported | `figure` and `figcaption` import as figure content plus Word caption paragraphs. |
-| Stylesheets | Supported | Inline `style`, embedded `<style>`, configured stylesheet contents, configured stylesheet paths, file links, and remote stylesheet links are parsed. |
+| Tables | Supported | `table`, `tr`, `th`, `td`, `thead`, `tbody`, `tfoot`, `caption`, `colgroup`, and `col` import with spans, section rows, captions, widths, borders, cell spacing, and cell styling. Body-level tables import directly without synthetic placeholder paragraphs. |
+| Figures | Supported | `figure` and `figcaption` import as figure content plus Word caption paragraphs. Leading and trailing figure captions normalize to Word's image-plus-caption order so common image figures export back as semantic `figure` / `figcaption` HTML. |
+| Stylesheets | Supported | Inline `style`, embedded `<style>`, configured stylesheet contents, configured stylesheet paths, head and body stylesheet links, file links, and remote stylesheet links are parsed. Document-provided links remain opt-in through `AllowDocumentStylesheetLinks`. Stylesheet URI schemes, hosts, declared content types, per-stylesheet byte limits, and aggregate CSS bytes can be restricted before or during external CSS loading. |
 | Language metadata | Supported | Document-level `html` / `body` language attributes map to the Word document language setting. Element-level `lang` / `xml:lang` values inherit to imported text runs as Word run language metadata. |
 | Accessibility diagnostics | Supported | When `HtmlToWordOptions.EnableAccessibilityDiagnostics` is enabled, import emits advisory diagnostics for missing image `alt`, weak or empty link text, skipped heading levels, and likely data tables without `th`, `thead`, or `scope`. |
-| Active and inert content | Not supported | `script` and `template` content is skipped with `HtmlElementSkipped` diagnostics; executable behavior is never converted. Unsupported harmless elements fall through to child content unless explicitly handled. |
-| Embedded media/widgets | Planned | `iframe`, `object`, `embed`, `video`, `audio`, and `canvas` do not have a Word conversion contract yet. |
-| Form controls | Partial | Checkbox task-list markers import as checkbox content controls. Text-like `input` and `textarea` elements import as structured document tags with value and alias/tag metadata. Single-select `select` elements import as dropdown list content controls. Richer input types and multi-select controls remain planned. |
+| Active and inert content | Not supported | `script` and `template` content is skipped with `HtmlElementSkipped` diagnostics; raw HTML comments are skipped with `HtmlCommentSkipped` diagnostics unless `ImportHtmlComments` is enabled. Executable behavior is never converted. Unsupported harmless elements fall through to child content unless explicitly handled. |
+| Embedded media/widgets | Not supported | `iframe`, `object`, `embed`, `video`, `audio`, and `canvas` are skipped with `HtmlEmbeddedContentSkipped` diagnostics instead of leaking fallback text into the Word document. |
+| Form controls | Partial | Checkbox task-list markers import as checkbox content controls. Text-like and visible value-bearing `input` elements (`text`, `search`, `email`, `url`, `tel`, `password`, `number`, `time`, `datetime-local`, `month`, `week`, `color`, and `range`), `textarea`, `meter`, and `progress` elements import as structured document tags with value and alias/tag metadata. Date inputs import as date picker content controls. Datalist-backed inputs import as combo boxes. Single-select `select` elements and named radio groups import as dropdown list content controls. Unselected radio groups include a blank selected item instead of defaulting to the first option. Multi-select `select` elements import selected values as newline-separated structured document tag text without defaulting to the first option. Hidden, file, button, submit, reset, and image controls are not imported as document content. Richer reciprocal form behavior remains planned. |
 
 ## CSS Import
 
@@ -45,14 +45,14 @@ This matrix documents the current `OfficeIMO.Word.Html` conversion surface. It i
 | Selectors | Partial | Common selectors, classes, specificity, inheritance, and `!important` are handled for supported properties; full browser selector/layout behavior is not the target yet. |
 | Fonts | Supported | `font`, `font-family`, `font-size`, `font-style`, `font-variant`, `font-weight`, and legacy `font` attributes map to Word run formatting. |
 | Colors | Supported | Hex, named colors, `rgb()`, modern space-separated `rgb()`, percentage channels, slash alpha syntax, and background colors map to Word colors where possible. |
-| Text decoration | Supported | Bold, italic, underline, strike, highlight, superscript, subscript, small caps, uppercase transforms, and code font mapping are supported. |
-| Paragraph alignment | Supported | `text-align`, direction/RTL, indentation, text indent, margins, line height, paragraph spacing, and white-space behavior map to Word paragraph formatting. |
+| Text decoration | Supported | Bold, italic, underline, CSS underline style variants, strike, highlight, superscript, subscript, small caps, uppercase transforms, and code font mapping are supported. `text-decoration:none` clears inherited underline/strike formatting. |
+| Paragraph alignment | Supported | Physical `text-align` values plus logical `start`/`end` values, direction/RTL, indentation, text indent, margins, line height, paragraph spacing, and white-space behavior map to Word paragraph formatting. |
 | Page breaks | Supported | `break-before`, `break-after`, and legacy page-break declarations map to Word page breaks. |
-| Tables | Supported | Table/cell width, borders, background color, alignment, padding, margins, `border-collapse`, captions, and colgroup widths are handled for common document tables. |
+| Tables | Supported | Table/cell width, borders, background color, horizontal and table-cell vertical alignment, padding, margins, `border-collapse`, `border-spacing`, captions, and colgroup widths are handled for common document tables. |
 | Lists | Supported | `list-style-type` maps to native Word list formats where OpenXML has a matching numbering style. |
 | Images | Supported | Width, height, percentage width, natural aspect ratio, and float/alignment hints are handled for common image placement. |
 | Browser layout | Planned | `display`, flexbox, grid, positioning, z-index, floats as layout, media queries, responsive breakpoints, and full box layout are not yet Word layout contracts. |
-| Unsupported CSS diagnostics | Partial | Unsupported effective inline and stylesheet CSS properties emit `UnsupportedCssDeclaration` diagnostics. Unsupported values for mapped CSS properties emit `UnsupportedCssValue` diagnostics. `HtmlToWordOptions.UnsupportedCssHandling` can ignore unsupported CSS, warn by default, or stop conversion with `HtmlUnsupportedCssException`. Broader value diagnostics for additional mapped properties remain planned. |
+| Unsupported CSS diagnostics | Partial | Unsupported effective inline and stylesheet CSS properties emit `UnsupportedCssDeclaration` diagnostics. Unsupported values for mapped CSS properties emit `UnsupportedCssValue` diagnostics, including partially mapped `text-decoration` values such as unsupported decoration colors. `HtmlToWordOptions.UnsupportedCssHandling` can ignore unsupported CSS, warn by default, or stop conversion with `HtmlUnsupportedCssException`. Broader value diagnostics for additional mapped properties remain planned. |
 
 ## Image And Resource Import
 
@@ -64,27 +64,31 @@ This matrix documents the current `OfficeIMO.Word.Html` conversion surface. It i
 | Local and file URL images | Supported | Local paths and `file:` URLs resolve directly or relative to `HtmlToWordOptions.BasePath`. |
 | Remote images | Supported | HTTP/HTTPS images load through the configured or default HTTP pipeline with optional timeout. |
 | SVG | Supported | Inline SVG, SVG files, remote SVG, and SVG data URIs can be embedded. |
-| Duplicate resources | Supported | Duplicate image sources are cached inside a conversion operation. |
+| Duplicate resources | Supported | Duplicate image sources are cached inside a conversion operation while preserving per-image `alt` and `title` metadata. |
 | Per-image byte limit | Supported | `MaxImageBytes` rejects oversized image resources with `ImageResourceTooLarge`. |
 | Aggregate byte budget | Supported | `MaxTotalImageBytes` rejects image resources that would exceed the conversion budget with `ImageResourceBudgetExceeded`. |
 | Content-type validation | Supported | `ValidateImageContentTypes` and `AllowedImageContentTypes` reject disallowed declared image types. |
 | URI policy | Supported | `AllowedImageUriSchemes` and `AllowedImageHosts` reject disallowed schemes/hosts before fetching or linking. |
-| Diagnostics | Supported | Skipped or degraded image resources, unsupported CSS declarations, unsupported mapped CSS values, and opt-in accessibility warnings populate `Diagnostics` and invoke `DiagnosticHandler`. |
-| Structural limits | Supported | `MaxHtmlNodes`, `MaxHtmlDepth`, `MaxCssBytes`, and `MaxTableCells` stop conversion with `HtmlConversionLimitException` and error diagnostics. |
-| Non-image resource budgets | Planned | CSS and other external resources do not yet share the image byte-budget pipeline. |
+| Diagnostics | Supported | Skipped or degraded image resources, skipped raw HTML comments when raw comment import is disabled or comments are empty, skipped embedded media/widgets, blocked stylesheet resources, disabled stylesheet links, missing stylesheet link `href` attributes, failed stylesheet HTTP statuses, stylesheet transport failures, stylesheet resource timeouts, rejected stylesheet content types, unsupported CSS declarations, unsupported mapped CSS values, and opt-in accessibility warnings populate `Diagnostics` and invoke `DiagnosticHandler`. |
+| Structural limits | Supported | `MaxHtmlNodes`, `MaxHtmlDepth`, `MaxCssBytes`, `MaxTotalCssBytes`, and `MaxTableCells` stop conversion with `HtmlConversionLimitException` and error diagnostics. `MaxCssBytes` is applied before parsing inline/embedded/configured CSS and before fully buffering local or remote external CSS where source length is available. `MaxTotalCssBytes` bounds CSS processed across one conversion. |
+| Stylesheet URI policy | Supported | `AllowedStylesheetUriSchemes` and `AllowedStylesheetHosts` reject disallowed external stylesheet sources before they are read or fetched and emit source-aware policy diagnostics. |
+| Stylesheet content-type validation | Supported | `ValidateStylesheetContentTypes` and `AllowedStylesheetContentTypes` reject disallowed declared remote stylesheet media types before content is read. Missing content types are accepted for compatibility. |
+| CSS aggregate byte budget | Supported | `MaxTotalCssBytes` rejects configured, embedded, local, and remote CSS that would exceed the conversion budget with `CssTotalSizeLimitExceeded`. |
+| Stylesheet parse cache | Supported | Parsed stylesheet rules are cached by CSS content hash, reusing identical CSS across conversions without reusing stale rules when a local path or remote URL returns changed content. |
+| Other non-image aggregate resource budgets | Planned | Non-CSS embedded media and future resource types do not yet share an aggregate byte-budget pipeline. |
 | Parallel prefetch | Planned | Resource loading is deterministic today; parallel prefetching remains a performance roadmap item. |
 
 ## Table Conversion
 
 | Feature | Import | Export | Notes |
 | --- | --- | --- | --- |
-| Basic tables | Supported | Supported | Rows and cells convert in both directions. |
-| Header/body/footer row groups | Supported | Partial | Import preserves row-group intent where Word can express it; export emits leading Word header rows as `<thead>` / `<th>` and body rows as `<tbody>` for those tables. Footer row-group export remains planned. |
-| Captions | Supported | Partial | Import supports caption placement; export emits figure/table-related captions in common cases. |
+| Basic tables | Supported | Supported | Rows and cells convert in both directions, including table-only HTML imports without leading empty placeholder paragraphs. |
+| Header/body/footer row groups | Supported | Supported | Import preserves `thead` rows as repeating Word header rows and `tfoot` intent as last-row conditional formatting where Word can express it; export emits leading Word header rows as `<thead>` / `<th scope="col">`, body rows as `<tbody>`, and a final conditionally formatted row as `<tfoot>`. Multiple-row footer groups remain lossy because Word exposes only a last-row table-look flag. |
+| Captions | Supported | Supported | Import supports table caption placement above or below the table; export emits adjacent `Caption`-style table captions as semantic `<caption>` elements. |
 | Column groups | Supported | Partial | Import uses `colgroup`/`col` widths. Export emits Word column widths as `colgroup`/`col` markup when `IncludeTableColumnGroups` is enabled. |
 | Colspan/rowspan | Supported | Supported | Grid spans and vertical merges convert in common and irregular table layouts. |
-| Widths and borders | Supported | Supported | Common CSS width and border values are mapped; full browser border conflict resolution is planned. |
-| Cell styles | Supported | Supported | Background color, alignment, width, and border styles are handled for common tables. |
+| Widths, borders, and spacing | Supported | Supported | Common CSS width, border, and table cell-spacing values are mapped; full browser border conflict resolution is planned. |
+| Cell styles | Supported | Supported | Background color, horizontal alignment, vertical alignment, width, and border styles are handled for common tables. |
 | Nested tables | Partial | Partial | Supported when represented by OfficeIMO section/table traversal; deeper malformed editor output needs more fixtures. |
 
 ## List Conversion
@@ -93,10 +97,11 @@ This matrix documents the current `OfficeIMO.Word.Html` conversion surface. It i
 | --- | --- | --- | --- |
 | Ordered and unordered lists | Supported | Supported | Native Word numbering is used where possible. |
 | Nested lists | Supported | Supported | Nested levels are tracked through Word list levels. |
+| Block children in list items | Supported | Partial | Import preserves source order for common list-item block children, including paragraphs followed by tables, by anchoring later block inserts after the latest block in the same Word container. Export keeps ordinary Word list paragraphs as list markup; richer nested block export remains tied to Word's list model. |
 | Starts and continuation | Supported | Supported | `start`, `value`, reversed lists, and continued numbering are handled for common cases. |
 | CSS list styles | Supported | Supported | Common bullet and ordered styles map to native OpenXML formats. |
 | International ordered styles | Supported | Supported | Russian, Hebrew, Arabic, Hiragana, Katakana, and related OpenXML-backed formats are mapped when available. |
-| Custom marker glyphs | Partial | Planned | A few common editor markers such as dash bullets are mapped; arbitrary generated marker content is planned. |
+| Custom marker glyphs | Supported | Supported | Common editor markers such as dash, en dash, em dash, asterisk, and plus bullets are mapped, and arbitrary quoted CSS marker strings round-trip as custom Word bullet marker text. |
 | Task list checkboxes | Supported | Supported | Checkbox task-list HTML imports as Word checkbox controls and exports back as disabled HTML checkboxes. Other native Word form controls export through the Word-to-HTML form-control path. |
 
 ## Word To HTML Export
@@ -105,29 +110,33 @@ This matrix documents the current `OfficeIMO.Word.Html` conversion surface. It i
 | --- | --- | --- |
 | Document shell | Supported | Emits HTML, root `lang` when the Word document language is set, head metadata, title, optional default CSS, additional meta tags, additional link tags, and optional body font family. |
 | Paragraphs and headings | Supported | Emits `p`, `h1` through `h6`, `blockquote`, `hr`, paragraph classes, alignment, spacing, indentation, background, and border styles. |
-| Runs | Supported | Emits `strong`, `em`, `u`, `s`, `sup`, `sub`, `q`, `cite`, `dfn`, `time`, `code`, font spans, run classes, colors, and highlights. |
+| Definition lists | Supported | Emits consecutive imported or marker-styled definition term/description paragraphs as `dl`, `dt`, and `dd` instead of degrading indented descriptions to `blockquote`; empty internal marker paragraphs created by table-cell imports are skipped. |
+| Runs | Supported | Emits `strong`, `em`, `u`, `s`, `del`, `ins`, `sup`, `sub`, `q`, `cite`, `dfn`, `time`, `abbr`, `mark`, `code`, font spans, run classes, colors, highlights, and run-level `lang` attributes when the run language differs from the document language. Imported `time datetime` values are preferred over parsing visible labels when available, and imported `mark` runs prefer semantic tags over generic highlight CSS. |
 | Links and bookmarks | Supported | Exports external and anchor hyperlinks as `a href`; ordinary Word bookmarks export as HTML `id` anchors and structural bookmarks export as matching structural elements. |
-| Images and SVG | Supported | Emits `img` with base64 data URIs or file/external references; SVG can be emitted inline or as image references depending on options. |
+| Images and SVG | Supported | Emits `img` with base64 data URIs or file/external references, preserving image `alt` and `title` metadata where available; SVG can be emitted inline or as image references depending on options. |
 | Lists | Supported | Emits `ol`, `ul`, `li`, `start`, `type`, optional CSS list styles, and optional reusable `word-list-*` definition classes plus a head stylesheet. |
-| Tables | Supported | Emits tables with spans, widths, borders, background, alignment, cell styles, optional `colgroup` column widths, and leading header rows as `<thead>` / `<th>` where Word marks them as repeating header rows. |
-| Figures and captions | Partial | Exports common image-plus-caption patterns as `figure` and `figcaption`. |
-| Notes | Supported | Emits footnote and endnote sections when enabled. Exported `section.footnotes` and `section.endnotes` links import back as native Word footnotes and endnotes. |
-| Comments | Partial | When `ExportComments` is enabled, emits linked Word comment references and a `section.comments` list with author, initials, date, and nested reply metadata. Exported comment sections import back as native Word comments with nested replies; arbitrary HTML comment import and richer range fidelity remain planned. |
+| Tables | Supported | Emits tables with spans, widths, borders, background, horizontal and vertical alignment, cell spacing as `border-spacing`, cell styles, optional `colgroup` column widths, adjacent `Caption`-style table captions as `<caption>`, leading header rows as `<thead>` / `<th scope="col">` where Word marks them as repeating header rows, and a final `<tfoot>` row when Word last-row conditional formatting is enabled. |
+| Figures and captions | Partial | Exports common image-plus-caption patterns as `figure` and `figcaption`; HTML import normalizes leading or trailing captions into that Word-compatible pattern. Richer non-image figure content remains partial. |
+| Notes | Supported | Emits footnote and endnote sections when enabled. Exported `section.footnotes` and `section.endnotes` links import back as native Word footnotes and endnotes. Imported blockquote citation notes are suppressed during HTML export when the original `blockquote cite` attribute is restored, including after saved DOCX package reload when citation note metadata is present. |
+| Comments | Partial | When `ExportComments` is enabled, emits linked Word comment references and a `section.comments` list with author, initials, date, and nested reply metadata. Exported comment sections import back as native Word comments with nested replies. Raw HTML comments remain skipped by default with `HtmlCommentSkipped`, but `HtmlToWordOptions.ImportHtmlComments` can import non-empty raw comments as native Word comments using configurable author and initials metadata. Richer comment range fidelity remains planned. |
 | Headers and footers | Partial | When `ExportHeadersAndFooters` is enabled, emits non-empty section headers and footers as semantic `header`/`footer` regions with `word-header`/`word-footer` classes, section indexes, and default/first/even type metadata. Exported regions import back into native section headers/footers; richer header/footer content remains planned. |
-| Form/content controls | Supported | Emits native Word checkbox, structured text, dropdown list, combo box, and date picker content controls as disabled HTML form controls with selected values, option lists, and available metadata. |
+| Form/content controls | Supported | Emits native Word checkbox, structured text, dropdown list, combo box, and date picker content controls as disabled HTML form controls with selected values, option lists, and available metadata. Single-line structured text exports as `input type="text"`; multiline structured text exports as `textarea` so HTML import can round-trip line breaks and metadata. |
 | Sections/page setup | Partial | When `IncludeSectionMetadata` is enabled, export wraps each Word section in a `section.word-section` element with page size, orientation, margin data attributes, and Word-like CSS dimensions. |
-| Properties and definitions | Partial | Built-in document properties export as standard metadata. Custom document properties export as typed meta tags when `IncludeCustomProperties` is enabled. Document language exports as root `html lang`. Paragraph/run style definitions export when class output is enabled. List definitions export as reusable CSS when `IncludeListDefinitions` is enabled. Broader run-level language and accessibility metadata export remains planned. |
+| Properties and definitions | Partial | Built-in document properties export as standard metadata. Custom document properties export as typed meta tags when `IncludeCustomProperties` is enabled. Document language exports as root `html lang`, run language exports as `span lang` when it differs from the document language, and image description/title metadata exports as `alt`/`title`. Paragraph/run style definitions export when class output is enabled. List definitions export as reusable CSS when `IncludeListDefinitions` is enabled. Broader accessibility metadata export remains planned. |
 
 ## Public Options
 
 | Option surface | Status | Key controls |
 | --- | --- | --- |
-| `HtmlToWordOptions` | Supported | Font family, quote text, default page size/orientation, class styles, list styles, numbering continuation, heading numbering, base path, notes, image processing mode, `HttpClient`, resource timeout, image limits, HTML/CSS/table limits, content-type validation, URI policy, diagnostics, opt-in accessibility diagnostics, unsupported CSS handling, stylesheet paths/contents, pre rendering mode, caption placement, and section handling. |
+| `HtmlToWordOptions` | Supported | Named profiles through `CreateOfficeIMOProfile()`, `CreateUntrustedHtmlProfile()`, and `CreateTrustedDocumentProfile()`; cloneable reusable templates; font family, quote text, default page size/orientation, class styles, list styles, numbering continuation, heading numbering, base path, notes, raw HTML comment import and author metadata, image processing mode, `HttpClient`, resource timeout, image limits, HTML/CSS/table limits, image and stylesheet content-type validation, image and stylesheet URI policy, diagnostics, opt-in accessibility diagnostics, unsupported CSS handling, stylesheet paths/contents, pre rendering mode, caption placement, and section handling. |
 | `WordToHtmlOptions` | Supported | Font family, font styles, list styles, list definitions, paragraph/run classes, run color/highlight styles, paragraph spacing/indentation styles, footnote and endnote export, header/footer export, comment export, custom property metadata export, section metadata export, table column-group export, image embedding mode, additional meta/link tags, and default CSS. |
+| `ReaderHtmlOptions` | Supported | `OfficeIMO.Reader.Html` exposes named adapter profiles for OfficeIMO-default, portable, and bounded untrusted HTML ingestion; nested `HtmlToMarkdownOptions` pass-through for markdown writer profiles, input limits, transforms, custom element converters, and visual round-trip hints; and `Clone()` for reusable registration templates. |
 
 ## Current Validation Evidence
 
 - HTML-focused tests under `OfficeIMO.Tests` cover import, export, tables, lists, images, links, inline styles, page settings, code blocks, task lists, async/cancellation, and options.
-- The current roadmap worktree last ran the broad HTML-focused test suite with `508/508` passing on `net8.0`, `net10.0`, and `net472`.
-- The current roadmap worktree also ran the full `OfficeIMO.Tests` project with `8,319` passed / `7` skipped on `net8.0`, `8,319` passed / `7` skipped on `net10.0`, and `8,315` passed / `7` skipped on `net472`.
+- On 2026-06-05, branch `codex/html-conversion-robustness-20260605` ran the broad HTML-focused test slice with `637/637` passing on `net8.0`.
+- On 2026-06-05, branch `codex/html-conversion-robustness-20260605` added artifact-level proof that imported image dimensions persist as saved DrawingML extents in a valid DOCX package.
+- On 2026-06-05, branch `codex/html-conversion-robustness-20260605` built `OfficeIMO.Word.Html`, `OfficeIMO.Markdown.Html`, and `OfficeIMO.Reader.Html` in Release across `netstandard2.0`, `net8.0`, `net10.0`, and `net472` with `0` warnings and `0` errors.
+- On 2026-06-05, branch `codex/html-conversion-robustness-20260605` added `HtmlArtifactGallery_GeneratesValidDocxAndRoundTripHtml`, which writes `quarterly-report.input.html`, `quarterly-report.docx`, and `quarterly-report.roundtrip.html`, then validates the generated DOCX package with OpenXML validation.
 - This matrix is a contract inventory. Rows marked Supported should continue gaining direct fixture or artifact evidence as the roadmap moves through the remaining phases.

--- a/OfficeIMO.Reader.Html/README.md
+++ b/OfficeIMO.Reader.Html/README.md
@@ -7,6 +7,9 @@ Current scope:
 - Markdown chunk emission in `ReaderChunk` shape
 - heading-aware chunk metadata (`Location.HeadingPath`, `Location.StartLine`) when `ReaderOptions.MarkdownChunkByHeadings = true`
 - path and stream dispatch via `DocumentReader` handler registration
+- `ReaderHtmlOptions.HtmlToMarkdownOptions` pass-through for markdown writer profiles, input limits, transforms, custom element converters, and visual round-trip hints
+- `ReaderHtmlOptions.CreateOfficeIMOProfile()`, `CreatePortableProfile()`, and `CreateUntrustedHtmlProfile(maxInputCharacters)` helpers for reusable adapter profiles
+- `ReaderHtmlOptions.Clone()` for safe option-template reuse during handler registration and direct reads
 - warning chunk when HTML yields no markdown content
 
 Registration into `OfficeIMO.Reader`:
@@ -16,6 +19,18 @@ using OfficeIMO.Reader.Html;
 
 DocumentReaderHtmlRegistrationExtensions.RegisterHtmlHandler();
 ```
+
+For untrusted or size-sensitive HTML, pass `ReaderHtmlOptions` during direct reads or handler registration:
+
+```csharp
+using OfficeIMO.Reader.Html;
+
+DocumentReaderHtmlRegistrationExtensions.RegisterHtmlHandler(
+    htmlOptions: ReaderHtmlOptions.CreateUntrustedHtmlProfile(maxInputCharacters: 100_000),
+    replaceExisting: true);
+```
+
+Use `ReaderHtmlOptions.CreatePortableProfile()` when the reader output should favor portable Markdown serialization. For custom ingestion contracts, set `HtmlToMarkdownOptions` directly or clone a profile and add transforms, element converters, or visual round-trip hints.
 
 Status:
 - packaged as `OfficeIMO.Reader.Html`

--- a/OfficeIMO.Reader.Html/ReaderHtmlOptions.cs
+++ b/OfficeIMO.Reader.Html/ReaderHtmlOptions.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Markdown.Html;
+using System;
 
 namespace OfficeIMO.Reader.Html;
 
@@ -7,7 +8,49 @@ namespace OfficeIMO.Reader.Html;
 /// </summary>
 public sealed class ReaderHtmlOptions {
     /// <summary>
+    /// Creates the default OfficeIMO HTML reader profile.
+    /// </summary>
+    /// <returns>A new <see cref="ReaderHtmlOptions"/> instance using the default HTML-to-Markdown profile.</returns>
+    public static ReaderHtmlOptions CreateOfficeIMOProfile() => new ReaderHtmlOptions {
+        HtmlToMarkdownOptions = HtmlToMarkdownOptions.CreateOfficeIMOProfile()
+    };
+
+    /// <summary>
+    /// Creates a portable HTML reader profile that favors portable Markdown output.
+    /// </summary>
+    /// <returns>A new <see cref="ReaderHtmlOptions"/> instance using the portable HTML-to-Markdown profile.</returns>
+    public static ReaderHtmlOptions CreatePortableProfile() => new ReaderHtmlOptions {
+        HtmlToMarkdownOptions = HtmlToMarkdownOptions.CreatePortableProfile()
+    };
+
+    /// <summary>
+    /// Creates a bounded HTML reader profile for untrusted or size-sensitive HTML ingestion.
+    /// </summary>
+    /// <param name="maxInputCharacters">Maximum HTML input length accepted by the HTML-to-Markdown stage.</param>
+    /// <returns>A new <see cref="ReaderHtmlOptions"/> instance with a configured HTML input character limit.</returns>
+    public static ReaderHtmlOptions CreateUntrustedHtmlProfile(int maxInputCharacters) {
+        if (maxInputCharacters <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxInputCharacters), "Maximum input characters must be greater than zero.");
+        }
+
+        var options = HtmlToMarkdownOptions.CreatePortableProfile();
+        options.MaxInputCharacters = maxInputCharacters;
+
+        return new ReaderHtmlOptions {
+            HtmlToMarkdownOptions = options
+        };
+    }
+
+    /// <summary>
     /// Options passed to HTML-to-Markdown conversion stage.
     /// </summary>
     public HtmlToMarkdownOptions? HtmlToMarkdownOptions { get; set; }
+
+    /// <summary>
+    /// Creates a copy of the current options instance so reader registrations can reuse templates safely.
+    /// </summary>
+    /// <returns>A new <see cref="ReaderHtmlOptions"/> with cloned nested HTML-to-Markdown options.</returns>
+    public ReaderHtmlOptions Clone() => new ReaderHtmlOptions {
+        HtmlToMarkdownOptions = HtmlToMarkdownOptions?.Clone()
+    };
 }

--- a/OfficeIMO.Reader.Html/ReaderHtmlOptionsCloner.cs
+++ b/OfficeIMO.Reader.Html/ReaderHtmlOptionsCloner.cs
@@ -4,26 +4,10 @@ namespace OfficeIMO.Reader.Html;
 
 internal static class ReaderHtmlOptionsCloner {
     public static ReaderHtmlOptions CloneOrDefault(ReaderHtmlOptions? options) {
-        return new ReaderHtmlOptions {
-            HtmlToMarkdownOptions = Clone(options?.HtmlToMarkdownOptions) ?? new HtmlToMarkdownOptions()
-        };
+        return options?.Clone() ?? ReaderHtmlOptions.CreateOfficeIMOProfile();
     }
 
     public static ReaderHtmlOptions? CloneNullable(ReaderHtmlOptions? options) {
-        if (options == null) return null;
-        return new ReaderHtmlOptions {
-            HtmlToMarkdownOptions = Clone(options.HtmlToMarkdownOptions)
-        };
-    }
-
-    public static HtmlToMarkdownOptions? Clone(HtmlToMarkdownOptions? options) {
-        if (options == null) return null;
-        return new HtmlToMarkdownOptions {
-            BaseUri = options.BaseUri,
-            UseBodyContentsOnly = options.UseBodyContentsOnly,
-            RemoveScriptsAndStyles = options.RemoveScriptsAndStyles,
-            PreserveUnsupportedBlocks = options.PreserveUnsupportedBlocks,
-            PreserveUnsupportedInlineHtml = options.PreserveUnsupportedInlineHtml
-        };
+        return options?.Clone();
     }
 }

--- a/OfficeIMO.Tests/ConversionOptions.cs
+++ b/OfficeIMO.Tests/ConversionOptions.cs
@@ -3,6 +3,8 @@ using OfficeIMO.Word.Markdown;
 using OfficeIMO.Word.Pdf;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
+using System;
+using System.Net.Http;
 using Xunit;
 
 namespace OfficeIMO.Tests;
@@ -17,6 +19,7 @@ public class ConversionOptionsTests {
             MaxHtmlNodes = 1000,
             MaxHtmlDepth = 64,
             MaxCssBytes = 8192,
+            MaxTotalCssBytes = 16384,
             MaxTableCells = 10000,
             EnableAccessibilityDiagnostics = true
         };
@@ -26,13 +29,155 @@ public class ConversionOptionsTests {
         Assert.Equal(1000, options.MaxHtmlNodes);
         Assert.Equal(64, options.MaxHtmlDepth);
         Assert.Equal(8192, options.MaxCssBytes);
+        Assert.Equal(16384, options.MaxTotalCssBytes);
         Assert.Equal(10000, options.MaxTableCells);
         Assert.False(options.AllowDocumentStylesheetLinks);
         Assert.True(options.ValidateImageContentTypes);
         Assert.Contains("image/png", options.AllowedImageContentTypes);
         Assert.Contains("https", options.AllowedImageUriSchemes);
         Assert.Empty(options.AllowedImageHosts);
+        Assert.True(options.ValidateStylesheetContentTypes);
+        Assert.Contains("text/css", options.AllowedStylesheetContentTypes);
+        Assert.Contains("https", options.AllowedStylesheetUriSchemes);
+        Assert.Contains("file", options.AllowedStylesheetUriSchemes);
+        Assert.Empty(options.AllowedStylesheetHosts);
         Assert.True(options.EnableAccessibilityDiagnostics);
+    }
+
+    [Fact]
+    public void HtmlToWordOptions_CreateProfilesExposeExpectedPolicies() {
+        var defaultProfile = HtmlToWordOptions.CreateOfficeIMOProfile();
+        Assert.False(defaultProfile.AllowDocumentStylesheetLinks);
+        Assert.Equal(ImageProcessingMode.Embed, defaultProfile.ImageProcessing);
+        Assert.Contains("https", defaultProfile.AllowedImageUriSchemes);
+        Assert.Contains("https", defaultProfile.AllowedStylesheetUriSchemes);
+        Assert.Null(defaultProfile.MaxHtmlNodes);
+
+        var untrustedProfile = HtmlToWordOptions.CreateUntrustedHtmlProfile();
+        Assert.False(untrustedProfile.AllowDocumentStylesheetLinks);
+        Assert.Equal(ImageProcessingMode.EmbedDataUriOnly, untrustedProfile.ImageProcessing);
+        Assert.Equal(TimeSpan.FromSeconds(5), untrustedProfile.ResourceTimeout);
+        Assert.Equal(10000, untrustedProfile.MaxHtmlNodes);
+        Assert.Equal(64, untrustedProfile.MaxHtmlDepth);
+        Assert.Equal(256L * 1024L, untrustedProfile.MaxCssBytes);
+        Assert.Equal(512L * 1024L, untrustedProfile.MaxTotalCssBytes);
+        Assert.Equal(50000, untrustedProfile.MaxTableCells);
+        Assert.Equal(new[] { "data" }, untrustedProfile.AllowedImageUriSchemes);
+        Assert.Empty(untrustedProfile.AllowedStylesheetUriSchemes);
+        Assert.True(untrustedProfile.EnableAccessibilityDiagnostics);
+
+        var trustedProfile = HtmlToWordOptions.CreateTrustedDocumentProfile();
+        Assert.True(trustedProfile.AllowDocumentStylesheetLinks);
+        Assert.Equal(ImageProcessingMode.Embed, trustedProfile.ImageProcessing);
+        Assert.True(trustedProfile.ValidateImageContentTypes);
+        Assert.True(trustedProfile.ValidateStylesheetContentTypes);
+    }
+
+    [Fact]
+    public void HtmlToWordOptions_CloneCopiesConfigurationWithoutDiagnostics() {
+        using var httpClient = new HttpClient();
+        Action<HtmlConversionDiagnostic> handler = _ => { };
+        var options = HtmlToWordOptions.CreateTrustedDocumentProfile();
+        options.FontFamily = "Aptos";
+        options.QuotePrefix = "[";
+        options.QuoteSuffix = "]";
+        options.DefaultPageSize = WordPageSize.A4;
+        options.DefaultOrientation = PageOrientationValues.Landscape;
+        options.IncludeListStyles = true;
+        options.ContinueNumbering = true;
+        options.SupportsHeadingNumbering = true;
+        options.BasePath = "C:\\Temp";
+        options.NoteReferenceType = NoteReferenceType.Endnote;
+        options.LinkNoteUrls = false;
+        options.ImageProcessing = ImageProcessingMode.LinkExternal;
+        options.HttpClient = httpClient;
+        options.ResourceTimeout = TimeSpan.FromSeconds(7);
+        options.MaxImageBytes = 11;
+        options.MaxTotalImageBytes = 22;
+        options.ValidateImageContentTypes = false;
+        options.ValidateStylesheetContentTypes = false;
+        options.MaxHtmlNodes = 33;
+        options.MaxHtmlDepth = 44;
+        options.MaxCssBytes = 55;
+        options.MaxTotalCssBytes = 66;
+        options.MaxTableCells = 77;
+        options.DiagnosticHandler = handler;
+        options.EnableAccessibilityDiagnostics = true;
+        options.ImportHtmlComments = true;
+        options.HtmlCommentAuthor = "HTML Reviewer";
+        options.HtmlCommentInitials = "HR";
+        options.UnsupportedCssHandling = HtmlUnsupportedCssHandling.Error;
+        options.RenderPreAsTable = true;
+        options.TableCaptionPosition = TableCaptionPosition.Below;
+        options.SectionTagHandling = SectionTagHandling.Block;
+        options.ClassStyles["lead"] = WordParagraphStyles.Heading2;
+        options.StylesheetPaths.Add("site.css");
+        options.StylesheetContents.Add("p{color:red}");
+        options.AllowedImageContentTypes.Clear();
+        options.AllowedImageContentTypes.Add("image/png");
+        options.AllowedImageUriSchemes.Clear();
+        options.AllowedImageUriSchemes.Add("data");
+        options.AllowedImageHosts.Add("images.example.test");
+        options.AllowedStylesheetUriSchemes.Clear();
+        options.AllowedStylesheetUriSchemes.Add("https");
+        options.AllowedStylesheetHosts.Add("styles.example.test");
+        options.AllowedStylesheetContentTypes.Clear();
+        options.AllowedStylesheetContentTypes.Add("text/css");
+        options.Diagnostics.Add(new HtmlConversionDiagnostic("Existing", "Existing diagnostic"));
+
+        var clone = options.Clone();
+
+        Assert.Equal(options.FontFamily, clone.FontFamily);
+        Assert.Equal(options.QuotePrefix, clone.QuotePrefix);
+        Assert.Equal(options.QuoteSuffix, clone.QuoteSuffix);
+        Assert.Equal(options.DefaultPageSize, clone.DefaultPageSize);
+        Assert.Equal(options.DefaultOrientation, clone.DefaultOrientation);
+        Assert.Equal(options.IncludeListStyles, clone.IncludeListStyles);
+        Assert.Equal(options.ContinueNumbering, clone.ContinueNumbering);
+        Assert.Equal(options.SupportsHeadingNumbering, clone.SupportsHeadingNumbering);
+        Assert.Equal(options.BasePath, clone.BasePath);
+        Assert.Equal(options.NoteReferenceType, clone.NoteReferenceType);
+        Assert.Equal(options.LinkNoteUrls, clone.LinkNoteUrls);
+        Assert.Equal(options.ImageProcessing, clone.ImageProcessing);
+        Assert.Same(httpClient, clone.HttpClient);
+        Assert.Equal(options.ResourceTimeout, clone.ResourceTimeout);
+        Assert.Equal(options.MaxImageBytes, clone.MaxImageBytes);
+        Assert.Equal(options.MaxTotalImageBytes, clone.MaxTotalImageBytes);
+        Assert.Equal(options.ValidateImageContentTypes, clone.ValidateImageContentTypes);
+        Assert.Equal(options.ValidateStylesheetContentTypes, clone.ValidateStylesheetContentTypes);
+        Assert.Equal(options.MaxHtmlNodes, clone.MaxHtmlNodes);
+        Assert.Equal(options.MaxHtmlDepth, clone.MaxHtmlDepth);
+        Assert.Equal(options.MaxCssBytes, clone.MaxCssBytes);
+        Assert.Equal(options.MaxTotalCssBytes, clone.MaxTotalCssBytes);
+        Assert.Equal(options.MaxTableCells, clone.MaxTableCells);
+        Assert.Same(handler, clone.DiagnosticHandler);
+        Assert.Equal(options.EnableAccessibilityDiagnostics, clone.EnableAccessibilityDiagnostics);
+        Assert.Equal(options.ImportHtmlComments, clone.ImportHtmlComments);
+        Assert.Equal(options.HtmlCommentAuthor, clone.HtmlCommentAuthor);
+        Assert.Equal(options.HtmlCommentInitials, clone.HtmlCommentInitials);
+        Assert.Equal(options.UnsupportedCssHandling, clone.UnsupportedCssHandling);
+        Assert.Equal(options.AllowDocumentStylesheetLinks, clone.AllowDocumentStylesheetLinks);
+        Assert.Equal(options.RenderPreAsTable, clone.RenderPreAsTable);
+        Assert.Equal(options.TableCaptionPosition, clone.TableCaptionPosition);
+        Assert.Equal(options.SectionTagHandling, clone.SectionTagHandling);
+        Assert.Equal(options.ClassStyles, clone.ClassStyles);
+        Assert.Equal(options.StylesheetPaths, clone.StylesheetPaths);
+        Assert.Equal(options.StylesheetContents, clone.StylesheetContents);
+        Assert.Equal(options.AllowedImageContentTypes, clone.AllowedImageContentTypes);
+        Assert.Equal(options.AllowedImageUriSchemes, clone.AllowedImageUriSchemes);
+        Assert.Equal(options.AllowedImageHosts, clone.AllowedImageHosts);
+        Assert.Equal(options.AllowedStylesheetUriSchemes, clone.AllowedStylesheetUriSchemes);
+        Assert.Equal(options.AllowedStylesheetHosts, clone.AllowedStylesheetHosts);
+        Assert.Equal(options.AllowedStylesheetContentTypes, clone.AllowedStylesheetContentTypes);
+        Assert.Empty(clone.Diagnostics);
+
+        clone.ClassStyles["lead"] = WordParagraphStyles.Heading3;
+        clone.StylesheetPaths.Add("other.css");
+        clone.AllowedImageUriSchemes.Add("https");
+
+        Assert.Equal(WordParagraphStyles.Heading2, options.ClassStyles["lead"]);
+        Assert.DoesNotContain("other.css", options.StylesheetPaths);
+        Assert.DoesNotContain("https", options.AllowedImageUriSchemes);
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Html.Abbreviations.cs
+++ b/OfficeIMO.Tests/Html.Abbreviations.cs
@@ -35,5 +35,19 @@ namespace OfficeIMO.Tests {
             Assert.Single(endNotes!);
             Assert.Equal("desc", endNotes![0].Paragraphs![1].Text);
         }
+
+        [Fact]
+        public void AbbrEndnoteRoundTripsAsAbbrTitle() {
+            const string html = "<abbr title=\"desc\">text</abbr>";
+            var options = new HtmlToWordOptions { NoteReferenceType = NoteReferenceType.Endnote };
+            using var doc = html.LoadFromHtml(options);
+
+            string roundTrip = doc.ToHtml(new WordToHtmlOptions { ExportEndnotes = true });
+
+            Assert.Contains("<abbr", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("title=\"desc\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(">text</abbr>", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("<sup", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/OfficeIMO.Tests/Html.ArtifactGallery.cs
+++ b/OfficeIMO.Tests/Html.ArtifactGallery.cs
@@ -1,0 +1,88 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Html {
+    [Fact]
+    public void HtmlArtifactGallery_GeneratesValidDocxAndRoundTripHtml() {
+        const string html = """
+            <!doctype html>
+            <html lang="en">
+            <head>
+                <title>Quarterly Report</title>
+                <style>
+                    body { font-family: Calibri; }
+                    table.report { width: 100%; border-collapse: separate; border-spacing: 6pt; }
+                    th, td { border: 1px solid #444; padding: 4pt; vertical-align: middle; }
+                    tfoot td { background-color: #eeeeee; font-weight: bold; }
+                </style>
+            </head>
+            <body>
+                <article id="report">
+                    <h1>Quarterly Report</h1>
+                    <p>Prepared for <strong>OfficeIMO</strong> HTML conversion validation.</p>
+                    <ul>
+                        <li><input type="checkbox" checked> Revenue reviewed</li>
+                        <li><input type="checkbox"> Risks pending</li>
+                    </ul>
+                    <table class="report">
+                        <thead>
+                            <tr><th>Metric</th><th>Value</th></tr>
+                        </thead>
+                        <tbody>
+                            <tr><td>Revenue</td><td>$42,000</td></tr>
+                            <tr><td>Margin</td><td>18%</td></tr>
+                        </tbody>
+                        <tfoot>
+                            <tr><td>Total</td><td>$42,000</td></tr>
+                        </tfoot>
+                    </table>
+                    <label>Owner <input name="owner" value="Ada Lovelace"></label>
+                    <label>Status <select name="status"><option>Draft</option><option selected>Approved</option></select></label>
+                    <!-- skipped comments are diagnostic evidence, not visible document content -->
+                </article>
+            </body>
+            </html>
+            """;
+
+        string artifactDirectory = Path.Combine(Path.GetTempPath(), "OfficeIMO.HtmlArtifactGallery");
+        Directory.CreateDirectory(artifactDirectory);
+        string inputPath = Path.Combine(artifactDirectory, "quarterly-report.input.html");
+        string docxPath = Path.Combine(artifactDirectory, "quarterly-report.docx");
+        string roundTripPath = Path.Combine(artifactDirectory, "quarterly-report.roundtrip.html");
+
+        var importOptions = HtmlToWordOptions.CreateTrustedDocumentProfile();
+        importOptions.EnableAccessibilityDiagnostics = true;
+        using var document = html.LoadFromHtml(importOptions);
+        using MemoryStream packageStream = document.SaveAsMemoryStream();
+
+        File.WriteAllText(inputPath, html);
+        File.WriteAllBytes(docxPath, packageStream.ToArray());
+        packageStream.Position = 0;
+        using WordprocessingDocument package = WordprocessingDocument.Open(packageStream, false);
+        var errors = new OpenXmlValidator().Validate(package).ToList();
+        Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
+
+        string roundTripHtml = document.ToHtml(new WordToHtmlOptions {
+            IncludeListStyles = true,
+            IncludeTableColumnGroups = true,
+            IncludeDefaultCss = true
+        });
+        File.WriteAllText(roundTripPath, roundTripHtml);
+
+        Assert.Contains("<h1>Quarterly Report</h1>", roundTripHtml, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<thead>", roundTripHtml, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<tfoot>", roundTripHtml, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("type=\"checkbox\"", roundTripHtml, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<select", roundTripHtml, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("skipped comments are diagnostic evidence", roundTripHtml, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(importOptions.Diagnostics, diagnostic => string.Equals(diagnostic.Code, "HtmlCommentSkipped", StringComparison.OrdinalIgnoreCase));
+        Assert.True(File.Exists(inputPath));
+        Assert.True(File.Exists(docxPath));
+        Assert.True(File.Exists(roundTripPath));
+    }
+}

--- a/OfficeIMO.Tests/Html.BlockquoteCitations.cs
+++ b/OfficeIMO.Tests/Html.BlockquoteCitations.cs
@@ -1,6 +1,7 @@
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
 using System;
+using System.IO;
 using Xunit;
 
 namespace OfficeIMO.Tests {
@@ -16,6 +17,34 @@ namespace OfficeIMO.Tests {
             Assert.NotNull(footNotes);
             Assert.Single(footNotes!);
             Assert.Contains(footNotes![0].Paragraphs!, p => p.Hyperlink?.Uri == new Uri("https://example.com"));
+        }
+
+        [Fact]
+        public void BlockquoteCitationRoundTripsAsCiteAttribute() {
+            string html = "<blockquote cite=\"https://example.com/source\"><p>Quoted text</p></blockquote>";
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            string roundTrip = doc.ToHtml(new WordToHtmlOptions { ExportFootnotes = true });
+
+            Assert.Contains("<blockquote cite=\"https://example.com/source\">", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Quoted text", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("<sup", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("class=\"footnotes\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void BlockquoteCitationSurvivesSavedDocumentRoundTrip() {
+            string html = "<blockquote cite=\"https://example.com/persisted\"><p>Persisted quote</p></blockquote>";
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            using MemoryStream packageStream = doc.SaveAsMemoryStream();
+            using var loaded = WordDocument.Load(packageStream);
+
+            string roundTrip = loaded.ToHtml(new WordToHtmlOptions { ExportFootnotes = true });
+
+            Assert.Contains("<blockquote cite=\"https://example.com/persisted\">", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Persisted quote", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("<sup", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("class=\"footnotes\"", roundTrip, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/OfficeIMO.Tests/Html.Comments.cs
+++ b/OfficeIMO.Tests/Html.Comments.cs
@@ -84,5 +84,37 @@ namespace OfficeIMO.Tests {
             Assert.Equal(commentDate, rootComment.DateTime);
             Assert.Equal(replyDate, rootReply.DateTime);
         }
+
+        [Fact]
+        public void HtmlToWord_RawHtmlComments_CanImportAsNativeWordComments() {
+            var options = new HtmlToWordOptions {
+                ImportHtmlComments = true,
+                HtmlCommentAuthor = "HTML Reviewer",
+                HtmlCommentInitials = "HR"
+            };
+            string html = "<p>Visible <!-- reviewer note -->text.</p>";
+
+            using var doc = html.LoadFromHtml(options);
+
+            Assert.Equal("Visible text.", string.Concat(doc.Paragraphs.Select(paragraph => paragraph.Text)));
+            Assert.DoesNotContain(options.Diagnostics, diagnostic => diagnostic.Code == "HtmlCommentSkipped");
+            var comment = Assert.Single(doc.Comments);
+            Assert.Equal("HTML Reviewer", comment.Author);
+            Assert.Equal("HR", comment.Initials);
+            Assert.Equal("reviewer note", comment.Text);
+
+            using var stream = doc.SaveAsMemoryStream();
+            using var loaded = WordDocument.Load(stream);
+            var loadedComment = Assert.Single(loaded.Comments);
+            Assert.Equal("HTML Reviewer", loadedComment.Author);
+            Assert.Equal("HR", loadedComment.Initials);
+            Assert.Equal("reviewer note", loadedComment.Text);
+
+            string roundTrip = loaded.ToHtml(new WordToHtmlOptions { ExportComments = true });
+            Assert.Contains("class=\"comments\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("data-author=\"HTML Reviewer\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("data-initials=\"HR\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("reviewer note", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/OfficeIMO.Tests/Html.CssAdditionalProperties.cs
+++ b/OfficeIMO.Tests/Html.CssAdditionalProperties.cs
@@ -41,5 +41,27 @@ namespace OfficeIMO.Tests {
             Assert.Equal(UnderlineValues.Single, run.Underline);
             Assert.True(run.Strike);
         }
+
+        [Fact]
+        public void HtmlToWord_Css_TextDecorationStyle_MapsUnderlineVariants() {
+            string html = "<p><span style=\"text-decoration:underline dotted\">dotted</span><span style=\"text-decoration-line:underline;text-decoration-style:wavy\">wavy</span></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var runs = doc.Paragraphs[0].GetRuns().ToArray();
+
+            Assert.Equal(UnderlineValues.Dotted, runs[0].Underline);
+            Assert.Equal(UnderlineValues.Wave, runs[1].Underline);
+        }
+
+        [Fact]
+        public void HtmlToWord_Css_TextDecorationNone_ClearsInheritedDecoration() {
+            string html = "<p style=\"text-decoration-line:underline;text-decoration-style:double\">under <span style=\"text-decoration:none\">plain</span></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var runs = doc.Paragraphs[0].GetRuns().ToArray();
+
+            Assert.Equal(UnderlineValues.Double, runs[0].Underline);
+            Assert.Null(runs[1].Underline);
+        }
     }
 }

--- a/OfficeIMO.Tests/Html.Definitions.cs
+++ b/OfficeIMO.Tests/Html.Definitions.cs
@@ -1,3 +1,5 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
 using System;
@@ -18,6 +20,54 @@ namespace OfficeIMO.Tests {
             string roundTrip = doc.ToHtml();
             Assert.Contains("<dfn", roundTrip, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("</dfn>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void DefinitionListImportsValidDocxAndRoundTripsAsDefinitionList() {
+            const string html = "<dl><dt>Term</dt><dd>Definition</dd></dl>";
+            using var doc = html.LoadFromHtml();
+
+            Assert.Equal("HtmlDefinitionTerm", doc.Paragraphs[0].StyleId);
+            Assert.Equal("HtmlDefinitionDescription", doc.Paragraphs[1].StyleId);
+            Assert.Equal(720, doc.Paragraphs[1].IndentationBefore);
+
+            using MemoryStream packageStream = doc.SaveAsMemoryStream();
+            packageStream.Position = 0;
+            using WordprocessingDocument package = WordprocessingDocument.Open(packageStream, false);
+            var errors = new OpenXmlValidator().Validate(package).ToList();
+            Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
+
+            string roundTrip = doc.ToHtml();
+            Assert.Contains("<dl><dt>Term</dt><dd>Definition</dd></dl>", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("<blockquote>Definition</blockquote>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void WordToHtmlDefinitionMarkersExportConsecutiveParagraphsAsDefinitionList() {
+            using var doc = WordDocument.Create();
+            doc.AddParagraph("Term").SetStyleId("HtmlDefinitionTerm");
+            doc.AddParagraph("Definition").SetStyleId("HtmlDefinitionDescription");
+            doc.AddParagraph("Next paragraph");
+
+            string html = doc.ToHtml();
+
+            Assert.Contains("<dl><dt>Term</dt><dd>Definition</dd></dl>", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<p>Next paragraph</p>", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void DefinitionListInTableCellRoundsTripAsDefinitionList() {
+            const string html = "<table><tr><td><dl><dt>Metric</dt><dd>Value</dd></dl></td></tr></table>";
+            using var doc = html.LoadFromHtml();
+            var cell = doc.Tables[0].Rows[0].Cells[0];
+
+            Assert.Contains(cell.Paragraphs, paragraph => paragraph.Text == "Metric" && paragraph.StyleId == "HtmlDefinitionTerm");
+            Assert.Contains(cell.Paragraphs, paragraph => paragraph.Text == "Value" && paragraph.StyleId == "HtmlDefinitionDescription");
+
+            string roundTrip = doc.ToHtml();
+
+            Assert.Contains("<dl><dt>Metric</dt><dd>Value</dd></dl>", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("<blockquote>Value</blockquote>", roundTrip, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/OfficeIMO.Tests/Html.Diagnostics.cs
+++ b/OfficeIMO.Tests/Html.Diagnostics.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word.Html;
 using System;
 using System.Linq;
@@ -39,7 +40,7 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void HtmlToWord_UnsupportedCssValues_AddDiagnostics() {
             var options = new HtmlToWordOptions();
-            string html = "<p style=\"font-size:clamp(12px,2vw,20px);text-align:start;color:not-a-color\">Text</p>";
+            string html = "<p style=\"font-size:clamp(12px,2vw,20px);text-align:match-parent;color:not-a-color\">Text</p>";
 
             html.LoadFromHtml(options);
 
@@ -74,7 +75,7 @@ namespace OfficeIMO.Tests {
                 UnsupportedCssHandling = HtmlUnsupportedCssHandling.Ignore
             };
 
-            "<p style=\"display:grid;text-align:start\">Text</p>".LoadFromHtml(options);
+            "<p style=\"display:grid;text-align:match-parent\">Text</p>".LoadFromHtml(options);
 
             Assert.DoesNotContain(options.Diagnostics, diagnostic => diagnostic.Code.StartsWith("UnsupportedCss", StringComparison.OrdinalIgnoreCase));
         }
@@ -86,11 +87,11 @@ namespace OfficeIMO.Tests {
             };
 
             var exception = Assert.Throws<HtmlUnsupportedCssException>(() =>
-                "<p style=\"text-align:start\">Text</p>".LoadFromHtml(options));
+                "<p style=\"text-align:match-parent\">Text</p>".LoadFromHtml(options));
 
             Assert.Equal("UnsupportedCssValue", exception.Code);
             Assert.Equal("p:text-align", exception.CssSource);
-            Assert.Contains("start", exception.Detail, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("match-parent", exception.Detail, StringComparison.OrdinalIgnoreCase);
             var diagnostic = Assert.Single(options.Diagnostics, d => d.Code == "UnsupportedCssValue");
             Assert.Equal(HtmlConversionDiagnosticSeverity.Error, diagnostic.Severity);
             Assert.Equal("p:text-align", diagnostic.Source);
@@ -119,6 +120,73 @@ namespace OfficeIMO.Tests {
             var diagnostics = options.Diagnostics.Where(diagnostic => diagnostic.Code == "UnsupportedCssValue").ToList();
             Assert.Contains(diagnostics, diagnostic => string.Equals(diagnostic.Source, "p:width", StringComparison.OrdinalIgnoreCase));
             Assert.Contains(diagnostics, diagnostic => string.Equals(diagnostic.Source, "p:height", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public void HtmlToWord_UnsupportedMappedCssValues_AddDiagnostics() {
+            var options = new HtmlToWordOptions();
+
+            "<p style=\"vertical-align:middle\">Text</p><table style=\"border-collapse:discard;border-spacing:calc(1px + 1px)\"><tr><td style=\"direction:sideways;vertical-align:middle\">Cell</td></tr></table>".LoadFromHtml(options);
+
+            var diagnostics = options.Diagnostics.Where(diagnostic => diagnostic.Code == "UnsupportedCssValue").ToList();
+            Assert.Contains(diagnostics, diagnostic =>
+                string.Equals(diagnostic.Source, "p:vertical-align", StringComparison.OrdinalIgnoreCase) &&
+                diagnostic.Detail?.Contains("middle", StringComparison.OrdinalIgnoreCase) == true);
+            Assert.DoesNotContain(diagnostics, diagnostic =>
+                string.Equals(diagnostic.Source, "td:vertical-align", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(diagnostics, diagnostic =>
+                string.Equals(diagnostic.Source, "table:border-collapse", StringComparison.OrdinalIgnoreCase) &&
+                diagnostic.Detail?.Contains("discard", StringComparison.OrdinalIgnoreCase) == true);
+            Assert.Contains(diagnostics, diagnostic =>
+                string.Equals(diagnostic.Source, "table:border-spacing", StringComparison.OrdinalIgnoreCase) &&
+                diagnostic.Detail?.Contains("calc", StringComparison.OrdinalIgnoreCase) == true);
+            Assert.Contains(diagnostics, diagnostic =>
+                string.Equals(diagnostic.Source, "td:direction", StringComparison.OrdinalIgnoreCase) &&
+                diagnostic.Detail?.Contains("sideways", StringComparison.OrdinalIgnoreCase) == true);
+        }
+
+        [Fact]
+        public void HtmlToWord_TextDecorationShorthandColor_AddsValueDiagnosticButMapsStyle() {
+            var options = new HtmlToWordOptions();
+
+            var doc = "<p style=\"text-decoration:underline wavy red\">Text</p>".LoadFromHtml(options);
+
+            var run = doc.Paragraphs[0].GetRuns().Single();
+            Assert.Equal(UnderlineValues.Wave, run.Underline);
+            var diagnostic = Assert.Single(options.Diagnostics, diagnostic =>
+                string.Equals(diagnostic.Code, "UnsupportedCssValue", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(diagnostic.Source, "p:text-decoration", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains("color token 'red'", diagnostic.Detail, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void HtmlToWord_TextDecorationLonghandDiagnostics_MatchMappedProperties() {
+            var options = new HtmlToWordOptions();
+
+            "<p style=\"text-decoration-line:underline;text-decoration-style:wavy;text-decoration-color:red\">Text</p>".LoadFromHtml(options);
+
+            Assert.DoesNotContain(options.Diagnostics, diagnostic => string.Equals(diagnostic.Source, "p:text-decoration-line", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(options.Diagnostics, diagnostic => string.Equals(diagnostic.Source, "p:text-decoration-style", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(options.Diagnostics, diagnostic =>
+                string.Equals(diagnostic.Code, "UnsupportedCssDeclaration", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(diagnostic.Source, "p:text-decoration-color", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Theory]
+        [InlineData("border-collapse:discard", "table:border-collapse", "discard")]
+        [InlineData("border-spacing:calc(1px + 1px)", "table:border-spacing", "calc")]
+        [InlineData("direction:sideways", "table:direction", "sideways")]
+        public void HtmlToWord_UnsupportedMappedCssValues_CanStopConversion(string style, string expectedSource, string expectedValue) {
+            var options = new HtmlToWordOptions {
+                UnsupportedCssHandling = HtmlUnsupportedCssHandling.Error
+            };
+
+            var exception = Assert.Throws<HtmlUnsupportedCssException>(() =>
+                $"<table style=\"{style}\"><tr><td>Cell</td></tr></table>".LoadFromHtml(options));
+
+            Assert.Equal("UnsupportedCssValue", exception.Code);
+            Assert.Equal(expectedSource, exception.CssSource);
+            Assert.Contains(expectedValue, exception.Detail, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Html.Direction.cs
+++ b/OfficeIMO.Tests/Html.Direction.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
 using Xunit;
@@ -37,6 +38,28 @@ namespace OfficeIMO.Tests {
 
             var paragraph = doc.Paragraphs.First(p => p.Text.Contains("Delta"));
             Assert.True(paragraph.BiDi);
+        }
+
+        [Fact]
+        public void HtmlToWord_LogicalTextAlign_UsesDirection() {
+            string html = "<p style=\"text-align:start\">Left</p><p dir=\"rtl\" style=\"text-align:start\">Right</p><p dir=\"rtl\" style=\"text-align:end\">LeftAgain</p>";
+
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Equal(JustificationValues.Left, doc.Paragraphs.First(p => p.Text.Contains("Left")).ParagraphAlignment);
+            Assert.Equal(JustificationValues.Right, doc.Paragraphs.First(p => p.Text.Contains("Right")).ParagraphAlignment);
+            Assert.Equal(JustificationValues.Left, doc.Paragraphs.First(p => p.Text.Contains("LeftAgain")).ParagraphAlignment);
+        }
+
+        [Fact]
+        public void HtmlToWord_TableCellLogicalTextAlign_UsesInheritedDirection() {
+            string html = "<table dir=\"rtl\"><tr><td style=\"text-align:start\">Start</td><td style=\"text-align:end\">End</td></tr></table>";
+
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var row = doc.Tables[0].Rows[0];
+
+            Assert.Equal(JustificationValues.Right, row.Cells[0].Paragraphs[0].ParagraphAlignment);
+            Assert.Equal(JustificationValues.Left, row.Cells[1].Paragraphs[0].ParagraphAlignment);
         }
     }
 }

--- a/OfficeIMO.Tests/Html.Figures.cs
+++ b/OfficeIMO.Tests/Html.Figures.cs
@@ -25,6 +25,24 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Html_FigureWithLeadingCaption_RoundTripsAsFigure() {
+            string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
+            byte[] imageBytes = File.ReadAllBytes(assetPath);
+            string base64 = Convert.ToBase64String(imageBytes);
+            string html = $"<figure><figcaption>Logo caption</figcaption><img src=\"data:image/png;base64,{base64}\" alt=\"Logo\"/></figure>";
+
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Single(doc.Images);
+            Assert.Equal("Logo caption", doc.Paragraphs[1].Text);
+            Assert.Equal("Caption", doc.Paragraphs[1].StyleId);
+
+            string roundTrip = doc.ToHtml();
+            Assert.Contains("<figure>", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<figcaption>Logo caption</figcaption>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void WordToHtml_FigureWithCaption_RendersFigure() {
             string assetPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png");
             using var doc = WordDocument.Create();

--- a/OfficeIMO.Tests/Html.Figures.cs
+++ b/OfficeIMO.Tests/Html.Figures.cs
@@ -34,12 +34,15 @@ namespace OfficeIMO.Tests {
             using var doc = html.LoadFromHtml(new HtmlToWordOptions());
 
             Assert.Single(doc.Images);
-            Assert.Equal("Logo caption", doc.Paragraphs[1].Text);
-            Assert.Equal("Caption", doc.Paragraphs[1].StyleId);
+            Assert.Equal("Logo caption", doc.Paragraphs[0].Text);
+            Assert.Equal("Caption", doc.Paragraphs[0].StyleId);
 
             string roundTrip = doc.ToHtml();
             Assert.Contains("<figure>", roundTrip, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("<figcaption>Logo caption</figcaption>", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.True(
+                roundTrip.IndexOf("<figcaption", StringComparison.OrdinalIgnoreCase) <
+                roundTrip.IndexOf("<img", StringComparison.OrdinalIgnoreCase));
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Html.Forms.cs
+++ b/OfficeIMO.Tests/Html.Forms.cs
@@ -209,6 +209,17 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void HtmlToWord_RadioGroupWithExplicitAndAncestorFormOwners_StaysTogether() {
+            const string html = "<form id=\"f\"><input type=\"radio\" name=\"status\" value=\"internal\" checked></form><input type=\"radio\" name=\"status\" form=\"f\" value=\"external\">";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            var dropDown = Assert.Single(doc.DropDownLists);
+            Assert.Equal(new[] { "internal", "external" }, dropDown.Items.ToArray());
+            Assert.Equal("internal", dropDown.SelectedValue);
+        }
+
+        [Fact]
         public void HtmlToWord_RadioGroup_SavesAsValidOpenXmlDocument() {
             const string html = "<p>Priority <label><input type=\"radio\" name=\"priority\" value=\"low\"> Low</label><label><input type=\"radio\" name=\"priority\" value=\"high\" checked> High</label></p>";
 

--- a/OfficeIMO.Tests/Html.Forms.cs
+++ b/OfficeIMO.Tests/Html.Forms.cs
@@ -1,6 +1,10 @@
 using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
 using DocumentFormat.OpenXml.Wordprocessing;
 using System;
+using System.IO;
 using System.Linq;
 using Xunit;
 
@@ -16,6 +20,70 @@ namespace OfficeIMO.Tests {
             Assert.Equal("Contoso", control.Text);
             Assert.Equal("Client name", control.Alias);
             Assert.Equal("client-name", control.Tag);
+        }
+
+        [Theory]
+        [InlineData("number", "42")]
+        [InlineData("time", "14:30")]
+        [InlineData("datetime-local", "2026-07-14T14:30")]
+        [InlineData("month", "2026-07")]
+        [InlineData("week", "2026-W29")]
+        [InlineData("color", "#336699")]
+        [InlineData("range", "75")]
+        public void HtmlToWord_ValueInputTypes_BecomeStructuredDocumentTags(string type, string value) {
+            string html = $"<p>Value <input type=\"{type}\" id=\"field\" name=\"field-name\" aria-label=\"Field\" value=\"{value}\"> saved</p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            var control = Assert.Single(doc.StructuredDocumentTags);
+            Assert.Equal(value, control.Text);
+            Assert.Equal("Field", control.Alias);
+            Assert.Equal("field", control.Tag);
+        }
+
+        [Fact]
+        public void HtmlToWord_NonDocumentInputControls_AreIgnored() {
+            const string html = "<p>Start <input type=\"hidden\" value=\"secret\"><input type=\"file\" value=\"C:\\fakepath\\report.docx\"><input type=\"button\" value=\"Click\"><input type=\"submit\" value=\"Send\"> End</p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Empty(doc.StructuredDocumentTags);
+            Assert.Empty(doc.CheckBoxes);
+            Assert.Empty(doc.DropDownLists);
+            Assert.Empty(doc.ComboBoxes);
+            var documentText = string.Concat(doc._document.MainDocumentPart!.Document.Body!.Descendants<Text>().Select(text => text.Text));
+            Assert.DoesNotContain("secret", documentText, StringComparison.Ordinal);
+            Assert.DoesNotContain("fakepath", documentText, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Click", documentText, StringComparison.Ordinal);
+            Assert.DoesNotContain("Send", documentText, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void HtmlToWord_ProgressAndMeter_BecomeStructuredDocumentTags() {
+            const string html = "<p>Build <progress id=\"build-progress\" aria-label=\"Build progress\" value=\"40\" max=\"100\"></progress> Quality <meter id=\"quality\" title=\"Quality score\" value=\"0.82\" max=\"1\"></meter></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Equal(2, doc.StructuredDocumentTags.Count);
+            Assert.Contains(doc.StructuredDocumentTags, control =>
+                control.Text == "40 / 100" &&
+                control.Alias == "Build progress" &&
+                control.Tag == "build-progress");
+            Assert.Contains(doc.StructuredDocumentTags, control =>
+                control.Text == "0.82 / 1" &&
+                control.Alias == "Quality score" &&
+                control.Tag == "quality");
+        }
+
+        [Fact]
+        public void HtmlToWord_ProgressWithoutValue_UsesFallbackText() {
+            const string html = "<p>Status <progress id=\"download\">Pending</progress></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            var control = Assert.Single(doc.StructuredDocumentTags);
+            Assert.Equal("Pending", control.Text);
+            Assert.Equal("download", control.Tag);
         }
 
         [Fact]
@@ -53,6 +121,103 @@ namespace OfficeIMO.Tests {
             Assert.Equal(new[] { "Poland", "Germany", "Global" }, dropDown.Items.ToArray());
             Assert.Equal("Germany", dropDown.SelectedValue);
             Assert.Equal("region", dropDown.Tag);
+        }
+
+        [Fact]
+        public void HtmlToWord_MultiSelect_BecomesStructuredDocumentTagWithSelectedValues() {
+            const string html = "<p>Regions <select multiple data-tag=\"regions\" aria-label=\"Regions\"><option selected>Poland</option><option>Germany</option><option value=\"global\" selected>Global</option></select></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Empty(doc.DropDownLists);
+            var control = Assert.Single(doc.StructuredDocumentTags);
+            Assert.Equal("Poland\nglobal", control.Text);
+            Assert.Equal("Regions", control.Alias);
+            Assert.Equal("regions", control.Tag);
+        }
+
+        [Fact]
+        public void HtmlToWord_MultiSelectWithoutSelection_DoesNotDefaultToFirstOption() {
+            const string html = "<p>Regions <select multiple data-tag=\"regions\"><option>Poland</option><option>Germany</option></select></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Empty(doc.DropDownLists);
+            var control = Assert.Single(doc.StructuredDocumentTags);
+            Assert.Equal(string.Empty, control.Text);
+            Assert.Equal("regions", control.Tag);
+        }
+
+        [Fact]
+        public void HtmlToWord_MultiSelect_SavesAsValidOpenXmlDocument() {
+            const string html = "<p>Regions <select multiple data-tag=\"regions\" aria-label=\"Regions\"><option selected>Poland</option><option value=\"global\" selected>Global</option></select></p>";
+
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            using MemoryStream stream = doc.SaveAsMemoryStream();
+            using WordprocessingDocument package = WordprocessingDocument.Open(stream, false);
+            var errors = new OpenXmlValidator().Validate(package).ToList();
+            Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
+        }
+
+        [Fact]
+        public void HtmlToWord_RadioGroup_BecomesSingleDropDownList() {
+            const string html = "<p>Priority <label><input type=\"radio\" name=\"priority\" value=\"low\"> Low</label><label><input type=\"radio\" name=\"priority\" value=\"high\" checked> High</label> today</p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            var dropDown = Assert.Single(doc.DropDownLists);
+            Assert.Equal(new[] { "low", "high" }, dropDown.Items.ToArray());
+            Assert.Equal("high", dropDown.SelectedValue);
+            Assert.Equal("priority", dropDown.Alias);
+            Assert.Equal("priority", dropDown.Tag);
+            var visibleText = string.Concat(doc._document.MainDocumentPart!.Document.Body!.Descendants<Text>().Select(text => text.Text));
+            Assert.DoesNotContain("Low", visibleText, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void HtmlToWord_RadioGroupWithoutValue_UsesLabelText() {
+            const string html = "<p><label><input type=\"radio\" name=\"priority\"> Low</label><label><input type=\"radio\" name=\"priority\" checked> High</label></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            var dropDown = Assert.Single(doc.DropDownLists);
+            Assert.Equal(new[] { "Low", "High" }, dropDown.Items.ToArray());
+            Assert.Equal("High", dropDown.SelectedValue);
+        }
+
+        [Fact]
+        public void HtmlToWord_RadioGroupWithoutSelection_DoesNotDefaultToFirstOption() {
+            const string html = "<p>Contact <input type=\"radio\" name=\"contact\" value=\"email\"><input type=\"radio\" name=\"contact\" value=\"phone\"></p>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            var dropDown = Assert.Single(doc.DropDownLists);
+            Assert.Equal(new[] { string.Empty, "email", "phone" }, dropDown.Items.ToArray());
+            Assert.Equal(string.Empty, dropDown.SelectedValue);
+        }
+
+        [Fact]
+        public void HtmlToWord_RadioGroupsWithSameNameInDifferentForms_StaySeparate() {
+            const string html = "<form><input type=\"radio\" name=\"status\" value=\"internal\" checked></form><form><input type=\"radio\" name=\"status\" value=\"external\" checked></form>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Equal(2, doc.DropDownLists.Count);
+            Assert.Contains(doc.DropDownLists, dropDown => dropDown.Items.SequenceEqual(new[] { "internal" }) && dropDown.SelectedValue == "internal");
+            Assert.Contains(doc.DropDownLists, dropDown => dropDown.Items.SequenceEqual(new[] { "external" }) && dropDown.SelectedValue == "external");
+        }
+
+        [Fact]
+        public void HtmlToWord_RadioGroup_SavesAsValidOpenXmlDocument() {
+            const string html = "<p>Priority <label><input type=\"radio\" name=\"priority\" value=\"low\"> Low</label><label><input type=\"radio\" name=\"priority\" value=\"high\" checked> High</label></p>";
+
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            using MemoryStream stream = doc.SaveAsMemoryStream();
+            using WordprocessingDocument package = WordprocessingDocument.Open(stream, false);
+            var errors = new OpenXmlValidator().Validate(package).ToList();
+            Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -205,6 +205,23 @@ public partial class Html {
     }
 
     [Fact]
+    public void Test_Html_BlockquoteInTableCell_RoundTripsWithoutPlaceholderParagraph() {
+        string html = "<table><tr><td><blockquote><p>Quoted cell</p></blockquote></td></tr></table>";
+
+        var doc = html.LoadFromHtml(new HtmlToWordOptions());
+        var cell = doc.Tables[0].Rows[0].Cells[0];
+
+        var textParagraphs = cell.Paragraphs.Where(paragraph => !string.IsNullOrWhiteSpace(paragraph.Text)).ToList();
+        Assert.Single(textParagraphs);
+        Assert.Equal("Quoted cell", textParagraphs[0].Text);
+        Assert.True(textParagraphs[0].IndentationBefore > 0);
+
+        string roundTrip = doc.ToHtml();
+        Assert.Matches("(?is)<td[^>]*><blockquote[^>]*>Quoted cell</blockquote></td>", roundTrip);
+        Assert.DoesNotContain("<p></p>", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Test_Html_Blockquote_WithoutQuoteStyle() {
         RemoveCustomStyle("Quote");
         string html = "<blockquote>Quoted text</blockquote>";

--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -1,5 +1,7 @@
 using OfficeIMO.Word.Html;
 using OfficeIMO.Word;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
 using System;
 using System.IO;
 using System.Linq;
@@ -50,6 +52,25 @@ namespace OfficeIMO.Tests {
                 File.Delete(dest);
                 Directory.Delete(dir);
             }
+        }
+
+        [Fact]
+        public void HtmlToWord_ImageTitleRoundTripsThroughSavedDocument() {
+            var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
+            string html = $"<img src=\"{path}\" alt=\"Company logo\" title=\"Quarterly report logo\" width=\"32\" height=\"32\" />";
+
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            var image = Assert.Single(doc.Images);
+            Assert.Equal("Company logo", image.Description);
+            Assert.Equal("Quarterly report logo", image.Title);
+
+            using MemoryStream stream = doc.SaveAsMemoryStream();
+            using var loaded = WordDocument.Load(stream);
+            string roundTrip = loaded.ToHtml();
+
+            Assert.Contains("alt=\"Company logo\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("title=\"Quarterly report logo\"", roundTrip, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -159,6 +180,28 @@ namespace OfficeIMO.Tests {
             Assert.Equal("ImageResourceRejectedByPolicy", diagnostic.Code);
             Assert.Equal("https://example.test/scheme.png", diagnostic.Source);
             Assert.Contains("https", diagnostic.Detail!, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void HtmlToWord_UntrustedProfile_SkipsExternalImageBeforeFetch() {
+            var fetched = false;
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(_ => {
+                fetched = true;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }));
+            var options = HtmlToWordOptions.CreateUntrustedHtmlProfile();
+            options.HttpClient = httpClient;
+            string html = "<img src=\"https://example.test/untrusted.png\" alt=\"Blocked by profile\" />";
+
+            var doc = html.LoadFromHtml(options);
+
+            Assert.False(fetched);
+            Assert.Empty(doc.Images);
+            Assert.Single(doc.Paragraphs);
+            Assert.Equal("Blocked by profile", doc.Paragraphs[0].Text);
+            var diagnostic = Assert.Single(options.Diagnostics);
+            Assert.Equal("ImageSkippedByPolicy", diagnostic.Code);
+            Assert.Equal("https://example.test/untrusted.png", diagnostic.Source);
         }
 
         [Fact]
@@ -486,6 +529,32 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void DuplicateImageSrcKeepsPerImageAltAndTitleMetadata() {
+            var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
+            var base64 = Convert.ToBase64String(File.ReadAllBytes(path));
+            var dataUri = $"data:image/png;base64,{base64}";
+            string html = $"<p><img src=\"{dataUri}\" alt=\"First logo\" title=\"First title\"/><img src=\"{dataUri}\" alt=\"Second logo\" title=\"Second title\"/></p>";
+
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            Assert.Equal(2, doc.Images.Count);
+            Assert.Equal(doc.Images[0].RelationshipId, doc.Images[1].RelationshipId);
+            Assert.Equal("First logo", doc.Images[0].Description);
+            Assert.Equal("First title", doc.Images[0].Title);
+            Assert.Equal("Second logo", doc.Images[1].Description);
+            Assert.Equal("Second title", doc.Images[1].Title);
+
+            using MemoryStream stream = doc.SaveAsMemoryStream();
+            using var loaded = WordDocument.Load(stream);
+            string roundTrip = loaded.ToHtml();
+
+            Assert.Contains("alt=\"First logo\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("title=\"First title\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("alt=\"Second logo\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("title=\"Second title\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void DuplicateImageFileSrcSharesPart() {
             var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
             string html = $"<p><img src=\"{path}\"/><img src=\"{path}\"/></p>";
@@ -556,6 +625,28 @@ namespace OfficeIMO.Tests {
             Assert.Equal(64D, Math.Round(img.Width!.Value));
             Assert.NotNull(img.Height);
             Assert.True(img.Height!.Value > 0);
+        }
+
+        [Fact]
+        public void HtmlToWord_ImageDimensionsPersistInSavedDrawingExtent() {
+            var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
+            string html = $"<img src=\"{path}\" width=\"64\" height=\"32\" alt=\"Logo\" />";
+
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            var img = Assert.Single(doc.Images);
+            Assert.Equal(64D, Math.Round(img.Width!.Value));
+            Assert.Equal(32D, Math.Round(img.Height!.Value));
+
+            using MemoryStream stream = doc.SaveAsMemoryStream();
+            using WordprocessingDocument package = WordprocessingDocument.Open(stream, false);
+            var errors = new OpenXmlValidator().Validate(package).ToList();
+            Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
+
+            var drawing = Assert.Single(package.MainDocumentPart!.Document.Body!.Descendants<DocumentFormat.OpenXml.Wordprocessing.Drawing>());
+            var extent = drawing.Inline!.Extent!;
+            Assert.Equal(64L * 9525L, extent.Cx!.Value);
+            Assert.Equal(32L * 9525L, extent.Cy!.Value);
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Html.ListNumbering.cs
+++ b/OfficeIMO.Tests/Html.ListNumbering.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
@@ -106,6 +107,50 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void HtmlToWord_ListStyleType_ImportsQuotedEditorMarkers() {
+            string html = "<ul style=\"list-style-type:'*'\"><li>Star</li></ul><ul style=\"list-style-type:'+'\"><li>Plus</li></ul>";
+
+            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            var listItems = doc.Paragraphs
+                .Where(p => p.IsListItem)
+                .GroupBy(p => p._paragraph)
+                .Select(group => group.First())
+                .ToList();
+            Assert.Equal(2, listItems.Count);
+            var first = DocumentTraversal.GetListInfo(listItems[0]);
+            var second = DocumentTraversal.GetListInfo(listItems[1]);
+            Assert.True(first.HasValue);
+            Assert.True(second.HasValue);
+            Assert.Equal("*", first.Value.LevelText);
+            Assert.Equal("+", second.Value.LevelText);
+        }
+
+        [Fact]
+        public void HtmlToWord_ListStyleType_ImportsArbitraryQuotedMarkers() {
+            string html = "<ul style=\"list-style-type:'\\2713'\"><li>Done</li></ul><ul style=\"list-style:'◆' outside\"><li>Diamond</li></ul>";
+
+            var options = new HtmlToWordOptions();
+            var doc = html.LoadFromHtml(options);
+
+            var listItems = doc.Paragraphs
+                .Where(p => p.IsListItem)
+                .GroupBy(p => p._paragraph)
+                .Select(group => group.First())
+                .ToList();
+            Assert.Equal(2, listItems.Count);
+            var first = DocumentTraversal.GetListInfo(listItems[0]);
+            var second = DocumentTraversal.GetListInfo(listItems[1]);
+            Assert.True(first.HasValue);
+            Assert.True(second.HasValue);
+            Assert.Equal("✓", first.Value.LevelText);
+            Assert.Equal("◆", second.Value.LevelText);
+            Assert.DoesNotContain(options.Diagnostics, diagnostic =>
+                string.Equals(diagnostic.Code, "UnsupportedCssValue", StringComparison.OrdinalIgnoreCase) &&
+                diagnostic.Source?.Contains("list-style", StringComparison.OrdinalIgnoreCase) == true);
+        }
+
+        [Fact]
         public void HtmlToWord_ListDefinitions_ApplyExportedIndentMetadata() {
             string html = "<ol data-left-indent-twips=\"1440\" data-hanging-indent-twips=\"360\" style=\"list-style-type:decimal\"><li>One</li></ol>";
 
@@ -142,6 +187,35 @@ namespace OfficeIMO.Tests {
             Assert.Equal(2, checkboxes.Count);
             Assert.Equal(W14.OnOffValues.One, checkboxes[0]!.Elements<W14.Checked>().Single().Val!.Value);
             Assert.Equal(W14.OnOffValues.Zero, checkboxes[1]!.Elements<W14.Checked>().Single().Val!.Value);
+        }
+
+        [Fact]
+        public void HtmlToWord_ListItemBlockChildrenPreserveSourceOrder() {
+            string html = "<ul><li>Intro<p>Details</p><table><tr><td>Metric</td></tr></table></li></ul><p>After</p>";
+
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            using MemoryStream stream = doc.SaveAsMemoryStream();
+            stream.Position = 0;
+            using WordprocessingDocument package = WordprocessingDocument.Open(stream, false);
+
+            var body = package.MainDocumentPart!.Document.Body!;
+            var sequence = body.ChildElements
+                .Where(element => element is Paragraph || element is Table)
+                .Select(element => element is Table
+                    ? "table:" + string.Join("|", element.Descendants<Text>().Select(text => text.Text))
+                    : "p:" + string.Concat(element.Descendants<Text>().Select(text => text.Text)))
+                .Where(value => !string.Equals(value, "p:", StringComparison.Ordinal))
+                .ToList();
+
+            int introIndex = sequence.FindIndex(value => string.Equals(value, "p:Intro", StringComparison.Ordinal));
+            int detailsIndex = sequence.FindIndex(value => string.Equals(value, "p:Details", StringComparison.Ordinal));
+            int tableIndex = sequence.FindIndex(value => value.StartsWith("table:", StringComparison.Ordinal) && value.Contains("Metric", StringComparison.Ordinal));
+            int afterIndex = sequence.FindIndex(value => string.Equals(value, "p:After", StringComparison.Ordinal));
+
+            Assert.True(introIndex >= 0, string.Join(", ", sequence));
+            Assert.True(detailsIndex > introIndex, string.Join(", ", sequence));
+            Assert.True(tableIndex > detailsIndex, string.Join(", ", sequence));
+            Assert.True(afterIndex > tableIndex, string.Join(", ", sequence));
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Html.Ruby.cs
+++ b/OfficeIMO.Tests/Html.Ruby.cs
@@ -1,0 +1,57 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word.Html;
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Html {
+    [Fact]
+    public void Test_Html_Ruby_ImportsAsWordRuby() {
+        var html = "<p><ruby lang=\"ja-JP\"><rb>漢字</rb><rp>(</rp><rt>かんじ</rt><rp>)</rp></ruby></p>";
+
+        using var document = html.LoadFromHtml(new HtmlToWordOptions { FontFamily = "Calibri" });
+
+        var paragraph = Assert.Single(document._wordprocessingDocument.MainDocumentPart!.Document.Body!.Elements<Paragraph>());
+        var ruby = Assert.Single(paragraph.Descendants<Ruby>());
+        Assert.Equal("漢字", ruby.RubyBase!.InnerText);
+        Assert.Equal("かんじ", ruby.RubyContent!.InnerText);
+        Assert.Equal(RubyAlignValues.Center, ruby.RubyProperties!.RubyAlign!.Val!.Value);
+    }
+
+    [Fact]
+    public void Test_Html_Ruby_FallbackWithoutAnnotationKeepsText() {
+        var html = "<p><ruby>漢字</ruby></p>";
+
+        using var document = html.LoadFromHtml(new HtmlToWordOptions());
+
+        var paragraph = Assert.Single(document._wordprocessingDocument.MainDocumentPart!.Document.Body!.Elements<Paragraph>());
+        Assert.Empty(paragraph.Elements<Ruby>());
+        Assert.Equal("漢字", paragraph.InnerText);
+    }
+
+    [Fact]
+    public void Test_Html_Ruby_DocxValidatesWithOpenXmlValidator() {
+        var html = "<p>Word <ruby><rb>東</rb><rt>とう</rt></ruby> ruby</p>";
+        var path = Path.Combine(Path.GetTempPath(), "officeimo-html-ruby-" + Guid.NewGuid().ToString("N") + ".docx");
+
+        try {
+            using (var document = html.LoadFromHtml(new HtmlToWordOptions())) {
+                document.Save(path);
+            }
+
+            using var package = WordprocessingDocument.Open(path, false);
+            var errors = new OpenXmlValidator().Validate(package).ToList();
+            Assert.True(errors.Count == 0, string.Join(Environment.NewLine, errors.Select(error => $"{error.Description} Path={error.Path?.XPath} Node={error.Node?.OuterXml}")));
+            Assert.Single(package.MainDocumentPart!.Document.Descendants<Ruby>());
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.Ruby.cs
+++ b/OfficeIMO.Tests/Html.Ruby.cs
@@ -54,4 +54,17 @@ public partial class Html {
             }
         }
     }
+
+    [Fact]
+    public void Test_Html_Ruby_RoundTripsToHtml() {
+        var html = "<p>Word <ruby><rb>東</rb><rt>とう</rt></ruby> ruby</p>";
+
+        using var document = html.LoadFromHtml(new HtmlToWordOptions());
+
+        string roundTrip = document.ToHtml();
+
+        Assert.Contains("<ruby>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<rb>東</rb>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<rt>とう</rt>", roundTrip, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/OfficeIMO.Tests/Html.Security.cs
+++ b/OfficeIMO.Tests/Html.Security.cs
@@ -1,4 +1,8 @@
 using OfficeIMO.Word.Html;
+using OfficeIMO.Word;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+using System.IO;
 using System.Linq;
 using Xunit;
 
@@ -30,6 +34,65 @@ namespace OfficeIMO.Tests {
             var diagnostic = Assert.Single(options.Diagnostics);
             Assert.Equal("HtmlElementSkipped", diagnostic.Code);
             Assert.Equal("template", diagnostic.Source);
+        }
+
+        [Fact]
+        public void HtmlToWord_RawHtmlComments_AreSkippedWithDiagnostic() {
+            var callbackDiagnostics = new System.Collections.Generic.List<HtmlConversionDiagnostic>();
+            var options = new HtmlToWordOptions {
+                DiagnosticHandler = diagnostic => callbackDiagnostics.Add(diagnostic)
+            };
+            string html = "<p>Visible before.</p><!-- reviewer note --><p>Visible after.</p>";
+
+            var document = html.LoadFromHtml(options);
+
+            Assert.Equal(new[] { "Visible before.", "Visible after." }, document.Paragraphs.Select(paragraph => paragraph.Text).ToArray());
+            Assert.DoesNotContain(document.Paragraphs, paragraph => paragraph.Text.Contains("reviewer note"));
+            var diagnostic = Assert.Single(options.Diagnostics, diagnostic => diagnostic.Code == "HtmlCommentSkipped");
+            Assert.Equal("comment", diagnostic.Source);
+            Assert.Null(diagnostic.Detail);
+            Assert.Contains(callbackDiagnostics, diagnostic => diagnostic.Code == "HtmlCommentSkipped");
+        }
+
+        [Fact]
+        public void HtmlToWord_EmbeddedMediaWidgets_AreSkippedWithDiagnostics() {
+            var options = new HtmlToWordOptions();
+            string html = """
+                <p>Before.</p>
+                <iframe src="https://example.com/widget">Hidden iframe fallback</iframe>
+                <object data="movie.swf">Hidden object fallback</object>
+                <embed src="movie.swf">
+                <video src="movie.mp4">Hidden video fallback</video>
+                <audio src="sound.mp3">Hidden audio fallback</audio>
+                <canvas>Hidden canvas fallback</canvas>
+                <p>After.</p>
+                """;
+
+            var document = html.LoadFromHtml(options);
+
+            Assert.Equal(new[] { "Before.", "After." }, document.Paragraphs.Select(paragraph => paragraph.Text).ToArray());
+            Assert.DoesNotContain(document.Paragraphs, paragraph => paragraph.Text.Contains("Hidden", System.StringComparison.Ordinal));
+            var diagnostics = options.Diagnostics.Where(diagnostic => diagnostic.Code == "HtmlEmbeddedContentSkipped").ToList();
+            Assert.Equal(6, diagnostics.Count);
+            Assert.Contains(diagnostics, diagnostic => diagnostic.Source == "iframe");
+            Assert.Contains(diagnostics, diagnostic => diagnostic.Source == "object");
+            Assert.Contains(diagnostics, diagnostic => diagnostic.Source == "embed");
+            Assert.Contains(diagnostics, diagnostic => diagnostic.Source == "video");
+            Assert.Contains(diagnostics, diagnostic => diagnostic.Source == "audio");
+            Assert.Contains(diagnostics, diagnostic => diagnostic.Source == "canvas");
+        }
+
+        [Fact]
+        public void HtmlToWord_EmbeddedMediaWidgets_SavesAsValidOpenXmlDocument() {
+            var options = new HtmlToWordOptions();
+            string html = "<p>Visible.</p><iframe src=\"https://example.com/widget\">Hidden iframe fallback</iframe><video src=\"movie.mp4\">Hidden video fallback</video>";
+
+            using var document = html.LoadFromHtml(options);
+
+            using MemoryStream stream = document.SaveAsMemoryStream();
+            using WordprocessingDocument package = WordprocessingDocument.Open(stream, false);
+            var errors = new OpenXmlValidator().Validate(package).ToList();
+            Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
         }
     }
 }

--- a/OfficeIMO.Tests/Html.SemanticInline.cs
+++ b/OfficeIMO.Tests/Html.SemanticInline.cs
@@ -1,0 +1,31 @@
+using OfficeIMO.Word.Html;
+using System;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Html {
+        [Fact]
+        public void HtmlDelAndInsRoundTripAsSemanticTags() {
+            const string html = "<p>Changed <del>old</del> to <ins>new</ins>.</p>";
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            string roundTrip = doc.ToHtml();
+
+            Assert.Contains("<del>old</del>", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<ins>new</ins>", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("<s>old</s>", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("<u>new</u>", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void HtmlMarkRoundTripsAsSemanticTag() {
+            const string html = "<p>Please <mark>review</mark> this.</p>";
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+
+            string roundTrip = doc.ToHtml();
+
+            Assert.Contains("<mark>review</mark>", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("background-color", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Html.StructuralTags.cs
+++ b/OfficeIMO.Tests/Html.StructuralTags.cs
@@ -58,7 +58,15 @@ namespace OfficeIMO.Tests {
             string roundTrip = doc.ToHtml();
             Assert.Contains("<section id=\"intro\">", roundTrip);
             Assert.Contains("<article id=\"art\">", roundTrip);
+            AssertContainedText(roundTrip, "<section id=\"intro\">", "</section>", "Intro");
+            AssertContainedText(roundTrip, "<article id=\"art\">", "</article>", "Article");
+        }
+
+        private static void AssertContainedText(string html, string openTag, string closeTag, string text) {
+            int start = html.IndexOf(openTag, StringComparison.OrdinalIgnoreCase);
+            int end = start >= 0 ? html.IndexOf(closeTag, start, StringComparison.OrdinalIgnoreCase) : -1;
+            int textIndex = start >= 0 ? html.IndexOf(text, start, StringComparison.OrdinalIgnoreCase) : -1;
+            Assert.True(start >= 0 && end > start && textIndex > start && textIndex < end);
         }
     }
 }
-

--- a/OfficeIMO.Tests/Html.StylesheetCache.cs
+++ b/OfficeIMO.Tests/Html.StylesheetCache.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections;
 using System.IO;
+using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using OfficeIMO.Word.Html;
 using Xunit;
 
@@ -23,20 +26,64 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void HtmlToWord_StylesheetCache_Reused_ForPath() {
+        public void HtmlToWord_StylesheetCache_Reused_ForPathContent() {
             var path = Path.GetTempFileName();
-            File.WriteAllText(path, "p { color:#111111; }");
+            const string css = "p { color:#111111; }";
+            File.WriteAllText(path, css);
             try {
                 var cache = GetCache();
-                cache.Remove(path);
+                var key = ComputeHash(css);
+                cache.Remove(key);
                 var html = $"<link rel=\"stylesheet\" href=\"{path}\" /><p>Test</p>";
-                html.LoadFromHtml(new HtmlToWordOptions());
-                var first = cache[path];
-                html.LoadFromHtml(new HtmlToWordOptions());
-                Assert.Same(first, cache[path]);
+                html.LoadFromHtml(new HtmlToWordOptions { AllowDocumentStylesheetLinks = true });
+                var first = cache[key];
+                html.LoadFromHtml(new HtmlToWordOptions { AllowDocumentStylesheetLinks = true });
+                Assert.Same(first, cache[key]);
             } finally {
                 File.Delete(path);
             }
+        }
+
+        [Fact]
+        public void HtmlToWord_StylesheetCache_DoesNotReuseStaleRules_WhenPathContentChanges() {
+            var path = Path.GetTempFileName();
+            string html = $"<link rel=\"stylesheet\" href=\"{path}\" /><p>Test</p>";
+            try {
+                File.WriteAllText(path, "p { color:#111111; }");
+                var firstDoc = html.LoadFromHtml(new HtmlToWordOptions { AllowDocumentStylesheetLinks = true });
+                Assert.Equal("111111", firstDoc.Paragraphs[0].GetRuns().First().ColorHex);
+
+                File.WriteAllText(path, "p { color:#222222; }");
+                var secondDoc = html.LoadFromHtml(new HtmlToWordOptions { AllowDocumentStylesheetLinks = true });
+
+                Assert.Equal("222222", secondDoc.Paragraphs[0].GetRuns().First().ColorHex);
+            } finally {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void HtmlToWord_StylesheetCache_DoesNotReuseStaleRules_WhenRemoteContentChanges() {
+            var call = 0;
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(_ => {
+                call++;
+                var color = call == 1 ? "333333" : "444444";
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent($"p {{ color:#{color}; }}", Encoding.UTF8, "text/css")
+                });
+            }));
+            string html = "<link rel=\"stylesheet\" href=\"https://styles.example.test/live.css\" /><p>Test</p>";
+            var options = new HtmlToWordOptions {
+                AllowDocumentStylesheetLinks = true,
+                HttpClient = httpClient
+            };
+
+            var firstDoc = html.LoadFromHtml(options);
+            var secondDoc = html.LoadFromHtml(options);
+
+            Assert.Equal("333333", firstDoc.Paragraphs[0].GetRuns().First().ColorHex);
+            Assert.Equal("444444", secondDoc.Paragraphs[0].GetRuns().First().ColorHex);
+            Assert.Equal(2, call);
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Html.Stylesheets.cs
+++ b/OfficeIMO.Tests/Html.Stylesheets.cs
@@ -2,8 +2,10 @@ using System;
 using OfficeIMO.Word.Html;
 using Xunit;
 using System.Net;
+using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace OfficeIMO.Tests {
@@ -61,6 +63,232 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void HtmlToWord_RemoteStylesheet_UsesConfiguredHttpClient() {
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(request => {
+                Assert.Equal(new Uri("https://styles.example.test/site.css"), request.RequestUri);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent("p { color:#abcdef; }", Encoding.UTF8, "text/css")
+                });
+            }));
+            string html = "<link rel=\"stylesheet\" href=\"https://styles.example.test/site.css\" /><p>Remote CSS</p>";
+            var options = new HtmlToWordOptions {
+                AllowDocumentStylesheetLinks = true,
+                HttpClient = httpClient
+            };
+
+            var doc = html.LoadFromHtml(options);
+
+            var run = doc.Paragraphs[0].GetRuns().First();
+            Assert.Equal("abcdef", run.ColorHex);
+        }
+
+        [Fact]
+        public void HtmlToWord_UntrustedProfile_SkipsDocumentStylesheetLinkBeforeFetch() {
+            var fetched = false;
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(_ => {
+                fetched = true;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent("p { color:#abcdef; }", Encoding.UTF8, "text/css")
+                });
+            }));
+            string html = "<link rel=\"stylesheet\" href=\"https://styles.example.test/untrusted.css\" /><p>Remote CSS</p>";
+            var options = HtmlToWordOptions.CreateUntrustedHtmlProfile();
+            options.HttpClient = httpClient;
+
+            var doc = html.LoadFromHtml(options);
+
+            Assert.False(fetched);
+            var run = doc.Paragraphs[0].GetRuns().First();
+            Assert.NotEqual("abcdef", run.ColorHex);
+            var diagnostic = Assert.Single(options.Diagnostics, item => item.Code == "HtmlStylesheetLinkSkipped");
+            Assert.Equal("https://styles.example.test/untrusted.css", diagnostic.Source);
+        }
+
+        [Fact]
+        public void HtmlToWord_RemoteStylesheet_DisallowedHost_EmitsDiagnosticAndSkipsFetch() {
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(_ => throw new InvalidOperationException("Disallowed stylesheet host should not be fetched.")));
+            string html = "<link rel=\"stylesheet\" href=\"https://blocked.example.test/site.css\" /><p>Remote CSS</p>";
+            var options = new HtmlToWordOptions {
+                AllowDocumentStylesheetLinks = true,
+                HttpClient = httpClient
+            };
+            options.AllowedStylesheetHosts.Add("styles.example.test");
+
+            var doc = html.LoadFromHtml(options);
+
+            var run = doc.Paragraphs[0].GetRuns().First();
+            Assert.NotEqual("abcdef", run.ColorHex);
+            var diagnostic = Assert.Single(options.Diagnostics);
+            Assert.Equal("StylesheetResourceRejectedByPolicy", diagnostic.Code);
+            Assert.Equal("https://blocked.example.test/site.css", diagnostic.Source);
+        }
+
+        [Fact]
+        public void HtmlToWord_RemoteStylesheet_MaxCssBytes_StopsBeforeReadingContent() {
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ThrowIfReadContent(1024)
+            })));
+            string html = "<link rel=\"stylesheet\" href=\"https://styles.example.test/max.css\" /><p>Remote CSS</p>";
+            var options = new HtmlToWordOptions {
+                AllowDocumentStylesheetLinks = true,
+                HttpClient = httpClient,
+                MaxCssBytes = 8
+            };
+
+            var exception = Assert.Throws<HtmlConversionLimitException>(() => html.LoadFromHtml(options));
+
+            Assert.Equal("CssSizeLimitExceeded", exception.Code);
+            Assert.Equal("https://styles.example.test/max.css", exception.LimitSource);
+            Assert.Equal(8, exception.Limit);
+            Assert.Equal(1024, exception.Actual);
+            var diagnostic = Assert.Single(options.Diagnostics);
+            Assert.Equal("CssSizeLimitExceeded", diagnostic.Code);
+        }
+
+        [Fact]
+        public void HtmlToWord_RemoteStylesheet_MaxTotalCssBytes_StopsBeforeReadingContent() {
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ThrowIfReadContent(1024)
+            })));
+            string seededCss = "body { color:#111111; }";
+            string html = "<link rel=\"stylesheet\" href=\"https://styles.example.test/total.css\" /><p>Remote CSS</p>";
+            var options = new HtmlToWordOptions {
+                AllowDocumentStylesheetLinks = true,
+                HttpClient = httpClient,
+                MaxTotalCssBytes = Encoding.UTF8.GetByteCount(seededCss) + 8
+            };
+            options.StylesheetContents.Add(seededCss);
+
+            var exception = Assert.Throws<HtmlConversionLimitException>(() => html.LoadFromHtml(options));
+
+            Assert.Equal("CssTotalSizeLimitExceeded", exception.Code);
+            Assert.Equal("https://styles.example.test/total.css", exception.LimitSource);
+            Assert.Equal(options.MaxTotalCssBytes, exception.Limit);
+            Assert.True(exception.Actual > exception.Limit);
+            var diagnostic = Assert.Single(options.Diagnostics);
+            Assert.Equal("CssTotalSizeLimitExceeded", diagnostic.Code);
+        }
+
+        [Fact]
+        public void HtmlToWord_RemoteStylesheet_DisallowedContentType_EmitsDiagnosticAndSkipsStylesheet() {
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent("p { color:#fedcba; }", Encoding.UTF8, "application/json")
+            })));
+            string html = "<link rel=\"stylesheet\" href=\"https://styles.example.test/rejected-content-type.css\" /><p>Remote CSS</p>";
+            var options = new HtmlToWordOptions {
+                AllowDocumentStylesheetLinks = true,
+                HttpClient = httpClient
+            };
+
+            var doc = html.LoadFromHtml(options);
+
+            var run = doc.Paragraphs[0].GetRuns().First();
+            Assert.NotEqual("fedcba", run.ColorHex);
+            var diagnostic = Assert.Single(options.Diagnostics);
+            Assert.Equal("StylesheetContentTypeRejected", diagnostic.Code);
+            Assert.Equal("https://styles.example.test/rejected-content-type.css", diagnostic.Source);
+        }
+
+        [Fact]
+        public void HtmlToWord_RemoteStylesheet_ContentTypeValidationCanBeDisabled() {
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent("p { color:#112233; }", Encoding.UTF8, "application/json")
+            })));
+            string html = "<link rel=\"stylesheet\" href=\"https://styles.example.test/json.css\" /><p>Remote CSS</p>";
+            var options = new HtmlToWordOptions {
+                AllowDocumentStylesheetLinks = true,
+                HttpClient = httpClient,
+                ValidateStylesheetContentTypes = false
+            };
+
+            var doc = html.LoadFromHtml(options);
+
+            var run = doc.Paragraphs[0].GetRuns().First();
+            Assert.Equal("112233", run.ColorHex);
+            Assert.Empty(options.Diagnostics);
+        }
+
+        [Fact]
+        public void HtmlToWord_RemoteStylesheet_NonSuccessStatus_EmitsSpecificDiagnosticAndSkipsStylesheet() {
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound) {
+                Content = new StringContent("p { color:#445566; }", Encoding.UTF8, "text/css")
+            })));
+            string html = "<link rel=\"stylesheet\" href=\"https://styles.example.test/not-found.css\" /><p>Remote CSS</p>";
+            var options = new HtmlToWordOptions {
+                AllowDocumentStylesheetLinks = true,
+                HttpClient = httpClient
+            };
+
+            var doc = html.LoadFromHtml(options);
+
+            var run = doc.Paragraphs[0].GetRuns().First();
+            Assert.NotEqual("445566", run.ColorHex);
+            var diagnostic = Assert.Single(options.Diagnostics);
+            Assert.Equal("StylesheetHttpStatusRejected", diagnostic.Code);
+            Assert.Equal("https://styles.example.test/not-found.css", diagnostic.Source);
+            Assert.Contains("404", diagnostic.Detail, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void HtmlToWord_RemoteStylesheet_TransportFailure_EmitsSpecificDiagnosticAndSkipsStylesheet() {
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(_ =>
+                Task.FromException<HttpResponseMessage>(new HttpRequestException("DNS resolution failed."))));
+            string html = "<link rel=\"stylesheet\" href=\"https://styles.example.test/transport.css\" /><p>Remote CSS</p>";
+            var options = new HtmlToWordOptions {
+                AllowDocumentStylesheetLinks = true,
+                HttpClient = httpClient
+            };
+
+            var doc = html.LoadFromHtml(options);
+
+            var run = doc.Paragraphs[0].GetRuns().First();
+            Assert.NotEqual("778899", run.ColorHex);
+            var diagnostic = Assert.Single(options.Diagnostics);
+            Assert.Equal("StylesheetTransportFailed", diagnostic.Code);
+            Assert.Equal("https://styles.example.test/transport.css", diagnostic.Source);
+            Assert.Contains("DNS resolution failed", diagnostic.Detail, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void HtmlToWord_RemoteStylesheet_ResourceTimeout_EmitsSpecificDiagnosticAndSkipsStylesheet() {
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(_ =>
+                Task.FromException<HttpResponseMessage>(new TaskCanceledException("The stylesheet request timed out."))));
+            string html = "<link rel=\"stylesheet\" href=\"https://styles.example.test/timeout.css\" /><p>Remote CSS</p>";
+            var options = new HtmlToWordOptions {
+                AllowDocumentStylesheetLinks = true,
+                HttpClient = httpClient,
+                ResourceTimeout = TimeSpan.FromMilliseconds(1)
+            };
+
+            var doc = html.LoadFromHtml(options);
+
+            var run = doc.Paragraphs[0].GetRuns().First();
+            Assert.NotEqual("aabbcc", run.ColorHex);
+            var diagnostic = Assert.Single(options.Diagnostics);
+            Assert.Equal("StylesheetLoadTimedOut", diagnostic.Code);
+            Assert.Equal("https://styles.example.test/timeout.css", diagnostic.Source);
+            Assert.Contains("timed out", diagnostic.Detail, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task HtmlToWord_RemoteStylesheet_CallerCancellationStillThrows() {
+            using var cts = new CancellationTokenSource();
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(_ => {
+                cts.Cancel();
+                return Task.FromException<HttpResponseMessage>(new OperationCanceledException(cts.Token));
+            }));
+            string html = "<link rel=\"stylesheet\" href=\"https://styles.example.test/caller-cancel.css\" /><p>Remote CSS</p>";
+            var options = new HtmlToWordOptions {
+                AllowDocumentStylesheetLinks = true,
+                HttpClient = httpClient
+            };
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => html.LoadFromHtmlAsync(options, cts.Token));
+
+            Assert.Empty(options.Diagnostics);
+        }
+
+        [Fact]
         public void HtmlToWord_RelativeStylesheet_UsesBaseUrl() {
             var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(dir);
@@ -78,6 +306,139 @@ namespace OfficeIMO.Tests {
                 Directory.Delete(dir);
             }
         }
+
+        [Fact]
+        public void HtmlToWord_FileStylesheet_DisallowedScheme_EmitsDiagnosticAndSkipsStylesheet() {
+            var path = Path.GetTempFileName();
+            File.WriteAllText(path, "p { color:#246810; }");
+            string html = $"<link rel=\"stylesheet\" href=\"{path}\" /><p>Local CSS</p>";
+            try {
+                var options = new HtmlToWordOptions { AllowDocumentStylesheetLinks = true };
+                options.AllowedStylesheetUriSchemes.Remove(Uri.UriSchemeFile);
+
+                var doc = html.LoadFromHtml(options);
+
+                var run = doc.Paragraphs[0].GetRuns().First();
+                Assert.NotEqual("246810", run.ColorHex);
+                var diagnostic = Assert.Single(options.Diagnostics);
+                Assert.Equal("StylesheetResourceRejectedByPolicy", diagnostic.Code);
+            } finally {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void HtmlToWord_FileStylesheet_MaxCssBytes_StopsBeforeParsingStylesheet() {
+            var path = Path.GetTempFileName();
+            File.WriteAllText(path, "p { color:#135790; }");
+            string html = $"<link rel=\"stylesheet\" href=\"{path}\" /><p>Local CSS</p>";
+            try {
+                var options = new HtmlToWordOptions {
+                    AllowDocumentStylesheetLinks = true,
+                    MaxCssBytes = 8
+                };
+
+                var exception = Assert.Throws<HtmlConversionLimitException>(() => html.LoadFromHtml(options));
+
+                Assert.Equal("CssSizeLimitExceeded", exception.Code);
+                Assert.Equal(path, exception.LimitSource);
+                Assert.Equal(8, exception.Limit);
+                Assert.True(exception.Actual > exception.Limit);
+                var diagnostic = Assert.Single(options.Diagnostics);
+                Assert.Equal("CssSizeLimitExceeded", diagnostic.Code);
+            } finally {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void HtmlToWord_FileStylesheet_MaxTotalCssBytes_StopsBeforeParsingSecondStylesheet() {
+            var path = Path.GetTempFileName();
+            File.WriteAllText(path, "p { color:#abcdef; }");
+            string seededCss = "body { color:#111111; }";
+            string html = $"<link rel=\"stylesheet\" href=\"{path}\" /><p>Local CSS</p>";
+            try {
+                var options = new HtmlToWordOptions {
+                    AllowDocumentStylesheetLinks = true,
+                    MaxTotalCssBytes = Encoding.UTF8.GetByteCount(seededCss) + 8
+                };
+                options.StylesheetContents.Add(seededCss);
+
+                var exception = Assert.Throws<HtmlConversionLimitException>(() => html.LoadFromHtml(options));
+
+                Assert.Equal("CssTotalSizeLimitExceeded", exception.Code);
+                Assert.Equal(path, exception.LimitSource);
+                Assert.Equal(options.MaxTotalCssBytes, exception.Limit);
+                Assert.True(exception.Actual > exception.Limit);
+                var diagnostic = Assert.Single(options.Diagnostics);
+                Assert.Equal("CssTotalSizeLimitExceeded", diagnostic.Code);
+            } finally {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void HtmlToWord_BodyStylesheetLink_AppliesToFollowingContent() {
+            var path = Path.GetTempFileName();
+            File.WriteAllText(path, "p { color:#456789; }");
+            string html = $"<p>Before</p><link rel=\"stylesheet\" href=\"{path}\" /><p>After</p>";
+            try {
+                var doc = html.LoadFromHtml(new HtmlToWordOptions { AllowDocumentStylesheetLinks = true });
+
+                var beforeRun = doc.Paragraphs[0].GetRuns().First();
+                var afterRun = doc.Paragraphs[1].GetRuns().First();
+                Assert.NotEqual("456789", beforeRun.ColorHex);
+                Assert.Equal("456789", afterRun.ColorHex);
+            } finally {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void HtmlToWord_BodyStylesheetLink_Disabled_EmitsDiagnosticAndSkipsStylesheet() {
+            var path = Path.GetTempFileName();
+            File.WriteAllText(path, "p { color:#765432; }");
+            string html = $"<p>Before</p><link rel=\"stylesheet\" href=\"{path}\" /><p>After</p>";
+            try {
+                var options = new HtmlToWordOptions();
+                var doc = html.LoadFromHtml(options);
+
+                var afterRun = doc.Paragraphs[1].GetRuns().First();
+                Assert.NotEqual("765432", afterRun.ColorHex);
+                var diagnostic = Assert.Single(options.Diagnostics);
+                Assert.Equal("HtmlStylesheetLinkSkipped", diagnostic.Code);
+                Assert.Equal(path, diagnostic.Source, ignoreCase: true);
+            } finally {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void HtmlToWord_StylesheetLinkWithoutHref_EmitsDiagnostic() {
+            string html = "<link rel=\"stylesheet\" /><p>Missing href</p>";
+            var options = new HtmlToWordOptions { AllowDocumentStylesheetLinks = true };
+
+            var doc = html.LoadFromHtml(options);
+
+            Assert.Equal("Missing href", doc.Paragraphs[0].Text);
+            var diagnostic = Assert.Single(options.Diagnostics);
+            Assert.Equal("HtmlStylesheetLinkMissingHref", diagnostic.Code);
+            Assert.Equal("link", diagnostic.Source);
+        }
+
+        [Fact]
+        public void HtmlToWord_StylesheetLinkUnsupportedScheme_EmitsPolicyDiagnostic() {
+            string html = "<link rel=\"stylesheet\" href=\"data:text/css,p%7Bcolor:%23999999%7D\" /><p>Unsupported scheme</p>";
+            var options = new HtmlToWordOptions { AllowDocumentStylesheetLinks = true };
+
+            var doc = html.LoadFromHtml(options);
+
+            var run = doc.Paragraphs[0].GetRuns().First();
+            Assert.NotEqual("999999", run.ColorHex);
+            var diagnostic = Assert.Single(options.Diagnostics);
+            Assert.Equal("StylesheetResourceRejectedByPolicy", diagnostic.Code);
+            Assert.Equal("data:text/css,p%7Bcolor:%23999999%7D", diagnostic.Source);
+            Assert.Contains("data", diagnostic.Detail, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }
-

--- a/OfficeIMO.Tests/Html.TableStyles.cs
+++ b/OfficeIMO.Tests/Html.TableStyles.cs
@@ -104,5 +104,33 @@ namespace OfficeIMO.Tests {
 
             Assert.Equal(TableRowAlignmentValues.Center, table.Alignment);
         }
+
+        [Fact]
+        public void HtmlToWord_TableStyles_CellSpacingAttributeSetsTableSpacing() {
+            string html = "<table cellspacing=\"6\"><tr><td>One</td><td>Two</td></tr></table>";
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var table = doc.Tables[0];
+
+            Assert.Equal((short)90, table.StyleDetails!.CellSpacing);
+        }
+
+        [Fact]
+        public void HtmlToWord_TableStyles_BorderSpacingSetsTableSpacing() {
+            string html = "<table cellspacing=\"2\" style=\"border-spacing:5pt 10pt\"><tr><td>One</td><td>Two</td></tr></table>";
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var table = doc.Tables[0];
+
+            Assert.Equal((short)100, table.StyleDetails!.CellSpacing);
+        }
+
+        [Fact]
+        public void HtmlToWord_TableStyles_VerticalAlignSetsCellVerticalAlignment() {
+            string html = "<table><tr><td style=\"vertical-align:middle\">Middle</td><td valign=\"bottom\">Bottom</td></tr></table>";
+            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var table = doc.Tables[0];
+
+            Assert.Equal(TableVerticalAlignmentValues.Center, table.Rows[0].Cells[0].VerticalAlignment);
+            Assert.Equal(TableVerticalAlignmentValues.Bottom, table.Rows[0].Cells[1].VerticalAlignment);
+        }
     }
 }

--- a/OfficeIMO.Tests/Html.Time.cs
+++ b/OfficeIMO.Tests/Html.Time.cs
@@ -1,6 +1,9 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
 using System;
+using System.IO;
 using System.Linq;
 using Xunit;
 
@@ -31,6 +34,30 @@ namespace OfficeIMO.Tests {
             Assert.Contains("datetime=\"2023-01-01\"", roundTrip, StringComparison.OrdinalIgnoreCase);
             Assert.Contains(">New Year's Day</time>", roundTrip, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("id=\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void TimePreservesDateTimeAfterSaveAndReload() {
+            const string html = "<p>On <time datetime=\"2023-01-01\">New Year's Day</time> we met.</p>";
+
+            using var doc = html.LoadFromHtml();
+            using MemoryStream stream = doc.SaveAsMemoryStream();
+            byte[] packageBytes = stream.ToArray();
+
+            using (var validationStream = new MemoryStream(packageBytes))
+            using (var package = WordprocessingDocument.Open(validationStream, false)) {
+                var errors = new OpenXmlValidator().Validate(package).ToList();
+                Assert.True(errors.Count == 0, Word.FormatValidationErrors(errors));
+            }
+
+            using var reloadStream = new MemoryStream(packageBytes);
+            using var reloaded = WordDocument.Load(reloadStream, readOnly: true);
+
+            string roundTrip = reloaded.ToHtml();
+
+            Assert.Contains("<time", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("datetime=\"2023-01-01\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(">New Year's Day</time>", roundTrip, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/OfficeIMO.Tests/Html.Time.cs
+++ b/OfficeIMO.Tests/Html.Time.cs
@@ -19,6 +19,19 @@ namespace OfficeIMO.Tests {
             Assert.Contains("datetime=\"2023-01-01", roundTrip, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("2023-01-01</time>", roundTrip, StringComparison.OrdinalIgnoreCase);
         }
+
+        [Fact]
+        public void TimePreservesDateTimeWhenVisibleTextDiffers() {
+            const string html = "<p>On <time datetime=\"2023-01-01\">New Year's Day</time> we met.</p>";
+            using var doc = html.LoadFromHtml();
+
+            string roundTrip = doc.ToHtml();
+
+            Assert.Contains("<time", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("datetime=\"2023-01-01\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(">New Year's Day</time>", roundTrip, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("id=\"", roundTrip, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }
 

--- a/OfficeIMO.Tests/Html.WordToHtml.cs
+++ b/OfficeIMO.Tests/Html.WordToHtml.cs
@@ -53,6 +53,26 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_WordToHtml_RunLanguage_RoundTripsLangAttributes() {
+            const string sourceHtml = "<html lang=\"en-US\"><body><p>Hello <span lang=\"pl-PL\">Czesc</span></p></body></html>";
+
+            using var doc = sourceHtml.LoadFromHtml();
+
+            Assert.Equal("en-US", doc.Settings.Language);
+            Assert.Contains(doc.Paragraphs[0].GetRuns(), run => string.Equals(run.Text, "Czesc", StringComparison.Ordinal) && string.Equals(run.Language, "pl-PL", StringComparison.OrdinalIgnoreCase));
+
+            string html = doc.ToHtml();
+
+            Assert.Contains("<html lang=\"en-US\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<span lang=\"pl-PL\">Czesc</span>", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("lang=\"en-US\">Hello", html, StringComparison.OrdinalIgnoreCase);
+
+            using var roundTrip = html.LoadFromHtml();
+
+            Assert.Contains(roundTrip.Paragraphs[0].GetRuns(), run => string.Equals(run.Text, "Czesc", StringComparison.Ordinal) && string.Equals(run.Language, "pl-PL", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
         public void Test_WordToHtml_BookmarkedHeading_ExportsId() {
             using var doc = WordDocument.Create();
             var heading = doc.AddParagraph("Bookmarked heading");
@@ -84,7 +104,7 @@ namespace OfficeIMO.Tests {
 
             string html = doc.ToHtml();
 
-            Assert.Contains("<article id=\"article-anchor\">Article content</article>", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<article id=\"article-anchor\"><p>Article content</p></article>", html, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("<p id=\"article:article-anchor\"", html, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -130,6 +150,8 @@ namespace OfficeIMO.Tests {
             string html = doc.ToHtml();
 
             Assert.Contains("<thead><tr><th", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(2, html.Split(new[] { "scope=\"col\"" }, StringSplitOptions.None).Length - 1);
+            Assert.DoesNotContain("<td scope=\"col\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("<p>Name</p>", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("<p>Score</p>", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("</th></tr></thead>", html, StringComparison.OrdinalIgnoreCase);
@@ -157,6 +179,78 @@ namespace OfficeIMO.Tests {
             Assert.True(roundTripTable.Rows[0].RepeatHeaderRowAtTheTopOfEachPage);
             Assert.True(roundTripTable.Rows[1].RepeatHeaderRowAtTheTopOfEachPage);
             Assert.False(roundTripTable.Rows[2].RepeatHeaderRowAtTheTopOfEachPage);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_TableFooterRow_ExportsTfootAndRoundTrips() {
+            using var doc = WordDocument.Create();
+            var table = doc.AddTable(3, 1);
+            table.ConditionalFormattingLastRow = true;
+            table.Rows[0].Cells[0].Paragraphs[0].Text = "Header";
+            table.Rows[1].Cells[0].Paragraphs[0].Text = "Body";
+            table.Rows[2].Cells[0].Paragraphs[0].Text = "Total";
+
+            string html = doc.ToHtml();
+
+            Assert.Contains("<tbody><tr><td", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<p>Body</p>", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<tfoot><tr><td", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<p>Total</p>", html, StringComparison.OrdinalIgnoreCase);
+            Assert.True(html.IndexOf("<tbody>", StringComparison.OrdinalIgnoreCase) < html.IndexOf("<tfoot>", StringComparison.OrdinalIgnoreCase));
+
+            using var roundTrip = html.LoadFromHtml();
+
+            Assert.True(roundTrip.Tables[0].ConditionalFormattingLastRow);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_TableCaption_ExportsCaptionElementAndRoundTrips() {
+            const string sourceHtml = "<table><caption>Score summary</caption><tr><td>Ada</td><td>42</td></tr></table>";
+
+            using var doc = sourceHtml.LoadFromHtml();
+
+            Assert.Contains(doc.Paragraphs, paragraph =>
+                string.Equals(paragraph.StyleId, "Caption", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(paragraph.Text, "Score summary", StringComparison.Ordinal));
+
+            string html = doc.ToHtml();
+
+            Assert.Contains("<caption>Score summary</caption>", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("<p>Score summary</p><table", html, StringComparison.OrdinalIgnoreCase);
+
+            using var roundTrip = html.LoadFromHtml();
+
+            Assert.Single(roundTrip.Tables);
+            Assert.Contains(roundTrip.Paragraphs, paragraph =>
+                string.Equals(paragraph.StyleId, "Caption", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(paragraph.Text, "Score summary", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void Test_WordToHtml_TableCaptionBelow_ExportsCaptionElementWithoutDuplicateParagraph() {
+            const string sourceHtml = "<table><caption>Totals</caption><tr><td>42</td></tr></table>";
+            var options = new HtmlToWordOptions {
+                TableCaptionPosition = TableCaptionPosition.Below
+            };
+
+            using var doc = sourceHtml.LoadFromHtml(options);
+
+            string html = doc.ToHtml();
+
+            Assert.Contains("<caption>Totals</caption>", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("</table><p>Totals</p>", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_TopLevelTable_DoesNotExportPlaceholderParagraph() {
+            const string sourceHtml = "<table><tr><td>42</td></tr></table>";
+
+            using var doc = sourceHtml.LoadFromHtml();
+
+            string html = doc.ToHtml();
+
+            Assert.Contains("<body><table>", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("<body><p></p><table>", html, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -478,6 +572,39 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_WordToHtml_EditorMarkerBulletListStyles() {
+            using var doc = WordDocument.Create();
+            var starList = doc.AddList(WordListStyle.Bulleted);
+            starList.Numbering.Levels[0]._level.LevelText!.Val = "*";
+            starList.AddItem("Star");
+            var plusList = doc.AddList(WordListStyle.Bulleted);
+            plusList.Numbering.Levels[0]._level.LevelText!.Val = "+";
+            plusList.AddItem("Plus");
+
+            string html = doc.ToHtml(new WordToHtmlOptions { IncludeListStyles = true });
+
+            Assert.Contains("list-style-type:'*'", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("list-style-type:'+'", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_CustomBulletListStyle() {
+            using var doc = WordDocument.Create();
+            var checkList = doc.AddList(WordListStyle.Bulleted);
+            checkList.Numbering.Levels[0]._level.LevelText!.Val = "✓";
+            checkList.AddItem("Done");
+            var diamondList = doc.AddList(WordListStyle.Bulleted);
+            diamondList.Numbering.Levels[0]._level.LevelText!.Val = "◆";
+            diamondList.AddItem("Diamond");
+
+            string html = doc.ToHtml(new WordToHtmlOptions { IncludeListStyles = true });
+
+            Assert.Contains("list-style-type:'✓'", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("list-style-type:'◆'", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("type=\"disc\"", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void Test_WordToHtml_CheckBoxControl() {
             using var doc = WordDocument.Create();
             var paragraph = doc.AddParagraph("");
@@ -528,6 +655,38 @@ namespace OfficeIMO.Tests {
             Assert.Contains("value=\"Contoso\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("aria-label=\"Client name\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("data-tag=\"client-name\"", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_MultilineStructuredDocumentTag_ExportsTextArea() {
+            using var doc = WordDocument.Create();
+            var paragraph = doc.AddParagraph("Notes: ");
+            paragraph.AddStructuredDocumentTag("Line one\nLine two", "Review notes", "notes");
+
+            string html = doc.ToHtml();
+
+            Assert.Contains("<textarea", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("disabled", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("aria-label=\"Review notes\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("data-tag=\"notes\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Line one", html, StringComparison.Ordinal);
+            Assert.Contains("Line two", html, StringComparison.Ordinal);
+            Assert.DoesNotContain("value=\"Line one", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_MultilineStructuredDocumentTag_RoundTripsThroughTextArea() {
+            using var doc = WordDocument.Create();
+            var paragraph = doc.AddParagraph("Notes: ");
+            paragraph.AddStructuredDocumentTag("Line one\nLine two", "Review notes", "notes");
+
+            string html = doc.ToHtml();
+            using var roundTrip = html.LoadFromHtml();
+
+            var control = Assert.Single(roundTrip.StructuredDocumentTags);
+            Assert.Equal("Line one\nLine two", control.Text);
+            Assert.Equal("Review notes", control.Alias);
+            Assert.Equal("notes", control.Tag);
         }
 
         [Fact]
@@ -600,6 +759,43 @@ namespace OfficeIMO.Tests {
 
             Assert.Contains("<table style=\"width:100%;border:1px solid black;border-collapse:collapse\">", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("<td style=\"width:50%;text-align:center;border:1px solid black\">", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_TableCellSpacing_ExportsBorderSpacingAndRoundTrips() {
+            using var doc = WordDocument.Create();
+            var table = doc.AddTable(1, 1);
+            table.StyleDetails!.CellSpacing = 240;
+            table.Rows[0].Cells[0].Paragraphs[0].Text = "Spaced";
+            table.Rows[0].Cells[0].Borders.LeftStyle = BorderValues.Single;
+            table.Rows[0].Cells[0].Borders.RightStyle = BorderValues.Single;
+            table.Rows[0].Cells[0].Borders.TopStyle = BorderValues.Single;
+            table.Rows[0].Cells[0].Borders.BottomStyle = BorderValues.Single;
+
+            string html = doc.ToHtml();
+
+            Assert.Contains("border-spacing:12pt", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("border-collapse:separate", html, StringComparison.OrdinalIgnoreCase);
+
+            using var roundTrip = html.LoadFromHtml();
+
+            Assert.Equal((short)240, roundTrip.Tables[0].StyleDetails!.CellSpacing);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_TableCellVerticalAlignment_RoundTrips() {
+            using var doc = WordDocument.Create();
+            var table = doc.AddTable(1, 1);
+            table.Rows[0].Cells[0].VerticalAlignment = TableVerticalAlignmentValues.Center;
+            table.Rows[0].Cells[0].Paragraphs[0].Text = "Centered";
+
+            string html = doc.ToHtml();
+
+            Assert.Contains("vertical-align:middle", html, StringComparison.OrdinalIgnoreCase);
+
+            using var roundTrip = html.LoadFromHtml();
+
+            Assert.Equal(TableVerticalAlignmentValues.Center, roundTrip.Tables[0].Rows[0].Cells[0].VerticalAlignment);
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Reader.Html.Modular.cs
+++ b/OfficeIMO.Tests/Reader.Html.Modular.cs
@@ -125,6 +125,76 @@ public sealed class ReaderHtmlModularTests {
     }
 
     [Fact]
+    public void DocumentReaderHtml_ReadHtmlString_PreservesConfiguredMaxInputCharacters() {
+        var html = "<html><body><p>Too much content for this limit.</p></body></html>";
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => DocumentReaderHtmlExtensions.ReadHtmlString(
+            html: html,
+            sourceName: "limited.html",
+            htmlOptions: new ReaderHtmlOptions {
+                HtmlToMarkdownOptions = new HtmlToMarkdownOptions {
+                    MaxInputCharacters = 12
+                }
+            }).ToList());
+
+        Assert.Contains("MaxInputCharacters", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReaderHtmlOptions_ProfilesExposeExpectedMarkdownOptions() {
+        var officeProfile = ReaderHtmlOptions.CreateOfficeIMOProfile();
+        Assert.NotNull(officeProfile.HtmlToMarkdownOptions);
+        Assert.Null(officeProfile.HtmlToMarkdownOptions.MarkdownWriteOptions);
+        Assert.Null(officeProfile.HtmlToMarkdownOptions.MaxInputCharacters);
+
+        var portableProfile = ReaderHtmlOptions.CreatePortableProfile();
+        Assert.NotNull(portableProfile.HtmlToMarkdownOptions);
+        Assert.NotNull(portableProfile.HtmlToMarkdownOptions.MarkdownWriteOptions);
+        Assert.Null(portableProfile.HtmlToMarkdownOptions.MaxInputCharacters);
+
+        var untrustedProfile = ReaderHtmlOptions.CreateUntrustedHtmlProfile(64);
+        Assert.NotNull(untrustedProfile.HtmlToMarkdownOptions);
+        Assert.NotNull(untrustedProfile.HtmlToMarkdownOptions.MarkdownWriteOptions);
+        Assert.Equal(64, untrustedProfile.HtmlToMarkdownOptions.MaxInputCharacters);
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => ReaderHtmlOptions.CreateUntrustedHtmlProfile(0));
+        Assert.Equal("maxInputCharacters", exception.ParamName);
+    }
+
+    [Fact]
+    public void ReaderHtmlOptions_CloneCopiesNestedOptionsIndependently() {
+        var options = ReaderHtmlOptions.CreateUntrustedHtmlProfile(64);
+        options.HtmlToMarkdownOptions!.BaseUri = new Uri("https://example.com/docs/");
+
+        var clone = options.Clone();
+
+        Assert.NotSame(options, clone);
+        Assert.NotNull(clone.HtmlToMarkdownOptions);
+        Assert.NotSame(options.HtmlToMarkdownOptions, clone.HtmlToMarkdownOptions);
+        Assert.Equal(options.HtmlToMarkdownOptions.BaseUri, clone.HtmlToMarkdownOptions.BaseUri);
+        Assert.Equal(options.HtmlToMarkdownOptions.MaxInputCharacters, clone.HtmlToMarkdownOptions.MaxInputCharacters);
+        Assert.NotNull(clone.HtmlToMarkdownOptions.MarkdownWriteOptions);
+        Assert.NotSame(options.HtmlToMarkdownOptions.MarkdownWriteOptions, clone.HtmlToMarkdownOptions.MarkdownWriteOptions);
+
+        clone.HtmlToMarkdownOptions.MaxInputCharacters = 128;
+
+        Assert.Equal(64, options.HtmlToMarkdownOptions.MaxInputCharacters);
+        Assert.Equal(128, clone.HtmlToMarkdownOptions.MaxInputCharacters);
+    }
+
+    [Fact]
+    public void DocumentReaderHtml_ReadHtmlString_UntrustedProfileEnforcesMaxInputCharacters() {
+        var html = "<html><body><p>Too much content for this profile limit.</p></body></html>";
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => DocumentReaderHtmlExtensions.ReadHtmlString(
+            html: html,
+            sourceName: "profile-limited.html",
+            htmlOptions: ReaderHtmlOptions.CreateUntrustedHtmlProfile(12)).ToList());
+
+        Assert.Contains("MaxInputCharacters", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void DocumentReaderHtml_ReadHtmlStream_EmitsLogicalSourceMetadata() {
         var html = "<html><body><h2>Registry HTML</h2><p>From stream.</p></body></html>";
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(html), writable: false);
@@ -252,6 +322,27 @@ public sealed class ReaderHtmlModularTests {
                 new ReaderOptions { MaxInputBytes = 16 }).ToList());
 
             Assert.Contains("Input exceeds MaxInputBytes", ex.Message, StringComparison.Ordinal);
+        } finally {
+            DocumentReaderHtmlRegistrationExtensions.UnregisterHtmlHandler();
+        }
+    }
+
+    [Fact]
+    public void DocumentReaderHtml_Registration_PreservesConfiguredMaxInputCharacters() {
+        try {
+            DocumentReaderHtmlRegistrationExtensions.RegisterHtmlHandler(
+                htmlOptions: new ReaderHtmlOptions {
+                    HtmlToMarkdownOptions = new HtmlToMarkdownOptions {
+                        MaxInputCharacters = 12
+                    }
+                },
+                replaceExisting: true);
+
+            var html = "<html><body><p>Too much content for this limit.</p></body></html>";
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(html), writable: false);
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => DocumentReader.Read(stream, "configured.html").ToList());
+
+            Assert.Contains("MaxInputCharacters", ex.Message, StringComparison.Ordinal);
         } finally {
             DocumentReaderHtmlRegistrationExtensions.UnregisterHtmlHandler();
         }

--- a/OfficeIMO.Word.Html/Converters/HtmlSemanticMetadata.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlSemanticMetadata.cs
@@ -1,0 +1,59 @@
+namespace OfficeIMO.Word.Html {
+    internal static class HtmlSemanticMetadata {
+        internal static void SetBlockquoteCite(WordParagraph paragraph, string? cite) {
+            if (string.IsNullOrWhiteSpace(cite) || paragraph._paragraph == null) {
+                return;
+            }
+
+            paragraph._paragraph.RemoveAnnotations<HtmlBlockquoteCiteAnnotation>();
+            paragraph._paragraph.AddAnnotation(new HtmlBlockquoteCiteAnnotation(cite!));
+        }
+
+        internal static bool TryGetBlockquoteCite(WordParagraph paragraph, out string cite) {
+            cite = string.Empty;
+            var annotation = paragraph._paragraph?.Annotation<HtmlBlockquoteCiteAnnotation>();
+            if (annotation == null || string.IsNullOrEmpty(annotation.Cite)) {
+                return false;
+            }
+
+            cite = annotation.Cite;
+            return true;
+        }
+
+        internal static void SetTimeDateTime(WordParagraph run, string? dateTime) {
+            if (string.IsNullOrWhiteSpace(dateTime) || run._run == null) {
+                return;
+            }
+
+            run._run.RemoveAnnotations<HtmlTimeAnnotation>();
+            run._run.AddAnnotation(new HtmlTimeAnnotation(dateTime!));
+        }
+
+        internal static bool TryGetTimeDateTime(WordParagraph run, out string dateTime) {
+            dateTime = string.Empty;
+            var annotation = run._run?.Annotation<HtmlTimeAnnotation>();
+            if (annotation == null || string.IsNullOrEmpty(annotation.DateTime)) {
+                return false;
+            }
+
+            dateTime = annotation.DateTime;
+            return true;
+        }
+
+        private sealed class HtmlTimeAnnotation {
+            internal HtmlTimeAnnotation(string dateTime) {
+                DateTime = dateTime;
+            }
+
+            internal string DateTime { get; }
+        }
+
+        private sealed class HtmlBlockquoteCiteAnnotation {
+            internal HtmlBlockquoteCiteAnnotation(string cite) {
+                Cite = cite;
+            }
+
+            internal string Cite { get; }
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlSemanticMetadata.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlSemanticMetadata.cs
@@ -1,5 +1,10 @@
+using DocumentFormat.OpenXml.Wordprocessing;
+using System;
+
 namespace OfficeIMO.Word.Html {
     internal static class HtmlSemanticMetadata {
+        private const string TimeDateTimeTagPrefix = "officeimo-html-time:";
+
         internal static void SetBlockquoteCite(WordParagraph paragraph, string? cite) {
             if (string.IsNullOrWhiteSpace(cite) || paragraph._paragraph == null) {
                 return;
@@ -27,17 +32,63 @@ namespace OfficeIMO.Word.Html {
 
             run._run.RemoveAnnotations<HtmlTimeAnnotation>();
             run._run.AddAnnotation(new HtmlTimeAnnotation(dateTime!));
+            SetTimeDateTimeMetadataRun(run._run, dateTime!);
         }
 
         internal static bool TryGetTimeDateTime(WordParagraph run, out string dateTime) {
             dateTime = string.Empty;
             var annotation = run._run?.Annotation<HtmlTimeAnnotation>();
-            if (annotation == null || string.IsNullOrEmpty(annotation.DateTime)) {
+            if (annotation != null && !string.IsNullOrEmpty(annotation.DateTime)) {
+                dateTime = annotation.DateTime;
+                return true;
+            }
+
+            if (run._run != null) {
+                var nextRun = run._run.NextSibling<Run>();
+                if (TryGetTimeDateTimeMetadata(nextRun, out dateTime)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        internal static bool IsTimeDateTimeMetadataRun(WordParagraph run) =>
+            TryGetTimeDateTimeMetadata(run._run, out _);
+
+        private static void SetTimeDateTimeMetadataRun(Run run, string dateTime) {
+            var tagValue = TimeDateTimeTagPrefix + Uri.EscapeDataString(dateTime);
+            var metadataRun = run.NextSibling<Run>();
+            if (!IsTimeDateTimeMetadataRun(metadataRun)) {
+                metadataRun = new Run(new RunProperties(new Vanish()));
+                run.InsertAfterSelf(metadataRun);
+            }
+
+            var text = metadataRun!.GetFirstChild<Text>();
+            if (text == null) {
+                metadataRun.AppendChild(new Text(tagValue) { Space = SpaceProcessingModeValues.Preserve });
+            } else {
+                text.Text = tagValue;
+                text.Space = SpaceProcessingModeValues.Preserve;
+            }
+        }
+
+        private static bool TryGetTimeDateTimeMetadata(Run? run, out string dateTime) {
+            dateTime = string.Empty;
+            if (!IsTimeDateTimeMetadataRun(run)) {
                 return false;
             }
 
-            dateTime = annotation.DateTime;
+            var tag = run!.GetFirstChild<Text>()?.Text;
+            dateTime = Uri.UnescapeDataString(tag!.Substring(TimeDateTimeTagPrefix.Length));
             return true;
+        }
+
+        private static bool IsTimeDateTimeMetadataRun(Run? run) {
+            var tag = run?.GetFirstChild<Text>()?.Text;
+            return !string.IsNullOrEmpty(tag) &&
+                tag!.StartsWith(TimeDateTimeTagPrefix, StringComparison.Ordinal) &&
+                run!.RunProperties?.GetFirstChild<Vanish>() != null;
         }
 
         private sealed class HtmlTimeAnnotation {

--- a/OfficeIMO.Word.Html/Converters/HtmlSemanticStyleIds.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlSemanticStyleIds.cs
@@ -1,0 +1,10 @@
+namespace OfficeIMO.Word.Html {
+    internal static class HtmlSemanticStyleIds {
+        internal const string BlockquoteCite = "HtmlBlockquoteCite";
+        internal const string DefinitionTerm = "HtmlDefinitionTerm";
+        internal const string DefinitionDescription = "HtmlDefinitionDescription";
+        internal const string DeletedText = "HtmlDeletedText";
+        internal const string InsertedText = "HtmlInsertedText";
+        internal const string MarkedText = "HtmlMarkedText";
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Comments.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Comments.cs
@@ -98,5 +98,31 @@ namespace OfficeIMO.Word.Html {
 
             return true;
         }
+
+        private void ProcessRawHtmlComment(
+            IComment comment,
+            WordSection section,
+            ref WordParagraph? currentParagraph,
+            WordTableCell? cell,
+            WordHeaderFooter? headerFooter,
+            HtmlToWordOptions options) {
+            if (!options.ImportHtmlComments) {
+                AddDiagnostic(options, "HtmlCommentSkipped", "HTML comment was skipped because raw HTML comment import is disabled.", "comment");
+                return;
+            }
+
+            var text = comment.TextContent?.Trim();
+            if (string.IsNullOrWhiteSpace(text)) {
+                AddDiagnostic(options, "HtmlCommentSkipped", "HTML comment was skipped because it was empty.", "comment");
+                return;
+            }
+
+            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+            if (!currentParagraph.GetRuns().Any()) {
+                currentParagraph.AddText(string.Empty);
+            }
+
+            currentParagraph.AddComment(options.HtmlCommentAuthor, options.HtmlCommentInitials, text!);
+        }
     }
 }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.CssDiagnostics.cs
@@ -6,6 +6,7 @@ namespace OfficeIMO.Word.Html {
             "background-color",
             "border",
             "border-collapse",
+            "border-spacing",
             "break-after",
             "break-before",
             "color",
@@ -36,6 +37,8 @@ namespace OfficeIMO.Word.Html {
             "page-break-before",
             "text-align",
             "text-decoration",
+            "text-decoration-line",
+            "text-decoration-style",
             "text-indent",
             "text-transform",
             "vertical-align",
@@ -98,7 +101,7 @@ namespace OfficeIMO.Word.Html {
                     continue;
                 }
 
-                if (TryGetUnsupportedCssValueReason(propertyName, pair.Value, out var reason)) {
+                if (TryGetUnsupportedCssValueReason(elementName, propertyName, pair.Value, out var reason)) {
                     AddUnsupportedCssDiagnostic(
                         "UnsupportedCssValue",
                         "CSS declaration value is not currently mapped to Word output.",
@@ -131,7 +134,7 @@ namespace OfficeIMO.Word.Html {
             AddDiagnostic(_options, code, message, source, detail == null ? null : new HtmlUnsupportedCssException(code, message, source, detail));
         }
 
-        private static bool TryGetUnsupportedCssValueReason(string propertyName, string? rawValue, out string reason) {
+        private static bool TryGetUnsupportedCssValueReason(string elementName, string propertyName, string? rawValue, out string reason) {
             reason = string.Empty;
             var value = NormalizeCssDiagnosticValue(rawValue);
             if (string.IsNullOrWhiteSpace(value) || IsCssGlobalKeyword(value)) {
@@ -181,17 +184,33 @@ namespace OfficeIMO.Word.Html {
                     }
                     return false;
                 case "text-align":
-                    if (lower is "left" or "right" or "center" or "justify") {
+                    if (lower is "left" or "right" or "center" or "justify" or "start" or "end") {
                         return false;
                     }
                     reason = $"Unsupported text-align value '{value}'.";
                     return true;
                 case "text-decoration":
-                    if (!ContainsSupportedTextDecorationOnly(lower)) {
-                        reason = $"Unsupported text-decoration value '{value}'.";
+                    if (TryGetUnsupportedTextDecorationReason(value, "text-decoration", out reason)) {
                         return true;
                     }
                     return false;
+                case "text-decoration-line":
+                    if (TryGetUnsupportedTextDecorationLineReason(value, "text-decoration-line", out reason)) {
+                        return true;
+                    }
+                    return false;
+                case "text-decoration-style":
+                    if (!IsSupportedTextDecorationStyle(lower)) {
+                        reason = $"Unsupported text-decoration-style value '{value}'.";
+                        return true;
+                    }
+                    return false;
+                case "direction":
+                    if (lower is "ltr" or "rtl") {
+                        return false;
+                    }
+                    reason = $"Unsupported direction value '{value}'.";
+                    return true;
                 case "text-transform":
                     if (lower is "none" or "uppercase" or "lowercase" or "capitalize") {
                         return false;
@@ -199,6 +218,9 @@ namespace OfficeIMO.Word.Html {
                     reason = $"Unsupported text-transform value '{value}'.";
                     return true;
                 case "vertical-align":
+                    if (IsTableCellElement(elementName) && lower is "top" or "middle" or "center" or "bottom") {
+                        return false;
+                    }
                     if (lower is "baseline" or "super" or "sup" or "sub") {
                         return false;
                     }
@@ -252,6 +274,18 @@ namespace OfficeIMO.Word.Html {
                         return true;
                     }
                     return false;
+                case "border-collapse":
+                    if (lower is "collapse" or "separate") {
+                        return false;
+                    }
+                    reason = $"Unsupported border-collapse value '{value}'.";
+                    return true;
+                case "border-spacing":
+                    if (!IsSupportedBorderSpacingValue(value)) {
+                        reason = $"Unsupported border-spacing value '{value}'.";
+                        return true;
+                    }
+                    return false;
                 case "letter-spacing":
                 case "text-indent":
                     if (!IsSupportedCssLength(value, allowNegative: true, allowPercent: false, allowAuto: false)) {
@@ -279,6 +313,25 @@ namespace OfficeIMO.Word.Html {
             }
 
             return false;
+        }
+
+        private static bool IsTableCellElement(string elementName) =>
+            elementName.Equals("td", StringComparison.OrdinalIgnoreCase) ||
+            elementName.Equals("th", StringComparison.OrdinalIgnoreCase);
+
+        private static bool IsSupportedBorderSpacingValue(string value) {
+            var tokens = value.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            if (tokens.Length is < 1 or > 2) {
+                return false;
+            }
+
+            foreach (var token in tokens) {
+                if (!IsSupportedCssLength(token, allowNegative: false, allowPercent: false, allowAuto: false)) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static bool IsSupportedFontShorthand(string value) {
@@ -351,19 +404,52 @@ namespace OfficeIMO.Word.Html {
             return parsed.LineHeight.HasValue;
         }
 
-        private static bool ContainsSupportedTextDecorationOnly(string value) {
-            if (string.IsNullOrWhiteSpace(value) || value == "none") {
+        private static bool TryGetUnsupportedTextDecorationReason(string value, string propertyName, out string reason) {
+            reason = string.Empty;
+            var tokens = value.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            if (tokens.Length == 0) {
+                return false;
+            }
+
+            foreach (var token in tokens) {
+                var lower = token.Trim().ToLowerInvariant();
+                if (IsSupportedTextDecorationLine(lower) || IsSupportedTextDecorationStyle(lower)) {
+                    continue;
+                }
+
+                if (NormalizeColor(token) != null ||
+                    lower is "currentcolor" or "transparent") {
+                    reason = $"Unsupported {propertyName} color token '{token}' in value '{value}'.";
+                    return true;
+                }
+
+                reason = $"Unsupported {propertyName} token '{token}' in value '{value}'.";
                 return true;
             }
 
-            foreach (var token in value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)) {
-                if (token is not ("underline" or "line-through")) {
-                    return false;
+            return false;
+        }
+
+        private static bool TryGetUnsupportedTextDecorationLineReason(string value, string propertyName, out string reason) {
+            reason = string.Empty;
+            foreach (var token in value.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)) {
+                var lower = token.Trim().ToLowerInvariant();
+                if (IsSupportedTextDecorationLine(lower)) {
+                    continue;
                 }
+
+                reason = $"Unsupported {propertyName} token '{token}' in value '{value}'.";
+                return true;
             }
 
-            return true;
+            return false;
         }
+
+        private static bool IsSupportedTextDecorationLine(string value) =>
+            value is "none" or "underline" or "line-through";
+
+        private static bool IsSupportedTextDecorationStyle(string value) =>
+            value is "solid" or "double" or "dotted" or "dashed" or "wavy";
 
         private static bool IsSupportedBoxLengthList(string value, bool allowAuto) {
             var tokens = value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Figures.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Figures.cs
@@ -1,0 +1,61 @@
+using AngleSharp.Dom;
+
+namespace OfficeIMO.Word.Html {
+    internal partial class HtmlToWordConverter {
+        private void ProcessFigureElement(
+            IElement element,
+            WordDocument doc,
+            WordSection section,
+            HtmlToWordOptions options,
+            WordParagraph? currentParagraph,
+            Stack<WordList> listStack,
+            TextFormatting formatting,
+            WordTableCell? cell,
+            WordHeaderFooter? headerFooter,
+            WordList? headingList) {
+            WordParagraph? figureParagraph = currentParagraph;
+            List<IElement> captions = new();
+
+            foreach (var child in element.ChildNodes) {
+                if (child is IElement childElement && string.Equals(childElement.TagName, "figcaption", StringComparison.OrdinalIgnoreCase)) {
+                    captions.Add(childElement);
+                    continue;
+                }
+
+                int startIndex = GetParagraphsInScope(section, cell, headerFooter).Count;
+                ProcessNode(child, doc, section, options, figureParagraph, listStack, formatting, cell, headerFooter, headingList);
+                if (figureParagraph == null) {
+                    var paragraphs = GetParagraphsInScope(section, cell, headerFooter);
+                    if (paragraphs.Count > startIndex) {
+                        figureParagraph = paragraphs[paragraphs.Count - 1];
+                    }
+                }
+            }
+
+            foreach (var caption in captions) {
+                ProcessFigureCaptionElement(caption, doc, section, options, listStack, formatting, cell, headerFooter, headingList);
+            }
+        }
+
+        private void ProcessFigureCaptionElement(
+            IElement caption,
+            WordDocument doc,
+            WordSection section,
+            HtmlToWordOptions options,
+            Stack<WordList> listStack,
+            TextFormatting formatting,
+            WordTableCell? cell,
+            WordHeaderFooter? headerFooter,
+            WordList? headingList) {
+            ApplyCssToElement(caption);
+            var paragraph = AddParagraphInScope(section, cell, headerFooter);
+            paragraph.SetStyleId("Caption");
+            ApplyParagraphStyleFromCss(paragraph, caption);
+            ApplyClassStyle(caption, paragraph, options);
+            AddBookmarkIfPresent(caption, paragraph);
+            foreach (var captionChild in caption.ChildNodes) {
+                ProcessNode(captionChild, doc, section, options, paragraph, listStack, formatting, cell, headerFooter, headingList);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Figures.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Figures.cs
@@ -14,11 +14,10 @@ namespace OfficeIMO.Word.Html {
             WordHeaderFooter? headerFooter,
             WordList? headingList) {
             WordParagraph? figureParagraph = currentParagraph;
-            List<IElement> captions = new();
 
             foreach (var child in element.ChildNodes) {
                 if (child is IElement childElement && string.Equals(childElement.TagName, "figcaption", StringComparison.OrdinalIgnoreCase)) {
-                    captions.Add(childElement);
+                    ProcessFigureCaptionElement(childElement, doc, section, options, listStack, formatting, cell, headerFooter, headingList);
                     continue;
                 }
 
@@ -30,10 +29,6 @@ namespace OfficeIMO.Word.Html {
                         figureParagraph = paragraphs[paragraphs.Count - 1];
                     }
                 }
-            }
-
-            foreach (var caption in captions) {
-                ProcessFigureCaptionElement(caption, doc, section, options, listStack, formatting, cell, headerFooter, headingList);
             }
         }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Formatting.cs
@@ -22,6 +22,7 @@ namespace OfficeIMO.Word.Html {
                 Bold = bold;
                 Italic = italic;
                 Underline = underline;
+                UnderlineStyle = underline ? UnderlineValues.Single : null;
                 Strike = strike;
                 Superscript = superscript;
                 Subscript = subscript;
@@ -39,6 +40,7 @@ namespace OfficeIMO.Word.Html {
             internal bool Bold { get; set; }
             internal bool Italic { get; set; }
             internal bool Underline { get; set; }
+            internal UnderlineValues? UnderlineStyle { get; set; }
             internal bool Strike { get; set; }
             internal bool Superscript { get; set; }
             internal bool Subscript { get; set; }
@@ -260,14 +262,8 @@ namespace OfficeIMO.Word.Html {
             }
 
             var align = GetInlinePropertyValue(declaration, styleAttribute, "text-align")?.Trim();
-            if (!string.IsNullOrEmpty(align)) {
-                alignment = align!.ToLowerInvariant() switch {
-                    "center" => JustificationValues.Center,
-                    "right" => JustificationValues.Right,
-                    "justify" => JustificationValues.Both,
-                    "left" => JustificationValues.Left,
-                    _ => alignment
-                };
+            if (TryMapTextAlign(align, GetBidiFromDir(element), out var mappedAlignment)) {
+                alignment = mappedAlignment;
             }
 
             var floatVal = GetInlinePropertyValue(declaration, styleAttribute, "float")?.Trim();
@@ -320,6 +316,36 @@ namespace OfficeIMO.Word.Html {
             return parsed;
         }
 
+        private static bool TryMapTextAlign(string? value, bool? bidi, out JustificationValues alignment) {
+            alignment = JustificationValues.Left;
+            if (string.IsNullOrWhiteSpace(value)) {
+                return false;
+            }
+
+            switch (value!.Trim().ToLowerInvariant()) {
+                case "center":
+                    alignment = JustificationValues.Center;
+                    return true;
+                case "right":
+                    alignment = JustificationValues.Right;
+                    return true;
+                case "justify":
+                    alignment = JustificationValues.Both;
+                    return true;
+                case "left":
+                    alignment = JustificationValues.Left;
+                    return true;
+                case "start":
+                    alignment = bidi == true ? JustificationValues.Right : JustificationValues.Left;
+                    return true;
+                case "end":
+                    alignment = bidi == true ? JustificationValues.Left : JustificationValues.Right;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         private static readonly Regex _urlRegex = new(@"((?:https?|ftp)://[^\s]+)", RegexOptions.IgnoreCase);
         private static readonly Regex _collapseWhitespaceRegex = new(@"\s+", RegexOptions.Compiled);
 
@@ -334,7 +360,7 @@ namespace OfficeIMO.Word.Html {
                 if (string.IsNullOrEmpty(segment)) {
                     return;
                 }
-                var run = paragraph.AddFormattedText(segment, formatting.Bold, formatting.Italic, formatting.Underline ? UnderlineValues.Single : null);
+                var run = paragraph.AddFormattedText(segment, formatting.Bold, formatting.Italic, GetUnderlineValue(formatting));
                 ApplyFormatting(run, formatting, options);
                 return;
             }
@@ -344,7 +370,7 @@ namespace OfficeIMO.Word.Html {
                 if (match.Index > lastIndex) {
                     var segment = text.Substring(lastIndex, match.Index - lastIndex);
                     segment = ApplyTextTransform(segment, formatting.Transform);
-                    var run = paragraph.AddFormattedText(segment, formatting.Bold, formatting.Italic, formatting.Underline ? UnderlineValues.Single : null);
+                    var run = paragraph.AddFormattedText(segment, formatting.Bold, formatting.Italic, GetUnderlineValue(formatting));
                     ApplyFormatting(run, formatting, options);
                 }
                 var display = ApplyTextTransform(match.Value, formatting.Transform);
@@ -355,7 +381,7 @@ namespace OfficeIMO.Word.Html {
             if (lastIndex < text.Length) {
                 var segment = text.Substring(lastIndex);
                 segment = ApplyTextTransform(segment, formatting.Transform);
-                var run = paragraph.AddFormattedText(segment, formatting.Bold, formatting.Italic, formatting.Underline ? UnderlineValues.Single : null);
+                var run = paragraph.AddFormattedText(segment, formatting.Bold, formatting.Italic, GetUnderlineValue(formatting));
                 ApplyFormatting(run, formatting, options);
             }
         }
@@ -384,7 +410,7 @@ namespace OfficeIMO.Word.Html {
         private static void ApplyFormatting(WordParagraph run, TextFormatting formatting, HtmlToWordOptions options) {
             if (formatting.Bold) run.SetBold();
             if (formatting.Italic) run.SetItalic();
-            if (formatting.Underline) run.SetUnderline(UnderlineValues.Single);
+            if (formatting.Underline) run.SetUnderline(GetUnderlineValue(formatting) ?? UnderlineValues.Single);
             if (formatting.Strike) run.SetStrike();
             if (formatting.Superscript) run.SetSuperScript();
             if (formatting.Subscript) run.SetSubScript();
@@ -407,6 +433,9 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
+        private static UnderlineValues? GetUnderlineValue(TextFormatting formatting) =>
+            formatting.Underline ? formatting.UnderlineStyle ?? UnderlineValues.Single : null;
+
         private static void ApplySpanStyles(IElement element, ref TextFormatting formatting) {
             var styleText = element.GetAttribute("style") ?? string.Empty;
             var parsed = CssStyleMapper.ParseStyles(styleText);
@@ -415,7 +444,7 @@ namespace OfficeIMO.Word.Html {
             if (!string.IsNullOrWhiteSpace(language)) {
                 formatting.Language = language;
             }
-            if (string.IsNullOrWhiteSpace(styleText) && declaration.Length == 0 && parsed.BackgroundColor == null && !parsed.Underline && !parsed.Strike) {
+            if (string.IsNullOrWhiteSpace(styleText) && declaration.Length == 0 && parsed.BackgroundColor == null && !parsed.Underline.HasValue && !parsed.Strike.HasValue && !parsed.UnderlineStyle.HasValue) {
                 return;
             }
 
@@ -487,11 +516,16 @@ namespace OfficeIMO.Word.Html {
                 formatting.Transform = transform.Value;
             }
 
-            if (parsed.Underline) {
-                formatting.Underline = true;
+            if (parsed.Underline.HasValue) {
+                formatting.Underline = parsed.Underline.Value;
             }
-            if (parsed.Strike) {
-                formatting.Strike = true;
+            if (parsed.UnderlineStyle.HasValue) {
+                formatting.UnderlineStyle = parsed.UnderlineStyle.Value;
+            } else if (formatting.Underline && !formatting.UnderlineStyle.HasValue) {
+                formatting.UnderlineStyle = UnderlineValues.Single;
+            }
+            if (parsed.Strike.HasValue) {
+                formatting.Strike = parsed.Strike.Value;
             }
             if (!string.IsNullOrEmpty(parsed.BackgroundColor)) {
                 var highlight = MapColorToHighlight(parsed.BackgroundColor);

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Forms.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Forms.cs
@@ -13,10 +13,19 @@ namespace OfficeIMO.Word.Html {
                 case "textarea":
                     ProcessTextArea(element, section, options, currentParagraph, formatting, cell, headerFooter);
                     break;
+                case "meter":
+                case "progress":
+                    ProcessValueElement(element, section, options, currentParagraph, formatting, cell, headerFooter);
+                    break;
             }
         }
 
         private void ProcessInput(IElement element, WordSection section, HtmlToWordOptions options, WordParagraph? currentParagraph, TextFormatting formatting, WordTableCell? cell, WordHeaderFooter? headerFooter) {
+            if (IsRadioInput(element)) {
+                ProcessRadioGroup(element, section, options, currentParagraph, formatting, cell, headerFooter);
+                return;
+            }
+
             if (!IsCheckboxInput(element) && !IsTextInput(element) && !IsDateInput(element)) {
                 return;
             }
@@ -49,6 +58,45 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
+        private void ProcessRadioGroup(IElement element, WordSection section, HtmlToWordOptions options, WordParagraph? currentParagraph, TextFormatting formatting, WordTableCell? cell, WordHeaderFooter? headerFooter) {
+            if (_processedRadioInputs.Contains(element)) {
+                return;
+            }
+
+            var group = GetRadioGroup(element);
+            if (group.Count == 0) {
+                return;
+            }
+
+            foreach (var radio in group) {
+                _processedRadioInputs.Add(radio);
+            }
+
+            var optionTexts = group.Select(GetRadioOptionText).ToList();
+            if (optionTexts.Count == 0) {
+                return;
+            }
+
+            var selected = group
+                .Where(IsCheckedInput)
+                .Select(GetRadioOptionText)
+                .FirstOrDefault();
+
+            if (selected == null && !optionTexts.Contains(string.Empty, StringComparer.Ordinal)) {
+                optionTexts.Insert(0, string.Empty);
+                selected = string.Empty;
+            }
+
+            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+            var (alias, tag) = GetRadioGroupMetadata(group);
+            var dropDown = currentParagraph.AddDropDownList(optionTexts, alias, tag);
+            dropDown.SelectedValue = selected ?? string.Empty;
+
+            if (ShouldAddSpaceAfterInput(element)) {
+                AddTextRun(currentParagraph, " ", formatting, options);
+            }
+        }
+
         private void ProcessSelect(IElement element, WordSection section, HtmlToWordOptions options, WordParagraph? currentParagraph, TextFormatting formatting, WordTableCell? cell, WordHeaderFooter? headerFooter) {
             var optionsList = element.QuerySelectorAll("option")
                 .Select(option => new {
@@ -63,6 +111,19 @@ namespace OfficeIMO.Word.Html {
 
             currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
             var (alias, tag) = GetInputMetadata(element);
+            if (element.HasAttribute("multiple")) {
+                var selectedValues = optionsList
+                    .Where(option => option.Selected)
+                    .Select(option => option.Text)
+                    .ToList();
+                currentParagraph.AddStructuredDocumentTag(string.Join("\n", selectedValues), alias, tag);
+                if (ShouldAddSpaceAfterInput(element)) {
+                    AddTextRun(currentParagraph, " ", formatting, options);
+                }
+
+                return;
+            }
+
             var dropDown = currentParagraph.AddDropDownList(optionsList.Select(option => option.Text), alias, tag);
             var selected = optionsList.FirstOrDefault(option => option.Selected)?.Text ?? optionsList[0].Text;
             dropDown.SelectedValue = selected;
@@ -82,9 +143,24 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
+        private void ProcessValueElement(IElement element, WordSection section, HtmlToWordOptions options, WordParagraph? currentParagraph, TextFormatting formatting, WordTableCell? cell, WordHeaderFooter? headerFooter) {
+            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+            var (alias, tag) = GetInputMetadata(element);
+            currentParagraph.AddStructuredDocumentTag(GetValueElementText(element), alias, tag);
+
+            if (ShouldAddSpaceAfterInput(element)) {
+                AddTextRun(currentParagraph, " ", formatting, options);
+            }
+        }
+
         private static bool IsCheckboxInput(IElement element) {
             var type = element.GetAttribute("type");
             return string.Equals(type, "checkbox", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsRadioInput(IElement element) {
+            var type = element.GetAttribute("type");
+            return string.Equals(type, "radio", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool IsCheckedInput(IElement element) =>
@@ -104,7 +180,8 @@ namespace OfficeIMO.Word.Html {
 
             var normalizedType = type!.ToLowerInvariant();
             return normalizedType switch {
-                "text" or "search" or "email" or "url" or "tel" or "password" => true,
+                "text" or "search" or "email" or "url" or "tel" or "password" or
+                "number" or "time" or "datetime-local" or "month" or "week" or "color" or "range" => true,
                 _ => false,
             };
         }
@@ -133,8 +210,149 @@ namespace OfficeIMO.Word.Html {
         private static string NormalizeFormText(string? text) =>
             text?.Replace("\r\n", "\n").Replace('\r', '\n') ?? string.Empty;
 
+        private static string GetValueElementText(IElement element) {
+            var value = element.GetAttribute("value");
+            if (string.IsNullOrWhiteSpace(value)) {
+                return NormalizeFormText(element.TextContent).Trim();
+            }
+
+            var max = element.GetAttribute("max");
+            return string.IsNullOrWhiteSpace(max) ? value! : $"{value} / {max}";
+        }
+
         private static string GetOptionText(IElement option) =>
             NormalizeFormText(option.GetAttribute("value") ?? option.TextContent);
+
+        private static List<IElement> GetRadioGroup(IElement element) {
+            var name = element.GetAttribute("name");
+            if (string.IsNullOrWhiteSpace(name)) {
+                return new List<IElement> { element };
+            }
+
+            var root = GetRootElement(element);
+            var explicitFormOwner = element.GetAttribute("form");
+            var ancestorFormOwner = FindAncestorForm(element);
+            return root.QuerySelectorAll("input")
+                .Where(IsRadioInput)
+                .Where(input => string.Equals(input.GetAttribute("name"), name, StringComparison.Ordinal))
+                .Where(input => SameRadioFormOwner(input, explicitFormOwner, ancestorFormOwner))
+                .ToList();
+        }
+
+        private static bool SameRadioFormOwner(IElement element, string? explicitFormOwner, IElement? ancestorFormOwner) {
+            var elementExplicitFormOwner = element.GetAttribute("form");
+            if (!string.IsNullOrWhiteSpace(explicitFormOwner) || !string.IsNullOrWhiteSpace(elementExplicitFormOwner)) {
+                return string.Equals(elementExplicitFormOwner, explicitFormOwner, StringComparison.Ordinal);
+            }
+
+            return ReferenceEquals(FindAncestorForm(element), ancestorFormOwner);
+        }
+
+        private static IElement? FindAncestorForm(IElement element) {
+            var current = element.ParentElement;
+            while (current != null) {
+                if (string.Equals(current.TagName, "form", StringComparison.OrdinalIgnoreCase)) {
+                    return current;
+                }
+
+                current = current.ParentElement;
+            }
+
+            return null;
+        }
+
+        private static string GetRadioOptionText(IElement element) {
+            var value = element.GetAttribute("value");
+            if (!string.IsNullOrEmpty(value)) {
+                return NormalizeFormText(value);
+            }
+
+            var label = GetRadioLabelText(element);
+            if (!string.IsNullOrWhiteSpace(label)) {
+                return label!;
+            }
+
+            return NormalizeFormText(element.GetAttribute("aria-label") ?? element.GetAttribute("title") ?? element.GetAttribute("id") ?? element.GetAttribute("name") ?? "on");
+        }
+
+        private static (string? Alias, string? Tag) GetRadioGroupMetadata(IReadOnlyList<IElement> group) {
+            var checkedInput = group.FirstOrDefault(IsCheckedInput);
+            var first = group[0];
+            var metadataSource = checkedInput ?? first;
+            var name = first.GetAttribute("name");
+            var alias = metadataSource.GetAttribute("aria-label") ?? metadataSource.GetAttribute("title") ?? name ?? metadataSource.GetAttribute("id");
+            var tag = metadataSource.GetAttribute("data-tag") ?? name ?? metadataSource.GetAttribute("id");
+            return (alias, tag);
+        }
+
+        private static bool IsRadioChoiceLabel(IElement element) {
+            if (!string.Equals(element.TagName, "label", StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            if (element.QuerySelectorAll("input").Any(IsRadioInput)) {
+                return true;
+            }
+
+            var targetId = element.GetAttribute("for");
+            if (string.IsNullOrWhiteSpace(targetId)) {
+                return false;
+            }
+
+            var target = FindElementById(GetRootElement(element), targetId!);
+            return target != null && IsRadioInput(target);
+        }
+
+        private static string? GetRadioLabelText(IElement element) {
+            var current = element.ParentElement;
+            while (current != null) {
+                if (string.Equals(current.TagName, "label", StringComparison.OrdinalIgnoreCase)) {
+                    return NormalizeFormText(current.TextContent).Trim();
+                }
+
+                current = current.ParentElement;
+            }
+
+            var id = element.GetAttribute("id");
+            if (string.IsNullOrWhiteSpace(id)) {
+                return null;
+            }
+
+            var root = GetRootElement(element);
+            var labels = root.QuerySelectorAll("label")
+                .Where(label => string.Equals(label.GetAttribute("for"), id, StringComparison.Ordinal))
+                .Select(label => NormalizeFormText(label.TextContent).Trim())
+                .Where(text => text.Length > 0)
+                .ToList();
+
+            return labels.Count == 0 ? null : labels[0];
+        }
+
+        private static IElement GetRootElement(IElement element) {
+            var root = element;
+            while (root.ParentElement != null) {
+                root = root.ParentElement;
+            }
+
+            return root;
+        }
+
+        private static IElement? FindElementById(IElement root, string id) {
+            var stack = new Stack<IElement>();
+            stack.Push(root);
+            while (stack.Count > 0) {
+                var current = stack.Pop();
+                if (string.Equals(current.GetAttribute("id"), id, StringComparison.Ordinal)) {
+                    return current;
+                }
+
+                foreach (var child in current.Children) {
+                    stack.Push(child);
+                }
+            }
+
+            return null;
+        }
 
         private static bool TryGetDataListOptions(IElement element, out List<string> options) {
             options = new List<string>();

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Forms.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Forms.cs
@@ -230,22 +230,24 @@ namespace OfficeIMO.Word.Html {
             }
 
             var root = GetRootElement(element);
-            var explicitFormOwner = element.GetAttribute("form");
-            var ancestorFormOwner = FindAncestorForm(element);
+            var formOwner = ResolveRadioFormOwner(element, root);
             return root.QuerySelectorAll("input")
                 .Where(IsRadioInput)
                 .Where(input => string.Equals(input.GetAttribute("name"), name, StringComparison.Ordinal))
-                .Where(input => SameRadioFormOwner(input, explicitFormOwner, ancestorFormOwner))
+                .Where(input => ReferenceEquals(ResolveRadioFormOwner(input, root), formOwner))
                 .ToList();
         }
 
-        private static bool SameRadioFormOwner(IElement element, string? explicitFormOwner, IElement? ancestorFormOwner) {
-            var elementExplicitFormOwner = element.GetAttribute("form");
-            if (!string.IsNullOrWhiteSpace(explicitFormOwner) || !string.IsNullOrWhiteSpace(elementExplicitFormOwner)) {
-                return string.Equals(elementExplicitFormOwner, explicitFormOwner, StringComparison.Ordinal);
+        private static IElement? ResolveRadioFormOwner(IElement element, IElement root) {
+            var explicitFormOwner = element.GetAttribute("form");
+            if (!string.IsNullOrWhiteSpace(explicitFormOwner)) {
+                var explicitOwner = FindElementById(root, explicitFormOwner!);
+                return explicitOwner != null && string.Equals(explicitOwner.TagName, "form", StringComparison.OrdinalIgnoreCase)
+                    ? explicitOwner
+                    : null;
             }
 
-            return ReferenceEquals(FindAncestorForm(element), ancestorFormOwner);
+            return FindAncestorForm(element);
         }
 
         private static IElement? FindAncestorForm(IElement element) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -30,6 +30,7 @@ namespace OfficeIMO.Word.Html {
             }
 
             var alt = img.AlternativeText ?? string.Empty;
+            var title = img.GetAttribute("title") ?? string.Empty;
             if (options.ImageProcessing == ImageProcessingMode.EmbedDataUriOnly && !src.StartsWith("data:image", StringComparison.OrdinalIgnoreCase)) {
                 AddDiagnostic(options, "ImageSkippedByPolicy", "External image was skipped because only data URI images are enabled.", src);
                 InsertAltText(currentParagraph, headerFooter, doc, alt);
@@ -56,7 +57,8 @@ namespace OfficeIMO.Word.Html {
 
             if (horizontalAlignment == null && _imageCache.TryGetValue(src, out var cached)) {
                 paragraph ??= headerFooter != null ? headerFooter.AddParagraph() : doc.AddParagraph();
-                cached.Clone(paragraph);
+                var clonedImage = cached.Clone(paragraph);
+                ApplyImageMetadata(clonedImage, alt, title);
                 return;
             }
 
@@ -162,6 +164,8 @@ namespace OfficeIMO.Word.Html {
                 }
             }
 
+            ApplyImageMetadata(image, alt, title);
+
             if (horizontalAlignment == null) {
                 _imageCache[src] = image;
             }
@@ -176,6 +180,7 @@ namespace OfficeIMO.Word.Html {
             width ??= TryParsePixelValue(img.GetAttribute("width"));
             height ??= TryParsePixelValue(img.GetAttribute("height"));
             var alt = img.AlternativeText;
+            var title = img.GetAttribute("title") ?? string.Empty;
 
             if (options.ImageProcessing == ImageProcessingMode.EmbedDataUriOnly && !src.StartsWith("data:image", StringComparison.OrdinalIgnoreCase)) {
                 AddDiagnostic(options, "ImageSkippedByPolicy", "External SVG image was skipped because only data URI images are enabled.", src);
@@ -234,6 +239,9 @@ namespace OfficeIMO.Word.Html {
                 try {
                     var paragraph = currentParagraph ?? (headerFooter != null ? headerFooter.AddParagraph() : doc.AddParagraph());
                     SvgHelper.AddSvg(paragraph, svgContent, width, height, alt ?? string.Empty);
+                    if (paragraph.Image != null) {
+                        ApplyImageMetadata(paragraph.Image, alt ?? string.Empty, title);
+                    }
                     _imageCache[src] = paragraph.Image!;
                     reservedBytes = 0;
                 } catch (Exception ex) {
@@ -320,6 +328,11 @@ namespace OfficeIMO.Word.Html {
             }
             var paragraph = currentParagraph ?? (headerFooter != null ? headerFooter.AddParagraph() : doc.AddParagraph());
             paragraph.AddText(alt);
+        }
+
+        private static void ApplyImageMetadata(WordImage image, string alt, string? title) {
+            image.Description = alt;
+            image.Title = string.IsNullOrEmpty(title) ? null : title;
         }
 
         private long EnsureFileWithinImageLimits(string path, HtmlToWordOptions options) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Limits.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Limits.cs
@@ -33,14 +33,43 @@ namespace OfficeIMO.Word.Html {
         }
 
         private void ValidateCssLimit(string css, string? source) {
-            if (!_options.MaxCssBytes.HasValue) {
+            var bytes = Encoding.UTF8.GetByteCount(css);
+            if (_options.MaxCssBytes.HasValue && bytes > _options.MaxCssBytes.Value) {
+                ThrowLimitExceeded(_options, "CssSizeLimitExceeded", "CSS size exceeded the configured conversion limit.", source ?? "stylesheet", bytes, _options.MaxCssBytes.Value);
+            }
+
+            ReserveCssBytes(bytes, source ?? "stylesheet");
+        }
+
+        private void ReserveCssBytes(long length, string source) {
+            if (!_options.MaxTotalCssBytes.HasValue) {
                 return;
             }
 
-            var bytes = Encoding.UTF8.GetByteCount(css);
-            if (bytes > _options.MaxCssBytes.Value) {
-                ThrowLimitExceeded(_options, "CssSizeLimitExceeded", "CSS size exceeded the configured conversion limit.", source ?? "stylesheet", bytes, _options.MaxCssBytes.Value);
+            var remaining = _options.MaxTotalCssBytes.Value - _cssBytesUsed;
+            if (length > remaining) {
+                ThrowLimitExceeded(_options, "CssTotalSizeLimitExceeded", "Total CSS size exceeded the configured conversion limit.", source, _cssBytesUsed + length, _options.MaxTotalCssBytes.Value);
             }
+
+            _cssBytesUsed += length;
+        }
+
+        private (long? Limit, bool LimitedByTotalBudget) GetCssReadLimit() {
+            var limit = _options.MaxCssBytes;
+            var limitedByTotalBudget = false;
+            if (_options.MaxTotalCssBytes.HasValue) {
+                var remaining = _options.MaxTotalCssBytes.Value - _cssBytesUsed;
+                if (remaining <= 0) {
+                    ThrowLimitExceeded(_options, "CssTotalSizeLimitExceeded", "Total CSS size exceeded the configured conversion limit.", "MaxTotalCssBytes", _cssBytesUsed, _options.MaxTotalCssBytes.Value);
+                }
+
+                if (!limit.HasValue || remaining < limit.Value) {
+                    limit = remaining;
+                    limitedByTotalBudget = true;
+                }
+            }
+
+            return (limit, limitedByTotalBudget);
         }
 
         private void ValidateTableLimit(HtmlToWordOptions options, int rows, int columns) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
@@ -164,15 +164,18 @@ namespace OfficeIMO.Word.Html {
                 trimmed = trimmed.Substring(0, importantIndex).Trim();
             }
             var token = trimmed.TrimEnd(',');
+            var quoted = false;
             if (token.Length >= 2 && ((token[0] == '\'' && token[token.Length - 1] == '\'') || (token[0] == '"' && token[token.Length - 1] == '"'))) {
+                quoted = true;
                 token = token.Substring(1, token.Length - 2);
             }
             token = DecodeCssStringToken(token);
             if (token.StartsWith("url(", StringComparison.OrdinalIgnoreCase)) {
                 return null;
             }
-            token = token.Trim().ToLowerInvariant();
-            return token switch {
+            var normalizedToken = token.Trim();
+            var lowerToken = normalizedToken.ToLowerInvariant();
+            return lowerToken switch {
                 "disc" => "disc",
                 "circle" => "circle",
                 "square" => "square",
@@ -203,7 +206,11 @@ namespace OfficeIMO.Word.Html {
                 "en-dash" => "en-dash",
                 "\u2014" => "em-dash",
                 "em-dash" => "em-dash",
-                _ => null,
+                "*" => "asterisk",
+                "asterisk" => "asterisk",
+                "+" => "plus",
+                "plus" => "plus",
+                _ => quoted && normalizedToken.Length > 0 ? "custom:" + normalizedToken : null,
             };
         }
 
@@ -338,6 +345,17 @@ namespace OfficeIMO.Word.Html {
                 case "em-dash":
                     level.LevelText = "\u2014";
                     break;
+                case "asterisk":
+                    level.LevelText = "*";
+                    break;
+                case "plus":
+                    level.LevelText = "+";
+                    break;
+                default:
+                    if (bulletToken.StartsWith("custom:", StringComparison.Ordinal)) {
+                        level.LevelText = token.Substring("custom:".Length);
+                    }
+                    break;
                 // disc/default -> no change
             }
         }
@@ -347,6 +365,7 @@ namespace OfficeIMO.Word.Html {
             var list = listStack.Peek();
             int level = listStack.Count - 1;
             var paragraph = list.AddItem("", level);
+            WordParagraph? blockAnchor = paragraph;
 
             ApplyParagraphStyleFromCss(paragraph, element);
             ApplyClassStyle(element, paragraph, options);
@@ -356,9 +375,80 @@ namespace OfficeIMO.Word.Html {
                 paragraph.BiDi = bidi.Value;
             }
             foreach (var child in element.ChildNodes) {
-                ProcessNode(child, doc, section, options, paragraph, listStack, formatting, cell, headerFooter);
+                if (IsListItemTableChild(child)) {
+                    var tableAnchor = blockAnchor ?? paragraph;
+                    ProcessNode(child, doc, section, options, tableAnchor, listStack, formatting, cell, headerFooter);
+                    blockAnchor = GetTrailingAnchorAfterTable(tableAnchor, section, cell, headerFooter);
+                    continue;
+                }
+
+                var anchor = IsListItemBlockChild(child) ? blockAnchor : paragraph;
+                ProcessNode(child, doc, section, options, anchor, listStack, formatting, cell, headerFooter);
+                if (IsListItemBlockChild(child)) {
+                    blockAnchor = GetLastParagraphInSameContainer(paragraph, section, cell, headerFooter);
+                }
             }
             ApplyPageBreakAfterFromCss(paragraph, element);
+        }
+
+        private static bool IsListItemTableChild(INode node) =>
+            node is IElement element && string.Equals(element.TagName, "table", StringComparison.OrdinalIgnoreCase);
+
+        private static bool IsListItemBlockChild(INode node) =>
+            node is IElement element && _blockTags.Contains(element.TagName);
+
+        private static WordParagraph GetLastParagraphInSameContainer(
+            WordParagraph anchor,
+            WordSection section,
+            WordTableCell? cell,
+            WordHeaderFooter? headerFooter) {
+            var parent = anchor._paragraph.Parent;
+            var paragraphs = GetParagraphsInScope(section, cell, headerFooter);
+            for (int i = paragraphs.Count - 1; i >= 0; i--) {
+                var candidate = paragraphs[i];
+                if (ReferenceEquals(candidate._paragraph.Parent, parent)) {
+                    return candidate;
+                }
+            }
+
+            return anchor;
+        }
+
+        private static WordParagraph? GetTrailingAnchorAfterTable(
+            WordParagraph anchor,
+            WordSection section,
+            WordTableCell? cell,
+            WordHeaderFooter? headerFooter) {
+            if (cell != null || headerFooter != null) {
+                return GetLastParagraphInSameContainer(anchor, section, cell, headerFooter);
+            }
+
+            var parent = anchor._paragraph.Parent;
+            if (parent == null) {
+                return null;
+            }
+
+            var children = parent.ChildElements.ToList();
+            var anchorIndex = children.IndexOf(anchor._paragraph);
+            if (anchorIndex < 0) {
+                return null;
+            }
+
+            var table = children
+                .Skip(anchorIndex + 1)
+                .OfType<Table>()
+                .LastOrDefault();
+            if (table == null) {
+                return null;
+            }
+
+            var trailing = table.NextSibling<Paragraph>();
+            if (trailing == null) {
+                trailing = new Paragraph();
+                table.InsertAfterSelf(trailing);
+            }
+
+            return new WordParagraph(anchor._document, trailing);
         }
 
         private static bool TryGetListItemValue(IHtmlListItemElement element, out int value) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -33,6 +33,16 @@ namespace OfficeIMO.Word.Html {
             return false;
         }
 
+        private static WordParagraph AddParagraphInScope(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter) {
+            if (cell != null) {
+                var paragraphs = cell.Paragraphs;
+                bool removeExisting = paragraphs.Count == 1 && string.IsNullOrEmpty(paragraphs[0].Text);
+                return cell.AddParagraph("", removeExisting);
+            }
+
+            return headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+        }
+
         private static List<WordParagraph> GetParagraphsInScope(WordSection section, WordTableCell? cell, WordHeaderFooter? headerFooter) =>
             cell?.Paragraphs ?? headerFooter?.Paragraphs ?? section.Paragraphs;
 
@@ -132,7 +142,7 @@ namespace OfficeIMO.Word.Html {
                                 }
                                 var secId = element.GetAttribute("id");
                                 if (!string.IsNullOrEmpty(secId)) {
-                                    var paragraph = section.Paragraphs.Count > startIndex ? section.Paragraphs[startIndex] : (cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph(""));
+                                    var paragraph = section.Paragraphs.Count > startIndex ? section.Paragraphs[startIndex] : AddParagraphInScope(section, cell, headerFooter);
                                     WordBookmark.AddBookmark(paragraph, $"section:{secId}");
                                 }
                             }
@@ -167,7 +177,7 @@ namespace OfficeIMO.Word.Html {
                             }
                             var id = element.GetAttribute("id");
                             if (!string.IsNullOrEmpty(id)) {
-                                var paragraph = section.Paragraphs.Count > startIndex ? section.Paragraphs[startIndex] : (cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph(""));
+                                var paragraph = section.Paragraphs.Count > startIndex ? section.Paragraphs[startIndex] : AddParagraphInScope(section, cell, headerFooter);
                                 WordBookmark.AddBookmark(paragraph, $"{element.TagName.ToLowerInvariant()}:{id}");
                             }
                             ApplyContainerPageBreaksFromCss(element, GetGeneratedParagraphs(section, cell, headerFooter, scopeStartIndex));
@@ -184,7 +194,7 @@ namespace OfficeIMO.Word.Html {
                             if (options.SupportsHeadingNumbering && headingList != null && cell == null) {
                                 paragraph = headingList.AddItem("", level - 1);
                             } else {
-                                paragraph = cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                                paragraph = AddParagraphInScope(section, cell, headerFooter);
                             }
                             paragraph.Style = HeadingStyleMapper.GetHeadingStyleForLevel(level);
                             var fmt = formatting;
@@ -203,7 +213,7 @@ namespace OfficeIMO.Word.Html {
                             break;
                         }
                     case "p": {
-                            var paragraph = cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                            var paragraph = AddParagraphInScope(section, cell, headerFooter);
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
                             var props = ApplyParagraphStyleFromCss(paragraph, element);
@@ -220,7 +230,7 @@ namespace OfficeIMO.Word.Html {
                             break;
                         }
                     case "dt": {
-                            var paragraph = cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                            var paragraph = AddParagraphInScope(section, cell, headerFooter);
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
                             var props = ApplyParagraphStyleFromCss(paragraph, element);
@@ -228,6 +238,7 @@ namespace OfficeIMO.Word.Html {
                                 fmt.WhiteSpace = props.WhiteSpace.Value;
                             }
                             ApplyClassStyle(element, paragraph, options);
+                            paragraph.SetStyleId(HtmlSemanticStyleIds.DefinitionTerm);
                             ApplyBidiIfPresent(element, paragraph);
                             AddBookmarkIfPresent(element, paragraph);
                             foreach (var child in element.ChildNodes) {
@@ -237,7 +248,7 @@ namespace OfficeIMO.Word.Html {
                             break;
                         }
                     case "dd": {
-                            var paragraph = cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                            var paragraph = AddParagraphInScope(section, cell, headerFooter);
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
                             var props = ApplyParagraphStyleFromCss(paragraph, element);
@@ -245,6 +256,7 @@ namespace OfficeIMO.Word.Html {
                                 fmt.WhiteSpace = props.WhiteSpace.Value;
                             }
                             ApplyClassStyle(element, paragraph, options);
+                            paragraph.SetStyleId(HtmlSemanticStyleIds.DefinitionDescription);
                             ApplyBidiIfPresent(element, paragraph);
                             AddBookmarkIfPresent(element, paragraph);
                             var currentIndent = paragraph.IndentationBefore ?? 0;
@@ -258,23 +270,25 @@ namespace OfficeIMO.Word.Html {
                             break;
                         }
                     case "blockquote": {
-                            var startIndex = doc.Paragraphs.Count;
+                            var startIndex = GetParagraphsInScope(section, cell, headerFooter).Count;
                             var cite = element.GetAttribute("cite");
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
                             WordParagraph? firstPara = null;
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, firstPara, listStack, fmt, cell, headerFooter, headingList);
-                                if (firstPara == null && doc.Paragraphs.Count > startIndex) {
-                                    firstPara = doc.Paragraphs[startIndex];
+                                var scopedParagraphs = GetParagraphsInScope(section, cell, headerFooter);
+                                if (firstPara == null && scopedParagraphs.Count > startIndex) {
+                                    firstPara = scopedParagraphs[startIndex];
                                 }
                             }
                             if (firstPara == null) {
-                                firstPara = cell?.AddParagraph("", true) ?? headerFooter?.AddParagraph("") ?? section.AddParagraph("");
+                                firstPara = AddParagraphInScope(section, cell, headerFooter);
                             }
-                            var endIndex = doc.Paragraphs.Count;
+                            var blockquoteParagraphs = GetParagraphsInScope(section, cell, headerFooter);
+                            var endIndex = blockquoteParagraphs.Count;
                             for (int i = startIndex; i < endIndex; i++) {
-                                var para = doc.Paragraphs[i];
+                                var para = blockquoteParagraphs[i];
                                 if (doc.StyleExists("Quote")) {
                                     para.SetStyleId("Quote");
                                 }
@@ -287,7 +301,9 @@ namespace OfficeIMO.Word.Html {
                                 }
                             }
                             if (!string.IsNullOrEmpty(cite)) {
+                                HtmlSemanticMetadata.SetBlockquoteCite(firstPara!, cite);
                                 var noteRef = AddNoteReference(firstPara!, cite ?? string.Empty, options);
+                                noteRef.SetCharacterStyleId(HtmlSemanticStyleIds.BlockquoteCite);
                                 TryLinkNoteReference(noteRef, cite ?? string.Empty, options);
                             }
                             break;
@@ -330,7 +346,7 @@ namespace OfficeIMO.Word.Html {
                             break;
                         }
                     case "br": {
-                            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                             currentParagraph.AddBreak();
                             break;
                         }
@@ -363,6 +379,7 @@ namespace OfficeIMO.Word.Html {
                     case "u": {
                             var fmt = formatting;
                             fmt.Underline = true;
+                            fmt.UnderlineStyle ??= UnderlineValues.Single;
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);
                             }
@@ -370,46 +387,67 @@ namespace OfficeIMO.Word.Html {
                         }
                     case "s":
                     case "del": {
+                            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                             var fmt = formatting;
                             fmt.Strike = true;
+                            int startRuns = currentParagraph.GetRuns().Count();
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);
+                            }
+                            if (string.Equals(element.TagName, "del", StringComparison.OrdinalIgnoreCase)) {
+                                var runs = currentParagraph.GetRuns().ToList();
+                                for (int i = startRuns; i < runs.Count; i++) {
+                                    runs[i].SetCharacterStyleId(HtmlSemanticStyleIds.DeletedText);
+                                }
                             }
                             break;
                         }
                     case "ins": {
+                            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                             var fmt = formatting;
                             fmt.Underline = true;
+                            fmt.UnderlineStyle ??= UnderlineValues.Single;
+                            int startRuns = currentParagraph.GetRuns().Count();
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);
+                            }
+                            var runs = currentParagraph.GetRuns().ToList();
+                            for (int i = startRuns; i < runs.Count; i++) {
+                                runs[i].SetCharacterStyleId(HtmlSemanticStyleIds.InsertedText);
                             }
                             break;
                         }
                     case "mark": {
+                            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                             var fmt = formatting;
                             fmt.Highlight = HighlightColorValues.Yellow;
+                            int startRuns = currentParagraph.GetRuns().Count();
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);
+                            }
+                            var runs = currentParagraph.GetRuns().ToList();
+                            for (int i = startRuns; i < runs.Count; i++) {
+                                runs[i].SetCharacterStyleId(HtmlSemanticStyleIds.MarkedText);
                             }
                             break;
                         }
                     case "q": {
-                            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
-                            var open = currentParagraph.AddFormattedText(options.QuotePrefix, fmt.Bold, fmt.Italic, fmt.Underline ? UnderlineValues.Single : null);
+                            var open = currentParagraph.AddFormattedText(options.QuotePrefix, fmt.Bold, fmt.Italic, GetUnderlineValue(fmt));
                             ApplyFormatting(open, fmt, options);
                             open.SetCharacterStyleId("HtmlQuote");
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);
                             }
-                            var close = currentParagraph.AddFormattedText(options.QuoteSuffix, fmt.Bold, fmt.Italic, fmt.Underline ? UnderlineValues.Single : null);
+                            var close = currentParagraph.AddFormattedText(options.QuoteSuffix, fmt.Bold, fmt.Italic, GetUnderlineValue(fmt));
                             ApplyFormatting(close, fmt, options);
                             close.SetCharacterStyleId("HtmlQuote");
                             break;
                         }
                     case "cite": {
-                            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                             var fmt = formatting;
                             fmt.Italic = true;
                             ApplySpanStyles(element, ref fmt);
@@ -424,7 +462,7 @@ namespace OfficeIMO.Word.Html {
                             break;
                         }
                     case "dfn": {
-                            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                             var fmt = formatting;
                             fmt.Italic = true;
                             ApplySpanStyles(element, ref fmt);
@@ -439,9 +477,10 @@ namespace OfficeIMO.Word.Html {
                             break;
                         }
                     case "time": {
-                            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
+                            var dateTime = element.GetAttribute("datetime");
                             int startRuns = currentParagraph.GetRuns().Count();
                             foreach (var child in element.ChildNodes) {
                                 ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);
@@ -449,6 +488,7 @@ namespace OfficeIMO.Word.Html {
                             var runs = currentParagraph.GetRuns().ToList();
                             for (int i = startRuns; i < runs.Count; i++) {
                                 runs[i].SetCharacterStyleId("HtmlTime");
+                                HtmlSemanticMetadata.SetTimeDateTime(runs[i], dateTime);
                             }
                             break;
                         }
@@ -530,7 +570,17 @@ namespace OfficeIMO.Word.Html {
                             }
                             break;
                         }
-                    case "ruby":
+                    case "ruby": {
+                            var fmt = formatting;
+                            ApplySpanStyles(element, ref fmt);
+                            if (TryProcessRubyElement(element, section, options, currentParagraph, fmt, cell, headerFooter)) {
+                                break;
+                            }
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);
+                            }
+                            break;
+                        }
                     case "rb":
                     case "rt":
                     case "rp": {
@@ -551,7 +601,7 @@ namespace OfficeIMO.Word.Html {
                         }
                     case "abbr":
                     case "acronym": {
-                            currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                             var title = element.GetAttribute("title");
                             var fmt = formatting;
                             ApplySpanStyles(element, ref fmt);
@@ -559,7 +609,7 @@ namespace OfficeIMO.Word.Html {
                                 ProcessNode(child, doc, section, options, currentParagraph, listStack, fmt, cell, headerFooter, headingList);
                             }
                             if (!string.IsNullOrEmpty(title)) {
-                                currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                                currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                                 var fnRun = AddNoteReference(currentParagraph, title ?? string.Empty, options);
                                 fnRun.SetCharacterStyleId("HtmlAbbr");
                                 TryLinkNoteReference(fnRun, title ?? string.Empty, options);
@@ -573,7 +623,7 @@ namespace OfficeIMO.Word.Html {
                             var idAttr = element.GetAttribute("id");
                             var nameAttr = element.GetAttribute("name");
                             if (!string.IsNullOrEmpty(idAttr) || !string.IsNullOrEmpty(nameAttr)) {
-                                currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                                currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                                 AddBookmarkIfPresent(element, currentParagraph);
                             }
                             if (string.IsNullOrWhiteSpace(href)) {
@@ -622,7 +672,7 @@ namespace OfficeIMO.Word.Html {
                                     break;
                                 }
 
-                                currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                                currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                                 var fmtAnchor = formatting;
                                 ApplySpanStyles(element, ref fmtAnchor);
                                 var hasBlockAnchor = HasBlockDescendant(element);
@@ -682,7 +732,7 @@ namespace OfficeIMO.Word.Html {
                             }
 
                             try {
-                                currentParagraph ??= cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
+                                currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
                                 var fmtExternal = formatting;
                                 ApplySpanStyles(element, ref fmtExternal);
                                 var hasBlock = HasBlockDescendant(element);
@@ -741,25 +791,7 @@ namespace OfficeIMO.Word.Html {
                             break;
                         }
                     case "figure": {
-                            WordParagraph? figPara = currentParagraph;
-                            foreach (var child in element.ChildNodes) {
-                                if (child is IElement childEl && string.Equals(childEl.TagName, "figcaption", StringComparison.OrdinalIgnoreCase)) {
-                                    ApplyCssToElement(childEl);
-                                    var paragraph = cell != null ? cell.AddParagraph("", true) : headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
-                                    paragraph.SetStyleId("Caption");
-                                    ApplyParagraphStyleFromCss(paragraph, childEl);
-                                    ApplyClassStyle(childEl, paragraph, options);
-                                    AddBookmarkIfPresent(childEl, paragraph);
-                                    foreach (var captionChild in childEl.ChildNodes) {
-                                        ProcessNode(captionChild, doc, section, options, paragraph, listStack, formatting, cell, headerFooter, headingList);
-                                    }
-                                } else {
-                                    ProcessNode(child, doc, section, options, figPara, listStack, formatting, cell, headerFooter, headingList);
-                                    if (figPara == null && doc.Paragraphs.Count > 0) {
-                                        figPara = doc.Paragraphs.Last();
-                                    }
-                                }
-                            }
+                            ProcessFigureElement(element, doc, section, options, currentParagraph, listStack, formatting, cell, headerFooter, headingList);
                             break;
                         }
                     case "img": {
@@ -768,8 +800,25 @@ namespace OfficeIMO.Word.Html {
                         }
                     case "input":
                     case "select":
-                    case "textarea": {
+                    case "textarea":
+                    case "meter":
+                    case "progress": {
                             ProcessFormControl(element, section, options, currentParagraph, formatting, cell, headerFooter);
+                            break;
+                        }
+                    case "label": {
+                            if (IsRadioChoiceLabel(element)) {
+                                foreach (var radio in element.QuerySelectorAll("input").Where(IsRadioInput)) {
+                                    ProcessFormControl(radio, section, options, currentParagraph, formatting, cell, headerFooter);
+                                }
+
+                                break;
+                            }
+
+                            foreach (var child in element.ChildNodes) {
+                                ProcessNode(child, doc, section, options, currentParagraph, listStack, formatting, cell, headerFooter, headingList);
+                            }
+
                             break;
                         }
                     case "datalist": {
@@ -778,6 +827,15 @@ namespace OfficeIMO.Word.Html {
                     case "script":
                     case "template": {
                             AddDiagnostic(options, "HtmlElementSkipped", "HTML element content was skipped because it is not rendered as document content.", element.TagName.ToLowerInvariant());
+                            break;
+                        }
+                    case "iframe":
+                    case "object":
+                    case "embed":
+                    case "video":
+                    case "audio":
+                    case "canvas": {
+                            AddDiagnostic(options, "HtmlEmbeddedContentSkipped", "Embedded HTML content was skipped because it does not have a Word conversion contract.", element.TagName.ToLowerInvariant());
                             break;
                         }
                     case "style": {
@@ -795,6 +853,8 @@ namespace OfficeIMO.Word.Html {
                             break;
                         }
                 }
+            } else if (node is IComment commentNode) {
+                ProcessRawHtmlComment(commentNode, section, ref currentParagraph, cell, headerFooter, options);
             } else if (node is IText textNode) {
                 var text = textNode.Text;
                 if (string.IsNullOrEmpty(text)) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Ruby.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Ruby.cs
@@ -1,0 +1,90 @@
+using AngleSharp.Dom;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+using System.Globalization;
+using System.Text;
+
+namespace OfficeIMO.Word.Html {
+    internal partial class HtmlToWordConverter {
+        private static bool TryProcessRubyElement(IElement element, WordSection section, HtmlToWordOptions options, WordParagraph? currentParagraph, TextFormatting formatting, WordTableCell? cell, WordHeaderFooter? headerFooter) {
+            if (!TryExtractRubyText(element, out var baseText, out var rubyText)) {
+                return false;
+            }
+
+            currentParagraph ??= AddParagraphInScope(section, cell, headerFooter);
+            currentParagraph._paragraph.AppendChild(new Run(new Ruby(
+                new RubyProperties(
+                    new RubyAlign { Val = RubyAlignValues.Center },
+                    new PhoneticGuideTextFontSize { Val = "10" },
+                    new PhoneticGuideRaise { Val = 18 },
+                    new PhoneticGuideBaseTextSize { Val = "20" },
+                    new LanguageId { Val = string.IsNullOrWhiteSpace(formatting.Language) ? "en-US" : formatting.Language! }),
+                new RubyContent(CreateRubyRun(rubyText, formatting, options)),
+                new RubyBase(CreateRubyRun(baseText, formatting, options)))));
+            return true;
+        }
+
+        private static bool TryExtractRubyText(IElement element, out string baseText, out string rubyText) {
+            var baseBuilder = new StringBuilder();
+            var rubyBuilder = new StringBuilder();
+
+            foreach (var child in element.ChildNodes) {
+                if (child is IElement childElement) {
+                    var tagName = childElement.TagName.ToLowerInvariant();
+                    if (tagName == "rt") {
+                        rubyBuilder.Append(childElement.TextContent);
+                    } else if (tagName == "rp") {
+                        continue;
+                    } else if (tagName == "rb") {
+                        baseBuilder.Append(childElement.TextContent);
+                    } else {
+                        baseBuilder.Append(childElement.TextContent);
+                    }
+                } else {
+                    baseBuilder.Append(child.TextContent);
+                }
+            }
+
+            baseText = NormalizeRubyText(baseBuilder.ToString());
+            rubyText = NormalizeRubyText(rubyBuilder.ToString());
+            return !string.IsNullOrWhiteSpace(baseText) && !string.IsNullOrWhiteSpace(rubyText);
+        }
+
+        private static string NormalizeRubyText(string text) =>
+            string.Join(" ", text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+        private static Run CreateRubyRun(string text, TextFormatting formatting, HtmlToWordOptions options) {
+            var run = new Run();
+            var properties = CreateRubyRunProperties(formatting, options);
+            if (properties.HasChildren || properties.HasAttributes) {
+                run.AppendChild(properties);
+            }
+            run.AppendChild(new Text(text) { Space = SpaceProcessingModeValues.Preserve });
+            return run;
+        }
+
+        private static RunProperties CreateRubyRunProperties(TextFormatting formatting, HtmlToWordOptions options) {
+            var properties = new RunProperties();
+            if (formatting.Bold) properties.AppendChild(new Bold());
+            if (formatting.Italic) properties.AppendChild(new Italic());
+            if (formatting.Underline) properties.AppendChild(new Underline { Val = GetUnderlineValue(formatting) ?? UnderlineValues.Single });
+            if (formatting.Strike) properties.AppendChild(new Strike());
+            if (formatting.Superscript) properties.AppendChild(new VerticalTextAlignment { Val = VerticalPositionValues.Superscript });
+            if (formatting.Subscript) properties.AppendChild(new VerticalTextAlignment { Val = VerticalPositionValues.Subscript });
+            if (!string.IsNullOrEmpty(formatting.ColorHex)) properties.AppendChild(new Color { Val = formatting.ColorHex!.TrimStart('#') });
+            if (formatting.Highlight.HasValue) properties.AppendChild(new Highlight { Val = formatting.Highlight.Value });
+            if (formatting.FontSize.HasValue) properties.AppendChild(new FontSize { Val = (formatting.FontSize.Value * 2).ToString(CultureInfo.InvariantCulture) });
+            if (formatting.Caps == CapsStyle.SmallCaps) properties.AppendChild(new SmallCaps());
+            if (formatting.Caps == CapsStyle.Caps) properties.AppendChild(new Caps());
+            if (formatting.LetterSpacing.HasValue) properties.AppendChild(new Spacing { Val = formatting.LetterSpacing.Value });
+            if (!string.IsNullOrWhiteSpace(formatting.Language)) properties.AppendChild(new Languages { Val = formatting.Language! });
+
+            var font = ResolveFontFamily(formatting.FontFamily) ?? ResolveFontFamily(options.FontFamily);
+            if (!string.IsNullOrEmpty(font)) {
+                properties.AppendChild(new RunFonts { Ascii = font, HighAnsi = font, EastAsia = font, ComplexScript = font });
+            }
+
+            return properties;
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.Links.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.Links.cs
@@ -2,41 +2,123 @@ using AngleSharp;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace OfficeIMO.Word.Html {
     internal partial class HtmlToWordConverter {
+        private async Task LoadConfiguredStylesheetsAsync(IDocument document, HtmlToWordOptions options, CancellationToken cancellationToken) {
+            foreach (var path in options.StylesheetPaths) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (string.IsNullOrEmpty(path)) {
+                    continue;
+                }
+
+                if (Uri.TryCreate(path, UriKind.Absolute, out var absolute)) {
+                    if (absolute.Scheme == Uri.UriSchemeHttp || absolute.Scheme == Uri.UriSchemeHttps) {
+                        await LoadAndParseCssAsync(new Url(absolute.ToString()), cancellationToken).ConfigureAwait(false);
+                    } else if (absolute.Scheme == Uri.UriSchemeFile && File.Exists(absolute.LocalPath)) {
+                        if (TryApplyStylesheetUriPolicy(absolute, absolute.ToString())) {
+                            ParseCss(ReadCssFileWithLimit(absolute.LocalPath), absolute.LocalPath);
+                        }
+                    }
+                } else if (document.BaseUrl != null) {
+                    var url = new Url(new Url(document.BaseUrl), path);
+                    if (url.Scheme == "http" || url.Scheme == "https") {
+                        await LoadAndParseCssAsync(url, cancellationToken).ConfigureAwait(false);
+                    } else if (url.Scheme == "file") {
+                        TryLoadCssFromFileUrl(url);
+                    }
+                } else if (File.Exists(path)) {
+                    if (TryApplyLocalStylesheetPolicy(path)) {
+                        ParseCss(ReadCssFileWithLimit(path), path);
+                    }
+                }
+            }
+
+            foreach (var content in options.StylesheetContents) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!string.IsNullOrEmpty(content)) {
+                    ParseCss(content);
+                }
+            }
+        }
+
+        private async Task LoadHeadStylesheetsAsync(IDocument document, CancellationToken cancellationToken) {
+            if (document.Head == null) {
+                return;
+            }
+
+            Uri? baseUri = null;
+            if (document.BaseUrl != null && Uri.TryCreate(document.BaseUrl.Href, UriKind.Absolute, out var documentBaseUri)) {
+                baseUri = documentBaseUri;
+            }
+
+            foreach (var node in document.Head.ChildNodes) {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (node is IHtmlBaseElement baseElement) {
+                    if (Uri.TryCreate(baseElement.Href, UriKind.Absolute, out var headBaseUri)) {
+                        baseUri = headBaseUri;
+                    }
+                    continue;
+                }
+
+                if (node is IHtmlStyleElement styleElement) {
+                    ParseCss(styleElement.TextContent);
+                    continue;
+                }
+
+                if (node is IHtmlLinkElement linkElement) {
+                    await ProcessStylesheetLinkElementAsync(linkElement, baseUri, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
         private void ProcessLinkedStylesheetElement(IElement element) {
+            ProcessStylesheetLinkElementAsync(element, baseUri: null, _cancellationToken).GetAwaiter().GetResult();
+        }
+
+        private async Task ProcessStylesheetLinkElementAsync(IElement element, Uri? baseUri, CancellationToken cancellationToken) {
             var rel = element.GetAttribute("rel");
             if (!string.Equals(rel, "stylesheet", StringComparison.OrdinalIgnoreCase)) {
                 return;
             }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var hrefAttr = element.GetAttribute("href");
+            var href = (element as IHtmlLinkElement)?.Href ?? hrefAttr;
             if (!_options.AllowDocumentStylesheetLinks) {
-                AddDiagnostic(_options, "HtmlStylesheetLinkSkipped", "HTML stylesheet link was skipped because document-provided stylesheet links are disabled.", "link");
+                AddDiagnostic(_options, "HtmlStylesheetLinkSkipped", "HTML stylesheet link was skipped because document-provided stylesheet links are disabled.", string.IsNullOrEmpty(href) ? "link" : href);
                 return;
             }
 
-            var hrefAttr = element.GetAttribute("href");
-            var href = (element as IHtmlLinkElement)?.Href ?? hrefAttr;
             if (string.IsNullOrEmpty(href)) {
+                AddDiagnostic(_options, "HtmlStylesheetLinkMissingHref", "HTML stylesheet link was skipped because it does not have an href attribute.", "link");
                 return;
             }
 
             if (!string.IsNullOrEmpty(hrefAttr) && File.Exists(hrefAttr)) {
-                ParseCss(File.ReadAllText(hrefAttr), hrefAttr);
+                if (TryApplyLocalStylesheetPolicy(hrefAttr!)) {
+                    ParseCss(ReadCssFileWithLimit(hrefAttr!), hrefAttr);
+                }
                 return;
             }
 
             var url = new Url(href);
-            if (!url.IsAbsolute && element.BaseUrl != null) {
+            if (!url.IsAbsolute && baseUri != null) {
+                url = new Url(new Url(baseUri.ToString()), href);
+            } else if (!url.IsAbsolute && element.BaseUrl != null) {
                 url = new Url(new Url(element.BaseUrl), href);
             }
 
             if (url.Scheme == "http" || url.Scheme == "https") {
                 if (_context != null) {
-                    LoadAndParseCssAsync(_context, url, CancellationToken.None).GetAwaiter().GetResult();
+                    await LoadAndParseCssAsync(url, cancellationToken).ConfigureAwait(false);
                 }
             } else if (url.Scheme == "file") {
                 TryLoadCssFromFileUrl(url);
+            } else if (url.IsAbsolute && Uri.TryCreate(url.Href, UriKind.Absolute, out var unsupportedUri)) {
+                TryApplyStylesheetUriPolicy(unsupportedUri, url.Href);
             }
         }
     }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.Links.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.Links.cs
@@ -88,7 +88,8 @@ namespace OfficeIMO.Word.Html {
             var hrefAttr = element.GetAttribute("href");
             var href = (element as IHtmlLinkElement)?.Href ?? hrefAttr;
             if (!_options.AllowDocumentStylesheetLinks) {
-                AddDiagnostic(_options, "HtmlStylesheetLinkSkipped", "HTML stylesheet link was skipped because document-provided stylesheet links are disabled.", string.IsNullOrEmpty(href) ? "link" : href);
+                var source = !string.IsNullOrEmpty(hrefAttr) ? hrefAttr : href;
+                AddDiagnostic(_options, "HtmlStylesheetLinkSkipped", "HTML stylesheet link was skipped because document-provided stylesheet links are disabled.", string.IsNullOrEmpty(source) ? "link" : source);
                 return;
             }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.cs
@@ -16,24 +16,30 @@ using System.Threading.Tasks;
 
 namespace OfficeIMO.Word.Html {
     internal partial class HtmlToWordConverter {
-        private async Task LoadAndParseCssAsync(IBrowsingContext context, Url url, CancellationToken cancellationToken) {
-            var loader = context.GetService<IResourceLoader>();
-            if (loader == null) {
+        private async Task LoadAndParseCssAsync(Url url, CancellationToken cancellationToken) {
+            if (!Uri.TryCreate(url.Href, UriKind.Absolute, out var uri)) {
                 return;
             }
-            var request = new ResourceRequest(null!, url);
-            var download = loader.FetchAsync(request);
-            var response = await download.Task.ConfigureAwait(false);
-            cancellationToken.ThrowIfCancellationRequested();
-            if (response.StatusCode == HttpStatusCode.OK) {
-                using var reader = new StreamReader(response.Content);
-#if NET8_0_OR_GREATER
-                var css = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-#else
-                var css = await reader.ReadToEndAsync().ConfigureAwait(false);
-                cancellationToken.ThrowIfCancellationRequested();
-#endif
-                ParseCss(css, url.Href);
+
+            if (!TryApplyStylesheetUriPolicy(uri, url.Href)) {
+                return;
+            }
+
+            try {
+                var css = await FetchCssStringAsync(uri, url.Href, cancellationToken).ConfigureAwait(false);
+                if (css != null) {
+                    ParseCss(css, url.Href);
+                }
+            } catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested) {
+                AddDiagnostic(_options, "StylesheetLoadTimedOut", "Stylesheet resource timed out or was canceled by the resource pipeline and was skipped.", url.Href, ex);
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (HttpRequestException ex) {
+                AddDiagnostic(_options, "StylesheetTransportFailed", "Stylesheet resource could not be fetched and was skipped.", url.Href, ex);
+            } catch (HtmlConversionLimitException) {
+                throw;
+            } catch (Exception ex) {
+                AddDiagnostic(_options, "StylesheetLoadFailed", "Stylesheet resource could not be loaded and was skipped.", url.Href, ex);
             }
         }
 
@@ -42,12 +48,16 @@ namespace OfficeIMO.Word.Html {
                 return;
             }
 
+            if (!TryApplyStylesheetUriPolicy(fileUri, url.Href)) {
+                return;
+            }
+
             var localPath = fileUri.LocalPath;
             if (string.IsNullOrEmpty(localPath) || !File.Exists(localPath)) {
                 return;
             }
 
-            ParseCss(File.ReadAllText(localPath), localPath);
+            ParseCss(ReadCssFileWithLimit(localPath), localPath);
         }
 
         private void ParseLeadingStylesheetChildren(IElement element) {
@@ -66,35 +76,136 @@ namespace OfficeIMO.Word.Html {
                     if (!string.Equals(rel, "stylesheet", StringComparison.OrdinalIgnoreCase)) {
                         break;
                     }
-                    if (!_options.AllowDocumentStylesheetLinks) {
-                        AddDiagnostic(_options, "HtmlStylesheetLinkSkipped", "HTML stylesheet link was skipped because document-provided stylesheet links are disabled.", "link");
-                        continue;
-                    }
-
-                    var hrefAttr = linkElement.GetAttribute("href");
-                    var href = linkElement.Href ?? hrefAttr;
-                    if (string.IsNullOrEmpty(href)) {
-                        continue;
-                    }
-
-                    if (!string.IsNullOrEmpty(hrefAttr) && File.Exists(hrefAttr)) {
-                        ParseCss(File.ReadAllText(hrefAttr), hrefAttr);
-                        continue;
-                    }
-
-                    var url = new Url(href);
-                    if (!url.IsAbsolute && linkElement.BaseUrl != null) {
-                        url = new Url(new Url(linkElement.BaseUrl), href);
-                    }
-
-                    if (url.Scheme == "file") {
-                        TryLoadCssFromFileUrl(url);
-                    }
+                    ProcessStylesheetLinkElementAsync(linkElement, baseUri: null, _cancellationToken).GetAwaiter().GetResult();
                     continue;
                 }
 
                 break;
             }
+        }
+
+        private async Task<string?> FetchCssStringAsync(Uri uri, string source, CancellationToken cancellationToken) {
+            using var cts = _resourceTimeout.HasValue
+                ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+                : null;
+            var token = cts?.Token ?? cancellationToken;
+            if (cts != null && _resourceTimeout.HasValue) {
+                cts.CancelAfter(_resourceTimeout.Value);
+            }
+
+            using var request = new HttpRequestMessage(System.Net.Http.HttpMethod.Get, uri);
+            using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode) {
+                AddDiagnostic(_options, "StylesheetHttpStatusRejected", "Stylesheet resource returned a non-success status and was skipped.", source, new HttpRequestException($"{(int)response.StatusCode} {response.StatusCode}"));
+                return null;
+            }
+
+            var contentType = response.Content.Headers.ContentType?.MediaType;
+            if (!IsStylesheetContentTypeAllowed(contentType)) {
+                AddDiagnostic(_options, "StylesheetContentTypeRejected", "Stylesheet resource content type is not allowed and was skipped.", source, new HtmlResourceContentTypeException($"Stylesheet content type '{contentType}' is not allowed."));
+                return null;
+            }
+
+            return await ReadCssContentWithLimitAsync(response.Content, source, token).ConfigureAwait(false);
+        }
+
+        private async Task<string> ReadCssContentWithLimitAsync(HttpContent content, string source, CancellationToken cancellationToken) {
+            var readLimit = GetCssReadLimit();
+            if (readLimit.Limit.HasValue && content.Headers.ContentLength.HasValue && content.Headers.ContentLength.Value > readLimit.Limit.Value) {
+                if (readLimit.LimitedByTotalBudget) {
+                    ThrowLimitExceeded(_options, "CssTotalSizeLimitExceeded", "Total CSS size exceeded the configured conversion limit.", source, _cssBytesUsed + content.Headers.ContentLength.Value, _options.MaxTotalCssBytes!.Value);
+                }
+
+                ThrowLimitExceeded(_options, "CssSizeLimitExceeded", "CSS size exceeded the configured conversion limit.", source, content.Headers.ContentLength.Value, readLimit.Limit.Value);
+            }
+
+            using var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var memory = new MemoryStream();
+            var buffer = new byte[81920];
+            long total = 0;
+            while (true) {
+                cancellationToken.ThrowIfCancellationRequested();
+#if NET8_0_OR_GREATER
+                var read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+#else
+                var read = await stream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+#endif
+                if (read == 0) {
+                    break;
+                }
+
+                total += read;
+                if (readLimit.Limit.HasValue && total > readLimit.Limit.Value) {
+                    if (readLimit.LimitedByTotalBudget) {
+                        ThrowLimitExceeded(_options, "CssTotalSizeLimitExceeded", "Total CSS size exceeded the configured conversion limit.", source, _cssBytesUsed + total, _options.MaxTotalCssBytes!.Value);
+                    }
+
+                    ThrowLimitExceeded(_options, "CssSizeLimitExceeded", "CSS size exceeded the configured conversion limit.", source, total, readLimit.Limit.Value);
+                }
+
+                memory.Write(buffer, 0, read);
+            }
+
+            return Encoding.UTF8.GetString(memory.ToArray());
+        }
+
+        private string ReadCssFileWithLimit(string path) {
+            var readLimit = GetCssReadLimit();
+            if (readLimit.Limit.HasValue) {
+                var length = new FileInfo(path).Length;
+                if (length > readLimit.Limit.Value) {
+                    if (readLimit.LimitedByTotalBudget) {
+                        ThrowLimitExceeded(_options, "CssTotalSizeLimitExceeded", "Total CSS size exceeded the configured conversion limit.", path, _cssBytesUsed + length, _options.MaxTotalCssBytes!.Value);
+                    }
+
+                    ThrowLimitExceeded(_options, "CssSizeLimitExceeded", "CSS size exceeded the configured conversion limit.", path, length, readLimit.Limit.Value);
+                }
+            }
+
+            return File.ReadAllText(path);
+        }
+
+        private bool TryApplyStylesheetUriPolicy(Uri uri, string source) {
+            if (!IsStylesheetSchemeAllowed(uri.Scheme, out var detail)) {
+                AddDiagnostic(_options, "StylesheetResourceRejectedByPolicy", "Stylesheet resource was skipped because its URI is not allowed by the current stylesheet policy.", source, new HtmlResourcePolicyException(detail));
+                return false;
+            }
+
+            if (!uri.IsFile && _options.AllowedStylesheetHosts.Count > 0 && !_options.AllowedStylesheetHosts.Contains(uri.Host)) {
+                detail = $"Stylesheet host '{uri.Host}' is not allowed.";
+                AddDiagnostic(_options, "StylesheetResourceRejectedByPolicy", "Stylesheet resource was skipped because its URI is not allowed by the current stylesheet policy.", source, new HtmlResourcePolicyException(detail));
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryApplyLocalStylesheetPolicy(string source) {
+            if (IsStylesheetSchemeAllowed(Uri.UriSchemeFile, out var detail)) {
+                return true;
+            }
+
+            AddDiagnostic(_options, "StylesheetResourceRejectedByPolicy", "Stylesheet resource was skipped because its URI is not allowed by the current stylesheet policy.", source, new HtmlResourcePolicyException(detail));
+            return false;
+        }
+
+        private bool IsStylesheetSchemeAllowed(string scheme, out string detail) {
+            if (_options.AllowedStylesheetUriSchemes.Contains(scheme)) {
+                detail = string.Empty;
+                return true;
+            }
+
+            detail = $"Stylesheet URI scheme '{scheme}' is not allowed.";
+            return false;
+        }
+
+        private bool IsStylesheetContentTypeAllowed(string? contentType) {
+            if (!_options.ValidateStylesheetContentTypes || string.IsNullOrWhiteSpace(contentType)) {
+                return true;
+            }
+
+            return _options.AllowedStylesheetContentTypes.Contains(contentType!.Trim());
         }
 
         private void ApplyClassStyle(IElement element, WordParagraph paragraph, HtmlToWordOptions options) {
@@ -128,14 +239,14 @@ namespace OfficeIMO.Word.Html {
 
             ValidateCssLimit(css, key);
 
-            key ??= ComputeHash(css);
-            if (!_stylesheetCache.TryGetValue(key, out var rules)) {
+            var cacheKey = ComputeHash(css);
+            if (!_stylesheetCache.TryGetValue(cacheKey, out var rules)) {
                 try {
                     var sheet = _cssParser.ParseStyleSheet(css);
                     rules = sheet.Rules.OfType<ICssStyleRule>().ToArray();
-                    _stylesheetCache[key] = rules;
+                    _stylesheetCache[cacheKey] = rules;
                 } catch (Exception) {
-                    _stylesheetCache[key] = Array.Empty<ICssStyleRule>();
+                    _stylesheetCache[cacheKey] = Array.Empty<ICssStyleRule>();
                     return;
                 }
             }

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -52,9 +52,10 @@ namespace OfficeIMO.Word.Html {
                 wordTable = cell.AddTable(rows, cols);
             } else if (currentParagraph != null) {
                 wordTable = currentParagraph.AddTableAfter(rows, cols);
+            } else if (headerFooter != null) {
+                wordTable = headerFooter.AddTable(rows, cols);
             } else {
-                var placeholder = headerFooter != null ? headerFooter.AddParagraph("") : section.AddParagraph("");
-                wordTable = placeholder.AddTableAfter(rows, cols);
+                wordTable = section.AddTable(rows, cols);
             }
             ApplyTableStyles(wordTable, tableElem);
             ApplyColumnGroup(wordTable, tableElem, cols);
@@ -144,6 +145,9 @@ namespace OfficeIMO.Word.Html {
             }
             if (tableElem.Foot != null) {
                 HandleRows(tableElem.Foot.Rows);
+                if (tableElem.Foot.Rows.Length > 0) {
+                    wordTable.ConditionalFormattingLastRow = true;
+                }
             }
 
             if (caption != null && options.TableCaptionPosition == TableCaptionPosition.Below) {
@@ -153,9 +157,9 @@ namespace OfficeIMO.Word.Html {
                 } else if (headerFooter != null) {
                     captionParagraphBelow = headerFooter.AddParagraph("");
                 } else {
-                    var lastCellParagraph = wordTable.Rows[wordTable.Rows.Count - 1]
-                        .Cells[wordTable.Rows[0].Cells.Count - 1].Paragraphs.Last();
-                    captionParagraphBelow = lastCellParagraph.AddParagraphAfterSelf(section);
+                    var paragraph = new Paragraph();
+                    wordTable._table.InsertAfterSelf(paragraph);
+                    captionParagraphBelow = new WordParagraph(doc, paragraph);
                 }
                 captionParagraphBelow.SetStyleId("Caption");
                 var propsBelow = ApplyParagraphStyleFromCss(captionParagraphBelow, caption);
@@ -355,7 +359,8 @@ namespace OfficeIMO.Word.Html {
             var style = tableElem.GetAttribute("style");
             var borderAttr = tableElem.GetAttribute("border");
             var alignAttr = tableElem.GetAttribute("align");
-            if (string.IsNullOrWhiteSpace(style) && string.IsNullOrWhiteSpace(borderAttr) && string.IsNullOrWhiteSpace(alignAttr)) {
+            var cellSpacingAttr = tableElem.GetAttribute("cellspacing");
+            if (string.IsNullOrWhiteSpace(style) && string.IsNullOrWhiteSpace(borderAttr) && string.IsNullOrWhiteSpace(alignAttr) && string.IsNullOrWhiteSpace(cellSpacingAttr)) {
                 return;
             }
 
@@ -369,6 +374,11 @@ namespace OfficeIMO.Word.Html {
             var sideBorders = new Dictionary<TableBorderSide, (BorderValues Style, UInt32Value Size, SixColor Color)>();
             bool borderSpecified = false;
             bool collapse = true;
+            int? cellSpacing = null;
+
+            if (!string.IsNullOrWhiteSpace(cellSpacingAttr) && TryParseTableCellSpacing(cellSpacingAttr!, htmlAttribute: true, out var attrSpacing)) {
+                cellSpacing = attrSpacing;
+            }
 
             if (!string.IsNullOrWhiteSpace(style)) {
                 foreach (var part in (style ?? string.Empty).Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
@@ -404,6 +414,11 @@ namespace OfficeIMO.Word.Html {
                         case "border-collapse":
                             if (value.Equals("separate", StringComparison.OrdinalIgnoreCase)) {
                                 collapse = false;
+                            }
+                            break;
+                        case "border-spacing":
+                            if (TryParseTableCellSpacing(value, htmlAttribute: false, out var spacing)) {
+                                cellSpacing = spacing;
                             }
                             break;
                         case "margin":
@@ -528,7 +543,81 @@ namespace OfficeIMO.Word.Html {
                 if (padBottom != null) styleDetails.MarginDefaultBottomWidth = (short)padBottom.Value;
                 if (padLeft != null) styleDetails.MarginDefaultLeftWidth = (short)padLeft.Value;
                 if (padRight != null) styleDetails.MarginDefaultRightWidth = (short)padRight.Value;
+                if (cellSpacing != null) styleDetails.CellSpacing = (short)cellSpacing.Value;
             }
+        }
+
+        private static bool TryParseTableCellSpacing(string value, bool htmlAttribute, out int twips) {
+            twips = 0;
+            if (string.IsNullOrWhiteSpace(value)) {
+                return false;
+            }
+
+            var token = value.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(token)) {
+                return false;
+            }
+
+            if (htmlAttribute && double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out var pixels)) {
+                if (pixels < 0) {
+                    return false;
+                }
+
+                return TryRoundTableCellSpacingTwips(pixels * 15, out twips);
+            }
+
+            var parser = new CssParser();
+            var decl = parser.ParseDeclaration($"x:{token}");
+            if (TryConvertToTwipAllowNegative(decl.GetProperty("x")?.RawValue, out twips)) {
+                return twips >= 0 && twips <= short.MaxValue;
+            }
+
+            return TryParseTableCellSpacingLengthLiteral(token, out twips);
+        }
+
+        private static bool TryParseTableCellSpacingLengthLiteral(string token, out int twips) {
+            twips = 0;
+            var value = token.Trim().ToLowerInvariant();
+            if (value == "0") {
+                return true;
+            }
+
+            (string Unit, double TwipsPerUnit)[] units = {
+                ("rem", _renderDevice.FontSize * 15),
+                ("em", _renderDevice.FontSize * 15),
+                ("px", 15),
+                ("pt", 20),
+                ("cm", 1440 / 2.54),
+                ("mm", 1440 / 25.4),
+                ("in", 1440),
+                ("pc", 240),
+                ("q", 1440 / 101.6),
+            };
+
+            foreach (var (unit, twipsPerUnit) in units) {
+                if (!value.EndsWith(unit, StringComparison.Ordinal)) {
+                    continue;
+                }
+
+                var numberText = value.Substring(0, value.Length - unit.Length);
+                if (!double.TryParse(numberText, NumberStyles.Float, CultureInfo.InvariantCulture, out var number) || number < 0) {
+                    return false;
+                }
+
+                return TryRoundTableCellSpacingTwips(number * twipsPerUnit, out twips);
+            }
+
+            return false;
+        }
+
+        private static bool TryRoundTableCellSpacingTwips(double value, out int twips) {
+            twips = 0;
+            if (double.IsNaN(value) || double.IsInfinity(value) || value < 0 || value > short.MaxValue) {
+                return false;
+            }
+
+            twips = (int)Math.Round(value);
+            return twips <= short.MaxValue;
         }
 
         private static void ApplyMarginShorthand(string value, ref string? marginLeft, ref string? marginRight) {
@@ -645,12 +734,17 @@ namespace OfficeIMO.Word.Html {
             var style = htmlCell.GetAttribute("style");
             var borderAttr = htmlCell.GetAttribute("border");
             var alignAttr = htmlCell.GetAttribute("align");
-            if (string.IsNullOrWhiteSpace(style) && string.IsNullOrWhiteSpace(borderAttr) && string.IsNullOrWhiteSpace(alignAttr)) {
+            var verticalAlignAttr = htmlCell.GetAttribute("valign");
+            if (string.IsNullOrWhiteSpace(style) && string.IsNullOrWhiteSpace(borderAttr) && string.IsNullOrWhiteSpace(alignAttr) && string.IsNullOrWhiteSpace(verticalAlignAttr)) {
                 return null;
             }
 
             JustificationValues? alignment = null;
             bool borderSet = false;
+            if (TryMapTableCellVerticalAlignment(verticalAlignAttr, out var attrVerticalAlignment)) {
+                cell.VerticalAlignment = attrVerticalAlignment;
+            }
+
             if (!string.IsNullOrWhiteSpace(style)) {
                 var styleText = style!;
                 foreach (var part in styleText.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
@@ -697,14 +791,14 @@ namespace OfficeIMO.Word.Html {
                             }
                             break;
                         case "text-align":
-                            var align = value.ToLowerInvariant();
-                            alignment = align switch {
-                                "center" => JustificationValues.Center,
-                                "right" => JustificationValues.Right,
-                                "justify" => JustificationValues.Both,
-                                "left" => JustificationValues.Left,
-                                _ => alignment
-                            };
+                            if (TryMapTextAlign(value, GetBidiFromDir(htmlCell), out var mappedAlignment)) {
+                                alignment = mappedAlignment;
+                            }
+                            break;
+                        case "vertical-align":
+                            if (TryMapTableCellVerticalAlignment(value, out var verticalAlignment)) {
+                                cell.VerticalAlignment = verticalAlignment;
+                            }
                             break;
                     }
                 }
@@ -729,6 +823,25 @@ namespace OfficeIMO.Word.Html {
                 }
             }
             return alignment;
+        }
+
+        private static bool TryMapTableCellVerticalAlignment(string? value, out TableVerticalAlignmentValues alignment) {
+            alignment = TableVerticalAlignmentValues.Top;
+            var normalized = value?.Trim().ToLowerInvariant();
+            switch (normalized) {
+                case "top":
+                    alignment = TableVerticalAlignmentValues.Top;
+                    return true;
+                case "middle":
+                case "center":
+                    alignment = TableVerticalAlignmentValues.Center;
+                    return true;
+                case "bottom":
+                    alignment = TableVerticalAlignmentValues.Bottom;
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         private enum TableBorderSide {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -30,6 +30,7 @@ namespace OfficeIMO.Word.Html {
         private readonly Dictionary<string, string[]> _endnoteMap = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, HtmlCommentInfo> _commentMap = new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _unsupportedCssDiagnosticKeys = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<IElement> _processedRadioInputs = new();
         private readonly List<ICssStyleRule> _cssRules = new();
         private readonly CssParser _cssParser = new();
         private readonly Dictionary<string, WordImage> _imageCache = new(StringComparer.OrdinalIgnoreCase);
@@ -43,6 +44,7 @@ namespace OfficeIMO.Word.Html {
         private CancellationToken _cancellationToken = CancellationToken.None;
         private TimeSpan? _resourceTimeout;
         private long _imageBytesUsed;
+        private long _cssBytesUsed;
         private HtmlToWordOptions _options = new HtmlToWordOptions();
         private static readonly Regex _classRegex = new(@"\.([a-zA-Z0-9_-]+)", RegexOptions.Compiled);
         private static readonly HashSet<string> _blockTags = new(StringComparer.OrdinalIgnoreCase) {
@@ -81,91 +83,17 @@ namespace OfficeIMO.Word.Html {
             _endnoteMap.Clear();
             _commentMap.Clear();
             _unsupportedCssDiagnosticKeys.Clear();
+            _processedRadioInputs.Clear();
             _cssRules.Clear();
             _imageCache.Clear();
             _cssClassStyles.Clear();
             _pendingTopBookmark = false;
             _imageBytesUsed = 0;
+            _cssBytesUsed = 0;
             ResetAccessibilityDiagnosticsState();
 
-            foreach (var path in options.StylesheetPaths) {
-                if (string.IsNullOrEmpty(path)) {
-                    continue;
-                }
-                if (Uri.TryCreate(path, UriKind.Absolute, out var absolute)) {
-                    if (absolute.Scheme == Uri.UriSchemeHttp || absolute.Scheme == Uri.UriSchemeHttps) {
-                        await LoadAndParseCssAsync(context, new Url(absolute.ToString()), cancellationToken).ConfigureAwait(false);
-                    } else if (absolute.Scheme == Uri.UriSchemeFile && File.Exists(absolute.LocalPath)) {
-                        ParseCss(File.ReadAllText(absolute.LocalPath), absolute.LocalPath);
-                    }
-                } else if (document.BaseUrl != null) {
-                    var url = new Url(new Url(document.BaseUrl), path);
-                    if (url.Scheme == "http" || url.Scheme == "https") {
-                        await LoadAndParseCssAsync(context, url, cancellationToken).ConfigureAwait(false);
-                    } else if (url.Scheme == "file") {
-                        TryLoadCssFromFileUrl(url);
-                    }
-                } else if (File.Exists(path)) {
-                    ParseCss(File.ReadAllText(path), path);
-                }
-            }
-            foreach (var content in options.StylesheetContents) {
-                if (!string.IsNullOrEmpty(content)) {
-                    ParseCss(content);
-                }
-            }
-
-            if (document.Head != null) {
-                Uri? baseUri = null;
-                if (document.BaseUrl != null && Uri.TryCreate(document.BaseUrl.Href, UriKind.Absolute, out var du)) {
-                    baseUri = du;
-                }
-
-                foreach (var node in document.Head.ChildNodes) {
-                    if (node is IHtmlBaseElement baseElement) {
-                        if (Uri.TryCreate(baseElement.Href, UriKind.Absolute, out var bu)) {
-                            baseUri = bu;
-                        }
-                        continue;
-                    }
-                    if (node is IHtmlStyleElement styleElement) {
-                        ParseCss(styleElement.TextContent);
-                        continue;
-                    }
-                    if (node is IHtmlLinkElement linkElement) {
-                        var rel = linkElement.GetAttribute("rel");
-                        if (!string.Equals(rel, "stylesheet", StringComparison.OrdinalIgnoreCase)) {
-                            continue;
-                        }
-                        if (!options.AllowDocumentStylesheetLinks) {
-                            AddDiagnostic(options, "HtmlStylesheetLinkSkipped", "HTML stylesheet link was skipped because document-provided stylesheet links are disabled.", "link");
-                            continue;
-                        }
-
-                        var hrefAttr = linkElement.GetAttribute("href");
-                        var href = linkElement.Href ?? hrefAttr;
-                        if (string.IsNullOrEmpty(href)) {
-                            continue;
-                        }
-
-                        if (!string.IsNullOrEmpty(hrefAttr) && File.Exists(hrefAttr)) {
-                            ParseCss(File.ReadAllText(hrefAttr), hrefAttr);
-                            continue;
-                        }
-
-                        var url = new Url(href);
-                        if (!url.IsAbsolute && baseUri != null) {
-                            url = new Url(new Url(baseUri.ToString()), href);
-                        }
-
-                        if (url.Scheme == "http" || url.Scheme == "https") {
-                            await LoadAndParseCssAsync(context, url, cancellationToken).ConfigureAwait(false);
-                        } else if (url.Scheme == "file") {
-                            TryLoadCssFromFileUrl(url);
-                        }
-                    }
-                }
-            }
+            await LoadConfiguredStylesheetsAsync(document, options, cancellationToken).ConfigureAwait(false);
+            await LoadHeadStylesheetsAsync(document, cancellationToken).ConfigureAwait(false);
 
             CaptureNoteSections(document);
             CaptureCommentSections(document);
@@ -210,91 +138,17 @@ namespace OfficeIMO.Word.Html {
             _endnoteMap.Clear();
             _commentMap.Clear();
             _unsupportedCssDiagnosticKeys.Clear();
+            _processedRadioInputs.Clear();
             _cssRules.Clear();
             _imageCache.Clear();
             _cssClassStyles.Clear();
             _pendingTopBookmark = false;
             _imageBytesUsed = 0;
+            _cssBytesUsed = 0;
             ResetAccessibilityDiagnosticsState();
 
-            foreach (var path in options.StylesheetPaths) {
-                if (string.IsNullOrEmpty(path)) {
-                    continue;
-                }
-                if (Uri.TryCreate(path, UriKind.Absolute, out var absolute)) {
-                    if (absolute.Scheme == Uri.UriSchemeHttp || absolute.Scheme == Uri.UriSchemeHttps) {
-                        await LoadAndParseCssAsync(context, new Url(absolute.ToString()), cancellationToken).ConfigureAwait(false);
-                    } else if (absolute.Scheme == Uri.UriSchemeFile && File.Exists(absolute.LocalPath)) {
-                        ParseCss(File.ReadAllText(absolute.LocalPath), absolute.LocalPath);
-                    }
-                } else if (document.BaseUrl != null) {
-                    var url = new Url(new Url(document.BaseUrl), path);
-                    if (url.Scheme == "http" || url.Scheme == "https") {
-                        await LoadAndParseCssAsync(context, url, cancellationToken).ConfigureAwait(false);
-                    } else if (url.Scheme == "file") {
-                        TryLoadCssFromFileUrl(url);
-                    }
-                } else if (File.Exists(path)) {
-                    ParseCss(File.ReadAllText(path), path);
-                }
-            }
-            foreach (var content in options.StylesheetContents) {
-                if (!string.IsNullOrEmpty(content)) {
-                    ParseCss(content);
-                }
-            }
-
-            if (document.Head != null) {
-                Uri? baseUri = null;
-                if (document.BaseUrl != null && Uri.TryCreate(document.BaseUrl.Href, UriKind.Absolute, out var du)) {
-                    baseUri = du;
-                }
-
-                foreach (var node in document.Head.ChildNodes) {
-                    if (node is IHtmlBaseElement baseElement) {
-                        if (Uri.TryCreate(baseElement.Href, UriKind.Absolute, out var bu)) {
-                            baseUri = bu;
-                        }
-                        continue;
-                    }
-                    if (node is IHtmlStyleElement styleElement) {
-                        ParseCss(styleElement.TextContent);
-                        continue;
-                    }
-                    if (node is IHtmlLinkElement linkElement) {
-                        var rel = linkElement.GetAttribute("rel");
-                        if (!string.Equals(rel, "stylesheet", StringComparison.OrdinalIgnoreCase)) {
-                            continue;
-                        }
-                        if (!options.AllowDocumentStylesheetLinks) {
-                            AddDiagnostic(options, "HtmlStylesheetLinkSkipped", "HTML stylesheet link was skipped because document-provided stylesheet links are disabled.", "link");
-                            continue;
-                        }
-
-                        var hrefAttr = linkElement.GetAttribute("href");
-                        var href = linkElement.Href ?? hrefAttr;
-                        if (string.IsNullOrEmpty(href)) {
-                            continue;
-                        }
-
-                        if (!string.IsNullOrEmpty(hrefAttr) && File.Exists(hrefAttr)) {
-                            ParseCss(File.ReadAllText(hrefAttr), hrefAttr);
-                            continue;
-                        }
-
-                        var url = new Url(href);
-                        if (!url.IsAbsolute && baseUri != null) {
-                            url = new Url(new Url(baseUri.ToString()), href);
-                        }
-
-                        if (url.Scheme == "http" || url.Scheme == "https") {
-                            await LoadAndParseCssAsync(context, url, cancellationToken).ConfigureAwait(false);
-                        } else if (url.Scheme == "file") {
-                            TryLoadCssFromFileUrl(url);
-                        }
-                    }
-                }
-            }
+            await LoadConfiguredStylesheetsAsync(document, options, cancellationToken).ConfigureAwait(false);
+            await LoadHeadStylesheetsAsync(document, cancellationToken).ConfigureAwait(false);
 
             CaptureNoteSections(document, cancellationToken);
             CaptureCommentSections(document, cancellationToken);
@@ -336,91 +190,17 @@ namespace OfficeIMO.Word.Html {
             _endnoteMap.Clear();
             _commentMap.Clear();
             _unsupportedCssDiagnosticKeys.Clear();
+            _processedRadioInputs.Clear();
             _cssRules.Clear();
             _imageCache.Clear();
             _cssClassStyles.Clear();
             _pendingTopBookmark = false;
             _imageBytesUsed = 0;
+            _cssBytesUsed = 0;
             ResetAccessibilityDiagnosticsState();
 
-            foreach (var path in options.StylesheetPaths) {
-                if (string.IsNullOrEmpty(path)) {
-                    continue;
-                }
-                if (Uri.TryCreate(path, UriKind.Absolute, out var absolute)) {
-                    if (absolute.Scheme == Uri.UriSchemeHttp || absolute.Scheme == Uri.UriSchemeHttps) {
-                        await LoadAndParseCssAsync(context, new Url(absolute.ToString()), cancellationToken).ConfigureAwait(false);
-                    } else if (absolute.Scheme == Uri.UriSchemeFile && File.Exists(absolute.LocalPath)) {
-                        ParseCss(File.ReadAllText(absolute.LocalPath), absolute.LocalPath);
-                    }
-                } else if (document.BaseUrl != null) {
-                    var url = new Url(new Url(document.BaseUrl), path);
-                    if (url.Scheme == "http" || url.Scheme == "https") {
-                        await LoadAndParseCssAsync(context, url, cancellationToken).ConfigureAwait(false);
-                    } else if (url.Scheme == "file") {
-                        TryLoadCssFromFileUrl(url);
-                    }
-                } else if (File.Exists(path)) {
-                    ParseCss(File.ReadAllText(path), path);
-                }
-            }
-            foreach (var content in options.StylesheetContents) {
-                if (!string.IsNullOrEmpty(content)) {
-                    ParseCss(content);
-                }
-            }
-
-            if (document.Head != null) {
-                Uri? baseUri = null;
-                if (document.BaseUrl != null && Uri.TryCreate(document.BaseUrl.Href, UriKind.Absolute, out var du)) {
-                    baseUri = du;
-                }
-
-                foreach (var node in document.Head.ChildNodes) {
-                    if (node is IHtmlBaseElement baseElement) {
-                        if (Uri.TryCreate(baseElement.Href, UriKind.Absolute, out var bu)) {
-                            baseUri = bu;
-                        }
-                        continue;
-                    }
-                    if (node is IHtmlStyleElement styleElement) {
-                        ParseCss(styleElement.TextContent);
-                        continue;
-                    }
-                    if (node is IHtmlLinkElement linkElement) {
-                        var rel = linkElement.GetAttribute("rel");
-                        if (!string.Equals(rel, "stylesheet", StringComparison.OrdinalIgnoreCase)) {
-                            continue;
-                        }
-                        if (!options.AllowDocumentStylesheetLinks) {
-                            AddDiagnostic(options, "HtmlStylesheetLinkSkipped", "HTML stylesheet link was skipped because document-provided stylesheet links are disabled.", "link");
-                            continue;
-                        }
-
-                        var hrefAttr = linkElement.GetAttribute("href");
-                        var href = linkElement.Href ?? hrefAttr;
-                        if (string.IsNullOrEmpty(href)) {
-                            continue;
-                        }
-
-                        if (!string.IsNullOrEmpty(hrefAttr) && File.Exists(hrefAttr)) {
-                            ParseCss(File.ReadAllText(hrefAttr), hrefAttr);
-                            continue;
-                        }
-
-                        var url = new Url(href);
-                        if (!url.IsAbsolute && baseUri != null) {
-                            url = new Url(new Url(baseUri.ToString()), href);
-                        }
-
-                        if (url.Scheme == "http" || url.Scheme == "https") {
-                            await LoadAndParseCssAsync(context, url, cancellationToken).ConfigureAwait(false);
-                        } else if (url.Scheme == "file") {
-                            TryLoadCssFromFileUrl(url);
-                        }
-                    }
-                }
-            }
+            await LoadConfiguredStylesheetsAsync(document, options, cancellationToken).ConfigureAwait(false);
+            await LoadHeadStylesheetsAsync(document, cancellationToken).ConfigureAwait(false);
 
             CaptureNoteSections(document, cancellationToken);
             CaptureCommentSections(document, cancellationToken);

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.DefinitionLists.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.DefinitionLists.cs
@@ -1,0 +1,26 @@
+using OfficeIMO.Word;
+
+namespace OfficeIMO.Word.Html {
+    internal partial class WordToHtmlConverter {
+        private static bool IsDefinitionListParagraph(WordParagraph paragraph) {
+            return IsDefinitionTerm(paragraph) || IsDefinitionDescription(paragraph);
+        }
+
+        private static string GetDefinitionListTagName(WordParagraph paragraph) {
+            return IsDefinitionDescription(paragraph) ? "dd" : "dt";
+        }
+
+        private static bool IsEmptyDefinitionListParagraph(WordParagraph paragraph) {
+            return !FormattingHelper.GetFormattedRuns(paragraph)
+                .Any(run => !string.IsNullOrEmpty(run.Text) || run.Image != null);
+        }
+
+        private static bool IsDefinitionTerm(WordParagraph paragraph) {
+            return string.Equals(paragraph.StyleId, HtmlSemanticStyleIds.DefinitionTerm, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsDefinitionDescription(WordParagraph paragraph) {
+            return string.Equals(paragraph.StyleId, HtmlSemanticStyleIds.DefinitionDescription, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Footnotes.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Footnotes.cs
@@ -18,15 +18,12 @@ namespace OfficeIMO.Word.Html {
             }
 
             if (options.ExportFootnotes && run.FootNote != null) {
+                if (IsBlockquoteCiteReference(run.CharacterStyleId)) {
+                    return true;
+                }
+
                 var note = run.FootNote;
-                if (string.Equals(run.CharacterStyleId, "HtmlAbbr", StringComparison.OrdinalIgnoreCase) && nodes.Count > 0) {
-                    string text = string.Join(string.Empty, note.Paragraphs?.Skip(1).Select(r => r.Text) ?? Enumerable.Empty<string>());
-                    var abbr = htmlDoc.CreateElement("abbr");
-                    abbr.SetAttribute("title", text);
-                    var lastNode = nodes[nodes.Count - 1];
-                    abbr.AppendChild(lastNode);
-                    nodes[nodes.Count - 1] = abbr;
-                } else {
+                if (!TryReplaceLastNodeWithAbbreviation(run.CharacterStyleId, htmlDoc, nodes, note.Paragraphs?.Skip(1).Select(r => r.Text))) {
                     long id = note.ReferenceId ?? 0;
                     if (!footnoteMap.TryGetValue(id, out int number)) {
                         number = footnotes.Count + 1;
@@ -46,24 +43,96 @@ namespace OfficeIMO.Word.Html {
             }
 
             if (options.ExportEndnotes && run.EndNote != null) {
-                var note = run.EndNote;
-                long id = note.ReferenceId ?? 0;
-                if (!endnoteMap.TryGetValue(id, out int number)) {
-                    number = endnotes.Count + 1;
-                    endnoteMap[id] = number;
-                    endnotes.Add((number, note));
+                if (IsBlockquoteCiteReference(run.CharacterStyleId)) {
+                    return true;
                 }
-                var sup = htmlDoc.CreateElement("sup");
-                var a = htmlDoc.CreateElement("a");
-                a.SetAttribute("href", $"#en{number}");
-                a.SetAttribute("id", $"enref{number}");
-                a.TextContent = number.ToString();
-                sup.AppendChild(a);
-                nodes.Add(sup);
+
+                var note = run.EndNote;
+                if (!TryReplaceLastNodeWithAbbreviation(run.CharacterStyleId, htmlDoc, nodes, note.Paragraphs?.Skip(1).Select(r => r.Text))) {
+                    long id = note.ReferenceId ?? 0;
+                    if (!endnoteMap.TryGetValue(id, out int number)) {
+                        number = endnotes.Count + 1;
+                        endnoteMap[id] = number;
+                        endnotes.Add((number, note));
+                    }
+                    var sup = htmlDoc.CreateElement("sup");
+                    var a = htmlDoc.CreateElement("a");
+                    a.SetAttribute("href", $"#en{number}");
+                    a.SetAttribute("id", $"enref{number}");
+                    a.TextContent = number.ToString();
+                    sup.AppendChild(a);
+                    nodes.Add(sup);
+                }
+
                 return true;
             }
 
             return false;
+        }
+
+        private static bool IsBlockquoteCiteReference(string? characterStyleId) {
+            return string.Equals(characterStyleId, HtmlSemanticStyleIds.BlockquoteCite, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool TryGetBlockquoteCiteAttribute(WordParagraph paragraph, out string cite) {
+            if (HtmlSemanticMetadata.TryGetBlockquoteCite(paragraph, out cite)) {
+                return true;
+            }
+
+            foreach (var run in paragraph.GetRuns()) {
+                if (!IsBlockquoteCiteReference(run.CharacterStyleId)) {
+                    continue;
+                }
+
+                if (run.FootNote != null && TryGetNoteCitation(run.FootNote.Paragraphs, out cite)) {
+                    return true;
+                }
+
+                if (run.EndNote != null && TryGetNoteCitation(run.EndNote.Paragraphs, out cite)) {
+                    return true;
+                }
+            }
+
+            cite = string.Empty;
+            return false;
+        }
+
+        private static bool TryGetNoteCitation(IEnumerable<WordParagraph>? noteParagraphs, out string cite) {
+            foreach (var paragraph in noteParagraphs?.Skip(1) ?? Enumerable.Empty<WordParagraph>()) {
+                if (paragraph.Hyperlink?.Uri != null) {
+                    cite = paragraph.Hyperlink.Uri.ToString();
+                    return true;
+                }
+
+                foreach (var run in paragraph.GetRuns()) {
+                    if (run.Hyperlink?.Uri != null) {
+                        cite = run.Hyperlink.Uri.ToString();
+                        return true;
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(paragraph.Text)) {
+                    cite = paragraph.Text.Trim();
+                    return true;
+                }
+            }
+
+            cite = string.Empty;
+            return false;
+        }
+
+        private static bool TryReplaceLastNodeWithAbbreviation(string? characterStyleId, IDocument htmlDoc, List<INode> nodes, IEnumerable<string?>? noteParagraphs) {
+            if (!string.Equals(characterStyleId, "HtmlAbbr", StringComparison.OrdinalIgnoreCase) || nodes.Count == 0) {
+                return false;
+            }
+
+            string text = string.Join(string.Empty, noteParagraphs ?? Enumerable.Empty<string?>());
+            var abbr = htmlDoc.CreateElement("abbr");
+            abbr.SetAttribute("title", text);
+            var lastNode = nodes[nodes.Count - 1];
+            abbr.AppendChild(lastNode);
+            nodes[nodes.Count - 1] = abbr;
+            return true;
         }
 
         private static void AppendFootnotes(

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Forms.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Forms.cs
@@ -73,6 +73,14 @@ namespace OfficeIMO.Word.Html {
         }
 
         IElement CreateStructuredDocumentTagInput(IDocument htmlDoc, WordStructuredDocumentTag structuredDocumentTag) {
+            if (HasLineBreaks(structuredDocumentTag.Text)) {
+                var textArea = htmlDoc.CreateElement("textarea");
+                textArea.SetAttribute("disabled", string.Empty);
+                textArea.TextContent = structuredDocumentTag.Text ?? string.Empty;
+                ApplyContentControlMetadata(textArea, structuredDocumentTag.Alias, structuredDocumentTag.Tag);
+                return textArea;
+            }
+
             var input = htmlDoc.CreateElement("input");
             input.SetAttribute("type", "text");
             input.SetAttribute("disabled", string.Empty);
@@ -82,6 +90,9 @@ namespace OfficeIMO.Word.Html {
             ApplyContentControlMetadata(input, structuredDocumentTag.Alias, structuredDocumentTag.Tag);
             return input;
         }
+
+        static bool HasLineBreaks(string? text) =>
+            !string.IsNullOrEmpty(text) && (text!.IndexOf('\n') >= 0 || text.IndexOf('\r') >= 0);
 
         static void ApplyContentControlMetadata(IElement element, string? alias, string? tag) {
             if (!string.IsNullOrEmpty(alias)) {

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Ruby.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.Ruby.cs
@@ -1,0 +1,37 @@
+using AngleSharp.Dom;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word.Html {
+    internal partial class WordToHtmlConverter {
+        private static bool TryCreateRubyNode(IDocument htmlDoc, WordParagraph run, out INode node) {
+            node = htmlDoc.CreateTextNode(string.Empty);
+            var ruby = run._run?.Elements<Ruby>().FirstOrDefault();
+            if (ruby == null) {
+                return false;
+            }
+
+            var baseText = ruby.RubyBase?.InnerText ?? string.Empty;
+            if (string.IsNullOrEmpty(baseText)) {
+                return false;
+            }
+
+            var rubyText = ruby.RubyContent?.InnerText ?? string.Empty;
+            if (string.IsNullOrEmpty(rubyText)) {
+                node = htmlDoc.CreateTextNode(baseText);
+                return true;
+            }
+
+            var rubyElement = htmlDoc.CreateElement("ruby");
+            var baseElement = htmlDoc.CreateElement("rb");
+            baseElement.TextContent = baseText;
+            rubyElement.AppendChild(baseElement);
+
+            var annotationElement = htmlDoc.CreateElement("rt");
+            annotationElement.TextContent = rubyText;
+            rubyElement.AppendChild(annotationElement);
+
+            node = rubyElement;
+            return true;
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.TableCss.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.TableCss.cs
@@ -24,6 +24,15 @@ namespace OfficeIMO.Word.Html {
                 return null;
             }
 
+            string? GetTableCellSpacingCss(WordTable table) {
+                var cellSpacing = table.StyleDetails?.CellSpacing;
+                if (cellSpacing == null || cellSpacing.Value <= 0) {
+                    return null;
+                }
+
+                return FormatTwips(cellSpacing.Value);
+            }
+
             void AppendColumnGroup(IDocument htmlDoc, IElement tableElement, WordTable table) {
                 var columns = GetColumnWidths(table);
                 if (columns.Count == 0) {

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -138,6 +138,9 @@ namespace OfficeIMO.Word.Html {
                                 if (!string.IsNullOrEmpty(imgObj.Description)) {
                                     imgSvg.AlternativeText = imgObj.Description;
                                 }
+                                if (!string.IsNullOrEmpty(imgObj.Title)) {
+                                    imgSvg.SetAttribute("title", imgObj.Title!);
+                                }
                                 nodes.Add(imgSvg);
                             }
                             continue;
@@ -160,6 +163,9 @@ namespace OfficeIMO.Word.Html {
                         if (!string.IsNullOrEmpty(imgObj.Description)) {
                             img.AlternativeText = imgObj.Description;
                         }
+                        if (!string.IsNullOrEmpty(imgObj.Title)) {
+                            img.SetAttribute("title", imgObj.Title!);
+                        }
                         nodes.Add(img);
                         continue;
                     }
@@ -171,6 +177,10 @@ namespace OfficeIMO.Word.Html {
                     if (string.IsNullOrEmpty(run.Text)) {
                         continue;
                     }
+
+                    bool isHtmlDeletedText = string.Equals(run.CharacterStyleId, HtmlSemanticStyleIds.DeletedText, StringComparison.OrdinalIgnoreCase);
+                    bool isHtmlInsertedText = string.Equals(run.CharacterStyleId, HtmlSemanticStyleIds.InsertedText, StringComparison.OrdinalIgnoreCase);
+                    bool isHtmlMarkedText = string.Equals(run.CharacterStyleId, HtmlSemanticStyleIds.MarkedText, StringComparison.OrdinalIgnoreCase);
 
                     if (string.Equals(run.CharacterStyleId, "HtmlQuote", StringComparison.OrdinalIgnoreCase)) {
                         if (!inQuote) {
@@ -198,13 +208,13 @@ namespace OfficeIMO.Word.Html {
                         node = em;
                     }
 
-                    if (run.Strike || run.DoubleStrike) {
+                    if ((run.Strike || run.DoubleStrike) && !isHtmlDeletedText) {
                         var s = htmlDoc.CreateElement("s");
                         s.AppendChild(node);
                         node = s;
                     }
 
-                    if (run.Underline != null) {
+                    if (run.Underline != null && !isHtmlInsertedText) {
                         var u = htmlDoc.CreateElement("u");
                         u.AppendChild(node);
                         node = u;
@@ -240,7 +250,22 @@ namespace OfficeIMO.Word.Html {
                     }
 
                     bool handledHtmlStyle = false;
-                    if (string.Equals(run.CharacterStyleId, "HtmlCite", StringComparison.OrdinalIgnoreCase)) {
+                    if (isHtmlDeletedText) {
+                        var del = htmlDoc.CreateElement("del");
+                        del.AppendChild(node);
+                        node = del;
+                        handledHtmlStyle = true;
+                    } else if (isHtmlInsertedText) {
+                        var ins = htmlDoc.CreateElement("ins");
+                        ins.AppendChild(node);
+                        node = ins;
+                        handledHtmlStyle = true;
+                    } else if (isHtmlMarkedText) {
+                        var mark = htmlDoc.CreateElement("mark");
+                        mark.AppendChild(node);
+                        node = mark;
+                        handledHtmlStyle = true;
+                    } else if (string.Equals(run.CharacterStyleId, "HtmlCite", StringComparison.OrdinalIgnoreCase)) {
                         var cite = htmlDoc.CreateElement("cite");
                         cite.AppendChild(node);
                         node = cite;
@@ -252,8 +277,11 @@ namespace OfficeIMO.Word.Html {
                         handledHtmlStyle = true;
                     } else if (string.Equals(run.CharacterStyleId, "HtmlTime", StringComparison.OrdinalIgnoreCase)) {
                         var time = htmlDoc.CreateElement("time");
-                        string dt = run.Text ?? string.Empty;
-                        if (DateTime.TryParse(run.Text, out var parsed)) {
+                        bool hasImportedDateTime = HtmlSemanticMetadata.TryGetTimeDateTime(run, out var dt);
+                        if (!hasImportedDateTime) {
+                            dt = run.Text ?? string.Empty;
+                        }
+                        if (!hasImportedDateTime && DateTime.TryParse(run.Text, out var parsed)) {
                             dt = parsed.ToString("o");
                         }
                         time.SetAttribute("datetime", dt);
@@ -308,7 +336,7 @@ namespace OfficeIMO.Word.Html {
                                 inlineStyles.Add($"color:#{normalized}");
                             }
                         }
-                        if (options.IncludeRunHighlightStyles) {
+                        if (options.IncludeRunHighlightStyles && !isHtmlMarkedText) {
                             var highlightCss = GetHighlightCss(run.Highlight);
                             if (!string.IsNullOrEmpty(highlightCss)) {
                                 inlineStyles.Add($"background-color:{highlightCss}");
@@ -328,6 +356,14 @@ namespace OfficeIMO.Word.Html {
                         spanClass.AppendChild(node);
                         node = spanClass;
                         runStyles.Add(run.CharacterStyleId!);
+                    }
+
+                    var runLanguage = NormalizeRunLanguage(run.Language, document.Settings.Language);
+                    if (!string.IsNullOrEmpty(runLanguage)) {
+                        var spanLanguage = htmlDoc.CreateElement("span");
+                        spanLanguage.SetAttribute("lang", runLanguage);
+                        spanLanguage.AppendChild(node);
+                        node = spanLanguage;
                     }
 
                     if (inQuote && quote != null) {
@@ -352,14 +388,14 @@ namespace OfficeIMO.Word.Html {
             }
 
 
-            void AppendParagraph(IElement parent, WordParagraph para) {
-                if (para.IsBookmark && para.Bookmark != null) {
+            void AppendParagraph(IElement parent, WordParagraph para, bool suppressStructuralBookmark = false) {
+                if (!suppressStructuralBookmark && para.IsBookmark && para.Bookmark != null) {
                     var name = para.Bookmark.Name ?? string.Empty;
                     var parts = name.Split(new[] { ':' }, 2);
                     if (parts.Length == 2 && IsStructuralTag(parts[0])) {
                         var structEl = htmlDoc.CreateElement(parts[0]);
                         structEl.SetAttribute("id", parts[1]);
-                        AppendRuns(structEl, para);
+                        AppendParagraph(structEl, para, suppressStructuralBookmark: true);
                         parent.AppendChild(structEl);
                         return;
                     }
@@ -386,6 +422,9 @@ namespace OfficeIMO.Word.Html {
                 bool isBlockQuote = (!string.IsNullOrEmpty(para.StyleId) && (string.Equals(para.StyleId, "Quote", StringComparison.OrdinalIgnoreCase) || string.Equals(para.StyleId, "IntenseQuote", StringComparison.OrdinalIgnoreCase)))
                     || (para.IndentationBefore.HasValue && para.IndentationBefore.Value > 0);
                 var element = htmlDoc.CreateElement(isBlockQuote ? "blockquote" : (level > 0 ? $"h{level}" : "p"));
+                if (isBlockQuote && TryGetBlockquoteCiteAttribute(para, out var blockquoteCite)) {
+                    element.SetAttribute("cite", blockquoteCite);
+                }
                 ApplyBookmarkId(element, para);
                 if (options.IncludeParagraphClasses && !string.IsNullOrEmpty(para.StyleId)) {
                     element.SetAttribute("class", para.StyleId);
@@ -447,20 +486,53 @@ namespace OfficeIMO.Word.Html {
                 parent.AppendChild(element);
             }
 
+            void AppendDefinitionListItem(IElement definitionList, WordParagraph para) {
+                var item = htmlDoc.CreateElement(GetDefinitionListTagName(para));
+                ApplyBookmarkId(item, para);
+                if (para.BiDi) {
+                    item.SetAttribute("dir", "rtl");
+                }
+                AppendRuns(item, para);
+                definitionList.AppendChild(item);
+            }
 
-            void AppendTable(IElement parent, WordTable table) {
+            bool IsCaptionParagraph(WordParagraph para) =>
+                string.Equals(para.StyleId, "Caption", StringComparison.OrdinalIgnoreCase);
+
+            void AppendTableCaption(IElement tableElement, WordParagraph captionParagraph) {
+                var caption = htmlDoc.CreateElement("caption");
+                ApplyBookmarkId(caption, captionParagraph);
+                if (captionParagraph.BiDi) {
+                    caption.SetAttribute("dir", "rtl");
+                }
+                if (options.IncludeParagraphClasses && !string.IsNullOrEmpty(captionParagraph.StyleId)) {
+                    caption.SetAttribute("class", captionParagraph.StyleId);
+                    paragraphStyles.Add(captionParagraph.StyleId!);
+                }
+                AppendRuns(caption, captionParagraph);
+                tableElement.AppendChild(caption);
+            }
+
+            void AppendTable(IElement parent, WordTable table, WordParagraph? captionParagraph = null) {
                 var tableEl = htmlDoc.CreateElement("table");
                 var tableStyles = new List<string>();
                 var tableWidth = GetWidthCss(table.WidthType, table.Width);
                 if (!string.IsNullOrEmpty(tableWidth)) {
                     tableStyles.Add($"width:{tableWidth}");
                 }
+                var tableCellSpacing = GetTableCellSpacingCss(table);
+                if (!string.IsNullOrEmpty(tableCellSpacing)) {
+                    tableStyles.Add($"border-spacing:{tableCellSpacing}");
+                }
                 if (TableHasBorder(table)) {
                     tableStyles.Add("border:1px solid black");
-                    tableStyles.Add("border-collapse:collapse");
+                    tableStyles.Add(!string.IsNullOrEmpty(tableCellSpacing) ? "border-collapse:separate" : "border-collapse:collapse");
                 }
                 if (tableStyles.Count > 0) {
                     tableEl.SetAttribute("style", string.Join(";", tableStyles));
+                }
+                if (captionParagraph != null) {
+                    AppendTableCaption(tableEl, captionParagraph);
                 }
                 if (options.IncludeTableColumnGroups) {
                     AppendColumnGroup(htmlDoc, tableEl, table);
@@ -470,19 +542,25 @@ namespace OfficeIMO.Word.Html {
                 while (headerRowCount < table.Rows.Count && table.Rows[headerRowCount].RepeatHeaderRowAtTheTopOfEachPage) {
                     headerRowCount++;
                 }
+                bool hasFooterRow = table.ConditionalFormattingLastRow == true && table.Rows.Count > headerRowCount;
                 IElement? thead = null;
                 IElement? tbody = null;
+                IElement? tfoot = null;
 
                 for (int r = 0; r < table.Rows.Count; r++) {
                     var row = table.Rows[r];
                     var tr = htmlDoc.CreateElement("tr");
                     bool isHeaderRow = headerRowCount > 0 && r < headerRowCount;
+                    bool isFooterRow = hasFooterRow && r == table.Rows.Count - 1;
                     for (int c = 0; c < row.Cells.Count; c++) {
                         var cell = row.Cells[c];
                         if (cell.HorizontalMerge == MergedCellValues.Continue || cell.VerticalMerge == MergedCellValues.Continue) {
                             continue;
                         }
                         var cellElement = htmlDoc.CreateElement(isHeaderRow ? "th" : "td");
+                        if (isHeaderRow) {
+                            cellElement.SetAttribute("scope", "col");
+                        }
                         int colSpan = 1;
                         int rowSpan = 1;
                         if (cell.HorizontalMerge == MergedCellValues.Restart) {
@@ -518,12 +596,10 @@ namespace OfficeIMO.Word.Html {
                         }
                         // Vertical alignment within table cells
                         if (cell.VerticalAlignment != null) {
-                            // Avoid enum switch expressions for broad TFM support
-                            var s = cell.VerticalAlignment.Value.ToString();
                             string vAlign = "top";
-                            if (string.Equals(s, nameof(TableVerticalAlignmentValues.Center), StringComparison.Ordinal)) {
+                            if (cell.VerticalAlignment.Value == TableVerticalAlignmentValues.Center) {
                                 vAlign = "middle";
-                            } else if (string.Equals(s, nameof(TableVerticalAlignmentValues.Bottom), StringComparison.Ordinal)) {
+                            } else if (cell.VerticalAlignment.Value == TableVerticalAlignmentValues.Bottom) {
                                 vAlign = "bottom";
                             }
                             cellStyles.Add($"vertical-align:{vAlign}");
@@ -540,13 +616,32 @@ namespace OfficeIMO.Word.Html {
                             cellElement.SetAttribute("style", string.Join(";", cellStyles));
                         }
 
-                        for (int pIdx = 0; pIdx < cell.Paragraphs.Count; pIdx++) {
-                            var p = cell.Paragraphs[pIdx];
+                        IElement? cellDefinitionList = null;
+                        var cellParagraphs = cell.Paragraphs;
+                        var processedCellParagraphs = new HashSet<WordParagraph>();
+                        for (int pIdx = 0; pIdx < cellParagraphs.Count; pIdx++) {
+                            var p = cellParagraphs[pIdx];
+                            if (processedCellParagraphs.Contains(p)) {
+                                continue;
+                            }
+                            if (IsDefinitionListParagraph(p) && IsEmptyDefinitionListParagraph(p)) {
+                                for (int j = pIdx + 1; j < cellParagraphs.Count; j++) {
+                                    if (!cellParagraphs[j].Equals(p)) {
+                                        break;
+                                    }
+                                    if (!IsEmptyDefinitionListParagraph(cellParagraphs[j])) {
+                                        p = cellParagraphs[j];
+                                        break;
+                                    }
+                                }
+                            }
+                            processedCellParagraphs.Add(p);
                             if (IsCodeParagraph(p)) {
+                                cellDefinitionList = null;
                                 List<string> lines = new();
                                 lines.Add(p.Text);
-                                while (pIdx + 1 < cell.Paragraphs.Count && IsCodeParagraph(cell.Paragraphs[pIdx + 1])) {
-                                    lines.Add(cell.Paragraphs[pIdx + 1].Text);
+                                while (pIdx + 1 < cellParagraphs.Count && IsCodeParagraph(cellParagraphs[pIdx + 1])) {
+                                    lines.Add(cellParagraphs[pIdx + 1].Text);
                                     pIdx++;
                                 }
                                 var pre = htmlDoc.CreateElement("pre");
@@ -554,7 +649,17 @@ namespace OfficeIMO.Word.Html {
                                 code.TextContent = string.Join("\n", lines);
                                 pre.AppendChild(code);
                                 cellElement.AppendChild(pre);
+                            } else if (IsDefinitionListParagraph(p)) {
+                                if (IsEmptyDefinitionListParagraph(p)) {
+                                    continue;
+                                }
+                                if (cellDefinitionList == null) {
+                                    cellDefinitionList = htmlDoc.CreateElement("dl");
+                                    cellElement.AppendChild(cellDefinitionList);
+                                }
+                                AppendDefinitionListItem(cellDefinitionList, p);
                             } else {
+                                cellDefinitionList = null;
                                 AppendParagraph(cellElement, p);
                             }
                         }
@@ -568,7 +673,7 @@ namespace OfficeIMO.Word.Html {
 
                         tr.AppendChild(cellElement);
                     }
-                    if (headerRowCount == 0) {
+                    if (headerRowCount == 0 && !hasFooterRow) {
                         tableEl.AppendChild(tr);
                     } else if (isHeaderRow) {
                         if (thead == null) {
@@ -576,6 +681,12 @@ namespace OfficeIMO.Word.Html {
                             tableEl.AppendChild(thead);
                         }
                         thead.AppendChild(tr);
+                    } else if (isFooterRow) {
+                        if (tfoot == null) {
+                            tfoot = htmlDoc.CreateElement("tfoot");
+                            tableEl.AppendChild(tfoot);
+                        }
+                        tfoot.AppendChild(tr);
                     } else {
                         if (tbody == null) {
                             tbody = htmlDoc.CreateElement("tbody");
@@ -615,7 +726,10 @@ namespace OfficeIMO.Word.Html {
                         "-" => "'-'",
                         "\u2013" => "'\\2013'",
                         "\u2014" => "'\\2014'",
-                        _ => "disc",
+                        "*" => "'*'",
+                        "+" => "'+'",
+                        "•" or "·" or "●" or "∙" or "" or null or "" => "disc",
+                        _ => QuoteCssListMarker(info.LevelText),
                     };
                 }
                 if (format != null && formatMap.TryGetValue(format.Value, out var map)) {
@@ -624,14 +738,25 @@ namespace OfficeIMO.Word.Html {
                 return null;
             }
 
+            string QuoteCssListMarker(string marker) {
+                var escaped = marker
+                    .Replace("\\", "\\\\")
+                    .Replace("'", "\\'")
+                    .Replace("\r", "\\d ")
+                    .Replace("\n", "\\a ")
+                    .Replace("\t", "\\9 ");
+                return $"'{escaped}'";
+            }
+
             string? GetListType(DocumentTraversal.ListInfo info) {
                 var format = info.NumberFormat;
                 if (format == NumberFormatValues.Bullet) {
                     return info.LevelText switch {
                         "o" or "◦" => "circle",
                         "■" or "§" => "square",
-                        "-" or "\u2013" or "\u2014" => null,
-                        _ => "disc",
+                        "-" or "\u2013" or "\u2014" or "*" or "+" => null,
+                        "•" or "·" or "●" or "∙" or "" or null or "" => "disc",
+                        _ => null,
                     };
                 }
                 if (format != null && formatMap.TryGetValue(format.Value, out var map)) {
@@ -651,7 +776,7 @@ namespace OfficeIMO.Word.Html {
                     sectionParent = CreateSectionElement(htmlDoc, section, sectionIndex, sectionIndex == 0);
                     body.AppendChild(sectionParent);
                 }
-                AppendHeaderFooterRegions(htmlDoc, sectionParent, section, sectionIndex, true, AppendParagraph, AppendTable, options, cancellationToken);
+                AppendHeaderFooterRegions(htmlDoc, sectionParent, section, sectionIndex, true, (parent, paragraph) => AppendParagraph(parent, paragraph), (parent, table) => AppendTable(parent, table), options, cancellationToken);
 
                 var elements = section.Elements;
                 if (elements == null || elements.Count == 0) {
@@ -664,9 +789,10 @@ namespace OfficeIMO.Word.Html {
                 if (elements == null) {
                     continue;
                 }
+                IElement? activeDefinitionList = null;
                 for (int idx = 0; idx < elements.Count; idx++) {
-                    var element = elements[idx];
-                    if (element is WordParagraph paragraph) {
+                        var element = elements[idx];
+                        if (element is WordParagraph paragraph) {
                         // Render each underlying OpenXml paragraph exactly once.
                         // Prefer the bookmark-bearing wrapper when multiple wrappers exist for the same paragraph.
                         if (processedParagraphs.Contains(paragraph)) {
@@ -683,8 +809,13 @@ namespace OfficeIMO.Word.Html {
                             }
                         }
                         processedParagraphs.Add(paragraph);
+                        if (IsCaptionParagraph(paragraph) && idx + 1 < elements.Count && elements[idx + 1] is WordTable) {
+                            activeDefinitionList = null;
+                            continue;
+                        }
                         var listInfo = DocumentTraversal.GetListInfo(paragraph);
                         if (listInfo != null) {
+                            activeDefinitionList = null;
                             int level = listInfo.Value.Level;
                             while (listStack.Count > level) {
                                 listStack.Pop();
@@ -730,7 +861,17 @@ namespace OfficeIMO.Word.Html {
                             AppendRuns(li, paragraph);
                         } else {
                             CloseLists();
-                            if (paragraph.IsImage && idx + 1 < elements.Count && elements[idx + 1] is WordParagraph captionPara && string.Equals(captionPara.StyleId, "Caption", StringComparison.OrdinalIgnoreCase)) {
+                            if (IsDefinitionListParagraph(paragraph)) {
+                                if (IsEmptyDefinitionListParagraph(paragraph)) {
+                                    continue;
+                                }
+                                if (activeDefinitionList == null) {
+                                    activeDefinitionList = htmlDoc.CreateElement("dl");
+                                    sectionParent.AppendChild(activeDefinitionList);
+                                }
+                                AppendDefinitionListItem(activeDefinitionList, paragraph);
+                            } else if (paragraph.IsImage && idx + 1 < elements.Count && elements[idx + 1] is WordParagraph captionPara && string.Equals(captionPara.StyleId, "Caption", StringComparison.OrdinalIgnoreCase)) {
+                                activeDefinitionList = null;
                                 var figure = htmlDoc.CreateElement("figure");
                                 ApplyBookmarkId(figure, paragraph);
                                 AppendRuns(figure, paragraph);
@@ -744,6 +885,7 @@ namespace OfficeIMO.Word.Html {
                                 sectionParent.AppendChild(figure);
                                 idx++;
                             } else if (IsCodeParagraph(paragraph)) {
+                                activeDefinitionList = null;
                                 List<string> lines = new();
                                 lines.Add(paragraph.Text);
                                 while (idx + 1 < elements.Count && elements[idx + 1] is WordParagraph nextPara && DocumentTraversal.GetListInfo(nextPara) == null && IsCodeParagraph(nextPara)) {
@@ -757,17 +899,27 @@ namespace OfficeIMO.Word.Html {
                                 pre.AppendChild(code);
                                 sectionParent.AppendChild(pre);
                             } else {
+                                activeDefinitionList = null;
                                 AppendParagraph(sectionParent, paragraph);
                             }
                         }
                     } else if (element is WordTable table) {
                         CloseLists();
-                        AppendTable(sectionParent, table);
+                        activeDefinitionList = null;
+                        WordParagraph? captionParagraph = null;
+                        if (idx > 0 && elements[idx - 1] is WordParagraph previousCaption && IsCaptionParagraph(previousCaption)) {
+                            captionParagraph = previousCaption;
+                        } else if (idx + 1 < elements.Count && elements[idx + 1] is WordParagraph nextCaption && IsCaptionParagraph(nextCaption)) {
+                            captionParagraph = nextCaption;
+                            processedParagraphs.Add(nextCaption);
+                            idx++;
+                        }
+                        AppendTable(sectionParent, table, captionParagraph);
                     }
                 }
                 if (options.ExportHeadersAndFooters) {
                     CloseLists();
-                    AppendHeaderFooterRegions(htmlDoc, sectionParent, section, sectionIndex, false, AppendParagraph, AppendTable, options, cancellationToken);
+                    AppendHeaderFooterRegions(htmlDoc, sectionParent, section, sectionIndex, false, (parent, paragraph) => AppendParagraph(parent, paragraph), (parent, table) => AppendTable(parent, table), options, cancellationToken);
                 }
                 if (options.IncludeSectionMetadata) {
                     CloseLists();
@@ -784,6 +936,21 @@ namespace OfficeIMO.Word.Html {
             AppendStyleDefinitions(document, htmlDoc, head, paragraphStyles, runStyles, cancellationToken);
 
             return htmlDoc.DocumentElement.OuterHtml;
+        }
+
+        private static string? NormalizeRunLanguage(string? language, string? documentLanguage) {
+            var normalized = language?.Trim();
+            if (string.IsNullOrEmpty(normalized)) {
+                return null;
+            }
+
+            var normalizedDocumentLanguage = documentLanguage?.Trim();
+            if (!string.IsNullOrEmpty(normalizedDocumentLanguage) &&
+                string.Equals(normalized, normalizedDocumentLanguage, StringComparison.OrdinalIgnoreCase)) {
+                return null;
+            }
+
+            return normalized;
         }
     }
 }

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -78,6 +78,10 @@ namespace OfficeIMO.Word.Html {
                 IElement? quote = null;
                 for (int i = 0; i < runs.Count; i++) {
                     var run = runs[i];
+                    if (HtmlSemanticMetadata.IsTimeDateTimeMetadataRun(run)) {
+                        continue;
+                    }
+
                     if (TryAppendNoteReference(htmlDoc, run, options, processNotes, nodes, footnotes, footnoteMap, endnotes, endnoteMap)) {
                         continue;
                     }
@@ -173,6 +177,10 @@ namespace OfficeIMO.Word.Html {
                     // Still honor explicit line breaks even when the run carries no text
                     if (run.Break != null && run.PageBreak == null) {
                         nodes.Add(htmlDoc.CreateElement("br"));
+                    }
+                    if (TryCreateRubyNode(htmlDoc, run, out var rubyNode)) {
+                        nodes.Add(rubyNode);
+                        continue;
                     }
                     if (string.IsNullOrEmpty(run.Text)) {
                         continue;
@@ -882,6 +890,20 @@ namespace OfficeIMO.Word.Html {
                                 }
                                 AppendRuns(figCap, captionPara);
                                 figure.AppendChild(figCap);
+                                sectionParent.AppendChild(figure);
+                                idx++;
+                            } else if (IsCaptionParagraph(paragraph) && idx + 1 < elements.Count && elements[idx + 1] is WordParagraph imagePara && imagePara.IsImage) {
+                                activeDefinitionList = null;
+                                var figure = htmlDoc.CreateElement("figure");
+                                ApplyBookmarkId(figure, imagePara);
+                                var figCap = htmlDoc.CreateElement("figcaption");
+                                if (options.IncludeParagraphClasses && !string.IsNullOrEmpty(paragraph.StyleId)) {
+                                    figCap.SetAttribute("class", paragraph.StyleId);
+                                    paragraphStyles.Add(paragraph.StyleId!);
+                                }
+                                AppendRuns(figCap, paragraph);
+                                figure.AppendChild(figCap);
+                                AppendRuns(figure, imagePara);
                                 sectionParent.AppendChild(figure);
                                 idx++;
                             } else if (IsCodeParagraph(paragraph)) {

--- a/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
+++ b/OfficeIMO.Word.Html/Helpers/CssStyleMapper.cs
@@ -20,8 +20,9 @@ namespace OfficeIMO.Word.Html {
             internal int? PaddingRight { get; set; }
             internal int? PaddingTop { get; set; }
             internal int? PaddingBottom { get; set; }
-            internal bool Underline { get; set; }
-            internal bool Strike { get; set; }
+            internal bool? Underline { get; set; }
+            internal UnderlineValues? UnderlineStyle { get; set; }
+            internal bool? Strike { get; set; }
             internal string? BackgroundColor { get; set; }
             internal int? LineHeight { get; set; }
             internal LineSpacingRuleValues? LineHeightRule { get; set; }
@@ -85,16 +86,14 @@ namespace OfficeIMO.Word.Html {
             if (properties.TryGetValue("padding-bottom", out string? pb) && TryParseLength(pb, out int pB)) result.PaddingBottom = pB;
 
             if (properties.TryGetValue("text-decoration", out string? deco)) {
-                foreach (var part in deco.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)) {
-                    switch (part.Trim().ToLowerInvariant()) {
-                        case "underline":
-                            result.Underline = true;
-                            break;
-                        case "line-through":
-                            result.Strike = true;
-                            break;
-                    }
-                }
+                ApplyTextDecoration(deco, result);
+            }
+            if (properties.TryGetValue("text-decoration-line", out string? decoLine)) {
+                ApplyTextDecorationLine(decoLine, result);
+            }
+            if (properties.TryGetValue("text-decoration-style", out string? decoStyle) &&
+                TryMapTextDecorationStyle(decoStyle, out var underlineStyle)) {
+                result.UnderlineStyle = underlineStyle;
             }
 
             if (properties.TryGetValue("background-color", out string? bg)) {
@@ -133,6 +132,75 @@ namespace OfficeIMO.Word.Html {
                 }
             }
             return dict;
+        }
+
+        private static void ApplyTextDecoration(string value, CssProperties result) {
+            foreach (var token in SplitCssTokens(value)) {
+                if (ApplyTextDecorationLineToken(token, result)) {
+                    continue;
+                }
+                if (TryMapTextDecorationStyle(token, out var underlineStyle)) {
+                    result.UnderlineStyle = underlineStyle;
+                }
+            }
+        }
+
+        private static void ApplyTextDecorationLine(string value, CssProperties result) {
+            foreach (var token in SplitCssTokens(value)) {
+                ApplyTextDecorationLineToken(token, result);
+            }
+        }
+
+        private static bool ApplyTextDecorationLineToken(string token, CssProperties result) {
+            switch (token.Trim().ToLowerInvariant()) {
+                case "none":
+                    result.Underline = false;
+                    result.Strike = false;
+                    result.UnderlineStyle = null;
+                    return true;
+                case "underline":
+                    result.Underline = true;
+                    result.UnderlineStyle ??= UnderlineValues.Single;
+                    return true;
+                case "line-through":
+                    result.Strike = true;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static bool TryMapTextDecorationStyle(string value, out UnderlineValues underlineStyle) {
+            underlineStyle = UnderlineValues.Single;
+            switch (value.Trim().ToLowerInvariant()) {
+                case "solid":
+                    underlineStyle = UnderlineValues.Single;
+                    return true;
+                case "double":
+                    underlineStyle = UnderlineValues.Double;
+                    return true;
+                case "dotted":
+                    underlineStyle = UnderlineValues.Dotted;
+                    return true;
+                case "dashed":
+                    underlineStyle = UnderlineValues.Dash;
+                    return true;
+                case "wavy":
+                    underlineStyle = UnderlineValues.Wave;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static IEnumerable<string> SplitCssTokens(string? value) {
+            if (string.IsNullOrWhiteSpace(value)) {
+                yield break;
+            }
+
+            foreach (var token in value!.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)) {
+                yield return token;
+            }
         }
 
         private static bool TryParseFontSize(string value, out double size) {

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -7,6 +7,57 @@ namespace OfficeIMO.Word.Html {
     /// </summary>
     public class HtmlToWordOptions {
         /// <summary>
+        /// Creates the default OfficeIMO HTML import profile.
+        /// </summary>
+        /// <returns>A new <see cref="HtmlToWordOptions"/> instance with the default compatibility-oriented settings.</returns>
+        public static HtmlToWordOptions CreateOfficeIMOProfile() => new HtmlToWordOptions();
+
+        /// <summary>
+        /// Creates a bounded offline profile for untrusted HTML ingestion.
+        /// </summary>
+        /// <remarks>
+        /// The profile keeps document-provided stylesheet links disabled, embeds only data URI images,
+        /// blocks external image and stylesheet URI schemes, enables accessibility diagnostics, and
+        /// applies conservative HTML, CSS, image, and table limits. Callers can relax individual
+        /// limits or allow-lists when their ingestion boundary is more trusted.
+        /// </remarks>
+        /// <returns>A new <see cref="HtmlToWordOptions"/> instance configured for untrusted HTML.</returns>
+        public static HtmlToWordOptions CreateUntrustedHtmlProfile() {
+            var options = new HtmlToWordOptions {
+                ImageProcessing = ImageProcessingMode.EmbedDataUriOnly,
+                ResourceTimeout = TimeSpan.FromSeconds(5),
+                MaxImageBytes = 5L * 1024L * 1024L,
+                MaxTotalImageBytes = 20L * 1024L * 1024L,
+                MaxHtmlNodes = 10000,
+                MaxHtmlDepth = 64,
+                MaxCssBytes = 256L * 1024L,
+                MaxTotalCssBytes = 512L * 1024L,
+                MaxTableCells = 50000,
+                EnableAccessibilityDiagnostics = true,
+                UnsupportedCssHandling = HtmlUnsupportedCssHandling.Warn
+            };
+
+            options.AllowedImageUriSchemes.Clear();
+            options.AllowedImageUriSchemes.Add("data");
+            options.AllowedStylesheetUriSchemes.Clear();
+
+            return options;
+        }
+
+        /// <summary>
+        /// Creates a profile for trusted HTML documents whose own linked stylesheets may be loaded.
+        /// </summary>
+        /// <remarks>
+        /// This profile preserves default conversion behavior and validation settings while enabling
+        /// <see cref="AllowDocumentStylesheetLinks"/>. Callers should still configure host allow-lists
+        /// or byte limits when trusted documents can reference broad network locations.
+        /// </remarks>
+        /// <returns>A new <see cref="HtmlToWordOptions"/> instance configured for trusted document links.</returns>
+        public static HtmlToWordOptions CreateTrustedDocumentProfile() => new HtmlToWordOptions {
+            AllowDocumentStylesheetLinks = true
+        };
+
+        /// <summary>
         /// Optional font family applied to created runs during conversion.
         /// </summary>
         public string? FontFamily { get; set; }
@@ -133,6 +184,34 @@ namespace OfficeIMO.Word.Html {
         public HashSet<string> AllowedImageHosts { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
+        /// Stylesheet URI schemes allowed during import. Defaults allow HTTP, HTTPS, and file-based stylesheets.
+        /// Remove entries to reject matching stylesheet sources before they are loaded.
+        /// </summary>
+        public HashSet<string> AllowedStylesheetUriSchemes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+            Uri.UriSchemeHttp,
+            Uri.UriSchemeHttps,
+            Uri.UriSchemeFile
+        };
+
+        /// <summary>
+        /// Optional host allow-list for absolute non-file stylesheet URIs. When empty, all hosts are allowed.
+        /// </summary>
+        public HashSet<string> AllowedStylesheetHosts { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// When true, validates declared content types for remote stylesheet resources.
+        /// Stylesheets with rejected content types are skipped and a diagnostic is emitted.
+        /// </summary>
+        public bool ValidateStylesheetContentTypes { get; set; } = true;
+
+        /// <summary>
+        /// Declared stylesheet media types allowed when <see cref="ValidateStylesheetContentTypes"/> is enabled.
+        /// </summary>
+        public HashSet<string> AllowedStylesheetContentTypes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+            "text/css"
+        };
+
+        /// <summary>
         /// Optional maximum number of parsed HTML nodes allowed for a conversion operation.
         /// When exceeded, conversion stops with <see cref="HtmlConversionLimitException"/> and an error diagnostic.
         /// </summary>
@@ -149,6 +228,12 @@ namespace OfficeIMO.Word.Html {
         /// When exceeded, conversion stops with <see cref="HtmlConversionLimitException"/> and an error diagnostic.
         /// </summary>
         public long? MaxCssBytes { get; set; }
+
+        /// <summary>
+        /// Optional maximum UTF-8 byte count allowed across all stylesheets in a single import operation.
+        /// When exceeded, conversion stops with <see cref="HtmlConversionLimitException"/> and an error diagnostic.
+        /// </summary>
+        public long? MaxTotalCssBytes { get; set; }
 
         /// <summary>
         /// Optional maximum number of Word table cells allowed for a single imported HTML table.
@@ -174,6 +259,23 @@ namespace OfficeIMO.Word.Html {
         /// and data tables without header cells.
         /// </summary>
         public bool EnableAccessibilityDiagnostics { get; set; }
+
+        /// <summary>
+        /// When true, raw HTML comment nodes are imported as native Word comments anchored at their DOM position.
+        /// Empty comments are skipped. Existing exported OfficeIMO comment sections are always imported through
+        /// their linked comment references.
+        /// </summary>
+        public bool ImportHtmlComments { get; set; }
+
+        /// <summary>
+        /// Author name used for native Word comments created from raw HTML comment nodes.
+        /// </summary>
+        public string HtmlCommentAuthor { get; set; } = "HTML";
+
+        /// <summary>
+        /// Author initials used for native Word comments created from raw HTML comment nodes.
+        /// </summary>
+        public string HtmlCommentInitials { get; set; } = "HTML";
 
         /// <summary>
         /// Controls how unsupported CSS properties and values are handled during import.
@@ -212,6 +314,86 @@ namespace OfficeIMO.Word.Html {
         /// Controls how the <c>&lt;section&gt;</c> tag is mapped into Word.
         /// </summary>
         public SectionTagHandling SectionTagHandling { get; set; } = SectionTagHandling.WordSection;
+
+        /// <summary>
+        /// Creates a copy of the current options instance so callers can reuse option templates safely.
+        /// </summary>
+        /// <remarks>
+        /// Configuration values, allow-lists, configured stylesheets, and the diagnostic callback are copied.
+        /// The runtime <see cref="Diagnostics"/> collection starts empty on the clone so diagnostics from one
+        /// conversion are not carried into the next.
+        /// </remarks>
+        /// <returns>A new <see cref="HtmlToWordOptions"/> with the same configuration values.</returns>
+        public HtmlToWordOptions Clone() {
+            var clone = new HtmlToWordOptions {
+                FontFamily = FontFamily,
+                QuotePrefix = QuotePrefix,
+                QuoteSuffix = QuoteSuffix,
+                DefaultPageSize = DefaultPageSize,
+                DefaultOrientation = DefaultOrientation,
+                IncludeListStyles = IncludeListStyles,
+                ContinueNumbering = ContinueNumbering,
+                SupportsHeadingNumbering = SupportsHeadingNumbering,
+                BasePath = BasePath,
+                NoteReferenceType = NoteReferenceType,
+                LinkNoteUrls = LinkNoteUrls,
+                ImageProcessing = ImageProcessing,
+                HttpClient = HttpClient,
+                ResourceTimeout = ResourceTimeout,
+                MaxImageBytes = MaxImageBytes,
+                MaxTotalImageBytes = MaxTotalImageBytes,
+                ValidateImageContentTypes = ValidateImageContentTypes,
+                ValidateStylesheetContentTypes = ValidateStylesheetContentTypes,
+                MaxHtmlNodes = MaxHtmlNodes,
+                MaxHtmlDepth = MaxHtmlDepth,
+                MaxCssBytes = MaxCssBytes,
+                MaxTotalCssBytes = MaxTotalCssBytes,
+                MaxTableCells = MaxTableCells,
+                DiagnosticHandler = DiagnosticHandler,
+                EnableAccessibilityDiagnostics = EnableAccessibilityDiagnostics,
+                ImportHtmlComments = ImportHtmlComments,
+                HtmlCommentAuthor = HtmlCommentAuthor,
+                HtmlCommentInitials = HtmlCommentInitials,
+                UnsupportedCssHandling = UnsupportedCssHandling,
+                AllowDocumentStylesheetLinks = AllowDocumentStylesheetLinks,
+                RenderPreAsTable = RenderPreAsTable,
+                TableCaptionPosition = TableCaptionPosition,
+                SectionTagHandling = SectionTagHandling
+            };
+
+            CopyDictionary(ClassStyles, clone.ClassStyles);
+            CopyList(StylesheetPaths, clone.StylesheetPaths);
+            CopyList(StylesheetContents, clone.StylesheetContents);
+            CopySet(AllowedImageContentTypes, clone.AllowedImageContentTypes);
+            CopySet(AllowedImageUriSchemes, clone.AllowedImageUriSchemes);
+            CopySet(AllowedImageHosts, clone.AllowedImageHosts);
+            CopySet(AllowedStylesheetUriSchemes, clone.AllowedStylesheetUriSchemes);
+            CopySet(AllowedStylesheetHosts, clone.AllowedStylesheetHosts);
+            CopySet(AllowedStylesheetContentTypes, clone.AllowedStylesheetContentTypes);
+
+            return clone;
+        }
+
+        private static void CopyDictionary<TKey, TValue>(IDictionary<TKey, TValue> source, IDictionary<TKey, TValue> destination) {
+            destination.Clear();
+            foreach (var pair in source) {
+                destination[pair.Key] = pair.Value;
+            }
+        }
+
+        private static void CopyList<T>(IEnumerable<T> source, ICollection<T> destination) {
+            destination.Clear();
+            foreach (var item in source) {
+                destination.Add(item);
+            }
+        }
+
+        private static void CopySet<T>(IEnumerable<T> source, ISet<T> destination) {
+            destination.Clear();
+            foreach (var item in source) {
+                destination.Add(item);
+            }
+        }
     }
 
     /// <summary>

--- a/OfficeIMO.Word.Html/README.md
+++ b/OfficeIMO.Word.Html/README.md
@@ -5,14 +5,20 @@ Bidirectional HTML conversion for `OfficeIMO.Word`.
 ## What It Does Today
 
 - Converts HTML into `WordDocument` with headings, paragraphs, inline formatting, links, images, SVG, lists, tables, captions, form controls, notes, headers, footers, and sections.
-- Converts `WordDocument` back to HTML with document metadata, optional custom property metadata, optional headers and footers, optional comments, paragraph/run styles, optional list definition CSS, lists, tables, images, SVG, footnotes, endnotes, and optional default CSS.
+- Converts `WordDocument` back to HTML with document metadata, optional custom property metadata, optional headers and footers, optional comments, paragraph/run styles, optional list definition CSS, lists, tables, images, SVG, footnotes, endnotes, disabled form controls, and optional default CSS.
 - Preserves document-level language metadata between HTML `lang` attributes and `WordDocument.Settings.Language`.
-- Supports inline CSS, embedded stylesheet content, external stylesheet paths, remote stylesheet loading through a caller-provided `HttpClient`, and common CSS page-break declarations.
-- Supports image embedding, external image links, data URI images, resource timeouts, optional per-image and total image byte limits, declared image content-type validation, and URI scheme/host policy controls.
-- Supports optional HTML node, HTML depth, CSS byte, and table-cell limits for safer conversion of large or hostile inputs.
-- Reports HTML import diagnostics through `HtmlToWordOptions.Diagnostics` and `DiagnosticHandler` when content is skipped, degraded, or not mapped, such as image load failures and unsupported CSS declarations or values.
+- Supports inline CSS, embedded stylesheet content, external stylesheet paths, remote stylesheet loading through a caller-provided `HttpClient`, stylesheet URI scheme/host policy controls, stylesheet content-type validation, aggregate CSS byte limits, and common CSS page-break declarations.
+- Reuses parsed stylesheet rules by CSS content hash, while changed local or remote stylesheet content is parsed as fresh input.
+- Supports image embedding, external image links, data URI images, resource timeouts, optional per-image and total image byte limits, declared image content-type validation, and image URI scheme/host policy controls.
+- Supports optional HTML node, HTML depth, per-stylesheet CSS byte, aggregate CSS byte, and table-cell limits for safer conversion of large or hostile inputs.
+- Provides named import profiles through `HtmlToWordOptions.CreateOfficeIMOProfile()`, `CreateUntrustedHtmlProfile()`, and `CreateTrustedDocumentProfile()`, plus `Clone()` for reusable option templates.
+- Reports HTML import diagnostics through `HtmlToWordOptions.Diagnostics` and `DiagnosticHandler` when content is skipped, degraded, or not mapped, such as image load failures, raw HTML comments, disabled or invalid stylesheet links, stylesheet policy/HTTP/transport/timeout failures, and unsupported CSS declarations or values.
+- Can opt in to import non-empty raw HTML comments as native Word comments with configurable author and initials metadata.
+- Skips unsupported embedded media/widget elements such as `iframe`, `object`, `embed`, `video`, `audio`, and `canvas` with diagnostics instead of importing fallback text as document content.
 - Can emit opt-in accessibility diagnostics for missing image alternate text, weak or empty link text, skipped heading levels, and data tables without header cells.
 - Lets callers choose unsupported CSS behavior with `HtmlToWordOptions.UnsupportedCssHandling`: ignore, warn by default, or stop conversion with `HtmlUnsupportedCssException`.
+- Maps common document-table styling, including table/cell widths, borders, padding, horizontal and vertical alignment, captions, column groups, header/footer row groups, HTML `cellspacing`, and CSS `border-spacing`.
+- Imports text and visible value-bearing inputs, dates, text areas, meter/progress values, single-select dropdowns, named radio groups, multi-select values, datalist-backed combo boxes, and checkbox markers into Word content controls where Word has a practical equivalent.
 - Targets `netstandard2.0`, `net8.0`, `net10.0`, and `net472` on Windows.
 
 The current supported feature set is tracked in `Docs/officeimo.word-html-support-matrix.md`.
@@ -35,6 +41,26 @@ string roundTrip = document.ToHtml(new WordToHtmlOptions {
 ```
 
 HTML can also be appended to an existing body, header, or footer with the `AddHtmlToBody`, `AddHtmlToHeader`, and `AddHtmlToFooter` extension methods.
+
+## Import Profiles
+
+```csharp
+var safeOptions = HtmlToWordOptions.CreateUntrustedHtmlProfile();
+safeOptions.MaxHtmlNodes = 5000;
+safeOptions.DiagnosticHandler = diagnostic => Console.WriteLine($"{diagnostic.Code}: {diagnostic.Source}");
+
+WordDocument safeDocument = html.LoadFromHtml(safeOptions);
+
+var trustedOptions = HtmlToWordOptions.CreateTrustedDocumentProfile();
+trustedOptions.AllowedStylesheetHosts.Add("cdn.example.com");
+
+WordDocument trustedDocument = trustedHtml.LoadFromHtml(trustedOptions);
+```
+
+- `CreateOfficeIMOProfile()` preserves the default compatibility-oriented behavior.
+- `CreateUntrustedHtmlProfile()` keeps external document resources offline by default, enables accessibility diagnostics, and applies bounded HTML, CSS, image, and table limits.
+- `CreateTrustedDocumentProfile()` enables document-provided stylesheet links for known-good HTML while retaining the current resource validation defaults.
+- `Clone()` copies configuration values, allow-lists, configured stylesheets, and callbacks while starting with an empty diagnostics collection.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- improves OfficeIMO Word HTML import/export robustness across semantic inline content, comments, forms, tables, lists, figures, stylesheets, resources, and diagnostics
- adds native simple HTML ruby import to Word `w:ruby` with validated DOCX output and fallback for annotation-less ruby
- expands Reader/Word HTML conversion options, support matrix, roadmap notes, and focused contract tests for the new conversion behavior

## Validation
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --filter "FullyQualifiedName~Test_Html_Ruby" /nr:false`
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --filter "FullyQualifiedName~OfficeIMO.Tests.Html" --no-build /nr:false`
- `dotnet build OfficeIMO.Word.Html\OfficeIMO.Word.Html.csproj /nr:false`
- `dotnet build OfficeIMO.Markdown.Html\OfficeIMO.Markdown.Html.csproj /nr:false`
- `dotnet build OfficeIMO.Reader.Html\OfficeIMO.Reader.Html.csproj /nr:false`
- `git diff --check`
- `git diff --cached --check`