### PR TITLE
Expose markdown native projection

### DIFF
--- a/OfficeIMO.Markdown/Native/MarkdownNativeBlockId.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeBlockId.cs
@@ -1,0 +1,27 @@
+namespace OfficeIMO.Markdown;
+
+internal static class MarkdownNativeBlockId {
+    internal static string Create(
+        MarkdownNativeBlockKind kind,
+        IMarkdownBlock sourceBlock,
+        MarkdownSyntaxNode syntaxNode,
+        MarkdownSourceSpan? sourceSpan) {
+        var span = sourceSpan.HasValue ? sourceSpan.Value.ToString() : "nosource";
+        var literal = syntaxNode.Literal ?? sourceBlock.RenderMarkdown() ?? string.Empty;
+        var key = kind.ToString() + "|" + syntaxNode.Kind + "|" + span + "|" + literal;
+        return "mdn-" + ComputeFnv1A64(key).ToString("x16", System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static ulong ComputeFnv1A64(string value) {
+        const ulong offsetBasis = 14695981039346656037UL;
+        const ulong prime = 1099511628211UL;
+
+        var hash = offsetBasis;
+        for (var i = 0; i < value.Length; i++) {
+            hash ^= value[i];
+            hash *= prime;
+        }
+
+        return hash;
+    }
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeBlockId.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeBlockId.cs
@@ -8,8 +8,23 @@ internal static class MarkdownNativeBlockId {
         MarkdownSourceSpan? sourceSpan) {
         var span = sourceSpan.HasValue ? sourceSpan.Value.ToString() : "nosource";
         var literal = syntaxNode.Literal ?? sourceBlock.RenderMarkdown() ?? string.Empty;
-        var key = kind.ToString() + "|" + syntaxNode.Kind + "|" + span + "|" + literal;
+        var path = BuildSyntaxPath(syntaxNode);
+        var key = kind.ToString() + "|" + syntaxNode.Kind + "|" + span + "|" + path + "|" + literal;
         return "mdn-" + ComputeFnv1A64(key).ToString("x16", System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    internal static string BuildSyntaxPath(MarkdownSyntaxNode syntaxNode) {
+        if (syntaxNode == null) {
+            return "noparent";
+        }
+
+        var indexes = new List<int>();
+        for (var current = syntaxNode; current != null; current = current.Parent) {
+            indexes.Add(current.IndexInParent);
+        }
+
+        indexes.Reverse();
+        return string.Join(".", indexes);
     }
 
     private static ulong ComputeFnv1A64(string value) {

--- a/OfficeIMO.Markdown/Native/MarkdownNativeBlockKind.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeBlockKind.cs
@@ -4,8 +4,23 @@ namespace OfficeIMO.Markdown;
 /// High-level block categories exposed by the native markdown projection.
 /// </summary>
 public enum MarkdownNativeBlockKind {
+    /// <summary>Heading text with level and inline markdown nodes.</summary>
+    Heading,
+
     /// <summary>Paragraph text with inline markdown nodes.</summary>
     Paragraph,
+
+    /// <summary>Ordered or unordered list with native list items.</summary>
+    List,
+
+    /// <summary>Quoted content with nested native blocks.</summary>
+    Quote,
+
+    /// <summary>Docs-style callout/admonition with title and nested native blocks.</summary>
+    Callout,
+
+    /// <summary>Image block with source, alternate text, title, sizing, link, and caption metadata.</summary>
+    Image,
 
     /// <summary>Fenced or indented code block.</summary>
     Code,
@@ -15,6 +30,15 @@ public enum MarkdownNativeBlockKind {
 
     /// <summary>Semantic fenced block for diagrams, charts, networks, data views, or host-defined visuals.</summary>
     Visual,
+
+    /// <summary>HTML details/disclosure block with summary and nested native blocks.</summary>
+    Details,
+
+    /// <summary>YAML front matter entries.</summary>
+    FrontMatter,
+
+    /// <summary>Raw HTML or HTML comment block.</summary>
+    Html,
 
     /// <summary>Any block that does not have a specialized native projection yet.</summary>
     Other

--- a/OfficeIMO.Markdown/Native/MarkdownNativeBlockKind.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeBlockKind.cs
@@ -1,0 +1,21 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// High-level block categories exposed by the native markdown projection.
+/// </summary>
+public enum MarkdownNativeBlockKind {
+    /// <summary>Paragraph text with inline markdown nodes.</summary>
+    Paragraph,
+
+    /// <summary>Fenced or indented code block.</summary>
+    Code,
+
+    /// <summary>Markdown table with structured cells.</summary>
+    Table,
+
+    /// <summary>Semantic fenced block for diagrams, charts, networks, data views, or host-defined visuals.</summary>
+    Visual,
+
+    /// <summary>Any block that does not have a specialized native projection yet.</summary>
+    Other
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeBlocks.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeBlocks.cs
@@ -291,7 +291,7 @@ public sealed class MarkdownNativeTableCell {
         Blocks = sourceCell != null ? sourceCell.Blocks : Array.Empty<IMarkdownBlock>();
         Children = children ?? Array.Empty<MarkdownNativeBlock>();
         Alignment = alignment;
-        InlineRuns = MarkdownNativeInlineProjection.FromFirstDescendantInlineContainer(syntaxNode);
+        InlineRuns = MarkdownNativeInlineProjection.FromTableCellDirectContent(syntaxNode);
     }
 
     /// <summary>Raw cell text from the table source.</summary>

--- a/OfficeIMO.Markdown/Native/MarkdownNativeBlocks.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeBlocks.cs
@@ -142,12 +142,12 @@ public sealed class MarkdownNativeTableBlock : MarkdownNativeBlock {
     public IReadOnlyList<IReadOnlyList<MarkdownNativeTableCell>> Rows { get; }
 
     private static IReadOnlyList<MarkdownNativeTableCell> BuildHeaderCells(TableBlock table, MarkdownSyntaxNode syntaxNode) {
-        if (table.HeaderCells.Count == 0 && table.Headers.Count == 0) {
+        if (table.Headers.Count == 0) {
             return Array.Empty<MarkdownNativeTableCell>();
         }
 
         var headerNode = syntaxNode.Children.FirstOrDefault(static child => child.Kind == MarkdownSyntaxKind.TableHeader);
-        return BuildCells(table.Headers, table.HeaderCells, headerNode, isHeader: true, rowIndex: -1);
+        return BuildCells(table.Headers, table.HeaderCells, table.Alignments, headerNode, isHeader: true, rowIndex: -1);
     }
 
     private static IReadOnlyList<IReadOnlyList<MarkdownNativeTableCell>> BuildRows(TableBlock table, MarkdownSyntaxNode syntaxNode) {
@@ -162,7 +162,7 @@ public sealed class MarkdownNativeTableBlock : MarkdownNativeBlock {
             var rawCells = rowIndex < table.Rows.Count ? table.Rows[rowIndex] : Array.Empty<string>();
             var structuredCells = rowIndex < table.RowCells.Count ? table.RowCells[rowIndex] : Array.Empty<TableCell>();
             var rowNode = rowIndex < rowNodes.Length ? rowNodes[rowIndex] : null;
-            rows.Add(BuildCells(rawCells, structuredCells, rowNode, isHeader: false, rowIndex: rowIndex));
+            rows.Add(BuildCells(rawCells, structuredCells, table.Alignments, rowNode, isHeader: false, rowIndex: rowIndex));
         }
 
         return rows;
@@ -171,6 +171,7 @@ public sealed class MarkdownNativeTableBlock : MarkdownNativeBlock {
     private static IReadOnlyList<MarkdownNativeTableCell> BuildCells(
         IReadOnlyList<string> rawCells,
         IReadOnlyList<TableCell> structuredCells,
+        IReadOnlyList<ColumnAlignment> columnAlignments,
         MarkdownSyntaxNode? rowNode,
         bool isHeader,
         int rowIndex) {
@@ -184,10 +185,24 @@ public sealed class MarkdownNativeTableBlock : MarkdownNativeBlock {
             var raw = rawCells != null && columnIndex < rawCells.Count ? rawCells[columnIndex] ?? string.Empty : string.Empty;
             var cell = structuredCells != null && columnIndex < structuredCells.Count ? structuredCells[columnIndex] : null;
             var cellNode = rowNode != null && columnIndex < rowNode.Children.Count ? rowNode.Children[columnIndex] : null;
-            cells.Add(new MarkdownNativeTableCell(raw, cell, cellNode, isHeader, rowIndex, columnIndex));
+            var alignment = ResolveAlignment(cell, columnAlignments, columnIndex);
+            cells.Add(new MarkdownNativeTableCell(raw, cell, cellNode, isHeader, rowIndex, columnIndex, alignment));
         }
 
         return cells;
+    }
+
+    private static ColumnAlignment ResolveAlignment(
+        TableCell? sourceCell,
+        IReadOnlyList<ColumnAlignment> columnAlignments,
+        int columnIndex) {
+        if (sourceCell != null && sourceCell.Alignment != ColumnAlignment.None) {
+            return sourceCell.Alignment;
+        }
+
+        return columnAlignments != null && columnIndex >= 0 && columnIndex < columnAlignments.Count
+            ? columnAlignments[columnIndex]
+            : ColumnAlignment.None;
     }
 }
 
@@ -201,7 +216,8 @@ public sealed class MarkdownNativeTableCell {
         MarkdownSyntaxNode? syntaxNode,
         bool isHeader,
         int rowIndex,
-        int columnIndex) {
+        int columnIndex,
+        ColumnAlignment alignment) {
         RawText = rawText ?? string.Empty;
         SourceCell = sourceCell;
         SyntaxNode = syntaxNode;
@@ -212,7 +228,7 @@ public sealed class MarkdownNativeTableCell {
         Text = ExtractText(sourceCell, RawText);
         Markdown = sourceCell?.Markdown ?? RawText;
         Blocks = sourceCell != null ? sourceCell.Blocks : Array.Empty<IMarkdownBlock>();
-        Alignment = sourceCell?.Alignment ?? ColumnAlignment.None;
+        Alignment = alignment;
     }
 
     /// <summary>Raw cell text from the table source.</summary>

--- a/OfficeIMO.Markdown/Native/MarkdownNativeBlocks.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeBlocks.cs
@@ -1,0 +1,275 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Base type for an AST-backed native markdown block projection.
+/// </summary>
+public abstract class MarkdownNativeBlock {
+    private protected MarkdownNativeBlock(
+        MarkdownNativeBlockKind kind,
+        IMarkdownBlock sourceBlock,
+        MarkdownSyntaxNode syntaxNode) {
+        Kind = kind;
+        SourceBlock = sourceBlock ?? throw new ArgumentNullException(nameof(sourceBlock));
+        SyntaxNode = syntaxNode ?? throw new ArgumentNullException(nameof(syntaxNode));
+        SourceSpan = syntaxNode.SourceSpan ?? (sourceBlock as MarkdownObject)?.SourceSpan;
+    }
+
+    /// <summary>Native projection kind.</summary>
+    public MarkdownNativeBlockKind Kind { get; }
+
+    /// <summary>Source span in the normalized markdown text when available.</summary>
+    public MarkdownSourceSpan? SourceSpan { get; }
+
+    /// <summary>Syntax node that produced this native block.</summary>
+    public MarkdownSyntaxNode SyntaxNode { get; }
+
+    /// <summary>Original OfficeIMO markdown block backing this projection.</summary>
+    public IMarkdownBlock SourceBlock { get; }
+
+    /// <summary>Returns <see langword="true"/> when this block's source span contains the supplied 1-based line.</summary>
+    public bool ContainsLine(int lineNumber) => SourceSpan.HasValue && SourceSpan.Value.ContainsLine(lineNumber);
+}
+
+/// <summary>
+/// Native projection for a paragraph block.
+/// </summary>
+public sealed class MarkdownNativeParagraphBlock : MarkdownNativeBlock {
+    internal MarkdownNativeParagraphBlock(ParagraphBlock paragraph, MarkdownSyntaxNode syntaxNode)
+        : base(MarkdownNativeBlockKind.Paragraph, paragraph, syntaxNode) {
+        Paragraph = paragraph;
+        Inlines = paragraph.Inlines;
+        Text = InlinePlainText.Extract(paragraph.Inlines);
+    }
+
+    /// <summary>Source paragraph block.</summary>
+    public ParagraphBlock Paragraph { get; }
+
+    /// <summary>Plain-text paragraph content.</summary>
+    public string Text { get; }
+
+    /// <summary>Structured inline nodes.</summary>
+    public InlineSequence Inlines { get; }
+}
+
+/// <summary>
+/// Native projection for a code block.
+/// </summary>
+public sealed class MarkdownNativeCodeBlock : MarkdownNativeBlock {
+    internal MarkdownNativeCodeBlock(CodeBlock code, MarkdownSyntaxNode syntaxNode)
+        : base(MarkdownNativeBlockKind.Code, code, syntaxNode) {
+        Code = code;
+        Language = code.Language;
+        InfoString = code.InfoString;
+        FenceInfo = code.FenceInfo;
+        Content = code.Content;
+        Caption = code.Caption;
+    }
+
+    /// <summary>Source code block.</summary>
+    public CodeBlock Code { get; }
+
+    /// <summary>Primary fence language token.</summary>
+    public string Language { get; }
+
+    /// <summary>Full fenced-code info string.</summary>
+    public string InfoString { get; }
+
+    /// <summary>Structured fenced-code metadata.</summary>
+    public MarkdownCodeFenceInfo FenceInfo { get; }
+
+    /// <summary>Code content with normalized line endings.</summary>
+    public string Content { get; }
+
+    /// <summary>Optional code-block caption.</summary>
+    public string? Caption { get; }
+}
+
+/// <summary>
+/// Native projection for a semantic visual fenced block.
+/// </summary>
+public sealed class MarkdownNativeVisualBlock : MarkdownNativeBlock {
+    internal MarkdownNativeVisualBlock(SemanticFencedBlock visual, MarkdownSyntaxNode syntaxNode)
+        : base(MarkdownNativeBlockKind.Visual, visual, syntaxNode) {
+        Visual = visual;
+        SemanticKind = visual.SemanticKind;
+        Language = visual.Language;
+        InfoString = visual.InfoString;
+        FenceInfo = visual.FenceInfo;
+        Content = visual.Content;
+        Caption = visual.Caption;
+    }
+
+    /// <summary>Source semantic fenced block.</summary>
+    public SemanticFencedBlock Visual { get; }
+
+    /// <summary>Host-defined semantic kind such as chart, network, dataview, or mermaid.</summary>
+    public string SemanticKind { get; }
+
+    /// <summary>Primary fence language token.</summary>
+    public string Language { get; }
+
+    /// <summary>Full fenced-code info string.</summary>
+    public string InfoString { get; }
+
+    /// <summary>Structured fenced-code metadata.</summary>
+    public MarkdownCodeFenceInfo FenceInfo { get; }
+
+    /// <summary>Visual payload with normalized line endings.</summary>
+    public string Content { get; }
+
+    /// <summary>Optional visual-block caption.</summary>
+    public string? Caption { get; }
+}
+
+/// <summary>
+/// Native projection for a markdown table.
+/// </summary>
+public sealed class MarkdownNativeTableBlock : MarkdownNativeBlock {
+    internal MarkdownNativeTableBlock(TableBlock table, MarkdownSyntaxNode syntaxNode)
+        : base(MarkdownNativeBlockKind.Table, table, syntaxNode) {
+        Table = table;
+        HeaderCells = BuildHeaderCells(table, syntaxNode);
+        Rows = BuildRows(table, syntaxNode);
+    }
+
+    /// <summary>Source table block.</summary>
+    public TableBlock Table { get; }
+
+    /// <summary>Header cells in document order.</summary>
+    public IReadOnlyList<MarkdownNativeTableCell> HeaderCells { get; }
+
+    /// <summary>Body rows and cells in document order.</summary>
+    public IReadOnlyList<IReadOnlyList<MarkdownNativeTableCell>> Rows { get; }
+
+    private static IReadOnlyList<MarkdownNativeTableCell> BuildHeaderCells(TableBlock table, MarkdownSyntaxNode syntaxNode) {
+        if (table.HeaderCells.Count == 0 && table.Headers.Count == 0) {
+            return Array.Empty<MarkdownNativeTableCell>();
+        }
+
+        var headerNode = syntaxNode.Children.FirstOrDefault(static child => child.Kind == MarkdownSyntaxKind.TableHeader);
+        return BuildCells(table.Headers, table.HeaderCells, headerNode, isHeader: true, rowIndex: -1);
+    }
+
+    private static IReadOnlyList<IReadOnlyList<MarkdownNativeTableCell>> BuildRows(TableBlock table, MarkdownSyntaxNode syntaxNode) {
+        if (table.Rows.Count == 0 && table.RowCells.Count == 0) {
+            return Array.Empty<IReadOnlyList<MarkdownNativeTableCell>>();
+        }
+
+        var rowNodes = syntaxNode.Children.Where(static child => child.Kind == MarkdownSyntaxKind.TableRow).ToArray();
+        var rows = new List<IReadOnlyList<MarkdownNativeTableCell>>(Math.Max(table.Rows.Count, table.RowCells.Count));
+        var rowCount = Math.Max(table.Rows.Count, table.RowCells.Count);
+        for (var rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+            var rawCells = rowIndex < table.Rows.Count ? table.Rows[rowIndex] : Array.Empty<string>();
+            var structuredCells = rowIndex < table.RowCells.Count ? table.RowCells[rowIndex] : Array.Empty<TableCell>();
+            var rowNode = rowIndex < rowNodes.Length ? rowNodes[rowIndex] : null;
+            rows.Add(BuildCells(rawCells, structuredCells, rowNode, isHeader: false, rowIndex: rowIndex));
+        }
+
+        return rows;
+    }
+
+    private static IReadOnlyList<MarkdownNativeTableCell> BuildCells(
+        IReadOnlyList<string> rawCells,
+        IReadOnlyList<TableCell> structuredCells,
+        MarkdownSyntaxNode? rowNode,
+        bool isHeader,
+        int rowIndex) {
+        var count = Math.Max(rawCells?.Count ?? 0, structuredCells?.Count ?? 0);
+        if (count == 0) {
+            return Array.Empty<MarkdownNativeTableCell>();
+        }
+
+        var cells = new List<MarkdownNativeTableCell>(count);
+        for (var columnIndex = 0; columnIndex < count; columnIndex++) {
+            var raw = rawCells != null && columnIndex < rawCells.Count ? rawCells[columnIndex] ?? string.Empty : string.Empty;
+            var cell = structuredCells != null && columnIndex < structuredCells.Count ? structuredCells[columnIndex] : null;
+            var cellNode = rowNode != null && columnIndex < rowNode.Children.Count ? rowNode.Children[columnIndex] : null;
+            cells.Add(new MarkdownNativeTableCell(raw, cell, cellNode, isHeader, rowIndex, columnIndex));
+        }
+
+        return cells;
+    }
+}
+
+/// <summary>
+/// Native projection for a table cell.
+/// </summary>
+public sealed class MarkdownNativeTableCell {
+    internal MarkdownNativeTableCell(
+        string rawText,
+        TableCell? sourceCell,
+        MarkdownSyntaxNode? syntaxNode,
+        bool isHeader,
+        int rowIndex,
+        int columnIndex) {
+        RawText = rawText ?? string.Empty;
+        SourceCell = sourceCell;
+        SyntaxNode = syntaxNode;
+        SourceSpan = syntaxNode?.SourceSpan ?? sourceCell?.SourceSpan;
+        IsHeader = isHeader;
+        RowIndex = rowIndex;
+        ColumnIndex = columnIndex;
+        Text = ExtractText(sourceCell, RawText);
+        Markdown = sourceCell?.Markdown ?? RawText;
+        Blocks = sourceCell != null ? sourceCell.Blocks : Array.Empty<IMarkdownBlock>();
+        Alignment = sourceCell?.Alignment ?? ColumnAlignment.None;
+    }
+
+    /// <summary>Raw cell text from the table source.</summary>
+    public string RawText { get; }
+
+    /// <summary>Plain-text cell content.</summary>
+    public string Text { get; }
+
+    /// <summary>Markdown representation of the cell content.</summary>
+    public string Markdown { get; }
+
+    /// <summary>Structured child blocks in the cell.</summary>
+    public IReadOnlyList<IMarkdownBlock> Blocks { get; }
+
+    /// <summary>Source table cell when structured cell data is available.</summary>
+    public TableCell? SourceCell { get; }
+
+    /// <summary>Syntax node that produced this cell when available.</summary>
+    public MarkdownSyntaxNode? SyntaxNode { get; }
+
+    /// <summary>Source span in the normalized markdown text when available.</summary>
+    public MarkdownSourceSpan? SourceSpan { get; }
+
+    /// <summary>Whether this cell belongs to the table header.</summary>
+    public bool IsHeader { get; }
+
+    /// <summary>Zero-based data row index, or <c>-1</c> for header cells.</summary>
+    public int RowIndex { get; }
+
+    /// <summary>Zero-based column index.</summary>
+    public int ColumnIndex { get; }
+
+    /// <summary>Cell-level alignment override when present.</summary>
+    public ColumnAlignment Alignment { get; }
+
+    private static string ExtractText(TableCell? sourceCell, string rawText) {
+        if (sourceCell == null || sourceCell.Blocks.Count == 0) {
+            return rawText ?? string.Empty;
+        }
+
+        if (sourceCell.Blocks.Count == 1 && sourceCell.Blocks[0] is ParagraphBlock paragraph) {
+            return InlinePlainText.Extract(paragraph.Inlines);
+        }
+
+        return sourceCell.Markdown;
+    }
+}
+
+/// <summary>
+/// Native projection for a markdown block without a specialized projection.
+/// </summary>
+public sealed class MarkdownNativeOtherBlock : MarkdownNativeBlock {
+    internal MarkdownNativeOtherBlock(IMarkdownBlock block, MarkdownSyntaxNode syntaxNode)
+        : base(MarkdownNativeBlockKind.Other, block, syntaxNode) {
+        Markdown = block.RenderMarkdown();
+    }
+
+    /// <summary>Markdown representation of the source block.</summary>
+    public string Markdown { get; }
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeBlocks.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeBlocks.cs
@@ -172,11 +172,14 @@ public sealed class MarkdownNativeVisualBlock : MarkdownNativeBlock {
 /// Native projection for a markdown table.
 /// </summary>
 public sealed class MarkdownNativeTableBlock : MarkdownNativeBlock {
-    internal MarkdownNativeTableBlock(TableBlock table, MarkdownSyntaxNode syntaxNode)
+    internal MarkdownNativeTableBlock(
+        TableBlock table,
+        MarkdownSyntaxNode syntaxNode,
+        ICollection<MarkdownNativeDiagnostic> diagnostics)
         : base(MarkdownNativeBlockKind.Table, table, syntaxNode) {
         Table = table;
-        HeaderCells = BuildHeaderCells(table, syntaxNode);
-        Rows = BuildRows(table, syntaxNode);
+        HeaderCells = BuildHeaderCells(table, syntaxNode, diagnostics);
+        Rows = BuildRows(table, syntaxNode, diagnostics);
     }
 
     /// <summary>Source table block.</summary>
@@ -188,16 +191,22 @@ public sealed class MarkdownNativeTableBlock : MarkdownNativeBlock {
     /// <summary>Body rows and cells in document order.</summary>
     public IReadOnlyList<IReadOnlyList<MarkdownNativeTableCell>> Rows { get; }
 
-    private static IReadOnlyList<MarkdownNativeTableCell> BuildHeaderCells(TableBlock table, MarkdownSyntaxNode syntaxNode) {
+    private static IReadOnlyList<MarkdownNativeTableCell> BuildHeaderCells(
+        TableBlock table,
+        MarkdownSyntaxNode syntaxNode,
+        ICollection<MarkdownNativeDiagnostic> diagnostics) {
         if (table.Headers.Count == 0) {
             return Array.Empty<MarkdownNativeTableCell>();
         }
 
         var headerNode = syntaxNode.Children.FirstOrDefault(static child => child.Kind == MarkdownSyntaxKind.TableHeader);
-        return BuildCells(table.Headers, table.HeaderCells, table.Alignments, headerNode, isHeader: true, rowIndex: -1);
+        return BuildCells(table.Headers, table.HeaderCells, table.Alignments, headerNode, diagnostics, isHeader: true, rowIndex: -1);
     }
 
-    private static IReadOnlyList<IReadOnlyList<MarkdownNativeTableCell>> BuildRows(TableBlock table, MarkdownSyntaxNode syntaxNode) {
+    private static IReadOnlyList<IReadOnlyList<MarkdownNativeTableCell>> BuildRows(
+        TableBlock table,
+        MarkdownSyntaxNode syntaxNode,
+        ICollection<MarkdownNativeDiagnostic> diagnostics) {
         if (table.Rows.Count == 0 && table.RowCells.Count == 0) {
             return Array.Empty<IReadOnlyList<MarkdownNativeTableCell>>();
         }
@@ -209,7 +218,7 @@ public sealed class MarkdownNativeTableBlock : MarkdownNativeBlock {
             var rawCells = rowIndex < table.Rows.Count ? table.Rows[rowIndex] : Array.Empty<string>();
             var structuredCells = rowIndex < table.RowCells.Count ? table.RowCells[rowIndex] : Array.Empty<TableCell>();
             var rowNode = rowIndex < rowNodes.Length ? rowNodes[rowIndex] : null;
-            rows.Add(BuildCells(rawCells, structuredCells, table.Alignments, rowNode, isHeader: false, rowIndex: rowIndex));
+            rows.Add(BuildCells(rawCells, structuredCells, table.Alignments, rowNode, diagnostics, isHeader: false, rowIndex: rowIndex));
         }
 
         return rows;
@@ -220,6 +229,7 @@ public sealed class MarkdownNativeTableBlock : MarkdownNativeBlock {
         IReadOnlyList<TableCell> structuredCells,
         IReadOnlyList<ColumnAlignment> columnAlignments,
         MarkdownSyntaxNode? rowNode,
+        ICollection<MarkdownNativeDiagnostic> diagnostics,
         bool isHeader,
         int rowIndex) {
         var count = Math.Max(rawCells?.Count ?? 0, structuredCells?.Count ?? 0);
@@ -233,7 +243,10 @@ public sealed class MarkdownNativeTableBlock : MarkdownNativeBlock {
             var cell = structuredCells != null && columnIndex < structuredCells.Count ? structuredCells[columnIndex] : null;
             var cellNode = rowNode != null && columnIndex < rowNode.Children.Count ? rowNode.Children[columnIndex] : null;
             var alignment = ResolveAlignment(cell, columnAlignments, columnIndex);
-            cells.Add(new MarkdownNativeTableCell(raw, cell, cellNode, isHeader, rowIndex, columnIndex, alignment));
+            var children = cellNode != null
+                ? MarkdownNativeProjectionFactory.CreateChildren(cellNode, diagnostics)
+                : Array.Empty<MarkdownNativeBlock>();
+            cells.Add(new MarkdownNativeTableCell(raw, cell, cellNode, isHeader, rowIndex, columnIndex, alignment, children));
         }
 
         return cells;
@@ -264,7 +277,8 @@ public sealed class MarkdownNativeTableCell {
         bool isHeader,
         int rowIndex,
         int columnIndex,
-        ColumnAlignment alignment) {
+        ColumnAlignment alignment,
+        IReadOnlyList<MarkdownNativeBlock> children) {
         RawText = rawText ?? string.Empty;
         SourceCell = sourceCell;
         SyntaxNode = syntaxNode;
@@ -275,6 +289,7 @@ public sealed class MarkdownNativeTableCell {
         Text = ExtractText(sourceCell, RawText);
         Markdown = sourceCell?.Markdown ?? RawText;
         Blocks = sourceCell != null ? sourceCell.Blocks : Array.Empty<IMarkdownBlock>();
+        Children = children ?? Array.Empty<MarkdownNativeBlock>();
         Alignment = alignment;
         InlineRuns = MarkdownNativeInlineProjection.FromFirstDescendantInlineContainer(syntaxNode);
     }
@@ -290,6 +305,9 @@ public sealed class MarkdownNativeTableCell {
 
     /// <summary>Structured child blocks in the cell.</summary>
     public IReadOnlyList<IMarkdownBlock> Blocks { get; }
+
+    /// <summary>Native child blocks projected from structured cell content.</summary>
+    public IReadOnlyList<MarkdownNativeBlock> Children { get; }
 
     /// <summary>Source table cell when structured cell data is available.</summary>
     public TableCell? SourceCell { get; }

--- a/OfficeIMO.Markdown/Native/MarkdownNativeBlocks.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeBlocks.cs
@@ -12,7 +12,11 @@ public abstract class MarkdownNativeBlock {
         SourceBlock = sourceBlock ?? throw new ArgumentNullException(nameof(sourceBlock));
         SyntaxNode = syntaxNode ?? throw new ArgumentNullException(nameof(syntaxNode));
         SourceSpan = syntaxNode.SourceSpan ?? (sourceBlock as MarkdownObject)?.SourceSpan;
+        Id = MarkdownNativeBlockId.Create(kind, sourceBlock, syntaxNode, SourceSpan);
     }
+
+    /// <summary>Deterministic identity for this projection within stable markdown input.</summary>
+    public string Id { get; }
 
     /// <summary>Native projection kind.</summary>
     public MarkdownNativeBlockKind Kind { get; }
@@ -63,6 +67,10 @@ public sealed class MarkdownNativeCodeBlock : MarkdownNativeBlock {
         FenceInfo = code.FenceInfo;
         Content = code.Content;
         Caption = code.Caption;
+        Attributes = code.FenceInfo.Attributes;
+        Classes = code.FenceInfo.Classes;
+        ElementId = code.FenceInfo.ElementId;
+        Title = code.FenceInfo.Title;
     }
 
     /// <summary>Source code block.</summary>
@@ -82,6 +90,18 @@ public sealed class MarkdownNativeCodeBlock : MarkdownNativeBlock {
 
     /// <summary>Optional code-block caption.</summary>
     public string? Caption { get; }
+
+    /// <summary>Parsed fence attributes.</summary>
+    public IReadOnlyDictionary<string, string?> Attributes { get; }
+
+    /// <summary>Parsed fence classes.</summary>
+    public IReadOnlyList<string> Classes { get; }
+
+    /// <summary>Parsed fence element id.</summary>
+    public string? ElementId { get; }
+
+    /// <summary>Convenience title resolved from fence metadata.</summary>
+    public string? Title { get; }
 }
 
 /// <summary>
@@ -97,6 +117,10 @@ public sealed class MarkdownNativeVisualBlock : MarkdownNativeBlock {
         FenceInfo = visual.FenceInfo;
         Content = visual.Content;
         Caption = visual.Caption;
+        Attributes = visual.FenceInfo.Attributes;
+        Classes = visual.FenceInfo.Classes;
+        ElementId = visual.FenceInfo.ElementId;
+        Title = visual.FenceInfo.Title;
     }
 
     /// <summary>Source semantic fenced block.</summary>
@@ -119,6 +143,18 @@ public sealed class MarkdownNativeVisualBlock : MarkdownNativeBlock {
 
     /// <summary>Optional visual-block caption.</summary>
     public string? Caption { get; }
+
+    /// <summary>Parsed fence attributes.</summary>
+    public IReadOnlyDictionary<string, string?> Attributes { get; }
+
+    /// <summary>Parsed fence classes.</summary>
+    public IReadOnlyList<string> Classes { get; }
+
+    /// <summary>Parsed fence element id.</summary>
+    public string? ElementId { get; }
+
+    /// <summary>Convenience title resolved from fence metadata.</summary>
+    public string? Title { get; }
 }
 
 /// <summary>

--- a/OfficeIMO.Markdown/Native/MarkdownNativeBlocks.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeBlocks.cs
@@ -32,6 +32,9 @@ public abstract class MarkdownNativeBlock {
 
     /// <summary>Returns <see langword="true"/> when this block's source span contains the supplied 1-based line.</summary>
     public bool ContainsLine(int lineNumber) => SourceSpan.HasValue && SourceSpan.Value.ContainsLine(lineNumber);
+
+    /// <summary>Creates a UI-safe snapshot of this block without parser object references.</summary>
+    public MarkdownNativeBlockSnapshot ToSnapshot() => MarkdownNativeSnapshotFactory.FromBlock(this);
 }
 
 /// <summary>
@@ -42,6 +45,7 @@ public sealed class MarkdownNativeParagraphBlock : MarkdownNativeBlock {
         : base(MarkdownNativeBlockKind.Paragraph, paragraph, syntaxNode) {
         Paragraph = paragraph;
         Inlines = paragraph.Inlines;
+        InlineRuns = MarkdownNativeInlineProjection.FromInlineContainer(syntaxNode);
         Text = InlinePlainText.Extract(paragraph.Inlines);
     }
 
@@ -53,6 +57,9 @@ public sealed class MarkdownNativeParagraphBlock : MarkdownNativeBlock {
 
     /// <summary>Structured inline nodes.</summary>
     public InlineSequence Inlines { get; }
+
+    /// <summary>AST-backed native inline projection with source spans.</summary>
+    public IReadOnlyList<MarkdownNativeInline> InlineRuns { get; }
 }
 
 /// <summary>
@@ -121,6 +128,7 @@ public sealed class MarkdownNativeVisualBlock : MarkdownNativeBlock {
         Classes = visual.FenceInfo.Classes;
         ElementId = visual.FenceInfo.ElementId;
         Title = visual.FenceInfo.Title;
+        Payload = MarkdownNativeVisualPayload.Create(visual);
     }
 
     /// <summary>Source semantic fenced block.</summary>
@@ -155,6 +163,9 @@ public sealed class MarkdownNativeVisualBlock : MarkdownNativeBlock {
 
     /// <summary>Convenience title resolved from fence metadata.</summary>
     public string? Title { get; }
+
+    /// <summary>Dependency-free typed payload hints for visual UI hosts.</summary>
+    public MarkdownNativeVisualPayload Payload { get; }
 }
 
 /// <summary>
@@ -265,6 +276,7 @@ public sealed class MarkdownNativeTableCell {
         Markdown = sourceCell?.Markdown ?? RawText;
         Blocks = sourceCell != null ? sourceCell.Blocks : Array.Empty<IMarkdownBlock>();
         Alignment = alignment;
+        InlineRuns = MarkdownNativeInlineProjection.FromFirstDescendantInlineContainer(syntaxNode);
     }
 
     /// <summary>Raw cell text from the table source.</summary>
@@ -299,6 +311,9 @@ public sealed class MarkdownNativeTableCell {
 
     /// <summary>Cell-level alignment override when present.</summary>
     public ColumnAlignment Alignment { get; }
+
+    /// <summary>AST-backed native inline projection for the cell content when available.</summary>
+    public IReadOnlyList<MarkdownNativeInline> InlineRuns { get; }
 
     private static string ExtractText(TableCell? sourceCell, string rawText) {
         if (sourceCell == null || sourceCell.Blocks.Count == 0) {

--- a/OfficeIMO.Markdown/Native/MarkdownNativeContainerBlocks.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeContainerBlocks.cs
@@ -1,0 +1,93 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Native projection for quoted content.
+/// </summary>
+public sealed class MarkdownNativeQuoteBlock : MarkdownNativeBlock {
+    internal MarkdownNativeQuoteBlock(
+        QuoteBlock quote,
+        MarkdownSyntaxNode syntaxNode,
+        IReadOnlyList<MarkdownNativeBlock> children)
+        : base(MarkdownNativeBlockKind.Quote, quote, syntaxNode) {
+        Quote = quote;
+        Lines = quote.Lines;
+        Children = children ?? Array.Empty<MarkdownNativeBlock>();
+    }
+
+    /// <summary>Source quote block.</summary>
+    public QuoteBlock Quote { get; }
+
+    /// <summary>Raw quote lines captured by the reader when available.</summary>
+    public IReadOnlyList<string> Lines { get; }
+
+    /// <summary>Nested native blocks in quote order.</summary>
+    public IReadOnlyList<MarkdownNativeBlock> Children { get; }
+}
+
+/// <summary>
+/// Native projection for a docs-style callout/admonition.
+/// </summary>
+public sealed class MarkdownNativeCalloutBlock : MarkdownNativeBlock {
+    internal MarkdownNativeCalloutBlock(
+        CalloutBlock callout,
+        MarkdownSyntaxNode syntaxNode,
+        IReadOnlyList<MarkdownNativeBlock> children)
+        : base(MarkdownNativeBlockKind.Callout, callout, syntaxNode) {
+        Callout = callout;
+        CalloutKind = callout.Kind;
+        Title = callout.Title;
+        TitleInlines = callout.TitleInlines;
+        Body = callout.Body;
+        Children = children ?? Array.Empty<MarkdownNativeBlock>();
+    }
+
+    /// <summary>Source callout block.</summary>
+    public CalloutBlock Callout { get; }
+
+    /// <summary>Callout kind such as info, warning, note, or success.</summary>
+    public string CalloutKind { get; }
+
+    /// <summary>Plain-text title.</summary>
+    public string Title { get; }
+
+    /// <summary>Structured title inline nodes.</summary>
+    public InlineSequence TitleInlines { get; }
+
+    /// <summary>Rendered markdown body.</summary>
+    public string Body { get; }
+
+    /// <summary>Nested native body blocks.</summary>
+    public IReadOnlyList<MarkdownNativeBlock> Children { get; }
+}
+
+/// <summary>
+/// Native projection for a details/disclosure block.
+/// </summary>
+public sealed class MarkdownNativeDetailsBlock : MarkdownNativeBlock {
+    internal MarkdownNativeDetailsBlock(
+        DetailsBlock details,
+        MarkdownSyntaxNode syntaxNode,
+        IReadOnlyList<MarkdownNativeBlock> children)
+        : base(MarkdownNativeBlockKind.Details, details, syntaxNode) {
+        Details = details;
+        Open = details.Open;
+        SummaryInlines = details.Summary?.Inlines;
+        Summary = SummaryInlines == null ? null : InlinePlainText.Extract(SummaryInlines);
+        Children = children ?? Array.Empty<MarkdownNativeBlock>();
+    }
+
+    /// <summary>Source details block.</summary>
+    public DetailsBlock Details { get; }
+
+    /// <summary>Whether the details element is initially expanded.</summary>
+    public bool Open { get; }
+
+    /// <summary>Plain-text summary when available.</summary>
+    public string? Summary { get; }
+
+    /// <summary>Structured summary inline nodes when available.</summary>
+    public InlineSequence? SummaryInlines { get; }
+
+    /// <summary>Nested native body blocks.</summary>
+    public IReadOnlyList<MarkdownNativeBlock> Children { get; }
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeContainerBlocks.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeContainerBlocks.cs
@@ -37,6 +37,7 @@ public sealed class MarkdownNativeCalloutBlock : MarkdownNativeBlock {
         CalloutKind = callout.Kind;
         Title = callout.Title;
         TitleInlines = callout.TitleInlines;
+        TitleInlineRuns = MarkdownNativeInlineProjection.FromInlineContainerChild(syntaxNode, MarkdownSyntaxKind.CalloutTitle);
         Body = callout.Body;
         Children = children ?? Array.Empty<MarkdownNativeBlock>();
     }
@@ -52,6 +53,9 @@ public sealed class MarkdownNativeCalloutBlock : MarkdownNativeBlock {
 
     /// <summary>Structured title inline nodes.</summary>
     public InlineSequence TitleInlines { get; }
+
+    /// <summary>AST-backed native title inline projection with source spans.</summary>
+    public IReadOnlyList<MarkdownNativeInline> TitleInlineRuns { get; }
 
     /// <summary>Rendered markdown body.</summary>
     public string Body { get; }
@@ -73,6 +77,7 @@ public sealed class MarkdownNativeDetailsBlock : MarkdownNativeBlock {
         Open = details.Open;
         SummaryInlines = details.Summary?.Inlines;
         Summary = SummaryInlines == null ? null : InlinePlainText.Extract(SummaryInlines);
+        SummaryInlineRuns = MarkdownNativeInlineProjection.FromInlineContainerChild(syntaxNode, MarkdownSyntaxKind.Summary);
         Children = children ?? Array.Empty<MarkdownNativeBlock>();
     }
 
@@ -87,6 +92,9 @@ public sealed class MarkdownNativeDetailsBlock : MarkdownNativeBlock {
 
     /// <summary>Structured summary inline nodes when available.</summary>
     public InlineSequence? SummaryInlines { get; }
+
+    /// <summary>AST-backed native summary inline projection with source spans.</summary>
+    public IReadOnlyList<MarkdownNativeInline> SummaryInlineRuns { get; }
 
     /// <summary>Nested native body blocks.</summary>
     public IReadOnlyList<MarkdownNativeBlock> Children { get; }

--- a/OfficeIMO.Markdown/Native/MarkdownNativeContentBlocks.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeContentBlocks.cs
@@ -71,7 +71,7 @@ public sealed class MarkdownNativeListItem {
         Children = children ?? Array.Empty<MarkdownNativeBlock>();
         Text = InlinePlainText.Extract(item.Content);
         Inlines = item.Content;
-        InlineRuns = MarkdownNativeInlineProjection.FromFirstDescendantInlineContainer(syntaxNode);
+        InlineRuns = MarkdownNativeInlineProjection.FromListItemLeadContent(syntaxNode, item);
         AdditionalParagraphs = item.AdditionalParagraphs;
         IsTask = item.IsTask;
         Checked = item.Checked;

--- a/OfficeIMO.Markdown/Native/MarkdownNativeContentBlocks.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeContentBlocks.cs
@@ -120,7 +120,8 @@ internal static class MarkdownNativeListItemId {
     internal static string Create(ListItem item, MarkdownSyntaxNode syntaxNode, MarkdownSourceSpan? sourceSpan) {
         var span = sourceSpan.HasValue ? sourceSpan.Value.ToString() : "nosource";
         var literal = syntaxNode.Literal ?? item.RenderMarkdown() ?? string.Empty;
-        var key = "ListItem|" + syntaxNode.Kind + "|" + span + "|" + literal;
+        var path = MarkdownNativeBlockId.BuildSyntaxPath(syntaxNode);
+        var key = "ListItem|" + syntaxNode.Kind + "|" + span + "|" + path + "|" + literal;
         return "mdn-li-" + ComputeFnv1A64(key).ToString("x16", System.Globalization.CultureInfo.InvariantCulture);
     }
 

--- a/OfficeIMO.Markdown/Native/MarkdownNativeContentBlocks.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeContentBlocks.cs
@@ -1,0 +1,243 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Native projection for a heading block.
+/// </summary>
+public sealed class MarkdownNativeHeadingBlock : MarkdownNativeBlock {
+    internal MarkdownNativeHeadingBlock(HeadingBlock heading, MarkdownSyntaxNode syntaxNode)
+        : base(MarkdownNativeBlockKind.Heading, heading, syntaxNode) {
+        Heading = heading;
+        Level = heading.Level;
+        Inlines = heading.Inlines;
+        Text = heading.Text;
+    }
+
+    /// <summary>Source heading block.</summary>
+    public HeadingBlock Heading { get; }
+
+    /// <summary>Heading level, where 1 is H1.</summary>
+    public int Level { get; }
+
+    /// <summary>Plain-text heading content.</summary>
+    public string Text { get; }
+
+    /// <summary>Structured inline nodes.</summary>
+    public InlineSequence Inlines { get; }
+}
+
+/// <summary>
+/// Native projection for an ordered or unordered list block.
+/// </summary>
+public sealed class MarkdownNativeListBlock : MarkdownNativeBlock {
+    internal MarkdownNativeListBlock(
+        IMarkdownListBlock list,
+        MarkdownSyntaxNode syntaxNode,
+        IReadOnlyList<MarkdownNativeListItem> items)
+        : base(MarkdownNativeBlockKind.List, list, syntaxNode) {
+        List = list;
+        Items = items ?? Array.Empty<MarkdownNativeListItem>();
+        IsOrdered = list is OrderedListBlock;
+        Start = list is OrderedListBlock ordered ? ordered.Start : null;
+    }
+
+    /// <summary>Source list block.</summary>
+    public IMarkdownBlock List { get; }
+
+    /// <summary>Whether the list is ordered.</summary>
+    public bool IsOrdered { get; }
+
+    /// <summary>Ordered-list start value, or <c>null</c> for unordered lists.</summary>
+    public int? Start { get; }
+
+    /// <summary>Native list items in document order.</summary>
+    public IReadOnlyList<MarkdownNativeListItem> Items { get; }
+}
+
+/// <summary>
+/// Native projection for a list item.
+/// </summary>
+public sealed class MarkdownNativeListItem {
+    internal MarkdownNativeListItem(
+        ListItem item,
+        MarkdownSyntaxNode syntaxNode,
+        IReadOnlyList<MarkdownNativeBlock> children) {
+        Item = item ?? throw new ArgumentNullException(nameof(item));
+        SyntaxNode = syntaxNode ?? throw new ArgumentNullException(nameof(syntaxNode));
+        SourceSpan = syntaxNode.SourceSpan ?? item.SourceSpan;
+        Children = children ?? Array.Empty<MarkdownNativeBlock>();
+        Text = InlinePlainText.Extract(item.Content);
+        Inlines = item.Content;
+        AdditionalParagraphs = item.AdditionalParagraphs;
+        IsTask = item.IsTask;
+        Checked = item.Checked;
+        Level = item.Level;
+        Id = MarkdownNativeListItemId.Create(item, syntaxNode, SourceSpan);
+    }
+
+    /// <summary>Deterministic identity for this list item within stable markdown input.</summary>
+    public string Id { get; }
+
+    /// <summary>Source list item.</summary>
+    public ListItem Item { get; }
+
+    /// <summary>Syntax node that produced this list item.</summary>
+    public MarkdownSyntaxNode SyntaxNode { get; }
+
+    /// <summary>Source span in the normalized markdown text when available.</summary>
+    public MarkdownSourceSpan? SourceSpan { get; }
+
+    /// <summary>Plain-text lead content.</summary>
+    public string Text { get; }
+
+    /// <summary>Structured lead inline nodes.</summary>
+    public InlineSequence Inlines { get; }
+
+    /// <summary>Additional paragraph inline nodes owned by this list item.</summary>
+    public IReadOnlyList<InlineSequence> AdditionalParagraphs { get; }
+
+    /// <summary>Nested native blocks, including lead paragraph blocks when present in the syntax tree.</summary>
+    public IReadOnlyList<MarkdownNativeBlock> Children { get; }
+
+    /// <summary>Whether this list item is a task item.</summary>
+    public bool IsTask { get; }
+
+    /// <summary>Whether this task item is checked.</summary>
+    public bool Checked { get; }
+
+    /// <summary>Indentation level from the source list item.</summary>
+    public int Level { get; }
+}
+
+internal static class MarkdownNativeListItemId {
+    internal static string Create(ListItem item, MarkdownSyntaxNode syntaxNode, MarkdownSourceSpan? sourceSpan) {
+        var span = sourceSpan.HasValue ? sourceSpan.Value.ToString() : "nosource";
+        var literal = syntaxNode.Literal ?? item.RenderMarkdown() ?? string.Empty;
+        var key = "ListItem|" + syntaxNode.Kind + "|" + span + "|" + literal;
+        return "mdn-li-" + ComputeFnv1A64(key).ToString("x16", System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static ulong ComputeFnv1A64(string value) {
+        const ulong offsetBasis = 14695981039346656037UL;
+        const ulong prime = 1099511628211UL;
+
+        var hash = offsetBasis;
+        for (var i = 0; i < value.Length; i++) {
+            hash ^= value[i];
+            hash *= prime;
+        }
+
+        return hash;
+    }
+}
+
+/// <summary>
+/// Native projection for an image block.
+/// </summary>
+public sealed class MarkdownNativeImageBlock : MarkdownNativeBlock {
+    internal MarkdownNativeImageBlock(ImageBlock image, MarkdownSyntaxNode syntaxNode)
+        : base(MarkdownNativeBlockKind.Image, image, syntaxNode) {
+        Image = image;
+        Source = image.Path;
+        Alt = image.Alt;
+        PlainAlt = image.PlainAlt;
+        Title = image.Title;
+        Width = image.Width;
+        Height = image.Height;
+        Caption = image.Caption;
+        LinkUrl = image.LinkUrl;
+        LinkTitle = image.LinkTitle;
+        LinkTarget = image.LinkTarget;
+        LinkRel = image.LinkRel;
+        PictureFallbackPath = image.PictureFallbackPath;
+        PictureSources = image.PictureSources.ToArray();
+    }
+
+    /// <summary>Source image block.</summary>
+    public ImageBlock Image { get; }
+
+    /// <summary>Image source path or URL.</summary>
+    public string Source { get; }
+
+    /// <summary>Alternate text markdown when available.</summary>
+    public string? Alt { get; }
+
+    /// <summary>Plain alternate text when available.</summary>
+    public string? PlainAlt { get; }
+
+    /// <summary>Image title when available.</summary>
+    public string? Title { get; }
+
+    /// <summary>Requested display width when available.</summary>
+    public double? Width { get; }
+
+    /// <summary>Requested display height when available.</summary>
+    public double? Height { get; }
+
+    /// <summary>Optional image caption.</summary>
+    public string? Caption { get; }
+
+    /// <summary>Optional link target wrapping the image.</summary>
+    public string? LinkUrl { get; }
+
+    /// <summary>Optional link title.</summary>
+    public string? LinkTitle { get; }
+
+    /// <summary>Optional link HTML target.</summary>
+    public string? LinkTarget { get; }
+
+    /// <summary>Optional link rel value.</summary>
+    public string? LinkRel { get; }
+
+    /// <summary>Optional fallback path for picture sources.</summary>
+    public string? PictureFallbackPath { get; }
+
+    /// <summary>Responsive picture sources in source order.</summary>
+    public IReadOnlyList<ImagePictureSource> PictureSources { get; }
+}
+
+/// <summary>
+/// Native projection for front matter.
+/// </summary>
+public sealed class MarkdownNativeFrontMatterBlock : MarkdownNativeBlock {
+    internal MarkdownNativeFrontMatterBlock(FrontMatterBlock frontMatter, MarkdownSyntaxNode syntaxNode)
+        : base(MarkdownNativeBlockKind.FrontMatter, frontMatter, syntaxNode) {
+        FrontMatter = frontMatter;
+        Entries = frontMatter.Entries;
+        Values = frontMatter.Entries.ToDictionary(
+            static entry => entry.Key,
+            static entry => entry.Value,
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Source front matter block.</summary>
+    public FrontMatterBlock FrontMatter { get; }
+
+    /// <summary>Structured front matter entries in source order.</summary>
+    public IReadOnlyList<FrontMatterBlock.Entry> Entries { get; }
+
+    /// <summary>Front matter values by key.</summary>
+    public IReadOnlyDictionary<string, object?> Values { get; }
+}
+
+/// <summary>
+/// Native projection for raw HTML and HTML comments.
+/// </summary>
+public sealed class MarkdownNativeHtmlBlock : MarkdownNativeBlock {
+    internal MarkdownNativeHtmlBlock(HtmlRawBlock html, MarkdownSyntaxNode syntaxNode)
+        : base(MarkdownNativeBlockKind.Html, html, syntaxNode) {
+        Html = html.Html;
+        IsComment = false;
+    }
+
+    internal MarkdownNativeHtmlBlock(HtmlCommentBlock comment, MarkdownSyntaxNode syntaxNode)
+        : base(MarkdownNativeBlockKind.Html, comment, syntaxNode) {
+        Html = comment.Comment;
+        IsComment = true;
+    }
+
+    /// <summary>Raw HTML or comment text.</summary>
+    public string Html { get; }
+
+    /// <summary>Whether this block came from an HTML comment.</summary>
+    public bool IsComment { get; }
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeContentBlocks.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeContentBlocks.cs
@@ -9,6 +9,7 @@ public sealed class MarkdownNativeHeadingBlock : MarkdownNativeBlock {
         Heading = heading;
         Level = heading.Level;
         Inlines = heading.Inlines;
+        InlineRuns = MarkdownNativeInlineProjection.FromInlineContainerChild(syntaxNode, MarkdownSyntaxKind.HeadingText);
         Text = heading.Text;
     }
 
@@ -23,6 +24,9 @@ public sealed class MarkdownNativeHeadingBlock : MarkdownNativeBlock {
 
     /// <summary>Structured inline nodes.</summary>
     public InlineSequence Inlines { get; }
+
+    /// <summary>AST-backed native inline projection with source spans.</summary>
+    public IReadOnlyList<MarkdownNativeInline> InlineRuns { get; }
 }
 
 /// <summary>
@@ -67,6 +71,7 @@ public sealed class MarkdownNativeListItem {
         Children = children ?? Array.Empty<MarkdownNativeBlock>();
         Text = InlinePlainText.Extract(item.Content);
         Inlines = item.Content;
+        InlineRuns = MarkdownNativeInlineProjection.FromFirstDescendantInlineContainer(syntaxNode);
         AdditionalParagraphs = item.AdditionalParagraphs;
         IsTask = item.IsTask;
         Checked = item.Checked;
@@ -91,6 +96,9 @@ public sealed class MarkdownNativeListItem {
 
     /// <summary>Structured lead inline nodes.</summary>
     public InlineSequence Inlines { get; }
+
+    /// <summary>AST-backed native inline projection for the lead content.</summary>
+    public IReadOnlyList<MarkdownNativeInline> InlineRuns { get; }
 
     /// <summary>Additional paragraph inline nodes owned by this list item.</summary>
     public IReadOnlyList<InlineSequence> AdditionalParagraphs { get; }

--- a/OfficeIMO.Markdown/Native/MarkdownNativeDiagnostics.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeDiagnostics.cs
@@ -1,0 +1,63 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Severity for native markdown projection diagnostics.
+/// </summary>
+public enum MarkdownNativeDiagnosticSeverity {
+    /// <summary>Informational diagnostic.</summary>
+    Info,
+
+    /// <summary>Warning diagnostic.</summary>
+    Warning,
+
+    /// <summary>Error diagnostic.</summary>
+    Error
+}
+
+/// <summary>
+/// Diagnostic emitted while building the native markdown projection.
+/// </summary>
+public sealed class MarkdownNativeDiagnostic {
+    internal MarkdownNativeDiagnostic(
+        string id,
+        string message,
+        MarkdownNativeDiagnosticSeverity severity,
+        MarkdownSourceSpan? sourceSpan = null,
+        MarkdownNativeBlock? block = null) {
+        Id = string.IsNullOrWhiteSpace(id) ? "native.diagnostic" : id.Trim();
+        Message = message ?? string.Empty;
+        Severity = severity;
+        SourceSpan = sourceSpan;
+        Block = block;
+    }
+
+    /// <summary>Stable diagnostic identifier.</summary>
+    public string Id { get; }
+
+    /// <summary>Human-readable diagnostic message.</summary>
+    public string Message { get; }
+
+    /// <summary>Diagnostic severity.</summary>
+    public MarkdownNativeDiagnosticSeverity Severity { get; }
+
+    /// <summary>Source span associated with the diagnostic when available.</summary>
+    public MarkdownSourceSpan? SourceSpan { get; }
+
+    /// <summary>Native block associated with the diagnostic when available.</summary>
+    public MarkdownNativeBlock? Block { get; }
+
+    internal static MarkdownNativeDiagnostic FromTransform(MarkdownDocumentTransformDiagnostic diagnostic) {
+        var sourceSpan = diagnostic.AffectedFinalBlockSpan
+            ?? diagnostic.AffectedOriginalBlockSpan
+            ?? diagnostic.AffectedSourceSpan;
+        var message = string.IsNullOrWhiteSpace(diagnostic.TransformName)
+            ? "Document transform ran while building the native markdown projection."
+            : $"Document transform '{diagnostic.TransformName}' ran while building the native markdown projection.";
+
+        return new MarkdownNativeDiagnostic(
+            "native.transform",
+            message,
+            MarkdownNativeDiagnosticSeverity.Info,
+            sourceSpan);
+    }
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeDocument.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeDocument.cs
@@ -4,13 +4,21 @@ namespace OfficeIMO.Markdown;
 /// Native, AST-backed projection of a parsed markdown document for UI hosts that need structured blocks and source spans.
 /// </summary>
 public sealed class MarkdownNativeDocument {
-    private MarkdownNativeDocument(MarkdownParseResult parseResult, IReadOnlyList<MarkdownNativeBlock> blocks) {
+    private MarkdownNativeDocument(
+        MarkdownParseResult parseResult,
+        string sourceMarkdown,
+        MarkdownNativeDocumentSourceKind sourceKind,
+        IReadOnlyList<MarkdownNativeBlock> blocks,
+        IReadOnlyList<MarkdownNativeDiagnostic> diagnostics) {
         ParseResult = parseResult ?? throw new ArgumentNullException(nameof(parseResult));
         Document = parseResult.Document;
         SyntaxTree = parseResult.SyntaxTree;
         FinalSyntaxTree = parseResult.FinalSyntaxTree;
         TransformDiagnostics = parseResult.TransformDiagnostics;
+        SourceMarkdown = sourceMarkdown ?? string.Empty;
+        SourceKind = sourceKind;
         Blocks = blocks ?? Array.Empty<MarkdownNativeBlock>();
+        Diagnostics = diagnostics ?? Array.Empty<MarkdownNativeDiagnostic>();
     }
 
     /// <summary>Underlying parse result, including original/final syntax trees and diagnostics.</summary>
@@ -28,42 +36,61 @@ public sealed class MarkdownNativeDocument {
     /// <summary>Document-transform diagnostics captured during parsing.</summary>
     public IReadOnlyList<MarkdownDocumentTransformDiagnostic> TransformDiagnostics { get; }
 
+    /// <summary>Markdown source text whose source spans back this projection.</summary>
+    public string SourceMarkdown { get; }
+
+    /// <summary>Identifies whether <see cref="SourceMarkdown"/> is direct reader input or renderer-preprocessed markdown.</summary>
+    public MarkdownNativeDocumentSourceKind SourceKind { get; }
+
     /// <summary>Top-level native block projection in document order.</summary>
     public IReadOnlyList<MarkdownNativeBlock> Blocks { get; }
+
+    /// <summary>Projection diagnostics including transform notices and unsupported block fallbacks.</summary>
+    public IReadOnlyList<MarkdownNativeDiagnostic> Diagnostics { get; }
 
     /// <summary>
     /// Parses markdown into the typed object model, syntax tree, diagnostics, and native block projection.
     /// </summary>
     public static MarkdownNativeDocument Parse(string markdown, MarkdownReaderOptions? options = null) {
-        var parseResult = MarkdownReader.ParseWithSyntaxTreeAndDiagnostics(markdown ?? string.Empty, options);
-        return FromParseResult(parseResult);
+        markdown ??= string.Empty;
+        var parseResult = MarkdownReader.ParseWithSyntaxTreeAndDiagnostics(markdown, options);
+        return FromParseResult(parseResult, markdown, MarkdownNativeDocumentSourceKind.ReaderInput);
     }
 
     /// <summary>
     /// Builds a native projection from an existing syntax-backed parse result.
     /// </summary>
-    public static MarkdownNativeDocument FromParseResult(MarkdownParseResult parseResult) {
+    public static MarkdownNativeDocument FromParseResult(
+        MarkdownParseResult parseResult,
+        string? sourceMarkdown = null,
+        MarkdownNativeDocumentSourceKind sourceKind = MarkdownNativeDocumentSourceKind.ReaderInput) {
         if (parseResult == null) {
             throw new ArgumentNullException(nameof(parseResult));
         }
 
         var blocks = new List<MarkdownNativeBlock>();
+        var diagnostics = new List<MarkdownNativeDiagnostic>();
+        for (var i = 0; i < parseResult.TransformDiagnostics.Count; i++) {
+            diagnostics.Add(MarkdownNativeDiagnostic.FromTransform(parseResult.TransformDiagnostics[i]));
+        }
+
         var children = parseResult.FinalSyntaxTree.Children;
         for (var i = 0; i < children.Count; i++) {
-            var block = CreateNativeBlock(children[i]);
+            var block = MarkdownNativeProjectionFactory.Create(children[i], diagnostics);
             if (block != null) {
                 blocks.Add(block);
             }
         }
 
-        return new MarkdownNativeDocument(parseResult, blocks);
+        return new MarkdownNativeDocument(parseResult, sourceMarkdown ?? string.Empty, sourceKind, blocks, diagnostics);
     }
 
-    /// <summary>Finds the first top-level native block whose source span contains the supplied 1-based line.</summary>
+    /// <summary>Finds the first native block whose source span contains the supplied 1-based line.</summary>
     public MarkdownNativeBlock? FindBlockAtLine(int lineNumber) {
         for (var i = 0; i < Blocks.Count; i++) {
-            if (Blocks[i].ContainsLine(lineNumber)) {
-                return Blocks[i];
+            var match = FindBlockAtLine(Blocks[i], lineNumber);
+            if (match != null) {
+                return match;
             }
         }
 
@@ -79,22 +106,36 @@ public sealed class MarkdownNativeDocument {
         }
     }
 
-    private static MarkdownNativeBlock? CreateNativeBlock(MarkdownSyntaxNode syntaxNode) {
-        if (syntaxNode?.AssociatedObject is not IMarkdownBlock block) {
-            return null;
+    private static MarkdownNativeBlock? FindBlockAtLine(MarkdownNativeBlock block, int lineNumber) {
+        switch (block) {
+            case MarkdownNativeQuoteBlock quote:
+                return FindChildBlockAtLine(quote.Children, lineNumber) ?? (quote.ContainsLine(lineNumber) ? quote : null);
+            case MarkdownNativeCalloutBlock callout:
+                return FindChildBlockAtLine(callout.Children, lineNumber) ?? (callout.ContainsLine(lineNumber) ? callout : null);
+            case MarkdownNativeDetailsBlock details:
+                return FindChildBlockAtLine(details.Children, lineNumber) ?? (details.ContainsLine(lineNumber) ? details : null);
+            case MarkdownNativeListBlock list:
+                for (var i = 0; i < list.Items.Count; i++) {
+                    var itemMatch = FindChildBlockAtLine(list.Items[i].Children, lineNumber);
+                    if (itemMatch != null) {
+                        return itemMatch;
+                    }
+                }
+
+                return list.ContainsLine(lineNumber) ? list : null;
+            default:
+                return block.ContainsLine(lineNumber) ? block : null;
+        }
+    }
+
+    private static MarkdownNativeBlock? FindChildBlockAtLine(IReadOnlyList<MarkdownNativeBlock> children, int lineNumber) {
+        for (var i = 0; i < children.Count; i++) {
+            var match = FindBlockAtLine(children[i], lineNumber);
+            if (match != null) {
+                return match;
+            }
         }
 
-        switch (block) {
-            case ParagraphBlock paragraph:
-                return new MarkdownNativeParagraphBlock(paragraph, syntaxNode);
-            case CodeBlock code:
-                return new MarkdownNativeCodeBlock(code, syntaxNode);
-            case SemanticFencedBlock visual:
-                return new MarkdownNativeVisualBlock(visual, syntaxNode);
-            case TableBlock table:
-                return new MarkdownNativeTableBlock(table, syntaxNode);
-            default:
-                return new MarkdownNativeOtherBlock(block, syntaxNode);
-        }
+        return null;
     }
 }

--- a/OfficeIMO.Markdown/Native/MarkdownNativeDocument.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeDocument.cs
@@ -97,6 +97,78 @@ public sealed class MarkdownNativeDocument {
         return null;
     }
 
+    /// <summary>Finds the first native block whose source span contains the supplied 1-based line and column.</summary>
+    public MarkdownNativeBlock? FindBlockAtPosition(int lineNumber, int columnNumber) {
+        for (var i = 0; i < Blocks.Count; i++) {
+            var match = FindBlockAtPosition(Blocks[i], lineNumber, columnNumber);
+            if (match != null) {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Finds a native block by deterministic id.</summary>
+    public MarkdownNativeBlock? FindBlockById(string id) {
+        if (string.IsNullOrWhiteSpace(id)) {
+            return null;
+        }
+
+        for (var i = 0; i < Blocks.Count; i++) {
+            var match = FindBlockById(Blocks[i], id);
+            if (match != null) {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Finds the first native inline whose source span contains the supplied 1-based line and column.</summary>
+    public MarkdownNativeInline? FindInlineAtPosition(int lineNumber, int columnNumber) {
+        foreach (var inline in EnumerateInlines()) {
+            var match = FindInlineAtPosition(inline, lineNumber, columnNumber);
+            if (match != null) {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Finds a native inline by deterministic id.</summary>
+    public MarkdownNativeInline? FindInlineById(string id) {
+        if (string.IsNullOrWhiteSpace(id)) {
+            return null;
+        }
+
+        foreach (var inline in EnumerateInlines()) {
+            var match = FindInlineById(inline, id);
+            if (match != null) {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Returns the top-level-to-target block path for a block id.</summary>
+    public IReadOnlyList<MarkdownNativeBlock> GetBlockPath(string id) {
+        if (string.IsNullOrWhiteSpace(id)) {
+            return Array.Empty<MarkdownNativeBlock>();
+        }
+
+        var path = new List<MarkdownNativeBlock>();
+        for (var i = 0; i < Blocks.Count; i++) {
+            if (TryBuildBlockPath(Blocks[i], id, path)) {
+                return path;
+            }
+        }
+
+        return Array.Empty<MarkdownNativeBlock>();
+    }
+
     /// <summary>Enumerates top-level native blocks of the requested projection type.</summary>
     public IEnumerable<TBlock> BlocksOfType<TBlock>() where TBlock : MarkdownNativeBlock {
         for (var i = 0; i < Blocks.Count; i++) {
@@ -104,6 +176,62 @@ public sealed class MarkdownNativeDocument {
                 yield return block;
             }
         }
+    }
+
+    /// <summary>Enumerates all native blocks in document order, including nested blocks.</summary>
+    public IEnumerable<MarkdownNativeBlock> DescendantBlocksAndSelf() {
+        for (var i = 0; i < Blocks.Count; i++) {
+            foreach (var block in DescendantBlocksAndSelf(Blocks[i])) {
+                yield return block;
+            }
+        }
+    }
+
+    /// <summary>Enumerates all native inline runs in document order.</summary>
+    public IEnumerable<MarkdownNativeInline> EnumerateInlines() {
+        for (var i = 0; i < Blocks.Count; i++) {
+            foreach (var inline in EnumerateInlines(Blocks[i])) {
+                yield return inline;
+            }
+        }
+    }
+
+    /// <summary>Creates a UI-safe snapshot of this document without parser object references.</summary>
+    public MarkdownNativeDocumentSnapshot ToSnapshot() => MarkdownNativeSnapshotFactory.FromDocument(this);
+
+    /// <summary>Creates a non-mutating source edit that replaces a source span.</summary>
+    public MarkdownNativeSourceEdit CreateReplaceEdit(MarkdownSourceSpan sourceSpan, string replacementMarkdown) {
+        if (!TryResolveOffsets(sourceSpan, out var startOffset, out var endOffsetInclusive)) {
+            throw new InvalidOperationException("The supplied source span cannot be mapped to offsets in this native document source.");
+        }
+
+        return new MarkdownNativeSourceEdit(sourceSpan, startOffset, endOffsetInclusive, replacementMarkdown);
+    }
+
+    /// <summary>Creates a non-mutating source edit that replaces a native block.</summary>
+    public MarkdownNativeSourceEdit CreateReplaceEdit(MarkdownNativeBlock block, string replacementMarkdown) {
+        if (block == null) {
+            throw new ArgumentNullException(nameof(block));
+        }
+
+        if (!block.SourceSpan.HasValue) {
+            throw new InvalidOperationException("The native block does not have a source span.");
+        }
+
+        return CreateReplaceEdit(block.SourceSpan.Value, replacementMarkdown);
+    }
+
+    /// <summary>Creates a non-mutating source edit that replaces a native inline.</summary>
+    public MarkdownNativeSourceEdit CreateReplaceEdit(MarkdownNativeInline inline, string replacementMarkdown) {
+        if (inline == null) {
+            throw new ArgumentNullException(nameof(inline));
+        }
+
+        if (!inline.SourceSpan.HasValue) {
+            throw new InvalidOperationException("The native inline does not have a source span.");
+        }
+
+        return CreateReplaceEdit(inline.SourceSpan.Value, replacementMarkdown);
     }
 
     private static MarkdownNativeBlock? FindBlockAtLine(MarkdownNativeBlock block, int lineNumber) {
@@ -128,6 +256,62 @@ public sealed class MarkdownNativeDocument {
         }
     }
 
+    private static MarkdownNativeBlock? FindBlockAtPosition(MarkdownNativeBlock block, int lineNumber, int columnNumber) {
+        switch (block) {
+            case MarkdownNativeQuoteBlock quote:
+                return FindChildBlockAtPosition(quote.Children, lineNumber, columnNumber) ?? (ContainsPosition(quote, lineNumber, columnNumber) ? quote : null);
+            case MarkdownNativeCalloutBlock callout:
+                return FindChildBlockAtPosition(callout.Children, lineNumber, columnNumber) ?? (ContainsPosition(callout, lineNumber, columnNumber) ? callout : null);
+            case MarkdownNativeDetailsBlock details:
+                return FindChildBlockAtPosition(details.Children, lineNumber, columnNumber) ?? (ContainsPosition(details, lineNumber, columnNumber) ? details : null);
+            case MarkdownNativeListBlock list:
+                for (var i = 0; i < list.Items.Count; i++) {
+                    var itemMatch = FindChildBlockAtPosition(list.Items[i].Children, lineNumber, columnNumber);
+                    if (itemMatch != null) {
+                        return itemMatch;
+                    }
+                }
+
+                return ContainsPosition(list, lineNumber, columnNumber) ? list : null;
+            default:
+                return ContainsPosition(block, lineNumber, columnNumber) ? block : null;
+        }
+    }
+
+    private static bool ContainsPosition(MarkdownNativeBlock block, int lineNumber, int columnNumber) =>
+        block.SourceSpan.HasValue && block.SourceSpan.Value.ContainsPosition(lineNumber, columnNumber);
+
+    private static MarkdownNativeBlock? FindBlockById(MarkdownNativeBlock block, string id) {
+        if (string.Equals(block.Id, id, StringComparison.Ordinal)) {
+            return block;
+        }
+
+        foreach (var child in GetChildBlocks(block)) {
+            var match = FindBlockById(child, id);
+            if (match != null) {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryBuildBlockPath(MarkdownNativeBlock block, string id, List<MarkdownNativeBlock> path) {
+        path.Add(block);
+        if (string.Equals(block.Id, id, StringComparison.Ordinal)) {
+            return true;
+        }
+
+        foreach (var child in GetChildBlocks(block)) {
+            if (TryBuildBlockPath(child, id, path)) {
+                return true;
+            }
+        }
+
+        path.RemoveAt(path.Count - 1);
+        return false;
+    }
+
     private static MarkdownNativeBlock? FindChildBlockAtLine(IReadOnlyList<MarkdownNativeBlock> children, int lineNumber) {
         for (var i = 0; i < children.Count; i++) {
             var match = FindBlockAtLine(children[i], lineNumber);
@@ -137,5 +321,236 @@ public sealed class MarkdownNativeDocument {
         }
 
         return null;
+    }
+
+    private static MarkdownNativeBlock? FindChildBlockAtPosition(IReadOnlyList<MarkdownNativeBlock> children, int lineNumber, int columnNumber) {
+        for (var i = 0; i < children.Count; i++) {
+            var match = FindBlockAtPosition(children[i], lineNumber, columnNumber);
+            if (match != null) {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<MarkdownNativeBlock> DescendantBlocksAndSelf(MarkdownNativeBlock block) {
+        yield return block;
+        foreach (var child in GetChildBlocks(block)) {
+            foreach (var descendant in DescendantBlocksAndSelf(child)) {
+                yield return descendant;
+            }
+        }
+    }
+
+    private static IEnumerable<MarkdownNativeBlock> GetChildBlocks(MarkdownNativeBlock block) {
+        switch (block) {
+            case MarkdownNativeQuoteBlock quote:
+                return quote.Children;
+            case MarkdownNativeCalloutBlock callout:
+                return callout.Children;
+            case MarkdownNativeDetailsBlock details:
+                return details.Children;
+            case MarkdownNativeListBlock list:
+                return EnumerateListItemChildren(list);
+            default:
+                return Array.Empty<MarkdownNativeBlock>();
+        }
+    }
+
+    private static IEnumerable<MarkdownNativeBlock> EnumerateListItemChildren(MarkdownNativeListBlock list) {
+        for (var i = 0; i < list.Items.Count; i++) {
+            for (var j = 0; j < list.Items[i].Children.Count; j++) {
+                yield return list.Items[i].Children[j];
+            }
+        }
+    }
+
+    private static IEnumerable<MarkdownNativeInline> EnumerateInlines(MarkdownNativeBlock block) {
+        foreach (var inline in GetInlineRuns(block)) {
+            foreach (var nested in EnumerateInlineAndChildren(inline)) {
+                yield return nested;
+            }
+        }
+
+        foreach (var child in GetChildBlocks(block)) {
+            foreach (var inline in EnumerateInlines(child)) {
+                yield return inline;
+            }
+        }
+    }
+
+    private static IEnumerable<MarkdownNativeInline> GetInlineRuns(MarkdownNativeBlock block) {
+        switch (block) {
+            case MarkdownNativeParagraphBlock paragraph:
+                return paragraph.InlineRuns;
+            case MarkdownNativeHeadingBlock heading:
+                return heading.InlineRuns;
+            case MarkdownNativeCalloutBlock callout:
+                return callout.TitleInlineRuns;
+            case MarkdownNativeDetailsBlock details:
+                return details.SummaryInlineRuns;
+            case MarkdownNativeTableBlock table:
+                return EnumerateTableInlines(table);
+            case MarkdownNativeListBlock list:
+                return EnumerateListItemInlines(list);
+            default:
+                return Array.Empty<MarkdownNativeInline>();
+        }
+    }
+
+    private static IEnumerable<MarkdownNativeInline> EnumerateTableInlines(MarkdownNativeTableBlock table) {
+        for (var i = 0; i < table.HeaderCells.Count; i++) {
+            for (var j = 0; j < table.HeaderCells[i].InlineRuns.Count; j++) {
+                yield return table.HeaderCells[i].InlineRuns[j];
+            }
+        }
+
+        for (var row = 0; row < table.Rows.Count; row++) {
+            for (var column = 0; column < table.Rows[row].Count; column++) {
+                for (var i = 0; i < table.Rows[row][column].InlineRuns.Count; i++) {
+                    yield return table.Rows[row][column].InlineRuns[i];
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<MarkdownNativeInline> EnumerateListItemInlines(MarkdownNativeListBlock list) {
+        for (var i = 0; i < list.Items.Count; i++) {
+            for (var j = 0; j < list.Items[i].InlineRuns.Count; j++) {
+                yield return list.Items[i].InlineRuns[j];
+            }
+        }
+    }
+
+    private static IEnumerable<MarkdownNativeInline> EnumerateInlineAndChildren(MarkdownNativeInline inline) {
+        yield return inline;
+        for (var i = 0; i < inline.Children.Count; i++) {
+            foreach (var child in EnumerateInlineAndChildren(inline.Children[i])) {
+                yield return child;
+            }
+        }
+    }
+
+    private static MarkdownNativeInline? FindInlineAtPosition(MarkdownNativeInline inline, int lineNumber, int columnNumber) {
+        if (!inline.ContainsPosition(lineNumber, columnNumber)) {
+            return null;
+        }
+
+        for (var i = 0; i < inline.Children.Count; i++) {
+            var match = FindInlineAtPosition(inline.Children[i], lineNumber, columnNumber);
+            if (match != null) {
+                return match;
+            }
+        }
+
+        return inline;
+    }
+
+    private static MarkdownNativeInline? FindInlineById(MarkdownNativeInline inline, string id) {
+        if (string.Equals(inline.Id, id, StringComparison.Ordinal)) {
+            return inline;
+        }
+
+        for (var i = 0; i < inline.Children.Count; i++) {
+            var match = FindInlineById(inline.Children[i], id);
+            if (match != null) {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    private bool TryResolveOffsets(MarkdownSourceSpan span, out int startOffset, out int endOffsetInclusive) {
+        if (span.StartOffset.HasValue && span.EndOffset.HasValue) {
+            startOffset = ClampOffset(span.StartOffset.Value);
+            endOffsetInclusive = ClampOffset(span.EndOffset.Value);
+            return endOffsetInclusive >= startOffset;
+        }
+
+        if (span.StartColumn.HasValue && span.EndColumn.HasValue
+            && TryGetOffset(span.StartLine, span.StartColumn.Value, out startOffset)
+            && TryGetOffset(span.EndLine, span.EndColumn.Value, out endOffsetInclusive)) {
+            return endOffsetInclusive >= startOffset;
+        }
+
+        if (TryGetLineStartOffset(span.StartLine, out startOffset)
+            && TryGetLineEndOffset(span.EndLine, out endOffsetInclusive)) {
+            return endOffsetInclusive >= startOffset;
+        }
+
+        startOffset = 0;
+        endOffsetInclusive = -1;
+        return false;
+    }
+
+    private int ClampOffset(int offset) {
+        if (SourceMarkdown.Length == 0) {
+            return 0;
+        }
+
+        if (offset < 0) {
+            return 0;
+        }
+
+        return offset >= SourceMarkdown.Length ? SourceMarkdown.Length - 1 : offset;
+    }
+
+    private bool TryGetOffset(int lineNumber, int columnNumber, out int offset) {
+        if (!TryGetLineStartOffset(lineNumber, out var lineStart)) {
+            offset = 0;
+            return false;
+        }
+
+        offset = Math.Min(SourceMarkdown.Length == 0 ? 0 : SourceMarkdown.Length - 1, lineStart + Math.Max(0, columnNumber - 1));
+        return true;
+    }
+
+    private bool TryGetLineStartOffset(int lineNumber, out int offset) {
+        offset = 0;
+        if (lineNumber < 1) {
+            return false;
+        }
+
+        if (lineNumber == 1) {
+            return true;
+        }
+
+        var currentLine = 1;
+        for (var i = 0; i < SourceMarkdown.Length; i++) {
+            if (SourceMarkdown[i] != '\n') {
+                continue;
+            }
+
+            currentLine++;
+            if (currentLine == lineNumber) {
+                offset = i + 1;
+                return offset <= SourceMarkdown.Length;
+            }
+        }
+
+        return false;
+    }
+
+    private bool TryGetLineEndOffset(int lineNumber, out int offset) {
+        if (!TryGetLineStartOffset(lineNumber, out var lineStart)) {
+            offset = 0;
+            return false;
+        }
+
+        offset = SourceMarkdown.Length == 0 ? 0 : SourceMarkdown.Length - 1;
+        for (var i = lineStart; i < SourceMarkdown.Length; i++) {
+            if (SourceMarkdown[i] == '\n') {
+                offset = Math.Max(lineStart, i - 1);
+                if (offset > lineStart && SourceMarkdown[offset] == '\r') {
+                    offset--;
+                }
+
+                return true;
+            }
+        }
+
+        return true;
     }
 }

--- a/OfficeIMO.Markdown/Native/MarkdownNativeDocument.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeDocument.cs
@@ -54,7 +54,7 @@ public sealed class MarkdownNativeDocument {
     public static MarkdownNativeDocument Parse(string markdown, MarkdownReaderOptions? options = null) {
         markdown ??= string.Empty;
         var parseResult = MarkdownReader.ParseWithSyntaxTreeAndDiagnostics(markdown, options);
-        return FromParseResult(parseResult, markdown, MarkdownNativeDocumentSourceKind.ReaderInput);
+        return FromParseResult(parseResult, sourceMarkdown: null, MarkdownNativeDocumentSourceKind.ReaderInput);
     }
 
     /// <summary>
@@ -82,7 +82,7 @@ public sealed class MarkdownNativeDocument {
             }
         }
 
-        return new MarkdownNativeDocument(parseResult, sourceMarkdown ?? string.Empty, sourceKind, blocks, diagnostics);
+        return new MarkdownNativeDocument(parseResult, sourceMarkdown ?? parseResult.SourceMarkdown, sourceKind, blocks, diagnostics);
     }
 
     /// <summary>Finds the first native block whose source span contains the supplied 1-based line.</summary>
@@ -254,6 +254,8 @@ public sealed class MarkdownNativeDocument {
                 }
 
                 return list.ContainsLine(lineNumber) ? list : null;
+            case MarkdownNativeTableBlock table:
+                return FindChildBlockAtLine(EnumerateTableChildren(table), lineNumber) ?? (table.ContainsLine(lineNumber) ? table : null);
             default:
                 return block.ContainsLine(lineNumber) ? block : null;
         }
@@ -276,6 +278,8 @@ public sealed class MarkdownNativeDocument {
                 }
 
                 return ContainsPosition(list, lineNumber, columnNumber) ? list : null;
+            case MarkdownNativeTableBlock table:
+                return FindChildBlockAtPosition(EnumerateTableChildren(table), lineNumber, columnNumber) ?? (ContainsPosition(table, lineNumber, columnNumber) ? table : null);
             default:
                 return ContainsPosition(block, lineNumber, columnNumber) ? block : null;
         }
@@ -356,9 +360,30 @@ public sealed class MarkdownNativeDocument {
                 return details.Children;
             case MarkdownNativeListBlock list:
                 return EnumerateListItemChildren(list);
+            case MarkdownNativeTableBlock table:
+                return EnumerateTableChildren(table);
             default:
                 return Array.Empty<MarkdownNativeBlock>();
         }
+    }
+
+    private static IReadOnlyList<MarkdownNativeBlock> EnumerateTableChildren(MarkdownNativeTableBlock table) {
+        if (table == null) {
+            return Array.Empty<MarkdownNativeBlock>();
+        }
+
+        var children = new List<MarkdownNativeBlock>();
+        for (var i = 0; i < table.HeaderCells.Count; i++) {
+            children.AddRange(table.HeaderCells[i].Children);
+        }
+
+        for (var row = 0; row < table.Rows.Count; row++) {
+            for (var column = 0; column < table.Rows[row].Count; column++) {
+                children.AddRange(table.Rows[row][column].Children);
+            }
+        }
+
+        return children;
     }
 
     private static IEnumerable<MarkdownNativeBlock> EnumerateListItemChildren(MarkdownNativeListBlock list) {
@@ -466,6 +491,12 @@ public sealed class MarkdownNativeDocument {
     }
 
     private bool TryResolveOffsets(MarkdownSourceSpan span, out int startOffset, out int endOffsetInclusive) {
+        if (SourceMarkdown.Length == 0) {
+            startOffset = 0;
+            endOffsetInclusive = -1;
+            return false;
+        }
+
         if (span.StartOffset.HasValue && span.EndOffset.HasValue) {
             startOffset = ClampOffset(span.StartOffset.Value);
             endOffsetInclusive = ClampOffset(span.EndOffset.Value);
@@ -489,10 +520,6 @@ public sealed class MarkdownNativeDocument {
     }
 
     private int ClampOffset(int offset) {
-        if (SourceMarkdown.Length == 0) {
-            return 0;
-        }
-
         if (offset < 0) {
             return 0;
         }
@@ -506,7 +533,7 @@ public sealed class MarkdownNativeDocument {
             return false;
         }
 
-        offset = Math.Min(SourceMarkdown.Length == 0 ? 0 : SourceMarkdown.Length - 1, lineStart + Math.Max(0, columnNumber - 1));
+        offset = Math.Min(SourceMarkdown.Length - 1, lineStart + Math.Max(0, columnNumber - 1));
         return true;
     }
 
@@ -542,7 +569,7 @@ public sealed class MarkdownNativeDocument {
             return false;
         }
 
-        offset = SourceMarkdown.Length == 0 ? 0 : SourceMarkdown.Length - 1;
+        offset = SourceMarkdown.Length - 1;
         for (var i = lineStart; i < SourceMarkdown.Length; i++) {
             if (SourceMarkdown[i] == '\n') {
                 offset = Math.Max(lineStart, i - 1);

--- a/OfficeIMO.Markdown/Native/MarkdownNativeDocument.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeDocument.cs
@@ -1,0 +1,100 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Native, AST-backed projection of a parsed markdown document for UI hosts that need structured blocks and source spans.
+/// </summary>
+public sealed class MarkdownNativeDocument {
+    private MarkdownNativeDocument(MarkdownParseResult parseResult, IReadOnlyList<MarkdownNativeBlock> blocks) {
+        ParseResult = parseResult ?? throw new ArgumentNullException(nameof(parseResult));
+        Document = parseResult.Document;
+        SyntaxTree = parseResult.SyntaxTree;
+        FinalSyntaxTree = parseResult.FinalSyntaxTree;
+        TransformDiagnostics = parseResult.TransformDiagnostics;
+        Blocks = blocks ?? Array.Empty<MarkdownNativeBlock>();
+    }
+
+    /// <summary>Underlying parse result, including original/final syntax trees and diagnostics.</summary>
+    public MarkdownParseResult ParseResult { get; }
+
+    /// <summary>Parsed OfficeIMO markdown document.</summary>
+    public MarkdownDoc Document { get; }
+
+    /// <summary>Original syntax tree produced before document transforms were applied.</summary>
+    public MarkdownSyntaxNode SyntaxTree { get; }
+
+    /// <summary>Final syntax tree aligned with <see cref="Document"/>.</summary>
+    public MarkdownSyntaxNode FinalSyntaxTree { get; }
+
+    /// <summary>Document-transform diagnostics captured during parsing.</summary>
+    public IReadOnlyList<MarkdownDocumentTransformDiagnostic> TransformDiagnostics { get; }
+
+    /// <summary>Top-level native block projection in document order.</summary>
+    public IReadOnlyList<MarkdownNativeBlock> Blocks { get; }
+
+    /// <summary>
+    /// Parses markdown into the typed object model, syntax tree, diagnostics, and native block projection.
+    /// </summary>
+    public static MarkdownNativeDocument Parse(string markdown, MarkdownReaderOptions? options = null) {
+        var parseResult = MarkdownReader.ParseWithSyntaxTreeAndDiagnostics(markdown ?? string.Empty, options);
+        return FromParseResult(parseResult);
+    }
+
+    /// <summary>
+    /// Builds a native projection from an existing syntax-backed parse result.
+    /// </summary>
+    public static MarkdownNativeDocument FromParseResult(MarkdownParseResult parseResult) {
+        if (parseResult == null) {
+            throw new ArgumentNullException(nameof(parseResult));
+        }
+
+        var blocks = new List<MarkdownNativeBlock>();
+        var children = parseResult.FinalSyntaxTree.Children;
+        for (var i = 0; i < children.Count; i++) {
+            var block = CreateNativeBlock(children[i]);
+            if (block != null) {
+                blocks.Add(block);
+            }
+        }
+
+        return new MarkdownNativeDocument(parseResult, blocks);
+    }
+
+    /// <summary>Finds the first top-level native block whose source span contains the supplied 1-based line.</summary>
+    public MarkdownNativeBlock? FindBlockAtLine(int lineNumber) {
+        for (var i = 0; i < Blocks.Count; i++) {
+            if (Blocks[i].ContainsLine(lineNumber)) {
+                return Blocks[i];
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Enumerates top-level native blocks of the requested projection type.</summary>
+    public IEnumerable<TBlock> BlocksOfType<TBlock>() where TBlock : MarkdownNativeBlock {
+        for (var i = 0; i < Blocks.Count; i++) {
+            if (Blocks[i] is TBlock block) {
+                yield return block;
+            }
+        }
+    }
+
+    private static MarkdownNativeBlock? CreateNativeBlock(MarkdownSyntaxNode syntaxNode) {
+        if (syntaxNode?.AssociatedObject is not IMarkdownBlock block) {
+            return null;
+        }
+
+        switch (block) {
+            case ParagraphBlock paragraph:
+                return new MarkdownNativeParagraphBlock(paragraph, syntaxNode);
+            case CodeBlock code:
+                return new MarkdownNativeCodeBlock(code, syntaxNode);
+            case SemanticFencedBlock visual:
+                return new MarkdownNativeVisualBlock(visual, syntaxNode);
+            case TableBlock table:
+                return new MarkdownNativeTableBlock(table, syntaxNode);
+            default:
+                return new MarkdownNativeOtherBlock(block, syntaxNode);
+        }
+    }
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeDocument.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeDocument.cs
@@ -189,9 +189,12 @@ public sealed class MarkdownNativeDocument {
 
     /// <summary>Enumerates all native inline runs in document order.</summary>
     public IEnumerable<MarkdownNativeInline> EnumerateInlines() {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
         for (var i = 0; i < Blocks.Count; i++) {
             foreach (var inline in EnumerateInlines(Blocks[i])) {
-                yield return inline;
+                if (seen.Add(inline.Id)) {
+                    yield return inline;
+                }
             }
         }
     }

--- a/OfficeIMO.Markdown/Native/MarkdownNativeDocumentSourceKind.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeDocumentSourceKind.cs
@@ -1,0 +1,12 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Identifies the markdown source represented by a native projection.
+/// </summary>
+public enum MarkdownNativeDocumentSourceKind {
+    /// <summary>The source text is the reader input supplied directly to OfficeIMO.Markdown.</summary>
+    ReaderInput,
+
+    /// <summary>The source text is renderer-preprocessed markdown after host preprocessing ran.</summary>
+    RendererPreprocessed
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeInlineId.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeInlineId.cs
@@ -1,0 +1,26 @@
+namespace OfficeIMO.Markdown;
+
+internal static class MarkdownNativeInlineId {
+    internal static string Create(
+        MarkdownNativeInlineKind kind,
+        MarkdownSyntaxNode syntaxNode,
+        MarkdownSourceSpan? sourceSpan) {
+        var span = sourceSpan.HasValue ? sourceSpan.Value.ToString() : "nosource";
+        var literal = syntaxNode.Literal ?? string.Empty;
+        var key = kind.ToString() + "|" + syntaxNode.Kind + "|" + span + "|" + literal;
+        return "mdn-in-" + ComputeFnv1A64(key).ToString("x16", System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    internal static ulong ComputeFnv1A64(string value) {
+        const ulong offsetBasis = 14695981039346656037UL;
+        const ulong prime = 1099511628211UL;
+
+        var hash = offsetBasis;
+        for (var i = 0; i < value.Length; i++) {
+            hash ^= value[i];
+            hash *= prime;
+        }
+
+        return hash;
+    }
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeInlineId.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeInlineId.cs
@@ -7,7 +7,8 @@ internal static class MarkdownNativeInlineId {
         MarkdownSourceSpan? sourceSpan) {
         var span = sourceSpan.HasValue ? sourceSpan.Value.ToString() : "nosource";
         var literal = syntaxNode.Literal ?? string.Empty;
-        var key = kind.ToString() + "|" + syntaxNode.Kind + "|" + span + "|" + literal;
+        var path = MarkdownNativeBlockId.BuildSyntaxPath(syntaxNode);
+        var key = kind.ToString() + "|" + syntaxNode.Kind + "|" + span + "|" + path + "|" + literal;
         return "mdn-in-" + ComputeFnv1A64(key).ToString("x16", System.Globalization.CultureInfo.InvariantCulture);
     }
 

--- a/OfficeIMO.Markdown/Native/MarkdownNativeInlineKind.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeInlineKind.cs
@@ -1,0 +1,39 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Native inline projection kind for UI/read-model consumers.
+/// </summary>
+public enum MarkdownNativeInlineKind {
+    /// <summary>Plain text content.</summary>
+    Text,
+    /// <summary>Inline code span.</summary>
+    Code,
+    /// <summary>Hyperlink inline.</summary>
+    Link,
+    /// <summary>Standalone inline image.</summary>
+    Image,
+    /// <summary>Linked inline image.</summary>
+    ImageLink,
+    /// <summary>Strong/bold inline content.</summary>
+    Strong,
+    /// <summary>Emphasis/italic inline content.</summary>
+    Emphasis,
+    /// <summary>Combined strong and emphasis inline content.</summary>
+    StrongEmphasis,
+    /// <summary>Strikethrough inline content.</summary>
+    Strikethrough,
+    /// <summary>Highlighted inline content.</summary>
+    Highlight,
+    /// <summary>Underline inline content.</summary>
+    Underline,
+    /// <summary>Hard line break.</summary>
+    HardBreak,
+    /// <summary>Inline HTML tag wrapper.</summary>
+    HtmlTag,
+    /// <summary>Raw inline HTML.</summary>
+    HtmlRaw,
+    /// <summary>Footnote reference.</summary>
+    FootnoteRef,
+    /// <summary>Inline node without a specialized native projection.</summary>
+    Other
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeInlineMetadata.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeInlineMetadata.cs
@@ -1,0 +1,25 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Source-backed metadata attached to a native inline, such as a link target or image title.
+/// </summary>
+public sealed class MarkdownNativeInlineMetadata {
+    internal MarkdownNativeInlineMetadata(string name, string value, MarkdownSyntaxNode syntaxNode) {
+        Name = name ?? string.Empty;
+        Value = value ?? string.Empty;
+        SyntaxNode = syntaxNode ?? throw new ArgumentNullException(nameof(syntaxNode));
+        SourceSpan = syntaxNode.SourceSpan;
+    }
+
+    /// <summary>Stable metadata name such as <c>target</c>, <c>title</c>, <c>alt</c>, or <c>source</c>.</summary>
+    public string Name { get; }
+
+    /// <summary>Metadata value.</summary>
+    public string Value { get; }
+
+    /// <summary>Syntax node that produced this metadata value.</summary>
+    public MarkdownSyntaxNode SyntaxNode { get; }
+
+    /// <summary>Source span for the metadata value when available.</summary>
+    public MarkdownSourceSpan? SourceSpan { get; }
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeInlines.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeInlines.cs
@@ -1,0 +1,301 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// AST-backed native projection for a markdown inline node.
+/// </summary>
+public sealed class MarkdownNativeInline {
+    internal MarkdownNativeInline(
+        MarkdownNativeInlineKind kind,
+        MarkdownSyntaxNode syntaxNode,
+        IReadOnlyList<MarkdownNativeInline> children,
+        IReadOnlyList<MarkdownNativeInlineMetadata> metadata) {
+        Kind = kind;
+        SyntaxNode = syntaxNode ?? throw new ArgumentNullException(nameof(syntaxNode));
+        SourceSpan = syntaxNode.SourceSpan;
+        SourceInline = syntaxNode.AssociatedObject as IMarkdownInline;
+        Literal = syntaxNode.Literal ?? string.Empty;
+        Children = children ?? Array.Empty<MarkdownNativeInline>();
+        Metadata = metadata ?? Array.Empty<MarkdownNativeInlineMetadata>();
+        Text = ResolvePlainText(SourceInline, Literal, Children);
+        Markdown = ResolveMarkdown(SourceInline, Literal);
+        Id = MarkdownNativeInlineId.Create(kind, syntaxNode, SourceSpan);
+    }
+
+    /// <summary>Deterministic identity for this inline projection within stable markdown input.</summary>
+    public string Id { get; }
+
+    /// <summary>Native inline projection kind.</summary>
+    public MarkdownNativeInlineKind Kind { get; }
+
+    /// <summary>Syntax kind that produced this native inline.</summary>
+    public MarkdownSyntaxKind SyntaxKind => SyntaxNode.Kind;
+
+    /// <summary>Source span in the normalized markdown text when available.</summary>
+    public MarkdownSourceSpan? SourceSpan { get; }
+
+    /// <summary>Syntax node that produced this native inline.</summary>
+    public MarkdownSyntaxNode SyntaxNode { get; }
+
+    /// <summary>Original OfficeIMO markdown inline backing this projection when available.</summary>
+    public IMarkdownInline? SourceInline { get; }
+
+    /// <summary>Literal syntax payload for leaf-like inline nodes.</summary>
+    public string Literal { get; }
+
+    /// <summary>Plain text represented by this inline node.</summary>
+    public string Text { get; }
+
+    /// <summary>Markdown represented by this inline node when renderable.</summary>
+    public string Markdown { get; }
+
+    /// <summary>Nested native inline nodes, excluding metadata leaves such as link target/title.</summary>
+    public IReadOnlyList<MarkdownNativeInline> Children { get; }
+
+    /// <summary>Source-backed metadata leaves such as link target/title or image alt/source.</summary>
+    public IReadOnlyList<MarkdownNativeInlineMetadata> Metadata { get; }
+
+    /// <summary>Returns the first metadata value with the supplied name.</summary>
+    public string? GetMetadata(string name) {
+        if (string.IsNullOrWhiteSpace(name) || Metadata.Count == 0) {
+            return null;
+        }
+
+        for (var i = 0; i < Metadata.Count; i++) {
+            if (string.Equals(Metadata[i].Name, name, StringComparison.OrdinalIgnoreCase)) {
+                return Metadata[i].Value;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Returns <see langword="true"/> when this inline's source span contains the supplied 1-based position.</summary>
+    public bool ContainsPosition(int lineNumber, int columnNumber) =>
+        SourceSpan.HasValue && SourceSpan.Value.ContainsPosition(lineNumber, columnNumber);
+
+    private static string ResolvePlainText(IMarkdownInline? sourceInline, string literal, IReadOnlyList<MarkdownNativeInline> children) {
+        if (sourceInline is IPlainTextMarkdownInline plainText) {
+            var sb = new StringBuilder();
+            plainText.AppendPlainText(sb);
+            return sb.ToString();
+        }
+
+        if (children != null && children.Count > 0) {
+            var sb = new StringBuilder();
+            for (var i = 0; i < children.Count; i++) {
+                sb.Append(children[i].Text);
+            }
+
+            return sb.ToString();
+        }
+
+        return literal ?? string.Empty;
+    }
+
+    private static string ResolveMarkdown(IMarkdownInline? sourceInline, string literal) {
+        if (sourceInline is IRenderableMarkdownInline renderable) {
+            return renderable.RenderMarkdown();
+        }
+
+        return literal ?? string.Empty;
+    }
+}
+
+internal static class MarkdownNativeInlineProjection {
+    internal static IReadOnlyList<MarkdownNativeInline> FromInlineContainer(MarkdownSyntaxNode? node) {
+        if (node == null || node.Children.Count == 0) {
+            return Array.Empty<MarkdownNativeInline>();
+        }
+
+        return FromSyntaxNodes(node.Children);
+    }
+
+    internal static IReadOnlyList<MarkdownNativeInline> FromInlineContainerChild(
+        MarkdownSyntaxNode? node,
+        MarkdownSyntaxKind childKind) {
+        if (node == null || node.Children.Count == 0) {
+            return Array.Empty<MarkdownNativeInline>();
+        }
+
+        for (var i = 0; i < node.Children.Count; i++) {
+            if (node.Children[i].Kind == childKind) {
+                return FromInlineContainer(node.Children[i]);
+            }
+        }
+
+        return Array.Empty<MarkdownNativeInline>();
+    }
+
+    internal static IReadOnlyList<MarkdownNativeInline> FromFirstDescendantInlineContainer(MarkdownSyntaxNode? node) {
+        var container = FindFirstInlineContainer(node);
+        return container == null ? Array.Empty<MarkdownNativeInline>() : FromInlineContainer(container);
+    }
+
+    private static IReadOnlyList<MarkdownNativeInline> FromSyntaxNodes(IReadOnlyList<MarkdownSyntaxNode> nodes) {
+        if (nodes == null || nodes.Count == 0) {
+            return Array.Empty<MarkdownNativeInline>();
+        }
+
+        var inlines = new List<MarkdownNativeInline>();
+        for (var i = 0; i < nodes.Count; i++) {
+            if (IsMetadataKind(nodes[i].Kind)) {
+                continue;
+            }
+
+            if (!IsInlineKind(nodes[i].Kind)) {
+                continue;
+            }
+
+            inlines.Add(Create(nodes[i]));
+        }
+
+        return inlines;
+    }
+
+    private static MarkdownNativeInline Create(MarkdownSyntaxNode node) {
+        return new MarkdownNativeInline(
+            MapKind(node.Kind),
+            node,
+            FromSyntaxNodes(node.Children),
+            CreateMetadata(node.Children));
+    }
+
+    private static IReadOnlyList<MarkdownNativeInlineMetadata> CreateMetadata(IReadOnlyList<MarkdownSyntaxNode> children) {
+        if (children == null || children.Count == 0) {
+            return Array.Empty<MarkdownNativeInlineMetadata>();
+        }
+
+        var metadata = new List<MarkdownNativeInlineMetadata>();
+        for (var i = 0; i < children.Count; i++) {
+            if (TryGetMetadataName(children[i].Kind, out var name)) {
+                metadata.Add(new MarkdownNativeInlineMetadata(name, children[i].Literal ?? string.Empty, children[i]));
+            }
+        }
+
+        return metadata;
+    }
+
+    private static MarkdownSyntaxNode? FindFirstInlineContainer(MarkdownSyntaxNode? node) {
+        if (node == null) {
+            return null;
+        }
+
+        if (ContainsInlineChildren(node)) {
+            return node;
+        }
+
+        for (var i = 0; i < node.Children.Count; i++) {
+            var match = FindFirstInlineContainer(node.Children[i]);
+            if (match != null) {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool ContainsInlineChildren(MarkdownSyntaxNode node) {
+        for (var i = 0; i < node.Children.Count; i++) {
+            if (IsInlineKind(node.Children[i].Kind) && !IsMetadataKind(node.Children[i].Kind)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static MarkdownNativeInlineKind MapKind(MarkdownSyntaxKind kind) {
+        switch (kind) {
+            case MarkdownSyntaxKind.InlineText:
+                return MarkdownNativeInlineKind.Text;
+            case MarkdownSyntaxKind.InlineCodeSpan:
+                return MarkdownNativeInlineKind.Code;
+            case MarkdownSyntaxKind.InlineLink:
+                return MarkdownNativeInlineKind.Link;
+            case MarkdownSyntaxKind.InlineImage:
+                return MarkdownNativeInlineKind.Image;
+            case MarkdownSyntaxKind.InlineImageLink:
+                return MarkdownNativeInlineKind.ImageLink;
+            case MarkdownSyntaxKind.InlineStrong:
+                return MarkdownNativeInlineKind.Strong;
+            case MarkdownSyntaxKind.InlineEmphasis:
+                return MarkdownNativeInlineKind.Emphasis;
+            case MarkdownSyntaxKind.InlineStrongEmphasis:
+                return MarkdownNativeInlineKind.StrongEmphasis;
+            case MarkdownSyntaxKind.InlineStrikethrough:
+                return MarkdownNativeInlineKind.Strikethrough;
+            case MarkdownSyntaxKind.InlineHighlight:
+                return MarkdownNativeInlineKind.Highlight;
+            case MarkdownSyntaxKind.InlineUnderline:
+                return MarkdownNativeInlineKind.Underline;
+            case MarkdownSyntaxKind.InlineHardBreak:
+                return MarkdownNativeInlineKind.HardBreak;
+            case MarkdownSyntaxKind.InlineHtmlTag:
+                return MarkdownNativeInlineKind.HtmlTag;
+            case MarkdownSyntaxKind.InlineHtmlRaw:
+                return MarkdownNativeInlineKind.HtmlRaw;
+            case MarkdownSyntaxKind.InlineFootnoteRef:
+                return MarkdownNativeInlineKind.FootnoteRef;
+            default:
+                return MarkdownNativeInlineKind.Other;
+        }
+    }
+
+    private static bool IsInlineKind(MarkdownSyntaxKind kind) {
+        switch (kind) {
+            case MarkdownSyntaxKind.InlineText:
+            case MarkdownSyntaxKind.InlineCodeSpan:
+            case MarkdownSyntaxKind.InlineLink:
+            case MarkdownSyntaxKind.InlineImage:
+            case MarkdownSyntaxKind.InlineImageLink:
+            case MarkdownSyntaxKind.InlineStrong:
+            case MarkdownSyntaxKind.InlineEmphasis:
+            case MarkdownSyntaxKind.InlineStrongEmphasis:
+            case MarkdownSyntaxKind.InlineStrikethrough:
+            case MarkdownSyntaxKind.InlineHighlight:
+            case MarkdownSyntaxKind.InlineUnderline:
+            case MarkdownSyntaxKind.InlineHardBreak:
+            case MarkdownSyntaxKind.InlineHtmlTag:
+            case MarkdownSyntaxKind.InlineHtmlRaw:
+            case MarkdownSyntaxKind.InlineFootnoteRef:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static bool IsMetadataKind(MarkdownSyntaxKind kind) => TryGetMetadataName(kind, out _);
+
+    private static bool TryGetMetadataName(MarkdownSyntaxKind kind, out string name) {
+        switch (kind) {
+            case MarkdownSyntaxKind.InlineLinkTarget:
+            case MarkdownSyntaxKind.ImageLinkTarget:
+                name = "target";
+                return true;
+            case MarkdownSyntaxKind.InlineLinkTitle:
+            case MarkdownSyntaxKind.ImageLinkTitle:
+                name = "title";
+                return true;
+            case MarkdownSyntaxKind.InlineLinkHtmlTarget:
+            case MarkdownSyntaxKind.ImageLinkHtmlTarget:
+                name = "htmlTarget";
+                return true;
+            case MarkdownSyntaxKind.InlineLinkHtmlRel:
+            case MarkdownSyntaxKind.ImageLinkHtmlRel:
+                name = "htmlRel";
+                return true;
+            case MarkdownSyntaxKind.ImageAlt:
+                name = "alt";
+                return true;
+            case MarkdownSyntaxKind.ImageSource:
+                name = "source";
+                return true;
+            case MarkdownSyntaxKind.ImageTitle:
+                name = "imageTitle";
+                return true;
+            default:
+                name = string.Empty;
+                return false;
+        }
+    }
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeInlines.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeInlines.cs
@@ -131,6 +131,24 @@ internal static class MarkdownNativeInlineProjection {
         return container == null ? Array.Empty<MarkdownNativeInline>() : FromInlineContainer(container);
     }
 
+    internal static IReadOnlyList<MarkdownNativeInline> FromTableCellDirectContent(MarkdownSyntaxNode? node) {
+        if (node == null) {
+            return Array.Empty<MarkdownNativeInline>();
+        }
+
+        if (ContainsInlineChildren(node)) {
+            return FromInlineContainer(node);
+        }
+
+        for (var i = 0; i < node.Children.Count; i++) {
+            if (node.Children[i].Kind == MarkdownSyntaxKind.Paragraph) {
+                return FromInlineContainer(node.Children[i]);
+            }
+        }
+
+        return Array.Empty<MarkdownNativeInline>();
+    }
+
     internal static IReadOnlyList<MarkdownNativeInline> FromListItemLeadContent(MarkdownSyntaxNode? node, ListItem? item) {
         if (node == null || item == null || item.Content.Nodes.Count == 0) {
             return Array.Empty<MarkdownNativeInline>();

--- a/OfficeIMO.Markdown/Native/MarkdownNativeInlines.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeInlines.cs
@@ -131,6 +131,20 @@ internal static class MarkdownNativeInlineProjection {
         return container == null ? Array.Empty<MarkdownNativeInline>() : FromInlineContainer(container);
     }
 
+    internal static IReadOnlyList<MarkdownNativeInline> FromListItemLeadContent(MarkdownSyntaxNode? node, ListItem? item) {
+        if (node == null || item == null || item.Content.Nodes.Count == 0) {
+            return Array.Empty<MarkdownNativeInline>();
+        }
+
+        for (var i = 0; i < node.Children.Count; i++) {
+            if (node.Children[i].Kind == MarkdownSyntaxKind.Paragraph) {
+                return FromInlineContainer(node.Children[i]);
+            }
+        }
+
+        return Array.Empty<MarkdownNativeInline>();
+    }
+
     private static IReadOnlyList<MarkdownNativeInline> FromSyntaxNodes(IReadOnlyList<MarkdownSyntaxNode> nodes) {
         if (nodes == null || nodes.Count == 0) {
             return Array.Empty<MarkdownNativeInline>();

--- a/OfficeIMO.Markdown/Native/MarkdownNativeProjectionFactory.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeProjectionFactory.cs
@@ -1,0 +1,84 @@
+namespace OfficeIMO.Markdown;
+
+internal static class MarkdownNativeProjectionFactory {
+    internal static MarkdownNativeBlock? Create(
+        MarkdownSyntaxNode syntaxNode,
+        ICollection<MarkdownNativeDiagnostic> diagnostics) {
+        if (syntaxNode?.AssociatedObject is not IMarkdownBlock block) {
+            return null;
+        }
+
+        MarkdownNativeBlock nativeBlock = block switch {
+            HeadingBlock heading => new MarkdownNativeHeadingBlock(heading, syntaxNode),
+            ParagraphBlock paragraph => new MarkdownNativeParagraphBlock(paragraph, syntaxNode),
+            OrderedListBlock ordered => new MarkdownNativeListBlock(ordered, syntaxNode, CreateListItems(syntaxNode, diagnostics)),
+            UnorderedListBlock unordered => new MarkdownNativeListBlock(unordered, syntaxNode, CreateListItems(syntaxNode, diagnostics)),
+            QuoteBlock quote => new MarkdownNativeQuoteBlock(quote, syntaxNode, CreateChildren(syntaxNode, diagnostics)),
+            CalloutBlock callout => new MarkdownNativeCalloutBlock(callout, syntaxNode, CreateChildren(syntaxNode, diagnostics)),
+            ImageBlock image => new MarkdownNativeImageBlock(image, syntaxNode),
+            CodeBlock code => new MarkdownNativeCodeBlock(code, syntaxNode),
+            SemanticFencedBlock visual => new MarkdownNativeVisualBlock(visual, syntaxNode),
+            TableBlock table => new MarkdownNativeTableBlock(table, syntaxNode),
+            DetailsBlock details => new MarkdownNativeDetailsBlock(details, syntaxNode, CreateChildren(syntaxNode, diagnostics, static node => node.AssociatedObject is not SummaryBlock)),
+            FrontMatterBlock frontMatter => new MarkdownNativeFrontMatterBlock(frontMatter, syntaxNode),
+            HtmlRawBlock html => new MarkdownNativeHtmlBlock(html, syntaxNode),
+            HtmlCommentBlock comment => new MarkdownNativeHtmlBlock(comment, syntaxNode),
+            _ => new MarkdownNativeOtherBlock(block, syntaxNode)
+        };
+
+        if (nativeBlock is MarkdownNativeOtherBlock) {
+            diagnostics.Add(new MarkdownNativeDiagnostic(
+                "native.unsupported-block",
+                $"No specialized native projection exists for markdown block '{block.GetType().Name}'.",
+                MarkdownNativeDiagnosticSeverity.Info,
+                nativeBlock.SourceSpan,
+                nativeBlock));
+        }
+
+        return nativeBlock;
+    }
+
+    internal static IReadOnlyList<MarkdownNativeBlock> CreateChildren(
+        MarkdownSyntaxNode parent,
+        ICollection<MarkdownNativeDiagnostic> diagnostics,
+        Func<MarkdownSyntaxNode, bool>? include = null) {
+        if (parent.Children.Count == 0) {
+            return Array.Empty<MarkdownNativeBlock>();
+        }
+
+        var children = new List<MarkdownNativeBlock>();
+        for (var i = 0; i < parent.Children.Count; i++) {
+            var child = parent.Children[i];
+            if (include != null && !include(child)) {
+                continue;
+            }
+
+            var nativeChild = Create(child, diagnostics);
+            if (nativeChild != null) {
+                children.Add(nativeChild);
+            }
+        }
+
+        return children;
+    }
+
+    private static IReadOnlyList<MarkdownNativeListItem> CreateListItems(
+        MarkdownSyntaxNode listNode,
+        ICollection<MarkdownNativeDiagnostic> diagnostics) {
+        if (listNode.Children.Count == 0) {
+            return Array.Empty<MarkdownNativeListItem>();
+        }
+
+        var items = new List<MarkdownNativeListItem>();
+        for (var i = 0; i < listNode.Children.Count; i++) {
+            var child = listNode.Children[i];
+            if (child.AssociatedObject is not ListItem item) {
+                continue;
+            }
+
+            items.Add(new MarkdownNativeListItem(item, child, CreateChildren(child, diagnostics)));
+        }
+
+        return items;
+    }
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeProjectionFactory.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeProjectionFactory.cs
@@ -18,7 +18,7 @@ internal static class MarkdownNativeProjectionFactory {
             ImageBlock image => new MarkdownNativeImageBlock(image, syntaxNode),
             CodeBlock code => new MarkdownNativeCodeBlock(code, syntaxNode),
             SemanticFencedBlock visual => new MarkdownNativeVisualBlock(visual, syntaxNode),
-            TableBlock table => new MarkdownNativeTableBlock(table, syntaxNode),
+            TableBlock table => new MarkdownNativeTableBlock(table, syntaxNode, diagnostics),
             DetailsBlock details => new MarkdownNativeDetailsBlock(details, syntaxNode, CreateChildren(syntaxNode, diagnostics, static node => node.AssociatedObject is not SummaryBlock)),
             FrontMatterBlock frontMatter => new MarkdownNativeFrontMatterBlock(frontMatter, syntaxNode),
             HtmlRawBlock html => new MarkdownNativeHtmlBlock(html, syntaxNode),

--- a/OfficeIMO.Markdown/Native/MarkdownNativeSnapshotFactory.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeSnapshotFactory.cs
@@ -226,7 +226,8 @@ internal static class MarkdownNativeSnapshotFactory {
             cell.ColumnIndex,
             cell.Alignment,
             ToSpanSnapshot(cell.SourceSpan),
-            FromInlines(cell.InlineRuns));
+            FromInlines(cell.InlineRuns),
+            FromBlocks(cell.Children));
     }
 
     private static MarkdownNativeSourceSpanSnapshot? ToSpanSnapshot(MarkdownSourceSpan? span) =>

--- a/OfficeIMO.Markdown/Native/MarkdownNativeSnapshotFactory.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeSnapshotFactory.cs
@@ -1,0 +1,249 @@
+namespace OfficeIMO.Markdown;
+
+internal static class MarkdownNativeSnapshotFactory {
+    internal static MarkdownNativeDocumentSnapshot FromDocument(MarkdownNativeDocument document) {
+        var blocks = new List<MarkdownNativeBlockSnapshot>(document.Blocks.Count);
+        for (var i = 0; i < document.Blocks.Count; i++) {
+            blocks.Add(FromBlock(document.Blocks[i]));
+        }
+
+        var diagnostics = new List<MarkdownNativeDiagnosticSnapshot>(document.Diagnostics.Count);
+        for (var i = 0; i < document.Diagnostics.Count; i++) {
+            diagnostics.Add(new MarkdownNativeDiagnosticSnapshot(document.Diagnostics[i]));
+        }
+
+        return new MarkdownNativeDocumentSnapshot(document.SourceKind, blocks, diagnostics);
+    }
+
+    internal static MarkdownNativeBlockSnapshot FromBlock(MarkdownNativeBlock block) {
+        var snapshot = new MarkdownNativeBlockSnapshot {
+            Id = block.Id,
+            Kind = block.Kind,
+            SourceSpan = ToSpanSnapshot(block.SourceSpan)
+        };
+
+        switch (block) {
+            case MarkdownNativeParagraphBlock paragraph:
+                snapshot.Text = paragraph.Text;
+                snapshot.Markdown = RenderBlock(paragraph.Paragraph);
+                snapshot.Inlines = FromInlines(paragraph.InlineRuns);
+                break;
+            case MarkdownNativeHeadingBlock heading:
+                snapshot.Text = heading.Text;
+                snapshot.Markdown = RenderBlock(heading.Heading);
+                snapshot.Inlines = FromInlines(heading.InlineRuns);
+                snapshot.Fields = Fields(("level", heading.Level.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+                break;
+            case MarkdownNativeCodeBlock code:
+                snapshot.Text = code.Content;
+                snapshot.Markdown = RenderBlock(code.Code);
+                snapshot.Fields = Fields(
+                    ("language", code.Language),
+                    ("infoString", code.InfoString),
+                    ("caption", code.Caption),
+                    ("title", code.Title),
+                    ("elementId", code.ElementId));
+                break;
+            case MarkdownNativeVisualBlock visual:
+                snapshot.Text = visual.Content;
+                snapshot.Markdown = RenderBlock(visual.Visual);
+                snapshot.Fields = Fields(
+                    ("semanticKind", visual.SemanticKind),
+                    ("language", visual.Language),
+                    ("infoString", visual.InfoString),
+                    ("caption", visual.Caption),
+                    ("title", visual.Title),
+                    ("elementId", visual.ElementId),
+                    ("payloadFormat", visual.Payload.Format.ToString()),
+                    ("payloadDetectedSemanticKind", visual.Payload.DetectedSemanticKind),
+                    ("payloadJsonType", visual.Payload.JsonType));
+                break;
+            case MarkdownNativeTableBlock table:
+                snapshot.HeaderCells = FromCells(table.HeaderCells);
+                snapshot.Rows = FromRows(table.Rows);
+                break;
+            case MarkdownNativeQuoteBlock quote:
+                snapshot.Markdown = RenderBlock(quote.Quote);
+                snapshot.Children = FromBlocks(quote.Children);
+                break;
+            case MarkdownNativeCalloutBlock callout:
+                snapshot.Text = callout.Title;
+                snapshot.Markdown = RenderBlock(callout.Callout);
+                snapshot.Inlines = FromInlines(callout.TitleInlineRuns);
+                snapshot.Children = FromBlocks(callout.Children);
+                snapshot.Fields = Fields(("calloutKind", callout.CalloutKind));
+                break;
+            case MarkdownNativeDetailsBlock details:
+                snapshot.Text = details.Summary;
+                snapshot.Markdown = RenderBlock(details.Details);
+                snapshot.Inlines = FromInlines(details.SummaryInlineRuns);
+                snapshot.Children = FromBlocks(details.Children);
+                snapshot.Fields = Fields(("open", details.Open ? "true" : "false"));
+                break;
+            case MarkdownNativeListBlock list:
+                snapshot.Markdown = list.List.RenderMarkdown();
+                snapshot.Items = FromListItems(list.Items);
+                snapshot.Fields = Fields(
+                    ("isOrdered", list.IsOrdered ? "true" : "false"),
+                    ("start", list.Start?.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+                break;
+            case MarkdownNativeImageBlock image:
+                snapshot.Text = image.PlainAlt ?? image.Alt;
+                snapshot.Markdown = RenderBlock(image.Image);
+                snapshot.Fields = Fields(
+                    ("source", image.Source),
+                    ("alt", image.Alt),
+                    ("plainAlt", image.PlainAlt),
+                    ("title", image.Title),
+                    ("caption", image.Caption),
+                    ("linkUrl", image.LinkUrl));
+                break;
+            case MarkdownNativeFrontMatterBlock frontMatter:
+                snapshot.Markdown = RenderBlock(frontMatter.FrontMatter);
+                snapshot.Fields = FromFrontMatter(frontMatter);
+                break;
+            case MarkdownNativeHtmlBlock html:
+                snapshot.Text = html.Html;
+                snapshot.Markdown = html.Html;
+                snapshot.Fields = Fields(("isComment", html.IsComment ? "true" : "false"));
+                break;
+            case MarkdownNativeOtherBlock other:
+                snapshot.Markdown = other.Markdown;
+                break;
+        }
+
+        return snapshot;
+    }
+
+    private static IReadOnlyDictionary<string, string?> FromFrontMatter(MarkdownNativeFrontMatterBlock frontMatter) {
+        var fields = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < frontMatter.Entries.Count; i++) {
+            fields[frontMatter.Entries[i].Key] = frontMatter.Entries[i].Value?.ToString();
+        }
+
+        return fields;
+    }
+
+    private static string RenderBlock(IMarkdownBlock block) => block.RenderMarkdown();
+
+    private static IReadOnlyList<MarkdownNativeBlockSnapshot> FromBlocks(IReadOnlyList<MarkdownNativeBlock> blocks) {
+        if (blocks == null || blocks.Count == 0) {
+            return Array.Empty<MarkdownNativeBlockSnapshot>();
+        }
+
+        var snapshots = new List<MarkdownNativeBlockSnapshot>(blocks.Count);
+        for (var i = 0; i < blocks.Count; i++) {
+            snapshots.Add(FromBlock(blocks[i]));
+        }
+
+        return snapshots;
+    }
+
+    private static IReadOnlyList<MarkdownNativeInlineSnapshot> FromInlines(IReadOnlyList<MarkdownNativeInline>? inlines) {
+        if (inlines == null || inlines.Count == 0) {
+            return Array.Empty<MarkdownNativeInlineSnapshot>();
+        }
+
+        var snapshots = new List<MarkdownNativeInlineSnapshot>(inlines.Count);
+        for (var i = 0; i < inlines.Count; i++) {
+            snapshots.Add(FromInline(inlines[i]));
+        }
+
+        return snapshots;
+    }
+
+    private static MarkdownNativeInlineSnapshot FromInline(MarkdownNativeInline inline) {
+        var metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < inline.Metadata.Count; i++) {
+            metadata[inline.Metadata[i].Name] = inline.Metadata[i].Value;
+        }
+
+        return new MarkdownNativeInlineSnapshot(
+            inline.Id,
+            inline.Kind,
+            inline.SyntaxKind,
+            inline.Text,
+            inline.Markdown,
+            inline.Literal,
+            ToSpanSnapshot(inline.SourceSpan),
+            metadata,
+            FromInlines(inline.Children));
+    }
+
+    private static IReadOnlyList<MarkdownNativeListItemSnapshot> FromListItems(IReadOnlyList<MarkdownNativeListItem> items) {
+        if (items == null || items.Count == 0) {
+            return Array.Empty<MarkdownNativeListItemSnapshot>();
+        }
+
+        var snapshots = new List<MarkdownNativeListItemSnapshot>(items.Count);
+        for (var i = 0; i < items.Count; i++) {
+            snapshots.Add(new MarkdownNativeListItemSnapshot(
+                items[i].Id,
+                items[i].Text,
+                items[i].IsTask,
+                items[i].Checked,
+                items[i].Level,
+                ToSpanSnapshot(items[i].SourceSpan),
+                FromInlines(items[i].InlineRuns),
+                FromBlocks(items[i].Children)));
+        }
+
+        return snapshots;
+    }
+
+    private static IReadOnlyList<MarkdownNativeTableCellSnapshot> FromCells(IReadOnlyList<MarkdownNativeTableCell> cells) {
+        if (cells == null || cells.Count == 0) {
+            return Array.Empty<MarkdownNativeTableCellSnapshot>();
+        }
+
+        var snapshots = new List<MarkdownNativeTableCellSnapshot>(cells.Count);
+        for (var i = 0; i < cells.Count; i++) {
+            snapshots.Add(FromCell(cells[i]));
+        }
+
+        return snapshots;
+    }
+
+    private static IReadOnlyList<IReadOnlyList<MarkdownNativeTableCellSnapshot>> FromRows(IReadOnlyList<IReadOnlyList<MarkdownNativeTableCell>> rows) {
+        if (rows == null || rows.Count == 0) {
+            return Array.Empty<IReadOnlyList<MarkdownNativeTableCellSnapshot>>();
+        }
+
+        var snapshots = new List<IReadOnlyList<MarkdownNativeTableCellSnapshot>>(rows.Count);
+        for (var i = 0; i < rows.Count; i++) {
+            snapshots.Add(FromCells(rows[i]));
+        }
+
+        return snapshots;
+    }
+
+    private static MarkdownNativeTableCellSnapshot FromCell(MarkdownNativeTableCell cell) {
+        return new MarkdownNativeTableCellSnapshot(
+            cell.Text,
+            cell.Markdown,
+            cell.IsHeader,
+            cell.RowIndex,
+            cell.ColumnIndex,
+            cell.Alignment,
+            ToSpanSnapshot(cell.SourceSpan),
+            FromInlines(cell.InlineRuns));
+    }
+
+    private static MarkdownNativeSourceSpanSnapshot? ToSpanSnapshot(MarkdownSourceSpan? span) =>
+        span.HasValue ? new MarkdownNativeSourceSpanSnapshot(span.Value) : null;
+
+    private static IReadOnlyDictionary<string, string?> Fields(params (string Key, string? Value)[] values) {
+        var fields = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        if (values == null) {
+            return fields;
+        }
+
+        for (var i = 0; i < values.Length; i++) {
+            if (!string.IsNullOrWhiteSpace(values[i].Key) && values[i].Value != null) {
+                fields[values[i].Key] = values[i].Value;
+            }
+        }
+
+        return fields;
+    }
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeSnapshots.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeSnapshots.cs
@@ -1,0 +1,284 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// UI-safe snapshot of a native markdown document without parser object references.
+/// </summary>
+public sealed class MarkdownNativeDocumentSnapshot {
+    internal MarkdownNativeDocumentSnapshot(
+        MarkdownNativeDocumentSourceKind sourceKind,
+        IReadOnlyList<MarkdownNativeBlockSnapshot> blocks,
+        IReadOnlyList<MarkdownNativeDiagnosticSnapshot> diagnostics) {
+        SourceKind = sourceKind;
+        Blocks = blocks ?? Array.Empty<MarkdownNativeBlockSnapshot>();
+        Diagnostics = diagnostics ?? Array.Empty<MarkdownNativeDiagnosticSnapshot>();
+    }
+
+    /// <summary>Identifies the markdown source backing this snapshot.</summary>
+    public MarkdownNativeDocumentSourceKind SourceKind { get; }
+
+    /// <summary>Top-level block snapshots.</summary>
+    public IReadOnlyList<MarkdownNativeBlockSnapshot> Blocks { get; }
+
+    /// <summary>Projection diagnostics.</summary>
+    public IReadOnlyList<MarkdownNativeDiagnosticSnapshot> Diagnostics { get; }
+}
+
+/// <summary>
+/// UI-safe snapshot of a native block.
+/// </summary>
+public sealed class MarkdownNativeBlockSnapshot {
+    internal MarkdownNativeBlockSnapshot() {
+        Fields = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        Inlines = Array.Empty<MarkdownNativeInlineSnapshot>();
+        Children = Array.Empty<MarkdownNativeBlockSnapshot>();
+        Items = Array.Empty<MarkdownNativeListItemSnapshot>();
+        HeaderCells = Array.Empty<MarkdownNativeTableCellSnapshot>();
+        Rows = Array.Empty<IReadOnlyList<MarkdownNativeTableCellSnapshot>>();
+    }
+
+    /// <summary>Stable block id.</summary>
+    public string Id { get; internal set; } = string.Empty;
+
+    /// <summary>Native block kind.</summary>
+    public MarkdownNativeBlockKind Kind { get; internal set; }
+
+    /// <summary>Source span snapshot when available.</summary>
+    public MarkdownNativeSourceSpanSnapshot? SourceSpan { get; internal set; }
+
+    /// <summary>Common text payload when the block exposes one.</summary>
+    public string? Text { get; internal set; }
+
+    /// <summary>Common markdown payload when the block exposes one.</summary>
+    public string? Markdown { get; internal set; }
+
+    /// <summary>String fields for block-specific metadata.</summary>
+    public IReadOnlyDictionary<string, string?> Fields { get; internal set; }
+
+    /// <summary>Inline snapshots owned directly by this block.</summary>
+    public IReadOnlyList<MarkdownNativeInlineSnapshot> Inlines { get; internal set; }
+
+    /// <summary>Nested child block snapshots.</summary>
+    public IReadOnlyList<MarkdownNativeBlockSnapshot> Children { get; internal set; }
+
+    /// <summary>List item snapshots for native list blocks.</summary>
+    public IReadOnlyList<MarkdownNativeListItemSnapshot> Items { get; internal set; }
+
+    /// <summary>Table header cell snapshots.</summary>
+    public IReadOnlyList<MarkdownNativeTableCellSnapshot> HeaderCells { get; internal set; }
+
+    /// <summary>Table body row snapshots.</summary>
+    public IReadOnlyList<IReadOnlyList<MarkdownNativeTableCellSnapshot>> Rows { get; internal set; }
+}
+
+/// <summary>
+/// UI-safe snapshot of a native inline.
+/// </summary>
+public sealed class MarkdownNativeInlineSnapshot {
+    internal MarkdownNativeInlineSnapshot(
+        string id,
+        MarkdownNativeInlineKind kind,
+        MarkdownSyntaxKind syntaxKind,
+        string text,
+        string markdown,
+        string literal,
+        MarkdownNativeSourceSpanSnapshot? sourceSpan,
+        IReadOnlyDictionary<string, string> metadata,
+        IReadOnlyList<MarkdownNativeInlineSnapshot> children) {
+        Id = id ?? string.Empty;
+        Kind = kind;
+        SyntaxKind = syntaxKind;
+        Text = text ?? string.Empty;
+        Markdown = markdown ?? string.Empty;
+        Literal = literal ?? string.Empty;
+        SourceSpan = sourceSpan;
+        Metadata = metadata ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        Children = children ?? Array.Empty<MarkdownNativeInlineSnapshot>();
+    }
+
+    /// <summary>Stable inline id.</summary>
+    public string Id { get; }
+
+    /// <summary>Native inline kind.</summary>
+    public MarkdownNativeInlineKind Kind { get; }
+
+    /// <summary>Syntax kind that produced this inline.</summary>
+    public MarkdownSyntaxKind SyntaxKind { get; }
+
+    /// <summary>Plain text represented by this inline.</summary>
+    public string Text { get; }
+
+    /// <summary>Markdown represented by this inline.</summary>
+    public string Markdown { get; }
+
+    /// <summary>Literal syntax payload.</summary>
+    public string Literal { get; }
+
+    /// <summary>Source span snapshot when available.</summary>
+    public MarkdownNativeSourceSpanSnapshot? SourceSpan { get; }
+
+    /// <summary>Metadata values such as target/title/source/alt.</summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; }
+
+    /// <summary>Nested inline snapshots.</summary>
+    public IReadOnlyList<MarkdownNativeInlineSnapshot> Children { get; }
+}
+
+/// <summary>
+/// UI-safe snapshot of a native list item.
+/// </summary>
+public sealed class MarkdownNativeListItemSnapshot {
+    internal MarkdownNativeListItemSnapshot(
+        string id,
+        string text,
+        bool isTask,
+        bool isChecked,
+        int level,
+        MarkdownNativeSourceSpanSnapshot? sourceSpan,
+        IReadOnlyList<MarkdownNativeInlineSnapshot> inlines,
+        IReadOnlyList<MarkdownNativeBlockSnapshot> children) {
+        Id = id ?? string.Empty;
+        Text = text ?? string.Empty;
+        IsTask = isTask;
+        IsChecked = isChecked;
+        Level = level;
+        SourceSpan = sourceSpan;
+        Inlines = inlines ?? Array.Empty<MarkdownNativeInlineSnapshot>();
+        Children = children ?? Array.Empty<MarkdownNativeBlockSnapshot>();
+    }
+
+    /// <summary>Stable list item id.</summary>
+    public string Id { get; }
+
+    /// <summary>Plain text lead content.</summary>
+    public string Text { get; }
+
+    /// <summary>Whether the item is a task item.</summary>
+    public bool IsTask { get; }
+
+    /// <summary>Whether the task item is checked.</summary>
+    public bool IsChecked { get; }
+
+    /// <summary>Indentation level from the source item.</summary>
+    public int Level { get; }
+
+    /// <summary>Source span snapshot when available.</summary>
+    public MarkdownNativeSourceSpanSnapshot? SourceSpan { get; }
+
+    /// <summary>Lead inline snapshots.</summary>
+    public IReadOnlyList<MarkdownNativeInlineSnapshot> Inlines { get; }
+
+    /// <summary>Nested child block snapshots.</summary>
+    public IReadOnlyList<MarkdownNativeBlockSnapshot> Children { get; }
+}
+
+/// <summary>
+/// UI-safe snapshot of a native table cell.
+/// </summary>
+public sealed class MarkdownNativeTableCellSnapshot {
+    internal MarkdownNativeTableCellSnapshot(
+        string text,
+        string markdown,
+        bool isHeader,
+        int rowIndex,
+        int columnIndex,
+        ColumnAlignment alignment,
+        MarkdownNativeSourceSpanSnapshot? sourceSpan,
+        IReadOnlyList<MarkdownNativeInlineSnapshot> inlines) {
+        Text = text ?? string.Empty;
+        Markdown = markdown ?? string.Empty;
+        IsHeader = isHeader;
+        RowIndex = rowIndex;
+        ColumnIndex = columnIndex;
+        Alignment = alignment;
+        SourceSpan = sourceSpan;
+        Inlines = inlines ?? Array.Empty<MarkdownNativeInlineSnapshot>();
+    }
+
+    /// <summary>Plain text cell content.</summary>
+    public string Text { get; }
+
+    /// <summary>Markdown cell content.</summary>
+    public string Markdown { get; }
+
+    /// <summary>Whether this is a header cell.</summary>
+    public bool IsHeader { get; }
+
+    /// <summary>Zero-based row index, or -1 for headers.</summary>
+    public int RowIndex { get; }
+
+    /// <summary>Zero-based column index.</summary>
+    public int ColumnIndex { get; }
+
+    /// <summary>Projected alignment.</summary>
+    public ColumnAlignment Alignment { get; }
+
+    /// <summary>Source span snapshot when available.</summary>
+    public MarkdownNativeSourceSpanSnapshot? SourceSpan { get; }
+
+    /// <summary>Inline snapshots for cell content when available.</summary>
+    public IReadOnlyList<MarkdownNativeInlineSnapshot> Inlines { get; }
+}
+
+/// <summary>
+/// UI-safe source span snapshot.
+/// </summary>
+public sealed class MarkdownNativeSourceSpanSnapshot {
+    internal MarkdownNativeSourceSpanSnapshot(MarkdownSourceSpan span) {
+        StartLine = span.StartLine;
+        StartColumn = span.StartColumn;
+        EndLine = span.EndLine;
+        EndColumn = span.EndColumn;
+        StartOffset = span.StartOffset;
+        EndOffset = span.EndOffset;
+        Display = span.ToString();
+    }
+
+    /// <summary>1-based start line.</summary>
+    public int StartLine { get; }
+
+    /// <summary>1-based start column when available.</summary>
+    public int? StartColumn { get; }
+
+    /// <summary>1-based end line.</summary>
+    public int EndLine { get; }
+
+    /// <summary>1-based end column when available.</summary>
+    public int? EndColumn { get; }
+
+    /// <summary>0-based start offset when available.</summary>
+    public int? StartOffset { get; }
+
+    /// <summary>0-based end offset when available.</summary>
+    public int? EndOffset { get; }
+
+    /// <summary>Human-readable span display.</summary>
+    public string Display { get; }
+}
+
+/// <summary>
+/// UI-safe diagnostic snapshot.
+/// </summary>
+public sealed class MarkdownNativeDiagnosticSnapshot {
+    internal MarkdownNativeDiagnosticSnapshot(MarkdownNativeDiagnostic diagnostic) {
+        Id = diagnostic.Id;
+        Message = diagnostic.Message;
+        Severity = diagnostic.Severity;
+        SourceSpan = diagnostic.SourceSpan.HasValue ? new MarkdownNativeSourceSpanSnapshot(diagnostic.SourceSpan.Value) : null;
+        BlockId = diagnostic.Block?.Id;
+    }
+
+    /// <summary>Diagnostic id.</summary>
+    public string Id { get; }
+
+    /// <summary>Diagnostic message.</summary>
+    public string Message { get; }
+
+    /// <summary>Diagnostic severity.</summary>
+    public MarkdownNativeDiagnosticSeverity Severity { get; }
+
+    /// <summary>Source span snapshot when available.</summary>
+    public MarkdownNativeSourceSpanSnapshot? SourceSpan { get; }
+
+    /// <summary>Associated block id when available.</summary>
+    public string? BlockId { get; }
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeSnapshots.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeSnapshots.cs
@@ -183,7 +183,8 @@ public sealed class MarkdownNativeTableCellSnapshot {
         int columnIndex,
         ColumnAlignment alignment,
         MarkdownNativeSourceSpanSnapshot? sourceSpan,
-        IReadOnlyList<MarkdownNativeInlineSnapshot> inlines) {
+        IReadOnlyList<MarkdownNativeInlineSnapshot> inlines,
+        IReadOnlyList<MarkdownNativeBlockSnapshot> children) {
         Text = text ?? string.Empty;
         Markdown = markdown ?? string.Empty;
         IsHeader = isHeader;
@@ -192,6 +193,7 @@ public sealed class MarkdownNativeTableCellSnapshot {
         Alignment = alignment;
         SourceSpan = sourceSpan;
         Inlines = inlines ?? Array.Empty<MarkdownNativeInlineSnapshot>();
+        Children = children ?? Array.Empty<MarkdownNativeBlockSnapshot>();
     }
 
     /// <summary>Plain text cell content.</summary>
@@ -217,6 +219,9 @@ public sealed class MarkdownNativeTableCellSnapshot {
 
     /// <summary>Inline snapshots for cell content when available.</summary>
     public IReadOnlyList<MarkdownNativeInlineSnapshot> Inlines { get; }
+
+    /// <summary>Native child block snapshots projected from structured cell content.</summary>
+    public IReadOnlyList<MarkdownNativeBlockSnapshot> Children { get; }
 }
 
 /// <summary>

--- a/OfficeIMO.Markdown/Native/MarkdownNativeSourceEdit.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeSourceEdit.cs
@@ -1,0 +1,42 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Non-mutating source edit derived from a native markdown source span.
+/// </summary>
+public sealed class MarkdownNativeSourceEdit {
+    internal MarkdownNativeSourceEdit(MarkdownSourceSpan sourceSpan, int startOffset, int endOffsetInclusive, string replacementMarkdown) {
+        SourceSpan = sourceSpan;
+        StartOffset = startOffset;
+        EndOffsetInclusive = endOffsetInclusive;
+        ReplacementMarkdown = replacementMarkdown ?? string.Empty;
+    }
+
+    /// <summary>Source span this edit replaces.</summary>
+    public MarkdownSourceSpan SourceSpan { get; }
+
+    /// <summary>0-based inclusive start offset in the source markdown.</summary>
+    public int StartOffset { get; }
+
+    /// <summary>0-based inclusive end offset in the source markdown.</summary>
+    public int EndOffsetInclusive { get; }
+
+    /// <summary>Replacement markdown.</summary>
+    public string ReplacementMarkdown { get; }
+
+    /// <summary>Applies this edit to the supplied markdown source and returns the edited text.</summary>
+    public string Apply(string sourceMarkdown) {
+        sourceMarkdown ??= string.Empty;
+        if (StartOffset < 0 || StartOffset > sourceMarkdown.Length) {
+            throw new InvalidOperationException("Edit start offset is outside the supplied markdown source.");
+        }
+
+        var endExclusive = Math.Min(sourceMarkdown.Length, EndOffsetInclusive + 1);
+        if (endExclusive < StartOffset) {
+            throw new InvalidOperationException("Edit end offset is before the start offset.");
+        }
+
+        return sourceMarkdown.Substring(0, StartOffset)
+               + ReplacementMarkdown
+               + sourceMarkdown.Substring(endExclusive);
+    }
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeVisualPayload.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeVisualPayload.cs
@@ -1,0 +1,172 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Dependency-free typed metadata for a semantic visual fenced-block payload.
+/// </summary>
+public sealed class MarkdownNativeVisualPayload {
+    private MarkdownNativeVisualPayload(
+        MarkdownNativeVisualPayloadFormat format,
+        string declaredSemanticKind,
+        string? detectedSemanticKind,
+        string? jsonType,
+        IReadOnlyDictionary<string, string> signals) {
+        Format = format;
+        DeclaredSemanticKind = declaredSemanticKind ?? string.Empty;
+        DetectedSemanticKind = detectedSemanticKind;
+        JsonType = jsonType;
+        Signals = signals ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Classified payload format.</summary>
+    public MarkdownNativeVisualPayloadFormat Format { get; }
+
+    /// <summary>Whether the payload appears to be JSON.</summary>
+    public bool IsJson => Format == MarkdownNativeVisualPayloadFormat.JsonObject || Format == MarkdownNativeVisualPayloadFormat.JsonArray;
+
+    /// <summary>Whether the payload appears to be a Mermaid diagram.</summary>
+    public bool IsMermaid => Format == MarkdownNativeVisualPayloadFormat.Mermaid;
+
+    /// <summary>Semantic kind declared by the fenced block.</summary>
+    public string DeclaredSemanticKind { get; }
+
+    /// <summary>Best-effort semantic kind detected from the payload, when available.</summary>
+    public string? DetectedSemanticKind { get; }
+
+    /// <summary>Best-effort value of a JSON <c>type</c> property, when available.</summary>
+    public string? JsonType { get; }
+
+    /// <summary>Small dependency-free signal map for UI hosts that need quick routing hints.</summary>
+    public IReadOnlyDictionary<string, string> Signals { get; }
+
+    /// <summary>
+    /// Classifies a semantic fenced block payload without introducing a JSON parser dependency.
+    /// </summary>
+    public static MarkdownNativeVisualPayload Create(SemanticFencedBlock visual) {
+        if (visual == null) {
+            throw new ArgumentNullException(nameof(visual));
+        }
+
+        var content = visual.Content ?? string.Empty;
+        var trimmed = content.Trim();
+        var signals = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var format = ClassifyFormat(visual, trimmed);
+        if (format != MarkdownNativeVisualPayloadFormat.Unknown) {
+            signals["format"] = format.ToString();
+        }
+
+        string? detectedSemanticKind = null;
+        if (MarkdownJsonVisualPayloadDetector.TryDetectSemanticKind(content, out var detected)) {
+            detectedSemanticKind = detected;
+            signals["detectedSemanticKind"] = detected;
+        }
+
+        var jsonType = TryReadJsonStringProperty(trimmed, "type");
+        if (!string.IsNullOrWhiteSpace(jsonType)) {
+            signals["json.type"] = jsonType!;
+        }
+
+        AddPresenceSignal(signals, trimmed, "data");
+        AddPresenceSignal(signals, trimmed, "options");
+        AddPresenceSignal(signals, trimmed, "nodes");
+        AddPresenceSignal(signals, trimmed, "edges");
+        AddPresenceSignal(signals, trimmed, "rows");
+        AddPresenceSignal(signals, trimmed, "columns");
+        AddPresenceSignal(signals, trimmed, "items");
+
+        return new MarkdownNativeVisualPayload(
+            format,
+            visual.SemanticKind,
+            detectedSemanticKind,
+            jsonType,
+            signals);
+    }
+
+    private static MarkdownNativeVisualPayloadFormat ClassifyFormat(SemanticFencedBlock visual, string trimmedContent) {
+        if (string.IsNullOrWhiteSpace(trimmedContent)) {
+            return MarkdownNativeVisualPayloadFormat.Unknown;
+        }
+
+        if (string.Equals(visual.SemanticKind, MarkdownSemanticKinds.Mermaid, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(visual.Language, "mermaid", StringComparison.OrdinalIgnoreCase)) {
+            return MarkdownNativeVisualPayloadFormat.Mermaid;
+        }
+
+        if (trimmedContent.Length >= 2) {
+            if (trimmedContent[0] == '{' && trimmedContent[trimmedContent.Length - 1] == '}') {
+                return MarkdownNativeVisualPayloadFormat.JsonObject;
+            }
+
+            if (trimmedContent[0] == '[' && trimmedContent[trimmedContent.Length - 1] == ']') {
+                return MarkdownNativeVisualPayloadFormat.JsonArray;
+            }
+        }
+
+        return MarkdownNativeVisualPayloadFormat.Text;
+    }
+
+    private static void AddPresenceSignal(IDictionary<string, string> signals, string payload, string propertyName) {
+        if (ContainsJsonProperty(payload, propertyName)) {
+            signals["json.has." + propertyName] = "true";
+        }
+    }
+
+    private static bool ContainsJsonProperty(string payload, string propertyName) {
+        if (string.IsNullOrWhiteSpace(payload) || string.IsNullOrWhiteSpace(propertyName)) {
+            return false;
+        }
+
+        return payload.IndexOf("\"" + propertyName + "\"", StringComparison.OrdinalIgnoreCase) >= 0
+               || payload.IndexOf("'" + propertyName + "'", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static string? TryReadJsonStringProperty(string payload, string propertyName) {
+        if (string.IsNullOrWhiteSpace(payload) || string.IsNullOrWhiteSpace(propertyName)) {
+            return null;
+        }
+
+        var quotedName = "\"" + propertyName + "\"";
+        var index = payload.IndexOf(quotedName, StringComparison.OrdinalIgnoreCase);
+        var quoteLength = quotedName.Length;
+        if (index < 0) {
+            quotedName = "'" + propertyName + "'";
+            index = payload.IndexOf(quotedName, StringComparison.OrdinalIgnoreCase);
+            quoteLength = quotedName.Length;
+        }
+
+        if (index < 0) {
+            return null;
+        }
+
+        var colon = payload.IndexOf(':', index + quoteLength);
+        if (colon < 0) {
+            return null;
+        }
+
+        var valueStart = colon + 1;
+        while (valueStart < payload.Length && char.IsWhiteSpace(payload[valueStart])) {
+            valueStart++;
+        }
+
+        if (valueStart >= payload.Length) {
+            return null;
+        }
+
+        var quote = payload[valueStart];
+        if (quote != '"' && quote != '\'') {
+            return null;
+        }
+
+        var valueEnd = valueStart + 1;
+        while (valueEnd < payload.Length) {
+            if (payload[valueEnd] == quote && payload[valueEnd - 1] != '\\') {
+                break;
+            }
+
+            valueEnd++;
+        }
+
+        return valueEnd > valueStart + 1 && valueEnd < payload.Length
+            ? payload.Substring(valueStart + 1, valueEnd - valueStart - 1)
+            : null;
+    }
+}

--- a/OfficeIMO.Markdown/Native/MarkdownNativeVisualPayloadFormat.cs
+++ b/OfficeIMO.Markdown/Native/MarkdownNativeVisualPayloadFormat.cs
@@ -1,0 +1,17 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Lightweight visual payload format classification.
+/// </summary>
+public enum MarkdownNativeVisualPayloadFormat {
+    /// <summary>Payload format is unknown or empty.</summary>
+    Unknown,
+    /// <summary>Plain text payload.</summary>
+    Text,
+    /// <summary>JSON object payload.</summary>
+    JsonObject,
+    /// <summary>JSON array payload.</summary>
+    JsonArray,
+    /// <summary>Mermaid diagram payload.</summary>
+    Mermaid
+}

--- a/OfficeIMO.Markdown/README.md
+++ b/OfficeIMO.Markdown/README.md
@@ -133,6 +133,42 @@ if (parsed.HasDocumentHeader && parsed.TryGetFrontMatterValue<string>("title", o
 }
 ```
 
+### Native AST projection for UI hosts
+
+Use `MarkdownNativeDocument` when an editor, transcript viewer, or chat shell needs an AST-backed read model with stable ids, source spans, native block kinds, inline runs, semantic visual metadata, and a DTO-style snapshot that avoids parser object references.
+
+````csharp
+var options = new MarkdownReaderOptions();
+options.DocumentTransforms.Add(new MarkdownJsonVisualCodeBlockTransform(
+    MarkdownVisualFenceLanguageMode.GenericSemanticFence));
+
+var native = MarkdownNativeDocument.Parse("""
+# Investigation
+
+See **CPU** in [dashboard](https://example.com).
+
+```chart {#cpu .wide title="CPU"}
+{"type":"bar","data":{"labels":["A"],"datasets":[{"label":"CPU","data":[42]}]}}
+```
+""", options);
+
+var heading = native.BlocksOfType<MarkdownNativeHeadingBlock>().Single();
+Console.WriteLine($"{heading.Id}: {heading.Text}");
+
+var link = native.EnumerateInlines()
+    .First(inline => inline.Kind == MarkdownNativeInlineKind.Link);
+Console.WriteLine($"{link.Text} -> {link.GetMetadata("target")}");
+
+var visual = native.BlocksOfType<MarkdownNativeVisualBlock>().Single();
+Console.WriteLine($"{visual.SemanticKind}: {visual.Payload.Format} / {visual.Payload.JsonType}");
+
+var snapshot = native.ToSnapshot();
+var edit = native.CreateReplaceEdit(heading, "## Investigation");
+var editedMarkdown = edit.Apply(native.SourceMarkdown);
+````
+
+`MarkdownRenderer.ParseNativeDocument(...)` uses the renderer's effective reader options and returns a native document backed by renderer-preprocessed markdown. The `OfficeIMO.MarkdownRenderer.IntelligenceX` transcript presets also expose `ParseTranscriptNative(...)` helpers so chat and desktop-shell hosts can consume the same native projection that rendering uses.
+
 ### Semantic fenced blocks and reader extensions
 
 ```csharp

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.NestedSyntax.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.NestedSyntax.cs
@@ -15,7 +15,7 @@ public static partial class MarkdownReader {
         var nestedOptions = CloneOptionsWithoutFrontMatter(options);
         var nestedState = CloneState(state);
         var syntaxChildren = new List<MarkdownSyntaxNode>();
-        var nestedDoc = ParseInternal(markdown, nestedOptions, nestedState, allowFrontMatter: false, out _, syntaxChildren, lineOffset: lineOffset, applyDocumentTransforms: false);
+        var nestedDoc = ParseInternal(markdown, nestedOptions, nestedState, allowFrontMatter: false, out _, out _, syntaxChildren, lineOffset: lineOffset, applyDocumentTransforms: false);
         return (nestedDoc.Blocks, syntaxChildren);
     }
 
@@ -31,7 +31,7 @@ public static partial class MarkdownReader {
         var nestedOptions = CloneOptionsWithoutFrontMatter(options);
         var nestedState = CloneState(state);
         var syntaxChildren = new List<MarkdownSyntaxNode>();
-        var nestedDoc = ParseInternal(markdown, nestedOptions, nestedState, allowFrontMatter: false, out _, syntaxChildren, lineOffset: 0, applyDocumentTransforms: false);
+        var nestedDoc = ParseInternal(markdown, nestedOptions, nestedState, allowFrontMatter: false, out _, out _, syntaxChildren, lineOffset: 0, applyDocumentTransforms: false);
         var remappedSyntaxChildren = RemapNestedSyntaxNodes(sourceLines, syntaxChildren);
         var remappedSyntaxTree = BuildDocumentSyntaxTree(remappedSyntaxChildren, nestedDoc);
         SynchronizeOwnedSyntaxCaches(remappedSyntaxTree);

--- a/OfficeIMO.Markdown/Reader/MarkdownReader.cs
+++ b/OfficeIMO.Markdown/Reader/MarkdownReader.cs
@@ -19,7 +19,7 @@ public static partial class MarkdownReader {
     public static MarkdownDoc Parse(string markdown, MarkdownReaderOptions? options = null) {
         options ??= new MarkdownReaderOptions();
         var state = new MarkdownReaderState();
-        return ParseInternal(markdown, options, state, allowFrontMatter: true, out _);
+        return ParseInternal(markdown, options, state, allowFrontMatter: true, out _, out _);
     }
 
     /// <summary>
@@ -30,7 +30,7 @@ public static partial class MarkdownReader {
         var state = new MarkdownReaderState();
         var syntaxNodes = new List<MarkdownSyntaxNode>();
         var diagnostics = new List<MarkdownDocumentTransformDiagnostic>();
-        var document = ParseInternal(markdown, options, state, allowFrontMatter: true, out var syntaxTree, syntaxNodes, lineOffset: 0, transformDiagnostics: diagnostics);
+        var document = ParseInternal(markdown, options, state, allowFrontMatter: true, out var syntaxTree, out var sourceMarkdown, syntaxNodes, lineOffset: 0, transformDiagnostics: diagnostics);
         var originalSyntaxTree = syntaxTree ?? BuildDocumentSyntaxTree(syntaxNodes, document);
         if (diagnostics.Any(diagnostic => diagnostic.ReplacedDocument)) {
             originalSyntaxTree = DetachOriginalSyntaxAssociations(originalSyntaxTree);
@@ -38,7 +38,7 @@ public static partial class MarkdownReader {
 
         var finalSyntaxTree = BuildFinalSyntaxTree(document, originalSyntaxTree, diagnostics);
         MarkdownObjectTreeBinder.BindDocument(document, finalSyntaxTree);
-        return new MarkdownParseResult(document, originalSyntaxTree, finalSyntaxTree);
+        return new MarkdownParseResult(document, originalSyntaxTree, finalSyntaxTree, sourceMarkdown);
     }
 
     /// <summary>
@@ -55,6 +55,7 @@ public static partial class MarkdownReader {
             state,
             allowFrontMatter: true,
             out var syntaxTree,
+            out var sourceMarkdown,
             syntaxNodes,
             lineOffset: 0,
             transformDiagnostics: diagnostics);
@@ -65,7 +66,7 @@ public static partial class MarkdownReader {
 
         var finalSyntaxTree = BuildFinalSyntaxTree(document, originalSyntaxTree, diagnostics);
         MarkdownObjectTreeBinder.BindDocument(document, finalSyntaxTree);
-        return new MarkdownParseResult(document, originalSyntaxTree, finalSyntaxTree, diagnostics);
+        return new MarkdownParseResult(document, originalSyntaxTree, finalSyntaxTree, sourceMarkdown, diagnostics);
     }
 
     /// <summary>Parses a Markdown file path into a <see cref="MarkdownDoc"/>.</summary>
@@ -120,38 +121,22 @@ public static partial class MarkdownReader {
         MarkdownReaderState state,
         bool allowFrontMatter,
         out MarkdownSyntaxNode? syntaxTree,
+        out string normalizedSourceText,
         List<MarkdownSyntaxNode>? syntaxNodes = null,
         int lineOffset = 0,
         ICollection<MarkdownDocumentTransformDiagnostic>? transformDiagnostics = null,
         bool applyDocumentTransforms = true) {
         var doc = MarkdownDoc.Create();
         syntaxTree = syntaxNodes != null ? BuildDocumentSyntaxTree(syntaxNodes, doc) : null;
+        normalizedSourceText = string.Empty;
         if (string.IsNullOrEmpty(markdown)) return doc;
         int previousLineOffset = state.SourceLineOffset;
         var previousSourceTextMap = state.SourceTextMap;
         state.SourceLineOffset = lineOffset;
 
         try {
-            // Normalize BOM (U+FEFF) at the very beginning to avoid blocking heading/html detection
-            if (markdown[0] == '\uFEFF') {
-                markdown = markdown.Substring(1);
-            }
-
-            ValidateInputLength(markdown, options.MaxInputCharacters, nameof(markdown));
-
-            // This specific repair must happen before block parsing: once a collapsed heading marker
-            // is swallowed into a table cell, the AST no longer knows the table boundary was malformed.
-            if (options.InputNormalization?.NormalizeCompactHeadingBoundaries == true) {
-                markdown = MarkdownInputNormalizer.NormalizeCollapsedTableHeadingBoundaries(markdown);
-            }
-
-            var preParseNormalization = CreatePreParseNormalizationOptions(options.InputNormalization);
-            if (preParseNormalization != null) {
-                markdown = MarkdownInputNormalizer.Normalize(markdown, preParseNormalization);
-            }
-
-            // Normalize line endings and split. Keep empty lines significant for block boundaries.
-            var text = markdown.Replace("\r\n", "\n").Replace('\r', '\n');
+            var text = PrepareMarkdownForParsing(markdown, options);
+            normalizedSourceText = text;
             if (lineOffset == 0 || state.SourceTextMap == null) {
                 state.SourceTextMap = new MarkdownSourceTextMap(text);
             }
@@ -218,6 +203,33 @@ public static partial class MarkdownReader {
             state.SourceLineOffset = previousLineOffset;
             state.SourceTextMap = previousSourceTextMap;
         }
+    }
+
+    private static string PrepareMarkdownForParsing(string markdown, MarkdownReaderOptions options) {
+        markdown ??= string.Empty;
+        if (markdown.Length == 0) {
+            return string.Empty;
+        }
+
+        // Normalize BOM (U+FEFF) at the very beginning to avoid blocking heading/html detection.
+        if (markdown[0] == '\uFEFF') {
+            markdown = markdown.Substring(1);
+        }
+
+        ValidateInputLength(markdown, options.MaxInputCharacters, nameof(markdown));
+
+        // This specific repair must happen before block parsing: once a collapsed heading marker
+        // is swallowed into a table cell, the AST no longer knows the table boundary was malformed.
+        if (options.InputNormalization?.NormalizeCompactHeadingBoundaries == true) {
+            markdown = MarkdownInputNormalizer.NormalizeCollapsedTableHeadingBoundaries(markdown);
+        }
+
+        var preParseNormalization = CreatePreParseNormalizationOptions(options.InputNormalization);
+        if (preParseNormalization != null) {
+            markdown = MarkdownInputNormalizer.Normalize(markdown, preParseNormalization);
+        }
+
+        return markdown.Replace("\r\n", "\n").Replace('\r', '\n');
     }
 
     private static void ValidateInputLength(string input, int? maxInputCharacters, string paramName) {

--- a/OfficeIMO.Markdown/Reader/Syntax/MarkdownParseResult.cs
+++ b/OfficeIMO.Markdown/Reader/Syntax/MarkdownParseResult.cs
@@ -15,6 +15,8 @@ public sealed class MarkdownParseResult {
     public MarkdownSyntaxNode SyntaxTree { get; }
     /// <summary>The syntax tree corresponding to the final returned <see cref="Document"/>.</summary>
     public MarkdownSyntaxNode FinalSyntaxTree { get; }
+    /// <summary>The normalized markdown source text used to compute syntax source spans.</summary>
+    public string SourceMarkdown { get; }
     /// <summary>Optional document-transform diagnostics captured during parsing.</summary>
     public IReadOnlyList<MarkdownDocumentTransformDiagnostic> TransformDiagnostics { get; }
 
@@ -22,10 +24,12 @@ public sealed class MarkdownParseResult {
         MarkdownDoc document,
         MarkdownSyntaxNode syntaxTree,
         MarkdownSyntaxNode? finalSyntaxTree = null,
+        string? sourceMarkdown = null,
         IReadOnlyList<MarkdownDocumentTransformDiagnostic>? transformDiagnostics = null) {
         Document = document;
         SyntaxTree = syntaxTree;
         FinalSyntaxTree = finalSyntaxTree ?? syntaxTree;
+        SourceMarkdown = sourceMarkdown ?? string.Empty;
         TransformDiagnostics = transformDiagnostics ?? Array.Empty<MarkdownDocumentTransformDiagnostic>();
     }
 

--- a/OfficeIMO.Markdown/Transforms/MarkdownJsonVisualCodeBlockTransform.cs
+++ b/OfficeIMO.Markdown/Transforms/MarkdownJsonVisualCodeBlockTransform.cs
@@ -49,6 +49,7 @@ public sealed class MarkdownJsonVisualCodeBlockTransform : IMarkdownDocumentTran
         language = block.Language ?? string.Empty;
 
         if (TryResolveKnownFenceLanguage(language, out semanticKind)) {
+            language = block.InfoString;
             return true;
         }
 
@@ -56,8 +57,18 @@ public sealed class MarkdownJsonVisualCodeBlockTransform : IMarkdownDocumentTran
             return false;
         }
 
-        language = ResolveUpgradedLanguage(semanticKind, language);
+        language = BuildResolvedInfoString(block, ResolveUpgradedLanguage(semanticKind, language));
         return true;
+    }
+
+    private static string BuildResolvedInfoString(CodeBlock block, string language) {
+        if (string.IsNullOrWhiteSpace(block.FenceInfo.AdditionalInfo)) {
+            return language ?? string.Empty;
+        }
+
+        return string.IsNullOrWhiteSpace(language)
+            ? block.FenceInfo.AdditionalInfo
+            : language.Trim() + " " + block.FenceInfo.AdditionalInfo;
     }
 
     private static bool TryResolveKnownFenceLanguage(string language, out string semanticKind) {

--- a/OfficeIMO.MarkdownRenderer.IntelligenceX/IntelligenceXMarkdownRenderer.cs
+++ b/OfficeIMO.MarkdownRenderer.IntelligenceX/IntelligenceXMarkdownRenderer.cs
@@ -172,7 +172,7 @@ public static class IntelligenceXMarkdownRenderer {
     /// </summary>
     public static MarkdownNativeDocument ParseTranscriptNative(string markdown, string? baseHref = null) {
         var options = CreateTranscript(baseHref);
-        return MarkdownNativeDocument.Parse(markdown, options.ReaderOptions);
+        return MarkdownRenderer.ParseNativeDocument(markdown, options);
     }
 
     /// <summary>
@@ -180,7 +180,7 @@ public static class IntelligenceXMarkdownRenderer {
     /// </summary>
     public static MarkdownNativeDocument ParseTranscriptNativeMinimal(string markdown, string? baseHref = null) {
         var options = CreateTranscriptMinimal(baseHref);
-        return MarkdownNativeDocument.Parse(markdown, options.ReaderOptions);
+        return MarkdownRenderer.ParseNativeDocument(markdown, options);
     }
 
     /// <summary>
@@ -188,7 +188,7 @@ public static class IntelligenceXMarkdownRenderer {
     /// </summary>
     public static MarkdownNativeDocument ParseTranscriptNativeDesktopShell(string markdown, string? baseHref = null) {
         var options = CreateTranscriptDesktopShell(baseHref);
-        return MarkdownNativeDocument.Parse(markdown, options.ReaderOptions);
+        return MarkdownRenderer.ParseNativeDocument(markdown, options);
     }
 
     /// <summary>
@@ -196,6 +196,6 @@ public static class IntelligenceXMarkdownRenderer {
     /// </summary>
     public static MarkdownNativeDocument ParseTranscriptNativeRelaxed(string markdown, string? baseHref = null) {
         var options = CreateTranscriptRelaxed(baseHref);
-        return MarkdownNativeDocument.Parse(markdown, options.ReaderOptions);
+        return MarkdownRenderer.ParseNativeDocument(markdown, options);
     }
 }

--- a/OfficeIMO.MarkdownRenderer.IntelligenceX/IntelligenceXMarkdownRenderer.cs
+++ b/OfficeIMO.MarkdownRenderer.IntelligenceX/IntelligenceXMarkdownRenderer.cs
@@ -166,4 +166,36 @@ public static class IntelligenceXMarkdownRenderer {
         ApplyVisuals(options);
         return options;
     }
+
+    /// <summary>
+    /// Parses transcript markdown into the shared AST-backed native document projection using the strict IX preset.
+    /// </summary>
+    public static MarkdownNativeDocument ParseTranscriptNative(string markdown, string? baseHref = null) {
+        var options = CreateTranscript(baseHref);
+        return MarkdownNativeDocument.Parse(markdown, options.ReaderOptions);
+    }
+
+    /// <summary>
+    /// Parses transcript markdown into the shared AST-backed native document projection using the minimal IX preset.
+    /// </summary>
+    public static MarkdownNativeDocument ParseTranscriptNativeMinimal(string markdown, string? baseHref = null) {
+        var options = CreateTranscriptMinimal(baseHref);
+        return MarkdownNativeDocument.Parse(markdown, options.ReaderOptions);
+    }
+
+    /// <summary>
+    /// Parses transcript markdown into the shared AST-backed native document projection using the desktop-shell IX preset.
+    /// </summary>
+    public static MarkdownNativeDocument ParseTranscriptNativeDesktopShell(string markdown, string? baseHref = null) {
+        var options = CreateTranscriptDesktopShell(baseHref);
+        return MarkdownNativeDocument.Parse(markdown, options.ReaderOptions);
+    }
+
+    /// <summary>
+    /// Parses transcript markdown into the shared AST-backed native document projection using the relaxed IX preset.
+    /// </summary>
+    public static MarkdownNativeDocument ParseTranscriptNativeRelaxed(string markdown, string? baseHref = null) {
+        var options = CreateTranscriptRelaxed(baseHref);
+        return MarkdownNativeDocument.Parse(markdown, options.ReaderOptions);
+    }
 }

--- a/OfficeIMO.MarkdownRenderer/MarkdownRenderer.cs
+++ b/OfficeIMO.MarkdownRenderer/MarkdownRenderer.cs
@@ -64,6 +64,7 @@ public static partial class MarkdownRenderer {
         return new MarkdownRendererParseResult(
             document,
             markdown,
+            parseResult.SourceMarkdown,
             parseResult.SyntaxTree,
             finalSyntaxTree,
             transformDiagnostics,
@@ -81,11 +82,11 @@ public static partial class MarkdownRenderer {
             result.Document,
             result.SyntaxTree,
             result.FinalSyntaxTree,
-            sourceMarkdown: result.PreprocessedMarkdown,
+            sourceMarkdown: result.SourceMarkdown,
             result.TransformDiagnostics);
         return MarkdownNativeDocument.FromParseResult(
             parseResult,
-            result.PreprocessedMarkdown,
+            sourceMarkdown: null,
             MarkdownNativeDocumentSourceKind.RendererPreprocessed);
     }
 

--- a/OfficeIMO.MarkdownRenderer/MarkdownRenderer.cs
+++ b/OfficeIMO.MarkdownRenderer/MarkdownRenderer.cs
@@ -71,6 +71,21 @@ public static partial class MarkdownRenderer {
     }
 
     /// <summary>
+    /// Parses Markdown using the renderer-owned pipeline and returns the AST-backed native projection.
+    /// </summary>
+    public static MarkdownNativeDocument ParseNativeDocument(
+        string markdown,
+        MarkdownRendererOptions? options = null) {
+        var result = ParseDocumentResult(markdown, options);
+        var parseResult = new MarkdownParseResult(
+            result.Document,
+            result.SyntaxTree,
+            result.FinalSyntaxTree,
+            result.TransformDiagnostics);
+        return MarkdownNativeDocument.FromParseResult(parseResult);
+    }
+
+    /// <summary>
     /// Parses Markdown using OfficeIMO.Markdown and returns an HTML fragment (typically an &lt;article class="markdown-body"&gt; wrapper).
     /// When Mermaid is enabled, Mermaid code blocks are annotated with hashes for incremental rendering.
     /// </summary>

--- a/OfficeIMO.MarkdownRenderer/MarkdownRenderer.cs
+++ b/OfficeIMO.MarkdownRenderer/MarkdownRenderer.cs
@@ -81,6 +81,7 @@ public static partial class MarkdownRenderer {
             result.Document,
             result.SyntaxTree,
             result.FinalSyntaxTree,
+            sourceMarkdown: result.PreprocessedMarkdown,
             result.TransformDiagnostics);
         return MarkdownNativeDocument.FromParseResult(
             parseResult,

--- a/OfficeIMO.MarkdownRenderer/MarkdownRenderer.cs
+++ b/OfficeIMO.MarkdownRenderer/MarkdownRenderer.cs
@@ -82,7 +82,10 @@ public static partial class MarkdownRenderer {
             result.SyntaxTree,
             result.FinalSyntaxTree,
             result.TransformDiagnostics);
-        return MarkdownNativeDocument.FromParseResult(parseResult);
+        return MarkdownNativeDocument.FromParseResult(
+            parseResult,
+            result.PreprocessedMarkdown,
+            MarkdownNativeDocumentSourceKind.RendererPreprocessed);
     }
 
     /// <summary>

--- a/OfficeIMO.MarkdownRenderer/MarkdownRendererParseResult.cs
+++ b/OfficeIMO.MarkdownRenderer/MarkdownRendererParseResult.cs
@@ -12,6 +12,9 @@ public sealed class MarkdownRendererParseResult {
     /// <summary>The final markdown text after renderer preprocessing and before parsing.</summary>
     public string PreprocessedMarkdown { get; }
 
+    /// <summary>The reader-normalized markdown source text used to compute syntax source spans.</summary>
+    public string SourceMarkdown { get; }
+
     /// <summary>The original syntax tree produced before document transforms were applied.</summary>
     public MarkdownSyntaxNode SyntaxTree { get; }
     /// <summary>The syntax tree corresponding to the final renderer-owned <see cref="Document"/>.</summary>
@@ -26,12 +29,14 @@ public sealed class MarkdownRendererParseResult {
     internal MarkdownRendererParseResult(
         MarkdownDoc document,
         string preprocessedMarkdown,
+        string sourceMarkdown,
         MarkdownSyntaxNode syntaxTree,
         MarkdownSyntaxNode? finalSyntaxTree = null,
         IReadOnlyList<MarkdownDocumentTransformDiagnostic>? transformDiagnostics = null,
         IReadOnlyList<MarkdownRendererPreProcessorDiagnostic>? preProcessorDiagnostics = null) {
         Document = document ?? throw new ArgumentNullException(nameof(document));
         PreprocessedMarkdown = preprocessedMarkdown ?? string.Empty;
+        SourceMarkdown = sourceMarkdown ?? string.Empty;
         SyntaxTree = syntaxTree ?? throw new ArgumentNullException(nameof(syntaxTree));
         FinalSyntaxTree = finalSyntaxTree ?? SyntaxTree;
         TransformDiagnostics = transformDiagnostics ?? Array.Empty<MarkdownDocumentTransformDiagnostic>();

--- a/OfficeIMO.Tests/Markdown/Markdown_IntelligenceXTranscript_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_IntelligenceXTranscript_Tests.cs
@@ -211,6 +211,29 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void IntelligenceXMarkdownRenderer_ParseTranscriptNative_Projects_Visual_Fences() {
+            var markdown = """
+Rendered result:
+
+```ix-chart
+{"type":"bar"}
+```
+""";
+
+            var native = IntelligenceXMarkdownRenderer.ParseTranscriptNative(markdown);
+
+            Assert.Equal(new[] {
+                MarkdownNativeBlockKind.Paragraph,
+                MarkdownNativeBlockKind.Visual
+            }, native.Blocks.Select(block => block.Kind).ToArray());
+
+            var visual = Assert.IsType<MarkdownNativeVisualBlock>(native.Blocks[1]);
+            Assert.Equal(MarkdownSemanticKinds.Chart, visual.SemanticKind);
+            Assert.Equal("ix-chart", visual.Language);
+            Assert.Equal(3, visual.SourceSpan!.Value.StartLine);
+        }
+
+        [Fact]
         public void MarkdownRendererPresets_CreateIntelligenceXTranscript_Reuses_Shared_Transcript_Reader_Contract() {
             var expected = MarkdownTranscriptPreparation.CreateIntelligenceXTranscriptReaderOptions(
                 preservesGroupedDefinitionLikeParagraphs: false,

--- a/OfficeIMO.Tests/Markdown/Markdown_IntelligenceXTranscript_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_IntelligenceXTranscript_Tests.cs
@@ -234,6 +234,22 @@ Rendered result:
         }
 
         [Fact]
+        public void IntelligenceXMarkdownRenderer_ParseTranscriptNativeDesktopShell_Uses_Renderer_Semantic_Fences() {
+            var markdown = """
+```mermaid
+flowchart LR
+  A-->B
+```
+""";
+
+            var native = IntelligenceXMarkdownRenderer.ParseTranscriptNativeDesktopShell(markdown);
+
+            var visual = Assert.IsType<MarkdownNativeVisualBlock>(Assert.Single(native.Blocks));
+            Assert.Equal(MarkdownSemanticKinds.Mermaid, visual.SemanticKind);
+            Assert.Equal("mermaid", visual.Language);
+        }
+
+        [Fact]
         public void MarkdownRendererPresets_CreateIntelligenceXTranscript_Reuses_Shared_Transcript_Reader_Contract() {
             var expected = MarkdownTranscriptPreparation.CreateIntelligenceXTranscriptReaderOptions(
                 preservesGroupedDefinitionLikeParagraphs: false,

--- a/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
@@ -171,6 +171,30 @@ Console.WriteLine(1);
     }
 
     [Fact]
+    public void Parse_Projects_Structured_Table_Cell_Blocks_As_Native_Children() {
+        var markdown = """
+| Name | Detail |
+| --- | --- |
+| CPU | - high<br>- low |
+""";
+
+        var native = MarkdownNativeDocument.Parse(markdown);
+
+        var table = Assert.IsType<MarkdownNativeTableBlock>(Assert.Single(native.Blocks));
+        var detailCell = table.Rows[0][1];
+        var list = Assert.IsType<MarkdownNativeListBlock>(Assert.Single(detailCell.Children));
+        Assert.Equal(new[] { "high", "low" }, list.Items.Select(item => item.Text).ToArray());
+        Assert.Same(list, native.FindBlockById(list.Id));
+        Assert.Equal(new[] { table.Id, list.Id }, native.GetBlockPath(list.Id).Select(block => block.Id).ToArray());
+        Assert.Contains(native.DescendantBlocksAndSelf(), block => ReferenceEquals(block, list));
+
+        var snapshotCell = native.ToSnapshot().Blocks[0].Rows[0][1];
+        var snapshotList = Assert.Single(snapshotCell.Children);
+        Assert.Equal(MarkdownNativeBlockKind.List, snapshotList.Kind);
+        Assert.Equal(new[] { "high", "low" }, snapshotList.Items.Select(item => item.Text).ToArray());
+    }
+
+    [Fact]
     public void Parse_Projects_Fence_Metadata_For_Code_And_Visual_Blocks() {
         var options = new MarkdownReaderOptions();
         options.DocumentTransforms.Add(new MarkdownJsonVisualCodeBlockTransform(MarkdownVisualFenceLanguageMode.IntelligenceXAliasFence));
@@ -256,6 +280,20 @@ Paragraph with `code` and ![Alt](img.png "Img").
 
         Assert.Single(native.EnumerateInlines(), inline => inline.Text == "foo");
         Assert.Single(native.EnumerateInlines(), inline => inline.Text == "Bar");
+    }
+
+    [Fact]
+    public void Parse_Includes_Syntax_Path_In_Block_Ids_For_Duplicated_Generated_Blocks() {
+        var options = new MarkdownReaderOptions();
+        options.DocumentTransforms.Add(new DuplicateParagraphTransform());
+
+        var native = MarkdownNativeDocument.Parse("Same", options);
+
+        Assert.Equal(2, native.Blocks.Count);
+        Assert.All(native.Blocks, block => Assert.Equal(MarkdownNativeBlockKind.Paragraph, block.Kind));
+        Assert.Equal(2, native.Blocks.Select(block => block.Id).Distinct().Count());
+        Assert.Equal(native.Blocks[0], native.FindBlockById(native.Blocks[0].Id));
+        Assert.Equal(native.Blocks[1], native.FindBlockById(native.Blocks[1].Id));
     }
 
     [Fact]
@@ -348,6 +386,36 @@ Outside
     }
 
     [Fact]
+    public void Source_Edit_Helpers_Use_Normalized_Source_That_Backs_SourceSpans() {
+        var markdown = "First\r\n\r\nSecond\r\n";
+
+        var native = MarkdownNativeDocument.Parse(markdown);
+        var paragraph = Assert.IsType<MarkdownNativeParagraphBlock>(native.Blocks[1]);
+
+        Assert.Equal("First\n\nSecond\n", native.SourceMarkdown);
+        var edit = native.CreateReplaceEdit(paragraph, "Updated");
+        var updated = edit.Apply(native.SourceMarkdown);
+
+        Assert.Equal("First\n\nUpdated\n", updated);
+    }
+
+    [Fact]
+    public void Source_Edit_Helpers_Reject_Spans_When_Backing_Source_Is_Missing() {
+        var parseResult = MarkdownReader.ParseWithSyntaxTreeAndDiagnostics("Editable");
+        var withoutSource = new MarkdownParseResult(
+            parseResult.Document,
+            parseResult.SyntaxTree,
+            parseResult.FinalSyntaxTree,
+            sourceMarkdown: null,
+            parseResult.TransformDiagnostics);
+        var native = MarkdownNativeDocument.FromParseResult(withoutSource, sourceMarkdown: string.Empty);
+        var paragraph = Assert.IsType<MarkdownNativeParagraphBlock>(Assert.Single(native.Blocks));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => native.CreateReplaceEdit(paragraph, "Updated"));
+        Assert.Contains("cannot be mapped", ex.Message);
+    }
+
+    [Fact]
     public void Renderer_ParseNativeDocument_Exposes_Preprocessed_Source_Kind_And_Transform_Diagnostics() {
         var markdown = """
 ix:cached-tool-evidence:v1
@@ -378,5 +446,14 @@ ix:cached-tool-evidence:v1
         var diagnostic = Assert.Single(native.Diagnostics, item => item.Id == "native.unsupported-block");
         Assert.Same(other, diagnostic.Block);
         Assert.Equal(MarkdownNativeDiagnosticSeverity.Info, diagnostic.Severity);
+    }
+
+    private sealed class DuplicateParagraphTransform : IMarkdownDocumentTransform {
+        public MarkdownDoc Transform(MarkdownDoc document, MarkdownDocumentTransformContext context) {
+            var clone = MarkdownDoc.Create();
+            clone.Add(new ParagraphBlock(new InlineSequence().Text("Same")));
+            clone.Add(new ParagraphBlock(new InlineSequence().Text("Same")));
+            return clone;
+        }
     }
 }

--- a/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
@@ -1,10 +1,91 @@
 using System.Linq;
 using OfficeIMO.Markdown;
+using OfficeIMO.MarkdownRenderer;
 using Xunit;
 
 namespace OfficeIMO.Tests.MarkdownSuite;
 
 public class Markdown_Native_Document_Tests {
+    [Fact]
+    public void Parse_Projects_UI_ReadModel_Blocks_With_Stable_Ids_And_Children() {
+        var markdown = """
+---
+title: Native projection
+---
+# Session
+
+> [!WARNING] Watch
+> Body text
+
+> Quoted text
+
+- [x] Done
+- Plain
+
+![Signal](images/signal.png "Signal")
+
+<details open>
+<summary>More context</summary>
+
+Inside details
+</details>
+""";
+
+        var native = MarkdownNativeDocument.Parse(markdown);
+        var reparsed = MarkdownNativeDocument.Parse(markdown);
+
+        Assert.Equal(MarkdownNativeDocumentSourceKind.ReaderInput, native.SourceKind);
+        Assert.Equal(markdown, native.SourceMarkdown);
+        Assert.Equal(
+            native.Blocks.Select(block => block.Id).ToArray(),
+            reparsed.Blocks.Select(block => block.Id).ToArray());
+
+        Assert.Equal(new[] {
+            MarkdownNativeBlockKind.FrontMatter,
+            MarkdownNativeBlockKind.Heading,
+            MarkdownNativeBlockKind.Callout,
+            MarkdownNativeBlockKind.Quote,
+            MarkdownNativeBlockKind.List,
+            MarkdownNativeBlockKind.Image,
+            MarkdownNativeBlockKind.Details
+        }, native.Blocks.Select(block => block.Kind).ToArray());
+
+        var frontMatter = Assert.IsType<MarkdownNativeFrontMatterBlock>(native.Blocks[0]);
+        Assert.Equal("Native projection", frontMatter.Values["title"]);
+
+        var heading = Assert.IsType<MarkdownNativeHeadingBlock>(native.Blocks[1]);
+        Assert.Equal(1, heading.Level);
+        Assert.Equal("Session", heading.Text);
+
+        var callout = Assert.IsType<MarkdownNativeCalloutBlock>(native.Blocks[2]);
+        Assert.Equal("warning", callout.CalloutKind);
+        Assert.Equal("Watch", callout.Title);
+        Assert.Equal("Body text", Assert.IsType<MarkdownNativeParagraphBlock>(Assert.Single(callout.Children)).Text);
+        Assert.Same(callout.Children[0], native.FindBlockAtLine(7));
+
+        var quote = Assert.IsType<MarkdownNativeQuoteBlock>(native.Blocks[3]);
+        Assert.Equal("Quoted text", Assert.IsType<MarkdownNativeParagraphBlock>(Assert.Single(quote.Children)).Text);
+
+        var list = Assert.IsType<MarkdownNativeListBlock>(native.Blocks[4]);
+        Assert.False(list.IsOrdered);
+        Assert.Equal(2, list.Items.Count);
+        Assert.True(list.Items[0].IsTask);
+        Assert.True(list.Items[0].Checked);
+        Assert.Equal("Done", list.Items[0].Text);
+        Assert.NotEmpty(list.Items[0].Id);
+        Assert.NotEmpty(list.Items[0].Children);
+
+        var image = Assert.IsType<MarkdownNativeImageBlock>(native.Blocks[5]);
+        Assert.Equal("images/signal.png", image.Source);
+        Assert.Equal("Signal", image.Alt);
+        Assert.Equal("Signal", image.Title);
+
+        var details = Assert.IsType<MarkdownNativeDetailsBlock>(native.Blocks[6]);
+        Assert.True(details.Open);
+        Assert.Equal("More context", details.Summary);
+        Assert.Equal("Inside details", Assert.IsType<MarkdownNativeParagraphBlock>(Assert.Single(details.Children)).Text);
+    }
+
     [Fact]
     public void Parse_Projects_Core_Blocks_With_SourceSpans() {
         var options = new MarkdownReaderOptions();
@@ -87,5 +168,68 @@ Console.WriteLine(1);
         Assert.Equal(ColumnAlignment.Right, table.HeaderCells[1].Alignment);
         Assert.Equal(ColumnAlignment.Left, table.Rows[0][0].Alignment);
         Assert.Equal(ColumnAlignment.Right, table.Rows[0][1].Alignment);
+    }
+
+    [Fact]
+    public void Parse_Projects_Fence_Metadata_For_Code_And_Visual_Blocks() {
+        var options = new MarkdownReaderOptions();
+        options.DocumentTransforms.Add(new MarkdownJsonVisualCodeBlockTransform(MarkdownVisualFenceLanguageMode.IntelligenceXAliasFence));
+        var markdown = """
+```csharp {#sample .wide title="Sample Code" copy=false}
+Console.WriteLine(1);
+```
+
+```ix-chart {#cpu .compact title="CPU Load" pinned=true rows=5}
+{"type":"bar"}
+```
+""";
+
+        var native = MarkdownNativeDocument.Parse(markdown, options);
+
+        var code = Assert.IsType<MarkdownNativeCodeBlock>(native.Blocks[0]);
+        Assert.Equal("sample", code.ElementId);
+        Assert.Equal("Sample Code", code.Title);
+        Assert.Contains("wide", code.Classes);
+        Assert.Equal("false", code.Attributes["copy"]);
+
+        var visual = Assert.IsType<MarkdownNativeVisualBlock>(native.Blocks[1]);
+        Assert.Equal("cpu", visual.ElementId);
+        Assert.Equal("CPU Load", visual.Title);
+        Assert.Contains("compact", visual.Classes);
+        Assert.Equal("true", visual.Attributes["pinned"]);
+        Assert.Equal("5", visual.Attributes["rows"]);
+    }
+
+    [Fact]
+    public void Renderer_ParseNativeDocument_Exposes_Preprocessed_Source_Kind_And_Transform_Diagnostics() {
+        var markdown = """
+ix:cached-tool-evidence:v1
+
+```json
+{"type":"bar","data":{"labels":["A"],"datasets":[{"label":"Count","data":[1]}]}}
+```
+""";
+
+        var native = OfficeIMO.MarkdownRenderer.MarkdownRenderer.ParseNativeDocument(
+            markdown,
+            MarkdownRendererPresets.CreateIntelligenceXTranscriptMinimal());
+
+        Assert.Equal(MarkdownNativeDocumentSourceKind.RendererPreprocessed, native.SourceKind);
+        Assert.Contains("ix:cached-tool-evidence:v1", native.SourceMarkdown);
+        Assert.Contains(native.Diagnostics, diagnostic => diagnostic.Id == "native.transform");
+        Assert.Contains(native.Blocks, block =>
+            block is MarkdownNativeVisualBlock visual
+            && visual.SemanticKind == MarkdownSemanticKinds.Chart
+            && visual.Language == "ix-chart");
+    }
+
+    [Fact]
+    public void Parse_Reports_Fallback_Diagnostics_For_Unsupported_Blocks() {
+        var native = MarkdownNativeDocument.Parse("***");
+
+        var other = Assert.IsType<MarkdownNativeOtherBlock>(Assert.Single(native.Blocks));
+        var diagnostic = Assert.Single(native.Diagnostics, item => item.Id == "native.unsupported-block");
+        Assert.Same(other, diagnostic.Block);
+        Assert.Equal(MarkdownNativeDiagnosticSeverity.Info, diagnostic.Severity);
     }
 }

--- a/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
@@ -55,4 +55,37 @@ Console.WriteLine(1);
         Assert.Equal(11, visual.SourceSpan!.Value.StartLine);
         Assert.Same(visual, native.FindBlockAtLine(12));
     }
+
+    [Fact]
+    public void Parse_Does_Not_Project_Phantom_Headers_For_Headerless_Tables() {
+        var markdown = """
+| One | 1 |
+| Two | 2 |
+""";
+
+        var native = MarkdownNativeDocument.Parse(markdown);
+
+        var table = Assert.IsType<MarkdownNativeTableBlock>(Assert.Single(native.Blocks));
+        Assert.Empty(table.HeaderCells);
+        Assert.Equal(2, table.Rows.Count);
+        Assert.Equal("One", table.Rows[0][0].Text);
+        Assert.Equal("2", table.Rows[1][1].Text);
+    }
+
+    [Fact]
+    public void Parse_Preserves_Table_Column_Alignment_In_Native_Cells() {
+        var markdown = """
+| Name | Value |
+| :--- | ---: |
+| CPU | 42 |
+""";
+
+        var native = MarkdownNativeDocument.Parse(markdown);
+
+        var table = Assert.IsType<MarkdownNativeTableBlock>(Assert.Single(native.Blocks));
+        Assert.Equal(ColumnAlignment.Left, table.HeaderCells[0].Alignment);
+        Assert.Equal(ColumnAlignment.Right, table.HeaderCells[1].Alignment);
+        Assert.Equal(ColumnAlignment.Left, table.Rows[0][0].Alignment);
+        Assert.Equal(ColumnAlignment.Right, table.Rows[0][1].Alignment);
+    }
 }

--- a/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using OfficeIMO.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests.MarkdownSuite;
+
+public class Markdown_Native_Document_Tests {
+    [Fact]
+    public void Parse_Projects_Core_Blocks_With_SourceSpans() {
+        var options = new MarkdownReaderOptions();
+        options.DocumentTransforms.Add(new MarkdownJsonVisualCodeBlockTransform(MarkdownVisualFenceLanguageMode.IntelligenceXAliasFence));
+        var markdown = """
+Intro text
+
+```csharp
+Console.WriteLine(1);
+```
+
+| Name | Value |
+| --- | --- |
+| CPU | 42 |
+
+```ix-chart
+{"type":"bar"}
+```
+""";
+
+        var native = MarkdownNativeDocument.Parse(markdown, options);
+
+        Assert.Equal(new[] {
+            MarkdownNativeBlockKind.Paragraph,
+            MarkdownNativeBlockKind.Code,
+            MarkdownNativeBlockKind.Table,
+            MarkdownNativeBlockKind.Visual
+        }, native.Blocks.Select(block => block.Kind).ToArray());
+
+        var paragraph = Assert.IsType<MarkdownNativeParagraphBlock>(native.Blocks[0]);
+        Assert.Equal("Intro text", paragraph.Text);
+        Assert.Equal(1, paragraph.SourceSpan!.Value.StartLine);
+
+        var code = Assert.IsType<MarkdownNativeCodeBlock>(native.Blocks[1]);
+        Assert.Equal("csharp", code.Language);
+        Assert.Equal("Console.WriteLine(1);", code.Content);
+        Assert.Equal(3, code.SourceSpan!.Value.StartLine);
+
+        var table = Assert.IsType<MarkdownNativeTableBlock>(native.Blocks[2]);
+        Assert.Equal("Name", table.HeaderCells[0].Text);
+        Assert.Equal("42", table.Rows[0][1].Text);
+        Assert.Equal(7, table.SourceSpan!.Value.StartLine);
+
+        var visual = Assert.IsType<MarkdownNativeVisualBlock>(native.Blocks[3]);
+        Assert.Equal(MarkdownSemanticKinds.Chart, visual.SemanticKind);
+        Assert.Equal("ix-chart", visual.Language);
+        Assert.Equal("{\"type\":\"bar\"}", visual.Content);
+        Assert.Equal(11, visual.SourceSpan!.Value.StartLine);
+        Assert.Same(visual, native.FindBlockAtLine(12));
+    }
+}

--- a/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
@@ -201,6 +201,124 @@ Console.WriteLine(1);
     }
 
     [Fact]
+    public void Parse_Projects_Native_Inlines_With_SourceSpans_And_Metadata() {
+        var markdown = """
+# Native **AST** [docs](https://example.com "Docs")
+
+Paragraph with `code` and ![Alt](img.png "Img").
+""";
+
+        var native = MarkdownNativeDocument.Parse(markdown);
+
+        var heading = Assert.IsType<MarkdownNativeHeadingBlock>(native.Blocks[0]);
+        Assert.Contains(heading.InlineRuns, inline => inline.Kind == MarkdownNativeInlineKind.Strong && inline.Text == "AST");
+
+        var link = Assert.Single(heading.InlineRuns, inline => inline.Kind == MarkdownNativeInlineKind.Link);
+        Assert.Equal("docs", link.Text);
+        Assert.Equal("https://example.com", link.GetMetadata("target"));
+        Assert.Equal("Docs", link.GetMetadata("title"));
+        Assert.True(link.SourceSpan.HasValue);
+        Assert.Same(link, native.FindInlineById(link.Id));
+        Assert.Same(link, native.FindInlineAtPosition(link.SourceSpan.Value.StartLine, link.SourceSpan.Value.StartColumn!.Value));
+
+        var paragraph = Assert.IsType<MarkdownNativeParagraphBlock>(native.Blocks[1]);
+        Assert.Contains(paragraph.InlineRuns, inline => inline.Kind == MarkdownNativeInlineKind.Code && inline.Text == "code");
+        var image = Assert.Single(paragraph.InlineRuns, inline => inline.Kind == MarkdownNativeInlineKind.Image);
+        Assert.Equal("Alt", image.GetMetadata("alt"));
+        Assert.Equal("img.png", image.GetMetadata("source"));
+        Assert.Equal("Img", image.GetMetadata("imageTitle"));
+    }
+
+    [Fact]
+    public void Parse_Exposes_Visual_Payload_Hints_Without_Json_Dependency() {
+        var options = new MarkdownReaderOptions();
+        options.DocumentTransforms.Add(new MarkdownJsonVisualCodeBlockTransform(MarkdownVisualFenceLanguageMode.IntelligenceXAliasFence));
+        options.FencedBlockExtensions.Add(new MarkdownFencedBlockExtension(
+            "Mermaid",
+            new[] { "mermaid" },
+            context => new SemanticFencedBlock(MarkdownSemanticKinds.Mermaid, context.InfoString, context.Content, context.Caption)));
+        var markdown = """
+```ix-chart {#cpu .wide title="CPU" pinned=true}
+{"type":"bar","data":{"labels":["A"],"datasets":[{"label":"CPU","data":[42]}]}}
+```
+
+```mermaid
+graph TD
+  A-->B
+```
+""";
+
+        var native = MarkdownNativeDocument.Parse(markdown, options);
+
+        var chart = Assert.IsType<MarkdownNativeVisualBlock>(native.Blocks[0]);
+        Assert.Equal(MarkdownNativeVisualPayloadFormat.JsonObject, chart.Payload.Format);
+        Assert.True(chart.Payload.IsJson);
+        Assert.Equal(MarkdownSemanticKinds.Chart, chart.Payload.DetectedSemanticKind);
+        Assert.Equal("bar", chart.Payload.JsonType);
+        Assert.Equal("true", chart.Payload.Signals["json.has.data"]);
+
+        var mermaid = Assert.IsType<MarkdownNativeVisualBlock>(native.Blocks[1]);
+        Assert.Equal(MarkdownNativeVisualPayloadFormat.Mermaid, mermaid.Payload.Format);
+        Assert.True(mermaid.Payload.IsMermaid);
+    }
+
+    [Fact]
+    public void ToSnapshot_Returns_UI_Safe_Block_Inline_Table_And_Diagnostic_Data() {
+        var markdown = """
+# Snapshot [docs](https://example.com)
+
+| Name | Value |
+| :--- | ---: |
+| **CPU** | `42` |
+
+***
+""";
+
+        var native = MarkdownNativeDocument.Parse(markdown);
+
+        var snapshot = native.ToSnapshot();
+
+        Assert.Equal(MarkdownNativeDocumentSourceKind.ReaderInput, snapshot.SourceKind);
+        Assert.Equal(native.Blocks.Count, snapshot.Blocks.Count);
+        var heading = snapshot.Blocks[0];
+        Assert.Equal(MarkdownNativeBlockKind.Heading, heading.Kind);
+        Assert.Equal("Snapshot docs", heading.Text);
+        Assert.Contains(heading.Inlines, inline => inline.Kind == MarkdownNativeInlineKind.Link && inline.Metadata["target"] == "https://example.com");
+
+        var table = snapshot.Blocks[1];
+        Assert.Equal(ColumnAlignment.Left, table.HeaderCells[0].Alignment);
+        Assert.Equal(ColumnAlignment.Right, table.Rows[0][1].Alignment);
+        Assert.Contains(table.Rows[0][0].Inlines, inline => inline.Kind == MarkdownNativeInlineKind.Strong && inline.Text == "CPU");
+
+        Assert.Contains(snapshot.Diagnostics, diagnostic =>
+            diagnostic.Id == "native.unsupported-block"
+            && diagnostic.BlockId == native.Blocks[2].Id);
+    }
+
+    [Fact]
+    public void Navigation_And_Source_Edit_Helpers_Find_Blocks_And_Draft_Replacements() {
+        var markdown = """
+> [!NOTE] Heads up
+> Body text
+
+Outside
+""";
+
+        var native = MarkdownNativeDocument.Parse(markdown);
+        var callout = Assert.IsType<MarkdownNativeCalloutBlock>(native.Blocks[0]);
+        var child = Assert.IsType<MarkdownNativeParagraphBlock>(Assert.Single(callout.Children));
+
+        Assert.Same(callout, native.FindBlockById(callout.Id));
+        Assert.Same(child, native.FindBlockAtPosition(child.SourceSpan!.Value.StartLine, child.SourceSpan.Value.StartColumn!.Value));
+        Assert.Equal(new[] { callout.Id, child.Id }, native.GetBlockPath(child.Id).Select(block => block.Id).ToArray());
+
+        var edit = native.CreateReplaceEdit(child, "> Updated body");
+        var updated = edit.Apply(native.SourceMarkdown);
+        Assert.Contains("> Updated body", updated);
+        Assert.DoesNotContain("> Body text", updated);
+    }
+
+    [Fact]
     public void Renderer_ParseNativeDocument_Exposes_Preprocessed_Source_Kind_And_Transform_Diagnostics() {
         var markdown = """
 ix:cached-tool-evidence:v1

--- a/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
@@ -230,6 +230,35 @@ Paragraph with `code` and ![Alt](img.png "Img").
     }
 
     [Fact]
+    public void Parse_Restricts_BlockFirst_List_Item_InlineRuns_To_Lead_Content() {
+        const string markdown = """
+- - foo
+- # Bar
+""";
+
+        var native = MarkdownNativeDocument.Parse(markdown, MarkdownReaderOptions.CreateCommonMarkProfile());
+
+        var list = Assert.IsType<MarkdownNativeListBlock>(Assert.Single(native.Blocks));
+        Assert.Equal(2, list.Items.Count);
+        Assert.Empty(list.Items[0].Text);
+        Assert.Empty(list.Items[0].InlineRuns);
+        Assert.Empty(list.Items[1].Text);
+        Assert.Empty(list.Items[1].InlineRuns);
+
+        var nestedList = Assert.IsType<MarkdownNativeListBlock>(Assert.Single(list.Items[0].Children));
+        var nestedItem = Assert.Single(nestedList.Items);
+        var nestedInline = Assert.Single(nestedItem.InlineRuns);
+        Assert.Equal("foo", nestedInline.Text);
+
+        var heading = Assert.IsType<MarkdownNativeHeadingBlock>(Assert.Single(list.Items[1].Children));
+        var headingInline = Assert.Single(heading.InlineRuns);
+        Assert.Equal("Bar", headingInline.Text);
+
+        Assert.Single(native.EnumerateInlines(), inline => inline.Text == "foo");
+        Assert.Single(native.EnumerateInlines(), inline => inline.Text == "Bar");
+    }
+
+    [Fact]
     public void Parse_Exposes_Visual_Payload_Hints_Without_Json_Dependency() {
         var options = new MarkdownReaderOptions();
         options.DocumentTransforms.Add(new MarkdownJsonVisualCodeBlockTransform(MarkdownVisualFenceLanguageMode.IntelligenceXAliasFence));

--- a/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
@@ -182,6 +182,7 @@ Console.WriteLine(1);
 
         var table = Assert.IsType<MarkdownNativeTableBlock>(Assert.Single(native.Blocks));
         var detailCell = table.Rows[0][1];
+        Assert.Empty(detailCell.InlineRuns);
         var list = Assert.IsType<MarkdownNativeListBlock>(Assert.Single(detailCell.Children));
         Assert.Equal(new[] { "high", "low" }, list.Items.Select(item => item.Text).ToArray());
         Assert.Same(list, native.FindBlockById(list.Id));
@@ -189,6 +190,7 @@ Console.WriteLine(1);
         Assert.Contains(native.DescendantBlocksAndSelf(), block => ReferenceEquals(block, list));
 
         var snapshotCell = native.ToSnapshot().Blocks[0].Rows[0][1];
+        Assert.Empty(snapshotCell.Inlines);
         var snapshotList = Assert.Single(snapshotCell.Children);
         Assert.Equal(MarkdownNativeBlockKind.List, snapshotList.Kind);
         Assert.Equal(new[] { "high", "low" }, snapshotList.Items.Select(item => item.Text).ToArray());
@@ -294,6 +296,12 @@ Paragraph with `code` and ![Alt](img.png "Img").
         Assert.Equal(2, native.Blocks.Select(block => block.Id).Distinct().Count());
         Assert.Equal(native.Blocks[0], native.FindBlockById(native.Blocks[0].Id));
         Assert.Equal(native.Blocks[1], native.FindBlockById(native.Blocks[1].Id));
+
+        var inlines = native.EnumerateInlines().Where(inline => inline.Text == "Same").ToArray();
+        Assert.Equal(2, inlines.Length);
+        Assert.Equal(2, inlines.Select(inline => inline.Id).Distinct().Count());
+        Assert.Equal(inlines[0], native.FindInlineById(inlines[0].Id));
+        Assert.Equal(inlines[1], native.FindInlineById(inlines[1].Id));
     }
 
     [Fact]
@@ -397,6 +405,23 @@ Outside
         var updated = edit.Apply(native.SourceMarkdown);
 
         Assert.Equal("First\n\nUpdated\n", updated);
+    }
+
+    [Fact]
+    public void Renderer_ParseNativeDocument_Uses_Reader_Normalized_Source_For_Edits() {
+        var markdown = "First\r\n\r\nSecond\r\n";
+
+        var parseResult = OfficeIMO.MarkdownRenderer.MarkdownRenderer.ParseDocumentResult(markdown);
+        var native = OfficeIMO.MarkdownRenderer.MarkdownRenderer.ParseNativeDocument(markdown);
+        var paragraph = Assert.IsType<MarkdownNativeParagraphBlock>(native.Blocks[1]);
+
+        Assert.Equal("First\r\n\r\nSecond\r\n", parseResult.PreprocessedMarkdown);
+        Assert.Equal("First\n\nSecond\n", parseResult.SourceMarkdown);
+        Assert.Equal(MarkdownNativeDocumentSourceKind.RendererPreprocessed, native.SourceKind);
+        Assert.Equal("First\n\nSecond\n", native.SourceMarkdown);
+
+        var edit = native.CreateReplaceEdit(paragraph, "Updated");
+        Assert.Equal("First\n\nUpdated\n", edit.Apply(native.SourceMarkdown));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add an AST-backed MarkdownNativeDocument projection over MarkdownReader.ParseWithSyntaxTreeAndDiagnostics
- expose native paragraph, code, table, visual, and fallback block projections with source spans
- add thin IntelligenceX transcript-native helpers that reuse the IX renderer presets
- cover the shared projection and IX visual-fence path with focused contract tests

## Validation
- dotnet build .\OfficeIMO.Markdown\OfficeIMO.Markdown.csproj -c Debug --no-restore
- dotnet build .\OfficeIMO.MarkdownRenderer.IntelligenceX\OfficeIMO.MarkdownRenderer.IntelligenceX.csproj -c Debug --no-restore
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~Markdown_Native_Document_Tests|FullyQualifiedName~Markdown_IntelligenceXTranscript_Tests"
- git diff --check
