### PR TITLE
Bump Word Markdown release package versions

### DIFF
--- a/OfficeIMO.Word.Markdown/OfficeIMO.Word.Markdown.csproj
+++ b/OfficeIMO.Word.Markdown/OfficeIMO.Word.Markdown.csproj
@@ -3,7 +3,7 @@
     <Description>Markdown converter for OfficeIMO.Word - Convert Word documents to/from Markdown using OfficeIMO.Markdown</Description>
     <AssemblyName>OfficeIMO.Word.Markdown</AssemblyName>
     <AssemblyTitle>OfficeIMO.Word.Markdown</AssemblyTitle>
-    <VersionPrefix>1.0.34</VersionPrefix>
+    <VersionPrefix>1.0.36</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Word/OfficeIMO.Word.csproj
+++ b/OfficeIMO.Word/OfficeIMO.Word.csproj
@@ -6,7 +6,7 @@
         <AssemblyName>OfficeIMO.Word</AssemblyName>
         <AssemblyTitle>OfficeIMO.Word</AssemblyTitle>
 
-        <VersionPrefix>1.0.60</VersionPrefix>
+        <VersionPrefix>1.0.61</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>


### PR DESCRIPTION
## Summary
- bump OfficeIMO.Word to 1.0.61
- bump OfficeIMO.Word.Markdown to 1.0.36
- records the package versions published from current master for Markdown template insertion support

## Validation
- built OfficeIMO.Word and OfficeIMO.Word.Markdown packages with PSPublishModule single-project config
- verified local runtime package smoke for Markdown template insertion
- published OfficeIMO.Word 1.0.61 and OfficeIMO.Word.Markdown 1.0.36 to NuGet