### PR TITLE
Limit remote HTML image candidate probing

### DIFF
--- a/OfficeIMO.Tests/ConversionOptions.cs
+++ b/OfficeIMO.Tests/ConversionOptions.cs
@@ -101,6 +101,7 @@ public class ConversionOptionsTests {
         options.ResourceTimeout = TimeSpan.FromSeconds(7);
         options.MaxImageBytes = 11;
         options.MaxTotalImageBytes = 22;
+        options.MaxRemoteImageCandidateProbes = null;
         options.ValidateImageContentTypes = false;
         options.ValidateStylesheetContentTypes = false;
         options.MaxHtmlNodes = 33;
@@ -153,6 +154,7 @@ public class ConversionOptionsTests {
         Assert.Equal(options.ResourceTimeout, clone.ResourceTimeout);
         Assert.Equal(options.MaxImageBytes, clone.MaxImageBytes);
         Assert.Equal(options.MaxTotalImageBytes, clone.MaxTotalImageBytes);
+        Assert.Equal(options.MaxRemoteImageCandidateProbes, clone.MaxRemoteImageCandidateProbes);
         Assert.Equal(options.ValidateImageContentTypes, clone.ValidateImageContentTypes);
         Assert.Equal(options.ValidateStylesheetContentTypes, clone.ValidateStylesheetContentTypes);
         Assert.Equal(options.MaxHtmlNodes, clone.MaxHtmlNodes);

--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -327,6 +327,58 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void HtmlToWord_ImageSelection_LimitsRemoteCandidateProbesPerElement() {
+            var requested = new List<Uri>();
+            var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
+            string base64 = Convert.ToBase64String(File.ReadAllBytes(path));
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(request => {
+                requested.Add(request.RequestUri!);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }));
+            var options = new HtmlToWordOptions {
+                HttpClient = httpClient
+            };
+            string html = $"<img srcset=\"https://cdn.example.test/one.png 1x, https://cdn.example.test/two.png 2x, https://cdn.example.test/three.png 3x\" src=\"data:image/png;base64,{base64}\" alt=\"Logo\" />";
+
+            var doc = html.LoadFromHtml(options);
+
+            Assert.Single(doc.Images);
+            Assert.Equal(new Uri("https://cdn.example.test/one.png"), Assert.Single(requested));
+            Assert.Empty(options.Diagnostics);
+        }
+
+        [Fact]
+        public void HtmlToWord_ImageSelection_AllowsTrustedCallersToProbeAllRemoteCandidates() {
+            var requested = new List<Uri>();
+            const string validPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(request => {
+                requested.Add(request.RequestUri!);
+                if (request.RequestUri!.AbsolutePath == "/two.png") {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                        Content = new ByteArrayContent(Convert.FromBase64String(validPng)) {
+                            Headers = {
+                                ContentType = new MediaTypeHeaderValue("image/png")
+                            }
+                        }
+                    });
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }));
+            var options = new HtmlToWordOptions {
+                HttpClient = httpClient,
+                MaxRemoteImageCandidateProbes = null
+            };
+            string html = """<img srcset="https://cdn.example.test/one.png 1x, https://cdn.example.test/two.png 2x" alt="Logo" />""";
+
+            var doc = html.LoadFromHtml(options);
+
+            Assert.Single(doc.Images);
+            Assert.Equal(new[] { "/one.png", "/two.png" }, requested.Select(uri => uri.AbsolutePath).ToArray());
+            Assert.Empty(options.Diagnostics);
+        }
+
+        [Fact]
         public void HtmlToWord_RemoteImageOverTotalMaxBytes_SkipsWithDiagnostic() {
             using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(_ =>
                 Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -445,6 +445,7 @@ namespace OfficeIMO.Word.Html {
 
         private string ResolveWordImageSource(IHtmlImageElement img, HtmlToWordOptions options) {
             string firstResolved = string.Empty;
+            int remoteCandidateProbeCount = 0;
             foreach (string candidate in EnumerateWordImageSourceCandidates(img, options)) {
                 string resolved = ResolveImageSourcePath(candidate, img, options);
                 if (string.IsNullOrWhiteSpace(resolved)) {
@@ -460,12 +461,23 @@ namespace OfficeIMO.Word.Html {
                 }
 
                 if (IsImageSourceAllowedForCurrentMode(resolved, img, options, out _)) {
-                    if (IsRemoteEmbeddedImageSource(resolved, options) && !TryFetchRemoteImageCandidate(resolved, options)) {
-                        if (string.IsNullOrEmpty(firstResolved)) {
-                            firstResolved = resolved;
+                    if (IsRemoteEmbeddedImageSource(resolved, options)) {
+                        if (!CanProbeRemoteImageCandidate(options, remoteCandidateProbeCount)) {
+                            if (string.IsNullOrEmpty(firstResolved)) {
+                                firstResolved = resolved;
+                            }
+
+                            continue;
                         }
 
-                        continue;
+                        remoteCandidateProbeCount++;
+                        if (!TryFetchRemoteImageCandidate(resolved, options)) {
+                            if (string.IsNullOrEmpty(firstResolved)) {
+                                firstResolved = resolved;
+                            }
+
+                            continue;
+                        }
                     }
 
                     if (IsLocalEmbeddedImageSource(resolved, options) && !TryProbeLocalImageCandidate(resolved, options)) {
@@ -485,6 +497,11 @@ namespace OfficeIMO.Word.Html {
             }
 
             return firstResolved;
+        }
+
+        private static bool CanProbeRemoteImageCandidate(HtmlToWordOptions options, int probeCount) {
+            return !options.MaxRemoteImageCandidateProbes.HasValue
+                || probeCount < options.MaxRemoteImageCandidateProbes.Value;
         }
 
         private static IEnumerable<string> EnumerateWordImageSourceCandidates(IHtmlImageElement img, HtmlToWordOptions options) {

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -153,6 +153,13 @@ namespace OfficeIMO.Word.Html {
         public long? MaxTotalImageBytes { get; set; }
 
         /// <summary>
+        /// Optional maximum number of remote image candidates probed while selecting a source for one HTML image element.
+        /// Defaults to one probe to avoid request fan-out from large srcset or picture candidate lists.
+        /// Set to <see langword="null"/> to restore unbounded probing for trusted HTML.
+        /// </summary>
+        public int? MaxRemoteImageCandidateProbes { get; set; } = 1;
+
+        /// <summary>
         /// When true, validates declared image content types for remote image resources and data URI images.
         /// Images with rejected content types are skipped, alt text is inserted when available, and a diagnostic is emitted.
         /// </summary>

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -356,6 +356,7 @@ namespace OfficeIMO.Word.Html {
                 ResourceTimeout = ResourceTimeout,
                 MaxImageBytes = MaxImageBytes,
                 MaxTotalImageBytes = MaxTotalImageBytes,
+                MaxRemoteImageCandidateProbes = MaxRemoteImageCandidateProbes,
                 ValidateImageContentTypes = ValidateImageContentTypes,
                 ValidateStylesheetContentTypes = ValidateStylesheetContentTypes,
                 MaxHtmlNodes = MaxHtmlNodes,


### PR DESCRIPTION
### Motivation
- The converter enumerates many image candidates (picture/source, srcset, lazy attributes) and previously probed remote candidates eagerly, which can cause request fan-out and SSRF when processing untrusted HTML.
- Introduce a conservative default to avoid uncontrolled outbound requests while preserving the ability for trusted callers to opt back into full probing.

### Description
- Add `MaxRemoteImageCandidateProbes` to `HtmlToWordOptions` with a default of `1` to limit remote candidate probes per HTML image element. (`OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs`)
- Update `ResolveWordImageSource` to count remote probes and skip further remote fetching once the limit is reached, preserving local/data fallback semantics. (`OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs`)
- Add `CanProbeRemoteImageCandidate` helper to centralize the probe-limit check. (`OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs`)
- Add two regression tests that verify the default single-probe behavior and that setting `MaxRemoteImageCandidateProbes = null` allows trusted callers to probe all candidates. (`OfficeIMO.Tests/Html.Images.cs`)

### Testing
- Ran the targeted unit tests with preview language mode: `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj -f net8.0 -p:TargetFrameworks=net8.0 -p:LangVersion=preview --filter "FullyQualifiedName~HtmlToWord_ImageSelection_LimitsRemoteCandidateProbesPerElement|FullyQualifiedName~HtmlToWord_ImageSelection_AllowsTrustedCallersToProbeAllRemoteCandidates"` and both tests passed (2/2).
- Built the Word HTML project for `netstandard2.0` with preview language mode using `dotnet build OfficeIMO.Word.Html/OfficeIMO.Word.Html.csproj -f netstandard2.0 -p:TargetFrameworks=netstandard2.0 -p:LangVersion=preview` and the build succeeded.
- Note: attempting a plain `net8.0` test/build without `-p:LangVersion=preview` failed in this environment due to existing preview-only syntax elsewhere in the repository (`CS8652`), and a full repository test run under the installed SDK produced `NETSDK1045` for `net10.0` targets; these are preexisting environment/SDK issues and did not block the focused tests above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fbe144940832eadab506af82f67dc)