### PR TITLE
Add Markdown template insertion support

### DIFF
--- a/OfficeIMO.Tests/Markdown.WordToMarkdown.cs
+++ b/OfficeIMO.Tests/Markdown.WordToMarkdown.cs
@@ -317,6 +317,91 @@ namespace OfficeIMO.Tests {
             Assert.Equal("Even footer", document.Footer!.Even!.Paragraphs.Single(paragraph => !string.IsNullOrWhiteSpace(paragraph.Text)).Text.Trim());
             Assert.Contains(document.Paragraphs, paragraph => paragraph.Text.Trim() == "Body line");
         }
+
+        [Fact]
+        public void MarkdownToWord_LoadFromMarkdownTemplate_Inserts_At_Bookmark_And_Preserves_Template_Content() {
+            string templatePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".docx");
+            try {
+                using (var template = WordDocument.Create(templatePath)) {
+                    template.AddParagraph("Before template content");
+                    template.AddParagraph("PLACEHOLDER").AddBookmark("MainContent");
+                    template.AddParagraph("After template content");
+                    template.Save();
+                }
+
+                const string markdown = """
+                    ---
+                    title: Hidden metadata
+                    ---
+                    # Inserted heading
+
+                    Inserted body.
+
+                    - First
+                    - Second
+                    """;
+
+                using var document = markdown.LoadFromMarkdownTemplate(
+                    templatePath,
+                    new MarkdownToWordTemplateOptions {
+                        BookmarkName = "MainContent"
+                    });
+
+                var paragraphTexts = document.Paragraphs
+                    .Select(paragraph => paragraph.Text.Trim())
+                    .Where(text => text.Length > 0)
+                    .ToArray();
+
+                Assert.DoesNotContain("PLACEHOLDER", paragraphTexts);
+                Assert.DoesNotContain(paragraphTexts, text => text.Contains("title: Hidden metadata", StringComparison.Ordinal));
+                Assert.True(Array.IndexOf(paragraphTexts, "Before template content") < Array.IndexOf(paragraphTexts, "Inserted heading"));
+                Assert.True(Array.IndexOf(paragraphTexts, "Inserted body.") < Array.IndexOf(paragraphTexts, "After template content"));
+                Assert.Contains(document.Paragraphs, paragraph => paragraph.Style == WordParagraphStyles.Heading1 && paragraph.Text.Trim() == "Inserted heading");
+                Assert.Contains(document.Paragraphs, paragraph => paragraph.Text.Trim() == "First" && paragraph.IsListItem);
+            } finally {
+                if (File.Exists(templatePath)) {
+                    File.Delete(templatePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void WordToMarkdown_Emits_ExternalImages_As_Links_Instead_Of_Failing() {
+            using var doc = WordDocument.Create();
+            doc.AddParagraph().AddImage(new Uri("cid:86dec9c7-5eda-46b3-b8fb-2e2b7b0d6fb8"), 50, 50, description: "Linked image");
+            var warnings = new List<string>();
+
+            string markdown = doc.ToMarkdown(new WordToMarkdownOptions {
+                ImageExportMode = ImageExportMode.File,
+                OnWarning = warnings.Add
+            });
+
+            Assert.Contains("![Linked image](cid:86dec9c7-5eda-46b3-b8fb-2e2b7b0d6fb8)", markdown);
+            Assert.Contains(warnings, warning => warning.Contains("Externally linked image", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void WordToMarkdown_Exports_Extensionless_ImageNames_With_Detected_Extension() {
+            using var doc = WordDocument.Create();
+            string imagePath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Assets", "OfficeIMO.png"));
+            using (var stream = File.OpenRead(imagePath)) {
+                doc.AddParagraph().AddImage(stream, "Picture 1", width: 32, height: 32, description: "Logo");
+            }
+
+            string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            try {
+                string markdown = doc.ToMarkdown(new WordToMarkdownOptions {
+                    ImageExportMode = ImageExportMode.File,
+                    ImageDirectory = tempDir
+                });
+
+                Assert.Contains("![Logo](Picture 1.png)", markdown);
+                Assert.True(File.Exists(Path.Combine(tempDir, "Picture 1.png")));
+            } finally {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
     }
 }
 

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.BlockRenderer.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.BlockRenderer.cs
@@ -304,6 +304,10 @@ namespace OfficeIMO.Word.Markdown {
             }
 
             protected override void VisitFrontMatterBlock(Omd.FrontMatterBlock block) {
+                if (!_options.RenderFrontMatter) {
+                    return;
+                }
+
                 var lines = block.Render().Replace("\r", string.Empty).Split('\n');
                 var monoFont = FontResolver.Resolve("monospace") ?? "Consolas";
 
@@ -341,6 +345,8 @@ namespace OfficeIMO.Word.Markdown {
                         RenderNested(blockChildren[i], listLevel: effectiveLevel + 1);
                     }
                 }
+
+                _host.NotifyListRendered(list);
             }
         }
     }

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.RenderHosts.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.RenderHosts.cs
@@ -1,3 +1,4 @@
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Drawing;
 using OfficeIMO.Markdown.Html;
@@ -17,6 +18,7 @@ namespace OfficeIMO.Word.Markdown {
             void InsertHtml(string html);
             bool SupportsHorizontalRule { get; }
             void InsertHorizontalRule();
+            void NotifyListRendered(WordList list);
         }
 
         private sealed class DocumentWordBlockRenderHost : IWordBlockRenderHost {
@@ -33,6 +35,7 @@ namespace OfficeIMO.Word.Markdown {
             public void InsertHtml(string html) => _document.AddHtmlToBody(html);
             public bool SupportsHorizontalRule => true;
             public void InsertHorizontalRule() => _document.AddHorizontalLine();
+            public void NotifyListRendered(WordList list) { }
         }
 
         private sealed class TableCellWordBlockRenderHost : IWordBlockRenderHost {
@@ -70,6 +73,7 @@ namespace OfficeIMO.Word.Markdown {
             public void InsertHtml(string html) { }
             public bool SupportsHorizontalRule => false;
             public void InsertHorizontalRule() { }
+            public void NotifyListRendered(WordList list) { }
         }
 
         private sealed class HeaderFooterWordBlockRenderHost : IWordBlockRenderHost {
@@ -86,6 +90,60 @@ namespace OfficeIMO.Word.Markdown {
             public void InsertHtml(string html) { }
             public bool SupportsHorizontalRule => true;
             public void InsertHorizontalRule() => _headerFooter.AddHorizontalLine();
+            public void NotifyListRendered(WordList list) { }
+        }
+
+        private sealed class BodyInsertionPointWordBlockRenderHost : IWordBlockRenderHost {
+            private readonly WordDocument _document;
+            private readonly OpenXmlElement _anchor;
+            private readonly List<Paragraph> _listSeeds = new();
+
+            public BodyInsertionPointWordBlockRenderHost(WordDocument document, OpenXmlElement anchor) {
+                _document = document ?? throw new ArgumentNullException(nameof(document));
+                _anchor = anchor ?? throw new ArgumentNullException(nameof(anchor));
+                if (_anchor.Parent == null) {
+                    throw new InvalidOperationException("Insertion anchor must be attached to a Word document.");
+                }
+            }
+
+            public WordParagraph CreateParagraph() {
+                var paragraph = new Paragraph();
+                _anchor.InsertBeforeSelf(paragraph);
+                return new WordParagraph(_document, paragraph);
+            }
+
+            public WordList CreateList(WordListStyle style) {
+                var seed = CreateSeedParagraph();
+                _listSeeds.Add(seed._paragraph);
+                return seed.AddList(style);
+            }
+
+            public WordTable CreateTable(int rows, int columns) {
+                var seed = CreateSeedParagraph();
+                try {
+                    return seed.AddTableAfter(rows, columns);
+                } finally {
+                    seed.Remove();
+                }
+            }
+
+            public bool SupportsHtmlInsertion => false;
+            public void InsertHtml(string html) { }
+            public bool SupportsHorizontalRule => true;
+            public void InsertHorizontalRule() => CreateParagraph().AddHorizontalLine();
+
+            public void NotifyListRendered(WordList list) {
+                foreach (var seed in _listSeeds) {
+                    seed.Remove();
+                }
+                _listSeeds.Clear();
+            }
+
+            private WordParagraph CreateSeedParagraph() {
+                var paragraph = new Paragraph();
+                _anchor.InsertBeforeSelf(paragraph);
+                return new WordParagraph(_document, paragraph);
+            }
         }
     }
 }

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Template.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.Template.cs
@@ -1,0 +1,179 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+using System.Threading;
+using System.Threading.Tasks;
+using Omd = OfficeIMO.Markdown;
+
+namespace OfficeIMO.Word.Markdown {
+    internal partial class MarkdownToWordConverter {
+        public WordDocument ConvertIntoTemplate(string markdown, WordDocument document, MarkdownToWordTemplateOptions options) {
+            return ConvertIntoTemplateAsync(markdown, document, options).GetAwaiter().GetResult();
+        }
+
+        public Task<WordDocument> ConvertIntoTemplateAsync(
+            string markdown,
+            WordDocument document,
+            MarkdownToWordTemplateOptions options,
+            CancellationToken cancellationToken = default) {
+            if (markdown == null) {
+                throw new ArgumentNullException(nameof(markdown));
+            }
+
+            options ??= new MarkdownToWordTemplateOptions();
+            var readerOptions = CreateEffectiveReaderOptions(options);
+            var markdownDocument = Omd.MarkdownReader.Parse(markdown, readerOptions);
+            return ConvertIntoTemplateAsync(markdownDocument, document, options, cancellationToken);
+        }
+
+        public WordDocument ConvertIntoTemplate(Omd.MarkdownDoc markdown, WordDocument document, MarkdownToWordTemplateOptions options) {
+            return ConvertIntoTemplateAsync(markdown, document, options).GetAwaiter().GetResult();
+        }
+
+        public Task<WordDocument> ConvertIntoTemplateAsync(
+            Omd.MarkdownDoc markdown,
+            WordDocument document,
+            MarkdownToWordTemplateOptions options,
+            CancellationToken cancellationToken = default) {
+            if (markdown == null) {
+                throw new ArgumentNullException(nameof(markdown));
+            }
+
+            if (document == null) {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            options ??= new MarkdownToWordTemplateOptions();
+            options.ApplyDefaults(document);
+
+            var insertion = ResolveTemplateInsertion(document, options);
+            var host = new BodyInsertionPointWordBlockRenderHost(document, insertion.Anchor);
+            var pageContentWidthPixels = EstimatePageContentWidthPixels(document);
+            RenderMarkdownDocument(markdown, host, document, options, pageContentWidthPixels, cancellationToken);
+
+            if (insertion.RemoveAfterRender && insertion.Anchor.Parent != null) {
+                insertion.Anchor.Remove();
+            }
+
+            return Task.FromResult(document);
+        }
+
+        private void RenderMarkdownDocument(
+            Omd.MarkdownDoc markdown,
+            IWordBlockRenderHost host,
+            WordDocument document,
+            MarkdownToWordOptions options,
+            double pageContentWidthPixels,
+            CancellationToken cancellationToken) {
+            var blocks = markdown.Blocks ?? Array.Empty<Omd.IMarkdownBlock>();
+
+            _currentFootnotes = blocks
+                .OfType<Omd.FootnoteDefinitionBlock>()
+                .GroupBy(f => f.Label)
+                .ToDictionary(g => g.Key, g => g.Last().Text);
+
+            if (markdown.DocumentHeader != null) {
+                RenderSharedBlockOmd(
+                    markdown.DocumentHeader,
+                    host,
+                    options,
+                    document,
+                    currentList: null,
+                    listLevel: 0,
+                    quoteDepth: 0,
+                    pageContentWidthPixels: pageContentWidthPixels,
+                    alignment: Omd.ColumnAlignment.None);
+            }
+
+            foreach (var block in blocks) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (block == null) {
+                    continue;
+                }
+
+                RenderSharedBlockOmd(
+                    block,
+                    host,
+                    options,
+                    document,
+                    currentList: null,
+                    listLevel: 0,
+                    quoteDepth: 0,
+                    pageContentWidthPixels: pageContentWidthPixels,
+                    alignment: Omd.ColumnAlignment.None);
+            }
+        }
+
+        private static TemplateInsertion ResolveTemplateInsertion(WordDocument document, MarkdownToWordTemplateOptions options) {
+            if (!string.IsNullOrWhiteSpace(options.ContentControlTag) || !string.IsNullOrWhiteSpace(options.ContentControlAlias)) {
+                var contentControl = FindBlockContentControl(document, options);
+                if (contentControl == null) {
+                    throw new InvalidOperationException("The requested block content control insertion point was not found.");
+                }
+
+                return new TemplateInsertion(contentControl, options.ReplacePlaceholder);
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.BookmarkName)) {
+                var bookmarkParagraph = FindBookmarkParagraph(document, options.BookmarkName!);
+                if (bookmarkParagraph == null) {
+                    throw new InvalidOperationException($"Bookmark '{options.BookmarkName}' was not found.");
+                }
+
+                return new TemplateInsertion(bookmarkParagraph, options.ReplacePlaceholder);
+            }
+
+            var marker = new Paragraph();
+            var sectionProperties = document.BodyRoot.Elements<SectionProperties>().LastOrDefault();
+            if (sectionProperties != null) {
+                document.BodyRoot.InsertBefore(marker, sectionProperties);
+            } else {
+                document.BodyRoot.Append(marker);
+            }
+
+            return new TemplateInsertion(marker, removeAfterRender: true);
+        }
+
+        private static SdtBlock? FindBlockContentControl(WordDocument document, MarkdownToWordTemplateOptions options) {
+            return document.BodyRoot
+                .Descendants<SdtBlock>()
+                .FirstOrDefault(sdt =>
+                    MatchesContentControlTag(sdt, options.ContentControlTag) &&
+                    MatchesContentControlAlias(sdt, options.ContentControlAlias));
+        }
+
+        private static bool MatchesContentControlTag(SdtBlock sdt, string? tag) {
+            if (string.IsNullOrWhiteSpace(tag)) {
+                return true;
+            }
+
+            var actual = sdt.SdtProperties?.GetFirstChild<Tag>()?.Val?.Value;
+            return string.Equals(actual, tag, StringComparison.Ordinal);
+        }
+
+        private static bool MatchesContentControlAlias(SdtBlock sdt, string? alias) {
+            if (string.IsNullOrWhiteSpace(alias)) {
+                return true;
+            }
+
+            var actual = sdt.SdtProperties?.GetFirstChild<SdtAlias>()?.Val?.Value;
+            return string.Equals(actual, alias, StringComparison.Ordinal);
+        }
+
+        private static Paragraph? FindBookmarkParagraph(WordDocument document, string bookmarkName) {
+            var bookmark = document.BodyRoot
+                .Descendants<BookmarkStart>()
+                .FirstOrDefault(start => string.Equals(start.Name?.Value, bookmarkName, StringComparison.Ordinal));
+            return bookmark?.Ancestors<Paragraph>().FirstOrDefault();
+        }
+
+        private readonly struct TemplateInsertion {
+            public TemplateInsertion(OpenXmlElement anchor, bool removeAfterRender) {
+                Anchor = anchor;
+                RemoveAfterRender = removeAfterRender;
+            }
+
+            public OpenXmlElement Anchor { get; }
+            public bool RemoveAfterRender { get; }
+        }
+    }
+}

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Ast.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Ast.cs
@@ -631,6 +631,10 @@ namespace OfficeIMO.Word.Markdown {
         }
 
         private string BuildImageSource(WordImage image, WordToMarkdownOptions options) {
+            if (TryGetExternalImageSource(image, options, out var externalSource)) {
+                return externalSource;
+            }
+
             if (options.ImageExportMode == ImageExportMode.File) {
                 string directory = options.ImageDirectory ?? Directory.GetCurrentDirectory();
                 Directory.CreateDirectory(directory);
@@ -642,6 +646,10 @@ namespace OfficeIMO.Word.Markdown {
                 string fileName = string.IsNullOrEmpty(image.FileName)
                     ? Guid.NewGuid().ToString("N") + fileExtension
                     : image.FileName!;
+                if (string.IsNullOrEmpty(Path.GetExtension(fileName))) {
+                    fileName += fileExtension;
+                }
+
                 string targetPath = Path.Combine(directory, fileName);
 
                 if (!string.IsNullOrEmpty(image.FilePath) && File.Exists(image.FilePath)) {
@@ -664,6 +672,25 @@ namespace OfficeIMO.Word.Markdown {
             };
             string base64 = System.Convert.ToBase64String(bytes);
             return $"data:{mime};base64,{base64}";
+        }
+
+        private static bool TryGetExternalImageSource(WordImage image, WordToMarkdownOptions options, out string source) {
+            source = string.Empty;
+            if (!image.IsExternal) {
+                return false;
+            }
+
+            if (!options.FallbackExternalImagesToLinks) {
+                return false;
+            }
+
+            source = image.ExternalUri?.ToString() ?? image.FilePath;
+            if (string.IsNullOrWhiteSpace(source)) {
+                source = image.ExternalRelationshipId ?? string.Empty;
+            }
+
+            options.OnWarning?.Invoke($"Externally linked image '{source}' was emitted as a Markdown image reference because the binary payload is not stored in the Word package.");
+            return true;
         }
 
         private TableBlock BuildTableBlock(WordTable table, WordToMarkdownOptions options) {

--- a/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Paragraphs.cs
+++ b/OfficeIMO.Word.Markdown/Converters/WordToMarkdownConverter.Paragraphs.cs
@@ -196,6 +196,15 @@ namespace OfficeIMO.Word.Markdown {
             }
 
             string alt = image.Description ?? string.Empty;
+            if (image.IsExternal && options.FallbackExternalImagesToLinks) {
+                string source = image.ExternalUri?.ToString() ?? image.FilePath;
+                if (string.IsNullOrWhiteSpace(source)) {
+                    source = image.ExternalRelationshipId ?? string.Empty;
+                }
+
+                options.OnWarning?.Invoke($"Externally linked image '{source}' was emitted as a Markdown image reference because the binary payload is not stored in the Word package.");
+                return $"![{alt}]({source})";
+            }
 
             if (options.ImageExportMode == ImageExportMode.File) {
                 string directory = options.ImageDirectory ?? Directory.GetCurrentDirectory();
@@ -207,6 +216,10 @@ namespace OfficeIMO.Word.Markdown {
                 string fileName = string.IsNullOrEmpty(image.FileName)
                     ? Guid.NewGuid().ToString("N") + extension
                     : image.FileName!;
+                if (string.IsNullOrEmpty(Path.GetExtension(fileName))) {
+                    fileName += extension;
+                }
+
                 string targetPath = Path.Combine(directory, fileName);
 
                 if (!string.IsNullOrEmpty(image.FilePath) && File.Exists(image.FilePath)) {

--- a/OfficeIMO.Word.Markdown/Options/MarkdownToWordOptions.cs
+++ b/OfficeIMO.Word.Markdown/Options/MarkdownToWordOptions.cs
@@ -86,6 +86,12 @@ namespace OfficeIMO.Word.Markdown {
         public OfficeIMO.Markdown.MarkdownReaderOptions? ReaderOptions { get; set; }
 
         /// <summary>
+        /// Controls whether front matter is rendered as visible Word content.
+        /// Disable this when front matter is consumed by a template or build pipeline as metadata.
+        /// </summary>
+        public bool RenderFrontMatter { get; set; } = true;
+
+        /// <summary>
         /// Optional hard cap (pixels) applied to rendered markdown image width.
         /// </summary>
         public double? MaxImageWidthPixels {

--- a/OfficeIMO.Word.Markdown/Options/MarkdownToWordTemplateOptions.cs
+++ b/OfficeIMO.Word.Markdown/Options/MarkdownToWordTemplateOptions.cs
@@ -1,0 +1,34 @@
+namespace OfficeIMO.Word.Markdown {
+    /// <summary>
+    /// Options for rendering Markdown into an existing Word template document.
+    /// </summary>
+    public class MarkdownToWordTemplateOptions : MarkdownToWordOptions {
+        /// <summary>
+        /// Creates template insertion options. Front matter is hidden by default because
+        /// template workflows usually consume it as metadata rather than body content.
+        /// </summary>
+        public MarkdownToWordTemplateOptions() {
+            RenderFrontMatter = false;
+        }
+
+        /// <summary>
+        /// Tag of a block content control that marks the Markdown insertion point.
+        /// </summary>
+        public string? ContentControlTag { get; set; }
+
+        /// <summary>
+        /// Alias of a block content control that marks the Markdown insertion point.
+        /// </summary>
+        public string? ContentControlAlias { get; set; }
+
+        /// <summary>
+        /// Bookmark name that marks the Markdown insertion point.
+        /// </summary>
+        public string? BookmarkName { get; set; }
+
+        /// <summary>
+        /// Replaces the target placeholder element after inserting Markdown.
+        /// </summary>
+        public bool ReplacePlaceholder { get; set; } = true;
+    }
+}

--- a/OfficeIMO.Word.Markdown/Options/WordToMarkdownOptions.cs
+++ b/OfficeIMO.Word.Markdown/Options/WordToMarkdownOptions.cs
@@ -32,6 +32,18 @@ namespace OfficeIMO.Word.Markdown {
         public string? ImageDirectory { get; set; }
 
         /// <summary>
+        /// Emits externally linked images as Markdown image references instead of failing extraction.
+        /// This keeps existing documents with linked or cid-based images convertible even when the
+        /// binary image payload is not stored in the package.
+        /// </summary>
+        public bool FallbackExternalImagesToLinks { get; set; } = true;
+
+        /// <summary>
+        /// Optional callback for non-fatal conversion warnings, such as external image fallback.
+        /// </summary>
+        public Action<string>? OnWarning { get; set; }
+
+        /// <summary>
         /// Enables exporting section headers and footers as semantic fenced blocks instead of omitting them.
         /// The fenced payload contains markdown for the header/footer body and can be reparsed with
         /// <see cref="CreateReaderOptions(OfficeIMO.Markdown.MarkdownReaderOptions.MarkdownDialectProfile)"/>.

--- a/OfficeIMO.Word.Markdown/WordMarkdownConverterExtensions.cs
+++ b/OfficeIMO.Word.Markdown/WordMarkdownConverterExtensions.cs
@@ -126,6 +126,28 @@ namespace OfficeIMO.Word.Markdown {
         }
 
         /// <summary>
+        /// Creates a Word document from Markdown by inserting the generated content into an existing template document.
+        /// The template retains its styles, sections, headers, footers, table of contents and other package settings.
+        /// </summary>
+        /// <param name="markdown">Markdown content to insert.</param>
+        /// <param name="templatePath">Path to the Word template document to copy and populate.</param>
+        /// <param name="options">Template insertion options.</param>
+        /// <returns>A populated <see cref="WordDocument"/> instance backed by an in-memory copy of the template.</returns>
+        public static WordDocument LoadFromMarkdownTemplate(this string markdown, string templatePath, MarkdownToWordTemplateOptions? options = null) {
+            if (string.IsNullOrWhiteSpace(templatePath)) {
+                throw new ArgumentException("Template path cannot be null or empty.", nameof(templatePath));
+            }
+
+            using var file = File.OpenRead(templatePath);
+            var stream = new MemoryStream();
+            file.CopyTo(stream);
+            stream.Position = 0;
+            var document = WordDocument.Load(stream);
+            var converter = new MarkdownToWordConverter();
+            return converter.ConvertIntoTemplate(markdown, document, options ?? new MarkdownToWordTemplateOptions());
+        }
+
+        /// <summary>
         /// Creates a new Word document directly from a typed <see cref="MarkdownDoc"/>.
         /// </summary>
         /// <param name="markdown">Typed markdown document to convert.</param>
@@ -134,6 +156,18 @@ namespace OfficeIMO.Word.Markdown {
         public static WordDocument ToWordDocument(this MarkdownDoc markdown, MarkdownToWordOptions? options = null) {
             var converter = new MarkdownToWordConverter();
             return converter.ConvertAsync(markdown, options ?? new MarkdownToWordOptions(), CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Inserts a typed Markdown document into an existing Word template document.
+        /// </summary>
+        /// <param name="markdown">Typed Markdown document to insert.</param>
+        /// <param name="templateDocument">Template document to populate.</param>
+        /// <param name="options">Template insertion options.</param>
+        /// <returns>The populated template document.</returns>
+        public static WordDocument ToWordDocument(this MarkdownDoc markdown, WordDocument templateDocument, MarkdownToWordTemplateOptions? options = null) {
+            var converter = new MarkdownToWordConverter();
+            return converter.ConvertIntoTemplate(markdown, templateDocument, options ?? new MarkdownToWordTemplateOptions());
         }
 
         /// <summary>

--- a/OfficeIMO.Word/OfficeIMO.Word.csproj
+++ b/OfficeIMO.Word/OfficeIMO.Word.csproj
@@ -92,6 +92,7 @@
     <ItemGroup>
         <InternalsVisibleTo Include="OfficeIMO.Tests" />
         <InternalsVisibleTo Include="OfficeIMO.Word.Html" />
+        <InternalsVisibleTo Include="OfficeIMO.Word.Markdown" />
         <InternalsVisibleTo Include="OfficeIMO.Word.Pdf" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- add generic Markdown-to-Word template insertion using bookmarks or block content controls
- keep template-owned styles, sections, headers, footers, TOC/package settings, and hide front matter by default for template workflows
- make Word-to-Markdown tolerate externally linked images and preserve detected image extensions for extensionless names

## Validation
- dotnet build .\OfficeIMO.Word.Markdown\OfficeIMO.Word.Markdown.csproj -c Debug --no-restore /p:BuildInParallel=false /m:1 /nr:false
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~MarkdownToWord_LoadFromMarkdownTemplate_Inserts_At_Bookmark_And_Preserves_Template_Content|FullyQualifiedName~WordToMarkdown_Emits_ExternalImages_As_Links_Instead_Of_Failing|FullyQualifiedName~WordToMarkdown_Exports_Extensionless_ImageNames_With_Detected_Extension" /p:BuildInParallel=false /m:1 /nr:false

## Notes
- A broad Markdown-name filtered test run still hits pre-existing PDF default-font failures in OfficeIMO.Tests\Pdf\Word.SaveAsPdf.cs, unrelated to this change.