### PR TITLE
Improve Excel direct tabular range handling

### DIFF
--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Metadata.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Metadata.cs
@@ -692,8 +692,34 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            range = sheetModel.Range;
+            DirectWorksheetMetadata? metadata = sheetModel.Metadata;
+            if (!TryCaptureDirectWorksheetMetadata(sheetModel, out DirectWorksheetMetadata? capturedMetadata, out _, metadataSourceOverride: sheet)) {
+                return false;
+            }
+
+            metadata = MergeDirectWorksheetMetadata(metadata, capturedMetadata, replaceOverlayCells: true);
+            range = GetDirectTabularSaveCandidateUsedRange(sheetModel, metadata);
             return true;
+        }
+
+        private static string GetDirectTabularSaveCandidateUsedRange(DirectDataSetSheetModel sheetModel, DirectWorksheetMetadata? metadata) {
+            string range = sheetModel.Range;
+            var overlayCells = metadata?.OverlayCells;
+            if (overlayCells == null || overlayCells.Count == 0 || !A1.TryParseRange(range, out int firstRow, out int firstColumn, out int lastRow, out int lastColumn)) {
+                return range;
+            }
+
+            for (int i = 0; i < overlayCells.Count; i++) {
+                var cell = overlayCells[i];
+                if (cell.IsDeleted) {
+                    continue;
+                }
+
+                lastRow = Math.Max(lastRow, cell.Row);
+                lastColumn = Math.Max(lastColumn, cell.Column);
+            }
+
+            return A1.CellReference(firstRow, firstColumn) + ":" + A1.CellReference(lastRow, lastColumn);
         }
 
         internal bool TryGetDeferredDirectTabularPivotSource(

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Metadata.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Metadata.cs
@@ -668,6 +668,34 @@ namespace OfficeIMO.Excel {
             return columnCount > 0;
         }
 
+        /// <summary>
+        /// Returns the pending used range for a clean direct-tabular save candidate before the package is materialized.
+        /// </summary>
+        /// <param name="sheet">Worksheet whose pending direct-tabular range should be reported.</param>
+        /// <param name="range">The candidate worksheet range in A1 notation when available.</param>
+        /// <returns><c>true</c> when the workbook has a valid single-sheet direct-tabular candidate for the worksheet.</returns>
+        internal bool TryGetDirectTabularSaveCandidateRange(ExcelSheet sheet, out string range) {
+            range = string.Empty;
+            if (sheet == null) throw new ArgumentNullException(nameof(sheet));
+            if (!ReferenceEquals(sheet.Document, this)) {
+                return false;
+            }
+
+            var candidate = _directDataSetSaveCandidate;
+            if (candidate == null || !candidate.IsValid || candidate.Model.Sheets.Count != 1) {
+                return false;
+            }
+
+            var sheetModel = candidate.Model.Sheets[0];
+            if (!string.Equals(sheetModel.SheetName, sheet.Name, StringComparison.Ordinal)
+                || string.IsNullOrWhiteSpace(sheetModel.Range)) {
+                return false;
+            }
+
+            range = sheetModel.Range;
+            return true;
+        }
+
         internal bool TryGetDeferredDirectTabularPivotSource(
             ExcelSheet sheet,
             int startRow,

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Package.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Package.cs
@@ -322,13 +322,21 @@ namespace OfficeIMO.Excel {
             out DirectWorksheetMetadata? metadata,
             out string? skipReason,
             bool allowDrawings = false,
-            bool allowUnsupportedOverlayStyles = false) {
+            bool allowUnsupportedOverlayStyles = false,
+            ExcelSheet? metadataSourceOverride = null) {
             metadata = null;
             skipReason = null;
 
             ExcelSheet? sheet = null;
+            if (metadataSourceOverride != null
+                && ReferenceEquals(metadataSourceOverride.Document, this)
+                && string.Equals(metadataSourceOverride.Name, sheetModel.SheetName, StringComparison.Ordinal)) {
+                sheet = metadataSourceOverride;
+            }
+
             var metadataSourceSheet = _directDataSetMetadataSourceSheet;
-            if (metadataSourceSheet != null
+            if (sheet == null
+                && metadataSourceSheet != null
                 && ReferenceEquals(metadataSourceSheet.Document, this)
                 && string.Equals(metadataSourceSheet.Name, sheetModel.SheetName, StringComparison.Ordinal)) {
                 sheet = metadataSourceSheet;

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -449,6 +449,7 @@ namespace OfficeIMO.Excel {
 
                 int lastDirectRow = sheetModel.Table.RowCount + (sheetModel.IncludeHeaders ? 1 : 0);
                 if (row > lastDirectRow || column > sheetModel.Table.ColumnCount) {
+                    _directDataSetMetadataSourceSheet = sheet;
                     _directDataSetSaveCandidatePreservationDepth++;
                     _materializedDirectDataSetFastSaveModelPreservationDepth++;
                     _directDataSetExternalCellMutationPreservationDepth++;

--- a/OfficeIMO.Excel/ExcelSheet.Core.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Core.cs
@@ -131,6 +131,10 @@ namespace OfficeIMO.Excel {
         /// Returns the used range of this worksheet as an A1 string by leveraging the read bridge.
         /// </summary>
         public string GetUsedRangeA1() {
+            if (_excelDocument.TryGetDirectTabularSaveCandidateRange(this, out string pendingRange)) {
+                return pendingRange;
+            }
+
             using var reader = _excelDocument.CreateReader();
             var sh = reader.GetSheet(this.Name);
             return sh.GetUsedRangeA1();

--- a/OfficeIMO.Tests/Excel.TabularValues.cs
+++ b/OfficeIMO.Tests/Excel.TabularValues.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void InsertObjectsWithTable_UsesDirectWriterForCleanWorkbook() {
+            using var memory = new MemoryStream();
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                object?[] rows = {
+                    new Dictionary<string, object?> {
+                        ["Region"] = "NA",
+                        ["Revenue"] = 100,
+                        ["Created"] = new DateTime(2026, 1, 1),
+                        ["Enabled"] = true
+                    },
+                    new Dictionary<string, object?> {
+                        ["Region"] = "EMEA",
+                        ["Revenue"] = 200,
+                        ["Created"] = new DateTime(2026, 1, 2),
+                        ["Enabled"] = false
+                    }
+                };
+
+                sheet.InsertObjects(rows);
+                string range = sheet.GetUsedRangeA1();
+                Assert.Equal("A1:D3", range);
+                sheet.AddTable(range, hasHeader: true, name: "Sales", style: OfficeIMO.Excel.TableStyle.TableStyleMedium9, includeAutoFilter: true);
+
+                document.Save(memory);
+                Assert.Equal(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+                Assert.True(document.LastSaveDiagnostics.UsedFastPackageWriter);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.Single();
+            var table = worksheetPart.TableDefinitionParts.Single().Table;
+            Assert.NotNull(table);
+            Assert.Equal("Sales", table!.Name?.Value);
+            Assert.Equal("A1:D3", table.Reference?.Value);
+
+            var worksheet = worksheetPart.Worksheet;
+            Assert.NotNull(worksheet);
+            Dictionary<string, Cell> cells = worksheet!.Descendants<Cell>()
+                .ToDictionary(cell => cell.CellReference!.Value!);
+            Assert.Equal("Region", GetSpreadsheetCellText(spreadsheet, cells["A1"]));
+            Assert.Equal("NA", GetSpreadsheetCellText(spreadsheet, cells["A2"]));
+            Assert.Equal("200", GetSpreadsheetCellText(spreadsheet, cells["B3"]));
+            Assert.Equal(CellValues.Boolean, cells["D3"].DataType!.Value);
+            Assert.Equal("0", cells["D3"].CellValue!.Text);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.TabularValues.cs
+++ b/OfficeIMO.Tests/Excel.TabularValues.cs
@@ -57,5 +57,40 @@ namespace OfficeIMO.Tests {
             Assert.Equal(CellValues.Boolean, cells["D3"].DataType!.Value);
             Assert.Equal("0", cells["D3"].CellValue!.Text);
         }
+
+        [Fact]
+        public void InsertObjects_GetUsedRangeIncludesOverlayCells() {
+            using var memory = new MemoryStream();
+            using (var document = ExcelDocument.Create(new MemoryStream(), autoSave: false)) {
+                var sheet = document.AddWorkSheet("Data");
+                object?[] rows = {
+                    new Dictionary<string, object?> {
+                        ["Region"] = "NA",
+                        ["Revenue"] = 100
+                    },
+                    new Dictionary<string, object?> {
+                        ["Region"] = "EMEA",
+                        ["Revenue"] = 200
+                    }
+                };
+
+                sheet.InsertObjects(rows);
+                sheet.CellValue(10, 5, "note");
+
+                Assert.Equal("A1:E10", sheet.GetUsedRangeA1());
+
+                document.Save(memory);
+                Assert.Equal(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+                Assert.True(document.LastSaveDiagnostics.UsedFastPackageWriter);
+            }
+
+            memory.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(memory, false);
+            var worksheet = spreadsheet.WorkbookPart!.WorksheetParts.Single().Worksheet;
+            Assert.NotNull(worksheet);
+            var dimension = worksheet!.SheetDimension;
+            Assert.NotNull(dimension);
+            Assert.Equal("A1:E10", dimension!.Reference?.Value);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Teach `ExcelSheet.GetUsedRangeA1()` to report the pending range for clean direct-tabular save candidates before the package is materialized.
- Keep the optimization inside OfficeIMO's existing `InsertObjects` / `GetUsedRangeA1` / `AddTable` flow without adding public benchmark-only APIs.
- Add an artifact-level Excel test proving the direct writer still produces a real workbook table and typed cells.

## Why
PSWriteOffice and other consumers need to compose tables after normal object insertion without forcing the direct writer path to fall back through a slower materialized read. This keeps the reusable performance behavior in OfficeIMO where future callers can benefit from it.

## Validation
- `dotnet build C:\Support\GitHub\OfficeIMO\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --no-restore`
- `dotnet test C:\Support\GitHub\OfficeIMO\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release -f net8.0 --no-restore -p:BuildProjectReferences=false --filter "FullyQualifiedName~InsertObjectsWithTable_UsesDirectWriterForCleanWorkbook|FullyQualifiedName~Reader_GetUsedRangeA1"`
- `git diff --check`

## Notes
This is the upstream performance piece for the matching PSWriteOffice Excel export routing PR.



Matching PSWriteOffice PR: EvotecIT/PSWriteOffice#113

