### PR TITLE
fix(excel): harden chart exports

### DIFF
--- a/OfficeIMO.Excel/ExcelChart.DataLabelHelpers.cs
+++ b/OfficeIMO.Excel/ExcelChart.DataLabelHelpers.cs
@@ -31,9 +31,7 @@ namespace OfficeIMO.Excel {
             ReplaceChild(labels, new C.ShowBubbleSize { Val = false });
 
             if (position != null) {
-                if (TryNormalizeDataLabelPosition(chartElement, position.Value, out var normalizedPosition)) {
-                    ReplaceChild(labels, new C.DataLabelPosition { Val = normalizedPosition });
-                }
+                ApplyDataLabelPosition(labels, chartElement, position.Value);
             }
 
             if (numberFormat != null) {
@@ -410,9 +408,7 @@ namespace OfficeIMO.Excel {
                 ReplaceChild(label, new C.ShowBubbleSize { Val = showBubbleSize.Value });
             }
             if (position != null) {
-                if (TryNormalizeDataLabelPosition(label, position.Value, out var normalizedPosition)) {
-                    ReplaceChild(label, new C.DataLabelPosition { Val = normalizedPosition });
-                }
+                ApplyDataLabelPosition(label, label, position.Value);
             }
             if (numberFormat != null) {
                 ReplaceChild(label, new C.NumberingFormat {
@@ -445,13 +441,22 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        private static void ApplyDataLabelPosition(OpenXmlCompositeElement labelContainer, OpenXmlElement context, C.DataLabelPositionValues position) {
+            if (TryNormalizeDataLabelPosition(context, position, out var normalizedPosition)) {
+                ReplaceChild(labelContainer, new C.DataLabelPosition { Val = normalizedPosition });
+                return;
+            }
+
+            labelContainer.RemoveAllChildren<C.DataLabelPosition>();
+        }
+
         private static bool TryNormalizeDataLabelPosition(OpenXmlElement context, C.DataLabelPositionValues position, out C.DataLabelPositionValues normalizedPosition) {
             normalizedPosition = position;
 
             for (OpenXmlElement? current = context; current != null; current = current.Parent) {
                 if (current is C.PieChart || current is C.Pie3DChart || current is C.OfPieChart || current is C.DoughnutChart
                     || current is C.PieChartSeries) {
-                    return false;
+                    return position != C.DataLabelPositionValues.BestFit;
                 }
 
                 if (position == C.DataLabelPositionValues.OutsideEnd

--- a/OfficeIMO.Excel/ExcelChart.DataLabelHelpers.cs
+++ b/OfficeIMO.Excel/ExcelChart.DataLabelHelpers.cs
@@ -454,8 +454,7 @@ namespace OfficeIMO.Excel {
             normalizedPosition = position;
 
             for (OpenXmlElement? current = context; current != null; current = current.Parent) {
-                if (current is C.PieChart || current is C.Pie3DChart || current is C.OfPieChart || current is C.DoughnutChart
-                    || current is C.PieChartSeries) {
+                if (current is C.DoughnutChart) {
                     return position != C.DataLabelPositionValues.BestFit;
                 }
 

--- a/OfficeIMO.Excel/ExcelChart.DataLabelHelpers.cs
+++ b/OfficeIMO.Excel/ExcelChart.DataLabelHelpers.cs
@@ -31,7 +31,9 @@ namespace OfficeIMO.Excel {
             ReplaceChild(labels, new C.ShowBubbleSize { Val = false });
 
             if (position != null) {
-                ReplaceChild(labels, new C.DataLabelPosition { Val = NormalizeDataLabelPosition(chartElement, position.Value) });
+                if (TryNormalizeDataLabelPosition(chartElement, position.Value, out var normalizedPosition)) {
+                    ReplaceChild(labels, new C.DataLabelPosition { Val = normalizedPosition });
+                }
             }
 
             if (numberFormat != null) {
@@ -408,7 +410,9 @@ namespace OfficeIMO.Excel {
                 ReplaceChild(label, new C.ShowBubbleSize { Val = showBubbleSize.Value });
             }
             if (position != null) {
-                ReplaceChild(label, new C.DataLabelPosition { Val = NormalizeDataLabelPosition(label, position.Value) });
+                if (TryNormalizeDataLabelPosition(label, position.Value, out var normalizedPosition)) {
+                    ReplaceChild(label, new C.DataLabelPosition { Val = normalizedPosition });
+                }
             }
             if (numberFormat != null) {
                 ReplaceChild(label, new C.NumberingFormat {
@@ -441,19 +445,31 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static C.DataLabelPositionValues NormalizeDataLabelPosition(OpenXmlElement context, C.DataLabelPositionValues position) {
-            if (position != C.DataLabelPositionValues.OutsideEnd) {
-                return position;
-            }
+        private static bool TryNormalizeDataLabelPosition(OpenXmlElement context, C.DataLabelPositionValues position, out C.DataLabelPositionValues normalizedPosition) {
+            normalizedPosition = position;
 
-            // Excel repairs line charts that contain an outEnd data label position.
             for (OpenXmlElement? current = context; current != null; current = current.Parent) {
-                if (current is C.LineChart || current is C.Line3DChart || current is C.LineChartSeries) {
-                    return C.DataLabelPositionValues.Top;
+                if (current is C.PieChart || current is C.Pie3DChart || current is C.OfPieChart || current is C.DoughnutChart
+                    || current is C.PieChartSeries) {
+                    return false;
+                }
+
+                if (position == C.DataLabelPositionValues.OutsideEnd
+                    && (current is C.LineChart || current is C.Line3DChart || current is C.LineChartSeries)) {
+                    normalizedPosition = C.DataLabelPositionValues.Top;
+                    return true;
+                }
+
+                if (position == C.DataLabelPositionValues.OutsideEnd && current is C.BarChart barChart) {
+                    var grouping = barChart.BarGrouping?.Val?.Value;
+                    if (grouping == C.BarGroupingValues.Stacked || grouping == C.BarGroupingValues.PercentStacked) {
+                        normalizedPosition = C.DataLabelPositionValues.Center;
+                        return true;
+                    }
                 }
             }
 
-            return position;
+            return true;
         }
 
         private static void ApplyDataLabelTemplate(OpenXmlCompositeElement series, ExcelChartDataLabelTemplate template) {

--- a/OfficeIMO.Excel/ExcelChartGridLayout.cs
+++ b/OfficeIMO.Excel/ExcelChartGridLayout.cs
@@ -1,0 +1,75 @@
+using System;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Produces sequential chart placements for worksheet dashboards.
+    /// </summary>
+    public sealed class ExcelChartGridLayout {
+        private const int DefaultColumnPixels = 64;
+        private const int DefaultRowPixels = 20;
+
+        private readonly int _startRow;
+        private readonly int _startColumn;
+        private readonly int _widthPixels;
+        private readonly int _heightPixels;
+        private readonly int _chartsPerRow;
+        private readonly int _horizontalAdvanceColumns;
+        private readonly int _verticalAdvanceRows;
+        private int _index;
+
+        /// <summary>
+        /// Initializes a chart grid layout.
+        /// </summary>
+        /// <param name="row">One-based worksheet row for the first chart.</param>
+        /// <param name="column">One-based worksheet column for the first chart.</param>
+        /// <param name="widthPixels">Chart width in pixels.</param>
+        /// <param name="heightPixels">Chart height in pixels.</param>
+        /// <param name="chartsPerRow">Number of charts to place before wrapping to the next row.</param>
+        /// <param name="horizontalGapPixels">Minimum horizontal gap between chart slots, in pixels.</param>
+        /// <param name="verticalGapRows">Minimum vertical gap between chart rows, in worksheet rows.</param>
+        public ExcelChartGridLayout(
+            int row,
+            int column,
+            int widthPixels = 520,
+            int heightPixels = 320,
+            int chartsPerRow = 2,
+            int horizontalGapPixels = 48,
+            int verticalGapRows = 2) {
+            if (row <= 0) throw new ArgumentOutOfRangeException(nameof(row));
+            if (column <= 0) throw new ArgumentOutOfRangeException(nameof(column));
+            if (widthPixels <= 0) throw new ArgumentOutOfRangeException(nameof(widthPixels));
+            if (heightPixels <= 0) throw new ArgumentOutOfRangeException(nameof(heightPixels));
+            if (chartsPerRow <= 0) throw new ArgumentOutOfRangeException(nameof(chartsPerRow));
+            if (horizontalGapPixels < 0) throw new ArgumentOutOfRangeException(nameof(horizontalGapPixels));
+            if (verticalGapRows < 0) throw new ArgumentOutOfRangeException(nameof(verticalGapRows));
+
+            _startRow = row;
+            _startColumn = column;
+            _widthPixels = widthPixels;
+            _heightPixels = heightPixels;
+            _chartsPerRow = chartsPerRow;
+            _horizontalAdvanceColumns = Math.Max(1, CeilDiv(widthPixels + horizontalGapPixels, DefaultColumnPixels));
+            _verticalAdvanceRows = Math.Max(1, CeilDiv(heightPixels, DefaultRowPixels) + verticalGapRows);
+        }
+
+        /// <summary>
+        /// Gets the next chart placement and advances the layout cursor.
+        /// </summary>
+        /// <returns>Chart placement for the next dashboard slot.</returns>
+        public ExcelChartPlacement Next() {
+            int rowOffset = _index / _chartsPerRow;
+            int columnOffset = _index % _chartsPerRow;
+            _index++;
+
+            return new ExcelChartPlacement(
+                _startRow + (rowOffset * _verticalAdvanceRows),
+                _startColumn + (columnOffset * _horizontalAdvanceColumns),
+                _widthPixels,
+                _heightPixels);
+        }
+
+        private static int CeilDiv(int value, int divisor) {
+            return (value + divisor - 1) / divisor;
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelChartGridLayout.cs
+++ b/OfficeIMO.Excel/ExcelChartGridLayout.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace OfficeIMO.Excel {
     /// <summary>
-    /// Produces sequential chart placements for worksheet dashboards.
+    /// Produces sequential chart placements for worksheet dashboards that use the default Excel row and column grid.
     /// </summary>
     public sealed class ExcelChartGridLayout {
         private const int DefaultColumnPixels = 64;
@@ -25,8 +25,8 @@ namespace OfficeIMO.Excel {
         /// <param name="widthPixels">Chart width in pixels.</param>
         /// <param name="heightPixels">Chart height in pixels.</param>
         /// <param name="chartsPerRow">Number of charts to place before wrapping to the next row.</param>
-        /// <param name="horizontalGapPixels">Minimum horizontal gap between chart slots, in pixels.</param>
-        /// <param name="verticalGapRows">Minimum vertical gap between chart rows, in worksheet rows.</param>
+        /// <param name="horizontalGapPixels">Minimum horizontal gap between chart slots, in pixels, calculated against default-width Excel columns.</param>
+        /// <param name="verticalGapRows">Minimum vertical gap between chart rows, in worksheet rows, calculated against default-height Excel rows.</param>
         public ExcelChartGridLayout(
             int row,
             int column,

--- a/OfficeIMO.Excel/ExcelChartPlacement.cs
+++ b/OfficeIMO.Excel/ExcelChartPlacement.cs
@@ -1,0 +1,40 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Represents a chart placement slot in an Excel worksheet.
+    /// </summary>
+    public sealed class ExcelChartPlacement {
+        /// <summary>
+        /// Initializes a new chart placement.
+        /// </summary>
+        /// <param name="row">One-based worksheet row where the chart should be anchored.</param>
+        /// <param name="column">One-based worksheet column where the chart should be anchored.</param>
+        /// <param name="widthPixels">Chart width in pixels.</param>
+        /// <param name="heightPixels">Chart height in pixels.</param>
+        public ExcelChartPlacement(int row, int column, int widthPixels, int heightPixels) {
+            Row = row;
+            Column = column;
+            WidthPixels = widthPixels;
+            HeightPixels = heightPixels;
+        }
+
+        /// <summary>
+        /// Gets the one-based worksheet row where the chart should be anchored.
+        /// </summary>
+        public int Row { get; }
+
+        /// <summary>
+        /// Gets the one-based worksheet column where the chart should be anchored.
+        /// </summary>
+        public int Column { get; }
+
+        /// <summary>
+        /// Gets the chart width in pixels.
+        /// </summary>
+        public int WidthPixels { get; }
+
+        /// <summary>
+        /// Gets the chart height in pixels.
+        /// </summary>
+        public int HeightPixels { get; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.ChartLayout.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ChartLayout.cs
@@ -1,0 +1,25 @@
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Creates a sequential chart layout helper for dashboard-style worksheets.
+        /// </summary>
+        /// <param name="row">One-based worksheet row for the first chart.</param>
+        /// <param name="column">One-based worksheet column for the first chart.</param>
+        /// <param name="widthPixels">Default chart width in pixels.</param>
+        /// <param name="heightPixels">Default chart height in pixels.</param>
+        /// <param name="chartsPerRow">Number of charts to place before wrapping to the next row.</param>
+        /// <param name="horizontalGapPixels">Minimum horizontal gap between chart slots, in pixels.</param>
+        /// <param name="verticalGapRows">Minimum vertical gap between chart rows, in worksheet rows.</param>
+        /// <returns>A layout helper that produces chart placement slots.</returns>
+        public ExcelChartGridLayout ChartLayout(
+            int row,
+            int column,
+            int widthPixels = 520,
+            int heightPixels = 320,
+            int chartsPerRow = 2,
+            int horizontalGapPixels = 48,
+            int verticalGapRows = 2) {
+            return new ExcelChartGridLayout(row, column, widthPixels, heightPixels, chartsPerRow, horizontalGapPixels, verticalGapRows);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.ChartLayout.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ChartLayout.cs
@@ -1,15 +1,15 @@
 namespace OfficeIMO.Excel {
     public partial class ExcelSheet {
         /// <summary>
-        /// Creates a sequential chart layout helper for dashboard-style worksheets.
+        /// Creates a sequential chart layout helper for dashboard-style worksheets that use the default Excel row and column grid.
         /// </summary>
         /// <param name="row">One-based worksheet row for the first chart.</param>
         /// <param name="column">One-based worksheet column for the first chart.</param>
         /// <param name="widthPixels">Default chart width in pixels.</param>
         /// <param name="heightPixels">Default chart height in pixels.</param>
         /// <param name="chartsPerRow">Number of charts to place before wrapping to the next row.</param>
-        /// <param name="horizontalGapPixels">Minimum horizontal gap between chart slots, in pixels.</param>
-        /// <param name="verticalGapRows">Minimum vertical gap between chart rows, in worksheet rows.</param>
+        /// <param name="horizontalGapPixels">Minimum horizontal gap between chart slots, in pixels, calculated against default-width Excel columns.</param>
+        /// <param name="verticalGapRows">Minimum vertical gap between chart rows, in worksheet rows, calculated against default-height Excel rows.</param>
         /// <returns>A layout helper that produces chart placement slots.</returns>
         public ExcelChartGridLayout ChartLayout(
             int row,

--- a/OfficeIMO.Tests/Excel.Charts.cs
+++ b/OfficeIMO.Tests/Excel.Charts.cs
@@ -1332,6 +1332,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ExcelCharts_PieOutsideEndDataLabelsArePreserved() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelCharts.PieOutsideEndLabels.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Pie");
+                sheet.CellValue(1, 1, "Status");
+                sheet.CellValue(1, 2, "Rules");
+                sheet.CellValue(2, 1, "High");
+                sheet.CellValue(2, 2, 5);
+                sheet.CellValue(3, 1, "Medium");
+                sheet.CellValue(3, 2, 3);
+
+                sheet.AddChartFromRange("A1:B3", row: 1, column: 4, widthPixels: 480, heightPixels: 300, type: ExcelChartType.Pie, title: "Status")
+                    .SetDataLabels(
+                        showValue: false,
+                        showCategoryName: true,
+                        showSeriesName: false,
+                        showLegendKey: false,
+                        showPercent: true,
+                        position: C.DataLabelPositionValues.OutsideEnd,
+                        numberFormat: "0%");
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = GetWorksheetPartWithCharts(spreadsheet);
+                C.DataLabelPosition position = wsPart.DrawingsPart!.ChartParts
+                    .SelectMany(part => part.ChartSpace.Descendants<C.DataLabelPosition>())
+                    .Single();
+
+                Assert.Equal(C.DataLabelPositionValues.OutsideEnd, position.Val!.Value);
+            }
+        }
+
+        [Fact]
         public void Test_ExcelCharts_RecipeCustomizationDoesNotLeakToNextBuilderChart() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelCharts.RecipeBuilderReuse.xlsx");
 

--- a/OfficeIMO.Tests/Excel.Charts.cs
+++ b/OfficeIMO.Tests/Excel.Charts.cs
@@ -1288,6 +1288,50 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ExcelCharts_ChartLayoutPlacesRecipeChartsWithoutOverlap() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelCharts.ChartLayout.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Dashboard");
+                sheet.CellValue(1, 1, "Status");
+                sheet.CellValue(1, 2, "Rules");
+                sheet.CellValue(2, 1, "High");
+                sheet.CellValue(2, 2, 5);
+                sheet.CellValue(3, 1, "Medium");
+                sheet.CellValue(3, 2, 3);
+                sheet.AddTable("A1:B3", hasHeader: true, name: "StatusData", style: OfficeIMO.Excel.TableStyle.TableStyleMedium4);
+
+                ExcelChartGridLayout layout = sheet.ChartLayout(row: 12, column: 4, widthPixels: 520, heightPixels: 300);
+                ExcelChartPlacement statusPlacement = layout.Next();
+                ExcelChartPlacement contributionPlacement = layout.Next();
+
+                sheet.AddStatusBreakdownChart("A1:B3", statusPlacement.Row, statusPlacement.Column, widthPixels: statusPlacement.WidthPixels, heightPixels: statusPlacement.HeightPixels);
+                sheet.AddContributionChart("A1:B3", contributionPlacement.Row, contributionPlacement.Column, widthPixels: contributionPlacement.WidthPixels, heightPixels: contributionPlacement.HeightPixels);
+                document.Save();
+
+                Assert.Equal(12, statusPlacement.Row);
+                Assert.Equal(4, statusPlacement.Column);
+                Assert.Equal(12, contributionPlacement.Row);
+                Assert.Equal(13, contributionPlacement.Column);
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = GetWorksheetPartWithCharts(spreadsheet);
+                var anchors = wsPart.DrawingsPart!.WorksheetDrawing!
+                    .Elements<Xdr.OneCellAnchor>()
+                    .ToList();
+
+                Assert.Equal(2, anchors.Count);
+                Assert.Equal("3", anchors[0].FromMarker!.ColumnId!.Text);
+                Assert.Equal("12", anchors[1].FromMarker!.ColumnId!.Text);
+                Assert.Equal(4953000L, anchors[0].Extent!.Cx!.Value);
+                Assert.Equal(2857500L, anchors[0].Extent!.Cy!.Value);
+                Assert.Equal(4953000L, anchors[1].Extent!.Cx!.Value);
+                Assert.Equal(2857500L, anchors[1].Extent!.Cy!.Value);
+            }
+        }
+
+        [Fact]
         public void Test_ExcelCharts_RecipeCustomizationDoesNotLeakToNextBuilderChart() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelCharts.RecipeBuilderReuse.xlsx");
 

--- a/OfficeIMO.Tests/Excel.Charts.cs
+++ b/OfficeIMO.Tests/Excel.Charts.cs
@@ -1367,6 +1367,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ExcelCharts_PieBestFitDataLabelsArePreserved() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelCharts.PieBestFitLabels.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Pie");
+                sheet.CellValue(1, 1, "Status");
+                sheet.CellValue(1, 2, "Rules");
+                sheet.CellValue(2, 1, "High");
+                sheet.CellValue(2, 2, 5);
+                sheet.CellValue(3, 1, "Medium");
+                sheet.CellValue(3, 2, 3);
+
+                sheet.AddChartFromRange("A1:B3", row: 1, column: 4, widthPixels: 480, heightPixels: 300, type: ExcelChartType.Pie, title: "Status")
+                    .SetDataLabels(
+                        showValue: false,
+                        showCategoryName: true,
+                        showSeriesName: false,
+                        showLegendKey: false,
+                        showPercent: true,
+                        position: C.DataLabelPositionValues.BestFit,
+                        numberFormat: "0%");
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = GetWorksheetPartWithCharts(spreadsheet);
+                C.DataLabelPosition position = wsPart.DrawingsPart!.ChartParts
+                    .SelectMany(part => part.ChartSpace.Descendants<C.DataLabelPosition>())
+                    .Single();
+
+                Assert.Equal(C.DataLabelPositionValues.BestFit, position.Val!.Value);
+            }
+        }
+
+        [Fact]
         public void Test_ExcelCharts_RecipeCustomizationDoesNotLeakToNextBuilderChart() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelCharts.RecipeBuilderReuse.xlsx");
 

--- a/OfficeIMO.Tests/Excel.ComValidation.cs
+++ b/OfficeIMO.Tests/Excel.ComValidation.cs
@@ -125,7 +125,8 @@ namespace OfficeIMO.Tests {
                 CreateDesktopExcelValuesWorkbook(Path.Combine(directory, "Values.Formulas.xlsx")),
                 CreateDesktopExcelTableWorkbook(Path.Combine(directory, "Table.Filter.Freeze.xlsx")),
                 CreateDesktopExcelFormattingWorkbook(Path.Combine(directory, "Formatting.Validation.xlsx")),
-                CreateDesktopExcelChartWorkbook(Path.Combine(directory, "Charts.ComboScatter.xlsx"))
+                CreateDesktopExcelChartWorkbook(Path.Combine(directory, "Charts.ComboScatter.xlsx")),
+                CreateDesktopExcelRecipeChartWorkbook(Path.Combine(directory, "Charts.Recipes.xlsx"))
             };
 
             AssertWorkbooksOpenViaExcelComWhenAvailable(files,
@@ -194,6 +195,35 @@ namespace OfficeIMO.Tests {
                 type: ExcelChartType.ColumnClustered, title: "Sales vs Trend");
             chart.SetSeriesDataLabels(1, showValue: true, position: DocumentFormat.OpenXml.Drawing.Charts.DataLabelPositionValues.Top)
                  .SetSeriesDataLabelForPoint(1, 2, showValue: true, position: DocumentFormat.OpenXml.Drawing.Charts.DataLabelPositionValues.OutsideEnd);
+
+            document.Save();
+            return filePath;
+        }
+
+        private static string CreateDesktopExcelRecipeChartWorkbook(string filePath) {
+            using var document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorkSheet("Dashboard");
+            sheet.CellValue(1, 1, "Month");
+            sheet.CellValue(1, 2, "Revenue");
+            sheet.CellValue(2, 1, "Jan");
+            sheet.CellValue(2, 2, 10d);
+            sheet.CellValue(3, 1, "Feb");
+            sheet.CellValue(3, 2, 16d);
+            sheet.CellValue(4, 1, "Mar");
+            sheet.CellValue(4, 2, 13d);
+            sheet.AddTable("A1:B4", hasHeader: true, name: "RevenueData", style: OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+
+            sheet.AddRevenueTrendChart("A1:B4", row: 1, column: 5);
+            sheet.AddTopNBarChart("A1:B4", row: 18, column: 5, title: "Top Revenue");
+            sheet.AddVarianceColumnChart("A1:B4", row: 35, column: 5, title: "Revenue Variance");
+            sheet.AddKpiScorecardChart("A1:B4", row: 52, column: 5, title: "Revenue KPI");
+            sheet.AddContributionChart("A1:B4", row: 69, column: 5, title: "Revenue Mix");
+            sheet.ChartFromTable("RevenueData")
+                .StatusBreakdown("Revenue Mix")
+                .At(86, 5);
+            sheet.ChartFromTable("RevenueData")
+                .VarianceWaterfall("Revenue Bridge")
+                .At(103, 5);
 
             document.Save();
             return filePath;


### PR DESCRIPTION
## Summary
- harden Excel chart data label serialization so unsupported label positions are omitted or normalized instead of producing repair-prone drawings
- add a reusable `ChartLayout` helper for dashboard chart placement to avoid overlapping one-cell chart anchors
- extend chart recipe and desktop Excel COM coverage for recipe/dashboard charts

## Validation
- `dotnet.exe test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~Test_ExcelCharts_ChartLayoutPlacesRecipeChartsWithoutOverlap|FullyQualifiedName~Test_ExcelCharts_RecipeHelpers_CreateExpectedChartTypes|FullyQualifiedName~ExcelWorkbooks_OpenInDesktopExcelWhenAvailable"`